### PR TITLE
Modify check_bucket method from AWSServerAccess

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -636,7 +636,6 @@ class AWSBucket(WazuhIntegration):
             except Exception as e:
                 debug("+++ Error marking log {} as completed: {}".format(log_file['Key'], e), 2)
 
-
     def db_count_region(self, aws_account_id, aws_region):
         """Counts the number of rows in DB for a region
         :param aws_account_id: AWS account ID
@@ -2624,7 +2623,8 @@ class AWSServerAccess(AWSCustomBucket):
     def check_bucket(self):
         """Check if the bucket is empty or the credentials are wrong."""
         try:
-            if not 'CommonPrefixes' in self.client.list_objects_v2(Bucket=self.bucket, Delimiter='/'):
+            bucket_objects = self.client.list_objects_v2(Bucket=self.bucket, Delimiter='/')
+            if not 'CommonPrefixes' in bucket_objects and not 'Contents' in bucket_objects:
                 print("ERROR: No files were found in '{0}'. No logs will be processed.".format(self.bucket_path))
                 exit(14)
         except botocore.exceptions.ClientError as error:

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2624,7 +2624,7 @@ class AWSServerAccess(AWSCustomBucket):
         """Check if the bucket is empty or the credentials are wrong."""
         try:
             bucket_objects = self.client.list_objects_v2(Bucket=self.bucket, Delimiter='/')
-            if not 'CommonPrefixes' in bucket_objects and not 'Contents' in bucket_objects:
+            if not 'CommonPrefixes' in bucket_objects and not bucket_objects['Contents']:
                 print("ERROR: No files were found in '{0}'. No logs will be processed.".format(self.bucket_path))
                 exit(14)
         except botocore.exceptions.ClientError as error:


### PR DESCRIPTION
|Related issue|
|---|
|Closes #15016 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
AWSServerAccess integration was not processing logs found in the root folder of the bucket unless it had folders inside of it.
Bug and Fix is described here:

- https://github.com/wazuh/wazuh/issues/15016 

Fix consist in evaluating existence of "Contents" list after getting Bucket Objects.
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->
Until now, when trying to get server access S3 bucket objects without a folder existing in the root folder, this error would appear:

```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -s 2021-NOV-12 -p dev -d2
DEBUG: +++ Debug mode on - Level: 2
ERROR: No files were found in 'wazuh-aws-wodle-access/'. No logs will be processed.
```

Now logs are found when there are no folders in root of Bucket as seen on image,

```
root@wazuh-master:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access-test -t server_access -s 2021-APR-29 -p dev -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: 2021-04-29
DEBUG: ++ Found new log: 2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Found new log: 2021-04-29-09-14-05-B61AAAC9147C7F9F
DEBUG: ++ Skipping previously processed file: 2021-04-29-09-14-48-5273CCCAE2158DCE
DEBUG: +++ DB Maintenance
```

S3 Bucket Image:

![Screenshot from 2023-01-27 16-36-30](https://user-images.githubusercontent.com/60372646/215181695-29bfce93-b2b7-45a6-8d10-69ced4844d31.png)
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->
```
=============================================== test session starts ===============================================
platform linux -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /home/halothus/git/wazuh/wodles/aws
collected 39 items                                                                                                

tests/test_aws.py .......................................                                                   [100%]

=============================================== 39 passed in 0.16s ================================================
```