### PR TITLE
Engine - Implementation Sophos/Sandstorm decoder

### DIFF
--- a/src/engine/ruleset/decoders/sophos/sandstorn.yml
+++ b/src/engine/ruleset/decoders/sophos/sandstorn.yml
@@ -1,0 +1,103 @@
+---
+name: decoder/sophos-sandstorn/0
+
+metadata:
+  module: sophos
+  title: Sophos logs decoder
+  description: Decoder for sophos logs
+  author:
+    name: Wazuh Inc. info@wazuh.com
+    date: 2023-01-12
+  references:
+    - documentation link
+
+check:
+  - event.original: +r_match/<\d+>\s*device=.*?date=.*?time=.*?device_name=.*?device_id=.*?log_id=.*?log_type="Sandbox"
+
+sources:
+  - decoder/queue-syslog/0
+  - decoder/queue-localfile/0
+
+parse:
+  logpar:
+    # <30>device="SFW" date=2017-01-31 time=14:52:11 timezone="IST" device_name="CR750iNG-XP" device_id=C44310050024-P29PUA log_id=138301618041 log_type="Sandbox" log_component="Mail" log_subtype="Allowed" priority=Information user_name="" src_ip= filename="" filetype="" filesize=0 sha1sum="" source="" reason="eligible" destination="" subject=""
+    # <30>device="SFW" date=2017-01-31 time=14:52:11 timezone="IST" device_name="CR750iNG-XP" device_id=C44310050024-P29PUA log_id=138302218042 log_type="Sandbox" log_component="Mail" log_subtype="Denied" priority=Critical user_name="jsmith@iview.com" src_ip=10.198.47.112 filename="1.exe" filetype="application/octet-stream" filesize=153006 sha1sum="83cd339302bf5e8ed5240ca6383418089c337a81" source="jsmith@iview.com" reason="cached malicious" destination="" subject=""
+    # <30>device="SFW" date=2017-01-31 time=15:28:25 timezone="IST" device_name="CR750iNG-XP" device_id=C44313350024-P29PUA log_id=136501618041 log_type="Sandbox" log_component="Web" log_subtype="Allowed" priority=Information user_name="" src_ip= filename="" filetype="" filesize=0 sha1sum="" source="" reason="eligible" destination="" subject=""
+    # <30>device="SFW" date=2017-01-31 time=15:28:25 timezone="IST" device_name="CR750iNG-XP" device_id=C44310050024-P29PUA log_id=136528618043 log_type="Sandbox" log_component="Web" log_subtype="Pending" priority=Information user_name="jsmith" src_ip=10.198.47.112 filename="19.exe" filetype="application/octet-stream" filesize=153010 sha1sum="3ce799580908df9ca0dc649aa8c2d06ab267e8c8" source="10.198.241.50" reason="pending" destination="" subject=""
+    # <30>device="SFW" date=2017-01-31 time=15:28:25 timezone="IST" device_name="CR750iNG-XP" device_id=C44310050024-P29PUA log_id=136502218042 log_type="Sandbox" log_component="Web" log_subtype="Denied" priority=Critical user_name="jsmith" src_ip=10.198.47.112 filename="19.exe" filetype="application/octet-stream" filesize=153010 sha1sum="3ce799580908df9ca0dc649aa8c2d06ab267e8c8" source="10.198.241.50" reason="cloud malicious" destination="" subject="
+    # <30>device="SFW" date=2020-05-18 time=14:38:36 timezone="IST" device_name="CR750iNG-XP" device_id=C44310050024-P29PUA log_id=136502218042 log_type="Sandbox" log_component="Web" log_subtype="Denied" priority=Critical user_name="" src_ip=172.16.34.24 filename="SBTestFile1.pdf" filetype="application/pdf" filesize=1124 sha1sum="d910c4a81122c360fe57f67a04999425a65249db" source="sophostest.com" reason="cached malicious" destination="" subject=""
+    - event.original: \<<~log.head_message>><~log.payload_messge>
+
+normalize:
+  - check:
+      - ~log.payload_messge: +ef_exists
+    logpar:
+      - ~log.payload_messge: <~tmp/kv/=/ /"/'>
+    map:
+      - event.action: $~tmp.log_subtype
+      - event.code: $~tmp.log_id
+      - event.dataset: sophos.xg
+      - event.kind: event
+      - event.module: sophos
+      - event.outcome: success
+      - event.reason: $~tmp.reason
+  - check:
+      - ~tmp.priority: Unknown
+    map:
+      - event.severity: 0
+  - check:
+      - ~tmp.priority: Alert
+    map:
+      - event.severity: 1
+  - check:
+      - ~tmp.priority: Critical
+    map:
+      - event.severity: 2
+  - check:
+      - ~tmp.priority: Error
+    map:
+      - event.severity: 3
+  - check:
+      - ~tmp.priority: Warning
+    map:
+      - event.severity: 4
+  - check:
+      - ~tmp.priority: Notification
+    map:
+      - event.severity: 5
+  - check:
+      - ~tmp.priority: Information
+    map:
+      - event.severity: 6
+  - map:
+      # TODO: need converter timezone abbrevation to UTC offset, for example 'IST' to -02:00
+      - event.timezone: $~tmp.timezone
+      - file.hash.sha: $~tmp.sha1sum
+      - file.mime_type: $~tmp.filetype
+      - file.size: $~tmp.filesize
+      - fileset.name: xg
+      - input.type: log
+      - log.level: $~tmp.priority
+      - observer.product: XG
+      - observer.serial_number: $~tmp.device_id
+      - observer.type: firewall
+      - observer.vendor: Sophos
+      - related.hash: [$~tmp.sha1sum]
+      - related.ip: [$~tmp.src_ip, $~tmp.source]
+      - related.user: [$~tmp.user_name]
+      - sophos.xg.device: $~tmp.device
+      - sophos.xg.device_name: $~tmp.device_name
+      - sophos.xg.log_component: $~tmp.log_type
+      - sophos.xg.log_id: $~tmp.log_type
+      - sophos.xg.log_subtype: $~tmp.log_subtype
+      - sophos.xg.log_type: $~tmp.log_type
+      - sophos.xg.priority: $~tmp.priority
+      - sophos.xg.source: $~tmp.source
+      - source.ip: $~tmp.src_ip
+      - source.user.name: $~tmp.user_name
+      - url.domain: $~tmp.source
+      - tags: [forwarded, preserve_original_even, sophos-xg]
+      - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time
+      - ~log: +ef_delete
+      - ~tmp: +ef_delete
+

--- a/src/engine/ruleset/decoders/sophos/sandstorn.yml
+++ b/src/engine/ruleset/decoders/sophos/sandstorn.yml
@@ -26,13 +26,15 @@ parse:
     # <30>device="SFW" date=2017-01-31 time=15:28:25 timezone="IST" device_name="CR750iNG-XP" device_id=C44310050024-P29PUA log_id=136528618043 log_type="Sandbox" log_component="Web" log_subtype="Pending" priority=Information user_name="jsmith" src_ip=10.198.47.112 filename="19.exe" filetype="application/octet-stream" filesize=153010 sha1sum="3ce799580908df9ca0dc649aa8c2d06ab267e8c8" source="10.198.241.50" reason="pending" destination="" subject=""
     # <30>device="SFW" date=2017-01-31 time=15:28:25 timezone="IST" device_name="CR750iNG-XP" device_id=C44310050024-P29PUA log_id=136502218042 log_type="Sandbox" log_component="Web" log_subtype="Denied" priority=Critical user_name="jsmith" src_ip=10.198.47.112 filename="19.exe" filetype="application/octet-stream" filesize=153010 sha1sum="3ce799580908df9ca0dc649aa8c2d06ab267e8c8" source="10.198.241.50" reason="cloud malicious" destination="" subject="
     # <30>device="SFW" date=2020-05-18 time=14:38:36 timezone="IST" device_name="CR750iNG-XP" device_id=C44310050024-P29PUA log_id=136502218042 log_type="Sandbox" log_component="Web" log_subtype="Denied" priority=Critical user_name="" src_ip=172.16.34.24 filename="SBTestFile1.pdf" filetype="application/pdf" filesize=1124 sha1sum="d910c4a81122c360fe57f67a04999425a65249db" source="sophostest.com" reason="cached malicious" destination="" subject=""
-    - event.original: \<<~log.head_message>><~log.payload_messge>
+    - event.original: \<<~tmp.head_message>><~tmp.payload_message>
 
 normalize:
   - check:
-      - ~log.payload_messge: +ef_exists
+      - ~tmp.payload_message: +ef_exists
+    map:
+      - ~tmp.payload_message: +s_replace/=""/=" "
     logpar:
-      - ~log.payload_messge: <~tmp/kv/=/ /"/'>
+      - ~tmp.payload_message: <~tmp/kv/=/ /"/'>
     map:
       - event.action: $~tmp.log_subtype
       - event.code: $~tmp.log_id

--- a/src/engine/ruleset/environments/wazuh-environment.yml
+++ b/src/engine/ruleset/environments/wazuh-environment.yml
@@ -21,6 +21,7 @@ decoders:
   - decoder/rootcheck/0
   - decoder/sca/0
   - decoder/sophos-antivirus/0
+  - decoder/sophos-sandstorn/0
   - decoder/sophos-systemhealth/0
   - decoder/sophos-utm/0
   - decoder/sophos-waf/0


### PR DESCRIPTION
|Related issue|
|---|
|#15851|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

With the aim of expanding the coverage of the decoders, this PR adds a decoder for Sophos/Sandstorm.

## Configuration options

Validate the new decoder:
- ./build/main catalog validate decoder/sophos-sandstorm/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/sandstorm.yml

Create decoder:
- ./build/main  catalog create decoder < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/sandstorm.yml

Update environment
- ./build/main catalog update environment/wazuh/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/environments/wazuh-environment.yml

Test new decoder
- ./build/main test -q 1

## Logs/Alerts example

- <30>device="SFW" date=2017-01-31 time=15:28:25 timezone="IST" device_name="CR750iNG-XP" device_id=C44310050024-P29PUA log_id=136502218042 log_type="Sandbox" log_component="Web" log_subtype="Denied" priority=Critical user_name="jsmith" src_ip=10.198.47.112 filename="19.exe" filetype="application/octet-stream" filesize=153010 sha1sum="3ce799580908df9ca0dc649aa8c2d06ab267e8c8" source="10.198.241.50" reason="cloud malicious" destination="" subject="

## Tests

Event:
- <30>device="SFW" date=2017-01-31 time=15:28:25 timezone="IST" device_name="CR750iNG-XP" device_id=C44310050024-P29PUA log_id=136502218042 log_type="Sandbox" log_component="Web" log_subtype="Denied" priority=Critical user_name="jsmith" src_ip=10.198.47.112 filename="19.exe" filetype="application/octet-stream" filesize=153010 sha1sum="3ce799580908df9ca0dc649aa8c2d06ab267e8c8" source="10.198.241.50" reason="cloud malicious" destination="" subject="


Output:
```

{
    "wazuh": {
        "queue": 49,
        "origin": "/dev/stdin"
    },
    "event": {
        "original": "<30>device=\"SFW\" date=2017-01-31 time=15:28:25 timezone=\"IST\" device_name=\"CR750iNG-XP\" device_id=C44310050024-P29PUA log_id=136502218042 log_type=\"Sandbox\" log_component=\"Web\" log_subtype=\"Denied\" priority=Critical user_name=\"jsmith\" src_ip=10.198.47.112 filename=\"19.exe\" filetype=\"application/octet-stream\" filesize=153010 sha1sum=\"3ce799580908df9ca0dc649aa8c2d06ab267e8c8\" source=\"10.198.241.50\" reason=\"cloud malicious\" destination=\"\" subject=\"",
        "action": "Denied",
        "code": 136502218042,
        "dataset": "sophos.xg",
        "kind": "event",
        "module": "sophos",
        "outcome": "success",
        "reason": "cloud malicious",
        "severity": 2,
        "timezone": "IST"
    },
    "file": {
        "hash": {
            "sha": "3ce799580908df9ca0dc649aa8c2d06ab267e8c8"
        },
        "mime_type": "application/octet-stream",
        "size": 153010
    },
    "fileset": {
        "name": "xg"
    },
    "input": {
        "type": "log"
    },
    "log": {
        "level": "Critical"
    },
    "observer": {
        "product": "XG",
        "serial_number": "C44310050024-P29PUA",
        "type": "firewall",
        "vendor": "Sophos"
    },
    "related": {
        "hash": [
            "3ce799580908df9ca0dc649aa8c2d06ab267e8c8"
        ],
        "ip": [
            "10.198.47.112",
            "10.198.241.50"
        ],
        "user": [
            "jsmith"
        ]
    },
    "sophos": {
        "xg": {
            "device": "SFW",
            "device_name": "CR750iNG-XP",
            "log_component": "Sandbox",
            "log_id": "Sandbox",
            "log_subtype": "Denied",
            "log_type": "Sandbox",
            "priority": "Critical",
            "source": "10.198.241.50"
        }
    },
    "source": {
        "ip": "10.198.47.112",
        "user": {
            "name": "jsmith"
        }
    },
    "url": {
        "domain": "10.198.241.50"
    },
    "tags": [
        "forwarded",
        "preserve_original_even",
        "sophos-xg"
    ],
    "\\@timestamp": "2017-01-31T15:28:25"
}



```
