### PR TITLE
Adding wildcards for folders in the localfile configuration on Windows

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -637,15 +637,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         if (strchr(logf[pl].file, '*') ||
             strchr(logf[pl].file, '?')) {
 
-            WIN32_FIND_DATA ffd;
-            HANDLE hFind = INVALID_HANDLE_VALUE;
-
-            hFind = FindFirstFile(logf[pl].file, &ffd);
-
-            if (INVALID_HANDLE_VALUE == hFind) {
-                minfo(GLOB_ERROR_WIN, logf[pl].file);
-            }
-
             os_realloc(log_config->globs, (gl + 2) * sizeof(logreader_glob), log_config->globs);
             os_strdup(logf[pl].file, log_config->globs[gl].gpath);
             memset(&log_config->globs[gl + 1], 0, sizeof(logreader_glob));
@@ -673,11 +664,9 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 
             if (Remove_Localfile(&logf, pl, 0, 0, NULL)) {
                 merror(REM_ERROR, logf[pl].file);
-                FindClose(hFind);
                 return (OS_INVALID);
             }
             log_config->config = logf;
-            FindClose(hFind);
             return 0;
 #else
         if (strchr(logf[pl].file, '*') ||

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -23,15 +23,6 @@ int maximum_files;
 int current_files;
 int total_files;
 
-#ifdef WIN32
-bool file_exist(const char *file)
-{
-    WIN32_FIND_DATA ffd;
-    return (INVALID_HANDLE_VALUE != FindFirstFile(file, &ffd))?true:false;
-}
-#endif
-
-
 /**
  * @brief gets the type filter from the type attribute
  * @param content type attribute string
@@ -643,82 +634,51 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     /* Deploy glob entries */
     if (!logf[pl].command) {
 #ifdef WIN32
-
         if (strchr(logf[pl].file, '*') ||
             strchr(logf[pl].file, '?')) {
 
-            int totalFiles = 0;
-            int file = 0;
+            WIN32_FIND_DATA ffd;
+            HANDLE hFind = INVALID_HANDLE_VALUE;
 
-            char** result = expand_win32_wildcards(logf[pl].file);
-            char** expand_files;
+            hFind = FindFirstFile(logf[pl].file, &ffd);
 
-            while (NULL != result[totalFiles++])
-                ;
-
-            totalFiles %= maximum_files;
-
-            os_calloc(totalFiles, sizeof(char*), expand_files);
-            totalFiles = 0;
-            
-            while (NULL != result[file]) {
-                if (file_exist(result[file]))
-                    os_strdup(result[file], expand_files[totalFiles++]);
-
-                file++;
+            if (INVALID_HANDLE_VALUE == hFind) {
+                minfo(GLOB_ERROR_WIN, logf[pl].file);
             }
 
-            file = 0;
-            
-            while(file < totalFiles) {
+            os_realloc(log_config->globs, (gl + 2) * sizeof(logreader_glob), log_config->globs);
+            os_strdup(logf[pl].file, log_config->globs[gl].gpath);
+            memset(&log_config->globs[gl + 1], 0, sizeof(logreader_glob));
+            os_calloc(1, sizeof(logreader), log_config->globs[gl].gfiles);
+            memcpy(log_config->globs[gl].gfiles, &logf[pl], sizeof(logreader));
+            log_config->globs[gl].gfiles->file = NULL;
 
-                os_free(logf[pl].file);
-                os_strdup(expand_files[file], logf[pl].file);
+            /* Wildcard exclusion, check for date */
+            if (logf[pl].exclude && strchr(logf[pl].exclude, '%')) {
 
-                os_realloc(log_config->globs, (gl + 2)*sizeof(logreader_glob), log_config->globs);
-                os_strdup(logf[pl].file, log_config->globs[gl].gpath);
+                time_t l_time = time(0);
+                char excluded_path_date[PATH_MAX] = { 0 };
+                size_t ret;
+                struct tm tm_result = { .tm_sec = 0 };
 
-
-                memset(&log_config->globs[gl + 1], 0, sizeof(logreader_glob));
-                os_calloc(1, sizeof(logreader), log_config->globs[gl].gfiles);
-
-                memcpy(log_config->globs[gl].gfiles, &logf[pl], sizeof(logreader));
-                log_config->globs[gl].gfiles->file = NULL;
-
-                /* Wildcard exclusion, check for date */
-                if (logf[pl].exclude && strchr(logf[pl].exclude, '%')) {
-
-                    time_t l_time = time(0);
-                    char excluded_path_date[PATH_MAX] = {0};
-                    size_t ret;
-                    struct tm tm_result = { .tm_sec = 0 };
-
-                    localtime_r(&l_time, &tm_result);
-                    ret = strftime(excluded_path_date, PATH_MAX, logf[pl].exclude, &tm_result);
-                    if (ret != 0) {
-                        os_strdup(excluded_path_date, log_config->globs[gl].exclude_path);
-                    }
+                localtime_r(&l_time, &tm_result);
+                ret = strftime(excluded_path_date, PATH_MAX, logf[pl].exclude, &tm_result);
+                if (ret != 0) {
+                    os_strdup(excluded_path_date, log_config->globs[gl].exclude_path);
                 }
-                else if (logf[pl].exclude) {
-                    os_strdup(logf[pl].exclude, log_config->globs[gl].exclude_path);
-                }
-
-                gl++;
-                file++;
-
+            }
+            else if (logf[pl].exclude) {
+                os_strdup(logf[pl].exclude, log_config->globs[gl].exclude_path);
             }
 
-            if (Remove_Localfile(&logf, pl, 0, 0,NULL)) {
+            if (Remove_Localfile(&logf, pl, 0, 0, NULL)) {
                 merror(REM_ERROR, logf[pl].file);
+                FindClose(hFind);
                 return (OS_INVALID);
-            } 
-
-             log_config->config = logf;
-
-            os_free(expand_files);
-            os_free(result);
+            }
+            log_config->config = logf;
+            FindClose(hFind);
             return 0;
-
 #else
         if (strchr(logf[pl].file, '*') ||
             strchr(logf[pl].file, '?') ||

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -637,7 +637,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         if (strchr(logf[pl].file, '*') ||
             strchr(logf[pl].file, '?')) {
 
-            os_realloc(log_config->globs, (gl + 2) * sizeof(logreader_glob), log_config->globs);
+            os_realloc(log_config->globs, (gl + 2)*sizeof(logreader_glob), log_config->globs);
             os_strdup(logf[pl].file, log_config->globs[gl].gpath);
             memset(&log_config->globs[gl + 1], 0, sizeof(logreader_glob));
             os_calloc(1, sizeof(logreader), log_config->globs[gl].gfiles);
@@ -648,7 +648,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             if (logf[pl].exclude && strchr(logf[pl].exclude, '%')) {
 
                 time_t l_time = time(0);
-                char excluded_path_date[PATH_MAX] = { 0 };
+                char excluded_path_date[PATH_MAX] = {0};
                 size_t ret;
                 struct tm tm_result = { .tm_sec = 0 };
 
@@ -662,7 +662,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 os_strdup(logf[pl].exclude, log_config->globs[gl].exclude_path);
             }
 
-            if (Remove_Localfile(&logf, pl, 0, 0, NULL)) {
+            if (Remove_Localfile(&logf, pl, 0, 0,NULL)) {
                 merror(REM_ERROR, logf[pl].file);
                 return (OS_INVALID);
             }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1518,196 +1518,106 @@ int check_pattern_expand(int do_seek) {
                 break;
             }
 
-            char* global_path = NULL;
-            char* wildcard = NULL;
-            
             char** result = expand_win32_wildcards(globs[j].gpath);
             
             if (result) {
-                
+
                 int file;
                 int totalFiles = 0;
-                
-                while (NULL != result[totalFiles++]);
+                char *full_path = NULL;
 
+                while (NULL != result[++totalFiles]);
                 totalFiles %= maximum_files;
 
-            //os_strdup(globs[j].gpath, global_path);
-                
-                for(file = 0; file < totalFiles; file++)
-                {
-                    os_strdup(result[file], global_path);
-                    wildcard = strrchr(global_path, '\\');
+                for (file = 0; file < totalFiles; file++) {
 
-                    if (wildcard) {
+                    os_strdup(result[file], full_path);
 
-                        DIR* dir = NULL;
-                        struct dirent* dirent = NULL;
-
-                        *wildcard = '\0';
-                        wildcard++;
-
-                        if (dir = opendir(global_path), !dir) {
-                            merror("Couldn't open directory '%s' due to: %s", global_path, win_strerror(WSAGetLastError()));
-                            os_free(global_path);
-                            continue;
+                    found = 0;
+                    for (i = 0; globs[j].gfiles[i].file; i++) {
+                        if (!strcmp(globs[j].gfiles[i].file, full_path)) {
+                            found = 1;
+                            break;
                         }
-
-                        while (dirent = readdir(dir), dirent) {
-
-                            // Skip "." and ".."
-                            if (dirent->d_name[0] == '.' && (dirent->d_name[1] == '\0' || (dirent->d_name[1] == '.' && dirent->d_name[2] == '\0'))) {
-                                continue;
-                            }
-
-                            if (current_files >= maximum_files) {
-                                mwarn(FILE_LIMIT, maximum_files);
-                                break;
-                            }
-
-                            char full_path[PATH_MAX] = { 0 };
-                            snprintf(full_path, PATH_MAX, "%s\\%s", global_path, dirent->d_name);
-
-                            /* Skip file if it is a directory */
-                            DIR* is_dir = NULL;
-
-                            if (is_dir = opendir(full_path), is_dir) {
-                                mdebug1("File %s is a directory. Skipping it.", full_path);
-                                closedir(is_dir);
-                                continue;
-                            }
-
-                            /* Match wildcard */
-                            char* regex = NULL;
-                            regex = wstr_replace(wildcard, ".", "\\p");
-                            os_free(regex);
-                            regex = wstr_replace(wildcard, "*", "\\.*");
-
-                            /* Add the starting ^ regex */
-                            {
-                                char p[PATH_MAX] = { 0 };
-                                snprintf(p, PATH_MAX, "^%s", regex);
-                                os_free(regex);
-                                os_strdup(p, regex);
-                            }
-
-                            /* If wildcard is only ^\.* add another \.* */
-                            if (strlen(regex) == 4) {
-                                char* rgx = NULL;
-                                rgx = wstr_replace(regex, "\\.*", "\\.*\\.*");
-                                os_free(regex);
-                                regex = rgx;
-                            }
-
-                            /* Add $ at the end of the regex */
-                            wm_strcat(&regex, "$", 0);
-
-                            if (!OS_Regex(regex, dirent->d_name)) {
-                                mdebug2("Regex %s doesn't match with file '%s'", regex, dirent->d_name);
-                                os_free(regex);
-                                continue;
-                            }
-
-                            os_free(regex);
-
-                            found = 0;
-                            for (i = 0; globs[j].gfiles[i].file; i++) {
-
-                                if (!strcmp(globs[j].gfiles[i].file, full_path)) {
-                                    found = 1;
-                                    break;
-                                }
-                            }
-
-                            if (!found) {
-                                retval = 1;
-                                int added = 0;
-
-                                char* ex_file = OSHash_Get(excluded_files, full_path);
-
-                                if (!ex_file) {
-
-                                    /*  Because Windows cache's files, we need to check if the file
-                                        exists. Deleted files can still appear due to caching */
-                                    HANDLE h1;
-
-                                    h1 = CreateFile(full_path, GENERIC_READ,
-                                        FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-                                        NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-
-                                    if (h1 == INVALID_HANDLE_VALUE) {
-                                        continue;
-                                    }
-
-                                    CloseHandle(h1);
-
-                                    minfo(NEW_GLOB_FILE, globs[j].gpath, full_path);
-
-                                    os_realloc(globs[j].gfiles, (i + 2) * sizeof(logreader), globs[j].gfiles);
-
-                                    /* Copy the current item to the end mark as it should be a pattern */
-                                    memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
-
-                                    os_strdup(full_path, globs[j].gfiles[i].file);
-                                    w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);
-                                    globs[j].gfiles[i].fp = NULL;
-                                    globs[j].gfiles[i].exists = 1;
-                                    globs[j].gfiles[i + 1].file = NULL;
-                                    globs[j].gfiles[i + 1].target = NULL;
-                                    current_files++;
-                                    globs[j].num_files++;
-                                    mdebug2(CURRENT_FILES, current_files, maximum_files);
-
-                                    if (!globs[j].gfiles[i].read) {
-                                        set_read(&globs[j].gfiles[i], i, j);
-                                    }
-                                    else {
-                                        handle_file(i, j, do_seek, 1);
-                                    }
-
-                                    added = 1;
-                                }
-
-                                char* file_excluded_binary = OSHash_Get(excluded_binaries, full_path);
-
-                                /* This file could have to non binary file */
-                                if (file_excluded_binary && !added) {
-                                    os_realloc(globs[j].gfiles, (i + 2) * sizeof(logreader), globs[j].gfiles);
-
-                                    /* Copy the current item to the end mark as it should be a pattern */
-                                    memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
-
-                                    os_strdup(full_path, globs[j].gfiles[i].file);
-                                    w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);
-                                    globs[j].gfiles[i].fp = NULL;
-                                    globs[j].gfiles[i].exists = 1;
-                                    globs[j].gfiles[i + 1].file = NULL;
-                                    globs[j].gfiles[i + 1].target = NULL;
-                                    current_files++;
-                                    globs[j].num_files++;
-                                    mdebug2(CURRENT_FILES, current_files, maximum_files);
-
-                                    if (!globs[j].gfiles[i].read) {
-                                        set_read(&globs[j].gfiles[i], i, j);
-                                    }
-                                    else {
-                                        handle_file(i, j, do_seek, 1);
-                                    }
-                                }
-                            }
-                        }
-                        
-                        closedir(dir);
                     }
 
-                    os_free(global_path);
+                    if (!found) {
+                        retval = 1;
+                        int added = 0;
+
+                        char* ex_file = OSHash_Get(excluded_files, full_path);
+
+                        if (!ex_file) {
+
+                            /*  Because Windows cache's files, we need to check if the file
+                                exists. Deleted files can still appear due to caching */
+                            HANDLE h1;
+
+                            h1 = CreateFile(full_path, GENERIC_READ,
+                                FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+                            if (h1 == INVALID_HANDLE_VALUE) {
+                                continue;
+                            }
+
+                            CloseHandle(h1);
+
+                            minfo(NEW_GLOB_FILE, globs[j].gpath, full_path);
+                            os_realloc(globs[j].gfiles, (i + 2) * sizeof(logreader), globs[j].gfiles);
+                            /* Copy the current item to the end mark as it should be a pattern */
+                            memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
+
+                            os_strdup(full_path, globs[j].gfiles[i].file);
+                            w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);
+                            globs[j].gfiles[i].fp = NULL;
+                            globs[j].gfiles[i].exists = 1;
+                            globs[j].gfiles[i + 1].file = NULL;
+                            globs[j].gfiles[i + 1].target = NULL;
+                            current_files++;
+                            globs[j].num_files++;
+                            mdebug2(CURRENT_FILES, current_files, maximum_files);
+
+                            if (!globs[j].gfiles[i].read) {
+                                set_read(&globs[j].gfiles[i], i, j);
+                            } else {
+                                handle_file(i, j, do_seek, 1);
+                            }
+
+                            added = 1;
+                        }
+
+                        char* file_excluded_binary = OSHash_Get(excluded_binaries, full_path);
+
+                        /* This file could have to non binary file */
+                        if (file_excluded_binary && !added) {
+                            os_realloc(globs[j].gfiles, (i + 2) * sizeof(logreader), globs[j].gfiles);
+
+                            /* Copy the current item to the end mark as it should be a pattern */
+                            memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
+
+                            os_strdup(full_path, globs[j].gfiles[i].file);
+                            w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);
+                            globs[j].gfiles[i].fp = NULL;
+                            globs[j].gfiles[i].exists = 1;
+                            globs[j].gfiles[i + 1].file = NULL;
+                            globs[j].gfiles[i + 1].target = NULL;
+                            current_files++;
+                            globs[j].num_files++;
+                            mdebug2(CURRENT_FILES, current_files, maximum_files);
+
+                            if (!globs[j].gfiles[i].read) {
+                                set_read(&globs[j].gfiles[i], i, j);
+                            } else {
+                                handle_file(i, j, do_seek, 1);
+                            }
+                        }
+                    }
+                    os_free(full_path);
                 }
-                //closedir(dir);
             }
-            //os_free(global_path);
         }
     }
-
     return retval;
 }
 #endif

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1515,6 +1515,7 @@ int check_pattern_expand(int do_seek) {
         for (j = 0; globs[j].gpath; j++) {
 
             if (current_files >= maximum_files) {
+                mwarn(FILE_LIMIT, maximum_files);
                 break;
             }
 
@@ -1523,16 +1524,14 @@ int check_pattern_expand(int do_seek) {
             if (result) {
 
                 int file;
-                int totalFiles = 0;
                 char *full_path = NULL;
 
-                while (NULL != result[totalFiles])
-                {
-                    totalFiles++;
-                }
-                totalFiles %= maximum_files;
+                for (file = 0; result[file] != NULL; file++) {
 
-                for (file = 0; file < totalFiles; file++) {
+                    if (current_files >= maximum_files) {
+                        mwarn(FILE_LIMIT, maximum_files);
+                        break;
+                    }
 
                     os_strdup(result[file], full_path);
 
@@ -1540,7 +1539,6 @@ int check_pattern_expand(int do_seek) {
                     for (i = 0; globs[j].gfiles[i].file; i++) {
                         if (!strcmp(globs[j].gfiles[i].file, full_path)) {
                             found = 1;
-                            os_free(full_path);
                             break;
                         }
                     }
@@ -1549,7 +1547,7 @@ int check_pattern_expand(int do_seek) {
                         retval = 1;
                         int added = 0;
 
-                        char* ex_file = OSHash_Get(excluded_files, full_path);
+                        char *ex_file = OSHash_Get(excluded_files, full_path);
 
                         if (!ex_file) {
 
@@ -1558,8 +1556,8 @@ int check_pattern_expand(int do_seek) {
                             HANDLE h1;
 
                             h1 = CreateFile(full_path, GENERIC_READ,
-                                FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-                                NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                                            FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                            NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
                             if (h1 == INVALID_HANDLE_VALUE) {
                                 os_free(full_path);
@@ -1592,7 +1590,7 @@ int check_pattern_expand(int do_seek) {
                             added = 1;
                         }
 
-                        char* file_excluded_binary = OSHash_Get(excluded_binaries, full_path);
+                        char *file_excluded_binary = OSHash_Get(excluded_binaries, full_path);
 
                         /* This file could have to non binary file */
                         if (file_excluded_binary && !added) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1526,7 +1526,10 @@ int check_pattern_expand(int do_seek) {
                 int totalFiles = 0;
                 char *full_path = NULL;
 
-                while (NULL != result[++totalFiles]);
+                while (NULL != result[totalFiles])
+                {
+                    totalFiles++;
+                }
                 totalFiles %= maximum_files;
 
                 for (file = 0; file < totalFiles; file++) {
@@ -1537,6 +1540,7 @@ int check_pattern_expand(int do_seek) {
                     for (i = 0; globs[j].gfiles[i].file; i++) {
                         if (!strcmp(globs[j].gfiles[i].file, full_path)) {
                             found = 1;
+                            os_free(full_path);
                             break;
                         }
                     }
@@ -1558,6 +1562,7 @@ int check_pattern_expand(int do_seek) {
                                 NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
                             if (h1 == INVALID_HANDLE_VALUE) {
+                                os_free(full_path);
                                 continue;
                             }
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1511,218 +1511,206 @@ int check_pattern_expand(int do_seek) {
     int i, j;
     int retval = 0;
 
-    const char *szTag = "***** CHECK_PATTERN_EXPAND  ****";
-    minfo("%s globs :%p", szTag, globs);
-
-
     if (globs) {
-
-        //minfo("%s globs[j].gpath :%s", szTag, globs[j].gpath);
-
         for (j = 0; globs[j].gpath; j++) {
-
-
-            minfo("%s globs[j].gpath: %s ", szTag, globs[j].gpath);
 
             if (current_files >= maximum_files) {
                 break;
             }
 
-            char full_path[PATH_MAX] = {0};
-            char *global_path = NULL;
-//            char *wildcard = NULL;
+            char* global_path = NULL;
+            char* wildcard = NULL;
+            
+            char** result = expand_win32_wildcards(globs[j].gpath);
+            
+            if (result) {
+                
+                int file;
+                int totalFiles = 0;
+                
+                while (NULL != result[totalFiles++]);
 
-            os_strdup(globs[j].gpath,global_path);
+                totalFiles %= maximum_files;
 
+            //os_strdup(globs[j].gpath, global_path);
+                
+                for(file = 0; file < totalFiles; file++)
+                {
+                    os_strdup(result[file], global_path);
+                    wildcard = strrchr(global_path, '\\');
 
-  //          wildcard = strrchr(global_path,'\\');
+                    if (wildcard) {
 
+                        DIR* dir = NULL;
+                        struct dirent* dirent = NULL;
 
+                        *wildcard = '\0';
+                        wildcard++;
 
-//              if ( wildcard ) {
-
-//                 DIR *dir = NULL;
-//                 struct dirent *dirent = NULL;
-
-//                 //minfo("%s wildcard: %s ", szTag, wildcard);
-
-//                 *wildcard = '\0';
-//                 wildcard++;
-
-//                 if (dir = opendir(global_path), !dir) {
-//                     merror("Couldn't open directory '%s' due to: %s", global_path, win_strerror(WSAGetLastError()));
-
-
-//                     os_free(global_path);
-//                     continue;
-//                 }
-
-//                 while (dirent = readdir(dir), dirent) {
-
-//                     //minfo("%s dirent->name: %s ", szTag, dirent->d_name);
-
-//                     // Skip "." and ".."
-//                     if (dirent->d_name[0] == '.' && (dirent->d_name[1] == '\0' || (dirent->d_name[1] == '.' && dirent->d_name[2] == '\0'))) {
-//                         continue;
-//                     }
-
-//                     if (current_files >= maximum_files) {
-//                         mwarn(FILE_LIMIT, maximum_files);
-//                         break;
-//                     }
-
-//                     char full_path[PATH_MAX] = {0};
-//                     snprintf(full_path,PATH_MAX,"%s\\%s",global_path,dirent->d_name);
-
-//                     //minfo("%s full_path: %s ", szTag, full_path);
-
-//                     /* Skip file if it is a directory */
-//                     DIR *is_dir = NULL;
-
-
-//                     if (is_dir = opendir(full_path), is_dir) {
-//                         mdebug1("File %s is a directory. Skipping it.", full_path);
-//                         closedir(is_dir);
-//                         continue;
-//                     }
-
-//                     /* Match wildcard */
-//                     char *regex = NULL;
-//                     regex = wstr_replace(wildcard,".","\\p");
-//                     os_free(regex);
-//                     regex = wstr_replace(wildcard,"*","\\.*");
-
-
-//                     /* Add the starting ^ regex */
-//                     {
-//                         char p[PATH_MAX] = {0};
-//                         snprintf(p,PATH_MAX,"^%s",regex);
-//                         os_free(regex);
-//                         os_strdup(p,regex);
-//                     }
-
-//                     /* If wildcard is only ^\.* add another \.* */
-//                     if (strlen(regex) == 4) {
-//                         char *rgx = NULL;
-//                         rgx = wstr_replace(regex,"\\.*","\\.*\\.*");
-//                         os_free(regex);
-//                         regex = rgx;
-
-//                         //minfo("%s (strlen==4) regex: %s ", szTag, regex);
-//                     }
-
-//                     /* Add $ at the end of the regex */
-//                     wm_strcat(&regex, "$", 0);
-
-
-//                     if (!OS_Regex(regex,dirent->d_name)) {
-//                         mdebug2("Regex %s doesn't match with file '%s'",regex,dirent->d_name);
-//                         os_free(regex);
-//                         continue;
-//                     }
-
-//                     os_free(regex);
-                     found = 0;
-                    for (i = 0; globs[j].gfiles[i].file; i++) {
-                        if (!strcmp(globs[j].gfiles[i].file, full_path)) {
-                            found = 1;
-                            break;
+                        if (dir = opendir(global_path), !dir) {
+                            merror("Couldn't open directory '%s' due to: %s", global_path, win_strerror(WSAGetLastError()));
+                            os_free(global_path);
+                            continue;
                         }
-                    }
 
+                        while (dirent = readdir(dir), dirent) {
 
-                    if (!found) {
-                        retval = 1;
-                        int added = 0;
-
-                        char *ex_file = OSHash_Get(excluded_files,full_path);
-
-
-minfo("%s ex_file: %s  found ", szTag, ex_file);
-
-                        if(!ex_file) {
-
-                            /*  Because Windows cache's files, we need to check if the file
-                                exists. Deleted files can still appear due to caching */
-                            HANDLE h1;
-
-                            h1 = CreateFile(full_path, GENERIC_READ,
-                                            FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-                                            NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-
-                            if (h1 == INVALID_HANDLE_VALUE) {
+                            // Skip "." and ".."
+                            if (dirent->d_name[0] == '.' && (dirent->d_name[1] == '\0' || (dirent->d_name[1] == '.' && dirent->d_name[2] == '\0'))) {
                                 continue;
                             }
 
-                            CloseHandle(h1);
-
-                            minfo(NEW_GLOB_FILE, globs[j].gpath, full_path);
-
-                            os_realloc(globs[j].gfiles, (i +2)*sizeof(logreader), globs[j].gfiles);
-
-                            /* Copy the current item to the end mark as it should be a pattern */
-                            memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
-
-                            os_strdup(full_path, globs[j].gfiles[i].file);
-                            w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);
-                            globs[j].gfiles[i].fp = NULL;
-                            globs[j].gfiles[i].exists = 1;
-                            globs[j].gfiles[i + 1].file = NULL;
-                            globs[j].gfiles[i + 1].target = NULL;
-                            current_files++;
-                            globs[j].num_files++;
-                            mdebug2(CURRENT_FILES, current_files, maximum_files);
-                            if  (!globs[j].gfiles[i].read) {
-                                set_read(&globs[j].gfiles[i], i, j);
-                            } else {
-                                handle_file(i, j, do_seek, 1);
+                            if (current_files >= maximum_files) {
+                                mwarn(FILE_LIMIT, maximum_files);
+                                break;
                             }
 
-                            added = 1;
-                        }
+                            char full_path[PATH_MAX] = { 0 };
+                            snprintf(full_path, PATH_MAX, "%s\\%s", global_path, dirent->d_name);
 
-                        char *file_excluded_binary = OSHash_Get(excluded_binaries,full_path);
+                            /* Skip file if it is a directory */
+                            DIR* is_dir = NULL;
 
-                        /* This file could have to non binary file */
-                        if (file_excluded_binary && !added) {
-                            os_realloc(globs[j].gfiles, (i +2)*sizeof(logreader), globs[j].gfiles);
+                            if (is_dir = opendir(full_path), is_dir) {
+                                mdebug1("File %s is a directory. Skipping it.", full_path);
+                                closedir(is_dir);
+                                continue;
+                            }
 
-                            /* Copy the current item to the end mark as it should be a pattern */
-                            memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
+                            /* Match wildcard */
+                            char* regex = NULL;
+                            regex = wstr_replace(wildcard, ".", "\\p");
+                            os_free(regex);
+                            regex = wstr_replace(wildcard, "*", "\\.*");
 
-                            os_strdup(full_path, globs[j].gfiles[i].file);
-                            w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);
-                            globs[j].gfiles[i].fp = NULL;
-                            globs[j].gfiles[i].exists = 1;
-                            globs[j].gfiles[i + 1].file = NULL;
-                            globs[j].gfiles[i + 1].target = NULL;
-                            current_files++;
-                            globs[j].num_files++;
-                            mdebug2(CURRENT_FILES, current_files, maximum_files);
-                            if  (!globs[j].gfiles[i].read) {
-                                set_read(&globs[j].gfiles[i], i, j);
-                            } else {
-                                handle_file(i, j, do_seek, 1);
+                            /* Add the starting ^ regex */
+                            {
+                                char p[PATH_MAX] = { 0 };
+                                snprintf(p, PATH_MAX, "^%s", regex);
+                                os_free(regex);
+                                os_strdup(p, regex);
+                            }
+
+                            /* If wildcard is only ^\.* add another \.* */
+                            if (strlen(regex) == 4) {
+                                char* rgx = NULL;
+                                rgx = wstr_replace(regex, "\\.*", "\\.*\\.*");
+                                os_free(regex);
+                                regex = rgx;
+                            }
+
+                            /* Add $ at the end of the regex */
+                            wm_strcat(&regex, "$", 0);
+
+                            if (!OS_Regex(regex, dirent->d_name)) {
+                                mdebug2("Regex %s doesn't match with file '%s'", regex, dirent->d_name);
+                                os_free(regex);
+                                continue;
+                            }
+
+                            os_free(regex);
+
+                            found = 0;
+                            for (i = 0; globs[j].gfiles[i].file; i++) {
+
+                                if (!strcmp(globs[j].gfiles[i].file, full_path)) {
+                                    found = 1;
+                                    break;
+                                }
+                            }
+
+                            if (!found) {
+                                retval = 1;
+                                int added = 0;
+
+                                char* ex_file = OSHash_Get(excluded_files, full_path);
+
+                                if (!ex_file) {
+
+                                    /*  Because Windows cache's files, we need to check if the file
+                                        exists. Deleted files can still appear due to caching */
+                                    HANDLE h1;
+
+                                    h1 = CreateFile(full_path, GENERIC_READ,
+                                        FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                        NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+                                    if (h1 == INVALID_HANDLE_VALUE) {
+                                        continue;
+                                    }
+
+                                    CloseHandle(h1);
+
+                                    minfo(NEW_GLOB_FILE, globs[j].gpath, full_path);
+
+                                    os_realloc(globs[j].gfiles, (i + 2) * sizeof(logreader), globs[j].gfiles);
+
+                                    /* Copy the current item to the end mark as it should be a pattern */
+                                    memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
+
+                                    os_strdup(full_path, globs[j].gfiles[i].file);
+                                    w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);
+                                    globs[j].gfiles[i].fp = NULL;
+                                    globs[j].gfiles[i].exists = 1;
+                                    globs[j].gfiles[i + 1].file = NULL;
+                                    globs[j].gfiles[i + 1].target = NULL;
+                                    current_files++;
+                                    globs[j].num_files++;
+                                    mdebug2(CURRENT_FILES, current_files, maximum_files);
+
+                                    if (!globs[j].gfiles[i].read) {
+                                        set_read(&globs[j].gfiles[i], i, j);
+                                    }
+                                    else {
+                                        handle_file(i, j, do_seek, 1);
+                                    }
+
+                                    added = 1;
+                                }
+
+                                char* file_excluded_binary = OSHash_Get(excluded_binaries, full_path);
+
+                                /* This file could have to non binary file */
+                                if (file_excluded_binary && !added) {
+                                    os_realloc(globs[j].gfiles, (i + 2) * sizeof(logreader), globs[j].gfiles);
+
+                                    /* Copy the current item to the end mark as it should be a pattern */
+                                    memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
+
+                                    os_strdup(full_path, globs[j].gfiles[i].file);
+                                    w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);
+                                    globs[j].gfiles[i].fp = NULL;
+                                    globs[j].gfiles[i].exists = 1;
+                                    globs[j].gfiles[i + 1].file = NULL;
+                                    globs[j].gfiles[i + 1].target = NULL;
+                                    current_files++;
+                                    globs[j].num_files++;
+                                    mdebug2(CURRENT_FILES, current_files, maximum_files);
+
+                                    if (!globs[j].gfiles[i].read) {
+                                        set_read(&globs[j].gfiles[i], i, j);
+                                    }
+                                    else {
+                                        handle_file(i, j, do_seek, 1);
+                                    }
+                                }
                             }
                         }
+                        
+                        closedir(dir);
                     }
 
-//                }
-//                closedir(dir);
-//            }
-            os_free(global_path);
+                    os_free(global_path);
+                }
+                //closedir(dir);
+            }
+            //os_free(global_path);
         }
     }
 
-    minfo("%s end retval :%d", szTag, retval);
-    
     return retval;
 }
-
-
-
 #endif
-
 
 static IT_control remove_duplicates(logreader *current, int i, int j) {
     IT_control d_control = CONTINUE_IT;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1511,92 +1511,118 @@ int check_pattern_expand(int do_seek) {
     int i, j;
     int retval = 0;
 
+    const char *szTag = "***** CHECK_PATTERN_EXPAND  ****";
+    minfo("%s globs :%p", szTag, globs);
+
+
     if (globs) {
+
+        //minfo("%s globs[j].gpath :%s", szTag, globs[j].gpath);
+
         for (j = 0; globs[j].gpath; j++) {
+
+
+            minfo("%s globs[j].gpath: %s ", szTag, globs[j].gpath);
 
             if (current_files >= maximum_files) {
                 break;
             }
 
+            char full_path[PATH_MAX] = {0};
             char *global_path = NULL;
-            char *wildcard = NULL;
+//            char *wildcard = NULL;
 
             os_strdup(globs[j].gpath,global_path);
 
-            wildcard = strrchr(global_path,'\\');
 
-            if ( wildcard ) {
+  //          wildcard = strrchr(global_path,'\\');
 
-                DIR *dir = NULL;
-                struct dirent *dirent = NULL;
 
-                *wildcard = '\0';
-                wildcard++;
 
-                if (dir = opendir(global_path), !dir) {
-                    merror("Couldn't open directory '%s' due to: %s", global_path, win_strerror(WSAGetLastError()));
-                    os_free(global_path);
-                    continue;
-                }
+//              if ( wildcard ) {
 
-                while (dirent = readdir(dir), dirent) {
+//                 DIR *dir = NULL;
+//                 struct dirent *dirent = NULL;
 
-                    // Skip "." and ".."
-                    if (dirent->d_name[0] == '.' && (dirent->d_name[1] == '\0' || (dirent->d_name[1] == '.' && dirent->d_name[2] == '\0'))) {
-                        continue;
-                    }
+//                 //minfo("%s wildcard: %s ", szTag, wildcard);
 
-                    if (current_files >= maximum_files) {
-                        mwarn(FILE_LIMIT, maximum_files);
-                        break;
-                    }
+//                 *wildcard = '\0';
+//                 wildcard++;
 
-                    char full_path[PATH_MAX] = {0};
-                    snprintf(full_path,PATH_MAX,"%s\\%s",global_path,dirent->d_name);
+//                 if (dir = opendir(global_path), !dir) {
+//                     merror("Couldn't open directory '%s' due to: %s", global_path, win_strerror(WSAGetLastError()));
 
-                    /* Skip file if it is a directory */
-                    DIR *is_dir = NULL;
 
-                    if (is_dir = opendir(full_path), is_dir) {
-                        mdebug1("File %s is a directory. Skipping it.", full_path);
-                        closedir(is_dir);
-                        continue;
-                    }
+//                     os_free(global_path);
+//                     continue;
+//                 }
 
-                    /* Match wildcard */
-                    char *regex = NULL;
-                    regex = wstr_replace(wildcard,".","\\p");
-                    os_free(regex);
-                    regex = wstr_replace(wildcard,"*","\\.*");
+//                 while (dirent = readdir(dir), dirent) {
 
-                    /* Add the starting ^ regex */
-                    {
-                        char p[PATH_MAX] = {0};
-                        snprintf(p,PATH_MAX,"^%s",regex);
-                        os_free(regex);
-                        os_strdup(p,regex);
-                    }
+//                     //minfo("%s dirent->name: %s ", szTag, dirent->d_name);
 
-                    /* If wildcard is only ^\.* add another \.* */
-                    if (strlen(regex) == 4) {
-                        char *rgx = NULL;
-                        rgx = wstr_replace(regex,"\\.*","\\.*\\.*");
-                        os_free(regex);
-                        regex = rgx;
-                    }
+//                     // Skip "." and ".."
+//                     if (dirent->d_name[0] == '.' && (dirent->d_name[1] == '\0' || (dirent->d_name[1] == '.' && dirent->d_name[2] == '\0'))) {
+//                         continue;
+//                     }
 
-                    /* Add $ at the end of the regex */
-                    wm_strcat(&regex, "$", 0);
+//                     if (current_files >= maximum_files) {
+//                         mwarn(FILE_LIMIT, maximum_files);
+//                         break;
+//                     }
 
-                    if (!OS_Regex(regex,dirent->d_name)) {
-                        mdebug2("Regex %s doesn't match with file '%s'",regex,dirent->d_name);
-                        os_free(regex);
-                        continue;
-                    }
+//                     char full_path[PATH_MAX] = {0};
+//                     snprintf(full_path,PATH_MAX,"%s\\%s",global_path,dirent->d_name);
 
-                    os_free(regex);
+//                     //minfo("%s full_path: %s ", szTag, full_path);
 
-                    found = 0;
+//                     /* Skip file if it is a directory */
+//                     DIR *is_dir = NULL;
+
+
+//                     if (is_dir = opendir(full_path), is_dir) {
+//                         mdebug1("File %s is a directory. Skipping it.", full_path);
+//                         closedir(is_dir);
+//                         continue;
+//                     }
+
+//                     /* Match wildcard */
+//                     char *regex = NULL;
+//                     regex = wstr_replace(wildcard,".","\\p");
+//                     os_free(regex);
+//                     regex = wstr_replace(wildcard,"*","\\.*");
+
+
+//                     /* Add the starting ^ regex */
+//                     {
+//                         char p[PATH_MAX] = {0};
+//                         snprintf(p,PATH_MAX,"^%s",regex);
+//                         os_free(regex);
+//                         os_strdup(p,regex);
+//                     }
+
+//                     /* If wildcard is only ^\.* add another \.* */
+//                     if (strlen(regex) == 4) {
+//                         char *rgx = NULL;
+//                         rgx = wstr_replace(regex,"\\.*","\\.*\\.*");
+//                         os_free(regex);
+//                         regex = rgx;
+
+//                         //minfo("%s (strlen==4) regex: %s ", szTag, regex);
+//                     }
+
+//                     /* Add $ at the end of the regex */
+//                     wm_strcat(&regex, "$", 0);
+
+
+//                     if (!OS_Regex(regex,dirent->d_name)) {
+//                         mdebug2("Regex %s doesn't match with file '%s'",regex,dirent->d_name);
+//                         os_free(regex);
+//                         continue;
+//                     }
+
+//                     os_free(regex);
+                     found = 0;
                     for (i = 0; globs[j].gfiles[i].file; i++) {
                         if (!strcmp(globs[j].gfiles[i].file, full_path)) {
                             found = 1;
@@ -1604,11 +1630,15 @@ int check_pattern_expand(int do_seek) {
                         }
                     }
 
+
                     if (!found) {
                         retval = 1;
                         int added = 0;
 
                         char *ex_file = OSHash_Get(excluded_files,full_path);
+
+
+minfo("%s ex_file: %s  found ", szTag, ex_file);
 
                         if(!ex_file) {
 
@@ -1676,15 +1706,21 @@ int check_pattern_expand(int do_seek) {
                             }
                         }
                     }
-                }
-                closedir(dir);
-            }
+
+//                }
+//                closedir(dir);
+//            }
             os_free(global_path);
         }
     }
 
+    minfo("%s end retval :%d", szTag, retval);
+    
     return retval;
 }
+
+
+
 #endif
 
 

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -18,7 +18,7 @@
 #define N_MIN_INPUT_THREADS 1
 #define N_OUPUT_THREADS 1
 #define OUTPUT_MIN_QUEUE_SIZE 128
-#define WIN32_MAX_FILES 200
+#define WIN32_MAX_FILES 100000
 
 ///< Size of hash table to save the status file
 #define LOCALFILES_TABLE_SIZE 40

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -18,7 +18,7 @@
 #define N_MIN_INPUT_THREADS 1
 #define N_OUPUT_THREADS 1
 #define OUTPUT_MIN_QUEUE_SIZE 128
-#define WIN32_MAX_FILES 100000
+#define WIN32_MAX_FILES 200
 
 ///< Size of hash table to save the status file
 #define LOCALFILES_TABLE_SIZE 40

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2069,11 +2069,9 @@ char **expand_win32_wildcards(const char *path) {
                 long unsigned errcode = GetLastError();
                 if (errcode == 2) {
                     mdebug2("No file that matches %s.", pattern);
-                }
-                else if (errcode == 3) {
+                } else if (errcode == 3) {
                     mdebug2("No folder that matches %s.", pattern);
-                }
-                else {
+                } else {
                     mdebug2("FindFirstFile failed (%lu) - '%s'\n", errcode, pattern);
                 }
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2065,19 +2065,18 @@ char **expand_win32_wildcards(const char *path) {
             }
 
             hFind = FindFirstFile(pattern, &FindFileData);
+
             if (hFind == INVALID_HANDLE_VALUE) {
                 long unsigned errcode = GetLastError();
                 if (errcode == 2) {
-                    mdebug2("No file/folder that matches %s.", pattern);
+                    mdebug2("No file that matches %s.", pattern);
+                } else if (errcode == 3) {
+                    mdebug2("No folder that matches %s.", pattern);
                 } else {
                     mdebug2("FindFirstFile failed (%lu) - '%s'\n", errcode, pattern);
                 }
-
-                os_free(pattern);
-                os_free(parent_path);
-                next_glob = NULL;
-                continue;
             }
+
             do {
                 if (strcmp(FindFileData.cFileName, ".") == 0 || strcmp(FindFileData.cFileName, "..") == 0) {
                     continue;

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2065,18 +2065,23 @@ char **expand_win32_wildcards(const char *path) {
             }
 
             hFind = FindFirstFile(pattern, &FindFileData);
-
             if (hFind == INVALID_HANDLE_VALUE) {
                 long unsigned errcode = GetLastError();
                 if (errcode == 2) {
                     mdebug2("No file that matches %s.", pattern);
-                } else if (errcode == 3) {
+                }
+                else if (errcode == 3) {
                     mdebug2("No folder that matches %s.", pattern);
-                } else {
+                }
+                else {
                     mdebug2("FindFirstFile failed (%lu) - '%s'\n", errcode, pattern);
                 }
-            }
 
+                os_free(pattern);
+                os_free(parent_path);
+                next_glob = NULL;
+                continue;
+            }
             do {
                 if (strcmp(FindFileData.cFileName, ".") == 0 || strcmp(FindFileData.cFileName, "..") == 0) {
                     continue;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12351|

## Description
Wildcard log monitoring for folders and files in Windows has been added to this branch.

Wildcards '*' and '?' are allowed in folders and files in Windows:

```
C:\Logs\10.0.01\date_10.0.0.1.log
C:\Logs\10.0.02\*.log
C:\Logs\10.0.03\date_10.0.0.?.log
C:\*\*\*.log
C:\Log?\*\date_10.0.0.2.log
C:\Logs\10.0.03\*log

```
Meaning:  '*' as a complete word and '?' as a character

## Sources:

The following files have been modified:

- src\config\localfile-config.c
- src\logcollector\logcollector.c 
- src\shared\file_op.c

**Log deleted:**
In the `Read_Localfile` function (in _localfile-config.c_) the call to the Win32 FindFirstFile function has been removed because it is not able to resolve wildcard paths, for this reason the following error message has also been removed:

`GLOB_ERROR_WIN "(1141): Glob error. Invalid pattern: '%s' or no files found."`


## Proof of concept:

In this proof of concept for Windows Agent, three types of monitoring are established:

1. Matching file
2. Folder doesn't exist:
3. File doesn't exist:

The ossec.conf has been configured for: 

```
<!-- Log analysis -->
 <localfile>
    <location>c:\log\one\*.log</location>
    <log_format>syslog</log_format>
  </localfile>

  <localfile>
    <location>c:\one\*.log</location>
    <log_format>syslog</log_format>
  </localfile>

  <localfile>
    <location>c:\log\one\two.*</location>
    <log_format>syslog</log_format>
  </localfile>
```

Given this folder structure:
```
       C:
        |
        |-----\log
                |
                |-----\one
                |       |
                |       |---- one.log
                |
                |-----\two
                |        |
                |        |-----two.log
                |
                |-----\three
                        |
                        |-----three.log

```


The following log (extract) was obtained with windows.debug=2

```
2023/02/14 16:20:43 wazuh-agent[8284] logcollector.c:1571 at check_pattern_expand(): INFO: (1957): New file that matches the 'c:\log\one\*.log' pattern: 'c:\log\one\one.log'.
2023/02/14 16:20:43 wazuh-agent[8284] logcollector.c:1257 at set_read(): DEBUG: Socket target for 'c:\log\one\one.log' -> agent
2023/02/14 16:20:43 wazuh-agent[8284] logcollector.c:431 at LogCollectorStart(): INFO: (1950): Analyzing file: 'c:\log\one\one.log'.

2023/02/14 16:20:43 wazuh-agent[8284] file_op.c:2035 at expand_win32_wildcards(): DEBUG: No folder that matches c:\one\*.log.
2023/02/14 16:20:43 wazuh-agent[8284] file_op.c:2032 at expand_win32_wildcards(): DEBUG: No file that matches c:\log\one\two.*.


2023/02/14 16:20:47 wazuh-agent[8284] read_syslog.c:150 at read_syslog(): DEBUG: Read 0 lines from c:\log\one\one.log

```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors