### PR TITLE
Unit tests for syscollector legacy decoder

### DIFF
--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -23,12 +23,18 @@
 #include "wazuhdb_op.h"
 #include "wazuh_db/wdb.h"
 
-static int error_package = 0;
-static int prev_package_id = 0;
-static int error_port = 0;
-static int prev_port_id = 0;
-static int error_process = 0;
-static int prev_process_id = 0;
+#ifdef WAZUH_UNIT_TESTING
+#define STATIC
+#else
+#define STATIC static
+#endif
+
+STATIC int error_package = 0;
+STATIC int prev_package_id = 0;
+STATIC int error_port = 0;
+STATIC int prev_port_id = 0;
+STATIC int error_process = 0;
+STATIC int prev_process_id = 0;
 
 static int decode_netinfo( Eventinfo *lf, cJSON * logJSON, int *socket);
 static int decode_osinfo( Eventinfo *lf, cJSON * logJSON, int *socket);
@@ -840,8 +846,8 @@ int decode_netinfo(Eventinfo *lf, cJSON * logJSON, int *socket) {
         msg_type = cJSON_GetObjectItem(logJSON, "type")->valuestring;
 
         if (!msg_type) {
-            merror("Invalid message. Type not found.");
-            goto end;
+            merror("Invalid message. Type not found."); // LCOV_EXCL_LINE
+            goto end;                                   // LCOV_EXCL_LINE
         } else if (strcmp(msg_type, "network_end") == 0) {
 
             cJSON * scan_id = cJSON_GetObjectItem(logJSON, "ID");
@@ -856,8 +862,8 @@ int decode_netinfo(Eventinfo *lf, cJSON * logJSON, int *socket) {
                 goto end;
             }
         } else {
-            merror("at decode_netinfo(): unknown type found.");
-            goto end;
+            merror("at decode_netinfo(): unknown type found."); // LCOV_EXCL_LINE
+            goto end;                                           // LCOV_EXCL_LINE
         }
     }
 
@@ -1192,8 +1198,8 @@ int decode_port( Eventinfo *lf, cJSON * logJSON,int *socket) {
         msg_type = cJSON_GetObjectItem(logJSON, "type")->valuestring;
 
         if (!msg_type) {
-            merror("Invalid message. Type not found.");
-            goto end;
+            merror("Invalid message. Type not found."); // LCOV_EXCL_LINE
+            goto end;                                   // LCOV_EXCL_LINE
         } else if (strcmp(msg_type, "port_end") == 0) {
             if (error_port) {
                 if (scan_id->valueint == prev_port_id) {
@@ -1514,8 +1520,8 @@ int decode_package( Eventinfo *lf,cJSON * logJSON,int *socket) {
         msg_type = cJSON_GetObjectItem(logJSON, "type")->valuestring;
 
         if (!msg_type) {
-            merror("Invalid message. Type not found.");
-            goto end;
+            merror("Invalid message. Type not found."); // LCOV_EXCL_LINE
+            goto end;                                   // LCOV_EXCL_LINE
         } else if (strcmp(msg_type, "program_end") == 0) {
             if (error_package) {
                 if (scan_id->valueint == prev_package_id) {
@@ -1584,9 +1590,9 @@ int decode_hotfix(Eventinfo *lf, cJSON * logJSON, int *socket) {
         msg_type = cJSON_GetObjectItem(logJSON, "type")->valuestring;
 
         if (!msg_type) {
-            merror("Invalid message. Type not found.");
-            free(msg);
-            return -1;
+            merror("Invalid message. Type not found."); // LCOV_EXCL_LINE
+            free(msg);                                  // LCOV_EXCL_LINE
+            return -1;                                  // LCOV_EXCL_LINE                 
         } else if (strcmp(msg_type, "hotfix_end") == 0) {
             snprintf(msg, OS_SIZE_1024 - 1, "agent %s hotfix del %d", lf->agent_id, scan_id->valueint);
 
@@ -1926,8 +1932,8 @@ int decode_process(Eventinfo *lf, cJSON * logJSON,int *socket) {
         msg_type = cJSON_GetObjectItem(logJSON, "type")->valuestring;
 
         if (!msg_type) {
-            merror("Invalid message. Type not found.");
-            goto end;
+            merror("Invalid message. Type not found."); // LCOV_EXCL_LINE
+            goto end;                                   // LCOV_EXCL_LINE
         } else if (strcmp(msg_type, "process_end") == 0) {
 
             if (error_process) {

--- a/src/unit_tests/analysisd/test_decoder_syscollector.c
+++ b/src/unit_tests/analysisd/test_decoder_syscollector.c
@@ -1051,6 +1051,666 @@ int test_cleanup(void **state)
     return 0;
 }
 
+int test_setup_hardware_valid_msg(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"hardware\",\
+            \"ID\":100,\
+            \"timestamp\":\"2021/10/29 14:26:24\",\
+            \"inventory\":{\
+                \"board_serial\" : \"86\",\
+                \"cpu_name\" : \"87\",\
+                \"cpu_cores\" : 88,\
+                \"cpu_mhz\" : 89.9,\
+                \"ram_total\" : 90,\
+                \"ram_free\" : 91,\
+                \"ram_usage\" : 92\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_hardware_valid_msg_inventory_empty(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"hardware\",\
+            \"inventory\":{\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_hardware_valid_msg_without_inventory(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"hardware\",\
+            \"ID\":100,\
+            \"timestamp\":\"2021/10/29 14:26:24\"\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_hotfix_valid_msg(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"hotfix\",\
+            \"ID\":100,\
+            \"timestamp\":\"2021/10/29 14:26:24\",\
+            \"hotfix\":\"hotfix-version-test\"\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_hotfix_valid_hotfix_end_msg(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"hotfix_end\",\
+            \"ID\":100\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_hotfix_valid_msg_empty(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"hotfix\"\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_netinfo_valid_msg(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"network\",\
+            \"ID\":100,\
+            \"timestamp\":\"2021/10/29 14:26:24\",\
+            \"iface\":{\
+                \"name\" : \"86\",\
+                \"adapter\" : \"87\",\
+                \"type\" : \"88\",\
+                \"state\" : \"89\",\
+                \"MAC\" : \"90\",\
+                \"tx_packets\" : 91,\
+                \"rx_packets\" : 92,\
+                \"tx_bytes\" : 93,\
+                \"rx_bytes\" : 94,\
+                \"tx_errors\" : 95,\
+                \"rx_errors\" : 96,\
+                \"tx_dropped\" : 97,\
+                \"rx_dropped\" : 98,\
+                \"MTU\" : 99,\
+                \"IPv4\":{\
+                    \"address\" : [ \"0.0.0.0\", \"0.0.1.0\" ],\
+                    \"netmask\" : [ \"255.255.255.255\", \"255.255.255.254\" ],\
+                    \"broadcast\" : [ \"0.0.0.1\", \"0.0.1.1\" ],\
+                    \"gateway\" : \"0.0.0.2\",\
+                    \"dhcp\" : \"0.0.0.3\",\
+                    \"metric\" : 10\
+                },\
+                \"IPv6\":{\
+                    \"address\" : [ \"0000:0000:0000:0:0000:0000:0000:0000\",\
+                                    \"0000:0000:0000:0:0000:0000:0001:0000\" ],\
+                    \"netmask\" : [ \"0000::\", \"0001::\" ],\
+                    \"broadcast\" : [ \"0000:0000:0000:0:0000:0000:0000:0001\",\
+                                      \"0000:0000:0000:0:0000:0000:0001:0001\" ],\
+                    \"gateway\" : \"0000:0000:0000:0:0000:0000:0000:0002\",\
+                    \"dhcp\" : \"0000:0000:0000:0:0000:0000:0000:0003\",\
+                    \"metric\" : 10\
+                }\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_netinfo_valid_msg_groups_empty(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"network\",\
+            \"iface\":{\
+                \"IPv4\":{\
+                },\
+                \"IPv6\":{\
+                }\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_netinfo_valid_msg_address_array_empty(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"network\",\
+            \"iface\":{\
+                \"IPv4\":{\
+                    \"address\" : [ \"0.0.0.0\" ]\
+                },\
+                \"IPv6\":{\
+                    \"address\" : [ \"0000:0000:0000:0:0000:0000:0000:0000\" ]\
+                }\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_netinfo_valid_msg_net_data_free(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"network\",\
+            \"iface\":{\
+                \"IPv4\":{\
+                    \"address\" : [ \"0.0.0.0\" ],\
+                    \"netmask\" : [ \"255.255.255.255\" ],\
+                    \"broadcast\" : [ \"0.0.0.1\" ]\
+                },\
+                \"IPv6\":{\
+                    \"address\" : [ \"0000:0000:0000:0:0000:0000:0000:0000\" ],\
+                    \"netmask\" : [ \"0000::\" ],\
+                    \"broadcast\" : [ \"0000:0000:0000:0:0000:0000:0000:0001\" ]\
+                }\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_netinfo_valid_network_end_msg(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"network_end\",\
+            \"ID\":100\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_osinfo_valid_msg(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"OS\",\
+            \"ID\":100,\
+            \"timestamp\":\"2021/10/29 14:26:24\",\
+            \"inventory\":{\
+                \"os_name\":\"name\",\
+                \"os_version\":\"0.0.1\",\
+                \"os_codename\":\"test\",\
+                \"hostname\":\"host\",\
+                \"architecture\":\"x86\",\
+                \"os_major\":\"0\",\
+                \"os_minor\":\"0\",\
+                \"os_build\":\"1\",\
+                \"os_platform\":\"platform\",\
+                \"sysname\":\"sysname\",\
+                \"release\":\"R1\",\
+                \"version\":\"0.0.2\",\
+                \"os_release\":\"R2\",\
+                \"os_patch\":\"P1\",\
+                \"os_display_version\":\"0.0.1-R2-P1\"\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_osinfo_valid_msg_inventory_empty(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"OS\",\
+            \"inventory\":{\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_package_valid_msg(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"program\",\
+            \"ID\":100,\
+            \"timestamp\":\"2021/10/29 14:26:24\",\
+            \"program\":{\
+                \"format\":\"format\",\
+                \"name\":\"name\",\
+                \"priority\":\"priority\",\
+                \"group\":\"group\",\
+                \"size\": 0,\
+                \"vendor\":\"vendor\",\
+                \"version\":\"version\",\
+                \"architecture\":\"architecture\",\
+                \"multi-arch\":\"multi-arch\",\
+                \"source\":\"source\",\
+                \"description\":\"description\",\
+                \"install_time\":\"install_time\",\
+                \"location\":\"location\"\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_package_valid_msg_program_empty(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"program\",\
+            \"ID\":100,\
+            \"program\":{\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_package_valid_msg_without_ID(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"program\",\
+            \"program\":{\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_package_valid_msg_program_end(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"program_end\",\
+            \"ID\":100\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_port_valid_msg(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"port\",\
+            \"ID\":100,\
+            \"timestamp\":\"2021/10/29 14:26:24\",\
+            \"port\":{\
+                \"protocol\":\"protocol\",\
+                \"local_ip\":\"0.0.0.0\",\
+                \"local_port\":10,\
+                \"remote_ip\":\"0.0.0.1\",\
+                \"remote_port\":11,\
+                \"tx_queue\":12,\
+                \"rx_queue\":13,\
+                \"inode\":14,\
+                \"state\":\"ok\",\
+                \"PID\":15,\
+                \"process\":\"process\"\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_port_valid_msg_port_empty(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"port\",\
+            \"ID\":100,\
+            \"port\":{\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_port_valid_msg_without_ID(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"port\",\
+            \"port\":{\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_port_valid_msg_port_end(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"port_end\",\
+            \"ID\":100\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_process_valid_msg(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"process\",\
+            \"ID\":100,\
+            \"timestamp\":\"2021/10/29 14:26:24\",\
+            \"process\":{\
+                \"pid\":10,\
+                \"name\":\"name\",\
+                \"state\":\"state\",\
+                \"ppid\":11,\
+                \"utime\":12,\
+                \"stime\":13,\
+                \"cmd\":\"cmd\",\
+                \"argvs\": [ \"arg\" ],\
+                \"euser\":\"euser\",\
+                \"ruser\":\"ruser\",\
+                \"suser\":\"suser\",\
+                \"egroup\":\"egroup\",\
+                \"rgroup\":\"rgroup\",\
+                \"sgroup\":\"sgroup\",\
+                \"fgroup\":\"fgroup\",\
+                \"priority\":14,\
+                \"nice\":15,\
+                \"size\":16,\
+                \"vm_size\":17,\
+                \"resident\":18,\
+                \"share\":19,\
+                \"start_time\":20,\
+                \"pgrp\":21,\
+                \"session\":22,\
+                \"nlwp\":23,\
+                \"tgid\":24,\
+                \"tty\":25,\
+                \"processor\":26\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_process_valid_msg_process_empty(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"process\",\
+            \"ID\":100,\
+            \"process\":{\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_process_valid_msg_without_ID(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"process\",\
+            \"process\":{\
+            }\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
+int test_setup_process_valid_msg_process_end(void **state)
+{
+    Eventinfo *lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    if (lf->log = strdup("\
+        {\
+            \"type\":\"process_end\",\
+            \"ID\":100\
+        }"),
+        lf->log == NULL)
+        return -1;
+    os_strdup("(>syscollector", lf->location);
+    os_strdup("001", lf->agent_id);
+
+    *state = lf;
+    return 0;
+}
+
 /* tests */
 void test_syscollector_dbsync_invalid_location(void **state)
 {
@@ -2087,6 +2747,1015 @@ void test_syscollector_dbsync_deleted_multiple_null_valid_msg(void ** state) {
     assert_string_equal(lf->fields[index++].value, "DELETED");
 }
 
+void test_syscollector_hardware_valid (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 hardware save 100|"
+            "2021/10/29 14:26:24|86|87|88|89.900000|"
+            "90.000000|91.000000|92";
+    const char *result = "ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+void test_syscollector_hardware_valid_inventory_empty (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 hardware save NULL|NULL|"
+            "NULL|NULL|NULL|NULL|NULL|NULL|NULL";
+    const char *result = "ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+void test_syscollector_hardware_valid_without_inventory (void **state)
+{
+    Eventinfo *lf = *state;
+
+    int ret = DecodeSyscollector(lf, 0);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_hardware_invalid_query (void **state)
+{
+    Eventinfo *lf = *state;
+    int sock = 1;
+    const char *result = "";
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_any(__wrap_wdbc_query_ex, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send hardware information to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_hardware_parse_result_not_ok (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *result = "not_ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_any(__wrap_wdbc_query_ex, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send hardware information to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_hotfix_valid (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 hotfix save 100|"
+            "2021/10/29 14:26:24|hotfix-version-test|";
+    const char *result = "ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+void test_syscollector_hotfix_valid_hotfix_end (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 hotfix del 100";
+    const char *result = "ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+void test_syscollector_hotfix_invalid_query (void **state)
+{
+    Eventinfo *lf = *state;
+    int sock = 1;
+    const char *result = "";
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_any(__wrap_wdbc_query_ex, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send hotfixes information to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_hotfix_invalid_hotfix_end_query (void **state)
+{
+    test_syscollector_hotfix_invalid_query(state);
+}
+
+void test_syscollector_hotfix_without_ID (void **state)
+{
+    Eventinfo *lf = *state;
+
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send hotfixes information to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, 0);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_hotfix_parse_result_not_ok (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *result = "not_ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_any(__wrap_wdbc_query_ex, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send hotfixes information to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_netinfo_valid (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *queries[] = { "agent 001 netinfo save 100|2021/10/29 14:26:24|"
+                "86|87|88|89|99|90|91|92|93|94|95|96|97|98",
+            "agent 001 netproto save 100|86|0|0.0.0.2|0.0.0.3|10",
+            "agent 001 netaddr save 100|86|0|0.0.0.0|255.255.255.255|0.0.0.1",
+            "agent 001 netaddr save 100|86|0|0.0.1.0|255.255.255.254|0.0.1.1",
+            "agent 001 netproto save 100|86|1|0000:0000:0000:0:0000:0000:0000:0002|"
+                "0000:0000:0000:0:0000:0000:0000:0003|10",
+            "agent 001 netaddr save 100|86|1|0000:0000:0000:0:0000:0000:0000:0000|"
+                "0000::|0000:0000:0000:0:0000:0000:0000:0001", 
+            "agent 001 netaddr save 100|86|1|0000:0000:0000:0:0000:0000:0001:0000|"
+                "0001::|0000:0000:0000:0:0000:0000:0001:0001" };
+
+    const char *result = "ok ";
+    int sock = 1;
+    size_t count = sizeof(queries) / sizeof(*queries);
+
+    for (int i = 0; i < count; i++)
+    {
+        expect_any(__wrap_wdbc_query_ex, *sock);
+        expect_string(__wrap_wdbc_query_ex, query, queries[i]);
+        expect_any(__wrap_wdbc_query_ex, len);
+        will_return(__wrap_wdbc_query_ex, result);
+        will_return(__wrap_wdbc_query_ex, 0);
+    }
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+static const char *valid_empty_queries[] = { "agent 001 netinfo save NULL|NULL|"
+                "NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL",
+            "agent 001 netproto save NULL|NULL|0|NULL|NULL|NULL",
+            "agent 001 netproto save NULL|NULL|1|NULL|"
+                "NULL|NULL" };
+
+void test_syscollector_netinfo_valid_groups_empty (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *result = "ok ";
+    int sock = 1;
+    size_t count = sizeof(valid_empty_queries) / sizeof(*valid_empty_queries);
+
+    for (int i = 0; i < count; i++)
+    {
+        expect_any(__wrap_wdbc_query_ex, *sock);
+        expect_string(__wrap_wdbc_query_ex, query, valid_empty_queries[i]);
+        expect_any(__wrap_wdbc_query_ex, len);
+        will_return(__wrap_wdbc_query_ex, result);
+        will_return(__wrap_wdbc_query_ex, 0);
+    }
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+static const char *valid_empty_address_array_queries[] = { "agent 001 netinfo save NULL|NULL|"
+                "NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL",
+            "agent 001 netproto save NULL|NULL|0|NULL|NULL|NULL",
+            "agent 001 netaddr save NULL|NULL|0|0.0.0.0|NULL|NULL",
+            "agent 001 netproto save NULL|NULL|1|NULL|"
+                "NULL|NULL",
+            "agent 001 netaddr save NULL|NULL|1|0000:0000:0000:0:0000:0000:0000:0000|"
+                "NULL|NULL" };
+
+void test_syscollector_netinfo_valid_address_array_empty (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *result = "ok ";
+    int sock = 1;
+    size_t count = sizeof(valid_empty_address_array_queries) / sizeof(*valid_empty_address_array_queries);
+
+    for (int i = 0; i < count; i++)
+    {
+        expect_any(__wrap_wdbc_query_ex, *sock);
+        expect_string(__wrap_wdbc_query_ex, query, valid_empty_address_array_queries[i]);
+        expect_any(__wrap_wdbc_query_ex, len);
+        will_return(__wrap_wdbc_query_ex, result);
+        will_return(__wrap_wdbc_query_ex, 0);
+    }
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+void test_syscollector_netinfo_valid_network_end (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 netinfo del 100";
+    const char *result = "ok ";
+    const char *result_not_ok = "not ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+ 
+    // Invalid query
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, -1);
+    expect_string(__wrap__merror, formatted_msg, "Unable to send netinfo message to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+
+    // Invalid parse
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result_not_ok);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__merror, formatted_msg, "Unable to send netinfo message to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_netinfo_invalid_query (void **state, const int edge, const bool parse)
+{
+    Eventinfo *lf = *state;
+
+    const char *result = "ok ";
+    const char *result_not_ok = "not ok ";
+    int sock = 1;
+    int i = 0;
+
+    for (; i < edge; i++)
+    {
+        expect_any(__wrap_wdbc_query_ex, *sock);
+        expect_string(__wrap_wdbc_query_ex, query, valid_empty_queries[i]);
+        expect_any(__wrap_wdbc_query_ex, len);
+        will_return(__wrap_wdbc_query_ex, result);
+        will_return(__wrap_wdbc_query_ex, 0);
+    }
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, valid_empty_queries[i]);
+    expect_any(__wrap_wdbc_query_ex, len);
+    if (parse)
+    {
+        will_return(__wrap_wdbc_query_ex, result_not_ok);
+        will_return(__wrap_wdbc_query_ex, 0);
+    }
+    else
+    {
+        will_return(__wrap_wdbc_query_ex, result);
+        will_return(__wrap_wdbc_query_ex, -1);
+    }
+    expect_string(__wrap__merror, formatted_msg, "Unable to send netinfo message to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_netinfo_invalid_queries (void **state)
+{
+    size_t count = sizeof(valid_empty_queries) / sizeof(*valid_empty_queries);
+
+    for (int i = 0; i < count; i++)
+    {
+        test_syscollector_netinfo_invalid_query (state, i, false);
+        test_syscollector_netinfo_invalid_query (state, i, true);
+    }
+}
+
+void test_syscollector_netinfo_invalid_address_array_empty_query (void **state, const int edge, const bool parse)
+{
+    Eventinfo *lf = *state;
+    const char *result = "ok ";
+    const char *result_not_ok = "not ok ";
+    int sock = 1;
+    int i = 0;
+
+    for (; i < edge; i++)
+    {
+        expect_any(__wrap_wdbc_query_ex, *sock);
+        expect_string(__wrap_wdbc_query_ex, query, valid_empty_address_array_queries[i]);
+        expect_any(__wrap_wdbc_query_ex, len);
+        will_return(__wrap_wdbc_query_ex, result);
+        will_return(__wrap_wdbc_query_ex, 0);
+    }
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, valid_empty_address_array_queries[i]);
+    expect_any(__wrap_wdbc_query_ex, len);
+    if (parse)
+    {
+        will_return(__wrap_wdbc_query_ex, result_not_ok);
+        will_return(__wrap_wdbc_query_ex, 0);
+    }
+    else
+    {
+        will_return(__wrap_wdbc_query_ex, result);
+        will_return(__wrap_wdbc_query_ex, -1);
+    }
+    expect_string(__wrap__merror, formatted_msg, "Unable to send netinfo message to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_netinfo_invalid_address_array_empty_queries (void **state)
+{
+    size_t count = sizeof(valid_empty_address_array_queries) / sizeof(*valid_empty_address_array_queries);
+
+    for (int i = 0; i < count; i++)
+    {
+        test_syscollector_netinfo_invalid_address_array_empty_query (state, i, false);
+        test_syscollector_netinfo_invalid_address_array_empty_query (state, i, true);
+    }
+}
+
+static const char *valid_empty_address_array_free[] = { "agent 001 netinfo save NULL|NULL|"
+                "NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL",
+            "agent 001 netproto save NULL|NULL|0|NULL|NULL|NULL",
+            "agent 001 netaddr save NULL|NULL|0|0.0.0.0|255.255.255.255|0.0.0.1",
+            "agent 001 netproto save NULL|NULL|1|NULL|"
+                "NULL|NULL",
+            "agent 001 netaddr save NULL|NULL|1|0000:0000:0000:0:0000:0000:0000:0000|"
+                "0000::|0000:0000:0000:0:0000:0000:0000:0001" };
+
+void test_syscollector_netinfo_net_array_data_free (void **state, const int edge, const bool parse)
+{
+    Eventinfo *lf = *state;
+    const char *result = "ok ";
+    const char *result_not_ok = "not ok ";
+    int sock = 1;
+    int i = 0;
+
+    for (; i < edge; i++)
+    {
+        expect_any(__wrap_wdbc_query_ex, *sock);
+        expect_string(__wrap_wdbc_query_ex, query, valid_empty_address_array_free[i]);
+        expect_any(__wrap_wdbc_query_ex, len);
+        will_return(__wrap_wdbc_query_ex, result);
+        will_return(__wrap_wdbc_query_ex, 0);
+    }
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, valid_empty_address_array_free[i]);
+    expect_any(__wrap_wdbc_query_ex, len);
+    if (parse)
+    {
+        will_return(__wrap_wdbc_query_ex, result_not_ok);
+        will_return(__wrap_wdbc_query_ex, 0);
+    }
+    else
+    {
+        will_return(__wrap_wdbc_query_ex, result);
+        will_return(__wrap_wdbc_query_ex, -1);
+    }
+    expect_string(__wrap__merror, formatted_msg, "Unable to send netinfo message to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_netinfo_net_data_free (void **state)
+{
+    size_t count = sizeof(valid_empty_address_array_free) / sizeof(*valid_empty_address_array_free);
+
+    for (int i = 0; i < count; i++)
+    {
+        test_syscollector_netinfo_net_array_data_free (state, i, false);
+        test_syscollector_netinfo_net_array_data_free (state, i, true);
+    }
+}
+
+void test_syscollector_osinfo_valid (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 osinfo set 100|2021/10/29 14:26:24|host|x86|"
+            "name|0.0.1|test|0|0|1|platform|sysname|R1|0.0.2|R2|P1|0.0.1-R2-P1";
+    const char *result = "ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+static const char *osinfo_empty_query = "agent 001 osinfo set NULL|NULL|NULL|NULL|NULL|NULL|"
+            "NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL";
+
+void test_syscollector_osinfo_valid_inventory_empty (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *result = "ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, osinfo_empty_query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+void test_syscollector_osinfo_invalid_inventory_empty (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *result = "ok ";
+    const char *result_not_ok = "not ok ";
+    int sock = 1;
+
+    // Invalid query out
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, osinfo_empty_query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send osinfo message to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+
+    // Invalid parse out
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, osinfo_empty_query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result_not_ok);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send osinfo message to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_package_valid (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 package save 100|2021/10/29 14:26:24|"
+            "format|name|priority|group|0|vendor|install_time|version|"
+            "architecture|multi-arch|source|description|location|"
+            "0b50c065ffd996675a6b8e95e716091165796053";
+    const char *result = "ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+extern int error_package;
+extern int prev_package_id;
+
+void test_syscollector_package_program_empty (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 package save 100|NULL|NULL|NULL|NULL|NULL|"
+            "NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|"
+            "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+    const char *result = "ok ";
+    const char *result_not_ok = "not ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Clean previous package error, and exit
+    error_package = 1;
+    prev_package_id = 100;
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Clean previous package error, and continue
+    error_package = 1;
+    prev_package_id++;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Query error out
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send packages information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+
+    // Parse error out
+    error_package = 0;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result_not_ok);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send packages information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_package_valid_without_ID (void **state)
+{
+    Eventinfo *lf = *state;
+
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send packages information to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, NULL);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_package_program_end (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 package del 100";
+    const char *result = "ok ";
+    const char *result_not_ok = "not ok ";
+    int sock = 1;
+
+    error_package = 0;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Invalid query out
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send packages information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+
+    // Return ok after query error
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Return ok after query error, changing package_id
+    prev_package_id++;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result_not_ok);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send packages information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+
+    // Invalid parse out
+    error_package = 0;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result_not_ok);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send packages information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_port_valid (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 port save 100|2021/10/29 14:26:24|protocol|"
+            "0.0.0.0|10|0.0.0.1|11|12|13|14|ok|15|process";
+    const char *result = "ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+extern int error_port;
+extern int prev_port_id;
+
+void test_syscollector_port_empty (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 port save 100|NULL|NULL|NULL|NULL|NULL|NULL|"
+            "NULL|NULL|NULL|NULL|NULL|NULL";
+    const char *result = "ok ";
+    const char *result_not_ok = "not ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Clean previous port error, and exit
+    error_port = 1;
+    prev_port_id = 100;
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Clean previous port error, and continue
+    error_port = 1;
+    prev_port_id++;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Query error out
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send ports information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+
+    // Parse error out
+    error_port = 0;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result_not_ok);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send ports information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_port_valid_without_ID (void **state)
+{
+    Eventinfo *lf = *state;
+
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send ports information to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, NULL);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_port_end (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 port del 100";
+    const char *result = "ok ";
+    const char *result_not_ok = "not ok ";
+    int sock = 1;
+
+    error_port = 0;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Invalid query out
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send ports information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+
+    // Return ok after query error
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Return ok after query error, changing port_id
+    prev_port_id++;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result_not_ok);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send ports information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+
+    // Invalid parse out
+    error_port = 0;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result_not_ok);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send ports information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_process_valid (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 process save 100|2021/10/29 14:26:24|10|name|"
+            "state|11|12|13|cmd|arg|euser|ruser|suser|egroup|rgroup|sgroup|fgroup|"
+            "14|15|16|17|18|19|20|21|22|23|24|25|26";
+    const char *result = "ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+
+    assert_int_not_equal(ret, 0);
+}
+
+extern int error_process;
+extern int prev_process_id;
+
+void test_syscollector_process_empty (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 process save 100|NULL|NULL|NULL|NULL|NULL|"
+            "NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|"
+            "NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL";
+    const char *result = "ok ";
+    const char *result_not_ok = "not ok ";
+    int sock = 1;
+
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Clean previous process error, and exit
+    error_process = 1;
+    prev_process_id = 100;
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Clean previous process error, and continue
+    error_process = 1;
+    prev_process_id++;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Query error out
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send processes information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+
+    // Parse error out
+    error_process = 0;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result_not_ok);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send processes information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_process_valid_without_ID (void **state)
+{
+    Eventinfo *lf = *state;
+
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send processes information to Wazuh DB.");
+
+    int ret = DecodeSyscollector(lf, NULL);
+
+    assert_int_not_equal(ret, -1);
+}
+
+void test_syscollector_process_end (void **state)
+{
+    Eventinfo *lf = *state;
+    const char *query = "agent 001 process del 100";
+    const char *result = "ok ";
+    const char *result_not_ok = "not ok ";
+    int sock = 1;
+
+    error_process = 0;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, 0);
+
+    int ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Invalid query out
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result);
+    will_return(__wrap_wdbc_query_ex, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send processes information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+
+    // Return ok after query error
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, 0);
+
+    // Return ok after query error, changing package_id
+    prev_process_id++;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result_not_ok);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send processes information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+
+    // Invalid parse out
+    error_process = 0;
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query);
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, result_not_ok);
+    will_return(__wrap_wdbc_query_ex, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, 
+            "Unable to send processes information to Wazuh DB.");
+
+    ret = DecodeSyscollector(lf, &sock);
+    assert_int_not_equal(ret, -1);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] = {
@@ -2127,7 +3796,47 @@ int main()
         cmocka_unit_test_setup_teardown(test_syscollector_dbsync_os_valid_msg_with_number_pk, test_setup_os_valid_msg_with_number_pk, test_cleanup),
         cmocka_unit_test_setup_teardown(test_syscollector_dbsync_insert_multiple_null_valid_msg, test_setup_insert_multiple_null_field_valid_msg, test_cleanup),
         cmocka_unit_test_setup_teardown(test_syscollector_dbsync_deleted_multiple_null_valid_msg, test_setup_deleted_multiple_null_field_valid_msg, test_cleanup),
-        cmocka_unit_test_setup_teardown(test_syscollector_dbsync_os_valid_msg_no_result_payload, test_setup_os_valid_msg_modified, test_cleanup)
+        cmocka_unit_test_setup_teardown(test_syscollector_dbsync_os_valid_msg_no_result_payload, test_setup_os_valid_msg_modified, test_cleanup),
+        // Hardware tests
+        cmocka_unit_test_setup_teardown(test_syscollector_hardware_valid, test_setup_hardware_valid_msg, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_hardware_valid_inventory_empty, test_setup_hardware_valid_msg_inventory_empty, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_hardware_valid_without_inventory, test_setup_hardware_valid_msg_without_inventory, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_hardware_invalid_query, test_setup_hardware_valid_msg_inventory_empty, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_hardware_parse_result_not_ok, test_setup_hardware_valid_msg_inventory_empty, test_cleanup),
+        // Hotfix tests
+        cmocka_unit_test_setup_teardown(test_syscollector_hotfix_valid, test_setup_hotfix_valid_msg, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_hotfix_valid_hotfix_end, test_setup_hotfix_valid_hotfix_end_msg, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_hotfix_invalid_query, test_setup_hotfix_valid_msg, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_hotfix_invalid_hotfix_end_query, test_setup_hotfix_valid_hotfix_end_msg, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_hotfix_without_ID, test_setup_hotfix_valid_msg_empty, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_hotfix_parse_result_not_ok, test_setup_hotfix_valid_msg, test_cleanup),
+        // Netinfo tests
+        cmocka_unit_test_setup_teardown(test_syscollector_netinfo_valid, test_setup_netinfo_valid_msg, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_netinfo_valid_groups_empty, test_setup_netinfo_valid_msg_groups_empty, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_netinfo_valid_address_array_empty, test_setup_netinfo_valid_msg_address_array_empty, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_netinfo_valid_network_end, test_setup_netinfo_valid_network_end_msg, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_netinfo_invalid_queries, test_setup_netinfo_valid_msg_groups_empty, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_netinfo_invalid_address_array_empty_queries, test_setup_netinfo_valid_msg_address_array_empty, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_netinfo_net_data_free, test_setup_netinfo_valid_msg_net_data_free, test_cleanup),
+        // OSinfo tests
+        cmocka_unit_test_setup_teardown(test_syscollector_osinfo_valid, test_setup_osinfo_valid_msg, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_osinfo_valid_inventory_empty, test_setup_osinfo_valid_msg_inventory_empty, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_osinfo_invalid_inventory_empty, test_setup_osinfo_valid_msg_inventory_empty, test_cleanup),
+        // Package tests
+        cmocka_unit_test_setup_teardown(test_syscollector_package_valid, test_setup_package_valid_msg, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_package_program_empty, test_setup_package_valid_msg_program_empty, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_package_valid_without_ID, test_setup_package_valid_msg_without_ID, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_package_program_end, test_setup_package_valid_msg_program_end, test_cleanup),
+        // Port tests
+        cmocka_unit_test_setup_teardown(test_syscollector_port_valid, test_setup_port_valid_msg, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_port_empty, test_setup_port_valid_msg_port_empty, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_port_valid_without_ID, test_setup_port_valid_msg_without_ID, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_port_end, test_setup_port_valid_msg_port_end, test_cleanup),
+        // Process tests
+        cmocka_unit_test_setup_teardown(test_syscollector_process_valid, test_setup_process_valid_msg, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_process_empty, test_setup_process_valid_msg_process_empty, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_process_valid_without_ID, test_setup_process_valid_msg_without_ID, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_syscollector_process_end, test_setup_process_valid_msg_process_end, test_cleanup)
     };
     return cmocka_run_group_tests(tests, test_setup_global, NULL);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#10368|

## Description

* Add 100% UT coverage on these functions:

    decode_netinfo()
    decode_osinfo()
    decode_hardware()
    decode_package()
    decode_hotfix()
    decode_port()
    decode_process()

## Tests
![2023-01-20_11-28](https://user-images.githubusercontent.com/93778492/213731236-6282c39f-4b87-4294-8c71-45d3bd5d305b.png)
![2023-01-20_11-35](https://user-images.githubusercontent.com/93778492/213731336-a86e5ed3-f85a-452d-b52a-4d9a55089ad9.png)

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors