### PR TITLE
Engine - Review CSV and KVmap

### DIFF
--- a/src/engine/source/hlp2/src/alphanumeric.cpp
+++ b/src/engine/source/hlp2/src/alphanumeric.cpp
@@ -28,19 +28,16 @@ parsec::Parser<json::Json> getAlphanumericParser(const std::string& name, Stop, 
             return res.value();
         }
 
-        auto begin {text.begin()};
-        std::advance(begin, index);
+        auto end = std::find_if(text.begin() + index, text.end(), [](char const& c) { return !std::isalnum(c); });
 
-        auto it = std::find_if(begin, text.end(), [](char const& c) { return !std::isalnum(c); });
+        auto endPos = end - text.begin();
 
-        if (it == text.end())
+        if (end == text.end())
         {
             json::Json alphaNumeric;
+            alphaNumeric.setString(std::string {text.substr(index, endPos - index)});
 
-            alphaNumeric.setString(std::string {text});
-            index += text.size();
-
-            return parsec::makeSuccess<json::Json>(std::move(alphaNumeric), index);
+            return parsec::makeSuccess<json::Json>(std::move(alphaNumeric), endPos);
         }
         else
         {

--- a/src/engine/source/hlp2/src/alphanumeric.cpp
+++ b/src/engine/source/hlp2/src/alphanumeric.cpp
@@ -28,21 +28,19 @@ parsec::Parser<json::Json> getAlphanumericParser(const std::string& name, Stop, 
             return res.value();
         }
 
-        auto end = std::find_if(text.begin() + index, text.end(), [](char const& c) { return !std::isalnum(c); });
+        const auto end = std::find_if(text.begin() + index, text.end(), [](char const& c) { return !std::isalnum(c); });
 
-        auto endPos = end - text.begin();
+        const auto endPos = end - text.begin();
 
-        if (end == text.end())
+        if (endPos == index)
         {
-            json::Json alphaNumeric;
-            alphaNumeric.setString(std::string {text.substr(index, endPos - index)});
+            return parsec::makeError<json::Json>(fmt::format("{}: Nothing to parse", name), endPos);
+        }
 
-            return parsec::makeSuccess<json::Json>(std::move(alphaNumeric), endPos);
-        }
-        else
-        {
-            return parsec::makeError<json::Json>(fmt::format("{}: Expected alphanumeric input", name), index);
-        }
+        json::Json alphaNumeric;
+        alphaNumeric.setString(std::string {text.substr(index, endPos - index)});
+
+        return parsec::makeSuccess<json::Json>(std::move(alphaNumeric), endPos);
     };
 }
 } // namespace hlp

--- a/src/engine/source/hlp2/src/dsv_csv.cpp
+++ b/src/engine/source/hlp2/src/dsv_csv.cpp
@@ -72,7 +72,7 @@ inline auto dsvParserFunction(std::string name,
             auto fValue = field.value();
 
             auto v = remaining.substr(fValue.start(), fValue.len());
-            updateDoc(doc, headers[i], v, fValue.isEscaped(), R"(")");
+            updateDoc(doc, headers[i], v, fValue.isEscaped(), R"(")", fValue.isQuoted());
 
             start += fValue.end() + 1;
             i++;

--- a/src/engine/source/hlp2/src/dsv_csv.cpp
+++ b/src/engine/source/hlp2/src/dsv_csv.cpp
@@ -72,7 +72,7 @@ inline auto dsvParserFunction(std::string name,
             auto fValue = field.value();
 
             auto v = remaining.substr(fValue.start(), fValue.len());
-            updateDoc(doc, headers[i], v, fValue.isEscaped(), R"(")", fValue.isQuoted());
+            updateDoc(doc, headers[i], v, fValue.isEscaped(), std::string {escapeChar}, fValue.isQuoted());
 
             start += fValue.end() + 1;
             i++;

--- a/src/engine/source/hlp2/src/dsv_csv.cpp
+++ b/src/engine/source/hlp2/src/dsv_csv.cpp
@@ -72,7 +72,7 @@ inline auto dsvParserFunction(std::string name,
             auto fValue = field.value();
 
             auto v = remaining.substr(fValue.start(), fValue.len());
-            updateDoc(doc, headers[i], v, fValue.isEscaped(), std::string {escapeChar}, fValue.isQuoted());
+            updateDoc(doc, headers[i], v, fValue.isEscaped(), std::string_view {&escapeChar, 1}, fValue.isQuoted());
 
             start += fValue.end() + 1;
             i++;

--- a/src/engine/source/hlp2/src/encodings.cpp
+++ b/src/engine/source/hlp2/src/encodings.cpp
@@ -90,7 +90,7 @@ parsec::Parser<json::Json> getBinaryParser(std::string name, Stop, Options lst)
         }
         json::Json doc;
         // copy can be slow
-        doc.setString(std::string {text.substr(index, endPos)});
+        doc.setString(std::string {text.substr(index, endPos - index)});
         return parsec::makeSuccess<json::Json>(std::move(doc), endPos);
     };
 }

--- a/src/engine/source/hlp2/src/ignore.cpp
+++ b/src/engine/source/hlp2/src/ignore.cpp
@@ -22,14 +22,8 @@ parsec::Parser<json::Json> getIgnoreParser(std::string name, Stop endTokens, Opt
                                  " with the string to match");
     }
 
-    return [repeatStr = lst.at(0), name](std::string_view text, int index)
+    return [repeatStr = lst.at(0)](std::string_view text, int index)
     {
-        auto res = internal::eofError<json::Json>(text, index);
-        if (res.has_value())
-        {
-            return res.value();
-        }
-
         std::size_t repPos {0ul};
         while (index < text.size() && text[index] == repeatStr[repPos])
         {

--- a/src/engine/source/hlp2/src/kvmap.cpp
+++ b/src/engine/source/hlp2/src/kvmap.cpp
@@ -106,8 +106,7 @@ parsec::Parser<json::Json> getKVParser(std::string name, Stop endTokens, Options
                     index);
             }
             end = kv[i + 1].end();
-            updateDoc(
-                doc, fmt::format("/{}", k), v, kv[i + 1].isEscaped(), std::string {esc});
+            updateDoc(doc, fmt::format("/{}", k), v, kv[i + 1].isEscaped(), std::string {esc}, kv[i + 1].isQuoted());
         }
 
         if (start - 1 != end)

--- a/src/engine/source/hlp2/src/kvmap.cpp
+++ b/src/engine/source/hlp2/src/kvmap.cpp
@@ -65,7 +65,7 @@ parsec::Parser<json::Json> getKVParser(std::string name, Stop endTokens, Options
         while (start <= fp.size())
         {
             auto remaining = fp.substr(start, fp.size() - start);
-            auto f = getField(remaining, dlm, quote, '\\', false);
+            auto f = getField(remaining, dlm, quote, '\\', true);
             if (!f.has_value())
             {
                 break;

--- a/src/engine/source/hlp2/src/kvmap.cpp
+++ b/src/engine/source/hlp2/src/kvmap.cpp
@@ -106,7 +106,7 @@ parsec::Parser<json::Json> getKVParser(std::string name, Stop endTokens, Options
                     index);
             }
             end = kv[i + 1].end();
-            updateDoc(doc, fmt::format("/{}", k), v, kv[i + 1].isEscaped(), std::string {esc}, kv[i + 1].isQuoted());
+            updateDoc(doc, fmt::format("/{}", k), v, kv[i + 1].isEscaped(), std::string_view {&esc, 1}, kv[i + 1].isQuoted());
         }
 
         if (start - 1 != end)

--- a/src/engine/source/hlp2/src/kvmap.cpp
+++ b/src/engine/source/hlp2/src/kvmap.cpp
@@ -110,13 +110,13 @@ parsec::Parser<json::Json> getKVParser(std::string name, Stop endTokens, Options
                 doc, fmt::format("/{}", k), v, kv[i + 1].isEscaped(), std::string {esc});
         }
 
-        if (start - 1 != pos)
+        if (start - 1 != end)
         {
             return parsec::makeError<json::Json>(
                 fmt::format("{}: Invalid key-value string", name), index);
         }
 
-        return parsec::makeSuccess(std::move(doc), end);
+        return parsec::makeSuccess(std::move(doc), pos);
     };
 }
 

--- a/src/engine/source/hlp2/src/parse_field.cpp
+++ b/src/engine/source/hlp2/src/parse_field.cpp
@@ -56,7 +56,7 @@ std::optional<Field> getField(std::string_view input,
                 }
                 else
                 {
-                    bool escaped = (last_escape_location + 1 == i);
+                    bool escaped = (last_escape_location + 1 == i) && (i > 1);
                     isEscaped = isEscaped || escaped;
                     last_escape_location += (i - last_escape_location) * size_t(!escaped);
                     quote_opened = escaped || (input[i + 1] != delimiter);

--- a/src/engine/source/hlp2/src/parse_field.cpp
+++ b/src/engine/source/hlp2/src/parse_field.cpp
@@ -90,7 +90,8 @@ void updateDoc(json::Json& doc,
                std::string_view hdr,
                std::string_view val,
                bool is_escaped,
-               std::string_view escape)
+               std::string_view escape,
+               bool is_quoted)
 {
     if (val.empty())
     {
@@ -98,21 +99,24 @@ void updateDoc(json::Json& doc,
         return;
     }
 
-    int64_t i;
-    auto [ptr, ec] {utils::from_chars(val.data(), val.data() + val.size(), i)};
-    if (std::errc() == ec && (val.data() + val.size()) == ptr)
+    if(!is_quoted)
     {
-        doc.setInt64(i, hdr);
-        return;
-    }
-    else
-    {
-        double_t d;
-        auto [ptr, ec] {utils::from_chars(val.data(), val.data() + val.size(), d)};
+        int64_t i;
+        auto [ptr, ec] {utils::from_chars(val.data(), val.data() + val.size(), i)};
         if (std::errc() == ec && (val.data() + val.size()) == ptr)
         {
-            doc.setDouble(d, hdr);
+            doc.setInt64(i, hdr);
             return;
+        }
+        else
+        {
+            double_t d;
+            auto [ptr, ec] {utils::from_chars(val.data(), val.data() + val.size(), d)};
+            if (std::errc() == ec && (val.data() + val.size()) == ptr)
+            {
+                doc.setDouble(d, hdr);
+                return;
+            }
         }
     }
 

--- a/src/engine/source/hlp2/src/parse_field.cpp
+++ b/src/engine/source/hlp2/src/parse_field.cpp
@@ -45,7 +45,7 @@ std::optional<Field> getField(std::string_view input,
                 {
                     // Handle opening quote
                     quote_opened = true;
-                    if (strict && (i > 1) && input[i - 1] != delimiter)
+                    if (strict && (1 < i) && input[i - 1] != delimiter)
                     {
                         // Invalid field if strict parsing is enabled and there is no delimiter before opening quote
                         return {};
@@ -58,7 +58,7 @@ std::optional<Field> getField(std::string_view input,
                 else
                 {
                     // Handle closing quote
-                    bool escaped = (last_escape_location + 1 == i) && (i > 1);
+                    bool escaped = (last_escape_location + 1 == i) && (1 < i);
                     isEscaped = isEscaped || escaped;
                     last_escape_location += (i - last_escape_location) * size_t(!escaped);
                     quote_opened = escaped || (input[i + 1] != delimiter);

--- a/src/engine/source/hlp2/src/parse_field.hpp
+++ b/src/engine/source/hlp2/src/parse_field.hpp
@@ -39,6 +39,8 @@ public:
 
     inline const bool isEscaped() const { return m_isEscaped; }
 
+    inline const bool isQuoted() const { return m_isQuoted; }
+
     inline void addOffset(const int offset)
     {
         m_start += offset;
@@ -72,7 +74,8 @@ void updateDoc(json::Json& doc,
                std::string_view hdr,
                std::string_view val,
                bool is_escaped,
-               std::string_view escape);
+               std::string_view escape,
+               bool is_quoted);
 
 } // namespace hlp
 #endif // WAZUH_ENGINE_PARSE_FIELD_HPP

--- a/src/engine/source/hlp2/src/parse_field.hpp
+++ b/src/engine/source/hlp2/src/parse_field.hpp
@@ -49,30 +49,43 @@ public:
 };
 
 /**
- * @brief Get the Field object
+ * @brief Parses a field from a string using the given delimiter, quote, and escape characters.
  *
- * @param in
- * @param pos
- * @param size
- * @param delimiter
- * @param quote
- * @param escape
- * @param s
- * @return std::optional<Field>
+ * @param input The string to parse the field from.
+ * @param delimiter The delimiter character used to separate fields.
+ * @param quote The quote character used to enclose fields that contain delimiter characters.
+ * @param escape The escape character used to escape quote or escape characters inside a field.
+ * @param strict Whether strict parsing should be used. If true, fields not enclosed in quotes cannot contain quotes.
+ * @return An optional Field object containing the parsed field, or std::nullopt if the input is invalid.
  */
 std::optional<Field> getField(std::string_view input,
                               const char delimiter,
                               const char quote,
-                              const char ecsape,
-                              bool s);
+                              const char escape,
+                              bool strict);
 
-// TODO:DOC THIS
+/**
+ * @brief Unescapes a string
+ *
+ * @param is_escaped Whether the string is escaped.
+ * @param vs The string to be unescaped.
+ * @param escape The escape character
+ */
 void unescape(bool is_escaped, std::string& vs, std::string_view escape);
 
-// TODO:DOC THIS
+/**
+ * @brief Adds a key:value pair to a JSON document. Unescapes the value if necessary.
+ *
+ * @param doc The JSON document to update.
+ * @param key The key to be added to the document.
+ * @param value The value to be added to the document.
+ * @param is_escaped Whether the value should be unescaped.
+ * @param escape The character used to unescape quote or escape characters inside the string value.
+ * @param is_quoted Whether the value is quoted. If false, it tries to parse the value as int or double.
+ */
 void updateDoc(json::Json& doc,
-               std::string_view hdr,
-               std::string_view val,
+               std::string_view key,
+               std::string_view value,
                bool is_escaped,
                std::string_view escape,
                bool is_quoted);

--- a/src/engine/test/source/hlp2/basic_test.cpp
+++ b/src/engine/test/source/hlp2/basic_test.cpp
@@ -302,10 +302,14 @@ TEST(HLP2, TextParser)
     }
 }
 
-TEST(HLP2, AlphanumericParser)
+TEST(AlphanumericParser, build)
 {
+    ASSERT_NO_THROW(hlp::getAlphanumericParser({}, {}, {}));
     ASSERT_THROW(hlp::getAlphanumericParser({}, {}, {"arg"}), std::runtime_error);
+}
 
+TEST(AlphanumericParser, parser)
+{
     auto fn = [](std::string in) -> json::Json
     {
         json::Json doc;
@@ -313,14 +317,16 @@ TEST(HLP2, AlphanumericParser)
         return doc;
     };
     std::vector<TestCase> testCases {
+        TestCase {"", false, {}, Options(), fn(""), 0},
+        TestCase {"#", false, {}, Options(), fn(""), 0},
         TestCase {"id98A", true, {}, Options(), fn("id98A"), 5},
-        TestCase {"id98A:69", false, {}, Options(), fn("id98A:69"), 0},
+        TestCase {"id98A:69", true, {}, Options(), fn("id98A"), 5},
         TestCase {"idARGbyu", true, {}, Options(), fn("idARGbyu"), 8},
         TestCase {"0123456789", true, {}, Options(), fn("0123456789"), 10},
-        TestCase {"Hello#@$%&/()[]{}!:-+*", false, {}, Options(), fn("Hello#@$%&/()[]{}!:-+*"), 0}};
+        TestCase {"Hello#@$%&/()[]{}!:-+*", true, {}, Options(), fn("Hello"), 5}};
 
     for (auto t : testCases)
     {
-        runTest(t, hlp::getAlphanumericParser, "header ", "");
+        runTest(t, hlp::getAlphanumericParser);
     }
 }

--- a/src/engine/test/source/hlp2/basic_test.cpp
+++ b/src/engine/test/source/hlp2/basic_test.cpp
@@ -321,6 +321,6 @@ TEST(HLP2, AlphanumericParser)
 
     for (auto t : testCases)
     {
-        runTest(t, hlp::getAlphanumericParser);
+        runTest(t, hlp::getAlphanumericParser, "header ", "");
     }
 }

--- a/src/engine/test/source/hlp2/dsv_csv_test.cpp
+++ b/src/engine/test/source/hlp2/dsv_csv_test.cpp
@@ -239,10 +239,6 @@ TEST(CSVParser, parser)
     {
         auto testCase = std::get<0>(t);
         runTest(t, hlp::getCSVParser);
-        runTest(t, hlp::getCSVParser, "header", "");
-        runTest(t, hlp::getCSVParser, "header", "tail");
-        runTest(t, hlp::getCSVParser, "", "tail");
-
     }
 }
 
@@ -498,8 +494,5 @@ TEST(DSVParser, parser)
     for (auto t : testCases)
     {
         runTest(t, hlp::getDSVParser);
-        runTest(t, hlp::getDSVParser, "header", "");
-        runTest(t, hlp::getDSVParser, "header", "tail");
-        runTest(t, hlp::getDSVParser, "", "tail");
     }
 }

--- a/src/engine/test/source/hlp2/ignore_test.cpp
+++ b/src/engine/test/source/hlp2/ignore_test.cpp
@@ -23,10 +23,11 @@ TEST(HLP2, ignoreParser)
         TestCase {R"(wazuhwa)", true, {""}, Options {"wazuh"}, fn(R"(null)"), 7},
         TestCase {R"(WAZUH)", true, {""}, Options {"wazuh"}, fn(R"(null)"), 0},
         TestCase {R"()", false, {""}, Options {"wazuh"}, fn(R"(null)"), 0},
+        TestCase {R"(wazuh)", false, {""}, Options {""}, fn(R"(null)"), 0}
     };
 
     for (auto t : testCases)
     {
-        runTest(t, hlp::getIgnoreParser);
+        runTest(t, hlp::getIgnoreParser, "header ", " tail", true);
     }
 }

--- a/src/engine/test/source/hlp2/ignore_test.cpp
+++ b/src/engine/test/source/hlp2/ignore_test.cpp
@@ -5,7 +5,19 @@
 #include <json/json.hpp>
 #include <string>
 
-TEST(HLP2, ignoreParser)
+TEST(IgnoreParser, build)
+{
+    // OK
+    ASSERT_NO_THROW(hlp::getIgnoreParser({}, {}, {"foo"}));
+    // The stop are optional
+    ASSERT_NO_THROW(hlp::getIgnoreParser({}, {""}, {"foo"}));
+
+    // Do not allow options
+    ASSERT_THROW(hlp::getIgnoreParser({}, {}, {""}), std::runtime_error);
+    ASSERT_THROW(hlp::getIgnoreParser({}, {}, {"foo", "bar"}), std::runtime_error);
+}
+
+TEST(IgnoreParser, parser)
 {
 
     auto fn = [](std::string in) -> json::Json
@@ -22,12 +34,12 @@ TEST(HLP2, ignoreParser)
         TestCase {R"(wazuhwazuh)", true, {""}, Options {"wazuh"}, fn(R"(null)"), 10},
         TestCase {R"(wazuhwa)", true, {""}, Options {"wazuh"}, fn(R"(null)"), 7},
         TestCase {R"(WAZUH)", true, {""}, Options {"wazuh"}, fn(R"(null)"), 0},
-        TestCase {R"()", false, {""}, Options {"wazuh"}, fn(R"(null)"), 0},
+        TestCase {R"()", true, {""}, Options {"wazuh"}, fn(R"(null)"), 0},
         TestCase {R"(wazuh)", false, {""}, Options {""}, fn(R"(null)"), 0}
     };
 
     for (auto t : testCases)
     {
-        runTest(t, hlp::getIgnoreParser, "header ", " tail", true);
+        runTest(t, hlp::getIgnoreParser);
     }
 }

--- a/src/engine/test/source/hlp2/kvmap_test.cpp
+++ b/src/engine/test/source/hlp2/kvmap_test.cpp
@@ -214,9 +214,6 @@ TEST(KVParser, parser)
     for (auto t : testCases)
     {
         runTest(t, hlp::getKVParser);
-        runTest(t, hlp::getKVParser, "header", "");
-        runTest(t, hlp::getKVParser, "header", "tail");
-        runTest(t, hlp::getKVParser, "", "tail");
     }
 }
 

--- a/src/engine/test/source/hlp2/run_test.hpp
+++ b/src/engine/test/source/hlp2/run_test.hpp
@@ -24,7 +24,6 @@ using namespace hlp;
 //   [3] std::list<std::string> options,
 //   [4] std::string which will be inside the json::Json returned value,
 //   [5] int index position
-//   [6] ReturnDoc a funcion wihch receives [4] and returns a json::Json document
 using TestCase = std::tuple<std::string, bool, Stop, Options, json::Json, size_t>;
 
 namespace
@@ -64,22 +63,27 @@ std::string to_string(const TestCase& testCase)
  *
  * @param t The tuple containing the test case parameters
  * @param parserBuilder The parser builder
+ * @header The header to be appended to the input string
+ * @tail The tail to be appended to the input string
+ * @strictStop The end token is not modified and no tail is added
  */
-static void runTest(TestCase t, std::function<parsec::Parser<json::Json>(std::string, Stop, Options)> parserBuilder)
+static void runTest(TestCase t,
+                    std::function<parsec::Parser<json::Json>(std::string, Stop, Options)> parserBuilder,
+                    const std::string& header = "header ",
+                    const std::string& tail = " tail",
+                    bool strictStop = false)
 {
     parsec::Parser<json::Json> parser;
     auto expectedSuccess = std::get<1>(t);
     auto expectedDoc = std::get<4>(t);
 
-    const std::string& headerString = "header";
-    const std::string& tailString = "tail";
-    std::string token[4][2] = {{"", ""}, {headerString, ""}, {"", tailString}, {headerString, tailString}};
+    std::string token[4][2] = {{"", ""}, {header, ""}, {"", tail}, {header, tail}};
 
     for (int i = 0; i < 4; i++)
     {
         auto stopString = printStop(std::get<2>(t));
         std::list<std::string> tokenList = {token[i][1]};
-        std::list<std::string> stopStringList = stopString.empty() ? tokenList : std::get<2>(t);
+        std::list<std::string> stopStringList = (strictStop || !stopString.empty()) ? std::get<2>(t) : tokenList;
         try
         {
             parser = parserBuilder({}, stopStringList, std::get<3>(t));
@@ -90,7 +94,7 @@ static void runTest(TestCase t, std::function<parsec::Parser<json::Json>(std::st
                 << fmt::format("Error building parser: {}", e.what());
             return;
         }
-        auto fullEvent = token[i][0] + std::get<0>(t) + token[i][1];
+        auto fullEvent = token[i][0] + std::get<0>(t) + (strictStop ? "" : token[i][1]);
         auto r = parser(fullEvent, token[i][0].size());
 
         ASSERT_EQ(r.success(), expectedSuccess)

--- a/src/engine/test/source/hlp2/run_test.hpp
+++ b/src/engine/test/source/hlp2/run_test.hpp
@@ -63,9 +63,9 @@ std::string to_string(const TestCase& testCase)
  *
  * @param t The tuple containing the test case parameters
  * @param parserBuilder The parser builder
- * @header The header to be appended to the input string
- * @tail The tail to be appended to the input string
- * @strictStop The end token is not modified and no tail is added
+ * @param header The header to be appended to the input string
+ * @param tail The tail to be appended to the input string
+ * @param strictStop The end token is not modified and no tail is added
  */
 static void runTest(TestCase t,
                     std::function<parsec::Parser<json::Json>(std::string, Stop, Options)> parserBuilder,

--- a/src/engine/test/source/hlp2/web_test.cpp
+++ b/src/engine/test/source/hlp2/web_test.cpp
@@ -223,7 +223,7 @@ TEST(UAParser, parser)
 
     for (auto t : testCases)
     {
-        runTest(t, hlp::getUAParser);
+        runTest(t, hlp::getUAParser, "header ", " tail", true);
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#16155|

## Description
This PR is intended to fix different corner cases detected in kvmap, csv and dsv.

### Fixed issues
After the QA testing phase, the following issues were found and opened, which have been fixed in this PR:
- #15854
- #15881

We have also received feedback from other users who have been using the engine in recent months. The following cases have been fixed in this PR:

- `kv` parser fails when a non-zero offset is used:
```
Enter a log in single line (Crtl+C to exit):

Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=89.160.20.156


DECODERS:
  decoder/test/0  ->  failure
    [decoder/test/0] [/event/original: <event.start/%b %d %T> <host.hostname> <~tmp/kv/=/ /"/'>] -> Failure: Parse operation failed: 
    Main error: <~tmp/kv/=/ /"/'>: Invalid key-value string at 28
    Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=89.160.20.156 
    ----------------------------^
    
    List of errors:
    <~tmp/kv/=/ /"/'>: Invalid key-value string at 28
    
    [decoder/test/0] [condition]:failure
```
- `kv` parser fails when the event contains an empty value `key=""`:
```
Enter a log in single line (Crtl+C to exit):

id=firewall sn=000SERIAL fw=89.160.20.156 pri=6 c=262144 m=98 msg="Connection Opened" n="" proto=tcp/50000


DECODERS:
  decoder/test/0  ->  failure
    [decoder/test/0] [/event/original: <~tmp/kv/=/ /"/'>] -> Failure: Parse operation failed: 
    Main error: <~tmp/kv/=/ /"/'>: Invalid number of key-value fields at 0
    id=firewall sn=000SERIAL fw=89.160.20.156 pri=6 c=262144 m=98 msg="Connection Opened" n="" proto=tcp/50000
    ^
    
    List of errors:
    <~tmp/kv/=/ /"/'>: Invalid number of key-value fields at 0
    
    [decoder/test/0] [condition]:failure
```
- `kv` parser converts a string `"key"="0123"` to a numeric value `"key"=123`:
```
Enter a log in single line (Crtl+C to exit):

key="0123"


DECODERS:
  decoder/test/0  ->  success
    [decoder/test/0] [/event/original: <~tmp/kv/=/ /"/'>] -> Success
    [decoder/test/0] [condition]:success

RULES:


OUTPUT:

{
    "wazuh": {
        "queue": 49,
        "origin": "/dev/stdin"
    },
    "event": {
        "original": "key=\"0123\""
    },
    "~tmp": {
        "key": 123
    }
}
```

## Tasks
- [x] Check kvmap performance
- [x] Create new test corner cases for kvmap
- [x] Fix issues in kvmap
- [x] Check csv performance
- [x] Create new test corner cases for csv
- [x] Fix issues in csv
- [x] Update Documentation
- [ ] QA validate