### PR TITLE
Alpine Linux detection on function get_unix_version added

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -396,6 +396,7 @@ os_info *get_unix_version()
     char *name = NULL;
     char *id = NULL;
     char *version = NULL;
+    char *version_id = NULL;
     char *codename = NULL;
     char *save_ptr = NULL;
     regmatch_t match[2];
@@ -423,12 +424,23 @@ os_info *get_unix_version()
                         info->os_name = strdup(name);
                     }
                 } else if (strcmp (tag,"VERSION") == 0) {
-                    if (!version) {
+                    if (!version) {    
+                        if (version_id) {
+                            os_free(info->os_version);
+                        }
                         version = strtok_r(NULL, "\n", &save_ptr);
                         if (version[0] == '\"' && (end = strchr(++version, '\"'), end)) {
                             *end = '\0';
                         }
                         info->os_version = strdup(version);
+                    }
+                } else if (strcmp (tag,"VERSION_ID") == 0) {
+                    if (!version && !version_id) {
+                        version_id = strtok_r(NULL, "\n", &save_ptr);
+                        if (version_id[0] == '\"' && (end = strchr(++version_id, '\"'), end)) {
+                            *end = '\0';
+                        }
+                        info->os_version = strdup(version_id);
                     }
                 } else if (strcmp (tag,"ID") == 0) {
                     if (!id) {
@@ -479,7 +491,7 @@ os_info *get_unix_version()
         os_free(info->os_platform);
         os_free(info->os_build);
         regex_t regexCompiled;
-        regmatch_t match[2];
+        regmatch_t match[4];
         int match_size;
         // CentOS
         if (version_release = fopen("/etc/centos-release","r"), version_release){
@@ -649,6 +661,24 @@ os_info *get_unix_version()
                     match_size = match[1].rm_eo - match[1].rm_so;
                     os_malloc(match_size + 1, info->os_version);
                     snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
+                    break;
+                }
+            }
+            regfree(&regexCompiled);
+            fclose(version_release);
+        // Alpine
+        } else if (version_release = fopen("/etc/alpine-release","r"), version_release){
+            info->os_name = strdup("Alpine Linux");
+            info->os_platform = strdup("alpine");
+            static const char *pattern = "([0-9]+\\.)?([0-9]+\\.)?([0-9]+)";
+            if (regcomp(&regexCompiled, pattern, REG_EXTENDED)) {
+                merror_exit("Cannot compile regular expression.");
+            }
+            while (fgets(buff, sizeof(buff) - 1, version_release)) {
+                if(regexec(&regexCompiled, buff, 4, match, 0) == 0){
+                    match_size = match[0].rm_eo - match[0].rm_so;
+                    os_malloc(match_size + 1, info->os_version);
+                    snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[0].rm_so);
                     break;
                 }
             }

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -162,6 +162,47 @@ void test_get_unix_version_opensuse_tumbleweed(void **state)
     assert_string_equal(ret->os_build, "rolling");
 }
 
+void test_get_unix_version_alpine(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "NAME=\"Alpine Linux\"");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "ID=alpine");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "VERSION_ID=3.17.1");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "PRETTY_NAME=\"Alpine Linux v3.17\"");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "HOME_URL=\"https://alpinelinux.org/\"");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "BUG_REPORT_URL=\"https://gitlab.alpinelinux.org/alpine/aports/-/issues\"");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, NULL);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Alpine Linux");
+    assert_string_equal(ret->os_major, "3");
+    assert_string_equal(ret->os_minor, "17");
+    assert_string_equal(ret->os_patch, "1");
+    assert_string_equal(ret->os_version, "3.17.1");
+    assert_string_equal(ret->os_platform, "alpine");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
 void test_get_unix_version_fail_os_release_centos(void **state)
 {
     (void) state;
@@ -826,6 +867,90 @@ void test_get_unix_version_fail_os_release_slackware(void **state)
     assert_string_equal(ret->sysname, "Linux");
 }
 
+void test_get_unix_version_fail_os_release_alpine(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/debian_version
+    expect_string(__wrap_fopen, path, "/etc/debian_version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/slackware-version
+    expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/alpine-release
+    expect_string(__wrap_fopen, path, "/etc/alpine-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "3.17.1");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Alpine Linux");
+    assert_string_equal(ret->os_major, "3");
+    assert_string_equal(ret->os_minor, "17");
+    assert_string_equal(ret->os_patch, "1");
+    assert_string_equal(ret->os_version, "3.17.1");
+    assert_string_equal(ret->os_platform, "alpine");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
 void test_get_unix_version_fail_os_release_uname_darwin(void **state)
 {
     (void) state;
@@ -883,6 +1008,11 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
 
     // Fail to open /etc/slackware-version
     expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/alpine-release
+    expect_string(__wrap_fopen, path, "/etc/alpine-release");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 0);
 
@@ -1026,6 +1156,11 @@ void test_get_unix_version_fail_os_release_uname_darwin_no_key(void **state)
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 0);
 
+    // Fail to open /etc/alpine-release
+    expect_string(__wrap_fopen, path, "/etc/alpine-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
     // uname
     expect_string(__wrap_popen, command, "uname");
     expect_string(__wrap_popen, type, "r");
@@ -1160,6 +1295,11 @@ void test_get_unix_version_fail_os_release_uname_sunos(void **state)
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 0);
 
+    // Fail to open /etc/alpine-release
+    expect_string(__wrap_fopen, path, "/etc/alpine-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
     // uname
     expect_string(__wrap_popen, command, "uname");
     expect_string(__wrap_popen, type, "r");
@@ -1252,6 +1392,11 @@ void test_get_unix_version_fail_os_release_uname_hp_ux(void **state)
 
     // Fail to open /etc/slackware-version
     expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/alpine-release
+    expect_string(__wrap_fopen, path, "/etc/alpine-release");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 0);
 
@@ -1350,6 +1495,11 @@ void test_get_unix_version_fail_os_release_uname_bsd(void **state)
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 0);
 
+    // Fail to open /etc/alpine-release
+    expect_string(__wrap_fopen, path, "/etc/alpine-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
     // uname
     expect_string(__wrap_popen, command, "uname");
     expect_string(__wrap_popen, type, "r");
@@ -1445,6 +1595,11 @@ void test_get_unix_version_zscaler(void **state)
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 0);
 
+    // Fail to open /etc/alpine-release
+    expect_string(__wrap_fopen, path, "/etc/alpine-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
     // uname
     expect_string(__wrap_popen, command, "uname");
     expect_string(__wrap_popen, type, "r");
@@ -1537,6 +1692,11 @@ void test_get_unix_version_fail_os_release_uname_aix(void **state)
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 0);
 
+    // Fail to open /etc/alpine-release
+    expect_string(__wrap_fopen, path, "/etc/alpine-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
     // uname
     expect_string(__wrap_popen, command, "uname");
     expect_string(__wrap_popen, type, "r");
@@ -1600,6 +1760,7 @@ int main(void) {
             cmocka_unit_test_teardown(test_get_unix_version_Ubuntu1904, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_centos, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_opensuse_tumbleweed, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_alpine, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_centos, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_fedora, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_redhat_centos, delete_os_info),
@@ -1612,6 +1773,7 @@ int main(void) {
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_arch, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_debian, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_slackware, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_alpine, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_darwin, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_darwin_no_key, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos, delete_os_info),


### PR DESCRIPTION
|Related issue|
|---|
|Closes #15698 |

## Description

With the aim of fixing the OS version detection of different distributions, this PR fix the detection on Linux Alpine (Global database).

Linux Alpine distribution information is in files "/etc/os-release" and "/etc/alpine-release". The content of these files is the following:
```
19d8de004a95:/etc# cat os-release
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.17.1
PRETTY_NAME="Alpine Linux v3.17"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
```
```
19d8de004a95:/etc# cat alpine-release 
3.17.1
```

# Before this fix:
Dashboard information of an Alpine Linux agent was:
![image](https://user-images.githubusercontent.com/101227434/216436580-7c03a28e-41dc-4e30-8907-02a2178734a9.png)

# After this fix:
Dashboard information of an Alpine Linux agent now is:
![image](https://user-images.githubusercontent.com/101227434/216436525-f53aebfa-5b23-459a-b4a8-d68301202895.png)

## Tests
2 new unit tests were created to cover this new parser: "test_get_unix_version_alpine" and "test_get_unix_version_fail_os_release_alpine".

```
matias@matias-X580VD:~/Proyectos_Wazuh/wazuh/src/unit_tests/build/shared$ ./test_version_op
[==========] Running 25 test(s).
[ RUN      ] test_get_unix_version_Ubuntu1904
[       OK ] test_get_unix_version_Ubuntu1904
[ RUN      ] test_get_unix_version_centos
[       OK ] test_get_unix_version_centos
[ RUN      ] test_get_unix_version_opensuse_tumbleweed
[       OK ] test_get_unix_version_opensuse_tumbleweed
[ RUN      ] test_get_unix_version_alpine
[       OK ] test_get_unix_version_alpine
[ RUN      ] test_get_unix_version_fail_os_release_centos
[       OK ] test_get_unix_version_fail_os_release_centos
[ RUN      ] test_get_unix_version_fail_os_release_fedora
[       OK ] test_get_unix_version_fail_os_release_fedora
[ RUN      ] test_get_unix_version_fail_os_release_redhat_centos
[       OK ] test_get_unix_version_fail_os_release_redhat_centos
[ RUN      ] test_get_unix_version_fail_os_release_redhat_fedora
[       OK ] test_get_unix_version_fail_os_release_redhat_fedora
[ RUN      ] test_get_unix_version_fail_os_release_redhat_rhel
[       OK ] test_get_unix_version_fail_os_release_redhat_rhel
[ RUN      ] test_get_unix_version_fail_os_release_redhat_rhel_server
[       OK ] test_get_unix_version_fail_os_release_redhat_rhel_server
[ RUN      ] test_get_unix_version_fail_os_release_ubuntu
[       OK ] test_get_unix_version_fail_os_release_ubuntu
[ RUN      ] test_get_unix_version_fail_os_release_gentoo
[       OK ] test_get_unix_version_fail_os_release_gentoo
[ RUN      ] test_get_unix_version_fail_os_release_suse
[       OK ] test_get_unix_version_fail_os_release_suse
[ RUN      ] test_get_unix_version_fail_os_release_arch
[       OK ] test_get_unix_version_fail_os_release_arch
[ RUN      ] test_get_unix_version_fail_os_release_debian
[       OK ] test_get_unix_version_fail_os_release_debian
[ RUN      ] test_get_unix_version_fail_os_release_slackware
[       OK ] test_get_unix_version_fail_os_release_slackware
[ RUN      ] test_get_unix_version_fail_os_release_alpine
[       OK ] test_get_unix_version_fail_os_release_alpine
[ RUN      ] test_get_unix_version_fail_os_release_uname_darwin
[       OK ] test_get_unix_version_fail_os_release_uname_darwin
[ RUN      ] test_get_unix_version_fail_os_release_uname_darwin_no_key
[       OK ] test_get_unix_version_fail_os_release_uname_darwin_no_key
[ RUN      ] test_get_unix_version_fail_os_release_uname_sunos
[       OK ] test_get_unix_version_fail_os_release_uname_sunos
[ RUN      ] test_get_unix_version_fail_os_release_uname_hp_ux
[       OK ] test_get_unix_version_fail_os_release_uname_hp_ux
[ RUN      ] test_get_unix_version_fail_os_release_uname_bsd
[       OK ] test_get_unix_version_fail_os_release_uname_bsd
[ RUN      ] test_get_unix_version_zscaler
[       OK ] test_get_unix_version_zscaler
[ RUN      ] test_get_unix_version_fail_os_release_uname_aix
[       OK ] test_get_unix_version_fail_os_release_uname_aix
[ RUN      ] test_OSX_ReleaseName
[       OK ] test_OSX_ReleaseName
[==========] 25 test(s) run.
[  PASSED  ] 25 test(s).
```