### PR TITLE
Fix the orden in which the global DB is populated after an upgrade

### DIFF
--- a/src/wazuh_db/schema_global_upgrade_v4.sql
+++ b/src/wazuh_db/schema_global_upgrade_v4.sql
@@ -16,9 +16,6 @@ CREATE TABLE IF NOT EXISTS _belongs (
     PRIMARY KEY (id_agent, id_group)
 );
 
-CREATE INDEX IF NOT EXISTS belongs_id_agent ON belongs (id_agent);
-CREATE INDEX IF NOT EXISTS belongs_id_group ON belongs (id_group);
-
 BEGIN;
 INSERT INTO _belongs (id_agent, id_group, priority) SELECT id_agent, id_group, belongs.rowid FROM belongs WHERE id_agent IN (SELECT id FROM agent) AND id_group IN (SELECT id FROM `group`);
 UPDATE _belongs SET priority=(SELECT temp.r_num - 1 FROM (SELECT *, row_number() OVER(PARTITION BY id_agent ORDER BY belongs.rowid) r_num FROM belongs) temp WHERE _belongs.id_agent = temp.id_agent AND _belongs.id_group = temp.id_group);
@@ -26,6 +23,9 @@ END;
 
 DROP TABLE IF EXISTS belongs;
 ALTER TABLE _belongs RENAME TO belongs;
+
+CREATE INDEX IF NOT EXISTS belongs_id_agent ON belongs (id_agent);
+CREATE INDEX IF NOT EXISTS belongs_id_group ON belongs (id_group);
 
 CREATE TABLE IF NOT EXISTS _agent (
     id INTEGER PRIMARY KEY,
@@ -64,9 +64,11 @@ END;
 
 DROP TABLE IF EXISTS agent;
 ALTER TABLE _agent RENAME TO agent;
+
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);
 CREATE INDEX IF NOT EXISTS agent_ip ON agent (ip);
 CREATE INDEX IF NOT EXISTS agent_group_hash ON agent (group_hash);
+
 CREATE TABLE IF NOT EXISTS `_group` (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT,
@@ -74,7 +76,7 @@ CREATE TABLE IF NOT EXISTS `_group` (
 );
 
 BEGIN;
-INSERT OR IGNORE INTO `_group` (name) SELECT name FROM `group`;
+INSERT INTO `_group` (name) SELECT name FROM `group`;
 END;
 
 DROP TABLE IF EXISTS `group`;

--- a/src/wazuh_db/schema_global_upgrade_v4.sql
+++ b/src/wazuh_db/schema_global_upgrade_v4.sql
@@ -16,11 +16,6 @@ CREATE TABLE IF NOT EXISTS _belongs (
     PRIMARY KEY (id_agent, id_group)
 );
 
-BEGIN;
-INSERT INTO _belongs (id_agent, id_group, priority) SELECT id_agent, id_group, belongs.rowid FROM belongs WHERE id_agent IN (SELECT id FROM agent) AND id_group IN (SELECT id FROM `group`);
-UPDATE _belongs SET priority=(SELECT temp.r_num - 1 FROM (SELECT *, row_number() OVER(PARTITION BY id_agent ORDER BY belongs.rowid) r_num FROM belongs) temp WHERE _belongs.id_agent = temp.id_agent AND _belongs.id_group = temp.id_group);
-END;
-
 DROP TABLE IF EXISTS belongs;
 ALTER TABLE _belongs RENAME TO belongs;
 
@@ -76,7 +71,7 @@ CREATE TABLE IF NOT EXISTS `_group` (
 );
 
 BEGIN;
-INSERT INTO `_group` (name) SELECT name FROM `group`;
+INSERT OR IGNORE INTO `_group` (name) SELECT name FROM `group`;
 END;
 
 DROP TABLE IF EXISTS `group`;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -170,7 +170,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_FIND_AGENT] = "SELECT id FROM agent WHERE name = ? AND (register_ip = ? OR register_ip LIKE ? || '/_%');",
     [WDB_STMT_GLOBAL_FIND_GROUP] = "SELECT id FROM `group` WHERE name = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_GROUPS_HASH] = "UPDATE agent SET group_hash = ? WHERE id = ?;",
-    [WDB_STMT_GLOBAL_INSERT_AGENT_GROUP] = "INSERT OR IGNORE INTO `group` (name) VALUES(?);",
+    [WDB_STMT_GLOBAL_INSERT_AGENT_GROUP] = "INSERT INTO `group` (name) VALUES(?);",
     [WDB_STMT_GLOBAL_SELECT_GROUP_BELONG] = "SELECT name FROM belongs JOIN `group` ON id = id_group WHERE id_agent = ? order by priority;",
     [WDB_STMT_GLOBAL_INSERT_AGENT_BELONG] = "INSERT OR REPLACE INTO belongs (id_group, id_agent, priority) VALUES(?,?,?);",
     [WDB_STMT_GLOBAL_DELETE_AGENT_BELONG] = "DELETE FROM belongs WHERE id_agent = ?;",

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -96,8 +96,6 @@ static void wm_sync_agents_artifacts();
 static void wm_clean_dangling_legacy_dbs();
 static void wm_clean_dangling_wdb_dbs();
 
-static void wm_sync_multi_groups(const char *dirname);
-
 #endif // LOCAL
 
 static int wm_sync_shared_group(const char *fname);
@@ -130,16 +128,29 @@ void* wm_database_main(wm_database *data) {
     is_worker = w_is_worker();
 
     // Manager name synchronization
-    if (data->sync_agents) {
-        wm_sync_manager();
-    }
+    wm_sync_manager();
 
     // During the startup, both workers and master nodes should perform the
     // agents synchronization with the database using the keys. In advance,
     // the master will only synchronize the artifacts and the agent addition
     // and removal from the database will be held by authd.
     wm_sync_agents();
+
+    // Synchronize agent artifacts only in master node
+    if (!is_worker) {
+        wm_sync_agents_artifacts();
+    }
+
+    // Groups synchronization with the database
+    wdb_update_groups(SHAREDCFG_DIR, &wdb_wmdb_sock);
+
+    // Legacy agent-group files need to be synchronized with the database
+    // and then removed in case an upgrade has just been performed.
     wm_sync_legacy_groups_files();
+
+    // Remove dangling agent databases
+    wm_clean_dangling_legacy_dbs();
+    wm_clean_dangling_wdb_dbs();
 
 #ifdef INOTIFY_ENABLED
     if (data->real_time) {
@@ -192,9 +203,7 @@ void* wm_database_main(wm_database *data) {
 #ifndef LOCAL
             if (data->sync_agents) {
                 wm_check_agents();
-                wm_sync_multi_groups(SHAREDCFG_DIR);
-                wm_clean_dangling_legacy_dbs();
-                wm_clean_dangling_wdb_dbs();
+                wdb_update_groups(SHAREDCFG_DIR, &wdb_wmdb_sock);
             }
 #endif
             gettime(&spec1);
@@ -544,11 +553,6 @@ void wm_clean_dangling_wdb_dbs() {
     closedir(dir);
 }
 
-void wm_sync_multi_groups(const char *dirname) {
-
-    wdb_update_groups(dirname, &wdb_wmdb_sock);
-}
-
 void wm_sync_legacy_groups_files() {
     DIR *dir = opendir(GROUPS_DIR);
 
@@ -826,26 +830,17 @@ void wm_inotify_setup(wm_database * data) {
     char * keysfile_dir = dirname(keysfile_path);
 
     if (data->sync_agents) {
-        if ((wd_agents = inotify_add_watch(inotify_fd, keysfile_dir, IN_CLOSE_WRITE | IN_MOVED_TO)) < 0)
+        if ((wd_agents = inotify_add_watch(inotify_fd, keysfile_dir, IN_CLOSE_WRITE | IN_MOVED_TO)) < 0) {
             mterror(WM_DATABASE_LOGTAG, "Couldn't watch client.keys file: %s.", strerror(errno));
+        }
 
         mtdebug2(WM_DATABASE_LOGTAG, "wd_agents='%d'", wd_agents);
 
-        if ((wd_shared_groups = inotify_add_watch(inotify_fd, SHAREDCFG_DIR, IN_CLOSE_WRITE | IN_MOVED_TO | IN_MOVED_FROM | IN_CREATE | IN_DELETE)) < 0)
+        if ((wd_shared_groups = inotify_add_watch(inotify_fd, SHAREDCFG_DIR, IN_CLOSE_WRITE | IN_MOVED_TO | IN_MOVED_FROM | IN_CREATE | IN_DELETE)) < 0) {
             mterror(WM_DATABASE_LOGTAG, "Couldn't watch the shared groups directory: %s.", strerror(errno));
+        }
 
         mtdebug2(WM_DATABASE_LOGTAG, "wd_shared_groups='%d'", wd_shared_groups);
-
-        // The syncronization with client.keys only happens in worker nodes
-        if (is_worker) {
-            wm_sync_agents();
-        }
-        else {
-            wm_sync_agents_artifacts();
-        }
-        wm_sync_multi_groups(SHAREDCFG_DIR);
-        wm_clean_dangling_legacy_dbs();
-        wm_clean_dangling_wdb_dbs();
     }
 
 #endif

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -195,6 +195,9 @@ void* wm_database_main(wm_database *data) {
         struct timespec spec0;
         struct timespec spec1;
 
+        // Initial wait
+        sleep(data->interval);
+
         while (1) {
             tstart = (long long) time(NULL);
             cstart = clock();


### PR DESCRIPTION
|Related issue|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/16201|https://github.com/wazuh/wazuh-qa/issues/3970|

## Description

This PR solves a problem produced when upgrading Wazuh to 4.4.

The order in which the global DB was populated was incorrect:

- First, `agent-group` files where synchronized.
- Later, group files where synchronized.

By modifying the order of these steps, we ensure that the manager will never try to add an entry in the belongs table before synchronizing the groups in the DB, which are used as a foreign key.

Also, some minor fixes where introduced in the SQL upgrade script.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Working on cluster environments