### PR TITLE
Authd x509 Certificate generation error message and args filters enhancemet

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -151,6 +151,11 @@ int main(int argc, char **argv)
     /* Initialize some variables */
     bio_err = 0;
 
+    /* Change working directory */
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+
     // Get options
     {
         int c;
@@ -387,11 +392,6 @@ int main(int argc, char **argv)
             } else {
                 merror_exit("Unable to generate auth certificates.");
             }
-        }
-
-        /* Change working directory */
-        if (chdir(home_path) == -1) {
-            merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
         }
 
         /* Set the Debug level */

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -152,7 +152,6 @@ int main(int argc, char **argv)
     bio_err = 0;
 
     // Get options
-
     {
         int c;
         int use_pass = 0;
@@ -231,7 +230,12 @@ int main(int argc, char **argv)
                     if (!optarg) {
                         merror_exit("-%c needs an argument", c);
                     }
-                    ciphers = optarg;
+                    else{
+                        if(w_str_is_number(optarg)){
+                            merror_exit("-%c needs a valid SSL cipher", c); 
+                        }
+                        ciphers = optarg;
+                    }
                     break;
 
                 case 'v':
@@ -280,9 +284,14 @@ int main(int argc, char **argv)
                         merror_exit("-%c needs an argument", c);
                     }
 
-                    generate_certificate = true;
-                    if (snprintf(cert_val, OS_SIZE_32 + 1, "%s", optarg) > OS_SIZE_32) {
-                        mwarn("-%c argument exceeds %d bytes. Certificate validity info truncated", c, OS_SIZE_32);
+                    if(w_str_is_number(optarg)){
+                        generate_certificate = true;
+                        if (snprintf(cert_val, OS_SIZE_32 + 1, "%s", optarg) > OS_SIZE_32) {
+                            mwarn("-%c argument exceeds %d bytes. Certificate validity info truncated", c, OS_SIZE_32);
+                        }
+                    }
+                    else{
+                        merror_exit("-%c needs a numeric argument", c);   
                     }
                     break;
 
@@ -290,10 +299,15 @@ int main(int argc, char **argv)
                     if (!optarg) {
                         merror_exit("-%c needs an argument", c);
                     }
-
-                    generate_certificate = true;
-                    if (snprintf(cert_key_bits, OS_SIZE_32 + 1, "%s", optarg) > OS_SIZE_32) {
-                        mwarn("-%c argument exceeds %d bytes. Certificate key size info truncated", c, OS_SIZE_32);
+                    
+                    if(w_str_is_number(optarg)){
+                        generate_certificate = true;
+                        if (snprintf(cert_key_bits, OS_SIZE_32 + 1, "%s", optarg) > OS_SIZE_32) {
+                            mwarn("-%c argument exceeds %d bytes. Certificate key size info truncated", c, OS_SIZE_32);
+                        }
+                    }
+                    else{
+                        merror_exit("-%c needs a numeric argument", c);
                     }
                     break;
 
@@ -335,6 +349,7 @@ int main(int argc, char **argv)
                     break;
             }
         }
+
 
         if (generate_certificate) {
             // Sanitize parameters

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -236,7 +236,7 @@ int main(int argc, char **argv)
                         merror_exit("-%c needs an argument", c);
                     }
                     else {
-                        if(w_str_is_number(optarg)){
+                        if (w_str_is_number(optarg)) {
                             merror_exit("-%c needs a valid SSL cipher", c); 
                         }
                         ciphers = optarg;

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -289,13 +289,13 @@ int main(int argc, char **argv)
                         merror_exit("-%c needs an argument", c);
                     }
 
-                    if(w_str_is_number(optarg)){
+                    if (w_str_is_number(optarg)) {
                         generate_certificate = true;
                         if (snprintf(cert_val, OS_SIZE_32 + 1, "%s", optarg) > OS_SIZE_32) {
                             mwarn("-%c argument exceeds %d bytes. Certificate validity info truncated", c, OS_SIZE_32);
                         }
                     }
-                    else{
+                    else {
                         merror_exit("-%c needs a numeric argument", c);   
                     }
                     break;
@@ -305,13 +305,13 @@ int main(int argc, char **argv)
                         merror_exit("-%c needs an argument", c);
                     }
                     
-                    if(w_str_is_number(optarg)){
+                    if (w_str_is_number(optarg)) {
                         generate_certificate = true;
                         if (snprintf(cert_key_bits, OS_SIZE_32 + 1, "%s", optarg) > OS_SIZE_32) {
                             mwarn("-%c argument exceeds %d bytes. Certificate key size info truncated", c, OS_SIZE_32);
                         }
                     }
-                    else{
+                    else {
                         merror_exit("-%c needs a numeric argument", c);
                     }
                     break;
@@ -354,7 +354,6 @@ int main(int argc, char **argv)
                     break;
             }
         }
-
 
         if (generate_certificate) {
             // Sanitize parameters

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -235,7 +235,7 @@ int main(int argc, char **argv)
                     if (!optarg) {
                         merror_exit("-%c needs an argument", c);
                     }
-                    else{
+                    else {
                         if(w_str_is_number(optarg)){
                             merror_exit("-%c needs a valid SSL cipher", c); 
                         }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -237,7 +237,7 @@ int main(int argc, char **argv)
                     }
                     else {
                         if (w_str_is_number(optarg)) {
-                            merror_exit("-%c needs a valid SSL cipher", c); 
+                            merror_exit("-%c needs a valid list of SSL ciphers", c); 
                         }
                         ciphers = optarg;
                     }


### PR DESCRIPTION
|Related issue|
|---|
|#14855|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
As described in the [related issue](#14855), the showed error messages when executing wazuh-authd were pretty poor and not very descriptive, this was due to another error appearing before the descriptive message was thrown. Additionally, the program seemed to work as expected when using wrong parameters, so the parameters filters have been improved in order to detect these cases and provide a descriptive error message.

Worth mentioning, this problem was occurring just when the call to the executable was done without providing its full path. This was due to the executing directory not changed before checking the `ossec.conf` while performing the error message creation, so when checking it, the program was unable to find and open it, throwing the following error: `wazuh-authd: CRITICAL: (1226): Error reading XML file 'etc/ossec.conf':  (line 0).` which was correct, but was not providing real information about the call which the user was doing.
<!--
Add a clear description of how the problem has been solved.
-->

## Logs/Alerts example
Now, the error messages, are descriptive and suggest the possible error cause.
```
### Characters in numeric value
root@server-ubu22:/var/ossec/bin# ./wazuh-authd -C ccc -B 2048 -K /var/ossec/etc/sslmanager.key -X /var/ossec/etc/sslmanager.cert -S "/C=US/ST=California/CN=wazuh/"
2023/02/15 16:07:09 wazuh-authd: CRITICAL: -C needs a numeric argument

### Characters in numeric value
root@server-ubu22:/var/ossec/bin# ./wazuh-authd -C 265 -B 2h048 -K /var/ossec/etc/sslmanager.key -X /var/ossec/etc/sslmanager.cert -S "/C=US/ST=California/CN=wazuh/"
2023/02/15 16:09:17 wazuh-authd: CRITICAL: -B needs a numeric argument

### Characters in numeric value (full path call)
root@server-ubu22:/home/vagrant# /var/ossec/bin/wazuh-authd -C ccc -B 2048 -K /var/ossec/etc/sslmanager.key -X /var/ossec/etc/sslmanager.cert -S "/C=US/ST=California/CN=wazuh/"
2023/02/15 16:16:14 wazuh-authd: CRITICAL: -C needs a numeric argument

### Wrong Flag
root@server-ubu22:/var/ossec/bin# ./wazuh-authd -c 265 -B 2048 -K /var/ossec/etc/sslmanager.key -X /var/ossec/etc/sslmanager.cert -S "/C=AR/ST=MockState/CN=TestCompany/"
2023/02/15 16:07:31 wazuh-authd: CRITICAL: -c needs a valid SSL cipher

### Missing flag
root@server-ubu22:/var/ossec/bin# ./wazuh-authd -C 265 -B 2048 -K /var/ossec/etc/sslmanager.key -X /var/ossec/etc/sslmanager.cert
2023/02/15 16:07:47 wazuh-authd: CRITICAL: Certificate subject not defined.
```
<!--
Paste here related logs and alerts
-->
