### PR TITLE
Fixing issues for the AIX manager

### DIFF
--- a/etc/templates/config/AIX/syscheck.manager.template
+++ b/etc/templates/config/AIX/syscheck.manager.template
@@ -1,0 +1,38 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <scan_on_start>yes</scan_on_start>
+
+    <!-- Generate alert when new file detected -->
+    <alert_new_files>yes</alert_new_files>
+
+    <!-- Don't ignore files that change more than 3 times -->
+    <auto_ignore>no</auto_ignore>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
+    <directories check_all="yes">/bin,/sbin</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+  </syscheck>

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -17,9 +17,15 @@ CC           = gcc
 CFLAGS       = -pipe -Wall -Wextra
 THREAD_FLAGS = -pthread
 RM_FILE      = rm -f
-INSTALL_DIR  = install -o root -g ${OSSEC_GROUP} -m 0750  -d
-INSTALL_EXEC = install -o root -g ${OSSEC_GROUP} -m 0750
-INSTALL_FILE = install -o root -g ${OSSEC_GROUP} -m 0640
+INSTALL      = install
+
+ifeq (${uname_S},AIX)
+	INSTALL  = "/opt/freeware/bin/install"
+endif
+
+INSTALL_DIR  = $(INSTALL) -o root -g ${OSSEC_GROUP} -m 0750  -d
+INSTALL_EXEC = $(INSTALL) -o root -g ${OSSEC_GROUP} -m 0750
+INSTALL_FILE = $(INSTALL) -o root -g ${OSSEC_GROUP} -m 0640
 
 SQLITE_DIR       = ../src/external/sqlite
 JSON_DIR         = ../src/external/cJSON

--- a/src/Makefile
+++ b/src/Makefile
@@ -322,6 +322,9 @@ ifeq (${TARGET},agent)
 	DEFINES+=-DCLIENT
 endif
 
+ifeq (${TARGET},local)
+$(error The target 'local' is not supported, use 'TARGET=server')
+endif
 
 .PHONY: build
 build: ${TARGET}

--- a/src/init/dist-detect.sh
+++ b/src/init/dist-detect.sh
@@ -101,6 +101,12 @@ else
         DIST_VER=$(uname -r | cut -d\. -f2)
         DIST_SUBVER=$(uname -r | cut -d\. -f3)
 
+    # AIX
+    elif [ "$(uname)" = "AIX" ]; then
+        DIST_NAME="AIX"
+        DIST_VER=$(oslevel | cut -d\. -f1)
+        DIST_SUBVER=$(oslevel | cut -d\. -f2)
+
     # BSD
     elif [ "X$(uname)" = "XOpenBSD" -o "X$(uname)" = "XNetBSD" -o "X$(uname)" = "XFreeBSD" -o "X$(uname)" = "XDragonFly" ]; then
         DIST_NAME="bsd"

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -491,7 +491,7 @@ InstallCommon(){
         INSTALL="ginstall"
     elif [ ${DIST_NAME} = "HP-UX" ]; then
         INSTALL="/usr/local/coreutils/bin/install"
-    elif [ ${NUNAME} = "AIX" ]; then
+    elif [ ${DIST_NAME} = "AIX" ]; then
 	      INSTALL="/opt/freeware/bin/install"
     fi
 
@@ -693,6 +693,12 @@ InstallServer(){
 
     InstallLocal
 
+    ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue/agent-groups
+
+    if [ ! -f ${PREFIX}/queue/agents-timestamp ]; then
+        ${INSTALL} -m 0600 -o root -g ${OSSEC_GROUP} /dev/null ${PREFIX}/queue/agents-timestamp
+    fi
+
     if [ "X$BUILDCLUSTERD" = "Xyes"   ]; then
         ${INSTALL} -m 0660 -o ${OSSEC_USER} -g ${OSSEC_GROUP} /dev/null ${PREFIX}/logs/cluster.log
     fi
@@ -707,13 +713,6 @@ InstallServer(){
         ${INSTALL} -m 0750 -o root -g 0 ossec-remoted ${PREFIX}/bin
         ${INSTALL} -m 0750 -o root -g 0 ossec-authd ${PREFIX}/bin
 
-
-        ${INSTALL} -d -m 0770 -o ${OSSEC_USER_REM} -g ${OSSEC_GROUP} ${PREFIX}/queue/rids
-        ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue/agent-groups
-
-        if [ ! -f ${PREFIX}/queue/agents-timestamp ]; then
-            ${INSTALL} -m 0600 -o root -g ${OSSEC_GROUP} /dev/null ${PREFIX}/queue/agents-timestamp
-        fi
 
         ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/backup/agents
         ${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/backup/groups

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -168,13 +168,14 @@ void wm_setup()
 
 void wm_cleanup()
 {
-    // Delete PID file
-
-    if (DeletePID(ARGV0) < 0)
-        merror("Couldn't delete PID file.");
-
     // Kill active child processes
     wm_kill_children();
+
+    // Delete PID file
+
+    if (DeletePID(ARGV0) < 0) {
+        merror("Couldn't delete PID file.");
+    }
 }
 
 // Action on signal


### PR DESCRIPTION
|Related issue|
|---|
| #15971 |

## Description

This PR is intended to provide a summary of the functionality issues raised by the QA team following the review. They will be divided in two blocks, the ones fixed by this PR and the issues that are not intended to be fixed in this PR.

### Fixed issues

After the QA testing phase, the following issues were found and opened, which have been fixed as explained below:
- #16019
  - The problem was in the `install` command executed in the framework _Makefile_. To fix it, the command used for AIX has been modified so that it runs the pre-installed binary `/opt/freeware/bin/install` when it detects that it is an AIX machine.
- #16020
  - For this issue, the `error` message has simply been modified to show that `target=local` is **_not supported_**, however it will still not be possible to upgrade from a manager that was installed as a `local` target.
- #16021
  - To prevent the error from appearing repeatedly when the `REMOTED` module is not built, the condition has been removed so that the `agent-groups` folder is always created.
- #16022
  - It has been verified that in `v4.3.10` this error does not appear, but to avoid the problem in `v3.1`, the _Syscheck_ configuration template has been configured so that when it detects that it is an AIX machine, it avoids monitoring the `/boot` folder.

### Unfixed issues in v3.1

These issues are not intended to be fixed in `v3.1`, because they are already fixed in `v4.3` and it would be too much effort to fix them:
- https://github.com/wazuh/wazuh/issues/16024
  - The same tests have been performed with the v4.3.10 agent connected to a manager and the alert fields appear correctly, so the issue is fixed for v4.3.
- https://github.com/wazuh/wazuh/issues/16025
  - The same tests have been performed with the v4.3.10 agent connected to a manager and the alerts appear correctly, so the issue seems to be fixed for v4.3.
- https://github.com/wazuh/wazuh/issues/16028
  - It has been verified that in v4.3.10 this issue is fixed, although to reduce the occurrence of the bug, the following fix has been applied and can be found in the commit: https://github.com/wazuh/wazuh/commit/342f0bdc12f7655e1357758a98fcec7fe7021b88. By `cherry-picking` and adding it to the branch.
  - After testing, it seems that the error still appears with the same intensity, so it would be necessary to apply further changes to first check if the process is still active, and in that case kill it before the `Error` message to avoid it.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] AIX
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
