### PR TITLE
Update 0040-auditd_decoders.xml

### DIFF
--- a/ruleset/decoders/0040-auditd_decoders.xml
+++ b/ruleset/decoders/0040-auditd_decoders.xml
@@ -49,6 +49,13 @@
   <order>audit.key</order>
 </decoder>
 
+<!-- SYSCALL - AUID - only with ENRICHED auditd Logs -->
+<decoder name="auditd-syscall">
+  <parent>auditd</parent>
+  <regex offset="after_regex">AUID=\((\S+)\)|AUID="(\S+)"|AUID=(\S+)</regex>
+  <order>audit.e_auid</order>
+</decoder>
+
 <!-- EXECVE -->
 <decoder name="auditd-syscall">
   <parent>auditd</parent>


### PR DESCRIPTION
Added a decoder rule to get the AUID from enriched auditd logs, as requested in https://github.com/wazuh/wazuh/issues/14688

|Related issue|
[14688](https://github.com/wazuh/wazuh/issues/14688)

## Description

auid in Auditd Logs only shows the ID-Number not the Username. In ENRICHED Logs the original Username is present as AUID.
Adapted the decoder to also parse AUID as audit.e_auid 

The BlogPost https://wazuh.com/blog/monitoring-root-actions-on-linux-using-auditd-and-wazuh/ can also be adapted to use this feature.

## Logs/Alerts example

type=SYSCALL msg=audit(1660044851.396:13358): arch=c000003e syscall=59 success=yes exit=0 a0=55e0c22be900 a1=55e0c22743f0 a2=55e0c218ea80 a3=8 items=2 ppid=1668 pid=27499 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=6 comm="vim" exe="/usr/bin/vim.nox" key="root-commands" ARCH=x86_64 SYSCALL=execve AUID="vagrant" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"

## Tests
Example works in logtest and I get audit.e_auid: 'vagrant'

**Phase 1: Completed pre-decoding.
	full event: 'type=SYSCALL msg=audit(1660044851.396:13358): arch=c000003e syscall=59 success=yes exit=0 a0=55e0c22be900 a1=55e0c22743f0 a2=55e0c218ea80 a3=8 items=2 ppid=1668 pid=27499 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=6 comm="vim" exe="/usr/bin/vim.nox" key="root-commands" ARCH=x86_64 SYSCALL=execve AUID="vagrant" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root'

**Phase 2: Completed decoding.
	name: 'auditd'
	parent: 'auditd'
	audit.arch: 'c000003e'
	audit.auid: '1000'
	audit.command: 'vim'
	audit.e_auid: 'vagrant'
	audit.egid: '0'
	audit.euid: '0'
	audit.exe: '/usr/bin/vim'
	audit.exit: '0'
	audit.fsgid: '0'
	audit.fsuid: '0'
	audit.gid: '0'
	audit.id: '13358'
	audit.key: 'root-commands'
	audit.pid: '27499'
	audit.ppid: '1668'
	audit.session: '6'
	audit.sgid: '0'
	audit.success: 'yes'
	audit.suid: '0'
	audit.syscall: '59'
	audit.tty: 'pts0'
	audit.type: 'SYSCALL'
	audit.uid: '0'

**Phase 3: Completed filtering (rules).
	id: '80700'
	level: '0'
	description: 'Audit: Messages grouped.'
	groups: '["audit"]'
	firedtimes: '2'
	mail: 'false'
