### PR TITLE
Exclude 1701 and 1707 error codes from PUT syscheck and rootcheck

### DIFF
--- a/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
@@ -103,7 +103,7 @@ test_name: PUT /rootcheck
 
 stages:
 
-  - name: Try to run a rootcheck scan in all agents
+  - name: Run a rootcheck scan in all agents
     request:
       verify: False
       method: PUT
@@ -113,19 +113,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: 2
+        error: 0
         data:
           affected_items: !anything
-          failed_items:
-            - error:
-                code: 1707
-              id:
-                - '009'
-                - '010'
-                - '011'
-                - '012'
+          failed_items: []
           total_affected_items: 5
-          total_failed_items: 4
+          total_failed_items: 0
 
   - name: Try to run a rootcheck scan on a list of agents
     request:

--- a/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
@@ -71,7 +71,7 @@ test_name: PUT /syscheck
 
 stages:
 
-  - name: Try to run a syscheck scan in all agents
+  - name: Run a syscheck scan in all agents
     request:
       verify: False
       method: PUT
@@ -81,19 +81,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: 2
+        error: 0
         data:
           affected_items: !anything
-          failed_items:
-            - error:
-                code: 1707
-              id:
-                - '009'
-                - '010'
-                - '011'
-                - '012'
+          failed_items: []
           total_affected_items: 5
-          total_failed_items: 4
+          total_failed_items: 0
         
   - name: Try to run a syscheck scan on a list of agents
     request:

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -513,7 +513,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: 2
+        error: 0
         data:
           affected_items:
             - "000"
@@ -525,18 +525,60 @@ stages:
             - "006"
             - "007"
             - "008"
+          failed_items: []
+          total_affected_items: 9
+          total_failed_items: 0
+
+  # PUT /rootcheck
+  - name: Try to run a rootcheck scan for non active agents
+    request:
+      verify: False
+      method: PUT
+      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '010,012'
+    response:
+      status_code: 200
+      json:
+        error: 1
+        data:
+          affected_items: []
           failed_items:
             - error:
                 code: 1707
               id:
-                - "009"
                 - "010"
-                - "011"
                 - "012"
-          total_affected_items: 9
-          total_failed_items: 4
-    delay_after: !float "{global_db_delay}"
+          total_affected_items: 0
+          total_failed_items: 2
 
+  # PUT /rootcheck
+  - name: Try to run rootcheck scan for non existing agents
+    request:
+      verify: False
+      method: PUT
+      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '040,050'
+    response:
+      status_code: 200
+      json:
+        error: 1
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1701
+              id:
+                - "040"
+                - "050"
+          total_affected_items: 0
+          total_failed_items: 2
+    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: DELETE /rootcheck/{agent_id}

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -551,6 +551,49 @@ stages:
           total_affected_items: 5
           total_failed_items: 2
 
+  - name: Try to run a syscheck scan for non existing agents
+    request:
+      verify: False
+      method: PUT
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '002,040,050,060'
+    response:
+      status_code: 200
+      json:
+        error: 2
+        data:
+          affected_items:
+            - '002'
+          failed_items:
+            - error:
+                code: 1701
+              id:
+                - '040'
+                - '050'
+                - '060'
+          total_affected_items: 1
+          total_failed_items: 3
+
+  - name: Run a syscheck scan in all agents
+    request:
+      verify: False
+      method: PUT
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: 9
+          total_failed_items: 0
+
 ---
 test_name: GET /syscheck/002
 
@@ -1015,32 +1058,3 @@ stages:
                 - '001'
           total_affected_items: 0
           total_failed_items: 1
----
-test_name: PUT /syscheck
-
-stages:
-
-    # PUT /syscheck
-  - name: Try to run a syscheck scan in all agents
-    request:
-      verify: False
-      method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 2
-        data:
-          affected_items: !anything
-          failed_items:
-            - error:
-                code: 1707
-              id:
-                - '009'
-                - '010'
-                - '011'
-                - '012'
-          total_affected_items: 9
-          total_failed_items: 4

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -12,7 +12,8 @@ from wazuh.core.wdb import WazuhDBConnection
 from wazuh.rbac.decorators import expose_resources
 
 
-@expose_resources(actions=["rootcheck:run"], resources=["agent:id:{agent_list}"])
+@expose_resources(actions=["rootcheck:run"], resources=["agent:id:{agent_list}"],
+                  post_proc_kwargs={'exclude_codes': [1701, 1707]})
 def run(agent_list: list = None) -> AffectedItemsWazuhResult:
     """Run a rootcheck scan in the specified agents.
 

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -16,7 +16,8 @@ from wazuh.core.wdb import WazuhDBConnection
 from wazuh.rbac.decorators import expose_resources
 
 
-@expose_resources(actions=["syscheck:run"], resources=["agent:id:{agent_list}"])
+@expose_resources(actions=["syscheck:run"], resources=["agent:id:{agent_list}"],
+                  post_proc_kwargs={'exclude_codes': [1701, 1707]})
 def run(agent_list: Union[str, None] = None) -> AffectedItemsWazuhResult:
     """Run a syscheck scan in the specified agents.
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #16208 |

## Description

This PR fixes the incorrect behavior reported in #16208 where both `PUT /syscheck` and `PUT /rootcheck` endpoints showed as failed items the non-active agents, in case a list of active agents was not specified.

Now they behave like `PUT /agents/restart` and other similar endpoints. If an agent list is not specified, the scan is run in all active agents without showing any of these error codes:
- **1701:** Agent does not exist
- **1707:** Cannot send request, agent is not active

> `PUT /syscheck` (4/5 active agents)

```JSON
{
  "data": {
    "affected_items": [
      "001",
      "003",
      "004",
      "005"
    ],
    "total_affected_items": 4,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Restart command was sent to all agents",
  "error": 0
}
```

However, if a non-existent or non-active agent ID is included inside `agents_list` parameter, the error is shown:

> `PUT /syscheck?agents_list=001,002,003,004,005`

```JSON
{
  "data": {
    "affected_items": [
      "001",
      "003",
      "004",
      "005"
    ],
    "total_affected_items": 4,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1707,
          "message": "Cannot send request, agent is not active",
          "remediation": "Please, check non-active agents connection and try again. Visit https://documentation.wazuh.com/current/user-manual/registering/index.html and https://documentation.wazuh.com/current/user-manual/agents/agent-connection.html to obtain more information on registering and connecting agents"
        },
        "id": [
          "002"
        ]
      }
    ]
  },
  "message": "Syscheck scan was not restarted on some agents",
  "error": 2
}
```


## Tests
### Unit tests
```
$ PYTHONPATH=/home/selu/Git/wazuh/api:/home/selu/Git/wazuh/framework python3 -m pytest framework/ -x --disable-warnings
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1, aiohttp-1.0.4, cov-4.0.0
asyncio: mode=auto
collected 2101 items                                                                                                                                                                                        

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ..............                                                                                                                                          [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                                                                [  1%]
framework/scripts/tests/test_rbac_control.py .........                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                 [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                                [  7%]
framework/wazuh/core/cluster/tests/test_common.py ....................................................................................                                                                [ 11%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                                             [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............                                                                                                                                [ 12%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                      [ 13%]
framework/wazuh/core/cluster/tests/test_master.py ....................................................                                                                                                [ 15%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                                                                       [ 17%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                          [ 17%]
framework/wazuh/core/cluster/tests/test_worker.py ...................................                                                                                                                 [ 19%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [ 20%]
framework/wazuh/core/tests/test_agent.py ...................................................................................................................................................          [ 27%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 28%]
framework/wazuh/core/tests/test_common.py .........                                                                                                                                                   [ 29%]
framework/wazuh/core/tests/test_configuration.py .......................................................................                                                                              [ 32%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 33%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 34%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 34%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 34%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 34%]
framework/wazuh/core/tests/test_manager.py ................                                                                                                                                           [ 35%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 35%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 36%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 38%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 38%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 39%]
framework/wazuh/core/tests/test_sca.py ........................                                                                                                                                       [ 40%]
framework/wazuh/core/tests/test_security.py .............                                                                                                                                             [ 41%]
framework/wazuh/core/tests/test_stats.py .................                                                                                                                                            [ 42%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 42%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 42%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 43%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 50%]
.........................................................................................                                                                                                             [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                                                [ 58%]
framework/wazuh/core/tests/test_wlogging.py ............                                                                                                                                              [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 58%]
framework/wazuh/rbac/tests/test_decorators.py .........................................................................................................                                               [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py ........................................................                                                                                     [ 66%]
framework/wazuh/rbac/tests/test_orm.py .................................................................                                                                                              [ 69%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 70%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [ 70%]
framework/wazuh/tests/test_agent.py ......................................................................................................................                                            [ 76%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 80%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 81%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 83%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 83%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 85%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 85%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 87%]
framework/wazuh/tests/test_rule.py .......................................................                                                                                                            [ 90%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                         [ 90%]
framework/wazuh/tests/test_security.py .......................................................................                                                                                        [ 94%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                   [ 94%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                     [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................................                                                                                                                  [100%]

=============================================================================== 2101 passed, 49 warnings in 322.77s (0:05:22) ===============================================================================
```

### AIT
#### Syscheck
```
$ pytest test_syscheck_endpoints.tavern.yaml -vv
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.6, pytest-7.2.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.15.0-60-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.2.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '2.0.2', 'metadata': '2.0.4'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, tavern-2.0.2, metadata-2.0.4
collected 34 items                                                                                                                                                                                          

test_syscheck_endpoints.tavern.yaml::GET /syscheck/000 PASSED                                                                                                                                         [  2%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[date] PASSED                                                                                                                                   [  5%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[mtime] PASSED                                                                                                                                  [  8%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[file] PASSED                                                                                                                                   [ 11%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[size] PASSED                                                                                                                                   [ 14%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[perm] PASSED                                                                                                                                   [ 17%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[uname] PASSED                                                                                                                                  [ 20%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[gname] PASSED                                                                                                                                  [ 23%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[md5] PASSED                                                                                                                                    [ 26%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[sha1] PASSED                                                                                                                                   [ 29%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[sha256] PASSED                                                                                                                                 [ 32%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[inode] PASSED                                                                                                                                  [ 35%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[gid] PASSED                                                                                                                                    [ 38%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[uid] PASSED                                                                                                                                    [ 41%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[type] PASSED                                                                                                                                   [ 44%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000/last_scan PASSED                                                                                                                               [ 47%]
test_syscheck_endpoints.tavern.yaml::PUT /syscheck PASSED                                                                                                                                             [ 50%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002 PASSED                                                                                                                                         [ 52%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[date] PASSED                                                                                                                                   [ 55%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[mtime] PASSED                                                                                                                                  [ 58%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[file] PASSED                                                                                                                                   [ 61%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[size] PASSED                                                                                                                                   [ 64%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[perm] PASSED                                                                                                                                   [ 67%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[uname] PASSED                                                                                                                                  [ 70%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[gname] PASSED                                                                                                                                  [ 73%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[md5] PASSED                                                                                                                                    [ 76%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[sha1] PASSED                                                                                                                                   [ 79%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[sha256] PASSED                                                                                                                                 [ 82%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[inode] PASSED                                                                                                                                  [ 85%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[gid] PASSED                                                                                                                                    [ 88%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[uid] PASSED                                                                                                                                    [ 91%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[type] PASSED                                                                                                                                   [ 94%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002/last_scan PASSED                                                                                                                               [ 97%]
test_syscheck_endpoints.tavern.yaml::DELETE /syscheck PASSED                                                                                                                                          [100%]

================================================================================ 34 passed, 2 warnings in 121.29s (0:02:01) =================================================================================

$ pytest test_rbac_white_syscheck_endpoints.tavern.yaml -vv
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.6, pytest-7.2.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.15.0-60-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.2.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '2.0.2', 'metadata': '2.0.4'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, tavern-2.0.2, metadata-2.0.4
collected 4 items                                                                                                                                                                                           

test_rbac_white_syscheck_endpoints.tavern.yaml::GET /syscheck PASSED                                                                                                                                  [ 25%]
test_rbac_white_syscheck_endpoints.tavern.yaml::GET /syscheck/{agent_id}/last_scan PASSED                                                                                                             [ 50%]
test_rbac_white_syscheck_endpoints.tavern.yaml::PUT /syscheck PASSED                                                                                                                                  [ 75%]
test_rbac_white_syscheck_endpoints.tavern.yaml::DELETE /syscheck PASSED                                                                                                                               [100%]

================================================================================= 4 passed, 2 warnings in 102.60s (0:01:42) =================================================================================

$ pytest test_rbac_black_syscheck_endpoints.tavern.yaml -vv
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.6, pytest-7.2.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.15.0-60-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.2.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '2.0.2', 'metadata': '2.0.4'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, tavern-2.0.2, metadata-2.0.4
collected 4 items                                                                                                                                                                                           

test_rbac_black_syscheck_endpoints.tavern.yaml::GET /syscheck PASSED                                                                                                                                  [ 25%]
test_rbac_black_syscheck_endpoints.tavern.yaml::GET /syscheck/{agent_id}/last_scan PASSED                                                                                                             [ 50%]
test_rbac_black_syscheck_endpoints.tavern.yaml::PUT /syscheck PASSED                                                                                                                                  [ 75%]
test_rbac_black_syscheck_endpoints.tavern.yaml::DELETE /syscheck PASSED                                                                                                                               [100%]

================================================================================= 4 passed, 2 warnings in 142.96s (0:02:22) =================================================================================
```

#### Rootcheck
```
$ pytest test_rootcheck_endpoints.tavern.yaml -vv
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.6, pytest-7.2.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.15.0-60-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.2.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '2.0.2', 'metadata': '2.0.4'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, tavern-2.0.2, metadata-2.0.4
collected 4 items                                                                                                                                                                                           

test_rootcheck_endpoints.tavern.yaml::GET /rootcheck/001 PASSED                                                                                                                                       [ 25%]
test_rootcheck_endpoints.tavern.yaml::GET /rootcheck/001/last_scan PASSED                                                                                                                             [ 50%]
test_rootcheck_endpoints.tavern.yaml::PUT /rootcheck PASSED                                                                                                                                           [ 75%]
test_rootcheck_endpoints.tavern.yaml::DELETE /rootcheck/{agent_id} PASSED                                                                                                                             [100%]

================================================================================= 4 passed, 2 warnings in 182.61s (0:03:02) =================================================================================

$ pytest test_rbac_white_rootcheck_endpoints.tavern.yaml -vv
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.6, pytest-7.2.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.15.0-60-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.2.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '2.0.2', 'metadata': '2.0.4'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, tavern-2.0.2, metadata-2.0.4
collected 4 items                                                                                                                                                                                           

test_rbac_white_rootcheck_endpoints.tavern.yaml::GET /rootcheck PASSED                                                                                                                                [ 25%]
test_rbac_white_rootcheck_endpoints.tavern.yaml::GET /rootcheck/{agent_id}/last_scan PASSED                                                                                                           [ 50%]
test_rbac_white_rootcheck_endpoints.tavern.yaml::PUT /rootcheck PASSED                                                                                                                                [ 75%]
test_rbac_white_rootcheck_endpoints.tavern.yaml::DELETE /rootcheck/{agent_id} PASSED                                                                                                                  [100%]

================================================================================= 4 passed, 2 warnings in 101.89s (0:01:41) =================================================================================

$ pytest test_rbac_black_rootcheck_endpoints.tavern.yaml -vv
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.6, pytest-7.2.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.15.0-60-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.2.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '2.0.2', 'metadata': '2.0.4'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, tavern-2.0.2, metadata-2.0.4
collected 4 items                                                                                                                                                                                           

test_rbac_black_rootcheck_endpoints.tavern.yaml::GET /rootcheck PASSED                                                                                                                                [ 25%]
test_rbac_black_rootcheck_endpoints.tavern.yaml::DELETE /rootcheck/{agent_id} PASSED                                                                                                                  [ 50%]
test_rbac_black_rootcheck_endpoints.tavern.yaml::GET /rootcheck/{agent_id}/last_scan PASSED                                                                                                           [ 75%]
test_rbac_black_rootcheck_endpoints.tavern.yaml::PUT /rootcheck PASSED                                                                                                                                [100%]

================================================================================= 4 passed, 2 warnings in 100.21s (0:01:40) =================================================================================
```
