### PR TITLE
Engine - Implementation Sophos/Systemhealth decoder

### DIFF
--- a/src/engine/ruleset/decoders/sophos/systemhealth.yml
+++ b/src/engine/ruleset/decoders/sophos/systemhealth.yml
@@ -11,6 +11,9 @@ metadata:
   references:
     - documentation link
 
+check:
+  - event.original: +r_match/<\d+>\s*device=.*?date=.*?time=.*?device_name=.*?device_id=.*?log_id=.*?log_type="System Health"
+
 sources:
   - decoder/queue-syslog/0
   - decoder/queue-localfile/0
@@ -35,11 +38,39 @@ normalize:
       - event.kind: event
       - event.module: sophos
       - event.dataset: sophos.xg
+  - check:
+      - ~tmp.priority: unknown
+    map:
+      - event.severity: 0
+  - check:
+      - ~tmp.priority: alert
+    map:
+      - event.severity: 1
+  - check:
+      - ~tmp.priority: critical
+    map:
+      - event.severity: 2
+  - check:
+      - ~tmp.priority: error
+    map:
+      - event.severity: 3
+  - check:
+      - ~tmp.priority: warning
+    map:
+      - event.severity: 4
+  - check:
+      - ~tmp.priority: notification
+    map:
+      - event.severity: 5
+  - check:
+      - ~tmp.priority: Information
+    map:
       - event.severity: 6
-      - event.timezone: -02:00
+  - map:
+      - event.timezone: $~tmp.timezone
       - fileset.name: xg
       - input.type": log
-      - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time/.000-02:00
+      - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time
       - log.level: $~tmp.priority
       - observer.product: XG
       - observer.serial_number: $~tmp.device_id

--- a/src/engine/ruleset/decoders/sophos/systemhealth.yml
+++ b/src/engine/ruleset/decoders/sophos/systemhealth.yml
@@ -25,13 +25,15 @@ parse:
     # <30>device="SFW" date=2018-06-05 time=15:10:00 timezone="CEST" device_name="SF01V" device_id=SFDemo-fe75a9f log_id=123526618031 log_type="System Health" log_component="Interface" log_subtype="Usage" priority=Information interface=Port1 receivedkbits=4.55 transmittedkbits=2.03 receivederrors=0.00 transmitteddrops=0.00 collisions=0.00 transmittederrors=0.00 receiveddrops=0.00
     # <30>device="SFW" date=2018-06-05 time=15:10:00 timezone="CEST" device_name="SF01V" device_id=SFDemo-fe75a9f log_id=127826618031 log_type="System Health" log_component="Disk" log_subtype="Usage" priority=Information Configuration=13.00% Reports=11.00% Signature=11.00% Temp=4.00%
     # <30>device="SFW" date=2018-06-05 time=15:10:00 timezone="CEST" device_name="SF01V" device_id=SFDemo-fe75a9f log_id=127926618031 log_type="System Health" log_component="Live User" log_subtype="Usage" priority=Information users=0
-    - event.original: \<<~log.head_message>><~log.payload_messge>
+    - event.original: \<<~tmp.head_message>><~tmp.payload_message>
 
 normalize:
   - check:
-      - ~log.payload_messge: +ef_exists
+      - ~tmp.payload_message: +ef_exists
+    map:
+      - ~tmp.payload_message: +s_replace/=""/=" "
     logpar:
-      - ~log.payload_messge: <~tmp/kv/=/ /"/'>
+      - ~tmp.payload_message: <~tmp/kv/=/ /"/'>
     map:
       - event.code: $~tmp.log_id
       - event.dataset: sophos.xg
@@ -103,5 +105,4 @@ normalize:
       - sophos.xg.user_cpu: $~tmp.user
       - service.type: sophos
       - tags: [forwarded, preserve_original_even, sophos-xg]
-      - ~log: +ef_delete
       - ~tmp: +ef_delete

--- a/src/engine/ruleset/decoders/sophos/systemhealth.yml
+++ b/src/engine/ruleset/decoders/sophos/systemhealth.yml
@@ -1,0 +1,76 @@
+---
+name: decoder/sophos-systemhealth/0
+
+metadata:
+  module: sophos
+  title: Sophos logs decoder
+  description: Decoder for sophos logs
+  author:
+    name: Wazuh Inc. info@wazuh.com
+    date: 2023-01-12
+  references:
+    - documentation link
+
+sources:
+  - decoder/queue-syslog/0
+  - decoder/queue-localfile/0
+
+parse:
+  logpar:
+    # <30>device="SFW" date=2018-06-05 time=15:10:00 timezone="CEST" device_name="SF01V" device_id=SFDemo-fe75a9f log_id=127626618031 log_type="System Health" log_component="CPU" log_subtype="Usage" priority=Information system=1.29% user=7.60% idle=91.11%
+    # <30>device="SFW" date=2018-06-05 time=15:10:00 timezone="CEST" device_name="SF01V" device_id=SFDemo-fe75a9f log_id=127726618031 log_type="System Health" log_component="Memory" log_subtype="Usage" priority=Information unit=byte total_memory=2100191232 free=578650112 used=1521541120
+    # <30>device="SFW" date=2018-06-05 time=15:10:00 timezone="CEST" device_name="SF01V" device_id=SFDemo-fe75a9f log_id=123526618031 log_type="System Health" log_component="Interface" log_subtype="Usage" priority=Information interface=Port1 receivedkbits=4.55 transmittedkbits=2.03 receivederrors=0.00 transmitteddrops=0.00 collisions=0.00 transmittederrors=0.00 receiveddrops=0.00
+    # <30>device="SFW" date=2018-06-05 time=15:10:00 timezone="CEST" device_name="SF01V" device_id=SFDemo-fe75a9f log_id=127826618031 log_type="System Health" log_component="Disk" log_subtype="Usage" priority=Information Configuration=13.00% Reports=11.00% Signature=11.00% Temp=4.00%
+    # <30>device="SFW" date=2018-06-05 time=15:10:00 timezone="CEST" device_name="SF01V" device_id=SFDemo-fe75a9f log_id=127926618031 log_type="System Health" log_component="Live User" log_subtype="Usage" priority=Information users=0
+    - event.original: \<<~log.head_message>><~log.payload_messge>
+
+normalize:
+  - check:
+      - ~log.payload_messge: +ef_exists
+    logpar:
+      - ~log.payload_messge: <~tmp/kv/=/ /"/'>
+    map:
+      - event.code: $~tmp.log_id
+      - event.dataset: sophos.xg
+      - event.kind: event
+      - event.module: sophos
+      - event.dataset: sophos.xg
+      - event.severity: 6
+      - event.timezone: -02:00
+      - fileset.name: xg
+      - input.type": log
+      - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time/.000-02:00
+      - log.level: $~tmp.priority
+      - observer.product: XG
+      - observer.serial_number: $~tmp.device_id
+      - observer.type: firewall
+      - observer.vendor: Sophos
+      - sophos.xg.collisions: $~tmp.collisions
+      - sophos.xg.configuration: $~tmp.Configuration
+      - sophos.xg.device: $~tmp.device
+      - sophos.xg.device_name: $~tmp.device_name
+      - sophos.xg.free: $~tmp.free
+      - sophos.xg.idle_cpu: $~tmp.idle
+      - sophos.xg.log_component: $~tmp.log_component
+      - sophos.xg.log_id: $~tmp.log_id
+      - sophos.xg.log_subtype: $~tmp.log_subtype
+      - sophos.xg.log_type: $~tmp.log_type
+      - sophos.xg.priority: $~tmp.priority
+      - sophos.xg.receiveddrops: $~tmp.receiveddrops
+      - sophos.xg.receivederrors: $~tmp.receivederrors
+      - sophos.xg.receivedkbits: $~tmp.receivedkbits
+      - sophos.xg.reports: $~tmp.Reports
+      - sophos.xg.signature: $~tmp.Signature
+      - sophos.xg.system_cpu: $~tmp.system
+      - sophos.xg.temp: $~tmp.Temp
+      - sophos.xg.total_memory: $~tmp.total_memory
+      - sophos.xg.transmitteddrop: $~tmp.transmitteddrop
+      - sophos.xg.transmittederrors: $~tmp.transmittederrors
+      - sophos.xg.transmittedkbits: $~tmp.transmittedkbits
+      - sophos.xg.unit: $~tmp.unit
+      - sophos.xg.used: $~tmp.used
+      - sophos.xg.user_cpu: $~tmp.user
+      - service.type: sophos
+      - tags: [forwarded, preserve_original_even, sophos-xg]
+      - ~log: +ef_delete
+      - ~tmp: +ef_delete

--- a/src/engine/ruleset/decoders/sophos/waf.yml
+++ b/src/engine/ruleset/decoders/sophos/waf.yml
@@ -25,13 +25,15 @@ parse:
     # <30>device="SFW" date=2020-05-19 time=17:20:29 timezone="IST" device_name="XG230" device_id=1234567890123457 log_id=075000617071 log_type="WAF" log_component="Web Application Firewall" priority=Information user_name="jsmith" server=www.iviewtest.com:8989 sourceip=10.198.235.254 localip=10.198.233.48 ws_protocol="HTTP/1.1" url=/ querystring= cookie="-" referer=- method=GET httpstatus=403 reason="Static URL Hardening" extra="No signature found" contenttype="text/html" useragent="Mozilla/5.0 (Windows NT 6.1; WOW64; rv:50.0) Gecko/20100101 Firefox/50.0" host=10.198.235.254 responsetime=19310 bytessent=726 bytesrcv=510 fw_rule_id=3
     # <30>device="SFW" date=2020-05-19 time=18:03:30 timezone="IST" device_name="XG230" device_id=1234567890123456 log_id=075000617071 log_type="WAF" log_component="Web Application Firewall" priority=Information user_name="jsmith" server=www.iviewtest.com:8990 sourceip=10.198.235.254 localip=10.198.233.48 ws_protocol="HTTP/1.1" url=/download/eicarcom2.zip querystring= cookie="; PHPSESSID=jetkd9iadd969hsr77jpj4q974; _pk_id.1.fc3a=3a6250e215194a92.1485866024.1.1485866069.1485866024.; _pk_ses.1.fc3a=*" referer=http://www.iviewtest.com:8990/85-0-Download.html method=GET httpstatus=403 reason="Antivirus" extra="EICAR-AV-Test" contenttype="text/html" useragent="Mozilla/5.0 (Windows NT 6.1; WOW64; rv:50.0) Gecko/20100101 Firefox/50.0" host=10.198.235.254 responsetime=403214 bytessent=739 bytesrcv=715 fw_rule_id=6
     # <30>device="SFW" date=2020-05-20 time=18:03:31 timezone="IST" device_name="XG230" device_id=1234567890123457 log_id=075000617071 log_type="WAF" log_component="Web Application Firewall" priority=Information user_name="-" server=- sourceip=89.160.20.112 localip=216.167.51.72 ws_protocol="HTTP/1.0" url=/ querystring="" cookie="-" referer="-" method=GET httpstatus=403 reason="WAF Anomaly" extra="Inbound Anomaly Score Exceeded (Total Score: 7, SQLi=, XSS=): Last Matched Message: Request Missing a User Agent Header" contenttype="text/html" useragent="-" host=89.160.20.112 responsetime=608 bytessent=5353 bytesrcv=295 fw_rule_id=3
-    - event.original: \<<~log.head_message>><~log.payload_message>
+    - event.original: \<<~tmp.head_message>><~tmp.payload_message>
 
 normalize:
   - check:
-      - ~log.payload_message: +ef_exists
+      - ~tmp.payload_message: +ef_exists
+    map:
+      - ~tmp.payload_message: +s_replace/=""/=" "
     logpar:
-      - ~log.payload_message: <~tmp/kv/=/ /"/'>
+      - ~tmp.payload_message: <~tmp/kv/=/ /"/'>
     map:
       - event.action: denied
       - event.code: $~tmp.log_id
@@ -109,5 +111,4 @@ normalize:
       - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time
       - url.full: $~tmp.url
       - user_agent.original: $~tmp.useragent
-      - ~log: +ef_delete
       - ~tmp: +ef_delete

--- a/src/engine/ruleset/decoders/sophos/wifi.yml
+++ b/src/engine/ruleset/decoders/sophos/wifi.yml
@@ -22,13 +22,15 @@ parse:
   logpar:
     # <30>device="SFW" date=2017-02-01 time=14:17:35 timezone="IST" device_name="SG115" device_id=S110016E28BA631 log_id=106025618011 log_type="Wireless Protection" log_component="Wireless Protection" log_subtype="Information" priority=Information ap=A40024A636F7862 ssid=SPIDIGO2015 clients_conn_SSID=2
     # <30>device="SFW" date=2017-02-01 time=14:19:47 timezone="IST" device_name="SG115" device_id=S110016E28BA631 log_id=106025618011 log_type="Wireless Protection" log_component="Wireless Protection" log_subtype="Information" priority=Information ap=A40024A636F7862 ssid=SPIDIGO2015 clients_conn_SSID=3
-    - event.original: \<<~log.head_message>><~log.payload_messge>
+    - event.original: \<<~tmp.head_message>><~tmp.payload_messge>
 
 normalize:
   - check:
-      - ~log.payload_messge: +ef_exists
+      - ~tmp.payload_message: +ef_exists
+    map:
+      - ~tmp.payload_message: +s_replace/=""/=" "
     logpar:
-      - ~log.payload_messge: <~tmp/kv/=/ /"/'>
+      - ~tmp.payload_message: <~tmp/kv/=/ /"/'>
     map:
       - event.kind: event
       - event.module: sophos

--- a/src/engine/ruleset/environments/wazuh-environment.yml
+++ b/src/engine/ruleset/environments/wazuh-environment.yml
@@ -21,8 +21,9 @@ decoders:
   - decoder/rootcheck/0
   - decoder/sca/0
   - decoder/sophos-antivirus/0
-  - decoder/sophos-waf/0
+  - decoder/sophos-systemhealth/0
   - decoder/sophos-utm/0
+  - decoder/sophos-waf/0
   - decoder/sophos-wifi/0
   - decoder/syscollector-base/0
   - decoder/syscollector-dbsync-network-protocol/0


### PR DESCRIPTION
|Related issue|
|---|
|#15851|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

With the aim of expanding the coverage of the decoders, this PR adds a decoder for Sophos/Systemhealth.

## Configuration options

Validate the new decoder:
- ./build/main catalog validate decoder/sophos-systemhealth/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/systemhealth.yml

Create decoder:
- ./build/main  catalog create decoder < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophossystemhealth.yml

Update environment
- ./build/main catalog update environment/wazuh/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/environments/wazuh-environment.yml

Test new decoder
- ./build/main test -q 1

## Logs/Alerts example

- <30>device="SFW" date=2018-06-05 time=15:10:00 timezone="CEST" device_name="SF01V" device_id=SFDemo-fe75a9f log_id=123526618031 log_type="System Health" log_component="Interface" log_subtype="Usage" priority=Information interface=Port1 receivedkbits=4.55 transmittedkbits=2.03 receivederrors=0.00 transmitteddrops=0.00 collisions=0.00 transmittederrors=0.00 receiveddrops=0.00

## Tests

Event:
- <30>device="SFW" date=2018-06-05 time=15:10:00 timezone="CEST" device_name="SF01V" device_id=SFDemo-fe75a9f log_id=123526618031 log_type="System Health" log_component="Interface" log_subtype="Usage" priority=Information interface=Port1 receivedkbits=4.55 transmittedkbits=2.03 receivederrors=0.00 transmitteddrops=0.00 collisions=0.00 transmittederrors=0.00 receiveddrops=0.00


Output:
```
{
    "wazuh": {
        "queue": 49,
        "origin": "/dev/stdin"
    },
    "event": {
        "original": "<30>device=\"SFW\" date=2018-06-05 time=15:10:00 timezone=\"CEST\" device_name=\"SF01V\" device_id=SFDemo-fe75a9f log_id=123526618031 log_type=\"System Health\" log_component=\"Interface\" log_subtype=\"Usage\" priority=Information interface=Port1 receivedkbits=4.55 transmittedkbits=2.03 receivederrors=0.00 transmitteddrops=0.00 collisions=0.00 transmittederrors=0.00 receiveddrops=0.00",
        "code": 123526618031,
        "dataset": "sophos.xg",
        "kind": "event",
        "module": "sophos",
        "severity": 6,
        "timezone": "-02:00"
    },
    "fileset": {
        "name": "xg"
    },
    "input": {
        "type\"": "log"
    },
    "\\@timestamp": "2018-06-05T15:10:00.000-02:00",
    "log": {
        "level": "Information"
    },
    "observer": {
        "product": "XG",
        "serial_number": "SFDemo-fe75a9f",
        "type": "firewall",
        "vendor": "Sophos"
    },
    "sophos": {
        "xg": {
            "collisions": 0.0,
            "device": "SFW",
            "device_name": "SF01V",
            "log_component": "Interface",
            "log_id": 123526618031,
            "log_subtype": "Usage",
            "log_type": "System Health",
            "priority": "Information",
            "receiveddrops": 0.0,
            "receivederrors": 0.0,
            "receivedkbits": 4.55,
            "transmittederrors": 0.0,
            "transmittedkbits": 2.03
        }
    },
    "service": {
        "type": "sophos"
    },
    "tags": [
        "forwarded",
        "preserve_original_even",
        "sophos-xg"
    ]
}

```