### PR TITLE
Centralize guess group functionality in the master node

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -141,98 +141,6 @@ STATIC bool fsum_changed(file_sum **old_sum, file_sum **new_sum);
 STATIC bool group_changed(const char *multi_group);
 
 /**
- * @brief Process group, update file sum structure and create merged.mg file
- * @param group Group name
- * @param _f_sum File sum structure to update
- * @param sharedcfg_dir Group directory
- * @param create_merged Flag indicating if merged.mg needs to be created
- */
-STATIC void c_group(const char *group, file_sum ***_f_sum, char * sharedcfg_dir, bool create_merged);
-
-/**
- * @brief Process multigroup, update file sum structure and create merged.mg file
- * @param multi_group Multigroup name
- * @param _f_sum File sum structure to update
- * @param hash_multigroup Multigroup hash
- * @param create_merged Flag indicating if merged.mg needs to be created
- */
-STATIC void c_multi_group(char *multi_group, file_sum ***_f_sum, char *hash_multigroup, bool create_merged);
-
-/**
- * @brief Process groups and multigroups files
- */
-STATIC void c_files(void);
-
-/**
- * @brief Analize and generate new groups, update existing groups
- */
-STATIC void process_groups();
-
-/**
- * @brief Analize and generate new multigroups, update existing multigroups
- */
-STATIC void process_multi_groups();
-
-/**
- * @brief Delete all groups that no longer exist
- */
-STATIC void process_deleted_groups();
-
-/**
- * @brief Delete all multigroups that no longer exist
- */
-STATIC void process_deleted_multi_groups();
-
-/**
- * @brief Find a group structure from its name
- * @param group Group name
- * @return Group structure if exists, NULL otherwise
- */
-STATIC group_t* find_group(const char *group);
-
-/**
- * @brief Find a multigroup structure from its name
- * @param multigroup Multigroup name
- * @return Multigroup structure if exists, NULL otherwise
- */
-STATIC group_t* find_multi_group(const char *multigroup);
-
-/**
- * @brief Find a group structure from a file name and md5
- * @param file File name
- * @param md5 MD5 of the file
- * @param group Array to store the group name if exists
- * @return Group structure if exists, NULL otherwise
- */
-STATIC group_t* find_group_from_file(const char * file, const char * md5, char group[OS_SIZE_65536]);
-
-/**
- * @brief Find a multigroup structure from a file name and md5
- * @param file File name
- * @param md5 MD5 of the file
- * @param multigroup Array to store the multigroup name if exists
- * @return Multigroup structure if exists, NULL otherwise
- */
-STATIC group_t* find_multi_group_from_file(const char * file, const char * md5, char multigroup[OS_SIZE_65536]);
-
-/**
- * @brief Compare and check if the file sum has changed
- * @param old_sum File sum of previous scan
- * @param new_sum File sum of new scan
- * @return true Changed
- * @return false Didn't change
- */
-STATIC bool fsum_changed(file_sum **old_sum, file_sum **new_sum);
-
-/**
- * @brief Check if any group of a given multigroup has changed
- * @param multi_group Multigroup name
- * @return true Any group changed
- * @return false Groups didn't change
- */
-STATIC bool group_changed(const char *multi_group);
-
-/**
  * @brief Get agent group
  * @param agent_id. Agent id to assign a group
  * @param msg. Message from agent to process and validate current configuration files
@@ -580,6 +488,41 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
     }
 
     os_free(clean);
+}
+
+/* Assign a group to an agent without group */
+cJSON *assign_group_to_agent(const char *agent_id, const char *md5) {
+    cJSON *result = NULL;
+    char* group = NULL;
+
+    os_calloc(OS_SIZE_65536 + 1, sizeof(char), group);
+
+    mdebug2("Agent '%s' with file '%s' MD5 '%s'", agent_id, SHAREDCFG_FILENAME, md5);
+
+    w_mutex_lock(&files_mutex);
+
+    if (!guess_agent_group || (!find_group_from_file(SHAREDCFG_FILENAME, md5, group) && !find_multi_group_from_file(SHAREDCFG_FILENAME, md5, group))) {
+        // If the group could not be guessed, set to "default"
+        // or if the user requested not to guess the group, through the internal
+        // option 'guess_agent_group', set to "default"
+        strncpy(group, "default", OS_SIZE_65536);
+    }
+
+    w_mutex_unlock(&files_mutex);
+
+    wdb_set_agent_groups_csv(atoi(agent_id),
+                            group,
+                            WDB_GROUP_MODE_EMPTY_ONLY,
+                            w_is_single_node(NULL) ? "synced" : "syncreq",
+                            NULL);
+
+    mdebug2("Group assigned: '%s'", group);
+
+    result = cJSON_CreateObject();
+    cJSON_AddStringToObject(result, "group", group);
+
+    os_free(group);
+    return result;
 }
 
 /* Generate merged file for groups */
@@ -1467,31 +1410,21 @@ STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group, 
 
         /* New agents only have merged.mg */
         if (strcmp(file, SHAREDCFG_FILENAME) == 0) {
+            cJSON *group_json = NULL;
+            cJSON *value = NULL;
 
-            // If group was not got, guess it by matching sum
-            os_calloc(OS_SIZE_65536 + 1, sizeof(char), group);
-            mdebug2("Agent '%s' with file '%s' MD5 '%s'", agent_id, SHAREDCFG_FILENAME, md5);
+            group_json = assign_group_to_agent(agent_id, md5);
 
-            w_mutex_lock(&files_mutex);
-
-            if (!guess_agent_group || (!find_group_from_file(file, md5, group) && !find_multi_group_from_file(file, md5, group))) {
-                // If the group could not be guessed, set to "default"
-                // or if the user requested not to guess the group, through the internal
-                // option 'guess_agent_group', set to "default"
-                strncpy(group, "default", OS_SIZE_65536);
+            value = cJSON_GetObjectItem(group_json, "group");
+            if(cJSON_IsString(value) && value->valuestring != NULL){
+                os_strdup(value->valuestring, *r_group);
+            } else {
+                merror("Agent '%s' invalid group assigned.", agent_id);
+                cJSON_Delete(group_json);
+                break;
             }
 
-            w_mutex_unlock(&files_mutex);
-
-            wdb_set_agent_groups_csv(atoi(agent_id),
-                                 group,
-                                 WDB_GROUP_MODE_EMPTY_ONLY,
-                                 w_is_single_node(NULL) ? "synced" : "syncreq",
-                                 NULL);
-            *r_group = group;
-
-            mdebug2("Group assigned: '%s'", group);
-
+            cJSON_Delete(group_json);
             os_free(fmsg);
             return OS_SUCCESS;
         }

--- a/src/remoted/remcom.c
+++ b/src/remoted/remcom.c
@@ -32,7 +32,8 @@ typedef enum _error_codes {
     ERROR_INVALID_AGENTS,
     ERROR_EMPTY_AGENTS,
     ERROR_EMPTY_LASTID,
-    ERROR_TOO_MANY_AGENTS
+    ERROR_TOO_MANY_AGENTS,
+    ERROR_EMPTY_AGENT_OR_MD5
 } error_codes;
 
 const char * error_messages[] = {
@@ -47,7 +48,8 @@ const char * error_messages[] = {
     [ERROR_INVALID_AGENTS] = "Invalid agents parameter",
     [ERROR_EMPTY_AGENTS] = "Error getting agents from DB",
     [ERROR_EMPTY_LASTID] = "Empty last id",
-    [ERROR_TOO_MANY_AGENTS] = "Too many agents"
+    [ERROR_TOO_MANY_AGENTS] = "Too many agents",
+    [ERROR_EMPTY_AGENT_OR_MD5] = "Invalid agent or md5 parameter"
 };
 
 /**
@@ -96,6 +98,8 @@ STATIC size_t remcom_dispatch(char* request, char** output) {
     cJSON *config_json = NULL;
     cJSON *agents_json = NULL;
     cJSON *last_id_json = NULL;
+    cJSON *agent_json = NULL;
+    cJSON *md5_json = NULL;
     const char *json_err;
     int *agents_ids;
     int count;
@@ -158,6 +162,18 @@ STATIC size_t remcom_dispatch(char* request, char** output) {
                     }
                 } else {
                     *output = remcom_output_builder(ERROR_EMPTY_SECTION, error_messages[ERROR_EMPTY_SECTION], NULL);
+                }
+            } else {
+                *output = remcom_output_builder(ERROR_EMPTY_PARAMATERS, error_messages[ERROR_EMPTY_PARAMATERS], NULL);
+            }
+        } else if (strcmp(command_json->valuestring, "assigngroup") == 0) {
+            if (parameters_json = cJSON_GetObjectItem(request_json, "parameters"), cJSON_IsObject(parameters_json)) {
+                agent_json = cJSON_GetObjectItem(parameters_json, "agent");
+                md5_json = cJSON_GetObjectItem(parameters_json, "md5");
+                if (cJSON_IsString(agent_json) && cJSON_IsString(md5_json)) {
+                    *output = remcom_output_builder(ERROR_OK, error_messages[ERROR_OK], assign_group_to_agent(agent_json->valuestring, md5_json->valuestring));
+                } else {
+                    *output = remcom_output_builder(ERROR_EMPTY_AGENT_OR_MD5, error_messages[ERROR_EMPTY_AGENT_OR_MD5], NULL);
                 }
             } else {
                 *output = remcom_output_builder(ERROR_EMPTY_PARAMATERS, error_messages[ERROR_EMPTY_PARAMATERS], NULL);

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -96,6 +96,9 @@ void *update_shared_files(void *none);
 /* Save control messages */
 void save_controlmsg(const keyentry * key, char *msg, size_t msg_length, int *wdb_sock);
 
+/* Assign a group to an agent without group */
+cJSON *assign_group_to_agent(const char *agent_id, const char *md5);
+
 // Initialize request module
 void req_init();
 

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -48,7 +48,8 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,wdb_remove_group_db -Wl,--wrap,wdb_get_all_agents -Wl,--wrap,wdb_get_agent_info \
                             -Wl,--wrap,rem_inc_send_ack -Wl,--wrap,rem_inc_recv_ctrl_request -Wl,--wrap,rem_inc_recv_ctrl_keepalive \
                             -Wl,--wrap,rem_inc_recv_ctrl_startup -Wl,--wrap,rem_inc_recv_ctrl_shutdown -Wl,--wrap,pthread_mutex_lock \
-                            -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,wdb_get_distinct_agent_groups")
+                            -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,wdb_get_distinct_agent_groups \
+                            -Wl,--wrap,w_create_sendsync_payload -Wl,--wrap,w_send_clustered_message")
 
 list(APPEND remoted_names "test_secure")
 list(APPEND remoted_flags "-Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
@@ -90,6 +91,7 @@ list(APPEND remoted_flags "-Wl,--wrap,time -Wl,--wrap,rem_get_qsize -Wl,--wrap,r
 list(APPEND remoted_names "test_remcom")
 list(APPEND remoted_flags "-Wl,--wrap,rem_create_state_json -Wl,--wrap,OS_BindUnixDomain -Wl,--wrap,select -Wl,--wrap,close -Wl,--wrap,accept \
                            -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,getRemoteConfig -Wl,--wrap,rem_create_agents_state_json  \
+                           -Wl,--wrap,assign_group_to_agent \
                            -Wl,--wrap,wdb_get_agents_ids_of_current_node -Wl,--wrap,json_parse_agents -Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS}")
 
 list(LENGTH remoted_names count)

--- a/src/unit_tests/remoted/test_remcom.c
+++ b/src/unit_tests/remoted/test_remcom.c
@@ -23,6 +23,7 @@
 #include "../wrappers/wazuh/os_net/os_net_wrappers.h"
 #include "../wrappers/wazuh/remoted/state_wrappers.h"
 #include "../wrappers/wazuh/remoted/config_wrappers.h"
+#include "../wrappers/wazuh/remoted/manager_wrappers.h"
 
 char* remcom_output_builder(int error_code, const char* message, cJSON* data_json);
 size_t remcom_dispatch(char * command, char ** output);
@@ -305,6 +306,52 @@ void test_remcom_dispatch_getagentsstats_array_ok(void ** state) {
 
     assert_non_null(response);
     assert_string_equal(response, "{\"error\":0,\"message\":\"ok\",\"data\":{}}");
+    assert_int_equal(size, strlen(response));
+}
+
+void test_remcom_dispatch_assigngroup(void ** state) {
+    char* request = "{\"command\":\"assigngroup\", \"parameters\": {\"agent\": \"001\", \"md5\": \"1234567890abcdef\"}}";
+    char *response = NULL;
+
+    cJSON* data_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(data_json, "group", "test1");
+
+    expect_string(__wrap_assign_group_to_agent, agent_id, "001");
+    expect_string(__wrap_assign_group_to_agent, md5, "1234567890abcdef");
+    will_return(__wrap_assign_group_to_agent, data_json);
+
+    size_t size = remcom_dispatch(request, &response);
+
+    *state = response;
+
+    assert_non_null(response);
+    assert_string_equal(response, "{\"error\":0,\"message\":\"ok\",\"data\":{\"group\":\"test1\"}}");
+    assert_int_equal(size, strlen(response));
+}
+
+void test_remcom_dispatch_assigngroup_invalid_parameters(void ** state) {
+    char* request = "{\"command\":\"assigngroup\", \"parameters\": {\"md5\": \"1234567890abcdef\"}}";
+    char *response = NULL;
+
+    size_t size = remcom_dispatch(request, &response);
+
+    *state = response;
+
+    assert_non_null(response);
+    assert_string_equal(response, "{\"error\":12,\"message\":\"Invalid agent or md5 parameter\",\"data\":{}}");
+    assert_int_equal(size, strlen(response));
+}
+
+void test_remcom_dispatch_assigngroup_empty_parameters(void ** state) {
+    char* request = "{\"command\":\"assigngroup\"}}";
+    char *response = NULL;
+
+    size_t size = remcom_dispatch(request, &response);
+
+    *state = response;
+
+    assert_non_null(response);
+    assert_string_equal(response, "{\"error\":5,\"message\":\"Empty parameters\",\"data\":{}}");
     assert_int_equal(size, strlen(response));
 }
 
@@ -675,6 +722,9 @@ int main(void) {
         cmocka_unit_test_teardown(test_remcom_dispatch_getagentsstats_all_ok, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_getagentsstats_array_empty_agents, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_getagentsstats_array_ok, test_teardown),
+        cmocka_unit_test_teardown(test_remcom_dispatch_assigngroup, test_teardown),
+        cmocka_unit_test_teardown(test_remcom_dispatch_assigngroup_invalid_parameters, test_teardown),
+        cmocka_unit_test_teardown(test_remcom_dispatch_assigngroup_empty_parameters, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_unknown_command, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_empty_command, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_invalid_json, test_teardown),

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks.c
@@ -15,6 +15,7 @@
 
 #include "../../wrappers/common.h"
 #include "../../wrappers/posix/unistd_wrappers.h"
+#include "../../wrappers/wazuh/shared/agent_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/cluster_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/hash_op_wrappers.h"
@@ -576,6 +577,7 @@ void test_wm_agent_send_task_information_worker(void **state)
     will_return(__wrap_cJSON_Duplicate, input);
 
     expect_string(__wrap_w_create_sendsync_payload, daemon_name, TASK_MANAGER_WM_NAME);
+    will_return(__wrap_w_create_sendsync_payload, 0);
     will_return(__wrap_w_create_sendsync_payload, cluster_request);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
@@ -733,6 +735,7 @@ void test_wm_agent_upgrade_send_tasks_information_worker(void **state)
     will_return(__wrap_cJSON_Duplicate, input);
 
     expect_string(__wrap_w_create_sendsync_payload, daemon_name, TASK_MANAGER_WM_NAME);
+    will_return(__wrap_w_create_sendsync_payload, 0);
     will_return(__wrap_w_create_sendsync_payload, cluster_request);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");

--- a/src/unit_tests/wrappers/wazuh/remoted/manager_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/remoted/manager_wrappers.c
@@ -1,0 +1,22 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "manager_wrappers.h"
+
+cJSON *__wrap_assign_group_to_agent(const char *agent_id, const char *md5) {
+    check_expected(agent_id);
+    check_expected(md5);
+
+    return mock_type(cJSON *);
+}

--- a/src/unit_tests/wrappers/wazuh/remoted/manager_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/remoted/manager_wrappers.h
@@ -1,0 +1,19 @@
+/*
+ * Wazuh Shared Configuration Manager
+ * Copyright (C) 2015, Wazuh Inc.
+ * Feb 1, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef REM_MANAGER_WRAPPERS_H
+#define REM_MANAGER_WRAPPERS_H
+
+#include <cJSON.h>
+
+cJSON *__wrap_assign_group_to_agent(const char *agent_id, const char *md5);
+
+#endif /* REM_MANAGER_WRAPPERS_H */

--- a/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.c
@@ -42,3 +42,22 @@ char* __wrap_get_agent_id_from_name(__attribute__((unused)) char *agent_name) {
 int __wrap_control_check_connection() {
     return mock();
 }
+
+cJSON* __wrap_w_create_sendsync_payload(const char *daemon_name, cJSON *message) {
+    check_expected(daemon_name);
+
+    if (mock()) {
+        cJSON_Delete(message);
+    }
+
+    return mock_type(cJSON*);
+}
+
+int __wrap_w_send_clustered_message(const char* command, const char* payload, char* response) {
+    check_expected(command);
+    check_expected(payload);
+
+    strcpy(response, mock_type(char*));
+
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.h
@@ -12,9 +12,13 @@
 #define AGENT_OP_WRAPPERS_H
 
 #include "stddef.h"
+#include "cJSON.h"
 
 int __wrap_auth_connect();
 char* __wrap_get_agent_id_from_name(__attribute__((unused)) char *agent_name);
 int __wrap_control_check_connection();
+
+cJSON* __wrap_w_create_sendsync_payload(const char *daemon_name, cJSON *message);
+int __wrap_w_send_clustered_message(const char* command, const char* payload, char* response);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.c
@@ -246,21 +246,6 @@ cJSON* __wrap_wm_agent_upgrade_parse_response(int error_id, cJSON *data) {
     return ret;
 }
 
-cJSON* __wrap_w_create_sendsync_payload(const char *daemon_name, __attribute__ ((__unused__)) cJSON *message) {
-    check_expected(daemon_name);
-
-    return mock_type(cJSON*);
-}
-
-int __wrap_w_send_clustered_message(const char* command, const char* payload, char* response) {
-    check_expected(command);
-    check_expected(payload);
-
-    strcpy(response, mock_type(char*));
-
-    return mock();
-}
-
 bool __wrap_wm_agent_upgrade_validate_task_ids_message(__attribute__ ((__unused__)) const cJSON *input_json, int *agent_id, int *task_id, char** data) {
     if (agent_id) *agent_id = mock();
     if (task_id) *task_id = mock();

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h
@@ -73,10 +73,6 @@ cJSON* __wrap_wm_agent_upgrade_parse_data_response(int error_id, const char* mes
 
 cJSON* __wrap_wm_agent_upgrade_parse_response(int error_id, cJSON *data);
 
-cJSON* __wrap_w_create_sendsync_payload(const char *daemon_name, cJSON *message);
-
-int __wrap_w_send_clustered_message(const char* command, const char* payload, char* response);
-
 bool __wrap_wm_agent_upgrade_validate_task_ids_message(const cJSON *input_json, int *agent_id, int *task_id, char** data);
 
 char* __wrap_wm_agent_upgrade_send_command_to_agent(const char *command, const size_t command_size);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/16038|

## Description

This PR modifies the mechanism that assigns groups to agents (code located in `wazuh-remoted`).

Now, in a cluster architecture, the master node is in charge of all group assignments:

- If an agent connects to the master node, it assigns the group where the agent belongs (nothing changes).
- If an agent connects to a worker node, it redirects a request to the master node and waits for a response with the group where the agent is assigned.

## Logs

- Worker

```
2023/02/01 13:40:28 wazuh-remoted[1718] manager.c:556 at assign_group_to_agent_worker(): DEBUG: Sending message to master node: '{"daemon_name":"remoted","message":{"command":"assigngroup","parameters":{"agent":"060","md5":"x"}}}'
2023/02/01 13:40:28 wazuh-remoted[1718] manager.c:560 at assign_group_to_agent_worker(): DEBUG: Message received from master node: '{"error":0,"message":"ok","data":{"group":"default"}}'
2023/02/01 13:40:28 wazuh-remoted[1718] manager.c:1598 at wait_for_msgs(): DEBUG: Sending file 'default/merged.mg' to agent '060'.
2023/02/01 13:40:28 wazuh-remoted[1718] manager.c:1614 at wait_for_msgs(): DEBUG: End sending file 'default/merged.mg' to agent '060'.
```

- Master

```
2023/02/01 13:40:28 wazuh-remoted[1877] manager.c:508 at assign_group_to_agent(): DEBUG: Agent '060' with file 'merged.mg' MD5 'x'
2023/02/01 13:40:28 wazuh-remoted[1877] manager.c:527 at assign_group_to_agent(): DEBUG: Group assigned: 'default'
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Working on cluster environments
- [x] Added unit tests (for new features)

## UT coverage

[coverage-report.zip](https://github.com/wazuh/wazuh/files/10561082/coverage-report.zip)