### PR TITLE
Unnecessary sanity check removed on wdb_syscollector_save2 function

### DIFF
--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -1359,9 +1359,6 @@ int wdb_syscollector_save2(wdb_t * wdb, wdb_component_t component, const char * 
     {
         result = wdb_syscollector_osinfo_save2(wdb, attributes);
     }
-    if(data)
-    {
-        cJSON_Delete(data);
-    }
+    cJSON_Delete(data);
     return result;
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10380  |

## Description

With the aim of improve code quality, an unnecessary sanity check was removed.