### PR TITLE
Restore `DELETE /groups` response format

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -670,6 +670,7 @@ def delete_groups(group_list=None):
                 raise WazuhError(1712)
             with WazuhDBQueryMultigroups(group_id=group_id, limit=None) as db_query:
                 agent_list = [agent['id'] for agent in db_query.run()['items']]
+                agent_list.sort(key=int)
 
             try:
                 affected_agents_result = remove_agents_from_group(call_func=False, agent_list=agent_list,
@@ -679,8 +680,7 @@ def delete_groups(group_list=None):
             except WazuhError:
                 raise WazuhError(4015)
             Agent.delete_single_group(group_id)
-            affected_agents_result.affected_items.sort(key=int)
-            result.affected_items.append({group_id: affected_agents_result.affected_items})
+            result.affected_items.append({group_id: agent_list})
         except WazuhException as e:
             result.add_failed_item(id_=group_id, error=e)
 


### PR DESCRIPTION
|Related issue|
|---|
| #16103 |

## Description

Until now, when a group was deleted, a list showing which agents were affected was included:
```JSON
{
  "data": {
    "affected_items": [
      {
        "new_group": [
          "001"
        ]
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected groups were deleted",
  "error": 0
}
``` 

However, after the changes performed in https://github.com/wazuh/wazuh/pull/16118, the list is always empty since the function to unassign agents is not called. This PR fixes it so the affected agents list is shown again.

## Tests
### Unit
``` 
python3 -m pytest framework/wazuh/tests/ -x --disable-warnings

============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1, aiohttp-1.0.4, cov-4.0.0
asyncio: mode=auto
collected 628 items                                                                                                                                                                                         

framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [  1%]
framework/wazuh/tests/test_agent.py ......................................................................................................................                                            [ 20%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 29%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 34%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 35%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 41%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 42%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 43%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 49%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 50%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 58%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                           [ 67%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                         [ 69%]
framework/wazuh/tests/test_security.py .........................................................................                                                                                      [ 80%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                   [ 83%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                     [ 87%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 89%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 93%]
framework/wazuh/tests/test_vulnerability.py ........................................                                                                                                                  [100%]

================================================================================ 628 passed, 10 warnings in 86.20s (0:01:26) ================================================================================
``` 
``` 
python3 -m pytest framework/wazuh/core/tests/ -x --disable-warnings
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1, aiohttp-1.0.4, cov-4.0.0
asyncio: mode=auto
collected 812 items                                                                                                                                                                                         

framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [  1%]
framework/wazuh/core/tests/test_agent.py ................................................................................................................................................             [ 19%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 24%]
framework/wazuh/core/tests/test_common.py .......                                                                                                                                                     [ 25%]
framework/wazuh/core/tests/test_configuration.py ......................................................................                                                                               [ 33%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 35%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 37%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 37%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 37%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 38%]
framework/wazuh/core/tests/test_manager.py ...............                                                                                                                                            [ 40%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 41%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 42%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 47%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 48%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 51%]
framework/wazuh/core/tests/test_sca.py ........................                                                                                                                                       [ 54%]
framework/wazuh/core/tests/test_security.py ............                                                                                                                                              [ 55%]
framework/wazuh/core/tests/test_stats.py .................                                                                                                                                            [ 58%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 58%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 59%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 60%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 79%]
.....................................................................................                                                                                                                 [ 89%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 90%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 92%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 95%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                                                [ 98%]
framework/wazuh/core/tests/test_wlogging.py .........                                                                                                                                                 [100%]

===================================================================================== 812 passed, 10 warnings in 20.61s =====================================================================================

``` 

### AIT
``` 
$ pytest -vv test_agent_DELETE_endpoints.tavern.yaml
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.6, pytest-7.2.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.15.0-58-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.2.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '2.0.2', 'metadata': '2.0.4'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, tavern-2.0.2, metadata-2.0.4
collected 6 items                                                                                                                                                                                           

test_agent_DELETE_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                                            [ 16%]
test_agent_DELETE_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                                       [ 33%]
test_agent_DELETE_endpoints.tavern.yaml::DELETE /agents/group PASSED                                                                                                                                  [ 50%]
test_agent_DELETE_endpoints.tavern.yaml::DELETE /groups (only one group) PASSED                                                                                                                       [ 66%]
test_agent_DELETE_endpoints.tavern.yaml::DELETE /groups (several groups) PASSED                                                                                                                       [ 83%]
test_agent_DELETE_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                                        [100%]

============================================================================================= warnings summary ==============================================================================================
``` 
``` 
$ pytest -vv test_rbac_white_agent_endpoints.tavern.yaml
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.6, pytest-7.2.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.15.0-58-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.2.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '2.0.2', 'metadata': '2.0.4'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, tavern-2.0.2, metadata-2.0.4
collected 42 items                                                                                                                                                                                          

test_rbac_white_agent_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                       [  2%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents?agents_list=agent_id PASSED                                                                                                                  [  4%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                         [  7%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                              [  9%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                        [ 11%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                                                                                              [ 14%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                                                                          [ 16%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                       [ 19%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                     [ 21%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                              [ 23%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                      [ 26%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                                      [ 28%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                                       [ 30%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                       [ 33%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                              [ 35%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                              [ 38%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                        [ 40%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                        [ 42%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                            [ 45%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                                        [ 47%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                                   [ 50%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/group?group_id={group_id} PASSED                                                                                                          [ 52%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /groups?groups_list={group_id} PASSED                                                                                                             [ 54%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                                    [ 57%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents?agents_list=agent_id&status=all PASSED                                                                                                    [ 59%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                                    [ 61%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                                      [ 64%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                               [ 66%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                                         [ 69%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                                      [ 71%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/group PASSED                                                                                                                                 [ 73%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                                              [ 76%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                                              [ 78%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/reconnect PASSED                                                                                                                             [ 80%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                               [ 83%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                                           [ 85%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                                    [ 88%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                               [ 90%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                                                                                                        [ 92%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                                        [ 95%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents (deny cluster:read) PASSED                                                                                                                   [ 97%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                                                [100%]

============================================================================================= warnings summary ==============================================================================================
``` 
``` 
$ pytest -vv test_rbac_black_agent_endpoints.tavern.yaml
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.6, pytest-7.2.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.15.0-58-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.2.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '2.0.2', 'metadata': '2.0.4'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, tavern-2.0.2, metadata-2.0.4
collected 42 items                                                                                                                                                                                          

test_rbac_black_agent_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                       [  2%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?agents_list=agent_id PASSED                                                                                                                  [  4%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                         [  7%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                              [  9%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                        [ 11%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                                                                                              [ 14%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                                                                          [ 16%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                       [ 19%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                     [ 21%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                              [ 23%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                      [ 26%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                                      [ 28%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                                       [ 30%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                       [ 33%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                              [ 35%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                              [ 38%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                        [ 40%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                        [ 42%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                            [ 45%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                                        [ 47%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                                        [ 50%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                                   [ 52%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/group?group_id=group_id PASSED                                                                                                            [ 54%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE groups?groups_list=group_id PASSED                                                                                                                [ 57%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                                    [ 59%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents?agents_list=agent_id PASSED                                                                                                               [ 61%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                                    [ 64%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                                      [ 66%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                               [ 69%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                                         [ 71%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                                      [ 73%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group?group_id={group_id} PASSED                                                                                                             [ 76%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                                              [ 78%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                                              [ 80%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/reconnect PASSED                                                                                                                             [ 83%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                               [ 85%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                                           [ 88%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                                    [ 90%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                               [ 92%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                                                                                                        [ 95%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents (allow cluster:read) PASSED                                                                                                                  [ 97%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                                                [100%]

============================================================================================= warnings summary ==============================================================================================

``` 