### PR TITLE
Engine - Implementation Sophos/Wifi decoder

### DIFF
--- a/src/engine/ruleset/decoders/sophos/wifi.yml
+++ b/src/engine/ruleset/decoders/sophos/wifi.yml
@@ -1,0 +1,90 @@
+---
+name: decoder/sophos-wifi/0
+
+metadata:
+  module: sophos
+  title: Sophos logs decoder
+  description: Decoder for sophos logs
+  author:
+    name: Wazuh Inc. info@wazuh.com
+    date: 2023-01-12
+  references:
+    - documentation link
+
+check:
+  - event.original: +r_match/<\d+>\s*device=.*?date=.*?time
+
+sources:
+  - decoder/queue-syslog/0
+  - decoder/queue-localfile/0
+
+parse:
+  logpar:
+    # <30>device="SFW" date=2017-02-01 time=14:17:35 timezone="IST" device_name="SG115" device_id=S110016E28BA631 log_id=106025618011 log_type="Wireless Protection" log_component="Wireless Protection" log_subtype="Information" priority=Information ap=A40024A636F7862 ssid=SPIDIGO2015 clients_conn_SSID=2
+    # <30>device="SFW" date=2017-02-01 time=14:19:47 timezone="IST" device_name="SG115" device_id=S110016E28BA631 log_id=106025618011 log_type="Wireless Protection" log_component="Wireless Protection" log_subtype="Information" priority=Information ap=A40024A636F7862 ssid=SPIDIGO2015 clients_conn_SSID=3
+    - event.original: \<<~log.head_message>><~log.payload_messge>
+
+normalize:
+  - check:
+      - ~log.payload_messge: +ef_exists
+    logpar:
+      - ~log.payload_messge: <~tmp/kv/=/ /"/'>
+    map:
+      - event.kind: event
+      - event.module: sophos
+      - event.dataset: sophos.xg
+      - event.outcome: success
+  - check:
+      - ~tmp.priority: unknown
+    map:
+      - event.severity: 0
+  - check:
+      - ~tmp.priority: alert
+    map:
+      - event.severity: 1
+  - check:
+      - ~tmp.priority: critical
+    map:
+      - event.severity: 2
+  - check:
+      - ~tmp.priority: error
+    map:
+      - event.severity: 3
+  - check:
+      - ~tmp.priority: warning
+    map:
+      - event.severity: 4
+  - check:
+      - ~tmp.priority: notification
+    map:
+      - event.severity: 5
+  - check:
+      - ~tmp.priority: Information
+    map:
+      - event.severity: 6
+  - map:
+      # TODO: need converter timezone abbrevation to UTC offset, for example 'IST' to -02:00
+      - event.timezone: $~tmp.timezone
+      - fileset.name: xg
+      - host.name: firewall.localgroup.local
+      - input.type: log
+      - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time
+      - log.level: $~tmp.log_subtype
+      - observer.product: XG
+      - observer.serial_number: $~tmp.device_id
+      - observer.type: firewall
+      - observer.vendor: Sophos
+      - sophos.xg.log_id: $~tmp.log_id
+      - sophos.xg.device_name: $~tmp.device_name
+      - sophos.xg.log_type: $~tmp.log_type
+      - sophos.xg.log_component: $~tmp.log_type
+      - sophos.xg.log_subtype: $~tmp.log_subtype
+      - sophos.xg.priority: $~tmp.log_subtype
+      - sophos.xg.ap: $~tmp.ap
+      - sophos.xg.ssid: $~tmp.ssid
+      - related.host: [$host.name]
+      - tags: [forwarded, preserve_original_even, sophos-xg]
+      - ~log: +ef_delete
+      - ~tmp: +ef_delete
+
+

--- a/src/engine/ruleset/decoders/sophos/wifi.yml
+++ b/src/engine/ruleset/decoders/sophos/wifi.yml
@@ -12,7 +12,7 @@ metadata:
     - documentation link
 
 check:
-  - event.original: +r_match/<\d+>\s*device=.*?date=.*?time
+  - event.original: +r_match/<\d+>\s*device=.*?date=.*?time=.*?device_name=.*?device_id=.*?log_id=.*?log_type="Wireless Protection"
 
 sources:
   - decoder/queue-syslog/0

--- a/src/engine/ruleset/environments/wazuh-environment.yml
+++ b/src/engine/ruleset/environments/wazuh-environment.yml
@@ -21,6 +21,7 @@ decoders:
   - decoder/rootcheck/0
   - decoder/sca/0
   - decoder/sophos-utm/0
+  - decoder/sophos-wifi/0
   - decoder/syscollector-base/0
   - decoder/syscollector-dbsync-network-protocol/0
   - decoder/syscollector-dbsync-osinfo/0


### PR DESCRIPTION
|Related issue|
|---|
|#15851|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

With the aim of expanding the coverage of the decoders, this PR adds a decoder for Sophos/Wifi.

## Configuration options

Validate the new decoder:
- ./build/main catalog validate decoder/sophos-wifi/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/wifi.yml

Create decoder:
- ./build/main  catalog create decoder < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/wifi.yml

Update environment
- ./build/main catalog update environment/wazuh/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/environments/wazuh-environment.yml

Test new decoder
- ./build/main test -q 1

## Logs/Alerts example

- <30>device="SFW" date=2017-02-01 time=14:17:35 timezone="IST" device_name="SG115" device_id=S110016E28BA631 log_id=106025618011 log_type="Wireless Protection" log_component="Wireless Protection" log_subtype="Information" priority=Information ap=A40024A636F7862 ssid=SPIDIGO2015 clients_conn_SSID=2

## Tests

Event:
- <30>device="SFW" date=2017-02-01 time=14:17:35 timezone="IST" device_name="SG115" device_id=S110016E28BA631 log_id=106025618011 log_type="Wireless Protection" log_component="Wireless Protection" log_subtype="Information" priority=Information ap=A40024A636F7862 ssid=SPIDIGO2015 clients_conn_SSID=2


Output:
```
{
    "wazuh": {
        "queue": 49,
        "origin": "/dev/stdin"
    },
    "event": {
        "original": "<30>device=\"SFW\" date=2017-02-01 time=14:17:35 timezone=\"IST\" device_name=\"SG115\" device_id=S110016E28BA631 log_id=106025618011 log_type=\"Wireless Protection\" log_component=\"Wireless Protection\" log_subtype=\"Information\" priority=Information ap=A40024A636F7862 ssid=SPIDIGO2015 clients_conn_SSID=2",
        "kind": "event",
        "module": "sophos",
        "dataset": "sophos.xg",
        "outcome": "success",
        "timezone": "-02:00"
    },
    "fileset": {
        "name": "xg"
    },
    "host": {
        "name": "firewall.localgroup.local"
    },
    "input": {
        "type\"": "log"
    },
    "\\@timestamp": "2017-02-01T14:17:35.000-02:00",
    "log": {
        "level": "Information"
    },
    "observer": {
        "product": "XG",
        "serial_number": "S110016E28BA631",
        "type": "firewall",
        "vendor": "Sophos,"
    },
    "sophos": {
        "xg": {
            "log_id": 106025618011,
            "device_name": "SG115",
            "log_type": "Wireless Protection",
            "log_component": "Wireless Protection",
            "log_subtype": "Information",
            "priority": "Information",
            "ap": "A40024A636F7862",
            "ssid": "SPIDIGO2015"
        }
    },
    "related": {
        "host": [
            "firewall.localgroup.local"
        ]
    },
    "tags": [
        "forwarded",
        "preserve_original_even",
        "sophos-xg"
    ]
}

```