### PR TITLE
Clear the cached group-hash after inserting or deleting an agent from the global database.

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -189,7 +189,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GROUP_PRIORITY_GET] = "SELECT MAX(priority) FROM belongs WHERE id_agent=?;",
     [WDB_STMT_GLOBAL_GROUP_CSV_GET] = "SELECT `group` from agent where id = ?;",
     [WDB_STMT_GLOBAL_GROUP_CTX_SET] = "UPDATE agent SET 'group' = ?, group_hash = ?, group_sync_status = ? WHERE id = ?;",
-    [WDB_STMT_GLOBAL_GROUP_HASH_GET] = "SELECT group_hash FROM agent WHERE group_hash IS NOT NULL ORDER BY id;",
+    [WDB_STMT_GLOBAL_GROUP_HASH_GET] = "SELECT group_hash FROM agent WHERE id > 0 AND group_hash IS NOT NULL ORDER BY id;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, connection_status = :connection_status, disconnection_time = :disconnection_time, group_config_status = :group_config_status, sync_status = :sync_status WHERE id = :id;",
     [WDB_STMT_GLOBAL_GET_GROUPS] = "SELECT DISTINCT `group`, group_hash from agent WHERE id > 0 AND group_hash > ? ORDER BY group_hash;",
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ?;",

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5045,6 +5045,8 @@ int wdb_parse_global_insert_agent(wdb_t * wdb, char * input, char * output) {
         }
     }
 
+    wdb_global_group_hash_cache(WDB_GLOBAL_GROUP_HASH_CLEAR, NULL);
+
     snprintf(output, OS_MAXSTR + 1, "ok");
     cJSON_Delete(agent_data);
 
@@ -5374,6 +5376,8 @@ int wdb_parse_global_delete_agent(wdb_t * wdb, char * input, char * output) {
         snprintf(output, OS_MAXSTR + 1, "err Error deleting agent from agent table in global.db.");
         return OS_INVALID;
     }
+
+    wdb_global_group_hash_cache(WDB_GLOBAL_GROUP_HASH_CLEAR, NULL);
 
     snprintf(output, OS_MAXSTR + 1, "ok");
 


### PR DESCRIPTION
|Related issue|Manual Testing|Integration Tests|
|---|---|---|
|#15966|https://github.com/wazuh/wazuh-qa/issues/3868|https://github.com/wazuh/wazuh-qa/pull/3895|


## Description

This PR adds two calls to clear the cached group-hash, one after inserting an agent into the global database and the other after removing an agent from the global database.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Working on cluster environments
- [ ] Stress test for affected components
