### PR TITLE
Fix wazuhdb race condition

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -186,9 +186,8 @@ STATIC void validate_shared_files(const char *src_path, const char *group, const
  * @param src_path Source path of the files to copy
  * @param dst_path Destination path of the files
  * @param group Group name
- * @param initial_iteration Flag indicating if it is the first iteration
  */
-STATIC void copy_directory(const char *src_path, const char *dst_path, char *group, bool initial_iteration);
+STATIC void copy_directory(const char *src_path, const char *dst_path, char *group);
 
 /* Groups structures and sizes */
 static group_t **groups;
@@ -739,7 +738,7 @@ STATIC void c_multi_group(char *multi_group, file_sum ***_f_sum, char *hash_mult
                 return;
             }
 
-            copy_directory(dir, multi_path, group, true);
+            copy_directory(dir, multi_path, group);
 
             group = strtok_r(NULL, delim, &save_ptr);
             closedir(dp);
@@ -1188,7 +1187,7 @@ STATIC void validate_shared_files(const char *src_path, const char *group, const
     return;
 }
 
-STATIC void copy_directory(const char *src_path, const char *dst_path, char *group, bool initial_iteration) {
+STATIC void copy_directory(const char *src_path, const char *dst_path, char *group) {
     unsigned int i;
     time_t *modify_time = NULL;
     int ignored;
@@ -1197,12 +1196,7 @@ STATIC void copy_directory(const char *src_path, const char *dst_path, char *gro
 
     if (files = wreaddir(src_path), !files) {
         if (errno != ENOTDIR) {
-            if (initial_iteration) {
-                mwarn("Could not open directory '%s'. Group folder was deleted.", src_path);
-                wdb_remove_group_db(group, NULL);
-            } else {
-                mdebug2("Could not open directory '%s': %s (%d)", src_path, strerror(errno), errno);
-            }
+            mwarn("Could not open directory '%s'. Group folder was deleted.", src_path);
         }
         return;
     }
@@ -1270,7 +1264,7 @@ STATIC void copy_directory(const char *src_path, const char *dst_path, char *gro
                 }
             }
 
-            copy_directory(source_path, destination_path, group, false);
+            copy_directory(source_path, destination_path, group);
             closedir(dir);
         }
     }

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -887,9 +887,6 @@ void test_c_multi_group_call_copy_directory(void **state)
 
     expect_string(__wrap__mwarn, formatted_msg, "Could not open directory 'etc/shared/multi_group_test'. Group folder was deleted.");
 
-    expect_string(__wrap_wdb_remove_group_db, name, "multi_group_test");
-    will_return(__wrap_wdb_remove_group_db, OS_SUCCESS);
-
     /* Open the multi-group files and generate merged */
     will_return(__wrap_opendir, 0);
     will_return(__wrap_strerror, "No such file or directory");
@@ -1053,9 +1050,6 @@ void test_c_multi_group_call_c_group(void **state)
 
     errno = 1;
     expect_string(__wrap__mwarn, formatted_msg, "Could not open directory 'etc/shared/multi_group_test'. Group folder was deleted.");
-
-    expect_string(__wrap_wdb_remove_group_db, name, "multi_group_test");
-    will_return(__wrap_wdb_remove_group_db, OS_SUCCESS);
 
     // End copy_directory function
 
@@ -3050,7 +3044,7 @@ void test_validate_shared_files_sub_subfolder_valid_file(void **state)
     assert_int_equal(f_size, 1);
 }
 
-void test_copy_directory_files_null_initial(void **state)
+void test_copy_directory_files_null(void **state)
 {
     expect_string(__wrap_wreaddir, name, "src_path");
     will_return(__wrap_wreaddir, NULL);
@@ -3058,23 +3052,7 @@ void test_copy_directory_files_null_initial(void **state)
     errno = 1;
     expect_string(__wrap__mwarn, formatted_msg, "Could not open directory 'src_path'. Group folder was deleted.");
 
-    expect_string(__wrap_wdb_remove_group_db, name, "group_test");
-    will_return(__wrap_wdb_remove_group_db, OS_SUCCESS);
-
-    copy_directory("src_path", "dst_path", "group_test", true);
-
-}
-
-void test_copy_directory_files_null_not_initial(void **state)
-{
-    expect_string(__wrap_wreaddir, name, "src_path");
-    will_return(__wrap_wreaddir, NULL);
-
-    errno = 1;
-    will_return(__wrap_strerror, "ERROR");
-    expect_string(__wrap__mdebug2, formatted_msg, "Could not open directory 'src_path': ERROR (1)");
-
-    copy_directory("src_path", "dst_path", "group_test", false);
+    copy_directory("src_path", "dst_path", "group_test");
 
 }
 
@@ -3089,7 +3067,7 @@ void test_copy_directory_hidden_file(void **state)
     expect_string(__wrap_wreaddir, name, "src_path");
     will_return(__wrap_wreaddir, files);
 
-    copy_directory("src_path", "dst_path", "group_test", true);
+    copy_directory("src_path", "dst_path", "group_test");
 }
 
 void test_copy_directory_merged_file(void **state)
@@ -3103,7 +3081,7 @@ void test_copy_directory_merged_file(void **state)
     expect_string(__wrap_wreaddir, name, "src_path");
     will_return(__wrap_wreaddir, files);
 
-    copy_directory("src_path", "dst_path", "group_test", true);
+    copy_directory("src_path", "dst_path", "group_test");
 }
 
 void test_copy_directory_source_path_too_long_warning(void **state)
@@ -3124,7 +3102,7 @@ void test_copy_directory_source_path_too_long_warning(void **state)
 
     reported_path_size_exceeded = 0;
 
-    copy_directory(LONG_PATH, "dst_path", "group_test", true);
+    copy_directory(LONG_PATH, "dst_path", "group_test");
 }
 
 void test_copy_directory_source_path_too_long_debug(void **state)
@@ -3145,7 +3123,7 @@ void test_copy_directory_source_path_too_long_debug(void **state)
 
     reported_path_size_exceeded = 1;
 
-    copy_directory(LONG_PATH, "dst_path", "group_test", true);
+    copy_directory(LONG_PATH, "dst_path", "group_test");
 
     reported_path_size_exceeded = 0;
 }
@@ -3168,7 +3146,7 @@ void test_copy_directory_destination_path_too_long_warning(void **state)
 
     reported_path_size_exceeded = 0;
 
-    copy_directory("src_path", LONG_PATH, "group_test", true);
+    copy_directory("src_path", LONG_PATH, "group_test");
 }
 
 void test_copy_directory_destination_path_too_long_debug(void **state)
@@ -3189,7 +3167,7 @@ void test_copy_directory_destination_path_too_long_debug(void **state)
 
     reported_path_size_exceeded = 1;
 
-    copy_directory("src_path", LONG_PATH, "group_test", true);
+    copy_directory("src_path", LONG_PATH, "group_test");
 
     reported_path_size_exceeded = 0;
 }
@@ -3219,7 +3197,7 @@ void test_copy_directory_invalid_file(void **state)
     expect_string(__wrap_OSHash_Get, key, "src_path/test-file");
     will_return(__wrap_OSHash_Get, last_modify);
 
-    copy_directory("src_path", "dst_path", "group_test", true);
+    copy_directory("src_path", "dst_path", "group_test");
 
     os_free(last_modify);
 }
@@ -3251,7 +3229,7 @@ void test_copy_directory_agent_conf_file(void **state)
     expect_value(__wrap_w_copy_file, silent, 1);
     will_return(__wrap_w_copy_file, 0);
 
-    copy_directory("src_path", "dst_path", "group_test", true);
+    copy_directory("src_path", "dst_path", "group_test");
 }
 
 void test_copy_directory_valid_file(void **state)
@@ -3281,7 +3259,7 @@ void test_copy_directory_valid_file(void **state)
     expect_value(__wrap_w_copy_file, silent, 1);
     will_return(__wrap_w_copy_file, 0);
 
-    copy_directory("src_path", "dst_path", "group_test", true);
+    copy_directory("src_path", "dst_path", "group_test");
 }
 
 void test_copy_directory_valid_file_subfolder_file(void **state)
@@ -3345,7 +3323,7 @@ void test_copy_directory_valid_file_subfolder_file(void **state)
     expect_value(__wrap_w_copy_file, silent, 1);
     will_return(__wrap_w_copy_file, 0);
 
-    copy_directory("src_path", "dst_path", "group_test", true);
+    copy_directory("src_path", "dst_path", "group_test");
 }
 
 void test_copy_directory_mkdir_fail(void **state)
@@ -3371,7 +3349,7 @@ void test_copy_directory_mkdir_fail(void **state)
     will_return(__wrap_strerror, "ERROR");
     expect_string(__wrap__merror, formatted_msg, "Cannot create directory 'dst_path/subfolder': ERROR (10)");
 
-    copy_directory("src_path", "dst_path", "group_test", true);
+    copy_directory("src_path", "dst_path", "group_test");
     errno = 0;
 }
 
@@ -3398,10 +3376,9 @@ void test_copy_directory_mkdir_exist(void **state)
     expect_string(__wrap_wreaddir, name, "src_path/subfolder");
     will_return(__wrap_wreaddir, NULL);
 
-    will_return(__wrap_strerror, "ERROR");
-    expect_string(__wrap__mdebug2, formatted_msg, "Could not open directory 'src_path/subfolder': ERROR (17)");
+    expect_string(__wrap__mwarn, formatted_msg, "Could not open directory 'src_path/subfolder'. Group folder was deleted.");
 
-    copy_directory("src_path", "dst_path", "group_test", true);
+    copy_directory("src_path", "dst_path", "group_test");
     errno = 0;
 }
 
@@ -3479,7 +3456,7 @@ void test_copy_directory_file_subfolder_file(void **state)
     expect_value(__wrap_w_copy_file, silent, 1);
     will_return(__wrap_w_copy_file, 0);
 
-    copy_directory("src_path", "dst_path", "group_test", true);
+    copy_directory("src_path", "dst_path", "group_test");
 }
 
 void test_save_controlmsg_request_error(void **state)
@@ -4147,8 +4124,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_validate_shared_files_valid_file_subfolder_valid_file, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_validate_shared_files_sub_subfolder_valid_file, test_c_group_setup, test_c_group_teardown),
         // Test copy_directory
-        cmocka_unit_test(test_copy_directory_files_null_initial),
-        cmocka_unit_test(test_copy_directory_files_null_not_initial),
+        cmocka_unit_test(test_copy_directory_files_null),
         cmocka_unit_test(test_copy_directory_hidden_file),
         cmocka_unit_test(test_copy_directory_merged_file),
         cmocka_unit_test(test_copy_directory_source_path_too_long_warning),

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -7443,7 +7443,7 @@ void test_wdb_global_assign_agent_group_find_error(void **state) {
     int agent_id = 1;
     int initial_priority = 0;
     cJSON* find_group_resp = cJSON_Parse("[{\"id\":1}]");
-    char debug_message[GROUPS_SIZE][OS_MAXSTR] = {0};
+    char warn_message[GROUPS_SIZE][OS_MAXSTR] = {0};
     char group_name[GROUPS_SIZE][OS_SIZE_128] = {0};
     cJSON* j_groups = __real_cJSON_CreateArray();
 
@@ -7454,8 +7454,9 @@ void test_wdb_global_assign_agent_group_find_error(void **state) {
         // wdb_global_find_group
         will_return(__wrap_wdb_begin2, OS_INVALID);
         expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
-        snprintf(debug_message[i], OS_MAXSTR, "Unable to find the id of the group '%s'", group_name[i]);
-        expect_string(__wrap__mdebug1, formatted_msg, debug_message[i]);
+        snprintf(warn_message[i], OS_MAXSTR, "Unable to find the id of the group '%s'", group_name[i]);
+        expect_string(__wrap__mwarn, formatted_msg, warn_message[i]);
+        expect_function_call(__wrap_cJSON_Delete);
     }
 
     wdbc_result result = wdb_global_assign_agent_group(data->wdb, agent_id, j_groups, initial_priority);
@@ -7656,7 +7657,7 @@ void test_wdb_global_unassign_agent_group_find_error(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     cJSON* find_group_resp = cJSON_Parse("[{\"id\":1}]");
-    char debug_message[GROUPS_SIZE][OS_MAXSTR] = {0};
+    char warn_message[GROUPS_SIZE][OS_MAXSTR] = {0};
     char group_name[GROUPS_SIZE][OS_SIZE_128] = {0};
     cJSON* j_groups = __real_cJSON_CreateArray();
 
@@ -7667,8 +7668,9 @@ void test_wdb_global_unassign_agent_group_find_error(void **state) {
         // wdb_global_find_group
         will_return(__wrap_wdb_begin2, OS_INVALID);
         expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
-        snprintf(debug_message[i], OS_MAXSTR, "Unable to find the id of the group '%s'", group_name[i]);
-        expect_string(__wrap__mdebug1, formatted_msg, debug_message[i]);
+        snprintf(warn_message[i], OS_MAXSTR, "Unable to find the id of the group '%s'", group_name[i]);
+        expect_string(__wrap__mwarn, formatted_msg, warn_message[i]);
+        expect_function_call(__wrap_cJSON_Delete);
     }
 
     wdbc_result result = wdb_global_unassign_agent_group(data->wdb, agent_id, j_groups);

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -7248,14 +7248,6 @@ void test_wdb_global_assign_agent_group_success(void **state) {
         snprintf(group_name[i], OS_SIZE_128, "GROUP%d", i);
         cJSON_AddItemToArray(j_groups, cJSON_CreateString(group_name[i]));
 
-        // wdb_global_insert_agent_group
-        will_return(__wrap_wdb_begin2, 1);
-        will_return(__wrap_wdb_stmt_cache, 1);
-        expect_value(__wrap_sqlite3_bind_text, pos, 1);
-        expect_string(__wrap_sqlite3_bind_text, buffer, group_name[i]);
-        will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-        will_return(__wrap_wdb_step, SQLITE_DONE);
-
         // wdb_global_find_group
         will_return(__wrap_wdb_begin2, 1);
         will_return(__wrap_wdb_stmt_cache, 1);
@@ -7302,14 +7294,6 @@ void test_wdb_global_assign_agent_group_insert_belong_error(void **state) {
         snprintf(group_name[i], OS_SIZE_128, "GROUP%d", i);
         cJSON_AddItemToArray(j_groups, cJSON_CreateString(group_name[i]));
 
-        // wdb_global_insert_agent_group
-        will_return(__wrap_wdb_begin2, 1);
-        will_return(__wrap_wdb_stmt_cache, 1);
-        expect_value(__wrap_sqlite3_bind_text, pos, 1);
-        expect_string(__wrap_sqlite3_bind_text, buffer, group_name[i]);
-        will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-        will_return(__wrap_wdb_step, SQLITE_DONE);
-
         // wdb_global_find_group
         will_return(__wrap_wdb_begin2, 1);
         will_return(__wrap_wdb_stmt_cache, 1);
@@ -7347,70 +7331,11 @@ void test_wdb_global_assign_agent_group_find_error(void **state) {
         snprintf(group_name[i], OS_SIZE_128, "GROUP%d", i);
         cJSON_AddItemToArray(j_groups, cJSON_CreateString(group_name[i]));
 
-        // wdb_global_insert_agent_group
-        will_return(__wrap_wdb_begin2, 1);
-        will_return(__wrap_wdb_stmt_cache, 1);
-        expect_value(__wrap_sqlite3_bind_text, pos, 1);
-        expect_string(__wrap_sqlite3_bind_text, buffer, group_name[i]);
-        will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-        will_return(__wrap_wdb_step, SQLITE_DONE);
-
         // wdb_global_find_group
         will_return(__wrap_wdb_begin2, OS_INVALID);
         expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
         snprintf(debug_message[i], OS_MAXSTR, "Unable to find the id of the group '%s'", group_name[i]);
         expect_string(__wrap__mdebug1, formatted_msg, debug_message[i]);
-    }
-
-    wdbc_result result = wdb_global_assign_agent_group(data->wdb, agent_id, j_groups, initial_priority);
-
-    assert_int_equal(result, WDBC_ERROR);
-    __real_cJSON_Delete(j_groups);
-    __real_cJSON_Delete(find_group_resp);
-}
-
-void test_wdb_global_assign_agent_group_insert_error(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
-    int group_id = 1;
-    int initial_priority = 0;
-    int current_priority = initial_priority;
-    cJSON* find_group_resp = cJSON_Parse("[{\"id\":1}]");
-    char group_name[GROUPS_SIZE][OS_SIZE_128] = {0};
-    cJSON* j_groups = __real_cJSON_CreateArray();
-
-    for (int i=0; i<GROUPS_SIZE; i++) {
-        snprintf(group_name[i], OS_SIZE_128, "GROUP%d", i);
-        cJSON_AddItemToArray(j_groups, cJSON_CreateString(group_name[i]));
-
-        // wdb_global_insert_agent_group
-        will_return(__wrap_wdb_begin2, OS_INVALID);
-        expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
-
-        // wdb_global_find_group
-        will_return(__wrap_wdb_begin2, 1);
-        will_return(__wrap_wdb_stmt_cache, 1);
-        expect_value(__wrap_sqlite3_bind_text, pos, 1);
-        expect_string(__wrap_sqlite3_bind_text, buffer, group_name[i]);
-        will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-        will_return(__wrap_wdb_exec_stmt, find_group_resp);
-
-        expect_function_call(__wrap_cJSON_Delete);
-
-        // wdb_global_insert_agent_belong
-        will_return(__wrap_wdb_begin2, 1);
-        will_return(__wrap_wdb_stmt_cache, 1);
-        expect_value(__wrap_sqlite3_bind_int, index, 1);
-        expect_value(__wrap_sqlite3_bind_int, value, group_id);
-        will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-        expect_value(__wrap_sqlite3_bind_int, index, 2);
-        expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-        will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-        expect_value(__wrap_sqlite3_bind_int, index, 3);
-        expect_value(__wrap_sqlite3_bind_int, value, current_priority);
-        current_priority++;
-        will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-        will_return(__wrap_wdb_step, SQLITE_DONE);
     }
 
     wdbc_result result = wdb_global_assign_agent_group(data->wdb, agent_id, j_groups, initial_priority);
@@ -7511,13 +7436,6 @@ void test_wdb_global_unassign_agent_group_success(void **state) {
  */
 void create_wdb_global_assign_agent_group_success_call(int agent_id, int group_id, char* group_name, cJSON* find_group_resp) {
     int actual_priority = 0;
-    // wdb_global_insert_agent_group
-    will_return(__wrap_wdb_begin2, 1);
-    will_return(__wrap_wdb_stmt_cache, 1);
-    expect_value(__wrap_sqlite3_bind_text, pos, 1);
-    expect_string(__wrap_sqlite3_bind_text, buffer, group_name);
-    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    will_return(__wrap_wdb_step, SQLITE_DONE);
     // wdb_global_find_group
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -9091,7 +9009,6 @@ int main()
                                         test_setup,
                                         test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_assign_agent_group_find_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_assign_agent_group_insert_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_assign_agent_group_invalid_json, test_setup, test_teardown),
         /* Tests wdb_global_unassign_agent_group */
         cmocka_unit_test_setup_teardown(test_wdb_global_unassign_agent_group_success, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -5254,6 +5254,7 @@ void test_wdb_global_delete_group_transaction_fail(void **state)
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
+    expect_function_call(__wrap_cJSON_Delete);
 
     result = wdb_global_delete_group(data->wdb, group_name);
 
@@ -5276,6 +5277,7 @@ void test_wdb_global_delete_group_cache_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
+    expect_function_call(__wrap_cJSON_Delete);
 
     result = wdb_global_delete_group(data->wdb, group_name);
 
@@ -5304,6 +5306,7 @@ void test_wdb_global_delete_group_bind_fail(void **state)
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_function_call(__wrap_cJSON_Delete);
 
     result = wdb_global_delete_group(data->wdb, group_name);
 
@@ -5334,6 +5337,7 @@ void test_wdb_global_delete_group_step_fail(void **state)
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
+    expect_function_call(__wrap_cJSON_Delete);
 
     result = wdb_global_delete_group(data->wdb, group_name);
 

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -99,7 +99,6 @@ int main(int argc, char ** argv)
     wconfig.free_pages_percentage = getDefine_Int("wazuh_db", "free_pages_percentage", 0, 99);
     wconfig.max_fragmentation = getDefine_Int("wazuh_db", "max_fragmentation", 0, 100);
     wconfig.check_fragmentation_interval = getDefine_Int("wazuh_db", "check_fragmentation_interval", 1, 30758400);
-    wconfig.is_worker = w_is_worker();
 
     // Allocating memory for configuration structures and setting default values
     wdb_init_conf();

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -99,6 +99,7 @@ int main(int argc, char ** argv)
     wconfig.free_pages_percentage = getDefine_Int("wazuh_db", "free_pages_percentage", 0, 99);
     wconfig.max_fragmentation = getDefine_Int("wazuh_db", "max_fragmentation", 0, 100);
     wconfig.check_fragmentation_interval = getDefine_Int("wazuh_db", "check_fragmentation_interval", 1, 30758400);
+    wconfig.is_worker = w_is_worker();
 
     // Allocating memory for configuration structures and setting default values
     wdb_init_conf();

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -69,7 +69,7 @@ CREATE INDEX IF NOT EXISTS group_name ON `group` (name);
 
 CREATE TABLE IF NOT EXISTS belongs (
     id_agent INTEGER REFERENCES agent (id) ON DELETE CASCADE,
-    id_group INTEGER,
+    id_group INTEGER REFERENCES `group` (id) ON DELETE CASCADE,
     priority INTEGER NOT NULL DEFAULT 0,
     UNIQUE (id_agent, priority),
     PRIMARY KEY (id_agent, id_group)

--- a/src/wazuh_db/schema_global_upgrade_v4.sql
+++ b/src/wazuh_db/schema_global_upgrade_v4.sql
@@ -10,7 +10,7 @@
 
 CREATE TABLE IF NOT EXISTS _belongs (
     id_agent INTEGER REFERENCES agent (id) ON DELETE CASCADE,
-    id_group INTEGER,
+    id_group INTEGER REFERENCES `group` (id) ON DELETE CASCADE,
     priority INTEGER NOT NULL DEFAULT 0,
     UNIQUE (id_agent, priority),
     PRIMARY KEY (id_agent, id_group)

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -176,7 +176,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_DELETE_AGENT_BELONG] = "DELETE FROM belongs WHERE id_agent = ?;",
     [WDB_STMT_GLOBAL_DELETE_TUPLE_BELONG] = "DELETE FROM belongs WHERE id_group = ? and id_agent = ?;",
     [WDB_STMT_GLOBAL_DELETE_GROUP] = "DELETE FROM `group` WHERE name = ?;",
-    [WDB_STMT_GLOBAL_GROUP_BELONG_FIND] = "SELECT 1 FROM belongs WHERE id_group = (SELECT id FROM 'group' WHERE name = ?);",
+    [WDB_STMT_GLOBAL_GROUP_BELONG_FIND] = "SELECT id_agent FROM belongs WHERE id_group = (SELECT id FROM 'group' WHERE name = ?);",
     [WDB_STMT_GLOBAL_GROUP_BELONG_GET] = "SELECT id_agent FROM belongs WHERE id_group = (SELECT id FROM 'group' WHERE name = ?) AND id_agent > ?;",
     [WDB_STMT_GLOBAL_SELECT_GROUPS] = "SELECT name FROM `group`;",
     [WDB_STMT_GLOBAL_SYNC_REQ_GET] = "SELECT id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, last_keepalive, connection_status, disconnection_time, group_config_status FROM agent WHERE id > ? AND sync_status = 'syncreq' LIMIT 1;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1312,7 +1312,7 @@ int wdb_parse_global_set_agent_groups(wdb_t* wdb, char* input, char* output);
  * @return WDBC_OK Success.
  *         WDBC_ERROR On error.
  */
-int recalculate_agent_groups_hash(wdb_t* wdb, int agent_id, char* sync_status);
+int wdb_global_recalculate_agent_groups_hash(wdb_t* wdb, int agent_id, char* sync_status);
 
 /**
  * @brief Function to parse sync-agent-info-get params and set next ID to iterate on further calls.
@@ -2094,13 +2094,13 @@ wdbc_result wdb_global_assign_agent_group(wdb_t *wdb, int id, cJSON* j_groups, i
 wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups);
 
 /**
- * @brief Sets default group to an agent.
+ * @brief Sets default group to an agent if it doesn't have any.
  *
  * @param [in] wdb The Global struct database.
  * @param [in] id ID of the agent to set default group.
  * @return wdbc_result representing the status of the command.
  */
-int wdb_set_default_agent_group(wdb_t *wdb, int id);
+int wdb_global_if_empty_set_default_agent_group(wdb_t *wdb, int id);
 
 /**
  * @brief Returns the number of groups that are assigned to an agent.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -372,6 +372,7 @@ typedef struct wdb_config {
     int free_pages_percentage;
     int max_fragmentation;
     int check_fragmentation_interval;
+    int is_worker;
     wdb_backup_settings_node** wdb_backup_settings;
 } wdb_config;
 
@@ -1304,6 +1305,17 @@ int wdb_parse_global_get_group_agents(wdb_t * wdb, char * input, char * output);
 int wdb_parse_global_set_agent_groups(wdb_t* wdb, char* input, char* output);
 
 /**
+ * @brief Function to recalculate the agent group hash.
+ *
+ * @param [in] wdb The global struct database.
+ * @param [in] agent_id Int with the agent id.
+ * @param [in] sync_status String with the sync_status to be set.
+ * @return WDBC_OK Success.
+ *         WDBC_ERROR On error.
+ */
+int recalculate_agent_groups_hash(wdb_t* wdb, int agent_id, char* sync_status);
+
+/**
  * @brief Function to parse sync-agent-info-get params and set next ID to iterate on further calls.
  *        If no last_id is provided. Last obtained ID is used.
  *
@@ -1920,9 +1932,9 @@ int wdb_global_delete_tuple_belong(wdb_t *wdb, int id_group, int id_agent);
  *
  * @param [in] wdb The Global struct database.
  * @param [in] group_name The group name.
- * @return Returns true if the group is empty, false if it isn´t empty or error.
+ * @return Returns cJSON* with agents id.
  */
-bool wdb_is_group_empty(wdb_t *wdb, char* group_name);
+cJSON* wdb_is_group_empty(wdb_t *wdb, char* group_name);
 
 /**
  * @brief Function to delete a group by using the name.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -372,7 +372,6 @@ typedef struct wdb_config {
     int free_pages_percentage;
     int max_fragmentation;
     int check_fragmentation_interval;
-    int is_worker;
     wdb_backup_settings_node** wdb_backup_settings;
 } wdb_config;
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -2095,6 +2095,15 @@ wdbc_result wdb_global_assign_agent_group(wdb_t *wdb, int id, cJSON* j_groups, i
 wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups);
 
 /**
+ * @brief Sets default group to an agent.
+ *
+ * @param [in] wdb The Global struct database.
+ * @param [in] id ID of the agent to set default group.
+ * @return wdbc_result representing the status of the command.
+ */
+int wdb_set_default_agent_group(wdb_t *wdb, int id);
+
+/**
  * @brief Returns the number of groups that are assigned to an agent.
  *
  * @param [in] wdb The Global struct database.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1208,7 +1208,7 @@ wdbc_result wdb_global_assign_agent_group(wdb_t *wdb, int id, cJSON* j_groups, i
         if (cJSON_IsString(j_group_name)){
             char* group_name = j_group_name->valuestring;
             cJSON* j_find_response = wdb_global_find_group(wdb, group_name);
-            if (j_find_response) {
+            if (j_find_response && cJSON_GetArraySize(j_find_response) > 0) {
                 cJSON* j_group_id = cJSON_GetObjectItem(j_find_response->child, "id");
                 if (cJSON_IsNumber(j_group_id)) {
                     if (OS_INVALID == wdb_global_insert_agent_belong(wdb, j_group_id->valueint, id, priority)) {
@@ -1218,13 +1218,14 @@ wdbc_result wdb_global_assign_agent_group(wdb_t *wdb, int id, cJSON* j_groups, i
                         priority++;
                     }
                 } else {
-                    mwarn("The group '%s' does not exist", group_name);
+                    mwarn("Invalid response from wdb_global_find_group.");
+                    result = WDBC_ERROR;
                 }
-                cJSON_Delete(j_find_response);
             } else {
-                mdebug1("Unable to find the id of the group '%s'", group_name);
+                mwarn("Unable to find the id of the group '%s'", group_name);
                 result = WDBC_ERROR;
             }
+            cJSON_Delete(j_find_response);
         } else {
             mdebug1("Invalid groups set information");
             result = WDBC_ERROR;
@@ -1240,7 +1241,7 @@ wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups)
         if (cJSON_IsString(j_group_name)) {
             char* group_name = j_group_name->valuestring;
             cJSON* j_find_response = wdb_global_find_group(wdb, group_name);
-            if (j_find_response) {
+            if (j_find_response && cJSON_GetArraySize(j_find_response) > 0) {
                 cJSON* j_group_id = cJSON_GetObjectItem(j_find_response->child, "id");
                 if (cJSON_IsNumber(j_group_id)) {
                     if (OS_SUCCESS == wdb_global_delete_tuple_belong(wdb, j_group_id->valueint, id)) {
@@ -1252,13 +1253,14 @@ wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups)
                         result = WDBC_ERROR;
                     }
                 } else {
-                    mwarn("The group '%s' does not exist", group_name);
+                    mwarn("Invalid response from wdb_global_find_group.");
+                    result = WDBC_ERROR;
                 }
-                cJSON_Delete(j_find_response);
             } else {
-                mdebug1("Unable to find the id of the group '%s'", group_name);
+                mwarn("Unable to find the id of the group '%s'", group_name);
                 result = WDBC_ERROR;
             }
+            cJSON_Delete(j_find_response);
         } else {
             mdebug1("Invalid groups remove information");
             result = WDBC_ERROR;

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -839,6 +839,7 @@ int wdb_global_delete_group(wdb_t *wdb, char* group_name) {
 
     sqlite3_stmt *stmt = NULL;
     cJSON* agent_id_item = NULL;
+    int result = OS_INVALID;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
         mdebug1("Cannot begin transaction");
@@ -872,16 +873,15 @@ int wdb_global_delete_group(wdb_t *wdb, char* group_name) {
                 }
             }
         }
-
-        cJSON_Delete(sql_agents_id);
-
-        return OS_SUCCESS;
+        result = OS_SUCCESS;
         break;
     default:
         mdebug1("SQLite: %s", sqlite3_errmsg(wdb->db));
-        cJSON_Delete(sql_agents_id);
-        return OS_INVALID;
+        break;
     }
+
+    cJSON_Delete(sql_agents_id);
+    return result;
 }
 
 cJSON* wdb_global_select_groups(wdb_t *wdb) {
@@ -1407,8 +1407,7 @@ wdbc_result wdb_global_set_agent_groups(wdb_t *wdb, wdb_groups_set_mode_t mode, 
                 }
             }
             if (OS_SUCCESS == valid_groups) {
-                int result = wdb_global_recalculate_agent_groups_hash(wdb, agent_id, sync_status);
-                if (result == WDBC_ERROR) {
+                if (WDBC_ERROR == wdb_global_recalculate_agent_groups_hash(wdb, agent_id, sync_status)) {
                     ret = WDBC_ERROR;
                     merror("Couldn't recalculate hash group for agent: '%03d'", agent_id);
                 }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1207,9 +1207,6 @@ wdbc_result wdb_global_assign_agent_group(wdb_t *wdb, int id, cJSON* j_groups, i
     cJSON_ArrayForEach (j_group_name, j_groups) {
         if (cJSON_IsString(j_group_name)){
             char* group_name = j_group_name->valuestring;
-            if (OS_INVALID == wdb_global_insert_agent_group(wdb, group_name)) {
-                result = WDBC_ERROR;
-            }
             cJSON* j_find_response = wdb_global_find_group(wdb, group_name);
             if (j_find_response) {
                 cJSON* j_group_id = cJSON_GetObjectItem(j_find_response->child, "id");

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -838,6 +838,7 @@ int wdb_global_delete_group(wdb_t *wdb, char* group_name) {
     cJSON* sql_agents_id = wdb_is_group_empty(wdb, group_name);
 
     sqlite3_stmt *stmt = NULL;
+    cJSON* agent_id_item = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
         mdebug1("Cannot begin transaction");
@@ -862,7 +863,6 @@ int wdb_global_delete_group(wdb_t *wdb, char* group_name) {
     switch (wdb_step(stmt)) {
     case SQLITE_ROW:
     case SQLITE_DONE:
-        cJSON* agent_id_item = NULL;
         cJSON_ArrayForEach(agent_id_item,sql_agents_id) {
             cJSON* agent_id = cJSON_GetObjectItem(agent_id_item, "id_agent");
             if (cJSON_IsNumber(agent_id)) {

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -868,10 +868,10 @@ int wdb_global_delete_group(wdb_t *wdb, char* group_name) {
                     if (WDBC_ERROR == wdb_set_default_agent_group (wdb, agent_id->valueint)) {
                             result = WDBC_ERROR;
                     } else {
-                        result = recalculate_agent_groups_hash(wdb, agent_id->valueint, wconfig.is_worker?"synced":"syncreq");
+                        result = recalculate_agent_groups_hash(wdb, agent_id->valueint, "syncreq");
                     }
                     if (result == WDBC_ERROR) {
-                        merror("Couldn't recalculate hash group for agent: '%d'", agent_id->valueint);
+                        merror("Couldn't recalculate hash group for agent: '%03d'", agent_id->valueint);
                     }
                 }
             }
@@ -1416,7 +1416,7 @@ wdbc_result wdb_global_set_agent_groups(wdb_t *wdb, wdb_groups_set_mode_t mode, 
                 int result = recalculate_agent_groups_hash(wdb, agent_id, sync_status);
                 if (result == WDBC_ERROR) {
                     ret = WDBC_ERROR;
-                    merror("Couldn't recalculate hash group for agent: '%d'", agent_id);
+                    merror("Couldn't recalculate hash group for agent: '%03d'", agent_id);
                 }
             }
         } else {


### PR DESCRIPTION
|Related issue|Manual testing|Integration tests|
|---|---|---|
|https://github.com/wazuh/wazuh/issues/16045|https://github.com/wazuh/wazuh-qa/issues/3907||
## Description

Now the deletion of the relationships between agents and groups stored in the table belongs will be performed by the database through a cascade deletion. Then the wazuh-db module will be in charge of recalculate the group_hash to update the agent table.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [ ] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)