### PR TITLE
Fix vulnerability API integration tests

### DIFF
--- a/api/test/integration/test_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_vulnerability_endpoints.tavern.yaml
@@ -26,8 +26,8 @@ stages:
               name: !anystr
               type: !anystr
               status: !anystr
-              cvss2_score: !anyfloat
-              cvss3_score: !anyfloat
+              cvss2_score: !anything
+              cvss3_score: !anything
               detection_time: !anystr
               severity: !anystr
               external_references: !anylist

--- a/api/test/integration/test_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_vulnerability_endpoints.tavern.yaml
@@ -34,7 +34,6 @@ stages:
               condition: !anystr
               title: !anystr
               published: !anystr
-              updated: !anystr
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -54,7 +53,6 @@ stages:
           expected_condition: data.affected_items[0].condition
           expected_title: data.affected_items[0].title
           expected_published: data.affected_items[0].published
-          expected_updated: data.affected_items[0].updated
 
   - name: Get agent's vulnerabilities (filter by Type)
     request:
@@ -211,19 +209,6 @@ stages:
           extra_kwargs:
             key: "published"
             expected_values: "{expected_published}"
-
-  - name: Get agent's vulnerabilities (filter by update date)
-    request:
-      <<: *vulnerability_request_001
-      params:
-        q: "updated={expected_updated}"
-    response:
-      status_code: 200
-      verify_response_with:
-        - function: tavern_utils:test_expected_value
-          extra_kwargs:
-            key: "updated"
-            expected_values: "{expected_updated}"
 
   - name: Try to get agent's vulnerabilities (filter by an unexistent CVSS3 score)
     request:


### PR DESCRIPTION
|Related issue|
|---|
|closes #16137 |

## Description

After investigating the cause of the error and discussing it with the team, we have concluded in removing the failing checks since they just check value types that could change with valid reasons like this case.

## API integration tests

```
==================================================================================================================================================== test session starts =====================================================================================================================================================
platform linux -- Python 3.9.9, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/vicferpoy/wazuh_venvs/ait-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.9', 'Platform': 'Linux-6.0.12-100.fc35.x86_64-x86_64-with-glibc2.34', 'Packages': {'pytest': '5.4.3', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'tavern': '1.0.0', 'html': '3.1.1'}}
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.11.0, tavern-1.0.0, html-3.1.1
collected 4 items                                                                                                                                                                                                                                                                                                            

test_vulnerability_endpoints.tavern.yaml::GET /vulnerability/{agent_id} PASSED                                                                                                                                                                                                                                         [ 25%]
test_vulnerability_endpoints.tavern.yaml::GET /vulnerability/001/last_scan PASSED                                                                                                                                                                                                                                      [ 50%]
test_vulnerability_endpoints.tavern.yaml::GET /vulnerability/{agent_id}/summary/{field} PASSED                                                                                                                                                                                                                         [ 75%]
test_vulnerability_endpoints.tavern.yaml::PUT /vulnerability PASSED                                                                                                                                                                                                                                                    [100%]

========================================================================================================================================= 4 passed, 5 warnings in 439.53s (0:07:19) ==========================================================================================================================================
```

Regards,
Víctor