### PR TITLE
Engine - Implementation Fortinet/Fortimail decoder

### DIFF
--- a/src/engine/ruleset/decoders/fortinet/fortimail.yml
+++ b/src/engine/ruleset/decoders/fortinet/fortimail.yml
@@ -19,104 +19,104 @@ parse:
   logpar:
     # date=2018-1-27 time=05:21:06 device_id=atcupid log_id=onse log_part=psa type=virus_file-signature pri=high destla to="fugitse" src=[10.12.86.130] session_id=dese msg="Attachment file (duntutla) has sha1 hash value: lamco"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> pri=<log.level> <~log.fill> to=<~rsa.email.email_dst>
-        src=[<source.ip>] session_id=<~rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~rsa.misc.checksum>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> <~log.fill> to=<~log.rsa.email.email_dst>
+        src=[<source.ip>] session_id=<~log.rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~log.rsa.misc.checksum>"
     # date=2018-11-9 time=02:12:32 device_id=dolo log_id=velites log_part=oloremi type=virus_file-signature pri=high apari to=tsunt src="caecat [10.108.10.197]" session_id=enim msg="Attachment file (umq) has sha1 hash value: sistena"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> pri=<log.level> <~log.fill> to=<~rsa.email.email_dst>
-        src="<source.domain> [<source.ip>]" session_id=<~rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~rsa.misc.checksum>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> <~log.fill> to=<~log.rsa.email.email_dst>
+        src="<source.domain> [<source.ip>]" session_id=<~log.rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~log.rsa.misc.checksum>"
     # date=2016-12-23 time=00:09:07 device_id=dolore log_id=onsecte log_part=nBCSedut type=virus subtype=file-signature pri=high from="modocons" to=gitsed src="10.16.177.212" session_id="emp" msg="Attachment file (pisciv) has sha1 hash value: lumdolor"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> from="<~rsa.email.email_src>" to=<~rsa.email.email_dst>
-        src="<source.ip>" session_id="<~rsa.misc.log_session_id>" msg="Attachment file \(<file.name>\) <~log.fill>: <~rsa.misc.checksum>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> subtype=<~log.rsa.internal.messageid> pri=<log.level> from="<~log.rsa.email.email_src>" to=<~log.rsa.email.email_dst>
+        src="<source.ip>" session_id="<~log.rsa.misc.log_session_id>" msg="Attachment file \(<file.name>\) <~log.fill>: <~log.rsa.misc.checksum>"
     # date=2019-8-7 time=16:01:23 device_id=sBonoru log_id=everi log_part=squ type=virus subtype=file-signature pri=medium from="utla" to=nse src=10.160.236.78 session_id=nostrude msg="Attachment file (rinc) has sha1 hash value: tno"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> from="<~rsa.email.email_src>" to=<~rsa.email.email_dst>
-        src=<source.ip> session_id=<~rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~rsa.misc.checksum>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> subtype=<~log.rsa.internal.messageid> pri=<log.level> from="<~log.rsa.email.email_src>" to=<~log.rsa.email.email_dst>
+        src=<source.ip> session_id=<~log.rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~log.rsa.misc.checksum>"
     # date=2019-11-1 time=10:16:48 device_id=equ log_id=turadip log_part=ataev type=virus_file-signature pri=medium from="oree" to="nimadmi" src="utaliq [10.78.38.143]" session_id=qui msg="Attachment file (epteurs) has sha1 hash value: did"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> pri=<log.level> from="<~rsa.email.email_src>" to="<~rsa.email.email_dst>" src="<source.domain> [<source.ip>]"
-        session_id=<~rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~rsa.misc.checksum>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> from="<~log.rsa.email.email_src>" to="<~log.rsa.email.email_dst>" src="<source.domain> [<source.ip>]"
+        session_id=<~log.rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~log.rsa.misc.checksum>"
     # date=2019-1-19 time=13:25:23 device_id=odit log_id=vol log_part=epteurs type=statistics pri=very-high session_id="cteturad" client_name="modi6930.internal.test[10.60.164.100]"dst_ip="10.161.1.146" from="etconse" to="nproiden" polid="ionem" domain="taevitae6868.www.corp" subject="ehende" mailer="rep" resolved="nostru" direction="internal" virus="ipiscin" disposition="trudexe" classifier="qua" message_length=modit
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> pri=<log.level> session_id="<~rsa.misc.log_session_id>" client_name="<~rsa.web.fqdn>[<source.ip>]"dst_ip="<destination.ip>"
-        from="<~rsa.email.email_src>" to="<~rsa.email.email_dst>" polid="<~log.fill>" domain="<server.domain>" subject="<~rsa.email.subject>" mailer="<~rsa.misc.client>"
-        resolved="<~rsa.misc.context>" direction="<network.direction>" virus="<~rsa.misc.virusname>" disposition="<~rsa.misc.disposition>" classifier="<~rsa.misc.filter>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> session_id="<~log.rsa.misc.log_session_id>" client_name="<~log.rsa.web.fqdn>[<source.ip>]"dst_ip="<destination.ip>"
+        from="<~log.rsa.email.email_src>" to="<~log.rsa.email.email_dst>" polid="<~log.fill>" domain="<server.domain>" subject="<~log.rsa.email.subject>" mailer="<~log.rsa.misc.client>"
+        resolved="<~log.rsa.misc.context>" direction="<network.direction>" virus="<~log.rsa.misc.virusname>" disposition="<~log.rsa.misc.disposition>" classifier="<~log.rsa.misc.filter>"
         message_length=<~log.fill>
     # date=2019-2-17 time=03:30:32 device_id=quidol log_id=tinv log_part=Utenima type=statistics pri=high session_id=temqu client_name=uradip7802.mail.example client_ip=10.44.35.57 dst_ip=10.93.239.216 from=vento hfrom=litsed to=ciun polid=rehender domain=tetura7106.www5.corp mailer=eosquir resolved=tqu src_type=emips direction=internal virus=tinvolu disposition=ptat classifier=amquisn message_length=Finibus subject=nsequat
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> pri=<log.level> session_id=<~rsa.misc.log_session_id> client_name=<~rsa.web.fqdn> client_ip=<source.ip>
-        dst_ip=<destination.ip> from=<~rsa.email.email_src> hfrom=<~log.fill> to=<~rsa.email.email_dst> polid=<~log.fill>
-        domain=<server.domain> mailer=<~rsa.misc.client> resolved=<~rsa.misc.context> src_type=<~log.fill> direction=<network.direction>
-        virus=<~rsa.misc.virusname> disposition=<~rsa.misc.disposition> classifier=<~rsa.misc.filter>
-        message_length=<~log.fill> subject=<~rsa.email.subject>
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> session_id=<~log.rsa.misc.log_session_id> client_name=<~log.rsa.web.fqdn> client_ip=<source.ip>
+        dst_ip=<destination.ip> from=<~log.rsa.email.email_src> hfrom=<~log.fill> to=<~log.rsa.email.email_dst> polid=<~log.fill>
+        domain=<server.domain> mailer=<~log.rsa.misc.client> resolved=<~log.rsa.misc.context> src_type=<~log.fill> direction=<network.direction>
+        virus=<~log.rsa.misc.virusname> disposition=<~log.rsa.misc.disposition> classifier=<~log.rsa.misc.filter>
+        message_length=<~log.fill> subject=<~log.rsa.email.subject>
     # date=2019-11-30 time=00:21:57 device_id=ntutlabo log_id=leumiure log_part=tasnu type=event subtype=smtp pri=high user=amquaui=tionevol(10.209.124.81) action=allowstatus=tobesession_id="ssequa" log_part=emp msg="to=<<emoeni, delay=officiad, xdelay=veniam, mailer=igmp, pri=entoreve, relay=ion3339.www.localdomain"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<~rsa.misc.event_type> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name>ui=<~rsa.network.network_service>(?\(<source.ip>\))
-        action=<event.action>status=<~rsa.misc.event_state>session_id="<~rsa.misc.log_session_id>" log_part=<~log.fill>
-        msg="<~rsa.internal.event_desc>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<~log.rsa.misc.event_type> subtype=<~log.rsa.internal.messageid> pri=<log.level> user=<user.name>ui=<~log.rsa.network.network_service>(?\(<source.ip>\))
+        action=<event.action>status=<~log.rsa.misc.event_state>session_id="<~log.rsa.misc.log_session_id>" log_part=<~log.fill>
+        msg="<~log.rsa.internal.event_desc>"
     # date=2018-12-7 time=16:17:40 device_id=econ log_id=aborio log_part=rve type=event subtype=smtp pri=medium user=nbyCiui=runtmollaction=blockstatus=velillumsession_id="ionev" msg="to=<<vitaedi>, delay=rna, xdelay=cons, mailer=ipv6-icmp, pri=lupta, relay=olaboris3175.internal.home[10.250.94.95], dsn=tno, stat=imve"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<~rsa.misc.event_type> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name>ui=<~rsa.network.network_service>(?\(<source.ip>\))action=<event.action>status=<~rsa.misc.event_state>session_id="<~rsa.misc.log_session_id>"
-        msg="<~rsa.internal.event_desc>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<~log.rsa.misc.event_type> subtype=<~log.rsa.internal.messageid> pri=<log.level> user=<user.name>ui=<~log.rsa.network.network_service>(?\(<source.ip>\))action=<event.action>status=<~log.rsa.misc.event_state>session_id="<~log.rsa.misc.log_session_id>"
+        msg="<~log.rsa.internal.event_desc>"
     # date=2018-11-23 time=09:15:06 device_id=imipsam log_id=eumiu log_part=tatevel type=event subtype=smtp pri=high user=quisnostui=sequines(10.115.154.104) action=cancelstatus=lorumsession_id="suntexpl" msg="DSN: to <<iqu>; reason:success; sessionid:tatis"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<~rsa.misc.event_type> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name>ui=<~rsa.network.network_service>(?\(<source.ip>\))
-        action=<event.action>status=<~rsa.misc.event_state>session_id="<~rsa.misc.filter>" msg="<~rsa.internal.event_desc>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<~log.rsa.misc.event_type> subtype=<~log.rsa.internal.messageid> pri=<log.level> user=<user.name>ui=<~log.rsa.network.network_service>(?\(<source.ip>\))
+        action=<event.action>status=<~log.rsa.misc.event_state>session_id="<~log.rsa.misc.filter>" msg="<~log.rsa.internal.event_desc>"
     # date=2019-5-28 time=04:48:31 device_id=iade log_id=tae log_part=obe type=event subtype=admin pri=medium user=ulapari ui=rittenby(10.31.31.193) action=deny status=nvol reason=unknown msg="luptatem"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<~rsa.misc.event_type> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~rsa.network.network_service>
-        action=<event.action> status=<~rsa.misc.event_state> reason=<~rsa.misc.result> msg="<~rsa.internal.event_desc>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<~log.rsa.misc.event_type> subtype=<~log.rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~log.rsa.network.network_service>
+        action=<event.action> status=<~log.rsa.misc.event_state> reason=<~log.rsa.misc.result> msg="<~log.rsa.internal.event_desc>"
     # date=2016-6-20 time=04:35:42 device_id=idestla log_id=Nemoeni log_part=uradi type=statistics pri=very-high session_id="lup" from="remeumf" mailer=antiumto client_name="10.241.165.37" MSISDN=aUteni resolved=ittenbyC to="aperi" direction="inbound" message_length=ita virus="ipi" disposition=rsitamet classifier="lupt" subject="xea"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> pri=<log.level> session_id="<~rsa.misc.filter>" from="<~rsa.email.email_src>" mailer=<~rsa.misc.client> client_name="<source.ip>"
-        <~log.fill> resolved=<~rsa.misc.context> to="<~rsa.email.email_dst>" direction="<network.direction>" <~log.fill> virus="<~rsa.misc.virusname>"
-        disposition=<~rsa.misc.disposition> classifier="<~rsa.misc.filter>" subject="<~rsa.email.subject>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> session_id="<~log.rsa.misc.filter>" from="<~log.rsa.email.email_src>" mailer=<~log.rsa.misc.client> client_name="<source.ip>"
+        <~log.fill> resolved=<~log.rsa.misc.context> to="<~log.rsa.email.email_dst>" direction="<network.direction>" <~log.fill> virus="<~log.rsa.misc.virusname>"
+        disposition=<~log.rsa.misc.disposition> classifier="<~log.rsa.misc.filter>" subject="<~log.rsa.email.subject>"
     # date=2017-10-4 time=21:00:32 device_id=umS log_id=iciadese log_part=riatur type=event subtype=webmail pri=very-high user=xeacommo ui=Cicero(10.247.53.179) action=cancel status=ditau msg=atemaccu
     # date=2017-12-29 time=15:15:58 device_id=iciade log_id=uis log_part=amc type=event subtype=webmail pri=medium user=Ute ui=ptassita action=allow status=runtm msg="eturadip"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<~rsa.misc.event_type> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~rsa.network.network_service>(?\(<source.ip>\)) action=<event.action>
-        status=<~rsa.misc.event_state> msg=<~rsa.internal.event_desc>(?"<~rsa.internal.event_desc>")
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<~log.rsa.misc.event_type> subtype=<~log.rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~log.rsa.network.network_service>(?\(<source.ip>\)) action=<event.action>
+        status=<~log.rsa.misc.event_state> msg=<~log.rsa.internal.event_desc>(?"<~log.rsa.internal.event_desc>")
     # date=2018-3-11 time=02:28:49 device_id=lupta log_id=byC log_part=imadm type=spam pri=low session_id="nci" from="orroquis" to="ulapa" subject="iumdo" msg="iusmodit"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> pri=<log.level> session_id="<~rsa.misc.filter>" from="<~rsa.email.email_src>" to="<~rsa.email.email_dst>"
-        subject="<~rsa.email.subject>" msg=<~rsa.internal.event_desc>(?"<~rsa.internal.event_desc>")
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> session_id="<~log.rsa.misc.filter>" from="<~log.rsa.email.email_src>" to="<~log.rsa.email.email_dst>"
+        subject="<~log.rsa.email.subject>" msg=<~log.rsa.internal.event_desc>(?"<~log.rsa.internal.event_desc>")
     # date=2016-2-12 time=13:12:33 device_id=ehend log_id=ritquiin log_part=umqui type=virus subtype=infected pri=very-high from="mest" to=enderitq client_name="sperna884.internal.domain" client_ip="10.165.201.71" session_id="pisciv" msg="uii"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> from="<~rsa.email.email_src>" to=<~rsa.email.email_dst>
-        client_name="<~rsa.web.fqdn>" client_ip="<source.ip>" session_id="<~rsa.misc.filter>" msg=<~rsa.internal.event_desc>(?"<~rsa.internal.event_desc>")
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> subtype=<~log.rsa.internal.messageid> pri=<log.level> from="<~log.rsa.email.email_src>" to=<~log.rsa.email.email_dst>
+        client_name="<~log.rsa.web.fqdn>" client_ip="<source.ip>" session_id="<~log.rsa.misc.filter>" msg=<~log.rsa.internal.event_desc>(?"<~log.rsa.internal.event_desc>")
     # date=2019-12-14 time=07:24:31 device_id=int log_id=oremagn log_part=rnatur type=virus pri=medium from=uptatev to="oditem" src="10.176.31.145" session_id="ineavo" msg=reseo
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> pri=<log.level> from=<~rsa.email.email_src> to="<~rsa.email.email_dst>" src="<source.ip>"
-        session_id="<~rsa.misc.filter>" msg=<~rsa.internal.event_desc>
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> from=<~log.rsa.email.email_src> to="<~log.rsa.email.email_dst>" src="<source.ip>"
+        session_id="<~log.rsa.misc.filter>" msg=<~log.rsa.internal.event_desc>
     # date=2017-1-6 time=07:11:41 device_id=uaUten log_id=nby log_part=mve type=event subtype=config pri=low user=isau ui=rautodi(10.96.97.81) module=pis submodule=nsequat msg=doloreme
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~rsa.network.network_service>\(<source.ip>\) module=<~log.fill> submodule=<~log.fill> msg=<~rsa.internal.event_desc>
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> subtype=<~log.rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~log.rsa.network.network_service>\(<source.ip>\) module=<~log.fill> submodule=<~log.fill> msg=<~log.rsa.internal.event_desc>
     # date=2018-3-25 time=09:31:24 device_id=obeataev log_id=umf log_part=olesti type=event subtype=config pri=low user=quaeabil ui=emip module=aturQu submodule=itesse msg="iamqui"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~rsa.network.network_service> module=<~log.fill> submodule=<~log.fill> msg="<~rsa.internal.event_desc>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> subtype=<~log.rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~log.rsa.network.network_service> module=<~log.fill> submodule=<~log.fill> msg="<~log.rsa.internal.event_desc>"
     # date=2016-6-5 time=21:33:08 device_id=ntutl log_id=caecatc log_part=onsequat type=event subtype=update pri=low msg="edquiano"
     - event.original: >-
-        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
-        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> msg="<~rsa.internal.event_desc>"
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~log.rsa.misc.reference_id1>
+        type=<event.action> subtype=<~log.rsa.internal.messageid> pri=<log.level> msg="<~log.rsa.internal.event_desc>"
 
 normalize:
   - map:
@@ -127,44 +127,44 @@ normalize:
     - observer.type: Firewall
     - observer.vendor: Fortinet
     - observer.product: FortiMail
-    - rsa.misc.reference_id1: $~rsa.misc.reference_id1
+    - rsa.misc.reference_id1: $~log.rsa.misc.reference_id1
     - rsa.misc.reference_id: $event.code
     - rsa.misc.msgIdPart1: $event.action
-    - rsa.misc.msgIdPart2: $~rsa.internal.messageid
+    - rsa.misc.msgIdPart2: $~log.rsa.internal.messageid
     - rsa.internal.messageid: $event.action
-    - rsa.internal.messageid: $~rsa.internal.messageid
+    - rsa.internal.messageid: $~log.rsa.internal.messageid
     - rsa.misc.event_type: $event.action
     - rsa.misc.severity: $log.level
-    - rsa.misc.filter: $~rsa.misc.filter
-    - rsa.misc.result: $~rsa.misc.result
+    - rsa.misc.filter: $~log.rsa.misc.filter
+    - rsa.misc.result: $~log.rsa.misc.result
     - rsa.network.domain: $server.domain
-    - rsa.misc.log_session_id: $~rsa.misc.filter
-    - rsa.email.email_src: $~rsa.email.email_src
-    - rsa.misc.client: $~rsa.misc.client
-    - rsa.web.fqdn: $~rsa.web.fqdn
-    - rsa.misc.context: $~rsa.misc.context
-    - rsa.email.email_dst: $~rsa.email.email_dst
-    - rsa.misc.virusname: $~rsa.misc.virusname
-    - rsa.misc.disposition: $~rsa.misc.disposition
-    - rsa.misc.filter: $~rsa.misc.filter
-    - rsa.email.subject: $~rsa.email.subject
-    - rsa.email.subject: $~rsa.misc.event_type
-    - rsa.internal.event_desc: $~rsa.internal.event_desc
-    - rsa.misc.checksum: $~rsa.misc.checksum
+    - rsa.misc.log_session_id: $~log.rsa.misc.filter
+    - rsa.email.email_src: $~log.rsa.email.email_src
+    - rsa.misc.client: $~log.rsa.misc.client
+    - rsa.web.fqdn: $~log.rsa.web.fqdn
+    - rsa.misc.context: $~log.rsa.misc.context
+    - rsa.email.email_dst: $~log.rsa.email.email_dst
+    - rsa.misc.virusname: $~log.rsa.misc.virusname
+    - rsa.misc.disposition: $~log.rsa.misc.disposition
+    - rsa.misc.filter: $~log.rsa.misc.filter
+    - rsa.email.subject: $~log.rsa.email.subject
+    - rsa.email.subject: $~log.rsa.misc.event_type
+    - rsa.internal.event_desc: $~log.rsa.internal.event_desc
+    - rsa.misc.checksum: $~log.rsa.misc.checksum
   - check:
       - rsa.internal.event_desc: +ef_exists
     logpar:
       - rsa.internal.event_desc: >-
-          <~log.fill> to \<\<<~rsa.email.email_dst>>; reason:<~rsa.misc.result>; <~log.fill>
+          <~log.fill> to \<\<<~log.rsa.email.email_dst>>; reason:<~log.rsa.misc.result>; <~log.fill>
       - rsa.internal.event_desc: >-
-          to=\<\<<~rsa.email.email_dst>>, delay=<~log.fill>, xdelay=<~log.fill>, mailer=<network.protocol>,
+          to=\<\<<~log.rsa.email.email_dst>>, delay=<~log.fill>, xdelay=<~log.fill>, mailer=<network.protocol>,
           pri=<~log.fill>, relay=<host.hostname>[<source.ip>], <~log.fill>
       - rsa.internal.event_desc: >-
-          to=\<\<<~rsa.email.email_dst>, delay=<~log.fill>, xdelay=<~log.fill>, mailer=<network.protocol>,
+          to=\<\<<~log.rsa.email.email_dst>, delay=<~log.fill>, xdelay=<~log.fill>, mailer=<network.protocol>,
           pri=<~log.fill>, relay=<host.hostname>
     map:
-      - rsa.misc.result: $~rsa.misc.result
-      - rsa.email.email_dst: $~rsa.email.email_dst
+      - rsa.misc.result: $~log.rsa.misc.result
+      - rsa.email.email_dst: $~log.rsa.email.email_dst
       - rsa.internal.event_desc: +ef_delete
   - check:
       - rsa.web.fqdn: +ef_exists
@@ -188,13 +188,12 @@ normalize:
       - related.ip: +a_append/$source.ip
   - map:
     - related.user: +a_append/$user.name
-    - rsa.misc.event_state: $~rsa.misc.event_state
+    - rsa.misc.event_state: $~log.rsa.misc.event_state
     - rsa.misc.hardware_id: $observer.serial_number
-    - rsa.network.network_service: $~rsa.network.network_service
+    - rsa.network.network_service: $~log.rsa.network.network_service
     - service.type: fortine
     - tags: +a_append/fortinet.fortimail/forwarded
     - /@timestamp: +s_concat/$~log.date/T/$~log.time/.000Z
     - rsa.time.event_time: $/@timestamp
     - ~log: +ef_delete
-    - ~rsa: +ef_delete
 

--- a/src/engine/ruleset/decoders/fortinet/fortimail.yml
+++ b/src/engine/ruleset/decoders/fortinet/fortimail.yml
@@ -1,0 +1,200 @@
+---
+name: decoder/fortinet-fortimail/0
+
+metadata:
+  title: Decoder for Fortinet fortimail
+  description: Decoder for Fortinet fortimail
+  compatibility: >
+    This decoder has been tested on Wazuh version 4.3
+  author:
+    name: Wazuh, Inc.
+    date: 2023/01/09
+  references:
+    - https://docs.fortinet.com
+
+sources:
+  - decoder/queue-localfile/0
+
+parse:
+  logpar:
+    # date=2018-1-27 time=05:21:06 device_id=atcupid log_id=onse log_part=psa type=virus_file-signature pri=high destla to="fugitse" src=[10.12.86.130] session_id=dese msg="Attachment file (duntutla) has sha1 hash value: lamco"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> <~log.fill> to=<~rsa.email.email_dst>
+        src=[<source.ip>] session_id=<~rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~rsa.misc.checksum>"
+    # date=2018-11-9 time=02:12:32 device_id=dolo log_id=velites log_part=oloremi type=virus_file-signature pri=high apari to=tsunt src="caecat [10.108.10.197]" session_id=enim msg="Attachment file (umq) has sha1 hash value: sistena"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> <~log.fill> to=<~rsa.email.email_dst>
+        src="<source.domain> [<source.ip>]" session_id=<~rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~rsa.misc.checksum>"
+    # date=2016-12-23 time=00:09:07 device_id=dolore log_id=onsecte log_part=nBCSedut type=virus subtype=file-signature pri=high from="modocons" to=gitsed src="10.16.177.212" session_id="emp" msg="Attachment file (pisciv) has sha1 hash value: lumdolor"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> from="<~rsa.email.email_src>" to=<~rsa.email.email_dst>
+        src="<source.ip>" session_id="<~rsa.misc.log_session_id>" msg="Attachment file \(<file.name>\) <~log.fill>: <~rsa.misc.checksum>"
+    # date=2019-8-7 time=16:01:23 device_id=sBonoru log_id=everi log_part=squ type=virus subtype=file-signature pri=medium from="utla" to=nse src=10.160.236.78 session_id=nostrude msg="Attachment file (rinc) has sha1 hash value: tno"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> from="<~rsa.email.email_src>" to=<~rsa.email.email_dst>
+        src=<source.ip> session_id=<~rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~rsa.misc.checksum>"
+    # date=2019-11-1 time=10:16:48 device_id=equ log_id=turadip log_part=ataev type=virus_file-signature pri=medium from="oree" to="nimadmi" src="utaliq [10.78.38.143]" session_id=qui msg="Attachment file (epteurs) has sha1 hash value: did"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> from="<~rsa.email.email_src>" to="<~rsa.email.email_dst>" src="<source.domain> [<source.ip>]"
+        session_id=<~rsa.misc.log_session_id> msg="Attachment file \(<file.name>\) <~log.fill>: <~rsa.misc.checksum>"
+    # date=2019-1-19 time=13:25:23 device_id=odit log_id=vol log_part=epteurs type=statistics pri=very-high session_id="cteturad" client_name="modi6930.internal.test[10.60.164.100]"dst_ip="10.161.1.146" from="etconse" to="nproiden" polid="ionem" domain="taevitae6868.www.corp" subject="ehende" mailer="rep" resolved="nostru" direction="internal" virus="ipiscin" disposition="trudexe" classifier="qua" message_length=modit
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> session_id="<~rsa.misc.log_session_id>" client_name="<~rsa.web.fqdn>[<source.ip>]"dst_ip="<destination.ip>"
+        from="<~rsa.email.email_src>" to="<~rsa.email.email_dst>" polid="<~log.fill>" domain="<server.domain>" subject="<~rsa.email.subject>" mailer="<~rsa.misc.client>"
+        resolved="<~rsa.misc.context>" direction="<network.direction>" virus="<~rsa.misc.virusname>" disposition="<~rsa.misc.disposition>" classifier="<~rsa.misc.filter>"
+        message_length=<~log.fill>
+    # date=2019-2-17 time=03:30:32 device_id=quidol log_id=tinv log_part=Utenima type=statistics pri=high session_id=temqu client_name=uradip7802.mail.example client_ip=10.44.35.57 dst_ip=10.93.239.216 from=vento hfrom=litsed to=ciun polid=rehender domain=tetura7106.www5.corp mailer=eosquir resolved=tqu src_type=emips direction=internal virus=tinvolu disposition=ptat classifier=amquisn message_length=Finibus subject=nsequat
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> session_id=<~rsa.misc.log_session_id> client_name=<~rsa.web.fqdn> client_ip=<source.ip>
+        dst_ip=<destination.ip> from=<~rsa.email.email_src> hfrom=<~log.fill> to=<~rsa.email.email_dst> polid=<~log.fill>
+        domain=<server.domain> mailer=<~rsa.misc.client> resolved=<~rsa.misc.context> src_type=<~log.fill> direction=<network.direction>
+        virus=<~rsa.misc.virusname> disposition=<~rsa.misc.disposition> classifier=<~rsa.misc.filter>
+        message_length=<~log.fill> subject=<~rsa.email.subject>
+    # date=2019-11-30 time=00:21:57 device_id=ntutlabo log_id=leumiure log_part=tasnu type=event subtype=smtp pri=high user=amquaui=tionevol(10.209.124.81) action=allowstatus=tobesession_id="ssequa" log_part=emp msg="to=<<emoeni, delay=officiad, xdelay=veniam, mailer=igmp, pri=entoreve, relay=ion3339.www.localdomain"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<~rsa.misc.event_type> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name>ui=<~rsa.network.network_service>(?\(<source.ip>\))
+        action=<event.action>status=<~rsa.misc.event_state>session_id="<~rsa.misc.log_session_id>" log_part=<~log.fill>
+        msg="<~rsa.internal.event_desc>"
+    # date=2018-12-7 time=16:17:40 device_id=econ log_id=aborio log_part=rve type=event subtype=smtp pri=medium user=nbyCiui=runtmollaction=blockstatus=velillumsession_id="ionev" msg="to=<<vitaedi>, delay=rna, xdelay=cons, mailer=ipv6-icmp, pri=lupta, relay=olaboris3175.internal.home[10.250.94.95], dsn=tno, stat=imve"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<~rsa.misc.event_type> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name>ui=<~rsa.network.network_service>(?\(<source.ip>\))action=<event.action>status=<~rsa.misc.event_state>session_id="<~rsa.misc.log_session_id>"
+        msg="<~rsa.internal.event_desc>"
+    # date=2018-11-23 time=09:15:06 device_id=imipsam log_id=eumiu log_part=tatevel type=event subtype=smtp pri=high user=quisnostui=sequines(10.115.154.104) action=cancelstatus=lorumsession_id="suntexpl" msg="DSN: to <<iqu>; reason:success; sessionid:tatis"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<~rsa.misc.event_type> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name>ui=<~rsa.network.network_service>(?\(<source.ip>\))
+        action=<event.action>status=<~rsa.misc.event_state>session_id="<~rsa.misc.filter>" msg="<~rsa.internal.event_desc>"
+    # date=2019-5-28 time=04:48:31 device_id=iade log_id=tae log_part=obe type=event subtype=admin pri=medium user=ulapari ui=rittenby(10.31.31.193) action=deny status=nvol reason=unknown msg="luptatem"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<~rsa.misc.event_type> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~rsa.network.network_service>
+        action=<event.action> status=<~rsa.misc.event_state> reason=<~rsa.misc.result> msg="<~rsa.internal.event_desc>"
+    # date=2016-6-20 time=04:35:42 device_id=idestla log_id=Nemoeni log_part=uradi type=statistics pri=very-high session_id="lup" from="remeumf" mailer=antiumto client_name="10.241.165.37" MSISDN=aUteni resolved=ittenbyC to="aperi" direction="inbound" message_length=ita virus="ipi" disposition=rsitamet classifier="lupt" subject="xea"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> session_id="<~rsa.misc.filter>" from="<~rsa.email.email_src>" mailer=<~rsa.misc.client> client_name="<source.ip>"
+        <~log.fill> resolved=<~rsa.misc.context> to="<~rsa.email.email_dst>" direction="<network.direction>" <~log.fill> virus="<~rsa.misc.virusname>"
+        disposition=<~rsa.misc.disposition> classifier="<~rsa.misc.filter>" subject="<~rsa.email.subject>"
+    # date=2017-10-4 time=21:00:32 device_id=umS log_id=iciadese log_part=riatur type=event subtype=webmail pri=very-high user=xeacommo ui=Cicero(10.247.53.179) action=cancel status=ditau msg=atemaccu
+    # date=2017-12-29 time=15:15:58 device_id=iciade log_id=uis log_part=amc type=event subtype=webmail pri=medium user=Ute ui=ptassita action=allow status=runtm msg="eturadip"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<~rsa.misc.event_type> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~rsa.network.network_service>(?\(<source.ip>\)) action=<event.action>
+        status=<~rsa.misc.event_state> msg=<~rsa.internal.event_desc>(?"<~rsa.internal.event_desc>")
+    # date=2018-3-11 time=02:28:49 device_id=lupta log_id=byC log_part=imadm type=spam pri=low session_id="nci" from="orroquis" to="ulapa" subject="iumdo" msg="iusmodit"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> session_id="<~rsa.misc.filter>" from="<~rsa.email.email_src>" to="<~rsa.email.email_dst>"
+        subject="<~rsa.email.subject>" msg=<~rsa.internal.event_desc>(?"<~rsa.internal.event_desc>")
+    # date=2016-2-12 time=13:12:33 device_id=ehend log_id=ritquiin log_part=umqui type=virus subtype=infected pri=very-high from="mest" to=enderitq client_name="sperna884.internal.domain" client_ip="10.165.201.71" session_id="pisciv" msg="uii"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> from="<~rsa.email.email_src>" to=<~rsa.email.email_dst>
+        client_name="<~rsa.web.fqdn>" client_ip="<source.ip>" session_id="<~rsa.misc.filter>" msg=<~rsa.internal.event_desc>(?"<~rsa.internal.event_desc>")
+    # date=2019-12-14 time=07:24:31 device_id=int log_id=oremagn log_part=rnatur type=virus pri=medium from=uptatev to="oditem" src="10.176.31.145" session_id="ineavo" msg=reseo
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> pri=<log.level> from=<~rsa.email.email_src> to="<~rsa.email.email_dst>" src="<source.ip>"
+        session_id="<~rsa.misc.filter>" msg=<~rsa.internal.event_desc>
+    # date=2017-1-6 time=07:11:41 device_id=uaUten log_id=nby log_part=mve type=event subtype=config pri=low user=isau ui=rautodi(10.96.97.81) module=pis submodule=nsequat msg=doloreme
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~rsa.network.network_service>\(<source.ip>\) module=<~log.fill> submodule=<~log.fill> msg=<~rsa.internal.event_desc>
+    # date=2018-3-25 time=09:31:24 device_id=obeataev log_id=umf log_part=olesti type=event subtype=config pri=low user=quaeabil ui=emip module=aturQu submodule=itesse msg="iamqui"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> user=<user.name> ui=<~rsa.network.network_service> module=<~log.fill> submodule=<~log.fill> msg="<~rsa.internal.event_desc>"
+    # date=2016-6-5 time=21:33:08 device_id=ntutl log_id=caecatc log_part=onsequat type=event subtype=update pri=low msg="edquiano"
+    - event.original: >-
+        date=<~log.date> time=<~log.time> device_id=<observer.serial_number> log_id=<event.code> log_part=<~rsa.misc.reference_id1>
+        type=<event.action> subtype=<~rsa.internal.messageid> pri=<log.level> msg="<~rsa.internal.event_desc>"
+
+normalize:
+  - map:
+    - event.dataset: fortinet.fortimail
+    - event.module": fortinet
+    - fileset.name": fortimail
+    - input.type": log
+    - observer.type: Firewall
+    - observer.vendor: Fortinet
+    - observer.product: FortiMail
+    - rsa.misc.reference_id1: $~rsa.misc.reference_id1
+    - rsa.misc.reference_id: $event.code
+    - rsa.misc.msgIdPart1: $event.action
+    - rsa.misc.msgIdPart2: $~rsa.internal.messageid
+    - rsa.internal.messageid: $event.action
+    - rsa.internal.messageid: $~rsa.internal.messageid
+    - rsa.misc.event_type: $event.action
+    - rsa.misc.severity: $log.level
+    - rsa.misc.filter: $~rsa.misc.filter
+    - rsa.misc.result: $~rsa.misc.result
+    - rsa.network.domain: $server.domain
+    - rsa.misc.log_session_id: $~rsa.misc.filter
+    - rsa.email.email_src: $~rsa.email.email_src
+    - rsa.misc.client: $~rsa.misc.client
+    - rsa.web.fqdn: $~rsa.web.fqdn
+    - rsa.misc.context: $~rsa.misc.context
+    - rsa.email.email_dst: $~rsa.email.email_dst
+    - rsa.misc.virusname: $~rsa.misc.virusname
+    - rsa.misc.disposition: $~rsa.misc.disposition
+    - rsa.misc.filter: $~rsa.misc.filter
+    - rsa.email.subject: $~rsa.email.subject
+    - rsa.email.subject: $~rsa.misc.event_type
+    - rsa.internal.event_desc: $~rsa.internal.event_desc
+    - rsa.misc.checksum: $~rsa.misc.checksum
+  - check:
+      - rsa.internal.event_desc: +ef_exists
+    logpar:
+      - rsa.internal.event_desc: >-
+          <~log.fill> to \<\<<~rsa.email.email_dst>>; reason:<~rsa.misc.result>; <~log.fill>
+      - rsa.internal.event_desc: >-
+          to=\<\<<~rsa.email.email_dst>>, delay=<~log.fill>, xdelay=<~log.fill>, mailer=<network.protocol>,
+          pri=<~log.fill>, relay=<host.hostname>[<source.ip>], <~log.fill>
+      - rsa.internal.event_desc: >-
+          to=\<\<<~rsa.email.email_dst>, delay=<~log.fill>, xdelay=<~log.fill>, mailer=<network.protocol>,
+          pri=<~log.fill>, relay=<host.hostname>
+    map:
+      - rsa.misc.result: $~rsa.misc.result
+      - rsa.email.email_dst: $~rsa.email.email_dst
+      - rsa.internal.event_desc: +ef_delete
+  - check:
+      - rsa.web.fqdn: +ef_exists
+    map:
+      - related.hosts: +a_append/$rsa.web.fqdn
+  - check:
+      - host.hostname: +ef_exists
+    map:
+      - related.hosts: +a_append/$host.hostname
+  - check:
+      - server.domain: +ef_exists
+    map:
+      - related.hosts: +a_append/$server.domain
+  - check:
+      - destination.ip: +ef_exists
+    map:
+      - related.ip: +a_append/$destination.ip
+  - check:
+      - source.ip: +ef_exists
+    map:
+      - related.ip: +a_append/$source.ip
+  - map:
+    - related.user: +a_append/$user.name
+    - rsa.misc.event_state: $~rsa.misc.event_state
+    - rsa.misc.hardware_id: $observer.serial_number
+    - rsa.network.network_service: $~rsa.network.network_service
+    - service.type: fortine
+    - tags: +a_append/fortinet.fortimail/forwarded
+    - /@timestamp: +s_concat/$~log.date/T/$~log.time/.000Z
+    - rsa.time.event_time: $/@timestamp
+    - ~log: +ef_delete
+    - ~rsa: +ef_delete
+

--- a/src/engine/ruleset/environments/wazuh-environment.yml
+++ b/src/engine/ruleset/environments/wazuh-environment.yml
@@ -63,6 +63,7 @@ decoders:
   # Fortinet
   - decoder/fortinet-client-endpoint/0
   - decoder/fortinet-firewall/0
+  - decoder/fortinet-fortimail/0
   - decoder/fortinet-fortimanager/0
 
 outputs:


### PR DESCRIPTION
|Related issue|
|---|
|#15850 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

With the aim of expanding the coverage of the decoders, this PR adds a decoder for Fortinet/Fortimail.

## Configuration options

Validate the new decoder:
- ./build/main catalog validate decoder/fortinet-fortimail/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/fortinet/fortimail.yml

Create decoder:
- ./build/main  catalog create decoder < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/fortinet/fortimail.yml

Update environment
- ./build/main catalog update environment/wazuh/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/environments/wazuh-environment.yml

Test new decoder
- ./build/main test -q 1

## Logs/Alerts example

- date=2019-2-17 time=03:30:32 device_id=quidol log_id=tinv log_part=Utenima type=statistics pri=high session_id=temqu client_name=uradip7802.mail.example client_ip=10.44.35.57 dst_ip=10.93.239.216 from=vento hfrom=litsed to=ciun polid=rehender domain=tetura7106.www5.corp mailer=eosquir resolved=tqu src_type=emips direction=internal virus=tinvolu disposition=ptat classifier=amquisn message_length=Finibus subject=nsequat
- date=2018-12-7 time=16:17:40 device_id=econ log_id=aborio log_part=rve type=event subtype=smtp pri=medium user=nbyCiui=runtmollaction=blockstatus=velillumsession_id="ionev" msg="to=<<vitaedi>, delay=rna, xdelay=cons, mailer=ipv6-icmp, pri=lupta, relay=olaboris3175.internal.home[10.250.94.95], dsn=tno, stat=imve"
## Tests

Event:
- date=2018-12-7 time=16:17:40 device_id=econ log_id=aborio log_part=rve type=event subtype=smtp pri=medium user=nbyCiui=runtmollaction=blockstatus=velillumsession_id="ionev" msg="to=<<vitaedi>, delay=rna, xdelay=cons, mailer=ipv6-icmp, pri=lupta, relay=olaboris3175.internal.home[10.250.94.95], dsn=tno, stat=imve"

Output:
```

{
    "wazuh": {
        "queue": 49,
        "origin": "/dev/stdin"
    },
    "event": {
        "original": "date=2018-12-7 time=16:17:40 device_id=econ log_id=aborio log_part=rve type=event subtype=smtp pri=medium user=nbyCiui=runtmollaction=blockstatus=velillumsession_id=\"ionev\" msg=\"to=<<vitaedi>, delay=rna, xdelay=cons, mailer=ipv6-icmp, pri=lupta, relay=olaboris3175.internal.home[10.250.94.95], dsn=tno, stat=imve\"",
        "code": "aborio",
        "action": "block",
        "dataset": "fortinet.fortimail",
        "module\"": "fortinet"
    },
    "observer": {
        "serial_number": "econ",
        "type": "Firewall",
        "vendor": "Fortinet",
        "product": "FortiMail"
    },
    "log": {
        "level": "medium"
    },
    "user": {
        "name": "nbyCi"
    },
    "fileset": {
        "name\"": "fortimail"
    },
    "input": {
        "type\"": "log"
    },
    "rsa": {
        "misc": {
            "reference_id1": "rve",
            "reference_id": "aborio",
            "msgIdPart1": "block",
            "msgIdPart2": "smtp",
            "event_type": "block",
            "severity": "medium",
            "event_state": "velillum",
            "hardware_id": "econ"
        },
        "internal": {
            "messageid": "smtp"
        },
        "email": {
            "subject": "event",
            "email_dst": "vitaedi"
        },
        "network": {
            "network_service": "runtmoll"
        },
        "time": {
            "event_time": "2018-12-7T16:17:40.000Z"
        }
    },
    "network": {
        "protocol": "ipv6-icmp"
    },
    "host": {
        "hostname": "olaboris3175.internal.home"
    },
    "source": {
        "ip": "10.250.94.95"
    },
    "related": {
        "hosts": [
            "olaboris3175.internal.home"
        ],
        "ip": [
            "10.250.94.95"
        ],
        "user": [
            "nbyCi"
        ]
    },
    "service": {
        "type": "fortine"
    },
    "tags": [
        "fortinet.fortimail",
        "forwarded"
    ],
    "/@timestamp": "2018-12-7T16:17:40.000Z"
}

```