### PR TITLE
Add new command to get active cluster.json configuration

### DIFF
--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -7,6 +7,7 @@
 import argparse
 import asyncio
 import itertools
+import json
 import logging
 import operator
 import sys
@@ -77,6 +78,13 @@ async def print_agents(filter_status: list, filter_node: list):
                'node_name': 'Node name'}
     data = map(operator.itemgetter(*headers.keys()), result['items'])
     __print_table(data, list(headers.values()), True)
+
+
+async def print_cluster_json_conf():
+    """Print internal active cluster configuration (cluster.json) of local node."""
+    lc = local_client.LocalClient()
+    result = await control.get_cluster_json_conf(lc)
+    print(json.dumps(result, indent=4))
 
 
 async def print_nodes(filter_node: list):
@@ -240,6 +248,7 @@ def main():
     exclusive.add_argument('-l', '--list-nodes', action='store_const', const='list_nodes', help='List nodes')
     exclusive.add_argument('-i', '--health', action='store', nargs='?', const='health', help='Show cluster health')
     exclusive.add_argument('-u', '--usage', action='store_true', help='Show usage')
+    exclusive.add_argument('-c', '--cluster-conf', action='store_true', help=argparse.SUPPRESS)
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.ERROR, format='%(levelname)s: %(message)s')
@@ -258,6 +267,8 @@ def main():
             sys.exit(1)
         elif args.list_agents:
             my_function, my_args = print_agents, (args.filter_status, args.filter_node,)
+        elif args.cluster_conf:
+            my_function, my_args = print_cluster_json_conf, ()
         elif args.list_nodes:
             my_function, my_args = print_nodes, (args.filter_node,)
         elif args.health:

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -212,7 +212,7 @@ async def print_health(config: dict, more: bool, filter_node: Union[str, list]):
 def usage():
     """Show the usage of the parameters."""
     msg = """
-    {0} [-h] [-d] [-fn [FILTER_NODE ...]] [-fs [FILTER_STATUS ...]][-a | -l | -i [HEALTH]]
+    {0} [-h] [-d] [-fn [FILTER_NODE ...]] [-fs [FILTER_STATUS ...]][-a | -l | -i [HEALTH] | -rc]
     Usage:
     \t-l                                    # List all nodes present in a cluster
     \t-l -fn <node_name>                    # List certain nodes that belong to the cluster
@@ -222,6 +222,7 @@ def usage():
     \t-a -fn <node_name> <agent_status>     # List agents reporting to certain node and with certain status
     \t-i                                    # Check cluster health
     \t-i -fn <node_name>                    # Check certain node's health
+    \t-rc                                   # Show active internal configuration
 
 
     Params:
@@ -232,6 +233,7 @@ def usage():
     \t-fs, --filter-agent-status
     \t-a, --list-agents
     \t-i, --health
+    \t-rc, --read-config
 
     """.format(path.basename(sys.argv[0]))
     print(msg)
@@ -248,7 +250,7 @@ def main():
     exclusive.add_argument('-l', '--list-nodes', action='store_const', const='list_nodes', help='List nodes')
     exclusive.add_argument('-i', '--health', action='store', nargs='?', const='health', help='Show cluster health')
     exclusive.add_argument('-u', '--usage', action='store_true', help='Show usage')
-    exclusive.add_argument('-c', '--cluster-conf', action='store_true', help=argparse.SUPPRESS)
+    exclusive.add_argument('-rc', '--read-config', action='store_true', help='Show active internal configuration')
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.ERROR, format='%(levelname)s: %(message)s')
@@ -267,7 +269,7 @@ def main():
             sys.exit(1)
         elif args.list_agents:
             my_function, my_args = print_agents, (args.filter_status, args.filter_node,)
-        elif args.cluster_conf:
+        elif args.read_config:
             my_function, my_args = print_cluster_json_conf, ()
         elif args.list_nodes:
             my_function, my_args = print_nodes, (args.filter_node,)

--- a/framework/scripts/tests/test_cluster_control.py
+++ b/framework/scripts/tests/test_cluster_control.py
@@ -57,6 +57,18 @@ async def test_print_agents(local_client_mock, get_agents_mock, print_table_mock
 
 
 @pytest.mark.asyncio
+@patch('builtins.print')
+@patch('scripts.cluster_control.control.get_cluster_json_conf', return_value={'files': {}, 'intervals': {}})
+@patch('scripts.cluster_control.local_client.LocalClient', return_value='LocalClient return value')
+async def test_print_cluster_json_conf(local_client_mock, get_cluster_conf_mock, print_mock):
+    await cluster_control.print_cluster_json_conf()
+
+    local_client_mock.assert_called_once()
+    get_cluster_conf_mock.assert_called_once_with(local_client_mock.return_value)
+    print_mock.assert_called_once_with('{\n    "files": {},\n    "intervals": {}\n}')
+
+
+@pytest.mark.asyncio
 @patch('builtins.map', return_value="")
 @patch('scripts.cluster_control.__print_table')
 @patch('scripts.cluster_control.control.get_nodes', return_value={'items': ''})
@@ -237,6 +249,7 @@ def test_main(get_cluster_status_mock, read_config_mock, check_cluster_config, p
             self.usage = False
             self.debug = False
             self.filter_node = False
+            self.cluster_conf = False
 
     class ExclusiveMock:
         """Auxiliary class."""
@@ -298,22 +311,17 @@ def test_main(get_cluster_status_mock, read_config_mock, check_cluster_config, p
 
         assert exclusive_mock.exclusive == [{'action': 'store_const', 'const': 'list_agents', 'dest': None,
                                              'flag': '-a', 'help': 'List agents', 'name': '--list-agents',
-                                             'nargs': None, 'type': None}, {'action': 'store_const',
-                                                                            'const': 'list_nodes',
-                                                                            'dest': None, 'flag': '-l',
-                                                                            'help': 'List nodes',
-                                                                            'name': '--list-nodes', 'nargs': None,
-                                                                            'type': None}, {'action': 'store',
-                                                                                            'const': 'health',
-                                                                                            'dest': None,
-                                                                                            'flag': '-i',
-                                                                                            'help': 'Show cluster '
-                                                                                                    'health',
-                                                                                            'name': '--health',
-                                                                                            'nargs': '?',
-                                                                                            'type': None},
+                                             'nargs': None, 'type': None},
+                                            {'action': 'store_const', 'const': 'list_nodes', 'dest': None, 'flag': '-l',
+                                             'help': 'List nodes', 'name': '--list-nodes', 'nargs': None, 'type': None},
+                                            {'action': 'store', 'const': 'health', 'dest': None, 'flag': '-i',
+                                             'help': 'Show cluster ' 'health', 'name': '--health', 'nargs': '?',
+                                             'type': None},
                                             {'action': 'store_true', 'const': None, 'dest': None, 'flag': '-u',
-                                             'help': 'Show usage', 'name': '--usage', 'nargs': None, 'type': None}]
+                                             'help': 'Show usage', 'name': '--usage', 'nargs': None, 'type': None},
+                                            {'action': 'store_true', 'const': None, 'dest': None, 'flag': '-c',
+                                             'help': '==SUPPRESS==', 'name': '--cluster-conf', 'nargs': None,
+                                             'type': None}]
 
         # Test the fifth condition
         get_cluster_status_mock.return_value['enabled'] = 'yes'

--- a/framework/scripts/tests/test_cluster_control.py
+++ b/framework/scripts/tests/test_cluster_control.py
@@ -199,7 +199,7 @@ def test_usage(basename_mock, print_mock):
     cluster_control.usage()
 
     msg = """
-    {0} [-h] [-d] [-fn [FILTER_NODE ...]] [-fs [FILTER_STATUS ...]][-a | -l | -i [HEALTH]]
+    {0} [-h] [-d] [-fn [FILTER_NODE ...]] [-fs [FILTER_STATUS ...]][-a | -l | -i [HEALTH] | -rc]
     Usage:
     \t-l                                    # List all nodes present in a cluster
     \t-l -fn <node_name>                    # List certain nodes that belong to the cluster
@@ -209,6 +209,7 @@ def test_usage(basename_mock, print_mock):
     \t-a -fn <node_name> <agent_status>     # List agents reporting to certain node and with certain status
     \t-i                                    # Check cluster health
     \t-i -fn <node_name>                    # Check certain node's health
+    \t-rc                                   # Show active internal configuration
 
 
     Params:
@@ -219,6 +220,7 @@ def test_usage(basename_mock, print_mock):
     \t-fs, --filter-agent-status
     \t-a, --list-agents
     \t-i, --health
+    \t-rc, --read-config
 
     """.format(basename_mock.return_value)
     print_mock.assert_called_once_with(msg)
@@ -249,7 +251,7 @@ def test_main(get_cluster_status_mock, read_config_mock, check_cluster_config, p
             self.usage = False
             self.debug = False
             self.filter_node = False
-            self.cluster_conf = False
+            self.read_config = False
 
     class ExclusiveMock:
         """Auxiliary class."""
@@ -309,19 +311,24 @@ def test_main(get_cluster_status_mock, read_config_mock, check_cluster_config, p
             {'flag': '-fs', 'name': '--filter-agent-status', 'action': None, 'nargs': '*', 'const': None, 'type': str,
              'dest': 'filter_status', 'help': 'Filter by agent status'}]
 
-        assert exclusive_mock.exclusive == [{'action': 'store_const', 'const': 'list_agents', 'dest': None,
-                                             'flag': '-a', 'help': 'List agents', 'name': '--list-agents',
-                                             'nargs': None, 'type': None},
-                                            {'action': 'store_const', 'const': 'list_nodes', 'dest': None, 'flag': '-l',
-                                             'help': 'List nodes', 'name': '--list-nodes', 'nargs': None, 'type': None},
-                                            {'action': 'store', 'const': 'health', 'dest': None, 'flag': '-i',
-                                             'help': 'Show cluster ' 'health', 'name': '--health', 'nargs': '?',
-                                             'type': None},
-                                            {'action': 'store_true', 'const': None, 'dest': None, 'flag': '-u',
-                                             'help': 'Show usage', 'name': '--usage', 'nargs': None, 'type': None},
-                                            {'action': 'store_true', 'const': None, 'dest': None, 'flag': '-c',
-                                             'help': '==SUPPRESS==', 'name': '--cluster-conf', 'nargs': None,
-                                             'type': None}]
+        assert exclusive_mock.exclusive == [
+            {
+                'action': 'store_const', 'const': 'list_agents', 'dest': None, 'flag': '-a', 'help': 'List agents',
+                'name': '--list-agents', 'nargs': None, 'type': None
+            }, {
+                'action': 'store_const', 'const': 'list_nodes', 'dest': None, 'flag': '-l', 'help': 'List nodes',
+                'name': '--list-nodes', 'nargs': None, 'type': None
+            }, {
+                'action': 'store', 'const': 'health', 'dest': None, 'flag': '-i', 'help': 'Show cluster health',
+                'name': '--health', 'nargs': '?', 'type': None
+            }, {
+                'action': 'store_true', 'const': None, 'dest': None, 'flag': '-u', 'help': 'Show usage',
+                'name': '--usage', 'nargs': None, 'type': None
+            }, {
+                'action': 'store_true', 'const': None, 'dest': None, 'flag': '-rc',
+                'help': 'Show active internal configuration', 'name': '--read-config', 'nargs': None, 'type': None
+            }
+        ]
 
         # Test the fifth condition
         get_cluster_status_mock.return_value['enabled'] = 'yes'

--- a/framework/scripts/tests/test_wazuh_clusterd.py
+++ b/framework/scripts/tests/test_wazuh_clusterd.py
@@ -335,41 +335,49 @@ def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock,
 
                             args.test_config = False
                             wazuh_clusterd.args = args
-                            with patch('wazuh.core.cluster.cluster.clean_up') as clean_up_mock:
-                                with patch('scripts.wazuh_clusterd.clean_pid_files') as clean_pid_files_mock:
-                                    with patch.object(wazuh_clusterd.pyDaemonModule, 'pyDaemon') as pyDaemon_mock:
-                                        with patch.object(wazuh_clusterd.pyDaemonModule,
-                                                          'create_pid') as create_pid_mock:
-                                            with patch.object(wazuh_clusterd.pyDaemonModule, 'delete_child_pids'):
-                                                with patch.object(wazuh_clusterd.pyDaemonModule,
-                                                                  'delete_pid') as delete_pid_mock:
-                                                    wazuh_clusterd.main()
-                                                    main_logger_mock.assert_any_call(
-                                                        "Unhandled exception: name 'cluster_items' is not defined")
-                                                    clean_up_mock.assert_called_once()
-                                                    clean_pid_files_mock.assert_called_once_with('wazuh-clusterd')
-                                                    pyDaemon_mock.assert_called_once()
-                                                    setuid_mock.assert_called_once_with('uid_test')
-                                                    setgid_mock.assert_called_once_with('gid_test')
-                                                    getpid_mock.assert_called()
-                                                    create_pid_mock.assert_called_once_with('wazuh-clusterd', 543)
-                                                    delete_pid_mock.assert_called_once_with('wazuh-clusterd', 543)
 
-                                                    args.foreground = True
-                                                    wazuh_clusterd.main()
-                                                    print_mock.assert_called_once_with(
-                                                        'Starting cluster in foreground (pid: 543)')
+                            with patch('wazuh.core.cluster.utils.get_cluster_items', side_effect=IndexError):
+                                with pytest.raises(SystemExit):
+                                    wazuh_clusterd.main()
+                                main_logger_mock.assert_called_once()
+                                exit_mock.assert_called_once_with(1)
+                                main_logger_mock.reset_mock()
+                                exit_mock.reset_mock()
 
-                                                    wazuh_clusterd.cluster_items = {}
-                                                    with patch('scripts.wazuh_clusterd.master_main',
-                                                               side_effect=KeyboardInterrupt('TESTING')):
+                            with patch('wazuh.core.cluster.utils.get_cluster_items', return_value={'files': {}}):
+                                with patch('wazuh.core.cluster.cluster.clean_up') as clean_up_mock:
+                                    with patch('scripts.wazuh_clusterd.clean_pid_files') as clean_pid_files_mock:
+                                        with patch.object(wazuh_clusterd.pyDaemonModule, 'pyDaemon') as pyDaemon_mock:
+                                            with patch.object(wazuh_clusterd.pyDaemonModule,
+                                                              'create_pid') as create_pid_mock:
+                                                with patch.object(wazuh_clusterd.pyDaemonModule, 'delete_child_pids'):
+                                                    with patch.object(wazuh_clusterd.pyDaemonModule,
+                                                                      'delete_pid') as delete_pid_mock:
                                                         wazuh_clusterd.main()
-                                                        main_logger_info_mock.assert_any_call(
-                                                            'SIGINT received. Bye!')
+                                                        clean_up_mock.assert_called_once()
+                                                        clean_pid_files_mock.assert_called_once_with('wazuh-clusterd')
+                                                        pyDaemon_mock.assert_called_once()
+                                                        setuid_mock.assert_called_once_with('uid_test')
+                                                        setgid_mock.assert_called_once_with('gid_test')
+                                                        getpid_mock.assert_called()
+                                                        create_pid_mock.assert_called_once_with('wazuh-clusterd', 543)
+                                                        delete_pid_mock.assert_called_once_with('wazuh-clusterd', 543)
 
-                                                    with patch('scripts.wazuh_clusterd.master_main',
-                                                               side_effect=MemoryError('TESTING')):
+                                                        args.foreground = True
                                                         wazuh_clusterd.main()
-                                                        main_logger_mock.assert_any_call(
-                                                            "Directory '/tmp' needs read, write & execution "
-                                                            "permission for 'wazuh' user")
+                                                        print_mock.assert_called_once_with(
+                                                            'Starting cluster in foreground (pid: 543)')
+
+                                                        wazuh_clusterd.cluster_items = {}
+                                                        with patch('scripts.wazuh_clusterd.master_main',
+                                                                   side_effect=KeyboardInterrupt('TESTING')):
+                                                            wazuh_clusterd.main()
+                                                            main_logger_info_mock.assert_any_call(
+                                                                'SIGINT received. Bye!')
+
+                                                        with patch('scripts.wazuh_clusterd.master_main',
+                                                                   side_effect=MemoryError('TESTING')):
+                                                            wazuh_clusterd.main()
+                                                            main_logger_mock.assert_any_call(
+                                                                "Directory '/tmp' needs read, write & execution "
+                                                                "permission for 'wazuh' user")

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -11,6 +11,8 @@ import os
 import signal
 import sys
 
+import wazuh.core.cluster.utils as cluster_utils
+from wazuh.core import pyDaemonModule, common, configuration
 from wazuh.core.utils import clean_pid_files
 from wazuh.core.wlogging import WazuhLogger
 
@@ -214,6 +216,13 @@ def main():
     if args.test_config:
         sys.exit(0)
 
+    try:
+        cluster_items = cluster_utils.get_cluster_items()
+        main_logger.info(f'Active configuration: {cluster_items}')
+    except Exception as e:
+        main_logger.error(e)
+        sys.exit(1)
+
     # Clean cluster files from previous executions
     wazuh.core.cluster.cluster.clean_up()
 
@@ -250,10 +259,6 @@ def main():
 
 
 if __name__ == '__main__':
-    import wazuh.core.cluster.utils as cluster_utils
-    from wazuh.core import pyDaemonModule, common, configuration
-
-    cluster_items = cluster_utils.get_cluster_items()
     original_sig_handler = signal.signal(signal.SIGTERM, exit_handler)
 
     args = get_script_arguments().parse_args()

--- a/framework/wazuh/core/cluster/control.py
+++ b/framework/wazuh/core/cluster/control.py
@@ -203,7 +203,7 @@ async def get_node_ruleset_integrity(lc: local_client.LocalClient) -> dict:
     Returns
     -------
     dict
-        Dictionary with results
+        Dictionary with results.
     """
     return await get_cluster_data(lc, 'get_hash')
 
@@ -219,6 +219,6 @@ async def get_cluster_json_conf(lc: local_client.LocalClient) -> dict:
     Returns
     -------
     dict
-        Dictionary with results
+        Dictionary with results.
     """
     return await get_cluster_data(lc, 'get_cl_conf')

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -60,6 +60,8 @@ class LocalServerHandler(server.AbstractServerHandler):
         """
         if command == b'get_config':
             return self.get_config()
+        elif command == b'get_cl_conf':
+            return self.get_cluster_config()
         elif command == b'get_nodes':
             return self.get_nodes(data)
         elif command == b'get_health':
@@ -73,7 +75,7 @@ class LocalServerHandler(server.AbstractServerHandler):
             return super().process_request(command, data)
 
     def get_config(self) -> Tuple[bytes, bytes]:
-        """Get active cluster configuration.
+        """Get active cluster configuration contained in the 'ossec.conf' file.
 
         Returns
         -------
@@ -83,6 +85,18 @@ class LocalServerHandler(server.AbstractServerHandler):
             JSON-like configuration.
         """
         return b'ok', json.dumps(self.server.configuration).encode()
+
+    def get_cluster_config(self):
+        """Get active cluster configuration contained inside 'cluster.json' file.
+
+        Returns
+        -------
+        bytes
+            Result.
+        bytes
+            JSON-like configuration.
+        """
+        return b'ok', json.dumps(self.cluster_items).encode()
 
     def get_node(self):
         """Get basic information about the node.

--- a/framework/wazuh/core/cluster/tests/test_control.py
+++ b/framework/wazuh/core/cluster/tests/test_control.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call, ANY
 
 import pytest
 
@@ -15,112 +15,89 @@ with patch('wazuh.common.getgrnam'):
                 from wazuh.core.cluster import control
                 from wazuh.core.cluster.local_client import LocalClient
                 from wazuh import WazuhInternalError, WazuhError
-
-
-async def async_local_client(command, data):
-    return None
+                from wazuh.core.cluster.common import WazuhJSONEncoder
 
 
 @pytest.mark.asyncio
-async def test_get_nodes():
+async def test_get_cluster_data():
+    """Verify that LocalClient.execute is called with expected params and exceptions are correctly raised."""
+    async def async_local_client(command, data):
+        return None
+
+    local_client = LocalClient()
+    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client) as mock_execute:
+        expected_result = {'test': 'value'}
+        with patch('json.loads', return_value=expected_result):
+            assert expected_result == await control.get_cluster_data(local_client, command='get_test')
+            mock_execute.assert_called_once_with(command=b'get_test', data=b'')
+
+        with patch('wazuh.core.cluster.local_client.LocalClient.execute',
+                   side_effect=[WazuhClusterError(3020), json.dumps(WazuhError(1000), cls=WazuhJSONEncoder)]):
+            with pytest.raises(WazuhClusterError):
+                await control.get_cluster_data(lc=local_client, command='get_test', data='test_data')
+
+            with pytest.raises(WazuhError):
+                await control.get_cluster_data(lc=local_client, command='get_test', data='test_data')
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.cluster.control.get_cluster_data', return_value={'items': [{'name': 'master'}, {'name': 'worker1'}]})
+async def test_get_nodes(get_cluster_data_mock):
     """Verify that get_nodes function returns the cluster nodes list."""
     local_client = LocalClient()
-    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client):
-        expected_result = {'items': [{'name': 'master'}, {'name': 'worker1'}], 'totalItems': 2}
-        with patch('json.loads', return_value=expected_result):
-            result = await control.get_nodes(lc=local_client)
-            assert result == expected_result
+    result = await control.get_nodes(lc=local_client)
+    assert result == {'items': [{'name': 'master'}, {'name': 'worker1'}]}
 
-            result_q = await control.get_nodes(lc=local_client, q='name=master')
-            assert result_q == {'items': [{'name': 'master'}], 'totalItems': 1}
-
-        with patch('json.loads', return_value=KeyError(1)):
-            with pytest.raises(KeyError):
-                await control.get_nodes(lc=local_client)
-
-    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=[WazuhClusterError(3020), 'error']):
-        with pytest.raises(WazuhClusterError):
-            await control.get_nodes(lc=local_client)
-
-        with pytest.raises(json.JSONDecodeError):
-            await control.get_nodes(lc=local_client)
+    result_q = await control.get_nodes(lc=local_client, q='name=master')
+    assert result_q == {'items': [{'name': 'master'}], 'totalItems': 1}
+    get_cluster_data_mock.assert_has_calls(
+        [call(local_client, 'get_nodes', '{"filter_node": null, "offset": 0, "limit": 500, "sort": null, '
+                                         '"search": null, "select": null, "filter_type": "all"}')]*2)
 
 
 @pytest.mark.asyncio
-async def test_get_node():
+@pytest.mark.parametrize('get_cluster_data_response, expected_response', [
+    ({'items': [{'name': 'master'}, {'name': 'worker1'}]}, {'name': 'master'}),
+    ({'items': []}, {}),
+])
+@patch('wazuh.core.cluster.control.get_cluster_data')
+async def test_get_node(get_cluster_data_mock, get_cluster_data_response, expected_response):
     """Verify that get_node function returns the current node name."""
     local_client = LocalClient()
-    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client):
-        expected_result = [{'items': [{'name': 'master'}]}, {'items': []}]
-        for expected in expected_result:
-            with patch('json.loads', return_value=expected):
-                result = await control.get_node(lc=local_client)
-                if len(expected['items']) > 0:
-                    assert result == expected['items'][0]
-                else:
-                    assert result == {}
-
-        with patch('json.loads', return_value=KeyError(1)):
-            with pytest.raises(KeyError):
-                await control.get_node(lc=local_client)
-
-    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=[WazuhClusterError(3020), 'error']):
-        with pytest.raises(WazuhClusterError):
-            await control.get_node(lc=local_client)
-
-        with pytest.raises(json.JSONDecodeError):
-            await control.get_node(lc=local_client)
+    get_cluster_data_mock.return_value = get_cluster_data_response
+    result = await control.get_node(lc=local_client, filter_node='master', select='test')
+    assert result == expected_response
+    get_cluster_data_mock.assert_called_once_with(local_client, 'get_nodes',
+                                                  '{"filter_node": "master", "offset": 0, "limit": 500, "sort": null, '
+                                                  '"search": null, "select": "test", "filter_type": "all"}')
 
 
 @pytest.mark.asyncio
-async def test_get_health():
-    """Verify that get_health function returns the current node health."""
+@patch('wazuh.core.cluster.control.get_cluster_data')
+async def test_get_health(get_cluster_data_mock):
+    """Verify that get_health function calls 'get_cluster_data' with expected params."""
     local_client = LocalClient()
-    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client):
-        expected_result = [{'items': [{'name': 'master'}]}, {'items': []}]
-        for expected in expected_result:
-            with patch('json.loads', return_value=expected):
-                result = await control.get_health(lc=local_client)
-                assert result == expected
-
-        with patch('json.loads', return_value=KeyError(1)):
-            with pytest.raises(KeyError):
-                await control.get_health(lc=local_client)
-
-    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=[WazuhClusterError(3020), 'error']):
-        with pytest.raises(WazuhClusterError):
-            await control.get_health(lc=local_client)
-
-        with pytest.raises(json.JSONDecodeError):
-            await control.get_health(lc=local_client)
+    await control.get_health(lc=local_client, filter_node=['test1', 'test2'])
+    get_cluster_data_mock.assert_called_once_with(local_client,  'get_health', '["test1", "test2"]')
 
 
 @pytest.mark.asyncio
-async def test_get_agents():
+@patch('wazuh.core.cluster.control.get_cluster_data', return_value={'items': [{'name': 'master', 'id': '001'}]})
+async def test_get_agents(get_cluster_data_mock):
     """Verify that get_agents function returns the health of the agents connected through the current node."""
     local_client = LocalClient()
-    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client):
-        expected_result = [{'items': [{'name': 'master'}]}, {'items': []}]
-        for expected in expected_result:
-            with patch('json.loads', return_value=expected):
-                result = await control.get_agents(lc=local_client)
-                assert result == expected
-
-        with patch('json.loads', return_value=KeyError(1)):
-            with pytest.raises(KeyError):
-                await control.get_agents(lc=local_client)
-
-    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=[WazuhClusterError(3020), 'error']):
-        with pytest.raises(WazuhClusterError):
-            await control.get_agents(lc=local_client)
-
-        with pytest.raises(json.JSONDecodeError):
-            await control.get_agents(lc=local_client)
+    result = await control.get_agents(lc=local_client, filter_status=['active'])
+    assert result == {'items': [{'name': 'master', 'id': '001', 'status': 'unknown', 'node_name': 'unknown',
+                                 'version': 'unknown', 'ip': 'unknown'}]}
+    get_cluster_data_mock.assert_called_once_with(local_client, 'dapi', ANY)
 
 
 @pytest.mark.asyncio
 async def test_get_system_nodes():
     """Verify that get_system_nodes function returns the name of all cluster nodes."""
+    async def async_local_client(command, data):
+        return None
+
     with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client):
         expected_result = [{'items': [{'name': 'master'}]}]
         for expected in expected_result:
@@ -141,21 +118,18 @@ async def test_get_system_nodes():
 
 
 @pytest.mark.asyncio
-async def test_get_node_ruleset_integrity():
-    """Verify that get_node_ruleset_integrity function uses the expected command."""
+@patch('wazuh.core.cluster.control.get_cluster_data')
+async def test_get_node_ruleset_integrity(get_cluster_data_mock):
+    """Verify that get_node_ruleset_integrity function calls 'get_cluster_data' with expected params."""
     local_client = LocalClient()
-    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client) as execute_mock:
-        with patch('json.loads'):
-            await control.get_node_ruleset_integrity(lc=local_client)
-        execute_mock.assert_called_once_with(command=b'get_hash', data=b'')
+    await control.get_node_ruleset_integrity(lc=local_client)
+    get_cluster_data_mock.assert_called_once_with(local_client,  'get_hash')
 
-        with patch('json.loads', return_value=KeyError(1)):
-            with pytest.raises(KeyError):
-                await control.get_node_ruleset_integrity(lc=local_client)
 
-    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=[WazuhClusterError(3020), 'error']):
-        with pytest.raises(WazuhClusterError):
-            await control.get_node_ruleset_integrity(lc=local_client)
-
-        with pytest.raises(json.JSONDecodeError):
-            await control.get_health(lc=local_client)
+@pytest.mark.asyncio
+@patch('wazuh.core.cluster.control.get_cluster_data')
+async def test_get_cluster_json_conf(get_cluster_data_mock):
+    """Verify that get_cluster_json_conf function calls 'get_cluster_data' with expected params."""
+    local_client = LocalClient()
+    await control.get_cluster_json_conf(lc=local_client)
+    get_cluster_data_mock.assert_called_once_with(local_client,  'get_cl_conf')

--- a/framework/wazuh/core/cluster/tests/test_local_server.py
+++ b/framework/wazuh/core/cluster/tests/test_local_server.py
@@ -58,6 +58,10 @@ def test_LocalServerHandler_process_request(process_request_mock):
         lsh.process_request(command=b"get_config", data=b"test")
         get_config_mock.assert_called_once()
 
+    with patch.object(lsh, "get_cluster_config") as get_cl_config_mock:
+        lsh.process_request(command=b"get_cl_conf", data=b"test")
+        get_cl_config_mock.assert_called_once()
+
     with patch.object(lsh, "get_nodes") as get_nodes_mock:
         lsh.process_request(command=b"get_nodes", data=b"test")
         get_nodes_mock.assert_called_once()
@@ -83,6 +87,13 @@ def test_LocalServerHandler_get_config():
 
     lsh = LocalServerHandler(server=ServerMock(), loop=loop, fernet_key=None, cluster_items={})
     assert lsh.get_config() == (b"ok", b'{"test": "get_config"}')
+
+
+def test_LocalServerHandler_get_cluster_config():
+    """Set the behavior of the get_cluster_config function."""
+    lsh = LocalServerHandler(server=MagicMock(), loop=loop, fernet_key=None,
+                             cluster_items={'files': {}, 'intervals': {}})
+    assert lsh.get_cluster_config() == (b'ok', b'{"files": {}, "intervals": {}}')
 
 
 def test_LocalServerHandler_get_node():


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14983 |

## Description

This PR adds a new cluster command, `get_cl_conf`, to obtain the active `cluster.json` configuration of the node where it is run. As this file is not intended to be modified by users, no API endpoint is required. A CLI option (`-rc`, `--read-config`) has been added to `/var/ossec/bin/cluster_control` instead:
```
# /var/ossec/bin/cluster_control   
usage: cluster_control.py [-h] [-d] [-fn [FILTER_NODE ...]] [-fs [FILTER_STATUS ...]] [-a | -l | -i [HEALTH] | -u | -rc]

optional arguments:
  -h, --help            show this help message and exit
  -d, --debug           Enable debug mode
  -fn [FILTER_NODE ...], --filter-node [FILTER_NODE ...]
                        Filter by node name
  -fs [FILTER_STATUS ...], --filter-agent-status [FILTER_STATUS ...]
                        Filter by agent status
  -a, --list-agents     List agents
  -l, --list-nodes      List nodes
  -i [HEALTH], --health [HEALTH]
                        Show cluster health
  -u, --usage           Show usage
  -rc, --read-config    Show active internal configuration
```

## Logs/Alerts example

```JSON
root@wazuh-master:/# /var/ossec/bin/cluster_control -rc 
{
    "files": {
        "etc/": {
            "permissions": 416,
            "source": "master",
            "files": [
                "client.keys"
            ],
            "recursive": false,
            "restart": false,
            "remove_subdirs_if_empty": false,
            "extra_valid": false,
            "description": "client keys file database"
        },
        "etc/shared/": {
            "permissions": 432,
            "source": "master",
            "files": [
                "all"
            ],
            "recursive": true,
            "restart": false,
            "remove_subdirs_if_empty": true,
            "extra_valid": false,
            "description": "shared configuration files"
        },
        "var/multigroups/": {
            "permissions": 432,
            "source": "master",
            "files": [
                "merged.mg"
            ],
            "recursive": true,
            "restart": false,
            "remove_subdirs_if_empty": true,
            "extra_valid": false,
            "description": "shared configuration files"
        },
        "etc/rules/": {
            "permissions": 432,
            "source": "master",
            "files": [
                "all"
            ],
            "recursive": true,
            "restart": true,
            "remove_subdirs_if_empty": false,
            "extra_valid": false,
            "description": "user rules"
        },
        "etc/decoders/": {
            "permissions": 432,
            "source": "master",
            "files": [
                "all"
            ],
            "recursive": true,
            "restart": true,
            "remove_subdirs_if_empty": false,
            "extra_valid": false,
            "description": "user decoders"
        },
        "etc/lists/": {
            "permissions": 432,
            "source": "master",
            "files": [
                "all"
            ],
            "recursive": true,
            "restart": true,
            "remove_subdirs_if_empty": false,
            "extra_valid": false,
            "description": "user CDB lists"
        },
        "excluded_files": [
            "ar.conf",
            "ossec.conf"
        ],
        "excluded_extensions": [
            "~",
            ".tmp",
            ".lock",
            ".swp"
        ]
    },
    "intervals": {
        "worker": {
            "sync_integrity": 9,
            "sync_agent_info": 10,
            "sync_agent_groups": 30,
            "timeout_agent_groups": 40,
            "keep_alive": 60,
            "connection_retry": 10,
            "max_failed_keepalive_attempts": 2,
            "agent_groups_mismatch_limit": 10
        },
        "master": {
            "process_pool_size": 2,
            "sync_agent_groups": 10,
            "timeout_extra_valid": 40,
            "recalculate_integrity": 8,
            "timeout_agent_info": 40,
            "agent_group_start_delay": 30,
            "check_worker_lastkeepalive": 60,
            "max_allowed_time_without_keepalive": 120,
            "max_locked_integrity_time": 1000
        },
        "communication": {
            "timeout_cluster_request": 20,
            "timeout_dapi_request": 200,
            "timeout_receiving_file": 120,
            "max_zip_size": 1073741824,
            "min_zip_size": 31457280,
            "compress_level": 1,
            "zip_limit_tolerance": 0.2
        }
    },
    "distributed_api": {
        "enabled": true
    }
}
```

In addition, the config is now logged to the `cluster.log` file every time the cluster process is started:
```
2023/03/15 09:26:24 INFO: [Cluster] [Main] Active configuration: {'files': {'etc/': {'permissions': 416, 'source': 'master', 'files': ['client.keys'], 'recursive': False, 'restart': False, 'remove_subdirs_if_empty': False, 'extra_valid': False, 'description': 'client keys file database'}, 'etc/shared/': {'permissions': 432, 'source': 'master', 'files': ['all'], 'recursive': True, 'restart': False, 'remove_subdirs_if_empty': True, 'extra_valid': False, 'description': 'shared configuration files'}, 'var/multigroups/': {'permissions': 432, 'source': 'master', 'files': ['merged.mg'], 'recursive': True, 'restart': False, 'remove_subdirs_if_empty': True, 'extra_valid': False, 'description': 'shared configuration files'}, 'etc/rules/': {'permissions': 432, 'source': 'master', 'files': ['all'], 'recursive': True, 'restart': True, 'remove_subdirs_if_empty': False, 'extra_valid': False, 'description': 'user rules'}, 'etc/decoders/': {'permissions': 432, 'source': 'master', 'files': ['all'], 'recursive': True, 'restart': True, 'remove_subdirs_if_empty': False, 'extra_valid': False, 'description': 'user decoders'}, 'etc/lists/': {'permissions': 432, 'source': 'master', 'files': ['all'], 'recursive': True, 'restart': True, 'remove_subdirs_if_empty': False, 'extra_valid': False, 'description': 'user CDB lists'}, 'excluded_files': ['ar.conf', 'ossec.conf'], 'excluded_extensions': ['~', '.tmp', '.lock', '.swp']}, 'intervals': {'worker': {'sync_integrity': 9, 'sync_agent_info': 10, 'sync_agent_groups': 30, 'timeout_agent_groups': 40, 'keep_alive': 60, 'connection_retry': 10, 'max_failed_keepalive_attempts': 2, 'agent_groups_mismatch_limit': 10}, 'master': {'process_pool_size': 2, 'sync_agent_groups': 10, 'timeout_extra_valid': 40, 'recalculate_integrity': 8, 'timeout_agent_info': 40, 'agent_group_start_delay': 30, 'check_worker_lastkeepalive': 60, 'max_allowed_time_without_keepalive': 120, 'max_locked_integrity_time': 1000}, 'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200, 'timeout_receiving_file': 120, 'max_zip_size': 1073741824, 'min_zip_size': 31457280, 'compress_level': 1, 'zip_limit_tolerance': 0.2}}, 'distributed_api': {'enabled': True}}
2023/03/15 09:26:24 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2023/03/15 09:26:24 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
```

## Tests

```
$ PYTHONPATH=/home/selu/Git/wazuh/api:/home/selu/Git/wazuh/framework python3 -m pytest framework -x --disable-warnings
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1, aiohttp-1.0.4, cov-4.0.0
asyncio: mode=auto
collected 2099 items                                                                                                                                                                                        

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ..............                                                                                                                                          [  1%]
framework/scripts/tests/test_cluster_control.py .......                                                                                                                                               [  1%]
framework/scripts/tests/test_rbac_control.py .........                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                 [  5%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                                [  7%]
framework/wazuh/core/cluster/tests/test_common.py ..................................................................................                                                                  [ 11%]
framework/wazuh/core/cluster/tests/test_control.py .........                                                                                                                                          [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............                                                                                                                                [ 12%]
framework/wazuh/core/cluster/tests/test_local_server.py .........................                                                                                                                     [ 13%]
framework/wazuh/core/cluster/tests/test_master.py ................................................                                                                                                    [ 15%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                                                                       [ 17%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                          [ 17%]
framework/wazuh/core/cluster/tests/test_worker.py ..................................                                                                                                                  [ 19%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [ 20%]
framework/wazuh/core/tests/test_agent.py ...................................................................................................................................................          [ 27%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 28%]
framework/wazuh/core/tests/test_common.py .........                                                                                                                                                   [ 29%]
framework/wazuh/core/tests/test_configuration.py .......................................................................                                                                              [ 32%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 33%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 34%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 34%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 34%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 34%]
framework/wazuh/core/tests/test_manager.py ................                                                                                                                                           [ 35%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 35%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 36%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 38%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 38%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 39%]
framework/wazuh/core/tests/test_sca.py ........................                                                                                                                                       [ 40%]
framework/wazuh/core/tests/test_security.py .............                                                                                                                                             [ 41%]
framework/wazuh/core/tests/test_stats.py .................                                                                                                                                            [ 42%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 42%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 42%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 43%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 50%]
......................................................................................                                                                                                                [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                                                [ 58%]
framework/wazuh/core/tests/test_wlogging.py ............                                                                                                                                              [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 58%]
framework/wazuh/rbac/tests/test_decorators.py .............................................................................................................                                           [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py ........................................................                                                                                     [ 66%]
framework/wazuh/rbac/tests/test_orm.py .................................................................                                                                                              [ 69%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 70%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [ 70%]
framework/wazuh/tests/test_agent.py ......................................................................................................................                                            [ 76%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 80%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 81%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 83%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 83%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 85%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 85%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 87%]
framework/wazuh/tests/test_rule.py .......................................................                                                                                                            [ 90%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                         [ 90%]
framework/wazuh/tests/test_security.py .......................................................................                                                                                        [ 94%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                   [ 94%]
framework/wazuh/tests/test_syscheck.py .........................                                                                                                                                      [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................................                                                                                                                  [100%]

=============================================================================== 2099 passed, 45 warnings in 302.12s (0:05:02) ===============================================================================
```