### PR TITLE
Constraint failed during the synchronization of sys_hwinfo table.

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_delta_event.c
+++ b/src/unit_tests/wazuh_db/test_wdb_delta_event.c
@@ -21,48 +21,49 @@
 #include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
 #include "wazuhdb_op.h"
 
-cJSON * wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field_type_t type, const cJSON * value,
-                                       bool convert_empty_string_as_null);
+cJSON * wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field_type_t type, const cJSON * value, const char * field_name,
+                                       const char * table_name, bool convert_empty_string_as_null);
 const char * wdb_dbsync_translate_field(const struct field * field);
 cJSON * wdb_dbsync_get_field_default(const struct field * field);
 
 #define ANY_PTR_VALUE 1
 #define TEST_INDEX    1
+#define HWINFO_TABLE "sys_hwinfo"
 
 /* wdb_dbsync_stmt_bind_from_json */
 
 void test_wdb_dbsync_stmt_bind_from_json_null_inputs(void ** state) {
-    assert_false(wdb_dbsync_stmt_bind_from_json(NULL, TEST_INDEX, FIELD_TEXT, (cJSON *) ANY_PTR_VALUE, true));
-    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, NULL, true));
-    assert_false(wdb_dbsync_stmt_bind_from_json(NULL, TEST_INDEX, FIELD_TEXT, NULL, true));
+    assert_false(wdb_dbsync_stmt_bind_from_json(NULL, TEST_INDEX, FIELD_TEXT, (cJSON *) ANY_PTR_VALUE, "", "", true));
+    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, NULL, "", "", true));
+    assert_false(wdb_dbsync_stmt_bind_from_json(NULL, TEST_INDEX, FIELD_TEXT, NULL, "", "", true));
 }
 
 void test_wdb_dbsync_stmt_bind_from_json_value_contains_null_ok(void ** state) {
     cJSON * value = cJSON_CreateNull();
     expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
     will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
-    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, true));
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, "", "", true));
     cJSON_Delete(value);
 }
 void test_wdb_dbsync_stmt_bind_from_json_value_contains_null_fail(void ** state) {
     cJSON * value = cJSON_CreateNull();
     expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
     will_return(__wrap_sqlite3_bind_null, SQLITE_ERROR);
-    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, true));
+    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, "", "", true));
     cJSON_Delete(value);
 }
 void test_wdb_dbsync_stmt_bind_from_json_string_to_text_empty_canbenull_ok(void ** state) {
     cJSON * value = cJSON_CreateString("");
     expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
     will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
-    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, true));
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, "", "", true));
     cJSON_Delete(value);
 }
 void test_wdb_dbsync_stmt_bind_from_json_string_to_text_empty_canbenull_err(void ** state) {
     cJSON * value = cJSON_CreateString("");
     expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
     will_return(__wrap_sqlite3_bind_null, SQLITE_ERROR);
-    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, true));
+    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -70,7 +71,7 @@ void test_wdb_dbsync_stmt_bind_from_json_string_to_text_not_empty_canbenull_err(
     cJSON * value = cJSON_CreateNull();
     expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
     will_return(__wrap_sqlite3_bind_null, SQLITE_ERROR);
-    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, true));
+    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, "", "", true));
     cJSON_Delete(value);
 }
 void test_wdb_dbsync_stmt_bind_from_json_string_to_text_not_empty_cannotbenull_ok(void ** state) {
@@ -78,7 +79,7 @@ void test_wdb_dbsync_stmt_bind_from_json_string_to_text_not_empty_cannotbenull_o
     expect_value(__wrap_sqlite3_bind_text, pos, TEST_INDEX);
     expect_string(__wrap_sqlite3_bind_text, buffer, "test string");
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, true));
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -87,7 +88,7 @@ void test_wdb_dbsync_stmt_bind_from_json_integer_to_text_ok(void ** state) {
     expect_value(__wrap_sqlite3_bind_text, pos, TEST_INDEX);
     expect_string(__wrap_sqlite3_bind_text, buffer, "12345");
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, true));
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -96,7 +97,7 @@ void test_wdb_dbsync_stmt_bind_from_json_real_to_text_ok(void ** state) {
     expect_value(__wrap_sqlite3_bind_text, pos, TEST_INDEX);
     expect_string(__wrap_sqlite3_bind_text, buffer, "3.141592");
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, true));
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_TEXT, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -105,14 +106,14 @@ void test_wdb_dbsync_stmt_bind_from_json_string_to_integer_ok(void ** state) {
     expect_value(__wrap_sqlite3_bind_int, index, TEST_INDEX);
     expect_value(__wrap_sqlite3_bind_int, value, 12345);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, true));
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "", "", true));
     cJSON_Delete(value);
 }
 
 void test_wdb_dbsync_stmt_bind_from_json_string_to_integer_err_conversion(void ** state) {
     cJSON * value = cJSON_CreateString("10Hz");
     assert_false(
-        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, true));
+        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -122,7 +123,7 @@ void test_wdb_dbsync_stmt_bind_from_json_string_to_integer_err_stmt(void ** stat
     expect_value(__wrap_sqlite3_bind_int, value, 12345);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     assert_false(
-        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, true));
+        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -131,7 +132,7 @@ void test_wdb_dbsync_stmt_bind_from_json_integer_to_integer_ok(void ** state) {
     expect_value(__wrap_sqlite3_bind_int, index, TEST_INDEX);
     expect_value(__wrap_sqlite3_bind_int, value, 12345);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, true));
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -141,7 +142,7 @@ void test_wdb_dbsync_stmt_bind_from_json_integer_to_integer_err_stmt(void ** sta
     expect_value(__wrap_sqlite3_bind_int, value, 12345);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     assert_false(
-        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, true));
+        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -151,7 +152,7 @@ void test_wdb_dbsync_stmt_bind_from_json_real_to_integer_ok(void ** state) {
     expect_value(__wrap_sqlite3_bind_int, index, 3.14156);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     assert_false(
-        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, true));
+        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -161,14 +162,14 @@ void test_wdb_dbsync_stmt_bind_from_json_string_to_long_ok(void ** state) {
     expect_value(__wrap_sqlite3_bind_int64, value, 123456789);
     will_return(__wrap_sqlite3_bind_int64, SQLITE_OK);
     assert_true(
-        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER_LONG, value, true));
+        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER_LONG, value, "", "", true));
     cJSON_Delete(value);
 }
 
 void test_wdb_dbsync_stmt_bind_from_json_string_to_long_err(void ** state) {
     cJSON * value = cJSON_CreateString("123456789Hz");
     assert_false(
-        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER_LONG, value, true));
+        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER_LONG, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -178,7 +179,7 @@ void test_wdb_dbsync_stmt_bind_from_json_string_to_long_err_stmt(void ** state) 
     expect_value(__wrap_sqlite3_bind_int64, value, 123456789);
     will_return(__wrap_sqlite3_bind_int64, SQLITE_ERROR);
     assert_false(
-        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER_LONG, value, true));
+        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER_LONG, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -188,7 +189,7 @@ void test_wdb_dbsync_stmt_bind_from_json_integer_to_long(void ** state) {
     expect_value(__wrap_sqlite3_bind_int64, value, 123456789);
     will_return(__wrap_sqlite3_bind_int64, SQLITE_OK);
     assert_true(
-        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER_LONG, value, true));
+        wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER_LONG, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -197,7 +198,7 @@ void test_wdb_dbsync_stmt_bind_from_json_string_to_real_ok(void ** state) {
     expect_value(__wrap_sqlite3_bind_double, index, TEST_INDEX);
     expect_value(__wrap_sqlite3_bind_double, value, 3.141592);
     will_return(__wrap_sqlite3_bind_double, SQLITE_OK);
-    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_REAL, value, true));
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_REAL, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -206,7 +207,7 @@ void test_wdb_dbsync_stmt_bind_from_json_string_to_real_err(void ** state) {
     expect_value(__wrap_sqlite3_bind_double, index, TEST_INDEX);
     expect_value(__wrap_sqlite3_bind_double, value, 3.141592);
     will_return(__wrap_sqlite3_bind_double, SQLITE_ERROR);
-    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_REAL, value, true));
+    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_REAL, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -215,7 +216,7 @@ void test_wdb_dbsync_stmt_bind_from_json_integer_to_real_ok(void ** state) {
     expect_value(__wrap_sqlite3_bind_double, index, TEST_INDEX);
     expect_value(__wrap_sqlite3_bind_double, value, 12345);
     will_return(__wrap_sqlite3_bind_double, SQLITE_OK);
-    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_REAL, value, true));
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_REAL, value, "", "", true));
     cJSON_Delete(value);
 }
 
@@ -224,7 +225,140 @@ void test_wdb_dbsync_stmt_bind_from_json_integer_to_real_err(void ** state) {
     expect_value(__wrap_sqlite3_bind_double, index, TEST_INDEX);
     expect_value(__wrap_sqlite3_bind_double, value, 12345);
     will_return(__wrap_sqlite3_bind_double, SQLITE_ERROR);
-    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_REAL, value, true));
+    assert_false(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_REAL, value, "", "", true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_cpu_mhz_from_negative_value_to_null (void **state) {
+    cJSON * value = cJSON_CreateNumber(-1);
+    expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_REAL, value, "cpu_mhz", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_cpu_cores_from_negative_value_to_null (void **state) {
+    cJSON * value = cJSON_CreateNumber(-1);
+    expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "cpu_cores", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_ram_free_from_negative_value_to_null (void **state) {
+    cJSON * value = cJSON_CreateNumber(-1);
+    expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "ram_free", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_ram_total_from_negative_value_to_null (void **state) {
+    cJSON * value = cJSON_CreateNumber(-1);
+    expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "ram_total", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_ram_usage_from_negative_value_to_null (void **state) {
+    cJSON * value = cJSON_CreateNumber(-1);
+    expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "ram_usage", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_cpu_mhz_from_zero_value_to_null (void **state) {
+    cJSON * value = cJSON_CreateNumber(0);
+    expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_REAL, value, "cpu_mhz", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_cpu_cores_from_zero_value_to_null (void **state) {
+    cJSON * value = cJSON_CreateNumber(0);
+    expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "cpu_cores", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_ram_free_from_zero_value_to_null (void **state) {
+    cJSON * value = cJSON_CreateNumber(0);
+    expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "ram_free", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_ram_total_from_zero_value_to_null (void **state) {
+    cJSON * value = cJSON_CreateNumber(0);
+    expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "ram_total", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_ram_usage_from_zero_value_to_null (void **state) {
+    cJSON * value = cJSON_CreateNumber(0);
+    expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "ram_usage", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_ram_usage_from_over_onehundred_value_to_null (void **state) {
+    cJSON * value = cJSON_CreateNumber(101);
+    expect_value(__wrap_sqlite3_bind_null, index, TEST_INDEX);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "ram_usage", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_cpu_mhz_from_valid_value_to_number (void **state) {
+    cJSON * value = cJSON_CreateNumber(100);
+    expect_value(__wrap_sqlite3_bind_double, index, TEST_INDEX);
+    expect_value(__wrap_sqlite3_bind_double, value, 100);
+    will_return(__wrap_sqlite3_bind_double, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_REAL, value, "cpu_mhz", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_cpu_cores_from_valid_value_to_number (void **state) {
+    cJSON * value = cJSON_CreateNumber(100);
+    expect_value(__wrap_sqlite3_bind_int, index, TEST_INDEX);
+    expect_value(__wrap_sqlite3_bind_int, value, 100);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "cpu_cores", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_ram_free_from_valid_value_to_number (void **state) {
+    cJSON * value = cJSON_CreateNumber(100);
+    expect_value(__wrap_sqlite3_bind_int, index, TEST_INDEX);
+    expect_value(__wrap_sqlite3_bind_int, value, 100);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "ram_free", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_ram_total_from_valid_value_to_number (void **state) {
+    cJSON * value = cJSON_CreateNumber(100);
+    expect_value(__wrap_sqlite3_bind_int, index, TEST_INDEX);
+    expect_value(__wrap_sqlite3_bind_int, value, 100);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "ram_total", HWINFO_TABLE, true));
+    cJSON_Delete(value);
+}
+
+void test_wdb_dbsync_stmt_bind_hwinfo_ram_usage_from_valid_value_to_number (void **state) {
+    cJSON * value = cJSON_CreateNumber(100);
+    expect_value(__wrap_sqlite3_bind_int, index, TEST_INDEX);
+    expect_value(__wrap_sqlite3_bind_int, value, 100);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    assert_true(wdb_dbsync_stmt_bind_from_json((sqlite3_stmt *) ANY_PTR_VALUE, TEST_INDEX, FIELD_INTEGER, value, "ram_usage", HWINFO_TABLE, true));
     cJSON_Delete(value);
 }
 
@@ -672,6 +806,26 @@ int main() {
         cmocka_unit_test(test_wdb_dbsync_stmt_bind_from_json_string_to_long_ok),
         cmocka_unit_test(test_wdb_dbsync_stmt_bind_from_json_string_to_long_err),
         cmocka_unit_test(test_wdb_dbsync_stmt_bind_from_json_integer_to_long),
+        // wdb_dbsync_stmt_bind_from_json for hwinfo
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_cpu_mhz_from_negative_value_to_null),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_cpu_cores_from_negative_value_to_null),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_ram_free_from_negative_value_to_null),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_ram_total_from_negative_value_to_null),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_ram_usage_from_negative_value_to_null),
+
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_cpu_mhz_from_zero_value_to_null),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_cpu_cores_from_zero_value_to_null),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_ram_free_from_zero_value_to_null),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_ram_total_from_zero_value_to_null),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_ram_usage_from_zero_value_to_null),
+
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_ram_usage_from_over_onehundred_value_to_null),
+
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_cpu_mhz_from_valid_value_to_number),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_cpu_cores_from_valid_value_to_number),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_ram_free_from_valid_value_to_number),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_ram_total_from_valid_value_to_number),
+        cmocka_unit_test(test_wdb_dbsync_stmt_bind_hwinfo_ram_usage_from_valid_value_to_number),
         /* wdb_upsert_dbsync */
         cmocka_unit_test(test_wdb_upsert_dbsync_err),
         cmocka_unit_test(test_wdb_upsert_dbsync_bad_cache),

--- a/src/unit_tests/wazuh_db/test_wdb_syscollector.c
+++ b/src/unit_tests/wazuh_db/test_wdb_syscollector.c
@@ -2952,7 +2952,7 @@ void test_wdb_hardware_save_success(void **state) {
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    output = wdb_hardware_save(data, "scan_id", "scan_time", "serial", "cpu_name", -1, -1, 0, 0, -1, "checksum", false);
+    output = wdb_hardware_save(data, "scan_id", "scan_time", "serial", "cpu_name", 0, 0, 0, 0, 0, "checksum", false);
     assert_int_equal(output, 0);
 }
 
@@ -5150,9 +5150,9 @@ static void test_wdb_hardware_insert_success_null_values(void **state) {
     int ret = OS_INVALID;
     test_struct_t *data = (test_struct_t *)*state;
     hardware_object temp_hardware = hardware;
-    temp_hardware.cpu_cores = -1;
-    temp_hardware.cpu_mhz = -1;
-    temp_hardware.ram_usage = -1;
+    temp_hardware.cpu_cores = 0;
+    temp_hardware.cpu_mhz = 0;
+    temp_hardware.ram_usage = 0;
     temp_hardware.ram_total = 0;
     temp_hardware.ram_free = 0;
 

--- a/src/unit_tests/wazuh_db/test_wdb_syscollector.c
+++ b/src/unit_tests/wazuh_db/test_wdb_syscollector.c
@@ -42,6 +42,8 @@ static int test_teardown(void **state) {
 
 #define ALLOW_ZERO      true
 #define NOT_ALLOW_ZERO  false
+#define ALLOW_OVER_ONEHUNDRED true
+#define NOT_ALLOW_OVER_ONEHUNDRED false
 
 typedef struct test_struct {
     wdb_t *wdb;
@@ -2999,7 +3001,7 @@ void test_wdb_hardware_insert_sql_fail(void **state) {
     expect_value(__wrap_sqlite3_bind_int64, value, 6144);
     will_return(__wrap_sqlite3_bind_int64, 0);
     expect_value(__wrap_sqlite3_bind_int, index, 9);
-    expect_value(__wrap_sqlite3_bind_int, value, 2048);
+    expect_value(__wrap_sqlite3_bind_int, value, 100);
     will_return(__wrap_sqlite3_bind_int, 0);
     expect_value(__wrap_sqlite3_bind_text, pos, 10);
     expect_string(__wrap_sqlite3_bind_text, buffer, "checksum");
@@ -3009,7 +3011,7 @@ void test_wdb_hardware_insert_sql_fail(void **state) {
     will_return(__wrap_sqlite3_errmsg, "ERROR");
     expect_string(__wrap__merror, formatted_msg, "at wdb_hardware_insert(): sqlite3_step(): ERROR");
 
-    output = wdb_hardware_insert(data, "scan_id", "scan_time", "serial", "cpu_name", 4, 2900, 8192, 6144, 2048, "checksum", false);
+    output = wdb_hardware_insert(data, "scan_id", "scan_time", "serial", "cpu_name", 4, 2900, 8192, 6144, 100, "checksum", false);
     assert_int_equal(output, -1);
 }
 
@@ -4314,6 +4316,15 @@ void configure_sqlite3_bind_int64(int position, int number, bool allow_zero) {
     }
 }
 
+void configure_sqlite3_bind_int_ex(int position, int number, bool allow_zero, bool allow_over_one_hundred) {
+    if (!allow_over_one_hundred && number > 100) {
+        will_return(__wrap_sqlite3_bind_null, OS_SUCCESS);
+        expect_value(__wrap_sqlite3_bind_null, index, position);
+    } else {
+        configure_sqlite3_bind_int(position, number, allow_zero);
+    }
+}
+
 void configure_sqlite3_bind_int(int position, int number, bool allow_zero) {
     if (number > 0 || (0 == number && allow_zero)) {
         will_return(__wrap_sqlite3_bind_int, OS_SUCCESS);
@@ -4478,7 +4489,7 @@ void configure_wdb_hardware_insert(hardware_object test_hardware, int sqlite_cod
     configure_sqlite3_bind_double(6, test_hardware.cpu_mhz, NOT_ALLOW_ZERO);
     configure_sqlite3_bind_int64(7, test_hardware.ram_total, NOT_ALLOW_ZERO);
     configure_sqlite3_bind_int64(8, test_hardware.ram_free, NOT_ALLOW_ZERO);
-    configure_sqlite3_bind_int(9, test_hardware.ram_usage, NOT_ALLOW_ZERO);
+    configure_sqlite3_bind_int_ex(9, test_hardware.ram_usage, NOT_ALLOW_ZERO, NOT_ALLOW_OVER_ONEHUNDRED);
     configure_sqlite3_bind_text(10, test_hardware.checksum);
 
     will_return(__wrap_sqlite3_step, 0);
@@ -5150,9 +5161,9 @@ static void test_wdb_hardware_insert_success_null_values(void **state) {
     int ret = OS_INVALID;
     test_struct_t *data = (test_struct_t *)*state;
     hardware_object temp_hardware = hardware;
-    temp_hardware.cpu_cores = 0;
-    temp_hardware.cpu_mhz = 0;
-    temp_hardware.ram_usage = 0;
+    temp_hardware.cpu_cores = -1;
+    temp_hardware.cpu_mhz = -1;
+    temp_hardware.ram_usage = 101;
     temp_hardware.ram_total = 0;
     temp_hardware.ram_free = 0;
 

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -397,7 +397,7 @@ CREATE INDEX IF NOT EXISTS cve_status ON vuln_cves (status);
 
 BEGIN;
 
-INSERT INTO metadata (key, value) VALUES ('db_version', '10');
+INSERT INTO metadata (key, value) VALUES ('db_version', '11');
 INSERT INTO scan_info (module) VALUES ('fim');
 INSERT INTO scan_info (module) VALUES ('syscollector');
 INSERT INTO sync_info (component) VALUES ('fim');

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -128,11 +128,11 @@ CREATE TABLE IF NOT EXISTS sys_hwinfo (
     scan_time TEXT,
     board_serial TEXT,
     cpu_name TEXT,
-    cpu_cores INTEGER CHECK (cpu_cores > 0),
-    cpu_mhz REAL CHECK (cpu_mhz > 0),
-    ram_total INTEGER CHECK (ram_total > 0),
-    ram_free INTEGER CHECK (ram_free > 0),
-    ram_usage INTEGER CHECK (ram_usage >= 0 AND ram_usage <= 100),
+    cpu_cores INTEGER,
+    cpu_mhz REAL,
+    ram_total INTEGER,
+    ram_free INTEGER,
+    ram_usage INTEGER,
     checksum TEXT NOT NULL CHECK (checksum <> ''),
     PRIMARY KEY (scan_id, board_serial)
 );

--- a/src/wazuh_db/schema_upgrade_v10.sql
+++ b/src/wazuh_db/schema_upgrade_v10.sql
@@ -11,4 +11,32 @@
 UPDATE sca_check SET result='not applicable' WHERE status='Not applicable';
 ALTER TABLE sca_check DROP COLUMN status;
 
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS _sys_hwinfo (
+    scan_id INTEGER,
+    scan_time TEXT,
+    board_serial TEXT,
+    cpu_name TEXT,
+    cpu_cores INTEGER,
+    cpu_mhz REAL,
+    ram_total INTEGER,
+    ram_free INTEGER,
+    ram_usage INTEGER,
+    checksum TEXT NOT NULL CHECK (checksum <> ''),
+    PRIMARY KEY (scan_id, board_serial)
+);
+
+INSERT INTO _sys_hwinfo (scan_id, scan_time, board_serial, cpu_name, cpu_cores,
+                         cpu_mhz, ram_total, ram_free, ram_usage, checksum)
+    SELECT scan_id, scan_time, board_serial, cpu_name, cpu_cores, cpu_mhz,
+           ram_total, ram_free, ram_usage, CASE WHEN checksum <> '' THEN 
+           checksum ELSE 'legacy' END AS checksum
+    FROM sys_hwinfo;
+
+DROP TABLE sys_hwinfo;
+ALTER TABLE _sys_hwinfo RENAME TO sys_hwinfo;
+
+COMMIT;
+
 INSERT OR REPLACE INTO metadata (key, value) VALUES ('db_version', 10);

--- a/src/wazuh_db/schema_upgrade_v10.sql
+++ b/src/wazuh_db/schema_upgrade_v10.sql
@@ -11,32 +11,4 @@
 UPDATE sca_check SET result='not applicable' WHERE status='Not applicable';
 ALTER TABLE sca_check DROP COLUMN status;
 
-BEGIN;
-
-CREATE TABLE IF NOT EXISTS _sys_hwinfo (
-    scan_id INTEGER,
-    scan_time TEXT,
-    board_serial TEXT,
-    cpu_name TEXT,
-    cpu_cores INTEGER,
-    cpu_mhz REAL,
-    ram_total INTEGER,
-    ram_free INTEGER,
-    ram_usage INTEGER,
-    checksum TEXT NOT NULL CHECK (checksum <> ''),
-    PRIMARY KEY (scan_id, board_serial)
-);
-
-INSERT INTO _sys_hwinfo (scan_id, scan_time, board_serial, cpu_name, cpu_cores,
-                         cpu_mhz, ram_total, ram_free, ram_usage, checksum)
-    SELECT scan_id, scan_time, board_serial, cpu_name, cpu_cores, cpu_mhz,
-           ram_total, ram_free, ram_usage, CASE WHEN checksum <> '' THEN 
-           checksum ELSE 'legacy' END AS checksum
-    FROM sys_hwinfo;
-
-DROP TABLE sys_hwinfo;
-ALTER TABLE _sys_hwinfo RENAME TO sys_hwinfo;
-
-COMMIT;
-
 INSERT OR REPLACE INTO metadata (key, value) VALUES ('db_version', 10);

--- a/src/wazuh_db/schema_upgrade_v11.sql
+++ b/src/wazuh_db/schema_upgrade_v11.sql
@@ -1,0 +1,39 @@
+/*
+ * SQL Schema for upgrading databases
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * Febrary 1, 2023.
+ *
+ * This program is a free software, you can redistribute it
+ * and/or modify it under the terms of GPLv2.
+*/
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS _sys_hwinfo (
+    scan_id INTEGER,
+    scan_time TEXT,
+    board_serial TEXT,
+    cpu_name TEXT,
+    cpu_cores INTEGER,
+    cpu_mhz REAL,
+    ram_total INTEGER,
+    ram_free INTEGER,
+    ram_usage INTEGER,
+    checksum TEXT NOT NULL CHECK (checksum <> ''),
+    PRIMARY KEY (scan_id, board_serial)
+);
+
+INSERT INTO _sys_hwinfo (scan_id, scan_time, board_serial, cpu_name, cpu_cores,
+                         cpu_mhz, ram_total, ram_free, ram_usage, checksum)
+    SELECT scan_id, scan_time, board_serial, cpu_name, cpu_cores, cpu_mhz,
+           ram_total, ram_free, ram_usage, CASE WHEN checksum <> '' THEN 
+           checksum ELSE 'legacy' END AS checksum
+    FROM sys_hwinfo;
+
+DROP TABLE sys_hwinfo;
+ALTER TABLE _sys_hwinfo RENAME TO sys_hwinfo;
+
+INSERT OR REPLACE INTO metadata (key, value) VALUES ('db_version', 11);
+
+COMMIT;

--- a/src/wazuh_db/schema_upgrade_v11.sql
+++ b/src/wazuh_db/schema_upgrade_v11.sql
@@ -2,7 +2,7 @@
  * SQL Schema for upgrading databases
  * Copyright (C) 2015, Wazuh Inc.
  *
- * Febrary 1, 2023.
+ * February 1, 2023.
  *
  * This program is a free software, you can redistribute it
  * and/or modify it under the terms of GPLv2.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -428,6 +428,7 @@ extern char *schema_upgrade_v7_sql;
 extern char *schema_upgrade_v8_sql;
 extern char *schema_upgrade_v9_sql;
 extern char *schema_upgrade_v10_sql;
+extern char *schema_upgrade_v11_sql;
 extern char *schema_global_upgrade_v1_sql;
 extern char *schema_global_upgrade_v2_sql;
 extern char *schema_global_upgrade_v3_sql;

--- a/src/wazuh_db/wdb_delta_event.c
+++ b/src/wazuh_db/wdb_delta_event.c
@@ -249,7 +249,7 @@ STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field
                 case cJSON_String: {
                     char * endptr;
                     const int integer_number = (int) strtol(value->valuestring, &endptr, 10);
-                    int sqlite3_bind = true;
+                    int sqlite3_bind = SQLITE_ERROR;
                     if (NULL != endptr && '\0' == *endptr) {
                         if (IS_VALID_VALUE(table_name, field_name, integer_number)) {
                             sqlite3_bind = sqlite3_bind_int(stmt, index, integer_number);
@@ -265,7 +265,7 @@ STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field
                     break;
                 }
                 case cJSON_Number: {
-                    int sqlite3_bind = true;
+                    int sqlite3_bind = SQLITE_ERROR;
                     if (IS_VALID_VALUE(table_name, field_name, value->valueint)) {
                         sqlite3_bind = sqlite3_bind_int(stmt, index, value->valueint);
                     } else {
@@ -284,7 +284,7 @@ STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field
                 case cJSON_String: {
                     char * endptr;
                     const double real_value = strtod(value->valuestring, &endptr);
-                    int sqlite3_bind = true;
+                    int sqlite3_bind = SQLITE_ERROR;
                     if (NULL != endptr && '\0' == *endptr) {
                         if (IS_VALID_VALUE(table_name, field_name, real_value)) {
                             sqlite3_bind = sqlite3_bind_double(stmt, index, real_value);
@@ -299,7 +299,7 @@ STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field
                     break;
                 }
                 case cJSON_Number: {
-                    int sqlite3_bind = true;
+                    int sqlite3_bind = SQLITE_ERROR;
                     if (IS_VALID_VALUE(table_name, field_name, value->valuedouble)) {
                         sqlite3_bind = sqlite3_bind_double(stmt, index, value->valuedouble);
                     } else {

--- a/src/wazuh_db/wdb_delta_event.c
+++ b/src/wazuh_db/wdb_delta_event.c
@@ -9,8 +9,29 @@
 
 #define QUERY_MAX_SIZE OS_SIZE_2048
 
-STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field_type_t type, const cJSON * value,
-                                           bool convert_empty_string_as_null);
+#define GT(X, Y) (X > Y ? true : false)
+#define LT(X, Y) (X < Y ? true : false)
+#define EQ(X, Y) (X == Y ? true : false)
+
+#define IS_VALID_HWINFO_VALUE(field_name, field_value) ( \
+    !strncmp(field_name, "cpu_cores", 9) ? \
+        GT(field_value, 0) : \
+    !strncmp(field_name, "cpu_mhz", 7) ? \
+        GT(field_value, 0) : \
+    !strncmp(field_name, "ram_total", 9) ? \
+        GT(field_value, 0) : \
+    !strncmp(field_name, "ram_free", 8) ? \
+        GT(field_value, 0) : \
+    !strncmp(field_name, "ram_usage", 9) ? \
+        (GT(field_value, 0) && (EQ(field_value, 100) || LT(field_value, 100))): true \
+)
+
+#define IS_VALID_VALUE(table_name, field_name, field_value) (\
+    !strncmp(table_name, "sys_hwinfo", 10) ? IS_VALID_HWINFO_VALUE(field_name, field_value) : true \
+)
+
+STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field_type_t type, const cJSON * value, const char * field_name,
+                                           const char * table_name, bool convert_empty_string_as_null);
 
 STATIC const char * wdb_dbsync_translate_field(const struct field * field) {
     return NULL == field->source_name ? field->target_name : field->source_name;
@@ -104,8 +125,8 @@ bool wdb_upsert_dbsync(wdb_t * wdb, struct kv const * kv_value, cJSON * data) {
                 }
 
                 if (NULL != field_value) {
-                    if (!wdb_dbsync_stmt_bind_from_json(stmt, index, column->value.type, field_value,
-                                                        column->value.convert_empty_string_as_null)) {
+                    if (!wdb_dbsync_stmt_bind_from_json(stmt, index, column->value.type, field_value, field_name,
+                                                        kv_value->value, column->value.convert_empty_string_as_null)) {
                         merror(DB_INVALID_DELTA_MSG, wdb->id, field_name, kv_value->key);
                         has_error = true;
                     }
@@ -120,8 +141,8 @@ bool wdb_upsert_dbsync(wdb_t * wdb, struct kv const * kv_value, cJSON * data) {
                     const char * field_name = wdb_dbsync_translate_field(&column->value);
                     cJSON * field_value = cJSON_GetObjectItem(data, field_name);
                     if (NULL != field_value &&
-                        !wdb_dbsync_stmt_bind_from_json(stmt, index, column->value.type, field_value,
-                                                        column->value.convert_empty_string_as_null)) {
+                        !wdb_dbsync_stmt_bind_from_json(stmt, index, column->value.type, field_value, field_name,
+                                                        kv_value->value, column->value.convert_empty_string_as_null)) {
                         merror(DB_INVALID_DELTA_MSG, wdb->id, field_name, kv_value->key);
                         has_error = true;
                     }
@@ -174,8 +195,8 @@ bool wdb_delete_dbsync(wdb_t * wdb, struct kv const * kv_value, cJSON * data) {
                     cJSON * field_value = cJSON_GetObjectItem(data, field_name);
                     if (NULL == field_value) {
                         has_error = true;
-                    } else if (!wdb_dbsync_stmt_bind_from_json(stmt, index, column->value.type, field_value,
-                                                               column->value.convert_empty_string_as_null)) {
+                    } else if (!wdb_dbsync_stmt_bind_from_json(stmt, index, column->value.type, field_value, field_name,
+                                                               kv_value->value, column->value.convert_empty_string_as_null)) {
                         merror(DB_INVALID_DELTA_MSG, wdb->id, field_name, kv_value->key);
                         has_error = true;
                     }
@@ -190,8 +211,8 @@ bool wdb_delete_dbsync(wdb_t * wdb, struct kv const * kv_value, cJSON * data) {
     return ret_val;
 }
 
-STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field_type_t type, const cJSON * value,
-                                           bool convert_empty_string_as_null) {
+STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field_type_t type, const cJSON * value, const char * field_name,
+                                           const char * table_name, bool convert_empty_string_as_null) {
 
     bool ret_val = false;
 
@@ -228,14 +249,30 @@ STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field
                 case cJSON_String: {
                     char * endptr;
                     const int integer_number = (int) strtol(value->valuestring, &endptr, 10);
-                    if (NULL != endptr && '\0' == *endptr &&
-                        SQLITE_OK == sqlite3_bind_int(stmt, index, integer_number)) {
+                    int sqlite3_bind = true;
+                    if (NULL != endptr && '\0' == *endptr) {
+                        if (IS_VALID_VALUE(table_name, field_name, integer_number)) {
+                            sqlite3_bind = sqlite3_bind_int(stmt, index, integer_number);
+                        } else {
+                            sqlite3_bind = sqlite3_bind_null(stmt, index);
+                        }
+                    }
+
+                    if (SQLITE_OK == sqlite3_bind) {
                         ret_val = true;
                     }
+
                     break;
                 }
                 case cJSON_Number:
-                    if (SQLITE_OK == sqlite3_bind_int(stmt, index, value->valueint)) {
+                    int sqlite3_bind = true;
+                    if (IS_VALID_VALUE(table_name, field_name, value->valueint)) {
+                        sqlite3_bind = sqlite3_bind_int(stmt, index, value->valueint);
+                    } else {
+                        sqlite3_bind = sqlite3_bind_null(stmt, index);
+                    }
+
+                    if (SQLITE_OK == sqlite3_bind) {
                         ret_val = true;
                     }
                     break;
@@ -246,14 +283,28 @@ STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field
                 case cJSON_String: {
                     char * endptr;
                     const double real_value = strtod(value->valuestring, &endptr);
-                    if (NULL != endptr && '\0' == *endptr &&
-                        SQLITE_OK == sqlite3_bind_double(stmt, index, real_value)) {
+                    int sqlite3_bind = true;
+                    if (NULL != endptr && '\0' == *endptr) {
+                        if (IS_VALID_VALUE(table_name, field_name, real_value)) {
+                            sqlite3_bind = sqlite3_bind_double(stmt, index, real_value);
+                        } else {
+                            sqlite3_bind = sqlite3_bind_null(stmt, index);
+                        }
+                    }
+
+                    if (SQLITE_OK == sqlite3_bind) {
                         ret_val = true;
                     }
                     break;
                 }
                 case cJSON_Number:
-                    if (SQLITE_OK == sqlite3_bind_double(stmt, index, value->valuedouble)) {
+                    int sqlite3_bind = true;
+                    if (IS_VALID_VALUE(table_name, field_name, value->valuedouble)) {
+                        sqlite3_bind = sqlite3_bind_double(stmt, index, value->valuedouble);
+                    } else {
+                        sqlite3_bind = sqlite3_bind_null(stmt, index);
+                    }
+                    if (SQLITE_OK == sqlite3_bind) {
                         ret_val = true;
                     }
                     break;

--- a/src/wazuh_db/wdb_delta_event.c
+++ b/src/wazuh_db/wdb_delta_event.c
@@ -264,7 +264,7 @@ STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field
 
                     break;
                 }
-                case cJSON_Number:
+                case cJSON_Number: {
                     int sqlite3_bind = true;
                     if (IS_VALID_VALUE(table_name, field_name, value->valueint)) {
                         sqlite3_bind = sqlite3_bind_int(stmt, index, value->valueint);
@@ -276,6 +276,7 @@ STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field
                         ret_val = true;
                     }
                     break;
+                }
                 }
                 break;
             case FIELD_REAL:
@@ -297,7 +298,7 @@ STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field
                     }
                     break;
                 }
-                case cJSON_Number:
+                case cJSON_Number: {
                     int sqlite3_bind = true;
                     if (IS_VALID_VALUE(table_name, field_name, value->valuedouble)) {
                         sqlite3_bind = sqlite3_bind_double(stmt, index, value->valuedouble);
@@ -308,6 +309,7 @@ STATIC bool wdb_dbsync_stmt_bind_from_json(sqlite3_stmt * stmt, int index, field
                         ret_val = true;
                     }
                     break;
+                }
                 }
                 break;
             case FIELD_INTEGER_LONG:

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -804,7 +804,7 @@ int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_tim
         sqlite3_bind_null(stmt, 8);
     }
 
-    if (ram_usage > 0) {
+    if (ram_usage > 0 && ram_usage <= 100) {
         sqlite3_bind_int(stmt, 9, ram_usage);
     } else {
         sqlite3_bind_null(stmt, 9);

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -42,7 +42,8 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
         schema_upgrade_v7_sql,
         schema_upgrade_v8_sql,
         schema_upgrade_v9_sql,
-        schema_upgrade_v10_sql
+        schema_upgrade_v10_sql,
+        schema_upgrade_v11_sql
     };
 
     char db_version[OS_SIZE_256];


### PR DESCRIPTION
|Related issue|
|---|
|#12343|
## Description
Remove checks in some fields at `sys_hwinfo` table
## Tests
![image](https://github.com/wazuh/wazuh/assets/93778492/030b5ded-ac26-490e-aecb-d91cb39b3cc2)
## Evidence of changes made

<details><summary>Expand </summary>

Manager install update sequence from `4.4.1` to `4.5` and null values saved

![2023-05-16_21-24](https://github.com/wazuh/wazuh/assets/93778492/5ab78064-25aa-49ff-a1fc-277204abe8d2)

Dashboard showing **forced** null values

![2023-05-16_21-25](https://github.com/wazuh/wazuh/assets/93778492/08298d96-f377-4d73-a430-7487c2142804)

</details>

## Update 07/05/23

<details><summary> Expand </summary>

![image](https://github.com/wazuh/wazuh/assets/13010397/1e8f8fbe-d492-49cb-8bf1-692aa6143962)
![image](https://github.com/wazuh/wazuh/assets/13010397/a1adb0c3-d233-46c4-b8d0-a2a000f9edbf)

</details>

<details><summary> Expand code </summary>

```python
#!/usr/bin/env python3
import socket
import struct
import yaml
import re

ERROR='\33[41m'
SUCCESS='\33[42m'
HEADER='\33[45m'
END='\33[0m'

class SocketCon:
    def __init__(self):
        ADDR = '/var/ossec/queue/db/wdb'
        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
        self.sock.connect(ADDR)
    def send(self,command):
        command = struct.pack('<I', len(command)) + command.encode()
        self.sock.send(command)
    def recv(self):
        data = self.recv_all(4)
        data_size = struct.unpack('<I', data[0:4])[0]
        data = self.recv_all(data_size).decode(encoding='utf-8', errors='ignore')
        return data
    def recv_all(self, size: int):
        buffer = bytearray()
        while len(buffer) < size:
            try:
                data = self.sock.recv(size - len(buffer))
                if not data:
                    break
                buffer.extend(data)
            except socket.timeout:
                if self.server.mitm.event.is_set():
                    break
        return bytes(buffer)
    def close(self):
        self.sock.close()

TEST_CASES_PATH = "tests_hwinfo.yaml"
test_cases = {}
with open(TEST_CASES_PATH) as f:
    test_cases = yaml.safe_load(f)

success_tests = 0
error_tests = 0
for test in test_cases:
    if 'repeat' in test:
        repeat = test['repeat']
    else:
        repeat = 0

    print("")
    print(HEADER + "TEST "+test['name'] + END)
    if 'description' in test:
        print('- '+test['description'])
    error = False
    for i in range(repeat+1):
        WDB_sock = SocketCon()
        command = test['command']
        expected = test['expected_response']
        WDB_sock.send(command)
        print("Sent: "+command)
        status = "due"
        while status == 'due':
            response = WDB_sock.recv()
            print("Expected: "+expected)
            print("Received: "+response)
            data = response.split(" ", 1)

            if 'regex' in test:
                if  re.match(expected, response) is None:
                    print(ERROR + "ERROR. Invalid response" + END)
                    error = True
                else:
                    print(SUCCESS + "SUCCESS" + END)
            else:
                if expected != response:
                    print(ERROR + "ERROR. Invalid response" + END)
                    error = True
                else:
                    print(SUCCESS + "SUCCESS" + END)

            if 'multi_chunk' in test:
                status = data[0]
            else:
                status = "ok"

        WDB_sock.close()
    if error:
        error_tests = error_tests+1
    else:
        success_tests = success_tests+1

print("")
print("Results:")
print(f"\33[104m SUCCESS: {success_tests}. ERROR: {error_tests}. \33[0m")
```

```yaml
- name: 'Clean hwinfo table'
  command: 'agent 000 sql delete from sys_hwinfo'
  expected_response: 'ok []'
-
  name: 'Set hwinfo values: cpu_mhz = -1, cpu_cores = -1, ram_free = -1, ram_total = -1, ram_usage = -1'
  command: 'agent 000 dbsync hwinfo INSERTED {"scan_time":"0","board_serial":"0","cpu_MHz":-1,"cpu_cores":-1,"cpu_name":"Intel","ram_free":-1,"ram_total":-1,"ram_usage":-1,"checksum":"0"}'
  expected_response: 'ok '
-
  name: "Check hwinfo values: cpu_mhz, cpu_cores, ram_free, ram_total and ram_usage are NULL"
  command: 'agent 000 sql select * from sys_hwinfo'
  expected_response: 'ok [{"scan_id":0,"scan_time":"0","board_serial":"0","cpu_name":"Intel","checksum":"0"}]'
-
  name: 'Set hwinfo values: cpu_mhz = 0, cpu_cores = 0, ram_free = 0, ram_total = 0, ram_usage = 0'
  command: 'agent 000 dbsync hwinfo INSERTED {"scan_time":"0","board_serial":"0","cpu_MHz":0,"cpu_cores":0,"cpu_name":"Intel","ram_free":0,"ram_total":0,"ram_usage":0,"checksum":"0"}'
  expected_response: 'ok '
-
  name: "Check hwinfo values: : cpu_mhz, cpu_cores, ram_free, ram_total and ram_usage are NULL"
  command: 'agent 000 sql select * from sys_hwinfo'
  expected_response: 'ok [{"scan_id":0,"scan_time":"0","board_serial":"0","cpu_name":"Intel","checksum":"0"}]'
-
  name: 'Set hwinfo values: cpu_mhz = 1, cpu_cores = 1, ram_free = 1, ram_total = 1, ram_usage = 1'
  command: 'agent 000 dbsync hwinfo INSERTED {"scan_time":"0","board_serial":"0","cpu_MHz":1,"cpu_cores":1,"cpu_name":"Intel","ram_free":1,"ram_total":1,"ram_usage":1,"checksum":"0"}'
  expected_response: 'ok '
-
  name: "Check hwinfo values: cpu_mhz, cpu_cores, ram_free, ram_total and ram_usage are NOT NULL"
  command: 'agent 000 sql select * from sys_hwinfo'
  expected_response: 'ok [{"scan_id":0,"scan_time":"0","board_serial":"0","cpu_name":"Intel","cpu_cores":1,"cpu_mhz":1,"ram_total":1,"ram_free":1,"ram_usage":1,"checksum":"0"}]'
-
  name: 'Set hwinfo values: cpu_mhz = 100, cpu_cores = 100, ram_free = 100, ram_total = 100, ram_usage = 100'
  command: 'agent 000 dbsync hwinfo INSERTED {"scan_time":"0","board_serial":"0","cpu_MHz":100,"cpu_cores":100,"cpu_name":"Intel","ram_free":100,"ram_total":100,"ram_usage":100,"checksum":"0"}'
  expected_response: 'ok '
-
  name: "Check hwinfo values: cpu_mhz, cpu_cores, ram_free, ram_total and ram_usage are NOT NULL"
  command: 'agent 000 sql select * from sys_hwinfo'
  expected_response: 'ok [{"scan_id":0,"scan_time":"0","board_serial":"0","cpu_name":"Intel","cpu_cores":100,"cpu_mhz":100,"ram_total":100,"ram_free":100,"ram_usage":100,"checksum":"0"}]'
-
  name: 'Set hwinfo values: cpu_mhz = 101, cpu_cores = 101, ram_free = 101, ram_total = 101, ram_usage = 101'
  command: 'agent 000 dbsync hwinfo INSERTED {"scan_time":"0","board_serial":"0","cpu_MHz":101,"cpu_cores":101,"cpu_name":"Intel","ram_free":101,"ram_total":101,"ram_usage":101,"checksum":"0"}'
  expected_response: 'ok '
-
  name: "Check hwinfo values: ram_usage is NULL"
  command: 'agent 000 sql select * from sys_hwinfo'
  expected_response: 'ok [{"scan_id":0,"scan_time":"0","board_serial":"0","cpu_name":"Intel","cpu_cores":101,"cpu_mhz":101,"ram_total":101,"ram_free":101,"checksum":"0"}]'
``` 

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Database upgrade
- [x] Update unit tests
