### PR TITLE
Engine - Implementation Sophos/Firewall decoder

### DIFF
--- a/src/engine/ruleset/decoders/sophos/firewall.yml
+++ b/src/engine/ruleset/decoders/sophos/firewall.yml
@@ -1,0 +1,129 @@
+---
+name: decoder/sophos-firewall/0
+
+metadata:
+  module: sophos
+  title: Sophos logs decoder
+  description: Decoder for sophos logs
+  author:
+    name: Wazuh Inc. info@wazuh.com
+    date: 2023-01-12
+  references:
+    - documentation link
+
+check:
+  - event.original: +r_match/<\d+>\s*device=.*?date=.*?time=.*?device_name=.*?device_id=.*?log_id=.*?log_type="Firewall"
+
+sources:
+  - decoder/queue-syslog/0
+  - decoder/queue-localfile/0
+
+parse:
+  logpar:
+    # <30>device="SFW" date=2020-05-18 time=14:38:45 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=010101600001 log_type="Firewall" log_component="Firewall Rule" log_subtype="Allowed" status="Allow" priority=Information duration=0 fw_rule_id=61 policy_type=2 user_name="elastic@user.local" user_gp="elastic.group.local" iap=0 ips_policy_id=11 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="ipsec0" out_interface="Port2" src_mac=00:00:00:00:00:00 src_ip=10.84.234.7 src_country_code=R1 dst_ip=172.16.34.50 dst_country_code=R1 protocol="TCP" src_port=58543 dst_port=443 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip="" tran_src_port=0 tran_dst_ip="" tran_dst_port=0 srczonetype="VPN" srczone="VPN" dstzonetype="VPN" dstzone="VPN" dir_disp="" connevent="Start" connid="1615935064" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature" app_is_cloud=0
+    - event.original: \<<~log.head_message>><~log.payload_messge>
+
+normalize:
+  - check:
+      - ~log.payload_messge: +ef_exists
+    logpar:
+      - ~log.payload_messge: <~tmp/kv/=/ /"/'>
+    map:
+      - destination.bytes: $~tmp.recv_bytes
+      - destination.ip: $~tmp.dst_ip
+      - destination.nat.ip: $~tmp.tran_dst_ip
+      - destination.nat.port: $~tmp.tran_dst_port
+      - destination.packets: $~tmp.recv_pkts
+      - destination.port: $~tmp.dst_port
+      - event.action: +s_lo/$~tmp.log_subtype
+      - event.code: $~tmp.log_id
+      - event.dataset: sophos.xg
+      - event.duration: $~tmp.duration
+      - event.end: +s_concat/$~tmp.date/T/$~tmp.time
+      - event.kind: event
+      - event.module: sophos
+      - event.outcome: success
+  - check:
+      - ~tmp.priority: Unknown
+    map:
+      - event.severity: 0
+  - check:
+      - ~tmp.priority: Alert
+    map:
+      - event.severity: 1
+  - check:
+      - ~tmp.priority: Critical
+    map:
+      - event.severity: 2
+  - check:
+      - ~tmp.priority: Error
+    map:
+      - event.severity: 3
+  - check:
+      - ~tmp.priority: Warning
+    map:
+      - event.severity: 4
+  - check:
+      - ~tmp.priority: Notification
+    map:
+      - event.severity: 5
+  - check:
+      - ~tmp.priority: Information
+    map:
+      - event.severity: 6
+  - map:
+      - event.start: +s_concat/$~tmp.date/T/$~tmp.time
+      - event.timezone: $~tmp.timezone
+      - event.type: [allowed, connection, start]
+      - fileset.name: xg
+      - input.type: log
+      - log.level: $~tmp.priority
+      - network.transport: +s_lo/$~tmp.protocol
+      - observer.egress.interface.name: $~tmp.out_interface
+      - observer.egress.zone: $~tmp.dstzone
+      - observer.ingress.interface.name: $~tmp.in_interface
+      - observer.ingress.zone: $~tmp.srczone
+      - observer.product: XG
+      - observer.serial_number: $~tmp.device_id
+      - observer.type: firewall
+      - observer.vendor: Sophos
+      - related.ip: [$~tmp.src_ip, $~tmp.dst_ip, $~tmp.tran_src_ip, $~tmp.tran_dst_ip]
+      - related.user: [$~tmp.user_name]
+      - rule.id: $~tmp.fw_rule_id
+      - rule.ruleset: $~tmp.policy_type
+      - service.type: sophos
+      - sophos.xg.app_is_cloud: $~tmp.app_is_cloud
+      - sophos.xg.appfilter_policy_id: $~tmp.appfilter_policy_id
+      - sophos.xg.application_risk: $~tmp.application_risk
+      - sophos.xg.appresolvedby: $~tmp.appresolvedby
+      - sophos.xg.connevent: $~tmp.connevent
+      - sophos.xg.connid: $~tmp.connid
+      - sophos.xg.device: $~tmp.device
+      - sophos.xg.device_name: $~tmp.device_name
+      - sophos.xg.dst_country_code: $~tmp.dst_country_code
+      - sophos.xg.dst_zone_type: $~tmp.dstzonetype
+      - sophos.xg.ether_type: $~tmp.ether_type
+      - sophos.xg.hb_health: $~tmp.hb_health
+      - sophos.xg.iap: $~tmp.iap
+      - sophos.xg.ips_policy_id: $~tmp.ips_policy_id
+      - sophos.xg.log_component: $~tmp.log_component
+      - sophos.xg.log_id: $~tmp.log_id
+      - sophos.xg.log_subtype: $~tmp.log_subtype
+      - sophos.xg.log_type: $~tmp.log_type
+      - sophos.xg.priority: $~tmp.priority
+      - sophos.xg.src_country_code: $~tmp.src_country_code
+      - sophos.xg.src_zone_type: $~tmp.srczonetype
+      - sophos.xg.status: $~tmp.status
+      - source.bytes: $~tmp.sent_bytes
+      - source.ip: $~tmp.src_ip
+      - source.mac: $~tmp.src_mac
+      - source.nat.ip: $~tmp.tran_src_ip
+      - source.nat.port: $~tmp.tran_src_port
+      - source.packets: $~tmp.sent_pkts
+      - source.port: $~tmp.src_port
+      - source.user.group.name: $~tmp.user_gp
+      - source.user.name: $~tmp.user_name
+      - tags: [forwarded, preserve_original_event, sophos-xg]
+      - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time
+      - ~tmp: +ef_delete
+      - ~log: +ef_delete

--- a/src/engine/ruleset/decoders/sophos/firewall.yml
+++ b/src/engine/ruleset/decoders/sophos/firewall.yml
@@ -21,13 +21,15 @@ sources:
 parse:
   logpar:
     # <30>device="SFW" date=2020-05-18 time=14:38:45 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=010101600001 log_type="Firewall" log_component="Firewall Rule" log_subtype="Allowed" status="Allow" priority=Information duration=0 fw_rule_id=61 policy_type=2 user_name="elastic@user.local" user_gp="elastic.group.local" iap=0 ips_policy_id=11 appfilter_policy_id=0 application="" application_risk=0 application_technology="" application_category="" in_interface="ipsec0" out_interface="Port2" src_mac=00:00:00:00:00:00 src_ip=10.84.234.7 src_country_code=R1 dst_ip=172.16.34.50 dst_country_code=R1 protocol="TCP" src_port=58543 dst_port=443 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip="" tran_src_port=0 tran_dst_ip="" tran_dst_port=0 srczonetype="VPN" srczone="VPN" dstzonetype="VPN" dstzone="VPN" dir_disp="" connevent="Start" connid="1615935064" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature" app_is_cloud=0
-    - event.original: \<<~log.head_message>><~log.payload_messge>
+    - event.original: \<<~tmp.head_message>><~tmp.payload_message>
 
 normalize:
   - check:
-      - ~log.payload_messge: +ef_exists
+      - ~tmp.payload_message: +ef_exists
+    map:
+      - ~tmp.payload_message: +s_replace/=""/=" "
     logpar:
-      - ~log.payload_messge: <~tmp/kv/=/ /"/'>
+      - ~tmp.payload_message: <~tmp/kv/=/ /"/'>
     map:
       - destination.bytes: $~tmp.recv_bytes
       - destination.ip: $~tmp.dst_ip
@@ -126,4 +128,3 @@ normalize:
       - tags: [forwarded, preserve_original_event, sophos-xg]
       - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time
       - ~tmp: +ef_delete
-      - ~log: +ef_delete

--- a/src/engine/ruleset/environments/wazuh-environment.yml
+++ b/src/engine/ruleset/environments/wazuh-environment.yml
@@ -21,6 +21,7 @@ decoders:
   - decoder/rootcheck/0
   - decoder/sca/0
   - decoder/sophos-antivirus/0
+  - decoder/sophos-firewall/0
   - decoder/sophos-idp/0
   - decoder/sophos-sandstorn/0
   - decoder/sophos-systemhealth/0


### PR DESCRIPTION
|Related issue|
|---|
|#15851|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

With the aim of expanding the coverage of the decoders, this PR adds a decoder for Sophos/Firewall.

## Configuration options

Validate the new decoder:
- ./build/main catalog validate decoder/sophos-ldp/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/firewall.yml

Create decoder:
- ./build/main  catalog create decoder < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/firewall.yml

Update environment
- ./build/main catalog update environment/wazuh/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/environments/wazuh-environment.yml

Test new decoder
- ./build/main test -q 1

## Logs/Alerts example

- <30>device="SFW" date=2020-05-18 time=14:38:37 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=010101600001 log_type="Firewall" log_component="Firewall Rule" log_subtype="Allowed" status="Allow" priority=Information duration=11 fw_rule_id=21 policy_type=1 user_name="" user_gp="" iap=0 ips_policy_id=0 appfilter_policy_id=0 application="HTTP" application_risk=1 application_technology="Browser Based" application_category="General Internet" in_interface="Port1" out_interface="Port2" src_mac=00:00:00:00:00:00 src_ip=1.128.3.4 src_country_code=R1 dst_ip=91.228.167.86 dst_country_code=SVK protocol="TCP" src_port=62841 dst_port=80 sent_pkts=6  recv_pkts=5 sent_bytes=459 recv_bytes=606 tran_src_ip=213.167.51.66 tran_src_port=0 tran_dst_ip="" tran_dst_port=0 srczonetype="LAN" srczone="LAN" dstzonetype="WAN" dstzone="WAN" dir_disp="" connevent="Stop" connid="1617925280" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature" app_is_cloud=0

## Tests

Event:
- <30>device="SFW" date=2020-05-18 time=14:38:37 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=010101600001 log_type="Firewall" log_component="Firewall Rule" log_subtype="Allowed" status="Allow" priority=Information duration=11 fw_rule_id=21 policy_type=1 user_name="" user_gp="" iap=0 ips_policy_id=0 appfilter_policy_id=0 application="HTTP" application_risk=1 application_technology="Browser Based" application_category="General Internet" in_interface="Port1" out_interface="Port2" src_mac=00:00:00:00:00:00 src_ip=1.128.3.4 src_country_code=R1 dst_ip=91.228.167.86 dst_country_code=SVK protocol="TCP" src_port=62841 dst_port=80 sent_pkts=6  recv_pkts=5 sent_bytes=459 recv_bytes=606 tran_src_ip=213.167.51.66 tran_src_port=0 tran_dst_ip="" tran_dst_port=0 srczonetype="LAN" srczone="LAN" dstzonetype="WAN" dstzone="WAN" dir_disp="" connevent="Stop" connid="1617925280" vconnid="" hb_health="No Heartbeat" message="" appresolvedby="Signature" app_is_cloud=0


Output:
```
{
    "wazuh": {
        "queue": 49,
        "origin": "/dev/stdin"
    },
    "event": {
        "original": "<30>device=\"SFW\" date=2020-05-18 time=14:38:37 timezone=\"CEST\" device_name=\"XG230\" device_id=1234567890123456 log_id=010101600001 log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" status=\"Allow\" priority=Information duration=11 fw_rule_id=21 policy_type=1 user_name=\"\" user_gp=\"\" iap=0 ips_policy_id=0 appfilter_policy_id=0 application=\"HTTP\" application_risk=1 application_technology=\"Browser Based\" application_category=\"General Internet\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=00:00:00:00:00:00 src_ip=1.128.3.4 src_country_code=R1 dst_ip=91.228.167.86 dst_country_code=SVK protocol=\"TCP\" src_port=62841 dst_port=80 sent_pkts=6  recv_pkts=5 sent_bytes=459 recv_bytes=606 tran_src_ip=213.167.51.66 tran_src_port=0 tran_dst_ip=\"\" tran_dst_port=0 srczonetype=\"LAN\" srczone=\"LAN\" dstzonetype=\"WAN\" dstzone=\"WAN\" dir_disp=\"\" connevent=\"Stop\" connid=\"1617925280\" vconnid=\"\" hb_health=\"No Heartbeat\" message=\"\" appresolvedby=\"Signature\" app_is_cloud=0",
        "action": "allowed",
        "code": 10101600001,
        "dataset": "sophos.xg",
        "duration": 11,
        "end": "2020-05-18T14:38:37",
        "kind": "event",
        "module": "sophos",
        "outcome": "success",
        "severity": 6,
        "start": "2020-05-18T14:38:37",
        "timezone": "CEST",
        "type": [
            "allowed",
            "connection",
            "start"
        ]
    },
    "destination": {
        "bytes": 606,
        "ip": "91.228.167.86",
        "nat": {
            "ip": "\" tran_dst_port=0 srczonetype=\"LAN"
        },
        "port": 80
    },
    "fileset": {
        "name": "xg"
    },
    "input": {
        "type": "log"
    },
    "log": {
        "level": "Information"
    },
    "network": {
        "transport": "tcp"
    },
    "observer": {
        "egress": {
            "interface": {
                "name": "Port2"
            },
            "zone": "WAN"
        },
        "ingress": {
            "interface": {
                "name": "Port1"
            },
            "zone": "LAN"
        },
        "product": "XG",
        "serial_number": 1234567890123456,
        "type": "firewall",
        "vendor": "Sophos"
    },
    "related": {
        "ip": [
            "1.128.3.4",
            "91.228.167.86",
            "213.167.51.66",
            "\" tran_dst_port=0 srczonetype=\"LAN"
        ],
        "user": [
            "\" user_gp=\"\" iap=0 ips_policy_id=0 appfilter_policy_id=0 application=\"HTTP"
        ]
    },
    "rule": {
        "id": 21,
        "ruleset": 1
    },
    "service": {
        "type": "sophos"
    },
    "sophos": {
        "xg": {
            "app_is_cloud": 0,
            "application_risk": 1,
            "connid": 1617925280,
            "device": "SFW",
            "device_name": "XG230",
            "dst_country_code": "SVK",
            "dst_zone_type": "WAN",
            "log_component": "Firewall Rule",
            "log_id": 10101600001,
            "log_subtype": "Allowed",
            "log_type": "Firewall",
            "priority": "Information",
            "src_country_code": "R1",
            "status": "Allow"
        }
    },
    "source": {
        "bytes": 459,
        "ip": "1.128.3.4",
        "mac": "00:00:00:00:00:00",
        "nat": {
            "ip": "213.167.51.66",
            "port": 0
        },
        "packets": 6,
        "port": 62841,
        "user": {
            "name": "\" user_gp=\"\" iap=0 ips_policy_id=0 appfilter_policy_id=0 application=\"HTTP"
        }
    },
    "tags": [
        "forwarded",
        "preserve_original_event",
        "sophos-xg"
    ],
    "\\@timestamp": "2020-05-18T14:38:37"
}
```
