### PR TITLE
FIM DB fix ignore functionality in dbsync

### DIFF
--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -70,6 +70,7 @@
 #define FIM_WHODATA_ERROR_CHECKING_POL          "(6951): Unable to check the necessary policies for whodata: %s (%lu)."
 #define FIM_WHODATA_POLICY_CHANGE_CHECKER       "(6952): Audit policy change detected. Switching directories to realtime."
 #define FIM_WHODATA_POLICY_CHANGE_CHANNEL       "(6953): Event 4719 received due to changes in audit policy. Switching directories to realtime."
+#define FIM_EMPTY_CHANGED_ATTRIBUTES            "(6954): Entry '%s' does not have any modified fields. No event will be generated."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -1382,7 +1382,7 @@ bool SQLiteDBEngine::getRowDiff(const std::vector<std::string>& primaryKeyList,
                 }
             };
 
-            if (!haveDiffOnNonIgnored(updatedData))
+            if (!haveDiffOnNonIgnored(oldData))
             {
                 updatedData.clear();
                 oldData.clear();

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -323,26 +323,10 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
     cJSON* timestamp = NULL;
     directory_t *configuration = NULL;
     fim_txn_context_t *txn_context = (fim_txn_context_t *) user_data;
-    bool process_event = false;
 
     // Do not process if it's the first scan
     if (_base_line == 0) {
         return; // LCOV_EXCL_LINE
-    }
-
-    // In the modification events, inside the old field there must be other fields
-    // than "path" and "last_event" to generate a modification event.
-    old_data = cJSON_GetObjectItem(result_json, "old");
-    if (old_data != NULL) {
-        cJSON_ArrayForEach(aux, old_data) {
-            if (strcmp(aux->string, "path") && strcmp(aux->string, "last_event")) {
-                process_event = true;
-                break;
-            }
-        }
-        if (!process_event) {
-            return;
-        }
     }
 
     // In case of deletions, latest_entry is NULL, so we need to get the path from the json event
@@ -421,6 +405,7 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
     } else {
         cJSON_AddItemToObject(data, "attributes", fim_attributes_json(txn_context->latest_entry->file_entry.data));
 
+        old_data = cJSON_GetObjectItem(result_json, "old");
         if (old_data) {
             old_attributes = cJSON_CreateObject();
             changed_attributes = cJSON_CreateArray();

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -166,7 +166,7 @@ static void registry_key_transaction_callback(ReturnTypeCallback resultType,
     cJSON_AddItemToObject(data, "attributes", fim_registry_key_attributes_json(result_json, key, configuration));
 
     old_data = cJSON_GetObjectItem(result_json, "old");
-    if (old_data = cJSON_GetObjectItem(result_json, "old"), old_data != NULL) {
+    if (old_data != NULL) {
         old_attributes = cJSON_CreateObject();
         changed_attributes = cJSON_CreateArray();
         cJSON_AddItemToObject(data, "old_attributes", old_attributes);

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -84,26 +84,10 @@ static void registry_key_transaction_callback(ReturnTypeCallback resultType,
     char *path = NULL;
     int arch = -1;
     char *hash_full_path;
-    bool process_event = false;
 
     // Do not process if it's the first scan
     if (_base_line == 0) {
         return;
-    }
-
-    // In the modification events, inside the old field there must be other fields
-    // than "path", "arch" and "last_event" to generate a modification event.
-    old_data = cJSON_GetObjectItem(result_json, "old");
-    if (old_data != NULL) {
-        cJSON_ArrayForEach(aux, old_data) {
-            if (strcmp(aux->string, "path") && strcmp(aux->string, "last_event") && strcmp(aux->string, "arch")) {
-                process_event = true;
-                break;
-            }
-        }
-        if (!process_event) {
-            return;
-        }
     }
 
     // In case of deletions, key is NULL, so we need to get the path and arch from the json event
@@ -181,6 +165,7 @@ static void registry_key_transaction_callback(ReturnTypeCallback resultType,
     }
     cJSON_AddItemToObject(data, "attributes", fim_registry_key_attributes_json(result_json, key, configuration));
 
+    old_data = cJSON_GetObjectItem(result_json, "old");
     if (old_data = cJSON_GetObjectItem(result_json, "old"), old_data != NULL) {
         old_attributes = cJSON_CreateObject();
         changed_attributes = cJSON_CreateArray();
@@ -232,26 +217,10 @@ static void registry_value_transaction_callback(ReturnTypeCallback resultType,
     char* diff = event_data->diff;
     fim_registry_value_data *value = event_data->data;
     char *hash_full_path;
-    bool process_event = false;
 
     // Do not process if it's the first scan
     if (_base_line == 0) {
         return;
-    }
-
-    // In the modification events, inside the old field there must be other fields
-    // than "path", "arch", "name" and "last_event" to generate a modification event.
-    old_data = cJSON_GetObjectItem(result_json, "old");
-    if (old_data != NULL) {
-        cJSON_ArrayForEach(aux, old_data) {
-            if (strcmp(aux->string, "path") && strcmp(aux->string, "last_event") && strcmp(aux->string, "arch") && strcmp(aux->string, "name")) {
-                process_event = true;
-                break;
-            }
-        }
-        if (!process_event) {
-            return;
-        }
     }
 
     // In case of deletions, value is NULL, so we need to get the path and arch from the json event

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -176,6 +176,11 @@ static void registry_key_transaction_callback(ReturnTypeCallback resultType,
                                             old_data,
                                             changed_attributes,
                                             old_attributes);
+
+        if (cJSON_GetArraySize(changed_attributes) == 0) {
+            mwarn(FIM_EMPTY_CHANGED_ATTRIBUTES, path);
+            goto end;
+        }
     }
 
     if (configuration->tag != NULL) {
@@ -315,6 +320,11 @@ static void registry_value_transaction_callback(ReturnTypeCallback resultType,
                                               old_data,
                                               changed_attributes,
                                               old_attributes);
+
+        if (cJSON_GetArraySize(changed_attributes) == 0) {
+            mwarn(FIM_EMPTY_CHANGED_ATTRIBUTES, path);
+            goto end;
+        }
     }
 
     if (configuration->tag != NULL) {


### PR DESCRIPTION
|Related issue|
|---|
|#9103|


## Description
Hello team,
This PR is to solve the error of false positives found in FIM. We have found some modified events without any changes in the FIM fields.
The cause was because recent changes in dbsync had changed the behavior of the ignored fields filter. And since by default there is always a modification in the last_event field (which should be ignored), modified events were being generated without changes.

- Fixed in dbsync the functionality of ignoring fields.
- Removed some filters that we had put in the FIM callbacks.
- Added a warning in case a similar case is found (It should never be the case of reaching the FIM callback with an event without change).
