### PR TITLE
Remove wdb condition in agent-groups

### DIFF
--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -432,7 +432,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w',
                                            data_retriever=wdb_conn.run_wdb_command,
                                            get_data_command='global sync-agent-groups-get ',
-                                           get_payload={"condition": "sync_status", "get_global_hash": True})
+                                           get_payload={"get_global_hash": True})
 
         local_agent_groups = await sync_object.retrieve_information()
         if not local_agent_groups:


### PR DESCRIPTION
|Related issue|
|---|
| Closes #16197 |

## Description

This PR removes the condition used in the `agent-groups` command sent from worker's clusterd to `wazuh-db` service. Now, only global groups hash is requested, so even if there were `syncreq` agents in the worker's db (which would be a bug anyway), the worker won't expect any data and won't enter an endless loop as described in #16195. 

## Logs/Alerts example
These logs are not included in the development, they are only used to show the command and its output:
```
2023/02/16 15:55:06 INFO: [Worker worker1] [Agent-groups recv] Command sent: global sync-agent-groups-get {"get_global_hash": true}
2023/02/16 15:55:06 INFO: [Worker worker1] [Agent-groups recv] Retrieved data: ['[{"data":[],"hash":"888bd7a8993035b50b14541d6bdb428336e24072"}]']

```
