### PR TITLE
Create buffer in whodata syscheck to store audit logs

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -113,7 +113,7 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->registry_nodiff_regex           = NULL;
     syscheck->enable_registry_synchronization = 1;
 #else
-    syscheck->whodata_queue_size              = 16384;
+    syscheck->queue_size                      = 16384;
 #endif
     syscheck->prefilter_cmd                   = NULL;
     syscheck->sync_interval                   = 300;
@@ -1660,7 +1660,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_64bit = "64bit";
     const char *xml_both = "both";
 #else
-    const char *xml_whodata_queue_size = "whodata_queue_size";
+    const char *xml_queue_size = "queue_size";
 #endif
     const char *xml_whodata_options = "whodata";
     const char *xml_audit_key = "audit_key";
@@ -2115,7 +2115,8 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         OS_ClearNode(children);
                         return(OS_INVALID);
                     }
-                } else if (strcmp(children[j]->element, xml_whodata_queue_size) == 0) {
+#ifndef WIN32
+                } else if (strcmp(children[j]->element, xml_queue_size) == 0) {
                     char * end;
                     long value = strtol(children[j]->content, &end, 10);
 
@@ -2125,8 +2126,9 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         return(OS_INVALID);
                     }
                     else {
-                        syscheck->whodata_queue_size = value;
+                        syscheck->queue_size = value;
                     }
+#endif
                 } else {
                     mwarn(XML_ELEMNULL);
                     OS_ClearNode(children);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -2120,7 +2120,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                     char * end;
                     long value = strtol(children[j]->content, &end, 10);
 
-                    if (*end || value < 1 || value > 1024 * 1024) {
+                    if (*end || value < 10 || value > 1024 * 1024) {
                         merror(XML_VALUEERR, children[j]->element, children[j]->content);
                         OS_ClearNode(children);
                         return(OS_INVALID);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -112,6 +112,8 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->registry_nodiff                 = NULL;
     syscheck->registry_nodiff_regex           = NULL;
     syscheck->enable_registry_synchronization = 1;
+#else
+    syscheck->whodata_queue_size              = 16384;
 #endif
     syscheck->prefilter_cmd                   = NULL;
     syscheck->sync_interval                   = 300;
@@ -1657,6 +1659,8 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_32bit = "32bit";
     const char *xml_64bit = "64bit";
     const char *xml_both = "both";
+#else
+    const char *xml_whodata_queue_size = "whodata_queue_size";
 #endif
     const char *xml_whodata_options = "whodata";
     const char *xml_audit_key = "audit_key";
@@ -2110,6 +2114,18 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         mwarn(XML_VALUEERR,children[j]->element,children[j]->content);
                         OS_ClearNode(children);
                         return(OS_INVALID);
+                    }
+                } else if (strcmp(children[j]->element, xml_whodata_queue_size) == 0) {
+                    char * end;
+                    long value = strtol(children[j]->content, &end, 10);
+
+                    if (*end || value < 1 || value > 1024 * 1024) {
+                        merror(XML_VALUEERR, children[j]->element, children[j]->content);
+                        OS_ClearNode(children);
+                        return(OS_INVALID);
+                    }
+                    else {
+                        syscheck->whodata_queue_size = value;
                     }
                 } else {
                     mwarn(XML_ELEMNULL);

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -435,7 +435,7 @@ typedef struct _config {
     pthread_mutex_t fim_realtime_mutex;
 #ifndef WIN32
     pthread_mutex_t fim_symlink_mutex;
-    unsigned int whodata_queue_size;                   /* Linux Audit message queue size for whodata */
+    unsigned int queue_size;                           /* Linux Audit message queue size for whodata */
 #endif
     rtfim *realtime;
     fdb_t *database;

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -435,6 +435,7 @@ typedef struct _config {
     pthread_mutex_t fim_realtime_mutex;
 #ifndef WIN32
     pthread_mutex_t fim_symlink_mutex;
+    unsigned int whodata_queue_size;                   /* Linux Audit message queue size for whodata */
 #endif
     rtfim *realtime;
     fdb_t *database;

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -64,6 +64,7 @@
 #define FIM_DISK_QUOTA_LIMIT_DISABLED       "(6043): Disk quota limit disabled."
 #define FIM_NO_DIFF_REGISTRY                "(6044): Option nodiff enabled for %s '%s'."
 #define FIM_AUDIT_CREATED_RULE_FILE         "(6045): Created audit rules file, due to audit immutable mode rules will be loaded in the next reboot."
+#define FIM_AUDIT_QUEUE_SIZE                "(6046): Internal audit queue size set to '%d'"
 
 /* wazuh-logtest information messages */
 #define LOGTEST_INITIALIZED                 "(7200): Logtest started"

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -64,7 +64,7 @@
 #define FIM_DISK_QUOTA_LIMIT_DISABLED       "(6043): Disk quota limit disabled."
 #define FIM_NO_DIFF_REGISTRY                "(6044): Option nodiff enabled for %s '%s'."
 #define FIM_AUDIT_CREATED_RULE_FILE         "(6045): Created audit rules file, due to audit immutable mode rules will be loaded in the next reboot."
-#define FIM_AUDIT_QUEUE_SIZE                "(6046): Internal audit queue size set to '%d'"
+#define FIM_AUDIT_QUEUE_SIZE                "(6046): Internal audit queue size set to '%d'."
 
 /* wazuh-logtest information messages */
 #define LOGTEST_INITIALIZED                 "(7200): Logtest started"

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -71,7 +71,7 @@
 #define FIM_WHODATA_POLICY_CHANGE_CHECKER       "(6952): Audit policy change detected. Switching directories to realtime."
 #define FIM_WHODATA_POLICY_CHANGE_CHANNEL       "(6953): Event 4719 received due to changes in audit policy. Switching directories to realtime."
 #define FIM_EMPTY_CHANGED_ATTRIBUTES            "(6954): Entry '%s' does not have any modified fields. No event will be generated."
-#define FIM_FULL_AUDIT_QUEUE                    "(6955): Internal audit queue is full. Some events may be lost."
+#define FIM_FULL_AUDIT_QUEUE                    "(6955): Internal audit queue is full. Some events may be lost. Next scheduled scan will recover lost data."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -71,6 +71,7 @@
 #define FIM_WHODATA_POLICY_CHANGE_CHECKER       "(6952): Audit policy change detected. Switching directories to realtime."
 #define FIM_WHODATA_POLICY_CHANGE_CHANNEL       "(6953): Event 4719 received due to changes in audit policy. Switching directories to realtime."
 #define FIM_EMPTY_CHANGED_ATTRIBUTES            "(6954): Entry '%s' does not have any modified fields. No event will be generated."
+#define FIM_FULL_AUDIT_QUEUE                    "(6955): Internal audit queue is full. Some events may be lost."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -491,6 +491,11 @@ void remove_audit_rule_syscheck(const char *path);
 void audit_read_events(int *audit_sock, atomic_int_t *running);
 
 /**
+ * @brief Thread in charge of pulling messages from the audit queue and parse them to generate events.
+ */
+void *audit_parse_thread();
+
+/**
  * @brief Makes Audit thread to wait for audit healthcheck to be performed
  *
  */

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -41,6 +41,7 @@
 /* Global config */
 extern syscheck_config syscheck;
 extern int sys_debug_level;
+extern int audit_queue_full_reported;
 
 typedef enum fim_event_type {
     FIM_ADD,

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -292,7 +292,7 @@ cJSON *getSyscheckConfig(void) {
     } else {
         cJSON_AddStringToObject(whodata,"startup_healthcheck","no");
     }
-    cJSON_AddNumberToObject(whodata, "whodata_queue_size", syscheck.whodata_queue_size);
+    cJSON_AddNumberToObject(whodata, "queue_size", syscheck.queue_size);
 
     cJSON_AddItemToObject(syscfg,"whodata",whodata);
 #endif

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -292,6 +292,8 @@ cJSON *getSyscheckConfig(void) {
     } else {
         cJSON_AddStringToObject(whodata,"startup_healthcheck","no");
     }
+    cJSON_AddNumberToObject(whodata, "whodata_queue_size", syscheck.whodata_queue_size);
+
     cJSON_AddItemToObject(syscfg,"whodata",whodata);
 #endif
 

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -312,7 +312,6 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
     cJSON* changed_attributes = NULL;
     cJSON* old_data = NULL;
     cJSON *attributes = NULL;
-    cJSON *aux = NULL;
     cJSON* timestamp = NULL;
     directory_t *configuration = NULL;
     fim_txn_context_t *txn_context = (fim_txn_context_t *) user_data;

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -616,6 +616,8 @@ time_t fim_scan() {
     if (isDebug()) {
         fim_print_info(start, end, cputime_start); // LCOV_EXCL_LINE
     }
+    audit_queue_full_reported = 0;
+
     return end_of_scan;
 }
 

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -19,8 +19,8 @@
 #include "db/include/fimCommonDefs.h"
 // Global variables
 syscheck_config syscheck;
-
 int sys_debug_level;
+int audit_queue_full_reported = 0;
 
 #ifdef USE_MAGIC
 #include <magic.h>

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -364,7 +364,7 @@ int audit_init(void) {
     }
 
     // Initialize audit queue
-    audit_queue = queue_init(1024 * 1024);
+    audit_queue = queue_init(syscheck.whodata_queue_size);
     w_create_thread(audit_parse_thread, NULL);
 
     // Perform Audit healthcheck

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -565,7 +565,10 @@ void audit_read_events(int *audit_sock, atomic_int_t *running) {
                 // Flush cache
                 os_strdup(cache, cache_dup);
                 if (queue_push_ex(audit_queue, cache_dup)) {
-                    mwarn(FIM_FULL_AUDIT_QUEUE);
+                    if (!audit_queue_full_reported) {
+                        mwarn(FIM_FULL_AUDIT_QUEUE);
+                        audit_queue_full_reported = 1;
+                    }
                     os_free(cache_dup);
                 }
                 cache_i = 0;
@@ -632,7 +635,10 @@ void audit_read_events(int *audit_sock, atomic_int_t *running) {
                     if (!event_too_long_id) {
                         os_strdup(cache, cache_dup);
                         if (queue_push_ex(audit_queue, cache_dup)) {
-                            mwarn(FIM_FULL_AUDIT_QUEUE);
+                            if (!audit_queue_full_reported) {
+                                mwarn(FIM_FULL_AUDIT_QUEUE);
+                                audit_queue_full_reported = 1;
+                            }
                             os_free(cache_dup);
                         }
                     }
@@ -665,7 +671,10 @@ void audit_read_events(int *audit_sock, atomic_int_t *running) {
         if (eoe_found && !event_too_long_id){
             os_strdup(cache, cache_dup);
             if (queue_push_ex(audit_queue, cache_dup)) {
-                mwarn(FIM_FULL_AUDIT_QUEUE);
+                if (!audit_queue_full_reported) {
+                    mwarn(FIM_FULL_AUDIT_QUEUE);
+                    audit_queue_full_reported = 1;
+                }
                 os_free(cache_dup);
             }
             cache_i = 0;

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -42,6 +42,7 @@ w_queue_t * audit_queue;
 //This variable controls if the the modification of the rule is made by syscheck.
 
 volatile int audit_db_consistency_flag = 0;
+volatile int audit_parse_thread_active = 0;
 atomic_int_t audit_thread_active = ATOMIC_INT_INITIALIZER(0);
 
 #ifdef ENABLE_AUDIT
@@ -365,6 +366,7 @@ int audit_init(void) {
 
     // Initialize audit queue
     audit_queue = queue_init(syscheck.whodata_queue_size);
+    audit_parse_thread_active = 1;
     w_create_thread(audit_parse_thread, NULL);
 
     // Print audit queue size
@@ -503,7 +505,7 @@ void *audit_main(audit_data_t *audit_data) {
 
     w_rwlock_unlock(&syscheck.directories_lock);
 
-
+    audit_parse_thread_active = 0;
 
     // Clean Audit added rules.
     if (audit_data->mode == AUDIT_ENABLED) {
@@ -517,11 +519,12 @@ void *audit_main(audit_data_t *audit_data) {
 void *audit_parse_thread() {
     char * audit_logs;
 
-    while (1) {
+    while (audit_parse_thread_active) {
         audit_logs = queue_pop_ex(audit_queue);
         audit_parse(audit_logs);
         os_free(audit_logs);
     }
+    queue_free(audit_queue);
 
     return NULL;
 }

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -363,12 +363,12 @@ int audit_init(void) {
     }
 
     // Initialize audit queue
-    audit_queue = queue_init(syscheck.whodata_queue_size);
+    audit_queue = queue_init(syscheck.queue_size);
     atomic_int_set(&audit_parse_thread_active, 1);
     w_create_thread(audit_parse_thread, NULL);
 
     // Print audit queue size
-    minfo(FIM_AUDIT_QUEUE_SIZE, syscheck.whodata_queue_size);
+    minfo(FIM_AUDIT_QUEUE_SIZE, syscheck.queue_size);
 
     // Perform Audit healthcheck
     if (syscheck.audit_healthcheck) {

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -1033,7 +1033,6 @@ void test_audit_read_events_select_success_recv_success(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     expect_string(__wrap__mwarn, formatted_msg, FIM_FULL_AUDIT_QUEUE);
-    expect_string(__wrap__mwarn, formatted_msg, FIM_FULL_AUDIT_QUEUE);
 
     expect_value(__wrap_atomic_int_get, atomic, &audit_thread_active);
     will_return(__wrap_atomic_int_get, 0);

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -1158,8 +1158,6 @@ void test_audit_parse_thread(void **state) {
 
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    //expect_value(__wrap_pthread_cond_wait, cond, &audit_queue->available);
-    //expect_value(__wrap_pthread_cond_wait, mutex, &audit_queue->mutex);
 
     expect_function_call(__wrap_audit_parse);
 


### PR DESCRIPTION
|Related issue| Documentation issue|
|---|---|
|https://github.com/wazuh/wazuh/issues/13920|https://github.com/wazuh/wazuh-documentation/issues/5941|


## Description

Hi team, in this PR we are going to implement a queue in the syscheck module, to store the logs that we receive from the audit dispatcher.
In this way, we avoid blocking the same thread that receives those logs while we process them, as this is generating problems in the system when there is a large number of events.

I have created a separate thread that pulls logs from that queue and processes them.


## Configuration options

```
<whodata>
    <queue_size>100000</queue_size>
</whodata>
```

## Logs/Alerts example
- Info message setting the audit queue size:
`2023/02/23 11:39:52 wazuh-syscheckd: INFO: (6046): Internal audit queue size set to '16384'`
- Warning when audit queue is full:
`2023/02/23 11:41:26 wazuh-syscheckd: WARNING: (6955): Internal audit queue is full. Some events may be lost. Next scheduled scan will recover lost data.`
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Configuration on demand reports new parameters
- [x] Added unit tests (for new features)
