### PR TITLE
Engine - Implementation Sophos/Waf decoder

### DIFF
--- a/src/engine/ruleset/decoders/sophos/waf.yml
+++ b/src/engine/ruleset/decoders/sophos/waf.yml
@@ -1,0 +1,82 @@
+---
+name: decoder/sophos-waf/0
+
+metadata:
+  module: sophos
+  title: Sophos logs decoder
+  description: Decoder for sophos logs
+  author:
+    name: Wazuh Inc. info@wazuh.com
+    date: 2023-01-12
+  references:
+    - documentation link
+
+sources:
+  - decoder/queue-syslog/0
+  - decoder/queue-localfile/0
+
+parse:
+  logpar:
+    # <30>device="SFW" date=2020-05-18 time=14:38:46 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=075000617071 log_type="WAF" log_component="Web Application Firewall" priority=Information user_name="-" server=webmail.elasticuser.com sourceip=216.160.83.61 localip=185.8.209.207 ws_protocol="HTTP/1.1" url=/mapi/nspi/ querystring=?MailboxId=642ea57c-90ab-4571-8e05-c6997b2256f8@elastic.user.com cookie="MapiContext=MAPIAAAAAPaw98Xx0uDQ4tL/z/rX59b2x/LI+8z2x/+lhrKGtIO7jbmBsxYNAAAAAAAA;MapiRouting=UlVNOjdmNWY0OGE3LTM5OWItNDc4Yi04ZDgwLWFmZTRmMzAyZTViMDoAitM4bv3XCA==;MapiSequence=10-GtgsIA==;X-BackEndCookie=642ea57c-90ab-4571-8e05-c6997b2256f8=u56Lnp2ejJqByZrHyZ7Mys7Sm8zJnNLLnM3J0sbJxsvSnZzIxs2ans+ezMrLgYHNz83P0s/J0s3Pq87Pxc7PxcrL" referer=- method=POST httpstatus=401 reason="-" extra="-" contenttype="-" useragent="Microsoft Office/16.0 (Windows NT 10.0; Microsoft Outlook 16.0.4954; Pro)" host=216.160.83.61 responsetime=11199 bytessent=5669 bytesrcv=1419 fw_rule_id=79
+    # <30>device="SFW" date=2020-05-18 time=14:38:47 timezone="CEST" device_name="XG230" device_id=1234567890123457 log_id=075000617071 log_type="WAF" log_component="Web Application Firewall" priority=Information user_name="-" server=webmail.elasticuser.com sourceip=216.160.83.61 localip=185.8.209.207 ws_protocol="HTTP/1.1"
+    # <30>device="SFW" date=2020-05-19 time=17:20:29 timezone="IST" device_name="XG230" device_id=1234567890123457 log_id=075000617071 log_type="WAF" log_component="Web Application Firewall" priority=Information user_name="jsmith" server=www.iviewtest.com:8989 sourceip=10.198.235.254 localip=10.198.233.48 ws_protocol="HTTP/1.1" url=/ querystring= cookie="-" referer=- method=GET httpstatus=403 reason="Static URL Hardening" extra="No signature found" contenttype="text/html" useragent="Mozilla/5.0 (Windows NT 6.1; WOW64; rv:50.0) Gecko/20100101 Firefox/50.0" host=10.198.235.254 responsetime=19310 bytessent=726 bytesrcv=510 fw_rule_id=3
+    # <30>device="SFW" date=2020-05-19 time=18:03:30 timezone="IST" device_name="XG230" device_id=1234567890123456 log_id=075000617071 log_type="WAF" log_component="Web Application Firewall" priority=Information user_name="jsmith" server=www.iviewtest.com:8990 sourceip=10.198.235.254 localip=10.198.233.48 ws_protocol="HTTP/1.1" url=/download/eicarcom2.zip querystring= cookie="; PHPSESSID=jetkd9iadd969hsr77jpj4q974; _pk_id.1.fc3a=3a6250e215194a92.1485866024.1.1485866069.1485866024.; _pk_ses.1.fc3a=*" referer=http://www.iviewtest.com:8990/85-0-Download.html method=GET httpstatus=403 reason="Antivirus" extra="EICAR-AV-Test" contenttype="text/html" useragent="Mozilla/5.0 (Windows NT 6.1; WOW64; rv:50.0) Gecko/20100101 Firefox/50.0" host=10.198.235.254 responsetime=403214 bytessent=739 bytesrcv=715 fw_rule_id=6
+    # <30>device="SFW" date=2020-05-20 time=18:03:31 timezone="IST" device_name="XG230" device_id=1234567890123457 log_id=075000617071 log_type="WAF" log_component="Web Application Firewall" priority=Information user_name="-" server=- sourceip=89.160.20.112 localip=216.167.51.72 ws_protocol="HTTP/1.0" url=/ querystring="" cookie="-" referer="-" method=GET httpstatus=403 reason="WAF Anomaly" extra="Inbound Anomaly Score Exceeded (Total Score: 7, SQLi=, XSS=): Last Matched Message: Request Missing a User Agent Header" contenttype="text/html" useragent="-" host=89.160.20.112 responsetime=608 bytessent=5353 bytesrcv=295 fw_rule_id=3
+    - event.original: \<<~log.head_message>><~log.payload_message>
+
+normalize:
+  - check:
+      - ~log.payload_message: +ef_exists
+    logpar:
+      - ~log.payload_message: <~tmp/kv/=/ /"/'>
+    map:
+      - event.action: denied
+      - event.code: $~tmp.log_id
+      - event.dataset: sophos.xg
+      - event.duration: +s_concat/$~tmp.responsetime/000
+      - event.kind: alert
+      - event.module: sophos
+      - event.severity: 6
+      - event.timezone: -02:00
+      - event.type: [connection, denied]
+      - destination.bytes: $~tmp.httpstatus
+      - destination.ip: $~tmp.localip
+      - fileset.name: xg
+      - http.request.method: $~tmp.method
+      - http.version: $~tmp.ws_protocol
+      - input.type": log
+      - log.level: $~tmp.log_subtype
+      - observer.product: XG
+      - observer.serial_number: $~tmp.device_id
+      - observer.type: firewall
+      - observer.vendor: Sophos
+      - related.ip: [$~tmp.localip, $~tmp.sourceip]
+      - service.type: sophos
+      - sophos.xg.cookie: $~tmp.cookie
+      - sophos.xg.device: $~tmp.device
+      - sophos.xg.device_name: $~tmp.device_name
+      - sophos.xg.extra: $~tmp.extra
+      - sophos.xg.fw_rule_id: $~tmp.fw_rule_id
+      - sophos.xg.host: $~tmp.sourceip
+      - sophos.xg.log_component: $~tmp.log_component
+      - sophos.xg.log_id: $~tmp.log_id
+      - sophos.xg.log_type: $~tmp.log_type
+      - sophos.xg.priority: $~tmp.priority
+      - sophos.xg.querystring: $~tmp.querystring
+      - sophos.xg.server: $~tmp.server
+      - sophos.xg.xss: $~tmp.XSS
+  - check:
+      - ~tmp.localip: +ef_exists
+    logpar:
+      - ~tmp.localip: <~tmp.fill>.<~tmp.fill>.<~tmp.source.as.number>.<~tmp.fill>
+    map:
+      - source.as.number: $~tmp.source.as.number
+  - map:
+      - source.bytes: $~tmp.bytesrcv
+      - source.ip: $~tmp.sourceip
+      - tags: [forwarded, preserve_original_even, sophos-xg]
+      - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time/.000-02:00
+      - url.full: $~tmp.url
+      - user_agent.original: $~tmp.useragent
+      - ~log: +ef_delete
+      - ~tmp: +ef_delete

--- a/src/engine/ruleset/decoders/sophos/waf.yml
+++ b/src/engine/ruleset/decoders/sophos/waf.yml
@@ -11,6 +11,9 @@ metadata:
   references:
     - documentation link
 
+check:
+  - event.original: +r_match/<\d+>\s*device=.*?date=.*?time=.*?device_name=.*?device_id=.*?log_id=.*?log_type="WAF"
+
 sources:
   - decoder/queue-syslog/0
   - decoder/queue-localfile/0
@@ -36,8 +39,36 @@ normalize:
       - event.duration: +s_concat/$~tmp.responsetime/000
       - event.kind: alert
       - event.module: sophos
+  - check:
+      - ~tmp.priority: unknown
+    map:
+      - event.severity: 0
+  - check:
+      - ~tmp.priority: alert
+    map:
+      - event.severity: 1
+  - check:
+      - ~tmp.priority: critical
+    map:
+      - event.severity: 2
+  - check:
+      - ~tmp.priority: error
+    map:
+      - event.severity: 3
+  - check:
+      - ~tmp.priority: warning
+    map:
+      - event.severity: 4
+  - check:
+      - ~tmp.priority: notification
+    map:
+      - event.severity: 5
+  - check:
+      - ~tmp.priority: Information
+    map:
       - event.severity: 6
-      - event.timezone: -02:00
+  - map:
+      - event.timezone: $~tmp.timezone
       - event.type: [connection, denied]
       - destination.bytes: $~tmp.httpstatus
       - destination.ip: $~tmp.localip
@@ -75,7 +106,7 @@ normalize:
       - source.bytes: $~tmp.bytesrcv
       - source.ip: $~tmp.sourceip
       - tags: [forwarded, preserve_original_even, sophos-xg]
-      - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time/.000-02:00
+      - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time
       - url.full: $~tmp.url
       - user_agent.original: $~tmp.useragent
       - ~log: +ef_delete

--- a/src/engine/ruleset/environments/wazuh-environment.yml
+++ b/src/engine/ruleset/environments/wazuh-environment.yml
@@ -21,6 +21,7 @@ decoders:
   - decoder/rootcheck/0
   - decoder/sca/0
   - decoder/sophos-antivirus/0
+  - decoder/sophos-waf/0
   - decoder/sophos-utm/0
   - decoder/sophos-wifi/0
   - decoder/syscollector-base/0


### PR DESCRIPTION
|Related issue|
|---|
|#15851|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

With the aim of expanding the coverage of the decoders, this PR adds a decoder for Sophos/Waf.

## Configuration options

Validate the new decoder:
- ./build/main catalog validate decoder/sophos-waf/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/waf.yml

Create decoder:
- ./build/main  catalog create decoder < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/waf.yml

Update environment
- ./build/main catalog update environment/wazuh/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/environments/wazuh-environment.yml

Test new decoder
- ./build/main test -q 1

## Logs/Alerts example

- <30>device="SFW" date=2020-05-18 time=14:38:46 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=075000617071 log_type="WAF" log_component="Web Application Firewall" priority=Information user_name="-" server=webmail.elasticuser.com sourceip=216.160.83.61 localip=185.8.209.207 ws_protocol="HTTP/1.1" url=/mapi/nspi/ querystring=?MailboxId=642ea57c-90ab-4571-8e05-c6997b2256f8@elastic.user.com cookie="MapiContext=MAPIAAAAAPaw98Xx0uDQ4tL/z/rX59b2x/LI+8z2x/+lhrKGtIO7jbmBsxYNAAAAAAAA;MapiRouting=UlVNOjdmNWY0OGE3LTM5OWItNDc4Yi04ZDgwLWFmZTRmMzAyZTViMDoAitM4bv3XCA==;MapiSequence=10-GtgsIA==;X-BackEndCookie=642ea57c-90ab-4571-8e05-c6997b2256f8=u56Lnp2ejJqByZrHyZ7Mys7Sm8zJnNLLnM3J0sbJxsvSnZzIxs2ans+ezMrLgYHNz83P0s/J0s3Pq87Pxc7PxcrL" referer=- method=POST httpstatus=401 reason="-" extra="-" contenttype="-" useragent="Microsoft Office/16.0 (Windows NT 10.0; Microsoft Outlook 16.0.4954; Pro)" host=216.160.83.61 responsetime=11199 bytessent=5669 bytesrcv=1419 fw_rule_id=79

## Tests

Event:
- <30>device="SFW" date=2020-05-18 time=14:38:46 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=075000617071 log_type="WAF" log_component="Web Application Firewall" priority=Information user_name="-" server=webmail.elasticuser.com sourceip=216.160.83.61 localip=185.8.209.207 ws_protocol="HTTP/1.1" url=/mapi/nspi/ querystring=?MailboxId=642ea57c-90ab-4571-8e05-c6997b2256f8@elastic.user.com cookie="MapiContext=MAPIAAAAAPaw98Xx0uDQ4tL/z/rX59b2x/LI+8z2x/+lhrKGtIO7jbmBsxYNAAAAAAAA;MapiRouting=UlVNOjdmNWY0OGE3LTM5OWItNDc4Yi04ZDgwLWFmZTRmMzAyZTViMDoAitM4bv3XCA==;MapiSequence=10-GtgsIA==;X-BackEndCookie=642ea57c-90ab-4571-8e05-c6997b2256f8=u56Lnp2ejJqByZrHyZ7Mys7Sm8zJnNLLnM3J0sbJxsvSnZzIxs2ans+ezMrLgYHNz83P0s/J0s3Pq87Pxc7PxcrL" referer=- method=POST httpstatus=401 reason="-" extra="-" contenttype="-" useragent="Microsoft Office/16.0 (Windows NT 10.0; Microsoft Outlook 16.0.4954; Pro)" host=216.160.83.61 responsetime=11199 bytessent=5669 bytesrcv=1419 fw_rule_id=79


Output:
```
{
    "wazuh": {
        "queue": 49,
        "origin": "/dev/stdin"
    },
    "event": {
        "original": "<30>device=\"SFW\" date=2020-05-18 time=14:38:46 timezone=\"CEST\" device_name=\"XG230\" device_id=1234567890123456 log_id=075000617071 log_type=\"WAF\" log_component=\"Web Application Firewall\" priority=Information user_name=\"-\" server=webmail.elasticuser.com sourceip=216.160.83.61 localip=185.8.209.207 ws_protocol=\"HTTP/1.1\" url=/mapi/nspi/ querystring=?MailboxId=642ea57c-90ab-4571-8e05-c6997b2256f8@elastic.user.com cookie=\"MapiContext=MAPIAAAAAPaw98Xx0uDQ4tL/z/rX59b2x/LI+8z2x/+lhrKGtIO7jbmBsxYNAAAAAAAA;MapiRouting=UlVNOjdmNWY0OGE3LTM5OWItNDc4Yi04ZDgwLWFmZTRmMzAyZTViMDoAitM4bv3XCA==;MapiSequence=10-GtgsIA==;X-BackEndCookie=642ea57c-90ab-4571-8e05-c6997b2256f8=u56Lnp2ejJqByZrHyZ7Mys7Sm8zJnNLLnM3J0sbJxsvSnZzIxs2ans+ezMrLgYHNz83P0s/J0s3Pq87Pxc7PxcrL\" referer=- method=POST httpstatus=401 reason=\"-\" extra=\"-\" contenttype=\"-\" useragent=\"Microsoft Office/16.0 (Windows NT 10.0; Microsoft Outlook 16.0.4954; Pro)\" host=216.160.83.61 responsetime=11199 bytessent=5669 bytesrcv=1419 fw_rule_id=79",
        "action": "denied",
        "code": 75000617071,
        "dataset": "sophos.xg",
        "duration": "11199000",
        "kind": "alert",
        "module": "sophos",
        "severity": 6,
        "timezone": "-02:00",
        "type": [
            "connection",
            "denied"
        ]
    },
    "destination": {
        "bytes": 401,
        "ip": "185.8.209.207"
    },
    "fileset": {
        "name": "xg"
    },
    "http": {
        "request": {
            "method": "POST"
        },
        "version": "HTTP/1.1"
    },
    "input": {
        "type\"": "log"
    },
    "observer": {
        "product": "XG",
        "serial_number": 1234567890123456,
        "type": "firewall",
        "vendor": "Sophos"
    },
    "related": {
        "ip": [
            "185.8.209.207",
            "216.160.83.61"
        ]
    },
    "service": {
        "type": "sophos"
    },
    "sophos": {
        "xg": {
            "cookie": "MapiContext=MAPIAAAAAPaw98Xx0uDQ4tL/z/rX59b2x/LI+8z2x/+lhrKGtIO7jbmBsxYNAAAAAAAA;MapiRouting=UlVNOjdmNWY0OGE3LTM5OWItNDc4Yi04ZDgwLWFmZTRmMzAyZTViMDoAitM4bv3XCA==;MapiSequence=10-GtgsIA==;X-BackEndCookie=642ea57c-90ab-4571-8e05-c6997b2256f8=u56Lnp2ejJqByZrHyZ7Mys7Sm8zJnNLLnM3J0sbJxsvSnZzIxs2ans+ezMrLgYHNz83P0s/J0s3Pq87Pxc7PxcrL",
            "device": "SFW",
            "device_name": "XG230",
            "extra": "-",
            "fw_rule_id": 79,
            "host": "216.160.83.61",
            "log_component": "Web Application Firewall",
            "log_id": 75000617071,
            "log_type": "WAF",
            "priority": "Information",
            "querystring": "?MailboxId=642ea57c-90ab-4571-8e05-c6997b2256f8@elastic.user.com",
            "server": "webmail.elasticuser.com"
        }
    },
    "source": {
        "as": {
            "number": "209"
        },
        "bytes": 1419,
        "ip": "216.160.83.61"
    },
    "tags": [
        "forwarded",
        "preserve_original_even",
        "sophos-xg"
    ],
    "\\@timestamp": "2020-05-18T14:38:46.000-02:00",
    "url": {
        "full": "/mapi/nspi/"
    },
    "user_agent": {
        "original": "Microsoft Office/16.0 (Windows NT 10.0; Microsoft Outlook 16.0.4954; Pro)"
    }
}

```