### PR TITLE
Fixes to wazuh-db sync-agent-groups-get endpoint

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -90,7 +90,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,-
                             -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,w_get_timestamp -Wl,--wrap,wdb_exec_stmt_silent -Wl,--wrap,w_compress_gzfile \
                             -Wl,--wrap,sqlite3_finalize -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,opendir -Wl,--wrap,closedir -Wl,--wrap,readdir \
                             -Wl,--wrap,stat -Wl,--wrap,w_uncompress_gzfile -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_close -Wl,--wrap,rename -Wl,--wrap,time \
-                            -Wl,--wrap,wdb_exec_stmt_single_column ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
+                            -Wl,--wrap,wdb_exec_stmt_single_column -Wl,--wrap,w_is_single_node ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_agents")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step \

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -15,6 +15,7 @@
 #include "../wrappers/wazuh/shared/time_op_wrappers.h"
 #include "../wrappers/posix/unistd_wrappers.h"
 #include "../wrappers/posix/time_wrappers.h"
+#include "../wrappers/wazuh/shared/cluster_op_wrappers.h"
 #include "wazuhdb_op.h"
 
 #define GROUPS_SIZE 10
@@ -5562,6 +5563,9 @@ void test_wdb_global_delete_group_recalculate_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
+    will_return(__wrap_w_is_single_node, 1);
+    will_return(__wrap_w_is_single_node, 1);
+
     /* wdb_global_get_agent_max_group_priority */
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_PRIORITY_GET);
     will_return(__wrap_wdb_init_stmt_in_cache, NULL);
@@ -5618,6 +5622,9 @@ void test_wdb_global_delete_group_success(void **state)
     expect_string(__wrap_sqlite3_bind_text, buffer, group_name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
+
+    will_return(__wrap_w_is_single_node, 0);
+    will_return(__wrap_w_is_single_node, 0);
 
     /* wdb_global_get_agent_max_group_priority */
     create_wdb_global_get_agent_max_group_priority_success_call(agent_id, j_priority_resp);

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -1136,7 +1136,6 @@ void test_wdb_global_sync_agent_groups_get_no_condition_get_hash_true(void **sta
     bool get_hash = true;
     cJSON *j_output = NULL;
 
-    will_return(__wrap_wdb_begin2, OS_SUCCESS);
     will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
     will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
 
@@ -1161,13 +1160,18 @@ void test_wdb_global_sync_agent_groups_get_transaction_fail(void **state)
     bool set_synced = true;
     bool get_hash = true;
     int agent_registration_delta = 10;
+    cJSON *j_output = NULL;
+
+    will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
+    will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
 
     will_return(__wrap_wdb_begin2, OS_INVALID);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_sync_agent_groups_get(data->wdb, condition, last_agent_id, set_synced, get_hash, agent_registration_delta, NULL);
+    result = wdb_global_sync_agent_groups_get(data->wdb, condition, last_agent_id, set_synced, get_hash, agent_registration_delta, &j_output);
 
     assert_int_equal(result, WDBC_ERROR);
+    __real_cJSON_Delete(j_output);
 }
 
 void test_wdb_global_sync_agent_groups_get_cache_fail(void **state)

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -99,7 +99,6 @@ int main(int argc, char ** argv)
     wconfig.free_pages_percentage = getDefine_Int("wazuh_db", "free_pages_percentage", 0, 99);
     wconfig.max_fragmentation = getDefine_Int("wazuh_db", "max_fragmentation", 0, 100);
     wconfig.check_fragmentation_interval = getDefine_Int("wazuh_db", "check_fragmentation_interval", 1, 30758400);
-    wconfig.is_worker = w_is_worker();
 
     // Allocating memory for configuration structures and setting default values
     wdb_init_conf();

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -99,6 +99,7 @@ int main(int argc, char ** argv)
     wconfig.free_pages_percentage = getDefine_Int("wazuh_db", "free_pages_percentage", 0, 99);
     wconfig.max_fragmentation = getDefine_Int("wazuh_db", "max_fragmentation", 0, 100);
     wconfig.check_fragmentation_interval = getDefine_Int("wazuh_db", "check_fragmentation_interval", 1, 30758400);
+    wconfig.is_worker = w_is_worker();
 
     // Allocating memory for configuration structures and setting default values
     wdb_init_conf();

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -70,7 +70,7 @@
 typedef enum wdb_groups_sync_condition_t {
         WDB_GROUP_SYNC_STATUS,      ///< Get groups by their sync status
         WDB_GROUP_ALL,              ///< Get all groups
-        WDB_GROUP_INVALID_CONDITION ///< Invalid condition
+        WDB_GROUP_NO_CONDITION      ///< No condition
 } wdb_groups_sync_condition_t;
 
 /// Enumeration of agent groups set mode
@@ -372,6 +372,7 @@ typedef struct wdb_config {
     int free_pages_percentage;
     int max_fragmentation;
     int check_fragmentation_interval;
+    int is_worker;
     wdb_backup_settings_node** wdb_backup_settings;
 } wdb_config;
 
@@ -2019,6 +2020,16 @@ wdbc_result wdb_global_sync_agent_groups_get(wdb_t* wdb,
                                              bool get_hash,
                                              int agent_registration_delta,
                                              cJSON** output);
+
+/**
+ * @brief Add global group hash to JSON response.
+ *
+ * @param wdb The Global struct database.
+ * @param response JSON response to fill with global group hash.
+ * @param response_size Current size of JSON response.
+ * @return int result to represent if global hash has being added to JSON response.
+ */
+int wdb_global_add_global_group_hash_to_resposne(wdb_t *wdb, cJSON** response, size_t response_size);
 
 /**
  * @brief Function to update group_sync_status of a particular agent.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -373,7 +373,6 @@ typedef struct wdb_config {
     int free_pages_percentage;
     int max_fragmentation;
     int check_fragmentation_interval;
-    int is_worker;
     wdb_backup_settings_node** wdb_backup_settings;
 } wdb_config;
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -70,7 +70,8 @@
 typedef enum wdb_groups_sync_condition_t {
         WDB_GROUP_SYNC_STATUS,      ///< Get groups by their sync status
         WDB_GROUP_ALL,              ///< Get all groups
-        WDB_GROUP_NO_CONDITION      ///< No condition
+        WDB_GROUP_NO_CONDITION,     ///< No condition
+        WDB_GROUP_INVALID_CONDITION ///< Invalid condition
 } wdb_groups_sync_condition_t;
 
 /// Enumeration of agent groups set mode
@@ -2029,7 +2030,7 @@ wdbc_result wdb_global_sync_agent_groups_get(wdb_t* wdb,
  * @param response_size Current size of JSON response.
  * @return int result to represent if global hash has being added to JSON response.
  */
-int wdb_global_add_global_group_hash_to_resposne(wdb_t *wdb, cJSON** response, size_t response_size);
+int wdb_global_add_global_group_hash_to_response(wdb_t *wdb, cJSON** response, size_t response_size);
 
 /**
  * @brief Function to update group_sync_status of a particular agent.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1584,11 +1584,6 @@ int wdb_global_add_global_group_hash_to_resposne(wdb_t *wdb, cJSON** response, s
         return WDBC_ERROR;
     }
 
-    if (response_size == NULL || response_size < 0) {
-        mdebug1("Invalid response_size.");
-        return WDBC_ERROR;
-    }
-
     size_t hash_len = strlen("hash:\"\"")+sizeof(os_sha1);
     if (response_size+hash_len+1 < WDB_MAX_RESPONSE_SIZE) {
         os_sha1 hash = {0};

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -868,7 +868,7 @@ int wdb_global_delete_group(wdb_t *wdb, char* group_name) {
             cJSON* agent_id = cJSON_GetObjectItem(agent_id_item, "id_agent");
             if (cJSON_IsNumber(agent_id)) {
                 if (WDBC_ERROR == wdb_global_if_empty_set_default_agent_group(wdb, agent_id->valueint) ||
-                    WDBC_ERROR == wdb_global_recalculate_agent_groups_hash(wdb, agent_id->valueint, "syncreq")) {
+                    WDBC_ERROR == wdb_global_recalculate_agent_groups_hash(wdb, agent_id->valueint, wconfig.is_worker?"synced":"syncreq")) {
                     merror("Couldn't recalculate hash group for agent: '%03d'", agent_id->valueint);
                 }
             }
@@ -1473,8 +1473,7 @@ wdbc_result wdb_global_sync_agent_groups_get(wdb_t *wdb, wdb_groups_sync_conditi
             sync_statement_index = WDB_STMT_GLOBAL_GROUP_SYNC_ALL_GET;
             break;
         default:
-            mdebug1("Invalid groups sync condition");
-            return WDBC_ERROR;
+            break;
     }
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
@@ -1493,98 +1492,119 @@ wdbc_result wdb_global_sync_agent_groups_get(wdb_t *wdb, wdb_groups_sync_conditi
     // Agents registered recently may be excluded depending on the 'agent_registration_delta' value.
     time_t agent_registration_time = time(NULL) - agent_registration_delta;
 
-    while (status == WDBC_UNKNOWN) {
-        //Prepare SQL query
-        if (wdb_stmt_cache(wdb, sync_statement_index) < 0) {
-            mdebug1("Cannot cache statement");
-            status = WDBC_ERROR;
-            break;
-        }
-        sqlite3_stmt* sync_stmt = wdb->stmt[sync_statement_index];
-        if (sqlite3_bind_int(sync_stmt, 1, last_agent_id) != SQLITE_OK) {
-            merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-            status = WDBC_ERROR;
-            break;
-        }
-        if (sqlite3_bind_int(sync_stmt, 2, agent_registration_time) != SQLITE_OK) {
-            merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-            status = WDBC_ERROR;
-            break;
-        }
-
-        //Get agents to sync
-        cJSON* j_agent_stmt = wdb_exec_stmt(sync_stmt);
-        if (j_agent_stmt && j_agent_stmt->child) {
-            cJSON* j_agent = j_agent_stmt->child;
-            cJSON* j_id = cJSON_GetObjectItem(j_agent, "id");
-            if (cJSON_IsNumber(j_id)) {
-                //Get agent ID
-                last_agent_id = j_id->valueint;
-
-                //Get the groups of the agent
-                cJSON* j_groups = wdb_global_select_group_belong(wdb, last_agent_id);
-                if (j_groups && j_groups->child) {
-                    cJSON_AddItemToObject(j_agent, "groups", j_groups);
-                } else {
-                    cJSON_Delete(j_groups);
-                    cJSON_AddItemToObject(j_agent, "groups", cJSON_CreateArray());
-                }
-
-                //Print Agent groups
-                char *agent_str = cJSON_PrintUnformatted(j_agent);
-                unsigned agent_len = strlen(agent_str);
-
-                //Check if new agent fits in response
-                if (response_size+agent_len+1 < WDB_MAX_RESPONSE_SIZE) {
-                    //Add new agent
-                    cJSON_AddItemToArray(j_data, cJSON_Duplicate(j_agent, true));
-                    //Save size
-                    response_size += agent_len+1;
-                } else {
-                    //Pending agents but buffer is full
-                    status = WDBC_DUE;
-                }
-                os_free(agent_str);
-
-                if (set_synced) {
-                    //Set groups sync status as synced
-                    if (OS_SUCCESS != wdb_global_set_agent_groups_sync_status(wdb, last_agent_id, "synced")) {
-                        merror("Cannot set group_sync_status for agent %d", last_agent_id);
-                        status = WDBC_ERROR;
-                    }
-                }
-            } else {
-                //Continue with the next agent
-                last_agent_id++;
+    if (condition != WDB_GROUP_NO_CONDITION) {
+        while (status == WDBC_UNKNOWN) {
+            //Prepare SQL query
+            if (wdb_stmt_cache(wdb, sync_statement_index) < 0) {
+                mdebug1("Cannot cache statement");
+                status = WDBC_ERROR;
+                break;
             }
-        } else {
-            //All agents have been obtained
-            if (get_hash) {
-                size_t hash_len = strlen("hash:\"\"")+sizeof(os_sha1);
-                if (response_size+hash_len+1 < WDB_MAX_RESPONSE_SIZE) {
-                    os_sha1 hash = {0};
-                    if (OS_SUCCESS == wdb_get_global_group_hash(wdb, hash)) {
-                        if (hash[0] == 0) {
-                            cJSON_AddItemToObject(j_response, "hash", cJSON_CreateNull());
-                        } else {
-                            cJSON_AddStringToObject(j_response, "hash", hash);
-                        }
-                        status = WDBC_OK;
+            sqlite3_stmt* sync_stmt = wdb->stmt[sync_statement_index];
+            if (sqlite3_bind_int(sync_stmt, 1, last_agent_id) != SQLITE_OK) {
+                merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+                status = WDBC_ERROR;
+                break;
+            }
+            if (sqlite3_bind_int(sync_stmt, 2, agent_registration_time) != SQLITE_OK) {
+                merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+                status = WDBC_ERROR;
+                break;
+            }
+
+            //Get agents to sync
+            cJSON* j_agent_stmt = wdb_exec_stmt(sync_stmt);
+            if (j_agent_stmt && j_agent_stmt->child) {
+                cJSON* j_agent = j_agent_stmt->child;
+                cJSON* j_id = cJSON_GetObjectItem(j_agent, "id");
+                if (cJSON_IsNumber(j_id)) {
+                    //Get agent ID
+                    last_agent_id = j_id->valueint;
+
+                    //Get the groups of the agent
+                    cJSON* j_groups = wdb_global_select_group_belong(wdb, last_agent_id);
+                    if (j_groups && j_groups->child) {
+                        cJSON_AddItemToObject(j_agent, "groups", j_groups);
                     } else {
-                        merror("Cannot obtain the global group hash");
-                        status = WDBC_ERROR;
+                        cJSON_Delete(j_groups);
+                        cJSON_AddItemToObject(j_agent, "groups", cJSON_CreateArray());
                     }
+
+                    //Print Agent groups
+                    char *agent_str = cJSON_PrintUnformatted(j_agent);
+                    unsigned agent_len = strlen(agent_str);
+
+                    //Check if new agent fits in response
+                    if (response_size+agent_len+1 < WDB_MAX_RESPONSE_SIZE) {
+                        //Add new agent
+                        cJSON_AddItemToArray(j_data, cJSON_Duplicate(j_agent, true));
+                        //Save size
+                        response_size += agent_len+1;
+
+                        if (set_synced) {
+                            //Set groups sync status as synced
+                            if (OS_SUCCESS != wdb_global_set_agent_groups_sync_status(wdb, last_agent_id, "synced")) {
+                                merror("Cannot set group_sync_status for agent %d", last_agent_id);
+                                status = WDBC_ERROR;
+                            }
+                        }
+                    } else {
+                        //Pending agents but buffer is full
+                        status = WDBC_DUE;
+                    }
+                    os_free(agent_str);
                 } else {
-                    status = WDBC_DUE;
+                    //Continue with the next agent
+                    last_agent_id++;
                 }
             } else {
-                status = WDBC_OK;
+                //All agents have been obtained
+                if (get_hash) {
+                    status = wdb_global_add_global_group_hash_to_resposne(wdb, &j_response, response_size);
+                } else {
+                    status = WDBC_OK;
+                }
             }
+            cJSON_Delete(j_agent_stmt);
         }
-        cJSON_Delete(j_agent_stmt);
+    } else {
+        if (get_hash) {
+            status = wdb_global_add_global_group_hash_to_resposne(wdb, &j_response, response_size);
+        } else {
+            status = WDBC_OK;
+        }
     }
 
     return status;
+}
+
+int wdb_global_add_global_group_hash_to_resposne(wdb_t *wdb, cJSON** response, size_t response_size) {
+    if (response == NULL || *response == NULL) {
+        mdebug1("Invalid JSON array.");
+        return WDBC_ERROR;
+    }
+
+    if (response_size == NULL || response_size < 0) {
+        mdebug1("Invalid response_size.");
+        return WDBC_ERROR;
+    }
+
+    size_t hash_len = strlen("hash:\"\"")+sizeof(os_sha1);
+    if (response_size+hash_len+1 < WDB_MAX_RESPONSE_SIZE) {
+        os_sha1 hash = {0};
+        if (OS_SUCCESS == wdb_get_global_group_hash(wdb, hash)) {
+            if (hash[0] == 0) {
+                cJSON_AddItemToObject(*response, "hash", cJSON_CreateNull());
+            } else {
+                cJSON_AddStringToObject(*response, "hash", hash);
+            }
+        } else {
+            merror("Cannot obtain the global group hash");
+            return WDBC_ERROR;
+        }
+        return WDBC_OK;
+    }
+    return WDBC_DUE;
 }
 
 int wdb_global_sync_agent_info_set(wdb_t *wdb, cJSON * json_agent) {

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1479,11 +1479,6 @@ wdbc_result wdb_global_sync_agent_groups_get(wdb_t *wdb, wdb_groups_sync_conditi
             break;
     }
 
-    if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("Cannot begin transaction");
-        return WDBC_ERROR;
-    }
-
     *output = cJSON_CreateArray();
     cJSON* j_response = cJSON_CreateObject();
     cJSON* j_data = cJSON_CreateArray();
@@ -1494,8 +1489,14 @@ wdbc_result wdb_global_sync_agent_groups_get(wdb_t *wdb, wdb_groups_sync_conditi
     os_free(out_aux);
 
     if (condition != WDB_GROUP_NO_CONDITION) {
+        if (!wdb->transaction && wdb_begin2(wdb) < 0) {
+            mdebug1("Cannot begin transaction");
+            return WDBC_ERROR;
+        }
+
         // Agents registered recently may be excluded depending on the 'agent_registration_delta' value.
         time_t agent_registration_time = time(NULL) - agent_registration_delta;
+
         while (status == WDBC_UNKNOWN) {
             //Prepare SQL query
             if (wdb_stmt_cache(wdb, sync_statement_index) < 0) {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5678,14 +5678,10 @@ int wdb_parse_global_sync_agent_groups_get(wdb_t* wdb, char* input, char* output
         cJSON *j_set_synced = cJSON_GetObjectItem(args, "set_synced");
         cJSON *j_get_hash = cJSON_GetObjectItem(args, "get_global_hash");
         cJSON *j_agent_registration_delta = cJSON_GetObjectItem(args, "agent_registration_delta");
-        // Checking the existence of mandatory parameters
-        if (!cJSON_IsString(j_sync_condition)) {
-            mdebug1("Missing mandatory 'condition' field in sync-agent-groups-get command.");
-            snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, missing required 'condition' field");
-            ret = OS_INVALID;
-        }
+
         // Checking data types of alternative parameters in case they would have been sent in the input JSON.
-        else if ((j_last_id && (!cJSON_IsNumber(j_last_id) || j_last_id->valueint < 0)) ||
+        if ((j_sync_condition && !cJSON_IsString(j_sync_condition)) ||
+            (j_last_id && (!cJSON_IsNumber(j_last_id) || j_last_id->valueint < 0)) ||
             (j_set_synced && !cJSON_IsBool(j_set_synced)) ||
             (j_get_hash && !cJSON_IsBool(j_get_hash)) ||
             (j_agent_registration_delta && (!cJSON_IsNumber(j_agent_registration_delta) || j_agent_registration_delta->valueint < 0))) {
@@ -5693,15 +5689,15 @@ int wdb_parse_global_sync_agent_groups_get(wdb_t* wdb, char* input, char* output
             snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, invalid alternative fields data");
             ret = OS_INVALID;
         } else {
-            wdb_groups_sync_condition_t condition = WDB_GROUP_INVALID_CONDITION;
+            wdb_groups_sync_condition_t condition = WDB_GROUP_NO_CONDITION;
             int last_id = 0;
             bool set_synced = false;
             bool get_hash = false;
             int agent_registration_delta = 0;
 
-            if (0 == strcmp(j_sync_condition->valuestring, "sync_status")) {
+            if (cJSON_IsString(j_sync_condition) && 0 == strcmp(j_sync_condition->valuestring, "sync_status")) {
                 condition = WDB_GROUP_SYNC_STATUS;
-            } else if (0 == strcmp(j_sync_condition->valuestring, "all")) {
+            } else if (cJSON_IsString(j_sync_condition) && 0 == strcmp(j_sync_condition->valuestring, "all")) {
                 condition = WDB_GROUP_ALL;
             }
             if (j_last_id) {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5695,10 +5695,12 @@ int wdb_parse_global_sync_agent_groups_get(wdb_t* wdb, char* input, char* output
             bool get_hash = false;
             int agent_registration_delta = 0;
 
-            if (cJSON_IsString(j_sync_condition) && 0 == strcmp(j_sync_condition->valuestring, "sync_status")) {
+            if (j_sync_condition && 0 == strcmp(j_sync_condition->valuestring, "sync_status")) {
                 condition = WDB_GROUP_SYNC_STATUS;
-            } else if (cJSON_IsString(j_sync_condition) && 0 == strcmp(j_sync_condition->valuestring, "all")) {
+            } else if (j_sync_condition && 0 == strcmp(j_sync_condition->valuestring, "all")) {
                 condition = WDB_GROUP_ALL;
+            } else if (j_sync_condition) {
+                condition = WDB_GROUP_INVALID_CONDITION;
             }
             if (j_last_id) {
                 last_id = j_last_id->valueint;


### PR DESCRIPTION
|Related issues|Manual testing|Integration tests|
|---|---|---|
|https://github.com/wazuh/wazuh/issues/16188|https://github.com/wazuh/wazuh-qa/issues/3951|https://github.com/wazuh/wazuh-qa/pull/3959|
|https://github.com/wazuh/wazuh/issues/16190|-|-|
|https://github.com/wazuh/wazuh/issues/16196|-|-|

## Description

These changes have been made to fix the above issues. They are related to ```sync-agent-groups-get``` wazuh-db endpoint and consist in:
- New function created to add global group hash to ```sync-agent-groups-get``` response. 
- The ```condition``` parameter of ```sync-agent-groups-get``` is optional now. 
- Fix to not set ```group_sync_status``` to ```synced``` status when the response is full.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Working on cluster environments
- [x] Added unit tests (for new features)