### PR TITLE
Fix detection of OS version for Linux Alpine

### DIFF
--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -26,11 +26,11 @@ static bool parseUnixFile(const std::vector<std::pair<std::string, std::string>>
 
     Utils::splitMapKeyValue(fileContent, separator, fileKeyValueMap);
 
-    for(auto keyMappingEntry : keyMapping)
+    for (auto keyMappingEntry : keyMapping)
     {
-        if(info.find(keyMappingEntry.second) == info.end())
+        if (info.find(keyMappingEntry.second) == info.end())
         {
-            if((itFileKeyValue = fileKeyValueMap.find(keyMappingEntry.first)) != fileKeyValueMap.end())
+            if ((itFileKeyValue = fileKeyValueMap.find(keyMappingEntry.first)) != fileKeyValueMap.end())
             {
                 info[keyMappingEntry.second] = itFileKeyValue->second;
                 ret = true;

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -133,7 +133,7 @@ bool UnixOsParser::parseFile(std::istream& in, nlohmann::json& info)
         {"BUILD_ID",         "os_build"},
         {"VERSION_CODENAME", "os_codename"}
     };
-    bool ret = parseUnixFile(KEY_MAPPING, SEPARATOR, in, info);
+    const auto ret {parseUnixFile(KEY_MAPPING, SEPARATOR, in, info)};
 
     if (ret && info.find("os_version") != info.end())
     {

--- a/src/data_provider/src/osinfo/sysOsParsers.h
+++ b/src/data_provider/src/osinfo/sysOsParsers.h
@@ -134,6 +134,14 @@ class HpUxOsParser : public ISysOsParser
         bool parseUname(const std::string& in, nlohmann::json& output) override;
 };
 
+class AlpineOsParser : public ISysOsParser
+{
+    public:
+        AlpineOsParser() = default;
+        ~AlpineOsParser() = default;
+        bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
 class MacOsParser
 {
     public:
@@ -212,6 +220,11 @@ class FactorySysOsParser final
             if (platform == "hp-ux")
             {
                 return std::make_unique<HpUxOsParser>();
+            }
+
+            if (platform == "alpine")
+            {
+                return std::make_unique<AlpineOsParser>();
             }
 
             throw std::runtime_error

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -306,6 +306,7 @@ static bool getOsInfoFromFiles(nlohmann::json& info)
         {"debian",      "/etc/debian_version"   },
         {"slackware",   "/etc/slackware-version"},
         {"ubuntu",      "/etc/lsb-release"      },
+        {"alpine",      "/etc/alpine-release"   },
     };
     const auto parseFnc
     {

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -115,6 +115,30 @@ TEST_F(SysInfoParsersTest, UnixArch)
     EXPECT_EQ("arch", output["os_platform"]);
 }
 
+TEST_F(SysInfoParsersTest, UnixAlpine)
+{
+    constexpr auto UNIX_RELEASE_FILE
+    {
+        R"(
+        NAME="Alpine Linux"
+        ID=alpine
+        VERSION_ID=3.17.1
+        PRETTY_NAME="Alpine Linux v3.17"
+        HOME_URL="https://alpinelinux.org/"
+        BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
+        )"
+    };
+    nlohmann::json output;
+    std::stringstream info{UNIX_RELEASE_FILE};
+    const auto spParser{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("3.17.1", output["os_version"]);
+    EXPECT_EQ("Alpine Linux", output["os_name"]);
+    EXPECT_EQ("alpine", output["os_platform"]);
+    EXPECT_EQ("3", output["os_major"]);
+    EXPECT_EQ("17", output["os_minor"]);
+    EXPECT_EQ("1", output["os_patch"]);
+}
 
 
 TEST_F(SysInfoParsersTest, Ubuntu)
@@ -424,6 +448,26 @@ TEST_F(SysInfoParsersTest, HPUX)
     EXPECT_EQ("hp-ux", output["os_platform"]);
     EXPECT_EQ("11", output["os_major"]);
     EXPECT_EQ("23", output["os_minor"]);
+}
+
+TEST_F(SysInfoParsersTest, Alpine)
+{
+    constexpr auto ALPINE_RELEASE_FILE
+    {
+        R"(
+        3.17.1
+        )"
+    };
+    nlohmann::json output;
+    std::stringstream info{ALPINE_RELEASE_FILE};
+    const auto spParser{FactorySysOsParser::create("alpine")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("3.17.1", output["os_version"]);
+    EXPECT_EQ("Alpine Linux", output["os_name"]);
+    EXPECT_EQ("alpine", output["os_platform"]);
+    EXPECT_EQ("3", output["os_major"]);
+    EXPECT_EQ("17", output["os_minor"]);
+    EXPECT_EQ("1", output["os_patch"]);
 }
 
 TEST_F(SysInfoParsersTest, UknownPlatform)

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -93,6 +93,35 @@ namespace Utils
         return ret;
     }
 
+    static std::string leftTrim(const std::string& str, const std::string& args = " ")
+    {
+        const auto pos{ str.find_first_not_of(args) };
+
+        if (pos != std::string::npos)
+        {
+            return str.substr(pos);
+        }
+
+        return str;
+    }
+
+    static std::string rightTrim(const std::string& str, const std::string& args = " ")
+    {
+        const auto pos{ str.find_last_not_of(args) };
+
+        if (pos != std::string::npos)
+        {
+            return str.substr(0, pos + 1);
+        }
+
+        return str;
+    }
+
+    static std::string trim(const std::string& str, const std::string& args = " ")
+    {
+        return leftTrim(rightTrim(str, args), args);
+    }
+    
     static std::vector<std::string> split(const std::string& str,
                                           const char delimiter)
     {
@@ -147,6 +176,29 @@ namespace Utils
         return ret;
     }
 
+    static void splitMapKeyValue(const std::string& str,
+                                 const char delimiter,
+                                 std::map<std::string, std::string>& mapResult)
+    {
+        constexpr auto NEWLINE_DELIMITER {'\n'};
+        std::string line;
+        std::vector<std::string> lineKeyValue;
+        std::istringstream strStream{ str };
+
+        mapResult.clear();
+        while (std::getline(strStream, line, NEWLINE_DELIMITER))
+        {
+            size_t delimiterPos = line.find_first_of(delimiter);
+            if(delimiterPos == std::string::npos) {
+                continue;
+            }
+            mapResult.insert(std::pair<std::string, std::string>(
+                trim(line.substr(0, delimiterPos), " \"\t"), 
+                trim(line.substr(delimiterPos + 1), " \"\t")
+            ));
+        }
+    }
+
     static std::string asciiToHex(const std::vector<unsigned char>& asciiData)
     {
         std::string ret;
@@ -179,35 +231,6 @@ namespace Utils
 
         // LCOV_EXCL_STOP
         return ret;
-    }
-
-    static std::string leftTrim(const std::string& str, const std::string& args = " ")
-    {
-        const auto pos{ str.find_first_not_of(args) };
-
-        if (pos != std::string::npos)
-        {
-            return str.substr(pos);
-        }
-
-        return str;
-    }
-
-    static std::string rightTrim(const std::string& str, const std::string& args = " ")
-    {
-        const auto pos{ str.find_last_not_of(args) };
-
-        if (pos != std::string::npos)
-        {
-            return str.substr(0, pos + 1);
-        }
-
-        return str;
-    }
-
-    static std::string trim(const std::string& str, const std::string& args = " ")
-    {
-        return leftTrim(rightTrim(str, args), args);
     }
 
     static std::string toUpperCase(const std::string& str)

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -121,7 +121,7 @@ namespace Utils
     {
         return leftTrim(rightTrim(str, args), args);
     }
-    
+
     static std::vector<std::string> split(const std::string& str,
                                           const char delimiter)
     {
@@ -186,16 +186,17 @@ namespace Utils
         std::istringstream strStream{ str };
 
         mapResult.clear();
+
         while (std::getline(strStream, line, NEWLINE_DELIMITER))
         {
             size_t delimiterPos = line.find_first_of(delimiter);
-            if(delimiterPos == std::string::npos) {
+
+            if (delimiterPos == std::string::npos)
+            {
                 continue;
             }
-            mapResult.insert(std::pair<std::string, std::string>(
-                trim(line.substr(0, delimiterPos), " \"\t"), 
-                trim(line.substr(delimiterPos + 1), " \"\t")
-            ));
+
+            mapResult.insert(std::pair<std::string, std::string>(trim(line.substr(0, delimiterPos), " \"\t"), trim(line.substr(delimiterPos + 1), " \"\t")));
         }
     }
 

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -170,6 +170,61 @@ TEST_F(StringUtilsTest, SplitDelimiterNullTerminated)
     EXPECT_EQ(tokens[1], "world");
 }
 
+TEST_F(StringUtilsTest, SplitMapKeyValue)
+{
+    std::string buffer("PRETTY_NAME=\"Ubuntu 22.04.1 LTS\"\n\
+NAME=\"Ubuntu\"\n\
+VERSION_ID=\"22.04\"\n\
+VERSION=\"22.04.1 LTS (Jammy Jellyfish)\"\n\
+VERSION_CODENAME=jammy\n\
+ID=ubuntu\n\
+ID_LIKE=debian\n\
+HOME_URL=\"https://www.ubuntu.com/\"\n\
+SUPPORT_URL=\"https://help.ubuntu.com/\"\n\
+BUG_REPORT_URL=\"https://bugs.launchpad.net/ubuntu/\"\n\
+PRIVACY_POLICY_URL=\"https://www.ubuntu.com/legal/terms-and-policies/privacy-policy\"\n\
+UBUNTU_CODENAME=jammy\n");
+    std::map<std::string, std::string> mapResult;
+    Utils::splitMapKeyValue(buffer, '=', mapResult);
+    std::map<std::string, std::string>::iterator itMapResult;
+    EXPECT_NE(itMapResult = mapResult.find("PRETTY_NAME"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "PRETTY_NAME");
+    EXPECT_EQ(itMapResult->second, "Ubuntu 22.04.1 LTS");
+    EXPECT_NE(itMapResult = mapResult.find("NAME"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "NAME");
+    EXPECT_EQ(itMapResult->second, "Ubuntu");
+    EXPECT_NE(itMapResult = mapResult.find("VERSION_ID"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "VERSION_ID");
+    EXPECT_EQ(itMapResult->second, "22.04");
+    EXPECT_NE(itMapResult = mapResult.find("VERSION"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "VERSION");
+    EXPECT_EQ(itMapResult->second, "22.04.1 LTS (Jammy Jellyfish)");
+    EXPECT_NE(itMapResult = mapResult.find("VERSION_CODENAME"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "VERSION_CODENAME");
+    EXPECT_EQ(itMapResult->second, "jammy");
+    EXPECT_NE(itMapResult = mapResult.find("ID"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "ID");
+    EXPECT_EQ(itMapResult->second, "ubuntu");
+    EXPECT_NE(itMapResult = mapResult.find("ID_LIKE"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "ID_LIKE");
+    EXPECT_EQ(itMapResult->second, "debian");
+    EXPECT_NE(itMapResult = mapResult.find("HOME_URL"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "HOME_URL");
+    EXPECT_EQ(itMapResult->second, "https://www.ubuntu.com/");
+    EXPECT_NE(itMapResult = mapResult.find("SUPPORT_URL"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "SUPPORT_URL");
+    EXPECT_EQ(itMapResult->second, "https://help.ubuntu.com/");
+    EXPECT_NE(itMapResult = mapResult.find("BUG_REPORT_URL"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "BUG_REPORT_URL");
+    EXPECT_EQ(itMapResult->second, "https://bugs.launchpad.net/ubuntu/");
+    EXPECT_NE(itMapResult = mapResult.find("PRIVACY_POLICY_URL"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "PRIVACY_POLICY_URL");
+    EXPECT_EQ(itMapResult->second, "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy");
+    EXPECT_NE(itMapResult = mapResult.find("UBUNTU_CODENAME"), mapResult.end());
+    EXPECT_EQ(itMapResult->first, "UBUNTU_CODENAME");
+    EXPECT_EQ(itMapResult->second, "jammy");
+}
+
 TEST_F(StringUtilsTest, CheckMultiReplacement)
 {
     std::string string_base { "hello         world" };


### PR DESCRIPTION
|Related issue|
|---|
|Closes #15697 |

## Description

With the aim of fixing the OS version detection of different distributions, this PR fix the detection on Linux Alpine.

Linux Alpine distribution information is in files "/etc/os-release" and "/etc/alpine-release". The content of these files is the following:
```
19d8de004a95:/etc# cat os-release
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.17.1
PRETTY_NAME="Alpine Linux v3.17"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
```
```
19d8de004a95:/etc# cat alpine-release 
3.17.1
```

# Before this fix:
The result of executing tool "sysinfo_test_tool" was:
```
{
  "os": {
    "architecture": "x86_64",
    "hostname": "19d8de004a95",
    "os_name": "Alpine Linux",
    "os_platform": "alpine",
    "release": "5.15.0-58-generic",
    "sysname": "Linux",
    "version": "#64-Ubuntu SMP Thu Jan 5 11:43:13 UTC 2023"
  }
}
```

# After this fix:
The result of executing tool "sysinfo_test_tool" now is:
```
{
  "os": {
    "architecture": "x86_64",
    "hostname": "19d8de004a95",
    "os_major": "3",
    "os_minor": "17",
    "os_name": "Alpine Linux",
    "os_patch": "1",
    "os_platform": "alpine",
    "os_version": "3.17.1",
    "release": "5.15.0-58-generic",
    "sysname": "Linux",
    "version": "#64-Ubuntu SMP Thu Jan 5 11:43:13 UTC 2023"
  }
}
```

## Tests
2 new unit tests were created to cover this new parser: "SysInfoParsersTest.UnixAlpine" and "SysInfoParsersTest.Alpine".

```
matias@matias-X580VD:~/Proyectos_Wazuh/wazuh/src/data_provider/build/bin$ ./sysinfo_unit_test
[==========] Running 48 tests from 3 test suites.
[----------] Global test environment set-up.
[----------] 26 tests from SysInfoParsersTest
[ RUN      ] SysInfoParsersTest.BaseClass
[       OK ] SysInfoParsersTest.BaseClass (0 ms)
[ RUN      ] SysInfoParsersTest.UnixLinux
[       OK ] SysInfoParsersTest.UnixLinux (1 ms)
[ RUN      ] SysInfoParsersTest.UnixCentos
[       OK ] SysInfoParsersTest.UnixCentos (0 ms)
[ RUN      ] SysInfoParsersTest.UnixArch
[       OK ] SysInfoParsersTest.UnixArch (0 ms)
[ RUN      ] SysInfoParsersTest.UnixAlpine
[       OK ] SysInfoParsersTest.UnixAlpine (1 ms)
[ RUN      ] SysInfoParsersTest.Ubuntu
[       OK ] SysInfoParsersTest.Ubuntu (1 ms)
[ RUN      ] SysInfoParsersTest.Centos
[       OK ] SysInfoParsersTest.Centos (1 ms)
[ RUN      ] SysInfoParsersTest.BSDFreeBSD
[       OK ] SysInfoParsersTest.BSDFreeBSD (1 ms)
[ RUN      ] SysInfoParsersTest.BSDOpenBSD
[       OK ] SysInfoParsersTest.BSDOpenBSD (1 ms)
[ RUN      ] SysInfoParsersTest.RedHatCentos
[       OK ] SysInfoParsersTest.RedHatCentos (0 ms)
[ RUN      ] SysInfoParsersTest.RedHatFedora
[       OK ] SysInfoParsersTest.RedHatFedora (0 ms)
[ RUN      ] SysInfoParsersTest.RedHatServer
[       OK ] SysInfoParsersTest.RedHatServer (0 ms)
[ RUN      ] SysInfoParsersTest.RedHatLinux
[       OK ] SysInfoParsersTest.RedHatLinux (0 ms)
[ RUN      ] SysInfoParsersTest.Debian
[       OK ] SysInfoParsersTest.Debian (1 ms)
[ RUN      ] SysInfoParsersTest.Arch
[       OK ] SysInfoParsersTest.Arch (2 ms)
[ RUN      ] SysInfoParsersTest.Slackware
[       OK ] SysInfoParsersTest.Slackware (2 ms)
[ RUN      ] SysInfoParsersTest.Gentoo
[       OK ] SysInfoParsersTest.Gentoo (2 ms)
[ RUN      ] SysInfoParsersTest.SuSE
[       OK ] SysInfoParsersTest.SuSE (1 ms)
[ RUN      ] SysInfoParsersTest.Fedora
[       OK ] SysInfoParsersTest.Fedora (1 ms)
[ RUN      ] SysInfoParsersTest.Solaris
[       OK ] SysInfoParsersTest.Solaris (0 ms)
[ RUN      ] SysInfoParsersTest.Solaris1
[       OK ] SysInfoParsersTest.Solaris1 (0 ms)
[ RUN      ] SysInfoParsersTest.HPUX
[       OK ] SysInfoParsersTest.HPUX (1 ms)
[ RUN      ] SysInfoParsersTest.Alpine
[       OK ] SysInfoParsersTest.Alpine (2 ms)
[ RUN      ] SysInfoParsersTest.UknownPlatform
[       OK ] SysInfoParsersTest.UknownPlatform (0 ms)
[ RUN      ] SysInfoParsersTest.MacOS
[       OK ] SysInfoParsersTest.MacOS (2 ms)
[ RUN      ] SysInfoParsersTest.MacOSOsDefaultName
[       OK ] SysInfoParsersTest.MacOSOsDefaultName (1 ms)
[----------] 26 tests from SysInfoParsersTest (30 ms total)

[----------] 21 tests from SysInfoTest
[ RUN      ] SysInfoTest.hardware
[       OK ] SysInfoTest.hardware (0 ms)
[ RUN      ] SysInfoTest.packages_cb
[       OK ] SysInfoTest.packages_cb (0 ms)
[ RUN      ] SysInfoTest.packages
[       OK ] SysInfoTest.packages (0 ms)
[ RUN      ] SysInfoTest.processes_cb
[       OK ] SysInfoTest.processes_cb (0 ms)
[ RUN      ] SysInfoTest.processes
[       OK ] SysInfoTest.processes (0 ms)
[ RUN      ] SysInfoTest.network
[       OK ] SysInfoTest.network (0 ms)
[ RUN      ] SysInfoTest.ports
[       OK ] SysInfoTest.ports (0 ms)
[ RUN      ] SysInfoTest.os
[       OK ] SysInfoTest.os (0 ms)
[ RUN      ] SysInfoTest.hotfixes
[       OK ] SysInfoTest.hotfixes (0 ms)
[ RUN      ] SysInfoTest.hardware_c_interface
[       OK ] SysInfoTest.hardware_c_interface (0 ms)
[ RUN      ] SysInfoTest.packages_c_interface
[       OK ] SysInfoTest.packages_c_interface (0 ms)
[ RUN      ] SysInfoTest.packages_cb_c_interface
[       OK ] SysInfoTest.packages_cb_c_interface (0 ms)
[ RUN      ] SysInfoTest.packages_cb_c_interface_test_empty_callback
[       OK ] SysInfoTest.packages_cb_c_interface_test_empty_callback (0 ms)
[ RUN      ] SysInfoTest.processes_c_interface
[       OK ] SysInfoTest.processes_c_interface (0 ms)
[ RUN      ] SysInfoTest.processes_cb_c_interface
[       OK ] SysInfoTest.processes_cb_c_interface (0 ms)
[ RUN      ] SysInfoTest.processes_cb_c_interface_test_empty_callback
[       OK ] SysInfoTest.processes_cb_c_interface_test_empty_callback (0 ms)
[ RUN      ] SysInfoTest.network_c_interface
[       OK ] SysInfoTest.network_c_interface (0 ms)
[ RUN      ] SysInfoTest.ports_c_interface
[       OK ] SysInfoTest.ports_c_interface (0 ms)
[ RUN      ] SysInfoTest.os_c_interface
[       OK ] SysInfoTest.os_c_interface (0 ms)
[ RUN      ] SysInfoTest.hotfixes_c_interface
[       OK ] SysInfoTest.hotfixes_c_interface (0 ms)
[ RUN      ] SysInfoTest.c_interfaces_bad_params
[       OK ] SysInfoTest.c_interfaces_bad_params (0 ms)
[----------] 21 tests from SysInfoTest (2 ms total)

[----------] 1 test from SysOsInfoTest
[ RUN      ] SysOsInfoTest.setOsInfoSchema
[       OK ] SysOsInfoTest.setOsInfoSchema (0 ms)
[----------] 1 test from SysOsInfoTest (0 ms total)

[----------] Global test environment tear-down
[==========] 48 tests from 3 test suites ran. (33 ms total)
[  PASSED  ] 48 tests.

```