### PR TITLE
Engine - Implementation Sophos/Atp decoder

### DIFF
--- a/src/engine/ruleset/decoders/sophos/atp.yml
+++ b/src/engine/ruleset/decoders/sophos/atp.yml
@@ -21,15 +21,15 @@ sources:
 parse:
   logpar:
     # <30>device="SFW" date=2020-05-18 time=14:38:34 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=086504418010 log_type="ATP" log_component="Web" log_subtype="Drop" priority=Warning user_name="" protocol="TCP" src_port=57579 dst_port=80 sourceip=172.16.34.24 destinationip=13.226.155.22 url=http://sophostest.com/callhome/index.html threatname=C2/Generic-A eventid=E91DAD80-BDE4-4682-B7E8-FE394B70A36C eventtype="Standard" login_user="" process_user="" ep_uuid="" execution_path=""
-    - event.original: \<<~log.head_message>><~log.payload_message>
+    - event.original: \<<~tmp.head_message>><~tmp.payload_message>
 
 normalize:
   - check:
-      - ~log.payload_message: +ef_exists
+      - ~tmp.payload_message: +ef_exists
     map:
-      - ~log.payload_message: +s_replace/=""/=" "
+      - ~tmp.payload_message: +s_replace/=""/=" "
     logpar:
-      - ~log.payload_message: <~tmp/kv/=/ /"/'>
+      - ~tmp.payload_message: <~tmp/kv/=/ /"/'>
   - map:
       - destination.ip: $~tmp.destinationip
       - destination.port: $~tmp.dst_port
@@ -110,5 +110,4 @@ normalize:
     map:
       - user_agent.os.name: $~tmp.agent.os.name
   - map:
-      - ~log: +ef_delete
       - ~tmp: +ef_delete

--- a/src/engine/ruleset/decoders/sophos/atp.yml
+++ b/src/engine/ruleset/decoders/sophos/atp.yml
@@ -1,0 +1,114 @@
+---
+name: decoder/sophos-atp/0
+
+metadata:
+  module: sophos
+  title: Sophos logs decoder
+  description: Decoder for sophos logs
+  author:
+    name: Wazuh Inc. info@wazuh.com
+    date: 2023-01-12
+  references:
+    - documentation link
+
+check:
+  - event.original: +r_match/<\d+>\s*device=.*?date=.*?time=.*?device_name=.*?device_id=.*?log_id=.*?log_type="ATP"
+
+sources:
+  - decoder/queue-syslog/0
+  - decoder/queue-localfile/0
+
+parse:
+  logpar:
+    # <30>device="SFW" date=2020-05-18 time=14:38:34 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=086504418010 log_type="ATP" log_component="Web" log_subtype="Drop" priority=Warning user_name="" protocol="TCP" src_port=57579 dst_port=80 sourceip=172.16.34.24 destinationip=13.226.155.22 url=http://sophostest.com/callhome/index.html threatname=C2/Generic-A eventid=E91DAD80-BDE4-4682-B7E8-FE394B70A36C eventtype="Standard" login_user="" process_user="" ep_uuid="" execution_path=""
+    - event.original: \<<~log.head_message>><~log.payload_message>
+
+normalize:
+  - check:
+      - ~log.payload_message: +ef_exists
+    map:
+      - ~log.payload_message: +s_replace/=""/=" "
+    logpar:
+      - ~log.payload_message: <~tmp/kv/=/ /"/'>
+  - map:
+      - destination.ip: $~tmp.destinationip
+      - destination.port: $~tmp.dst_port
+      - event.action: +s_lo/$~tmp.log_subtype
+      - event.code: $~tmp.log_id
+      - event.dataset: sophos.xg
+      - event.id: $~tmp.eventid
+      - event.kind: event
+      - event.module: sophos
+      - event.outcome: success
+  - check:
+      - ~tmp.priority: Unknown
+    map:
+      - event.severity: 0
+  - check:
+      - ~tmp.priority: Alert
+    map:
+      - event.severity: 1
+  - check:
+      - ~tmp.priority: Critical
+    map:
+      - event.severity: 2
+  - check:
+      - ~tmp.priority: Error
+    map:
+      - event.severity: 3
+  - check:
+      - ~tmp.priority: Warning
+    map:
+      - event.severity: 4
+  - check:
+      - ~tmp.priority: Notification
+    map:
+      - event.severity: 5
+  - check:
+      - ~tmp.priority: Information
+    map:
+      - event.severity: 6
+  - map:
+      - event.timezone: $~tmp.timezone
+      - fileset.name: xg
+      - input.type: log
+      - log.level: $~tmp.priority
+      - observer.product: XG
+      - observer.serial_number: $~tmp.device_id
+      - observer.type: firewall
+      - observer.vendor: Sophos
+      - network.transport: +s_lo/$~tmp.protocol
+      - service.type: sophos
+      - sophos.xg.device: $~tmp.device
+      - sophos.xg.device_name: $~tmp.device_name
+      - sophos.xg.eventtype: $~tmp.eventtype
+      - sophos.xg.log_component: $~tmp.log_component
+      - sophos.xg.log_id: $~tmp.log_id
+      - sophos.xg.log_subtype: $~tmp.log_subtype
+      - sophos.xg.log_type: $~tmp.log_type
+      - sophos.xg.priority: $~tmp.priority
+      - sophos.xg.threatname: $~tmp.threatname
+      - source.ip: $~tmp.sourceip
+      - source.port: $~tmp.src_port
+      - tags: [forwarded, preserve_original_event, sophos-xg]
+      - \@timestamp: +s_concat/$~tmp.date/T/$~tmp.time
+  - logpar:
+        # "http://sophostest.com/callhome/index.html"
+      - ~tmp.url: <~tmp.schema>://<~tmp.domain>/<~tmp.path>
+    map:
+      - ~tmp.aux_slash: /
+      - url.domain: $~tmp.domain
+      - url.full: $~tmp.url
+      - url.original: $~tmp.url
+      - url.path: +s_concat/$~tmp.aux_slash/$~tmp.path
+      - url.scheme: $~tmp.schema
+  - map:
+      - related.ip: [$destination.ip, $source.ip]
+      - user_agent.original: $~tmp.user_agent
+  - logpar:
+      - user_agent.original: <~tmp.fill>\(<~tmp.agent.os.name>;<~tmp.fill>
+    map:
+      - user_agent.os.name: $~tmp.agent.os.name
+  - map:
+      - ~log: +ef_delete
+      - ~tmp: +ef_delete

--- a/src/engine/ruleset/environments/wazuh-environment.yml
+++ b/src/engine/ruleset/environments/wazuh-environment.yml
@@ -21,6 +21,7 @@ decoders:
   - decoder/rootcheck/0
   - decoder/sca/0
   - decoder/sophos-antivirus/0
+  - decoder/sophos-atp/0
   - decoder/sophos-event/0
   - decoder/sophos-firewall/0
   - decoder/sophos-idp/0


### PR DESCRIPTION
|Related issue|
|---|
|#15851|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

With the aim of expanding the coverage of the decoders, this PR adds a decoder for Sophos/Atp.

## Configuration options

Validate the new decoder:
- ./build/main catalog validate decoder/sophos-atp/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/atp.yml

Create decoder:
- ./build/main  catalog create decoder < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/sophos/atp.yml

Update environment
- ./build/main catalog update environment/wazuh/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/environments/wazuh-environment.yml

Test new decoder
- ./build/main test -q 1

## Logs/Alerts example

- <30>device="SFW" date=2020-05-18 time=14:38:34 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=086504418010 log_type="ATP" log_component="Web" log_subtype="Drop" priority=Warning user_name="" protocol="TCP" src_port=57579 dst_port=80 sourceip=172.16.34.24 destinationip=13.226.155.22 url=http://sophostest.com/callhome/index.html threatname=C2/Generic-A eventid=E91DAD80-BDE4-4682-B7E8-FE394B70A36C eventtype="Standard" login_user="" process_user="" ep_uuid="" execution_path=""

## Tests

Event:

- <30>device="SFW" date=2020-05-18 time=14:38:34 timezone="CEST" device_name="XG230" device_id=1234567890123456 log_id=086504418010 log_type="ATP" log_component="Web" log_subtype="Drop" priority=Warning user_name="" protocol="TCP" src_port=57579 dst_port=80 sourceip=172.16.34.24 destinationip=13.226.155.22 url=http://sophostest.com/callhome/index.html threatname=C2/Generic-A eventid=E91DAD80-BDE4-4682-B7E8-FE394B70A36C eventtype="Standard" login_user="" process_user="" ep_uuid="" execution_path=""


Output:
```
{
    "wazuh": {
        "queue": 49,
        "origin": "/dev/stdin"
    },
    "event": {
        "original": "<30>device=\"SFW\" date=2020-05-18 time=14:38:34 timezone=\"CEST\" device_name=\"XG230\" device_id=1234567890123456 log_id=086504418010 log_type=\"ATP\" log_component=\"Web\" log_subtype=\"Drop\" priority=Warning user_name=\"\" protocol=\"TCP\" src_port=57579 dst_port=80 sourceip=172.16.34.24 destinationip=13.226.155.22 url=http://sophostest.com/callhome/index.html threatname=C2/Generic-A eventid=E91DAD80-BDE4-4682-B7E8-FE394B70A36C eventtype=\"Standard\" login_user=\"\" process_user=\"\" ep_uuid=\"\" execution_path=\"\"",
        "action": "drop",
        "code": 86504418010,
        "dataset": "sophos.xg",
        "id": "E91DAD80-BDE4-4682-B7E8-FE394B70A36C",
        "kind": "event",
        "module": "sophos",
        "outcome": "success",
        "severity": 4,
        "timezone": "CEST"
    },
    "destination": {
        "ip": "13.226.155.22",
        "port": 80
    },
    "fileset": {
        "name": "xg"
    },
    "input": {
        "type": "log"
    },
    "log": {
        "level": "Warning"
    },
    "observer": {
        "product": "XG",
        "serial_number": 1234567890123456,
        "type": "firewall",
        "vendor": "Sophos"
    },
    "network": {
        "transport": "tcp"
    },
    "service": {
        "type": "sophos"
    },
    "sophos": {
        "xg": {
            "device": "SFW",
            "device_name": "XG230",
            "eventtype": "Standard",
            "log_component": "Web",
            "log_id": 86504418010,
            "log_subtype": "Drop",
            "log_type": "ATP",
            "priority": "Warning",
            "threatname": "C2/Generic-A"
        }
    },
    "source": {
        "ip": "172.16.34.24",
        "port": 57579
    },
    "tags": [
        "forwarded",
        "preserve_original_event",
        "sophos-xg"
    ],
    "\\@timestamp": "2020-05-18T14:38:34",
    "url": {
        "domain": "sophostest.com",
        "full": "http://sophostest.com/callhome/index.html",
        "original": "http://sophostest.com/callhome/index.html",
        "path": "/callhome/index.html",
        "scheme": "http"
    },
    "related": {
        "ip": [
            "13.226.155.22",
            "172.16.34.24"
        ]
    }
}
```