### PR TITLE
Synchronize complete groups information including agents without group

### DIFF
--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1390,19 +1390,18 @@ wdbc_result wdb_global_set_agent_groups(wdb_t *wdb, wdb_groups_set_mode_t mode, 
             }
             if (OS_SUCCESS == valid_groups) {
                 char* agent_groups_csv = wdb_global_calculate_agent_group_csv(wdb, agent_id);
+                char groups_hash[WDB_GROUP_HASH_SIZE+1] = {0};
                 if (agent_groups_csv) {
-                    char groups_hash[WDB_GROUP_HASH_SIZE+1] = {0};
                     OS_SHA256_String_sized(agent_groups_csv, groups_hash, WDB_GROUP_HASH_SIZE);
-                    if (WDBC_ERROR == wdb_global_set_agent_group_context(wdb, agent_id, agent_groups_csv, groups_hash, sync_status)) {
-                        ret = WDBC_ERROR;
-                        merror("There was an error assigning the groups context to agent '%03d'", agent_id);
-                    }
-                    os_free(agent_groups_csv);
-                    wdb_global_group_hash_cache(WDB_GLOBAL_GROUP_HASH_CLEAR, NULL);
                 } else {
-                    ret = WDBC_ERROR;
-                    mdebug1("The agent groups where empty right after the set");
+                    mwarn("The groups were empty right after the set for agent '%03d'", agent_id);
                 }
+                if (WDBC_ERROR == wdb_global_set_agent_group_context(wdb, agent_id, agent_groups_csv, agent_groups_csv ? groups_hash : NULL, sync_status)) {
+                    ret = WDBC_ERROR;
+                    merror("There was an error assigning the groups context to agent '%03d'", agent_id);
+                }
+                os_free(agent_groups_csv);
+                wdb_global_group_hash_cache(WDB_GLOBAL_GROUP_HASH_CLEAR, NULL);
             }
         } else {
             ret = WDBC_ERROR;
@@ -1490,30 +1489,32 @@ wdbc_result wdb_global_sync_agent_groups_get(wdb_t *wdb, wdb_groups_sync_conditi
             if (cJSON_IsNumber(j_id)) {
                 //Get agent ID
                 last_agent_id = j_id->valueint;
+
                 //Get the groups of the agent
                 cJSON* j_groups = wdb_global_select_group_belong(wdb, last_agent_id);
-                if (j_groups) {
-                    if (j_groups->child) {
-                        cJSON_AddItemToObject(j_agent, "groups", j_groups);
-                        //Print Agent groups
-                        char *agent_str = cJSON_PrintUnformatted(j_agent);
-                        unsigned agent_len = strlen(agent_str);
-
-                        //Check if new agent fits in response
-                        if (response_size+agent_len+1 < WDB_MAX_RESPONSE_SIZE) {
-                            //Add new agent
-                            cJSON_AddItemToArray(j_data, cJSON_Duplicate(j_agent, true));
-                            //Save size
-                            response_size += agent_len+1;
-                        } else {
-                            //Pending agents but buffer is full
-                            status = WDBC_DUE;
-                        }
-                        os_free(agent_str);
-                    } else {
-                        cJSON_Delete(j_groups);
-                    }
+                if (j_groups && j_groups->child) {
+                    cJSON_AddItemToObject(j_agent, "groups", j_groups);
+                } else {
+                    cJSON_Delete(j_groups);
+                    cJSON_AddItemToObject(j_agent, "groups", cJSON_CreateArray());
                 }
+
+                //Print Agent groups
+                char *agent_str = cJSON_PrintUnformatted(j_agent);
+                unsigned agent_len = strlen(agent_str);
+
+                //Check if new agent fits in response
+                if (response_size+agent_len+1 < WDB_MAX_RESPONSE_SIZE) {
+                    //Add new agent
+                    cJSON_AddItemToArray(j_data, cJSON_Duplicate(j_agent, true));
+                    //Save size
+                    response_size += agent_len+1;
+                } else {
+                    //Pending agents but buffer is full
+                    status = WDBC_DUE;
+                }
+                os_free(agent_str);
+
                 if (set_synced) {
                     //Set groups sync status as synced
                     if (OS_SUCCESS != wdb_global_set_agent_groups_sync_status(wdb, last_agent_id, "synced")) {


### PR DESCRIPTION
|Related issue|Manual testing|Integration tests|
|---|---|---|
|https://github.com/wazuh/wazuh/issues/16076|https://github.com/wazuh/wazuh-qa/issues/3904||

## Description

It was detected that, under certain circumstances, an agent can be removed from all the groups to which it belongs in the DB. For example, a situation where the manager disk is full.

To avoid a problem with the synchronization mechanism between master and workers, this PR presents a solution that will allow synchronizing agents with empty groups.

However, since this situation is not normal behavior, this will be alerted with a warning message.

## Logs/Alerts example

```
2023/02/03 13:53:43 wazuh-db[4865] wdb_parser.c:821 at wdb_parse(): DEBUG: Global query: set-agent-groups {"mode":"override","sync_status":"synced","data":[{"id":1,"groups":[]},{"id":2,"groups":["default","test1","test2"]},{"id":3,"groups":["default","test1","test2"]},{"id":4,"groups":["default","test1","test2"]},{"id":5,"groups":["default","test1","test2"]},{"id":6,"groups":["default","test1","test2"]},{"id":7,"groups":["default","test1","test2"]},{"id":8,"groups":["default","test1","test2"]},{"id":9,"groups":["default","test1","test2"]},{"id":10,"groups":["default","test1","test2"]},{"id":11,"groups":["default","test1","test2"]},{"id":12,"groups":["default","test1","test2"]},{"id":13,"groups":["default","test1","test2"]},{"id":14,"groups":["default","test1","test2"]},{"id":15,"groups":["default","test1","test2"]},{"id":16,"groups":["default","test1","test2"]},{"id":17,"groups":["default","test1","test2"]},{"id":18,"groups":["default","test1","test2"]},{"id":19,"groups":["default","test1","test2"]},{"id":20,"groups":["default","test1","test2"]},{"id":21,"groups":["default","test1","test2"]},{"id":22,"groups":["default","test1","test2"]},{"id":23,"groups":["default","test1","test2"]},{"id":24,"groups":["default","test1","test2"]},{"id":25,"groups":["default","test1","test2"]},{"id":26,"groups":["default","test1","test2"]},{"id":27,"groups":["default","test1","test2"]},{"id":28,"groups":["default","test1","test2"]},{"id":29,"groups":["default","test1","test2"]},{"id":30,"groups":["default","test1","test2"]},{"id":31,"groups":["default","test1","test2"]},{"id":32,"groups":["default","test1","test2"]},{"id":33,"groups":["default","test1","test2"]},{"id":34,"groups":["default","test1","test2"]},{"id":35,"groups":["default","test1","test2"]},{"id":36,"groups":["default","test1","test2"]},{"id":37,"groups":["default","test1","test2"]},{"id":38,"groups":["default","test1","test2"]},{"id":39,"groups":["default","test1","test2"]},{"id":41,"groups":["default","test1","test2"]},{"id":42,"groups":["default","test1","test2"]},{"id":43,"groups":["default","test1","test2"]},{"id":44,"groups":["default","test1","test2"]},{"id":45,"groups":["default","test1","test2"]},{"id":46,"groups":["default","test1","test2"]},{"id":47,"groups":["default","test1","test2"]},{"id":48,"groups":["default","test1","test2"]},{"id":49,"groups":["default","test1","test2"]},{"id":50,"groups":["default","test1","test2"]},{"id":51,"groups":["default","test1","test2"]},{"id":52,"groups":["default","test1","test2"]},{"id":53,"groups":["default","test1","test2"]},{"id":54,"groups":["default","test1","test2"]},{"id":55,"groups":["default","test1","test2"]},{"id":56,"groups":["default","test1","test2"]},{"id":57,"groups":["default","test1","test2"]},{"id":58,"groups":["default","test1","test2"]},{"id":59,"groups":["default","test1","test2"]},{"id":60,"groups":["default","test1","test2"]},{"id":61,"groups":["default","test1","test2"]}]}
2023/02/03 13:53:43 wazuh-db[4865] wdb_global.c:1397 at wdb_global_set_agent_groups(): WARNING: The groups were empty right after the set for agent '001'
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Working on cluster environments
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components

## UT coverage

[coverage-report.zip](https://github.com/wazuh/wazuh/files/10580717/coverage-report.zip)
