### PR TITLE
Include workaround for the Streams library bug in `Agent-groups send full` task

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -163,6 +163,7 @@ def test_sst_init(setup_coro_mock, create_task_mock):
     with patch.object(TaskMock, "add_done_callback") as done_callback_mock:
         sst_task = cluster_common.SendStringTask(wazuh_common=cluster_common.WazuhCommon(), logger='')
         assert sst_task.logger == ''
+        assert sst_task.task in sst_task.tasks_hard_reference
         assert isinstance(sst_task.wazuh_common, cluster_common.WazuhCommon)
         setup_coro_mock.assert_called_once()
         done_callback_mock.assert_called_once()
@@ -200,8 +201,10 @@ def test_sst_done_callback(setup_coro_mock, create_task_mock):
         logger = logging.getLogger('wazuh')
         with patch.object(logger, "error") as logger_mock:
             sst_task = cluster_common.SendStringTask(wazuh_common=wazuh_common_mock, logger=logger)
+            assert sst_task.task in sst_task.tasks_hard_reference
             sst_task.done_callback()
             logger_mock.assert_called_once_with(Exception)
+            assert sst_task.task not in sst_task.tasks_hard_reference
 
 
 # Test ReceiveStringTask methods


### PR DESCRIPTION
|Related issue|
|---|
| Closes #15958 |

## Description

The library [streams](https://docs.python.org/3/library/asyncio-stream.html) used in the Wazuh cluster for async communication with wazuh-db socket (https://github.com/wazuh/wazuh/pull/14843) has a bug that was reported and fixed here:
- https://github.com/python/cpython/issues/90467

The fix seems to be available starting with Python 3.10.8, but since Python 3.9.9 is still used in Wazuh 4.4.0, a temporary workaround needs to be applied. It consists of creating a reference to the task where the StreamReaderProtocol is located so that it is not removed by the garbage collector.

## Logs/Alerts example

Until now, if the master simultaneously started multiple tasks (worker1, worker2 and worker3) to read from wazuh-db, this error would appear and only one of them would be completed (worker2 in this case):
```
2023/01/25 11:29:14 INFO: [Master] [Local agent-groups] Finished in 0.022s.
2023/01/25 11:29:14 INFO: [Worker worker1] [Agent-groups send] Starting.
2023/01/25 11:29:14 INFO: [Worker worker2] [Agent-groups send] Starting.
2023/01/25 11:29:14 INFO: [Worker worker1] [Agent-groups send] Finished in 0.019s. Updated 1 chunks.
2023/01/25 11:29:14 INFO: [Worker worker2] [Agent-groups send] Finished in 0.018s. Updated 1 chunks.
2023/01/25 11:29:14 INFO: [Worker worker3] [Agent-groups send] Starting.
2023/01/25 11:29:14 INFO: [Worker worker3] [Agent-groups send] Finished in 0.014s. Updated 1 chunks.
Unhandled error in exception handler
context: {'message': 'Task was destroyed but it is pending!', 'task': <Task pending name='Task-31' coro=<MasterHandler.send_entire_agent_groups_information() done, defined at /var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.4.0-py3.9.egg/wazuh/core/cluster/master.py:682> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7f6eba268490>()]> cb=[SendStringTask.done_callback()]>}
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/asyncio/base_events.py", line 1775, in call_exception_handler
    self._exception_handler(self, context)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.4.0-py3.9.egg/wazuh/core/cluster/common.py", line 1579, in asyncio_exception_handler
    logging.error(f"Unhandled exception: {context['exception']} {context['message']}\n"
KeyError: 'exception'
Unhandled error in exception handler
context: {'message': 'Task was destroyed but it is pending!', 'task': <Task pending name='Task-32' coro=<MasterHandler.send_entire_agent_groups_information() done, defined at /var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.4.0-py3.9.egg/wazuh/core/cluster/master.py:682> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7f6eba268460>()]> cb=[SendStringTask.done_callback()]>}
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/asyncio/base_events.py", line 1775, in call_exception_handler
    self._exception_handler(self, context)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.4.0-py3.9.egg/wazuh/core/cluster/common.py", line 1579, in asyncio_exception_handler
    logging.error(f"Unhandled exception: {context['exception']} {context['message']}\n"
KeyError: 'exception'
2023/01/25 11:29:15 INFO: [Worker worker2] [Agent-groups send full] Requested entire agent-groups information by the worker node. Starting.
2023/01/25 11:29:15 INFO: [Worker worker2] [Agent-groups send full] Sending all agent-groups information from the master node database.
2023/01/25 11:29:17 INFO: [Master] [Local integrity] Starting.
2023/01/25 11:29:17 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 39 files.
```

Now, the three tasks are successfully completed:
```
2023/01/25 13:58:03 INFO: [Master] [Local agent-groups] Finished in 0.021s.
2023/01/25 13:58:03 INFO: [Worker worker2] [Agent-groups send] Starting.
2023/01/25 13:58:03 INFO: [Worker worker1] [Agent-groups send] Starting.
2023/01/25 13:58:03 INFO: [Worker worker3] [Agent-groups send] Starting.
2023/01/25 13:58:03 INFO: [Worker worker1] [Agent-groups send] Finished in 0.016s. Updated 1 chunks.
2023/01/25 13:58:03 INFO: [Worker worker2] [Agent-groups send] Finished in 0.019s. Updated 1 chunks.
2023/01/25 13:58:04 INFO: [Worker worker3] [Agent-groups send] Finished in 0.016s. Updated 1 chunks.
2023/01/25 13:58:05 INFO: [Worker worker3] [Agent-groups send full] Requested entire agent-groups information by the worker node. Starting.
2023/01/25 13:58:05 INFO: [Worker worker3] [Agent-groups send full] Sending all agent-groups information from the master node database.
2023/01/25 13:58:05 INFO: [Worker worker1] [Agent-groups send full] Requested entire agent-groups information by the worker node. Starting.
2023/01/25 13:58:05 INFO: [Worker worker1] [Agent-groups send full] Sending all agent-groups information from the master node database.
2023/01/25 13:58:05 INFO: [Worker worker2] [Agent-groups send full] Requested entire agent-groups information by the worker node. Starting.
2023/01/25 13:58:05 INFO: [Worker worker2] [Agent-groups send full] Sending all agent-groups information from the master node database.
2023/01/25 13:58:06 INFO: [Master] [Local integrity] Starting.
2023/01/25 13:58:06 INFO: [Master] [Local integrity] Finished in 0.004s. Calculated metadata of 39 files.
```

## Tests
```
$ python3 -m pytest framework/ -x
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1, aiohttp-1.0.4, cov-4.0.0
asyncio: mode=auto
collected 2051 items                                                                                                                                                                                        

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                                                                         [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                                                                [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                 [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                                [  7%]
framework/wazuh/core/cluster/tests/test_common.py .............................................................................                                                                       [ 10%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                                             [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                 [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                      [ 13%]
framework/wazuh/core/cluster/tests/test_master.py .................................................                                                                                                   [ 15%]
framework/wazuh/core/cluster/tests/test_server.py ...................                                                                                                                                 [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                          [ 16%]
framework/wazuh/core/cluster/tests/test_worker.py .....................................                                                                                                               [ 18%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [ 19%]
framework/wazuh/core/tests/test_agent.py ................................................................................................................................................             [ 26%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 28%]
framework/wazuh/core/tests/test_common.py .......                                                                                                                                                     [ 28%]
framework/wazuh/core/tests/test_configuration.py ......................................................................                                                                               [ 31%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 32%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 33%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 33%]
framework/wazuh/core/tests/test_manager.py ...............                                                                                                                                            [ 34%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 35%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 35%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 37%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 39%]
framework/wazuh/core/tests/test_sca.py ........................                                                                                                                                       [ 40%]
framework/wazuh/core/tests/test_security.py ............                                                                                                                                              [ 40%]
framework/wazuh/core/tests/test_stats.py .................                                                                                                                                            [ 41%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 42%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 42%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 50%]
.....................................................................................                                                                                                                 [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                                                [ 57%]
framework/wazuh/core/tests/test_wlogging.py .........                                                                                                                                                 [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 58%]
framework/wazuh/rbac/tests/test_decorators.py .........................................................................................................                                               [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py ........................................................                                                                                     [ 66%]
framework/wazuh/rbac/tests/test_orm.py ......................................................                                                                                                         [ 68%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 69%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [ 69%]
framework/wazuh/tests/test_agent.py ......................................................................................................................                                            [ 75%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 79%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 80%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 82%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 82%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 84%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 84%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 87%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                           [ 90%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                         [ 90%]
framework/wazuh/tests/test_security.py .........................................................................                                                                                      [ 94%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                   [ 94%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                     [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................................                                                                                                                  [100%]

============================================================================================= warnings summary ==============================================================================================
../../venv/3.9-unittest-env/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

../../venv/3.9-unittest-env/lib/python3.9/site-packages/jsonschema/compat.py:6
../../venv/3.9-unittest-env/lib/python3.9/site-packages/jsonschema/compat.py:6
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import MutableMapping, Sequence  # noqa

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:48
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:48: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def problems_middleware(request, handler):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:169
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:169: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_json(self, request):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:177
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:177: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_yaml(self, request):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:236
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:236: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_home(self, req):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:246
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:246: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_config(self, req):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:295
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:295: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_request(cls, req):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:324
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:324: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_response(cls, response, mimetype=None, request=None):

framework/wazuh/core/cluster/tests/test_local_client.py:7
  /home/selu/Git/wazuh/framework/wazuh/core/cluster/tests/test_local_client.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import Callable

scripts/tests/test_agent_groups.py::test_show_groups
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:42: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls([call(func=agent.get_agent_groups, kwargs={}),

scripts/tests/test_agent_groups.py::test_show_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:69: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.get_agents, f_kwargs={'agent_list': agent_id}))

scripts/tests/test_agent_groups.py::test_show_synced_agent
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:98: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.get_agents_sync_group, f_kwargs={'agent_list': [agent_id]}))

scripts/tests/test_agent_groups.py::test_show_agents_with_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:125: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.get_agents_in_group, f_kwargs={'group_list': 'testing'}))

scripts/tests/test_agent_groups.py::test_show_group_files
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:152: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.get_group_files, f_kwargs={'group_list': 'testing'}))

scripts/tests/test_agent_groups.py::test_unset_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:181: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.remove_agent_from_groups,

scripts/tests/test_agent_groups.py::test_remove_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:217: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.delete_groups, f_kwargs={'group_list': ['testing']}))

scripts/tests/test_agent_groups.py::test_set_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:252: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.assign_agents_to_group,

scripts/tests/test_agent_groups.py::test_create_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:291: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.create_group, f_kwargs={'group_id': group_id}))

scripts/tests/test_cluster_control.py::test_main
  /usr/lib/python3.9/unittest/mock.py:328: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    self.__dict__[_the_name] = value

wazuh/core/cluster/tests/test_client.py::test_ac_client_echo_ok
  /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'Handler.send_request' was never awaited
    self.name = name

wazuh/core/cluster/tests/test_common.py::test_response_init
  /home/selu/Git/wazuh/framework/wazuh/core/cluster/tests/test_common.py:66: DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
    event = asyncio.Event(loop=loop)

wazuh/core/cluster/tests/test_common.py::test_response_read
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/_pytest/fixtures.py:1675: RuntimeWarning: coroutine 'test_run_in_pool.<locals>.LoopMock.run_in_executor' was never awaited
    fixturedefs = self._arg2fixturedefs[argname]

wazuh/core/cluster/tests/test_common.py::test_handler_update_chunks_wdb
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'Response.read' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_local_client.py::test_localclient_send_api_request_ko
wazuh/core/cluster/tests/test_master.py::test_rit_init
wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_integrity
wazuh/core/tests/test_configuration.py::test_get_active_configuration[001-logcollector-remote-sockets-ok {"logcollector": {"enabled": "yes"}}]
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_process_request
  /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'test_LocalServerHandler_get_send_file_response.<locals>.func_mock' was never awaited
    self.name = name

wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_process_request
  /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    self.name = name

wazuh/core/cluster/tests/test_master.py::test_master_handler_execute_ok
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/pytest_asyncio/plugin.py:375: RuntimeWarning: coroutine 'test_LocalServerHandlerMaster_send_file_request.<locals>.func_mock' was never awaited
    old_loop.close()

wazuh/core/cluster/tests/test_master.py::test_master_handler_hello_ok
wazuh/core/cluster/tests/test_master.py::test_master_handler_process_sync_error_from_worker
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'Event.wait' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_master.py::test_master_handler_process_dapi_res_ko
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'Handler.forward_dapi_response' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_worker_files_ko
  /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'test_master_handler_sync_worker_files_ko.<locals>.EventMock.wait' was never awaited
    self.name = name

wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_integrity_ok
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'test_master_handler_sync_worker_files_ok.<locals>.EventMock.wait' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_integrity_ok
  /usr/lib/python3.9/unittest/mock.py:328: RuntimeWarning: coroutine 'test_master_handler_sync_integrity_ok.<locals>.EventMock.wait' was never awaited
    self.__dict__[_the_name] = value

wazuh/core/cluster/tests/test_master.py::test_master_handler_process_files_from_worker_ok
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'test_master_handler_sync_integrity_ko.<locals>.EventMock.wait' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_master.py::test_agent_groups_update
  /usr/lib/python3.9/_weakrefset.py:49: RuntimeWarning: coroutine 'test_master_handler_sync_integrity_ko.<locals>.EventMock.wait' was never awaited
    self._iterating = set()

wazuh/core/cluster/tests/test_server.py::test_AbstractServer_start
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'MasterHandler.send_agent_groups_information' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_server.py::test_AbstractServer_start
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'test_master_handler_sync_integrity_ok.<locals>.EventMock.wait' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_worker.py::test_sync_files_sync_ok
  /usr/lib/python3.9/unittest/mock.py:491: RuntimeWarning: coroutine 'WorkerHandler.process_files_from_master' was never awaited
    for attr in dir(spec):

wazuh/core/tests/test_configuration.py::test_get_active_configuration[001-logcollector-remote-sockets-ok {"logcollector": {"enabled": "yes"}}]
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'AbstractServer.check_clients_keepalive' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/rbac/tests/test_auth_context.py::test_auth_roles
  /home/selu/Git/wazuh/framework/wazuh/rbac/auth_context.py:177: FutureWarning: Possible nested set at position 2
    regex = re.compile(regex)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================== 2051 passed, 45 warnings in 331.05s (0:05:31) ===============================================================================
```