### PR TITLE
Fix memory leak in the SCA decoder when received event with no result

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1450,7 +1450,6 @@ static int CheckEventJSON(cJSON *event, cJSON **scan_id, cJSON **id, cJSON **nam
         if ( *result = cJSON_GetObjectItem(*check, "result"), !*result) {
             *result = cJSON_CreateString("not applicable");
             cJSON_AddItemToObject(*check, "result", *result);
-            cJSON_ReplaceItemInObject(event, "check", *check);
         } else {
             obj = *result;
             if(!obj->valuestring ) {

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1449,6 +1449,8 @@ static int CheckEventJSON(cJSON *event, cJSON **scan_id, cJSON **id, cJSON **nam
 
         if ( *result = cJSON_GetObjectItem(*check, "result"), !*result) {
             *result = cJSON_CreateString("not applicable");
+            cJSON_AddItemToObject(*check, "result", *result);
+            cJSON_ReplaceItemInObject(event, "check", *check);
         } else {
             obj = *result;
             if(!obj->valuestring ) {


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #16211|

## Description

This PR aims to fix this memory leak, that appears when received event with no `result`:
```
==12914== 11,316 (9,216 direct, 2,100 indirect) bytes in 144 blocks are definitely lost in loss record 519 of 618
==12914==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==12914==    by 0x49792CD: cJSON_New_Item.isra.2 (in /var/ossec/lib/libwazuhext.so)
==12914==    by 0x497ACEC: cJSON_CreateString (in /var/ossec/lib/libwazuhext.so)
==12914==    by 0x1807DA: CheckEventJSON (security_configuration_assessment.c:1451)
==12914==    by 0x17DBAE: HandleCheckEvent (security_configuration_assessment.c:768)
==12914==    by 0x17B77F: DecodeSCA (security_configuration_assessment.c:199)
==12914==    by 0x1547A0: w_decode_sca_thread (analysisd.c:1658)
==12914==    by 0x5189608: start_thread (pthread_create.c:477)
==12914==    by 0x52C5292: clone (clone.S:95)
...
==12914== LEAK SUMMARY:
==12914==    definitely lost: 9,216 bytes in 144 blocks
==12914==    indirectly lost: 2,100 bytes in 140 blocks
==12914==      possibly lost: 44,064 bytes in 153 blocks
==12914==    still reachable: 24,168,343 bytes in 131,035 blocks
==12914==         suppressed: 0 bytes in 0 blocks
```

## Rationale

When an event is received that does not contain a result, a `cJSON` item is created with a string and assigned to `*result`. However, the created item is not being added to the `*result` `cJSON` object, which results in memory not being freed when the `cJSON` structure is freed.

## Proposed fix

Add the item to the `cJSON` object and mark the `check` object as checked, that way we avoid not freeing the memory of the `result` variable.

## Memory report with fix
```
==38918== LEAK SUMMARY:
==38918==    definitely lost: 0 bytes in 0 blocks
==38918==    indirectly lost: 0 bytes in 0 blocks
==38918==      possibly lost: 45,216 bytes in 157 blocks
==38918==    still reachable: 22,149,195 bytes in 120,936 blocks
==38918==         suppressed: 0 bytes in 0 blocks
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
