### PR TITLE
Update GCloud Subscriber Unit Test

### DIFF
--- a/wodles/gcloud/tests/test_subscriber.py
+++ b/wodles/gcloud/tests/test_subscriber.py
@@ -99,8 +99,8 @@ def test_WazuhGCloudSubscriber_check_permissions(mock_credentials):
 
 
 @pytest.mark.parametrize('errcode, msg', [
-    (1204, "project not found or user does not have access"),
-    (1205, ""),
+    (1204, ""),
+    (1205, "project not found or user does not have access"),
     (1206, "")
 ])
 @patch('pubsub.subscriber.pubsub.subscriber.Client.from_service_account_file')


### PR DESCRIPTION
|Related issue|
|---|
| Closes #16043  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

GCloud unit tests were failing due to test_WazuhGCloudSubscriber_check_permissions_ko not being updated after merging the changes mentioned in #15569.
Test changes explained here:
- https://github.com/wazuh/wazuh/issues/16043

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

Until now when trying to run GCloud test they would fail:

```
==================================================== test session starts =====================================================
platform linux -- Python 3.10.6, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/halothus/git/wazuh/wodles/gcloud
plugins: aiohttp-1.0.4, trio-0.7.0, asyncio-0.18.1, anyio-3.6.2, metadata-2.0.2, html-3.0.0, cov-3.0.0
asyncio: mode=auto
collected 72 items                                                                                                           

tests/test_bucket.py .................................                                                                 [ 45%]
tests/test_gcloud.py .........                                                                                         [ 58%]
tests/test_integration.py ........                                                                                     [ 69%]
tests/test_subscriber.py ......FF......                                                                                [ 88%]
tests/test_tools.py ........                                                                                           [100%]

========================================================== FAILURES ==========================================================
____________ test_WazuhGCloudSubscriber_check_permissions_ko[1204-project not found or user does not have access] ____________

mock_credentials = <MagicMock name='from_service_account_file' id='140223482090384'>, errcode = 1204
msg = 'project not found or user does not have access'

    @pytest.mark.parametrize('errcode, msg', [
        (1204, "project not found or user does not have access"),
        (1205, ""),
        (1206, "")
    ])
    @patch('pubsub.subscriber.pubsub.subscriber.Client.from_service_account_file')
    def test_WazuhGCloudSubscriber_check_permissions_ko(mock_credentials, errcode, msg):
        """Test check_permissions raises the expected GCloudError when the subscriber does not have the required
        permissions."""
        pubsub = WazuhGCloudSubscriber(**get_wodle_config(credentials_file="credentials"))
        if errcode != 1206:
            pubsub.subscriber.test_iam_permissions.side_effect = google_exceptions.NotFound(msg)
        with pytest.raises(GCloudError) as e:
            pubsub.check_permissions()
>       assert e.value.errcode == errcode
E       assert 1205 == 1204
E        +  where 1205 = GCloudError("GCloudPubSubProjectError: The '<MagicMock name='from_service_account_file().subscription_path().split().__getitem__()' id='140223483033776'>' project ID is incorrect or the user does not have permissions to access to it").errcode
E        +    where GCloudError("GCloudPubSubProjectError: The '<MagicMock name='from_service_account_file().subscription_path().split().__getitem__()' id='140223483033776'>' project ID is incorrect or the user does not have permissions to access to it") = <ExceptionInfo GCloudError("GCloudPubSubProjectError: The '<MagicMock name='from_service_account_file().subscription_p...em__()' id='140223483033776'>' project ID is incorrect or the user does not have permissions to access to it") tblen=2>.value

tests/test_subscriber.py:115: AssertionError
___________________________________ test_WazuhGCloudSubscriber_check_permissions_ko[1205-] ___________________________________

mock_credentials = <MagicMock name='from_service_account_file' id='140223482415952'>, errcode = 1205, msg = ''

    @pytest.mark.parametrize('errcode, msg', [
        (1204, "project not found or user does not have access"),
        (1205, ""),
        (1206, "")
    ])
    @patch('pubsub.subscriber.pubsub.subscriber.Client.from_service_account_file')
    def test_WazuhGCloudSubscriber_check_permissions_ko(mock_credentials, errcode, msg):
        """Test check_permissions raises the expected GCloudError when the subscriber does not have the required
        permissions."""
        pubsub = WazuhGCloudSubscriber(**get_wodle_config(credentials_file="credentials"))
        if errcode != 1206:
            pubsub.subscriber.test_iam_permissions.side_effect = google_exceptions.NotFound(msg)
        with pytest.raises(GCloudError) as e:
            pubsub.check_permissions()
>       assert e.value.errcode == errcode
E       assert 1204 == 1205
E        +  where 1204 = GCloudError("GCloudPubSubSubscriptionError: The '<MagicMock name='from_service_account_file().subscription_path().split().__getitem__()' id='140223483186528'>' subscription is incorrect or the user credentials are not valid").errcode
E        +    where GCloudError("GCloudPubSubSubscriptionError: The '<MagicMock name='from_service_account_file().subscription_path().split().__getitem__()' id='140223483186528'>' subscription is incorrect or the user credentials are not valid") = <ExceptionInfo GCloudError("GCloudPubSubSubscriptionError: The '<MagicMock name='from_service_account_file().subscript...plit().__getitem__()' id='140223483186528'>' subscription is incorrect or the user credentials are not valid") tblen=2>.value

tests/test_subscriber.py:115: AssertionError
====================================================== warnings summary ======================================================
../../venv/lib/python3.10/site-packages/pytest_aiohttp/plugin.py:28
  /home/halothus/git/wazuh/venv/lib/python3.10/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

tests/test_subscriber.py::test_WazuhGCloudSubscriber_check_permissions_ko[1204-project not found or user does not have access]
tests/test_subscriber.py::test_WazuhGCloudSubscriber_check_permissions_ko[1205-]
  /home/halothus/git/wazuh/venv/lib/python3.10/site-packages/pytest_trio/plugin.py:62: TrioDeprecationWarning: trio.MultiError is deprecated since Trio 0.22.0; use BaseExceptionGroup (on Python 3.11 and later) or exceptiongroup.BaseExceptionGroup (earlier versions) instead (https://github.com/python-trio/trio/issues/2211)
    if issubclass(call.excinfo.type, trio.MultiError):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================== short test summary info ===================================================
FAILED tests/test_subscriber.py::test_WazuhGCloudSubscriber_check_permissions_ko[1204-project not found or user does not have access]
FAILED tests/test_subscriber.py::test_WazuhGCloudSubscriber_check_permissions_ko[1205-] - assert 1204 == 1205
========================================== 2 failed, 70 passed, 3 warnings in 0.62s ==========================================
```

Now after updating the unit test:

```
/home/halothus/git/wazuh/venv/bin/python /snap/pycharm-professional/316/plugins/python/helpers/pycharm/_jb_pytest_runner.py --target test_subscriber.py::test_WazuhGCloudSubscriber_check_permissions_ko 
Testing started at 17:36 ...
Launching pytest with arguments test_subscriber.py::test_WazuhGCloudSubscriber_check_permissions_ko --no-header --no-summary -q in /home/halothus/git/wazuh/wodles/gcloud/tests

============================= test session starts ==============================
collecting ... collected 3 items

test_subscriber.py::test_WazuhGCloudSubscriber_check_permissions_ko[1204-] 
test_subscriber.py::test_WazuhGCloudSubscriber_check_permissions_ko[1205-project not found or user does not have access] 
test_subscriber.py::test_WazuhGCloudSubscriber_check_permissions_ko[1206-] 

========================= 3 passed, 1 warning in 0.21s =========================
```
## Tests

```
==================================================== test session starts =====================================================
platform linux -- Python 3.10.6, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/halothus/git/wazuh/wodles/gcloud
plugins: aiohttp-1.0.4, trio-0.7.0, asyncio-0.18.1, anyio-3.6.2, metadata-2.0.2, html-3.0.0, cov-3.0.0
asyncio: mode=auto
collected 72 items                                                                                                           

tests/test_bucket.py .................................                                                                 [ 45%]
tests/test_gcloud.py .........                                                                                         [ 58%]
tests/test_integration.py ........                                                                                     [ 69%]
tests/test_subscriber.py ..............                                                                                [ 88%]
tests/test_tools.py ........                                                                                           [100%]
```

