### PR TITLE
Fix race condition in wazuh-analysisd when handling rule ignore option

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -498,11 +498,11 @@ int main_analysisd(int argc, char **argv)
         merror_exit(SETGID_ERROR, group, errno, strerror(errno));
     }
 
-    /* Chroot 
+    /* Chroot */
     if (Privsep_Chroot(home_path) < 0) {
         merror_exit(CHROOT_ERROR, home_path, errno, strerror(errno));
     }
-    nowChroot();*/
+    nowChroot();
 
     /* Set the user */
     if (Privsep_SetUser(uid) < 0) {

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -37,7 +37,6 @@ extern OSDecoderInfo *NULL_Decoder;
 extern rlim_t nofile;
 extern int sys_debug_level;
 extern OSDecoderInfo *fim_decoder;
-extern time_t current_time;
 
 /**
  * @brief Structure to save all CDB lists.
@@ -107,5 +106,24 @@ extern int num_rule_matching_threads;
 #define FIM_MAX_WAZUH_DB_ATTEMPS 5
 #define SYS_MAX_WAZUH_DB_ATTEMPS 5
 #define PM_MAX_WAZUH_DB_ATTEMPS 5
+
+/**
+ * @brief mutex for any condition passed as an argument
+ * @return none
+ * */
+#define w_guard_mutex_variable(mutex, AnyVariable)              \
+    w_mutex_lock(&mutex);                                       \
+    (void)(AnyVariable);                                        \
+    w_mutex_unlock(&mutex)
+
+/**
+ * @breif mutex for any condition passed as an argument
+ * @return condition the evaluated condition
+ * */
+#define w_guard_mutex_conditioned_variable(mutex, AnyVariable)  \
+    ({w_mutex_lock(&mutex);                                     \
+    bool condition = (AnyVariable);                             \
+    w_mutex_unlock(&mutex);                                     \
+    condition;})
 
 #endif /* LOGAUDIT_H */

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -116,15 +116,6 @@ extern int num_rule_matching_threads;
     (void)(AnyVariable);                                        \
     w_mutex_unlock(&mutex)
 
-/**
- * @breif mutex for any condition passed as an argument
- * @return result of the evaluated condition
- * */
-#define w_guard_mutex_conditioned_variable(mutex, AnyVariable)  \
-    ({w_mutex_lock(&mutex);                                     \
-    bool condition = (AnyVariable);                             \
-    w_mutex_unlock(&mutex);                                     \
-    condition;})
 
 time_t w_get_current_time(void);
 

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -118,12 +118,14 @@ extern int num_rule_matching_threads;
 
 /**
  * @breif mutex for any condition passed as an argument
- * @return condition the evaluated condition
+ * @return result of the evaluated condition
  * */
 #define w_guard_mutex_conditioned_variable(mutex, AnyVariable)  \
     ({w_mutex_lock(&mutex);                                     \
     bool condition = (AnyVariable);                             \
     w_mutex_unlock(&mutex);                                     \
     condition;})
+
+time_t w_get_current_time(void);
 
 #endif /* LOGAUDIT_H */

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -42,8 +42,6 @@ size_t field_offset[] = {
     offsetof(Eventinfo, location)
 };
 
-static pthread_mutex_t rule_level_mutex = PTHREAD_MUTEX_INITIALIZER;
-extern time_t w_get_current_time(void);
 
 // Function to check for repetitions from same fields
 
@@ -226,7 +224,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, __attribute__((unused)) EventList *
         /* We avoid multiple triggers for the same rule
          * or rules with a lower level.
          */
-        if (w_guard_mutex_conditioned_variable(rule_level_mutex, (lf->matched >= rule->level))) {
+        if (lf->matched >= rule->level) {
             lf = NULL;
             goto end;
         }
@@ -248,7 +246,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, __attribute__((unused)) EventList *
         /* If reached here, we matched */
         my_lf->matched = rule->level;
         if (first_matched) { // To protect from a possible frequency 0
-            w_guard_mutex_variable(rule_level_mutex,(first_matched->matched = rule->level));
+            first_matched->matched = rule->level;
         }
         goto end;
     } while ((lf_node = lf_node->prev) != NULL);
@@ -1116,7 +1114,7 @@ void w_copy_event_for_log(Eventinfo *lf,Eventinfo *lf_cpy){
     lf_cpy->p_name_size = lf->p_name_size;
 
     /* Other internal variables */
-    w_guard_mutex_variable(rule_level_mutex,(lf_cpy->matched = lf->matched));
+    lf_cpy->matched = lf->matched;
     lf_cpy->time = lf->time;
     lf_cpy->day = lf->day;
     lf_cpy->year = lf->year;

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -97,6 +97,10 @@ typedef struct _Eventinfo {
     EventNode *node;
     // Process thread id
     int tid;
+
+    /* Pointer to the previous rule matched */
+    void *prev_rule;
+
 } Eventinfo;
 
 /* Events List structure */

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -208,8 +208,6 @@ typedef struct _RuleInfo {
 
     char *file;
 
-    /* Pointer to the previous rule matched */
-    void *prev_rule;
 
     /* Dynamic fields to compare between events */
     char ** same_fields;


### PR DESCRIPTION
|Related issue|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/14099|https://github.com/wazuh/wazuh-qa/issues/4032|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR solves the issue https://github.com/wazuh/wazuh/issues/14099, the proposed solution was add a locking and unlocking mechanism for some variables.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
1. Configure rule with ignore option , for example:
```
   <rule id="100222" level="5" frequency="3" timeframe="120" ignore="10">
    <if_matched_sid>5716</if_matched_sid>
    <match>^Failed|^error: PAM: Authentication</match>
    <description>sshd: authentication failed.</description>
    <mitre>
      <id>T1110</id>
    </mitre>
   <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
    </rule>
```

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
### How testing:
2. Restart wazuh-manager
3. Stop `wazuh-analysisd` `kill -9 $(pidof wazuh-analysisd)`
4. Add  `-fsanitize=thread ` to `AR_LDFLAGS` `OSSEC_LDFLAGS` `OSSEC_CFLAGS` flags in Makefile
5. Build wazuh-master with DEBUG=1
6. Copy and paste wazuh-analysisd binary file to `/var/ossec/bin`
7. Execute `wazuh-analysisd -f -u root`
8. For rule trigger, create a file `test.txt` 
9. `Dec 10 01:02:02 host sshd[1234]: Failed none for root from 192.168.56.66 port 1066 ssh2
` paste and save three times.
10. You should not see any race conditions at the time the rule is triggered **100222**

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language


<!-- Depending on the affected OS -->
- Memory tests for Linux
   - [ ] AddressSanitizer


