### PR TITLE
Allow API endpoints to read between default and custom ruleset using query parameter

### DIFF
--- a/api/api/controllers/decoder_controller.py
+++ b/api/api/controllers/decoder_controller.py
@@ -204,7 +204,7 @@ async def get_decoders_parents(request, pretty: bool = False, wait_for_complete:
 
 
 async def get_file(request, pretty: bool = False, wait_for_complete: bool = False, filename: str = None,
-                   raw: bool = False) -> Union[web.Response, ConnexionResponse]:
+                   raw: bool = False, default_ruleset: bool = True) -> Union[web.Response, ConnexionResponse]:
     """Get decoder file content.
 
     Parameters
@@ -218,6 +218,8 @@ async def get_file(request, pretty: bool = False, wait_for_complete: bool = Fals
         Filename to download.
     raw : bool
         Whether to return the file content in raw or JSON format.
+    default_ruleset : bool
+        Whether to search for the rule in the default ruleset path or not. Default `True`
 
     Returns
     -------
@@ -227,7 +229,7 @@ async def get_file(request, pretty: bool = False, wait_for_complete: bool = Fals
             raw=False (default) -> web.Response (application/json)
         If any exception was raised, it will return a web.Response with details.
     """
-    f_kwargs = {'filename': filename, 'raw': raw}
+    f_kwargs = {'filename': filename, 'raw': raw, 'default_ruleset': default_ruleset}
 
     dapi = DistributedAPI(f=decoder_framework.get_decoder_file,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/rule_controller.py
+++ b/api/api/controllers/rule_controller.py
@@ -266,7 +266,7 @@ async def get_rules_files(request, pretty: bool = False, wait_for_complete: bool
 
 @cache(expires=api_conf['cache']['time'])
 async def get_file(request, pretty: bool = False, wait_for_complete: bool = False, filename: str = None,
-                   raw: bool = False) -> Union[web.Response, ConnexionResponse]:
+                   raw: bool = False, default_ruleset: bool = True) -> Union[web.Response, ConnexionResponse]:
     """Get rule file content.
 
     Parameters
@@ -280,6 +280,8 @@ async def get_file(request, pretty: bool = False, wait_for_complete: bool = Fals
         Filename to download.
     raw : bool, optional
         Whether to return the file content in raw or JSON format. Default `False`
+    default_ruleset : bool
+        Whether to search for the rule in the default ruleset path or not. Default `True`
 
     Returns
     -------
@@ -289,7 +291,7 @@ async def get_file(request, pretty: bool = False, wait_for_complete: bool = Fals
             raw=False (default) -> web.Response      (application/json)
         If any exception was raised, it will return a web.Response with details.
     """
-    f_kwargs = {'filename': filename, 'raw': raw}
+    f_kwargs = {'filename': filename, 'raw': raw, 'default_ruleset': default_ruleset}
 
     dapi = DistributedAPI(f=rule_framework.get_rule_file,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/test/test_decoder_controller.py
+++ b/api/api/controllers/test/test_decoder_controller.py
@@ -127,7 +127,8 @@ async def test_get_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_bool,
     with patch('api.controllers.decoder_controller.isinstance', return_value=mock_bool) as mock_isinstance:
         result = await get_file(request=mock_request)
         f_kwargs = {'filename': None,
-                    'raw': False
+                    'raw': False,
+                    'default_ruleset': True
                     }
         mock_dapi.assert_called_once_with(f=decoder_framework.get_decoder_file,
                                           f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_rule_controller.py
+++ b/api/api/controllers/test/test_rule_controller.py
@@ -166,7 +166,8 @@ async def test_get_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_bool,
     with patch('api.controllers.rule_controller.isinstance', return_value=mock_bool) as mock_isinstance:
         result = await get_file(request=mock_request)
         f_kwargs = {'filename': None,
-                    'raw': False
+                    'raw': False,
+                    'default_ruleset': True
                     }
         mock_dapi.assert_called_once_with(f=rule_framework.get_rule_file,
                                           f_kwargs=mock_remove.return_value,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6994,6 +6994,14 @@ components:
       schema:
         type: string
         format: xml_filename_path
+    default_ruleset_path:
+      in: query
+      name: default_ruleset
+      description: "Search for the given filename in the Wazuh default ruleset if true. Otherwise, search for it in the custom user ruleset"
+      required: false
+      schema:
+        type: boolean
+        default: true
 
 
 tags:
@@ -13996,6 +14004,7 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/xml_filename_path'
         - $ref: '#/components/parameters/raw'
+        - $ref: '#/components/parameters/default_ruleset_path'
       responses:
         '200':
           description: "Rule content"
@@ -14772,6 +14781,7 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/xml_filename_path'
         - $ref: '#/components/parameters/raw'
+        - $ref: '#/components/parameters/default_ruleset_path'
       responses:
         '200':
           description: "Decoder content"

--- a/api/test/integration/test_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoder_endpoints.tavern.yaml
@@ -1012,6 +1012,29 @@ stages:
           total_failed_items: 1
         error: 1
 
+  - name: Download a decoders file (user ruleset, decoder belongs to default ruleset)
+    request:
+      verify: False
+      method: GET
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        default_ruleset: false
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items: []
+          total_affected_items: 0
+          failed_items:
+            - error:
+                code: 1503
+              id:
+                - "0005-wazuh_decoders.xml"
+          total_failed_items: 1
+        error: 1
+
   - name: Download decoder (invalid file 1)
     request:
       verify: False

--- a/api/test/integration/test_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rule_endpoints.tavern.yaml
@@ -1675,6 +1675,28 @@ stages:
           total_failed_items: 1
         error: 1
 
+  - name: Download rule (user ruleset, rule belongs to default ruleset)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0350-amazon_rules.xml"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        default_ruleset: false
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items: []
+          total_affected_items: 0
+          failed_items:
+            - error:
+                code: 1415
+              id:
+                - "0350-amazon_rules.xml"
+          total_failed_items: 1
+        error: 1
+
   - name: Download rule (invalid file 1)
     request:
       verify: False

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -201,6 +201,7 @@ def get_decoder_file(filename: str, raw: bool = False, default_ruleset: bool = T
                                       all_msg='Selected decoder was returned')
     decoders = get_decoders_files(filename=filename).affected_items
     decoder_path = common.DECODERS_PATH if default_ruleset else common.USER_DECODERS_PATH
+    exc_path = join(decoder_path.replace(common.WAZUH_PATH, 'WAZUH_HOME'), filename)
 
     if len(decoders) > 0 and any([decoder for decoder in decoders if decoder['relative_dirname'] in decoder_path]):
         try:
@@ -215,14 +216,14 @@ def get_decoder_file(filename: str, raw: bool = False, default_ruleset: bool = T
                 result.total_affected_items = 1
         except ExpatError as e:
             result.add_failed_item(id_=filename,
-                                   error=WazuhError(1501, extra_message=f"{join('WAZUH_HOME', decoder_path, filename)}:"
-                                                                        f" {str(e)}"))
+                                   error=WazuhError(1501,
+                                                    extra_message=f"{exc_path}: {str(e)}"))
         except OSError:
             result.add_failed_item(id_=filename,
-                                   error=WazuhError(1502, extra_message=join('WAZUH_HOME', decoder_path, filename)))
+                                   error=WazuhError(1502, extra_message=exc_path))
 
     else:
-        result.add_failed_item(id_=filename, error=WazuhError(1503))
+        result.add_failed_item(id_=filename, error=WazuhError(1503, extra_message=exc_path))
 
     return result
 

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -179,7 +179,8 @@ def get_decoders_files(status: str = None, relative_dirname: str = None, filenam
     return result
 
 
-def get_decoder_file(filename: str, raw: bool = False) -> Union[str, AffectedItemsWazuhResult]:
+def get_decoder_file(filename: str, raw: bool = False, default_ruleset: bool = True) -> \
+        Union[str, AffectedItemsWazuhResult]:
     """Read content of a specified file.
 
     Parameters
@@ -188,6 +189,8 @@ def get_decoder_file(filename: str, raw: bool = False) -> Union[str, AffectedIte
         Name of the decoder file.
     raw : bool
         Whether to return the content in raw format (str->XML) or JSON.
+    default_ruleset : bool
+        Whether to search for the rule in the default ruleset path or not. Default `True`
 
     Returns
     -------
@@ -197,11 +200,11 @@ def get_decoder_file(filename: str, raw: bool = False) -> Union[str, AffectedIte
     result = AffectedItemsWazuhResult(none_msg='No decoder was returned',
                                       all_msg='Selected decoder was returned')
     decoders = get_decoders_files(filename=filename).affected_items
+    decoder_path = common.DECODERS_PATH if default_ruleset else common.USER_DECODERS_PATH
 
-    if len(decoders) > 0:
-        decoder_path = decoders[0]['relative_dirname']
+    if len(decoders) > 0 and any([decoder for decoder in decoders if decoder['relative_dirname'] in decoder_path]):
         try:
-            full_path = join(common.WAZUH_PATH, decoder_path, filename)
+            full_path = join(decoder_path, filename)
             with open(full_path) as f:
                 file_content = f.read()
             if raw:

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -329,6 +329,7 @@ def get_rule_file(filename: str = None, raw: bool = False, default_ruleset: bool
                                       all_msg='Selected rule was returned')
     files = get_rules_files(filename=filename).affected_items
     rules_path = common.RULES_PATH if default_ruleset else common.USER_RULES_PATH
+    exc_path = join(rules_path.replace(common.WAZUH_PATH, 'WAZUH_HOME'), filename)
 
     if len(files) > 0 and any([file for file in files if file['relative_dirname'] in rules_path]):
         try:
@@ -343,14 +344,13 @@ def get_rule_file(filename: str = None, raw: bool = False, default_ruleset: bool
                 result.total_affected_items = 1
         except ExpatError as e:
             result.add_failed_item(id_=filename,
-                                   error=WazuhError(1413, extra_message=f"{join('WAZUH_HOME', rules_path, filename)}:"
-                                                                        f" {str(e)}"))
+                                   error=WazuhError(1413, extra_message=f"{exc_path}: {str(e)}"))
         except OSError:
             result.add_failed_item(id_=filename,
-                                   error=WazuhError(1414, extra_message=join('WAZUH_HOME', rules_path, filename)))
+                                   error=WazuhError(1414, extra_message=exc_path))
 
     else:
-        result.add_failed_item(id_=filename, error=WazuhError(1415))
+        result.add_failed_item(id_=filename, error=WazuhError(1415, extra_message=exc_path))
 
     return result
 

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -307,7 +307,8 @@ def get_requirement(requirement: str = None, offset: int = 0, limit: int = commo
     return result
 
 
-def get_rule_file(filename: str = None, raw: bool = False) -> Union[str, AffectedItemsWazuhResult]:
+def get_rule_file(filename: str = None, raw: bool = False, default_ruleset: bool = True) -> \
+        Union[str, AffectedItemsWazuhResult]:
     """Read content of specified file.
 
     Parameters
@@ -316,6 +317,8 @@ def get_rule_file(filename: str = None, raw: bool = False) -> Union[str, Affecte
         Name of the rule file. Default `None`
     raw : bool, optional
         Whether to return the content in raw format (str->XML) or JSON. Default `False` (JSON format)
+    default_ruleset : bool
+        Whether to search for the rule in the default ruleset path or not. Default `True`
 
     Returns
     -------
@@ -325,11 +328,11 @@ def get_rule_file(filename: str = None, raw: bool = False) -> Union[str, Affecte
     result = AffectedItemsWazuhResult(none_msg='No rule was returned',
                                       all_msg='Selected rule was returned')
     files = get_rules_files(filename=filename).affected_items
+    rules_path = common.RULES_PATH if default_ruleset else common.USER_RULES_PATH
 
-    if len(files) > 0:
-        rules_path = files[0]['relative_dirname']
+    if len(files) > 0 and any([file for file in files if file['relative_dirname'] in rules_path]):
         try:
-            full_path = join(common.WAZUH_PATH, rules_path, filename)
+            full_path = join(rules_path, filename)
             with open(full_path) as f:
                 content = f.read()
             if raw:

--- a/framework/wazuh/tests/test_decoder.py
+++ b/framework/wazuh/tests/test_decoder.py
@@ -133,6 +133,7 @@ def test_get_decoders_files_filters(status, relative_dirname, filename, expected
     'test1_decoders.xml',
     'test2_decoders.xml'
 ])
+@patch('wazuh.core.common.DECODERS_PATH', new=os.path.join(test_data_path, "tests", "data", "decoders"))
 def test_get_decoder_file(filename):
     """Test get file function.
 
@@ -160,15 +161,17 @@ def test_get_decoder_file_exceptions():
     assert result.render()['data']['failed_items'][0]['error']['code'] == 1503
 
     # Invalid XML
-    result = decoder.get_decoder_file(filename='wrong_decoders.xml')
-    assert not result.affected_items
-    assert result.render()['data']['failed_items'][0]['error']['code'] == 1501
+    with patch('wazuh.core.common.DECODERS_PATH', new=os.path.join(test_data_path, "tests", "data", "decoders")):
+        result = decoder.get_decoder_file(filename='wrong_decoders.xml')
+        assert not result.affected_items
+        assert result.render()['data']['failed_items'][0]['error']['code'] == 1501
 
     # File permissions
     with patch('builtins.open', side_effect=PermissionError):
-        result = decoder.get_decoder_file(filename='test2_decoders.xml')
-        assert not result.affected_items
-        assert result.render()['data']['failed_items'][0]['error']['code'] == 1502
+        with patch('wazuh.core.common.DECODERS_PATH', new=os.path.join(test_data_path, "tests", "data", "decoders")):
+            result = decoder.get_decoder_file(filename='test2_decoders.xml')
+            assert not result.affected_items
+            assert result.render()['data']['failed_items'][0]['error']['code'] == 1502
 
 
 @pytest.mark.parametrize('file, overwrite', [
@@ -181,6 +184,7 @@ def test_get_decoder_file_exceptions():
 @patch('wazuh.decoder.remove')
 @patch('wazuh.decoder.safe_move')
 @patch('wazuh.core.utils.check_remote_commands')
+@patch('wazuh.core.common.DECODERS_PATH', new=os.path.join(test_data_path, "tests", "data", "decoders"))
 def test_upload_file(mock_remote_commands, mock_safe_move, mock_remove, mock_full_copy, mock_xml, mock_delete, file,
                      overwrite):
     """Test uploading a decoder file.

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -12,26 +12,27 @@ with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
+
         del sys.modules['wazuh.rbac.orm']
         from wazuh.tests.util import RBAC_bypasser
+
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 
         from wazuh import rule
         from wazuh.core.results import AffectedItemsWazuhResult
         from wazuh.core.exception import WazuhError
 
-
 # Variables
 parent_directory = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 data_path = 'core/tests/data/rules'
 
 rule_ossec_conf = {
-  "ruleset": {
-    "rule_dir": [
-      "core/tests/data/rules"
-    ],
-    "rule_exclude": ["0010-rules_config.xml"]
-  }
+    "ruleset": {
+        "rule_dir": [
+            "core/tests/data/rules"
+        ],
+        "rule_exclude": ["0010-rules_config.xml"]
+    }
 }
 
 other_rule_ossec_conf = {
@@ -42,7 +43,6 @@ other_rule_ossec_conf = {
         'list': ['etc/lists/audit-keys', 'etc/lists/amazon/aws-eventnames', 'etc/lists/security-eventchannel']
     }
 }
-
 
 rule_contents = '''
 <group name="ossec,">
@@ -231,6 +231,7 @@ def test_get_requirement_invalid(mocked_config, requirement):
     ('0010-rules_config.xml', True),
     ('0015-ossec_rules.xml', False)
 ])
+@patch('wazuh.core.common.RULES_PATH', new=os.path.join(parent_directory, data_path))
 @patch('wazuh.core.configuration.get_ossec_conf', return_value=rule_ossec_conf)
 def test_get_rules_file(mock_config, file_, raw):
     """Test downloading a specified rule filter."""
@@ -243,20 +244,23 @@ def test_get_rules_file(mock_config, file_, raw):
         assert not d_files.failed_items
 
 
-@pytest.mark.parametrize('item, file_, error_code', [
-    ([{'relative_dirname': 'ruleset/rules'}], 'no_exists_os_error.xml', 1414),
-    ([], 'no_exists_unk_error.xml', 1415)
-])
+@patch('wazuh.core.common.RULES_PATH', new=os.path.join(parent_directory, data_path))
 @patch('wazuh.core.configuration.get_ossec_conf', return_value=rule_ossec_conf)
-def test_get_rules_file_failed(mock_config, item, file_, error_code):
+def test_get_rules_file_failed(mock_config):
     """Test downloading a specified rule filter."""
-    with patch('wazuh.rule.get_rules_files', return_value=AffectedItemsWazuhResult(
-            all_msg='test', affected_items=item)):
-        result = rule.get_rule_file(filename=file_)
+    with patch('wazuh.rule.get_rules_files', return_value=AffectedItemsWazuhResult(all_msg="test", affected_items=[
+                                                                               {'relative_dirname': data_path}])):
+        result = rule.get_rule_file(filename="does_not_exist.xml")
         assert not result.affected_items
-        assert result.render()['data']['failed_items'][0]['error']['code'] == error_code
+        assert result.render()['data']['failed_items'][0]['error']['code'] == 1414
+
+    with patch('wazuh.rule.get_rules_files', return_value=AffectedItemsWazuhResult(all_msg="test", affected_items=[])):
+        result = rule.get_rule_file(filename="does_not_exist.xml")
+        assert not result.affected_items
+        assert result.render()['data']['failed_items'][0]['error']['code'] == 1415
 
 
+@patch('wazuh.core.common.RULES_PATH', new=os.path.join(parent_directory, "tests", "data"))
 @patch('wazuh.rule.get_rules_files', return_value=AffectedItemsWazuhResult(
     affected_items=[{'relative_dirname': 'tests/data'}]))
 def test_get_rules_file_invalid_xml(get_rules_mock):
@@ -331,7 +335,7 @@ def test_delete_rule_file():
     with patch('wazuh.rule.exists', return_value=True):
         # Assert returned type is AffectedItemsWazuhResult when everything is correct
         with patch('wazuh.rule.remove'):
-            assert(isinstance(rule.delete_rule_file(filename='file'), AffectedItemsWazuhResult))
+            assert (isinstance(rule.delete_rule_file(filename='file'), AffectedItemsWazuhResult))
         # Assert error code when remove() method returns IOError
         with patch('wazuh.manager.remove', side_effect=IOError()):
             result = rule.delete_rule_file(filename='file')


### PR DESCRIPTION
|Related issue|
|---|
|closes #15994 |

## Description

As proposed, this PR implements a new query parameter named `default_ruleset` for the `GET /rules/files/{filename}` and `GET /decoders/files/{filename}` endpoints to allow to decide where to read the given filename (for situations where we could have a disabled default rule but enabled as custom, for instance).

By default, the Wazuh default ruleset will be read.

## Examples

### `GET /rules/files/0315-apparmor_rules.xml` (default_ruleset=True)

```json
{
  "data": {
    "affected_items": [
      {
        "group": {
          "@name": "local,syslog,apparmor,",
          "rule": [
            {
              "@id": "52000",
              "@level": "3",
              "decoded_as": "kernel",
              "match": "apparmor=",
              "description": "Apparmor messages grouped."
            },
            {
              "@id": "52001",
              "@level": "0",
              "if_sid": "52000",
              "status": "ALLOWED|STATUS",
              "description": "Apparmor Ignore ALLOWED or STATUS"
            },
            {
              "@id": "52002",
              "@level": "3",
              "if_sid": "52000",
              "status": "DENIED",
              "match": "apparmor=",
              "description": "Apparmor DENIED"
            },
            {
              "@id": "52003",
              "@level": "5",
              "if_sid": "52002",
              "extra_data": "exec",
              "description": "Apparmor DENIED exec operation.",
              "group": "pci_dss_10.2.7,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AU.6,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,"
            },
            {
              "@id": "52004",
              "@level": "4",
              "if_sid": "52002",
              "extra_data": "mknod",
              "description": "Apparmor DENIED mknod operation.",
              "group": "pci_dss_10.2.7,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AU.6,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,"
            }
          ]
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Selected rule was returned",
  "error": 0
}
```

### `GET /rules/files/0315-apparmor_rules.xml` (default_ruleset=False)

```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1415,
          "message": "Rules file not found: WAZUH_HOME/etc/rules/0315-apparmor_rules.xml",
          "remediation": "Please, use GET /rules/files to list all available rules"
        },
        "id": [
          "0315-apparmor_rules.xml"
        ]
      }
    ]
  },
  "message": "No rule was returned",
  "error": 1
}
```

> **NOTE:** Notice how the path adapts to the query parameter value in the error message.

## Tests

### Unit tests

```
============================= test session starts =============================
platform linux -- Python 3.9.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: testinfra-5.0.0, metadata-1.11.0, cov-2.12.0, asyncio-0.18.3, aiohttp-0.3.0, html-3.1.1, trio-0.7.0
asyncio: mode=legacy
collected 2101 items                                                          

framework/scripts/tests/test_agent_groups.py ..............             [  0%]
framework/scripts/tests/test_agent_upgrade.py ..............            [  1%]
framework/scripts/tests/test_cluster_control.py ......                  [  1%]
framework/scripts/tests/test_rbac_control.py .........                  [  2%]
framework/scripts/tests/test_wazuh_clusterd.py .......                  [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................    [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py .................. [  4%]
..............                                                          [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................      [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py .................... [  6%]
...............                                                         [  7%]
framework/wazuh/core/cluster/tests/test_common.py ..................... [  8%]
...............................................................         [ 11%]
framework/wazuh/core/cluster/tests/test_control.py ......               [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............  [ 12%]
framework/wazuh/core/cluster/tests/test_local_server.py ............... [ 13%]
.........                                                               [ 13%]
framework/wazuh/core/cluster/tests/test_master.py ..................... [ 14%]
...............................                                         [ 15%]
framework/wazuh/core/cluster/tests/test_server.py ..................... [ 16%]
........                                                                [ 17%]
framework/wazuh/core/cluster/tests/test_utils.py ...........            [ 17%]
framework/wazuh/core/cluster/tests/test_worker.py ..................... [ 18%]
..............                                                          [ 19%]
framework/wazuh/core/tests/test_active_response.py ..............       [ 20%]
framework/wazuh/core/tests/test_agent.py .............................. [ 21%]
....................................................................... [ 24%]
..............................................                          [ 27%]
framework/wazuh/core/tests/test_cdb_list.py ........................... [ 28%]
...........                                                             [ 28%]
framework/wazuh/core/tests/test_common.py .........                     [ 29%]
framework/wazuh/core/tests/test_configuration.py ...................... [ 30%]
.................................................                       [ 32%]
framework/wazuh/core/tests/test_database.py .............               [ 33%]
framework/wazuh/core/tests/test_decoder.py ................             [ 34%]
framework/wazuh/core/tests/test_exception.py ...                        [ 34%]
framework/wazuh/core/tests/test_input_validator.py ...                  [ 34%]
framework/wazuh/core/tests/test_logtest.py ..                           [ 34%]
framework/wazuh/core/tests/test_manager.py ................             [ 35%]
framework/wazuh/core/tests/test_mitre.py .............                  [ 35%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                 [ 36%]
framework/wazuh/core/tests/test_results.py ............................ [ 37%]
............                                                            [ 38%]
framework/wazuh/core/tests/test_rootcheck.py .............              [ 38%]
framework/wazuh/core/tests/test_rule.py ......................          [ 39%]
framework/wazuh/core/tests/test_sca.py ........................         [ 40%]
framework/wazuh/core/tests/test_security.py .............               [ 41%]
framework/wazuh/core/tests/test_stats.py .................              [ 42%]
framework/wazuh/core/tests/test_syscheck.py .......                     [ 42%]
framework/wazuh/core/tests/test_syscollector.py ...                     [ 42%]
framework/wazuh/core/tests/test_task.py ........                        [ 43%]
framework/wazuh/core/tests/test_utils.py .............................. [ 44%]
....................................................................... [ 47%]
....................................................................... [ 51%]
....................................................................... [ 54%]
..                                                                      [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                     [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................     [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................    [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................  [ 58%]
framework/wazuh/core/tests/test_wlogging.py ............                [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                      [ 58%]
framework/wazuh/rbac/tests/test_decorators.py ......................... [ 60%]
....................................................................... [ 63%]
.........                                                                                                                                                                                                                             [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py .............. [ 64%]
..........................................                                                                                                                                                                                            [ 66%]
framework/wazuh/rbac/tests/test_orm.py ................................ [ 68%]
.................................                                                                                                                                                                                                     [ 69%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                                                           [ 70%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                                                            [ 70%]
framework/wazuh/tests/test_agent.py ................................... [ 72%]
....................................................................... [ 75%]
............                                                                                                                                                                                                                          [ 76%]
framework/wazuh/tests/test_cdb_list.py ................................ [ 77%]
.....................                                                                                                                                                                                                                 [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                                                [ 80%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                                                      [ 81%]
framework/wazuh/tests/test_decoder.py ................................. [ 82%]
..                                                                                                                                                                                                                                    [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                                                           [ 83%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                                                          [ 83%]
framework/wazuh/tests/test_manager.py ................................. [ 84%]
...                                                                                                                                                                                                                                   [ 85%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                                                           [ 85%]
framework/wazuh/tests/test_rootcheck.py ............................... [ 86%]
...................                                                                                                                                                                                                                   [ 87%]
framework/wazuh/tests/test_rule.py .................................... [ 89%]
...................                                                                                                                                                                                                                   [ 90%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                                                         [ 90%]
framework/wazuh/tests/test_security.py ................................ [ 92%]
.......................................                                                                                                                                                                                               [ 94%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                                                   [ 94%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                                                     [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................... [ 99%]
.............                                                                                                                                                                                                                         [100%]

=============================================================================================== 2101 passed, 50 warnings in 323.85s (0:05:23) ===============================================================================================
```

### API integration tests

```
test_decoder_endpoints_cluster - Cluster environment
	 25 passed, 30 warnings

test_rule_endpoints_cluster - Cluster environment
	 15 passed, 16 warnings
```

Regards,
Víctor