### PR TITLE
Pre initialize pthread condition variable

### DIFF
--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -27,10 +27,10 @@ static void wm_sys_stop(wm_sys_t *sys);         // Module stopper
 const char *WM_SYS_LOCATION = "syscollector";   // Location field for event sending
 cJSON *wm_sys_dump(const wm_sys_t *sys);
 int wm_sync_message(const char *data);
-pthread_cond_t sys_stop_condition;
-pthread_mutex_t sys_stop_mutex;
+pthread_cond_t sys_stop_condition = PTHREAD_COND_INITIALIZER;
+pthread_mutex_t sys_stop_mutex = PTHREAD_MUTEX_INITIALIZER;
 bool need_shutdown_wait = false;
-pthread_mutex_t sys_reconnect_mutex;
+pthread_mutex_t sys_reconnect_mutex = PTHREAD_MUTEX_INITIALIZER;
 bool shutdown_process_started = false;
 
 const wm_context WM_SYS_CONTEXT = {


### PR DESCRIPTION
|Related issue|
|---|
|#16080|

## Description

This PR is a backport fix done initially for Wazuh 4.5 as part of this issue https://github.com/wazuh/wazuh/issues/15412.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux