### PR TITLE
Fix an error code in GetSecurityInfo function in FIM code

### DIFF
--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -207,7 +207,7 @@ endif()
 list(APPEND shared_tests_names "test_syscheck_op")
 set(SYSCHECK_OP_BASE_FLAGS "-Wl,--wrap,rmdir_ex -Wl,--wrap,wreaddir -Wl,--wrap,getpwuid_r -Wl,--wrap,w_getgrgid \
                             -Wl,--wrap,wstr_split -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP \
-                            -Wl,--wrap,sysconf ${DEBUG_OP_WRAPPERS}")
+                            -Wl,--wrap,sysconf -Wl,--wrap,win_strerror ${DEBUG_OP_WRAPPERS}")
 if(${TARGET} STREQUAL "winagent")
     # cJSON_CreateArray@0 instead of cJSON_CreateArray since linker will be looking for cdecl forma
     # More info at: (https://devblogs.microsoft.com/oldnewthing/20040108-00/?p=41163)

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -3584,15 +3584,15 @@ static void test_get_file_user_GetSecurityInfo_error(void **state) {
 
     expect_GetSecurityInfo_call(NULL, (PSID)"", ERROR_ACCESS_DENIED);
 
-    expect_GetLastError_call(ERROR_ACCESS_DENIED);
+    expect_ConvertSidToStringSid_call("", FALSE);
 
-    expect_ConvertSidToStringSid_call("dummy", FALSE);
+    will_return(__wrap_win_strerror,"Access denied.");
 
     expect_string(__wrap__mdebug1, formatted_msg, "The user's SID could not be extracted.");
 
     snprintf(error_msg,
              OS_SIZE_1024,
-             "GetSecurityInfo error = %lu",
+             "GetSecurityInfo error code = (%lu), 'Access denied.'",
              ERROR_ACCESS_DENIED);
 
     expect_string(__wrap__merror, formatted_msg, error_msg);
@@ -4109,11 +4109,12 @@ void test_get_registry_group_GetSecurityInfo_fails(void **state) {
     char error_msg[OS_SIZE_1024];
 
     expect_GetSecurityInfo_call(NULL, (PSID)"", ERROR_ACCESS_DENIED);
-    expect_GetLastError_call(ERROR_ACCESS_DENIED);
+    expect_ConvertSidToStringSid_call("", TRUE);
+    will_return(__wrap_win_strerror, "Access denied.");
 
     snprintf(error_msg,
              OS_SIZE_1024,
-             "GetSecurityInfo error = %lu",
+             "GetSecurityInfo error code = (%lu), 'Access denied.'",
              ERROR_ACCESS_DENIED);
 
     expect_string(__wrap__merror, formatted_msg, error_msg);

--- a/src/unit_tests/wrappers/wazuh/shared/debug_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/debug_op_wrappers.c
@@ -219,3 +219,8 @@ void __wrap__mwarn(__attribute__((unused)) const char * file,
 
     check_expected(formatted_msg);
 }
+
+char * __wrap_win_strerror(__attribute__((unused)) unsigned long error) {
+    return mock_type(char*);
+}
+

--- a/src/unit_tests/wrappers/wazuh/shared/debug_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/debug_op_wrappers.h
@@ -86,4 +86,6 @@ void __wrap__mwarn(const char * file,
                    const char * func,
                    const char *msg, ...);
 
+char * __wrap_win_strerror(unsigned long error);
+
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#11088|


## Description
Hello team, 
This PR is to modify the error output of the GetSecurityInfo function. 
We had encountered some problems with the error code we were displaying using GetLastError as shown in the examples in the Windows documentation:
https://learn.microsoft.com/en-us/windows/win32/secauthz/finding-the-owner-of-a-file-object-in-c--

After analyzing the problem in depth, and seeing the errors that appear with "meaningless" error codes, they must be race conditions in which an error is first given during the execution of the GetSecurityInfo function, but nevertheless, the GetLastError function returns a value that does not seem to correspond to the function we are analyzing.

However, in this case for the GetSecurityInfo function it is not necessary, since the error code is returned in the function itself.
We will use the return to display the code, and also add the formatted error message.