### PR TITLE
Engine - Implementation Sophos/Cfilter decoder

### DIFF
--- a/src/engine/ruleset/decoders/sophos/cfilter.yml
+++ b/src/engine/ruleset/decoders/sophos/cfilter.yml
@@ -1,0 +1,130 @@
+---
+name: decoder/sophos-cfilter/0
+
+metadata:
+  module: sophos
+  title: Sophos logs decoder
+  description: Decoder for sophos logs
+  author:
+    name: Wazuh Inc. info@wazuh.com
+    date: 2023-01-12
+  references:
+    - documentation link
+
+check:
+  - event.original: +r_match/<\d+>\s*device=.*?date=.*?time=.*?device_name=.*?device_id=.*?log_id=.*?log_type="Content Filtering"
+
+sources:
+  - decoder/queue-syslog/0
+  - decoder/queue-localfile/0
+
+parse:
+  logpar:
+    # <30>device="SFW" date=2020-05-18 time=14:38:53 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=050901616001 log_type="Content Filtering" log_component="HTTP" log_subtype="Allowed" status="" priority=Information fw_rule_id=2 user_name="" user_gp="" iap=13 category="Information Technology" category_type="Acceptable" url="http://update.eset.com/eset_upd/ep7/dll/update.ver.signed" contenttype="" override_token="" httpresponsecode="" src_ip=1.128.3.4 dst_ip=91.228.167.133 protocol="TCP" src_port=65391 dst_port=80 sent_bytes=980 recv_bytes=295 domain=update.eset.com exceptions=av,https,sandstorm activityname="" reason="" user_agent="EFSW Update (Windows; U; 64bit; BPC 7.1.12010.0; OS: 10.0.17763 SP 0.0 NT; TDB 45511; CL 1.1.1; x64s; APP efsw; PX 1; PUA 1; CD 1; RA 1; PEV 0; UNS 1; UBR 1158; HVCI 0; SHA256 1; WU 3; HWF: 01009DAA-757A-D666-EFD2-92DD0D501284; PLOC de_de; PCODE 211.0.0; " status_code="304" transactionid="" referer="" download_file_name="" download_file_type="" upload_file_name="" upload_file_type="" con_id=248426360 application="" app_is_cloud=0 override_name="" override_authorizer=""
+    - event.original: \<<~tmp.head_message>><~tmp.payload_message>
+
+normalize:
+  - check:
+      - ~tmp.payload_message: +ef_exists
+    map:
+      - ~tmp.payload_message: +s_replace/=""/=" "
+    logpar:
+      - ~tmp.payload_message: <~tmp/kv/=/ /"/'>
+  - map:
+      - destination.bytes: $~tmp.recv_bytes
+      - destination.ip: $~tmp.dst_ip
+      - destination.port: $~tmp.dst_port
+      - event.action: +s_lo/$~tmp.log_subtype
+      - event.code: $~tmp.log_id
+      - event.dataset: sophos.xg
+      - event.duration: $~tmp.duration
+      - event.end: +s_concat/$~tmp.date/T/$~tmp.time
+      - event.kind: event
+      - event.module: sophos
+      - event.outcome: success
+  - check:
+      - ~tmp.priority: Unknown
+    map:
+      - event.severity: 0
+  - check:
+      - ~tmp.priority: Alert
+    map:
+      - event.severity: 1
+  - check:
+      - ~tmp.priority: Critical
+    map:
+      - event.severity: 2
+  - check:
+      - ~tmp.priority: Error
+    map:
+      - event.severity: 3
+  - check:
+      - ~tmp.priority: Warning
+    map:
+      - event.severity: 4
+  - check:
+      - ~tmp.priority: Notification
+    map:
+      - event.severity: 5
+  - check:
+      - ~tmp.priority: Information
+    map:
+      - event.severity: 6
+  - map:
+      - event.start: +s_concat/$~tmp.date/T/$~tmp.time
+      - event.timezone: $~tmp.timezone
+      - fileset.name: xg
+      - http.response.status_code: $~tmp.status_code
+      - input.type: log
+      - log.level: $~tmp.priority
+      - message: +s_lo/$~tmp.protocol
+      - observer.product: XG
+      - observer.serial_number: $~tmp.device_id
+      - observer.type: firewall
+      - observer.vendor: Sophos
+      - network.protocol: +s_lo/$~tmp.log_component
+      - network.transport: +s_lo/$~tmp.protocol
+      - service.type: sophos
+      - sophos.xg.app_is_cloud: $~tmp.app_is_cloud
+      - sophos.xg.category: $~tmp.category
+      - sophos.xg.category_type: $~tmp.category_type
+      - sophos.xg.con_id: $~tmp.con_id
+      - sophos.xg.device: $~tmp.device
+      - sophos.xg.device_name: $~tmp.device_name
+      - sophos.xg.exceptions: $~tmp.exceptions
+      - sophos.xg.fw_rule_id: $~tmp.fw_rule_id
+      - sophos.xg.iap: $~tmp.iap
+      - sophos.xg.log_component: $~tmp.log_component
+      - sophos.xg.log_id: $~tmp.log_id
+      - sophos.xg.log_subtype: $~tmp.log_subtype
+      - sophos.xg.log_type: $~tmp.log_type
+      - sophos.xg.priority: $~tmp.priority
+      - sophos.xg.status_code: $~tmp.status_code
+      - source.bytes: $~tmp.sent_bytes
+      - source.ip: $~tmp.src_ip
+      - source.port: $~tmp.src_port
+      - tags: [forwarded, preserve_original_event, sophos-xg]
+      - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time
+      - url.domain: $~tmp.domain
+  - logpar:
+        # http://update.eset.com/eset_upd/ep7/dll/update.ver.signed"
+      - ~tmp.url: <~tmp.schema>://<~tmp.domain>/<~tmp.path>
+    map:
+      - ~tmp.aux_slash: /
+      - url.full: $~tmp.url
+      - url.original: $~tmp.url
+      - url.path: +s_concat/$~tmp.aux_slash/$~tmp.path
+      - url.scheme: $~tmp.schema
+  - logpar:
+      - url.path: /<~tmp.fill>/<~tmp.fill>/<~tmp.fill>/<~tmp.fill>.<~tmp.fill>.<~tmp.extension>
+    map:
+      - url.extension: $~tmp.extension
+  - map:
+      - related.ip: [$destination.ip, $source.ip]
+      - user_agent.original: $~tmp.user_agent
+  - logpar:
+      - user_agent.original: <~tmp.fill>\(<~tmp.agent.os.name>;<~tmp.fill>
+    map:
+      - user_agent.os.name: $~tmp.agent.os.name
+  - map:
+      - ~tmp: +ef_delete

--- a/src/engine/ruleset/environments/wazuh-environment.yml
+++ b/src/engine/ruleset/environments/wazuh-environment.yml
@@ -22,6 +22,7 @@ decoders:
   - decoder/sca/0
   - decoder/sophos-antivirus/0
   - decoder/sophos-atp/0
+  - decoder/sophos-cfilter/0
   - decoder/sophos-event/0
   - decoder/sophos-firewall/0
   - decoder/sophos-idp/0


### PR DESCRIPTION
|Related issue|
|---|
|#15851|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

With the aim of expanding the coverage of the decoders, this PR adds a decoder for Sophos/Cfilter.

## Configuration options

Validate the new decoder:
- ./build/main catalog validate decoder/sophos-cfilter/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/cfilter.yml

Create decoder:
- ./build/main  catalog create decoder < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/cfilter.yml

Update environment
- ./build/main catalog update environment/wazuh/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/environments/wazuh-environment.yml

Test new decoder
- ./build/main test -q 1

## Logs/Alerts example

- <30>device="SFW" date=2020-05-18 time=14:38:53 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=050901616001 log_type="Content Filtering" log_component="HTTP" log_subtype="Allowed" status="" priority=Information fw_rule_id=2 user_name="" user_gp="" iap=13 category="Information Technology" category_type="Acceptable" url="http://update.eset.com/eset_upd/ep7/dll/update.ver.signed" contenttype="" override_token="" httpresponsecode="" src_ip=1.128.3.4 dst_ip=91.228.167.133 protocol="TCP" src_port=65391 dst_port=80 sent_bytes=980 recv_bytes=295 domain=update.eset.com exceptions=av,https,sandstorm activityname="" reason="" user_agent="EFSW Update (Windows; U; 64bit; BPC 7.1.12010.0; OS: 10.0.17763 SP 0.0 NT; TDB 45511; CL 1.1.1; x64s; APP efsw; PX 1; PUA 1; CD 1; RA 1; PEV 0; UNS 1; UBR 1158; HVCI 0; SHA256 1; WU 3; HWF: 01009DAA-757A-D666-EFD2-92DD0D501284; PLOC de_de; PCODE 211.0.0; " status_code="304" transactionid="" referer="" download_file_name="" download_file_type="" upload_file_name="" upload_file_type="" con_id=248426360 application="" app_is_cloud=0 override_name="" override_authorizer=""

## Tests

Event:

- <30>device="SFW" date=2020-05-18 time=14:38:53 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=050901616001 log_type="Content Filtering" log_component="HTTP" log_subtype="Allowed" status="" priority=Information fw_rule_id=2 user_name="" user_gp="" iap=13 category="Information Technology" category_type="Acceptable" url="http://update.eset.com/eset_upd/ep7/dll/update.ver.signed" contenttype="" override_token="" httpresponsecode="" src_ip=1.128.3.4 dst_ip=91.228.167.133 protocol="TCP" src_port=65391 dst_port=80 sent_bytes=980 recv_bytes=295 domain=update.eset.com exceptions=av,https,sandstorm activityname="" reason="" user_agent="EFSW Update (Windows; U; 64bit; BPC 7.1.12010.0; OS: 10.0.17763 SP 0.0 NT; TDB 45511; CL 1.1.1; x64s; APP efsw; PX 1; PUA 1; CD 1; RA 1; PEV 0; UNS 1; UBR 1158; HVCI 0; SHA256 1; WU 3; HWF: 01009DAA-757A-D666-EFD2-92DD0D501284; PLOC de_de; PCODE 211.0.0; " status_code="304" transactionid="" referer="" download_file_name="" download_file_type="" upload_file_name="" upload_file_type="" con_id=248426360 application="" app_is_cloud=0 override_name="" override_authorizer=""


Output:
```
{
    "wazuh": {
        "queue": 49,
        "origin": "/dev/stdin"
    },
    "event": {
        "original": "<30>device=\"SFW\" date=2020-05-18 time=14:38:53 timezone=\"CEST\" device_name=\"XG230\" device_id=1234567890123456 log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" status=\"\" priority=Information fw_rule_id=2 user_name=\"\" user_gp=\"\" iap=13 category=\"Information Technology\" category_type=\"Acceptable\" url=\"http://update.eset.com/eset_upd/ep7/dll/update.ver.signed\" contenttype=\"\" override_token=\"\" httpresponsecode=\"\" src_ip=1.128.3.4 dst_ip=91.228.167.133 protocol=\"TCP\" src_port=65391 dst_port=80 sent_bytes=980 recv_bytes=295 domain=update.eset.com exceptions=av,https,sandstorm activityname=\"\" reason=\"\" user_agent=\"EFSW Update (Windows; U; 64bit; BPC 7.1.12010.0; OS: 10.0.17763 SP 0.0 NT; TDB 45511; CL 1.1.1; x64s; APP efsw; PX 1; PUA 1; CD 1; RA 1; PEV 0; UNS 1; UBR 1158; HVCI 0; SHA256 1; WU 3; HWF: 01009DAA-757A-D666-EFD2-92DD0D501284; PLOC de_de; PCODE 211.0.0; \" status_code=\"304\" transactionid=\"\" referer=\"\" download_file_name=\"\" download_file_type=\"\" upload_file_name=\"\" upload_file_type=\"\" con_id=248426360 application=\"\" app_is_cloud=0 override_name=\"\" override_authorizer=\"\"",
        "action": "allowed",
        "code": 50901616001,
        "dataset": "sophos.xg",
        "end": "2020-05-18T14:38:53",
        "kind": "event",
        "module": "sophos",
        "outcome": "success",
        "severity": 6,
        "start": "2020-05-18T14:38:53",
        "timezone": "CEST"
    },
    "destination": {
        "bytes": 295,
        "ip": "91.228.167.133",
        "port": 80
    },
    "fileset": {
        "name": "xg"
    },
    "http": {
        "response": {
            "status_code": 304
        }
    },
    "input": {
        "type": "log"
    },
    "log": {
        "level": "Information"
    },
    "message": "tcp",
    "observer": {
        "product": "XG",
        "serial_number": 1234567890123456,
        "type": "firewall",
        "vendor": "Sophos"
    },
    "network": {
        "protocol": "http",
        "transport": "tcp"
    },
    "service": {
        "type": "sophos"
    },
    "sophos": {
        "xg": {
            "app_is_cloud": 0,
            "category": "Information Technology",
            "category_type": "Acceptable",
            "con_id": 248426360,
            "device": "SFW",
            "device_name": "XG230",
            "exceptions": "av,https,sandstorm",
            "fw_rule_id": 2,
            "iap": 13,
            "log_component": "HTTP",
            "log_id": 50901616001,
            "log_subtype": "Allowed",
            "log_type": "Content Filtering",
            "priority": "Information",
            "status_code": 304
        }
    },
    "source": {
        "bytes": 980,
        "ip": "1.128.3.4",
        "port": 65391
    },
    "tags": [
        "forwarded",
        "preserve_original_event",
        "sophos-xg"
    ],
    "\\@timestamp": "2020-05-18T14:38:53",
    "url": {
        "domain": "update.eset.com",
        "full": "http://update.eset.com/eset_upd/ep7/dll/update.ver.signed",
        "original": "http://update.eset.com/eset_upd/ep7/dll/update.ver.signed",
        "path": "/eset_upd/ep7/dll/update.ver.signed",
        "scheme": "http",
        "extension": "signed"
    },
    "related": {
        "ip": [
            "91.228.167.133",
            "1.128.3.4"
        ]
    },
    "user_agent": {
        "original": "EFSW Update (Windows; U; 64bit; BPC 7.1.12010.0; OS: 10.0.17763 SP 0.0 NT; TDB 45511; CL 1.1.1; x64s; APP efsw; PX 1; PUA 1; CD 1; RA 1; PEV 0; UNS 1; UBR 1158; HVCI 0; SHA256 1; WU 3; HWF: 01009DAA-757A-D666-EFD2-92DD0D501284; PLOC de_de; PCODE 211.0.0; ",
        "os": {
            "name": "Windows"
        }
    }
}
```