### PR TITLE
Fix agent starts with an invalid fim configuration

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -397,13 +397,13 @@ int main_analysisd(int argc, char **argv)
     /* Initialize Active response */
     AR_Init();
     if (AR_ReadConfig(cfg) < 0) {
-        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
+        merror_exit(CONFIG_ERROR, cfg);
     }
     mdebug1(ASINIT);
 
     /* Read configuration file */
     if (GlobalConf(cfg) < 0) {
-        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
+        merror_exit(CONFIG_ERROR, cfg);
     }
 
     mdebug1(READ_CONFIG);

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -397,13 +397,13 @@ int main_analysisd(int argc, char **argv)
     /* Initialize Active response */
     AR_Init();
     if (AR_ReadConfig(cfg) < 0) {
-        merror_exit(CONFIG_ERROR, cfg);
+        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
     }
     mdebug1(ASINIT);
 
     /* Read configuration file */
     if (GlobalConf(cfg) < 0) {
-        merror_exit(CONFIG_ERROR, cfg);
+        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
     }
 
     mdebug1(READ_CONFIG);

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -142,22 +142,22 @@ int main(int argc, char **argv)
 
     /* Read config */
     if (ClientConf(cfg) < 0) {
-        merror_exit(CLIENT_ERROR);
+        mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 
     if (!(agt->server && agt->server[0].rip)) {
         merror(AG_INV_IP);
-        merror_exit(CLIENT_ERROR);
+        mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 
     if (!Validate_Address(agt->server)){
         merror(AG_INV_MNGIP, agt->server[0].rip);
-        merror_exit(CLIENT_ERROR);
+        mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 
     if (!Validate_IPv6_Link_Local_Interface(agt->server)){
         merror(AG_INV_INT);
-        merror_exit(CLIENT_ERROR);
+        mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 
     if (agt->notify_time == 0) {

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -329,7 +329,7 @@ int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2)
             /* Main element does not need to have any child */
             if (chld_node) {
                 if (read_main_elements(&xml, modules, chld_node, d1, d2) < 0) {
-                    merror(CONFIG_ERROR, cfgfile);
+                    PrintErrorAcordingToModules(modules, cfgfile);
                     OS_ClearNode(chld_node);
                     OS_ClearNode(node);
                     OS_ClearXML(&xml);
@@ -463,4 +463,36 @@ int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2)
     OS_ClearNode(node);
     OS_ClearXML(&xml);
     return (0);
+}
+
+#define BITMASK(modules)   (\
+                            (modules & CGLOBAL       ) | (modules & CRULES        ) | (modules & CSYSCHECK     )|\
+                            (modules & CROOTCHECK    ) | (modules & CALERTS       ) | (modules & CLOCALFILE    )|\
+                            (modules & CREMOTE       ) | (modules & CCLIENT       ) | (modules & CMAIL         )|\
+                            (modules & CAR           ) | (modules & CDBD          ) | (modules & CSYSLOGD      )|\
+                            (modules & CAGENT_CONFIG ) | (modules & CAGENTLESS    ) | (modules & CREPORTS      )|\
+                            (modules & CINTEGRATORD  ) | (modules & CWMODULE      ) | (modules & CLABELS       )|\
+                            (modules & CAUTHD        ) | (modules & CBUFFER       ) | (modules & CCLUSTER      )|\
+                            (modules & CSOCKET       ) | (modules & CLOGTEST      ) | (modules & WAZUHDB       ) )
+
+void PrintErrorAcordingToModules(int modules, const char *cfgfile) {
+
+    switch (BITMASK(modules)) {
+        case CSYSCHECK:
+            mwarn(CONFIG_ERROR, cfgfile);
+            break;
+        case CCLIENT:
+            merror(CONFIG_ERROR, cfgfile);
+            break;
+        case CROOTCHECK:
+            mwarn(CONFIG_ERROR, cfgfile);
+            break;
+        case CWMODULE:
+            /*syscollector*/
+            merror(CONFIG_ERROR, cfgfile);
+            break;
+        default:
+            merror("modules: %09o default\n", modules);
+            break;
+    }
 }

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -329,7 +329,7 @@ int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2)
             /* Main element does not need to have any child */
             if (chld_node) {
                 if (read_main_elements(&xml, modules, chld_node, d1, d2) < 0) {
-                    merror(CONFIG_ERROR, cfgfile);
+                    mwarn(CONFIG_ERROR, cfgfile);
                     OS_ClearNode(chld_node);
                     OS_ClearNode(node);
                     OS_ClearXML(&xml);

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -329,7 +329,7 @@ int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2)
             /* Main element does not need to have any child */
             if (chld_node) {
                 if (read_main_elements(&xml, modules, chld_node, d1, d2) < 0) {
-                    mwarn(CONFIG_ERROR, cfgfile);
+                    merror(CONFIG_ERROR, cfgfile);
                     OS_ClearNode(chld_node);
                     OS_ClearNode(node);
                     OS_ClearXML(&xml);

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -485,7 +485,6 @@ void PrintErrorAcordingToModules(int modules, const char *cfgfile) {
             merror(CONFIG_ERROR, cfgfile);
             break;
         default:
-            merror("Configuration error at module: %09o default\n", modules); /*delete*/
             break;
     }
 }

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -465,16 +465,6 @@ int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2)
     return (0);
 }
 
-#define BITMASK(modules)   (\
-                            (modules & CGLOBAL       ) | (modules & CRULES        ) | (modules & CSYSCHECK     )|\
-                            (modules & CROOTCHECK    ) | (modules & CALERTS       ) | (modules & CLOCALFILE    )|\
-                            (modules & CREMOTE       ) | (modules & CCLIENT       ) | (modules & CMAIL         )|\
-                            (modules & CAR           ) | (modules & CDBD          ) | (modules & CSYSLOGD      )|\
-                            (modules & CAGENT_CONFIG ) | (modules & CAGENTLESS    ) | (modules & CREPORTS      )|\
-                            (modules & CINTEGRATORD  ) | (modules & CWMODULE      ) | (modules & CLABELS       )|\
-                            (modules & CAUTHD        ) | (modules & CBUFFER       ) | (modules & CCLUSTER      )|\
-                            (modules & CSOCKET       ) | (modules & CLOGTEST      ) | (modules & WAZUHDB       ) )
-
 void PrintErrorAcordingToModules(int modules, const char *cfgfile) {
 
     switch (BITMASK(modules)) {
@@ -491,8 +481,11 @@ void PrintErrorAcordingToModules(int modules, const char *cfgfile) {
             /*syscollector*/
             merror(CONFIG_ERROR, cfgfile);
             break;
+        case CBUFFER|CLABELS:
+            merror(CONFIG_ERROR, cfgfile);
+            break;
         default:
-            merror("modules: %09o default\n", modules);
+            merror("Configuration error at module: %09o default\n", modules); /*delete*/
             break;
     }
 }

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -470,7 +470,6 @@ void PrintErrorAcordingToModules(int modules, const char *cfgfile) {
     switch (BITMASK(modules)) {
         case CSYSCHECK:
         case CROOTCHECK:
-        case CWMODULE:
             mwarn(CONFIG_ERROR, cfgfile);
             break;
         default:

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -470,6 +470,7 @@ void PrintErrorAcordingToModules(int modules, const char *cfgfile) {
     switch (BITMASK(modules)) {
         case CSYSCHECK:
         case CROOTCHECK:
+        case CWMODULE:
             mwarn(CONFIG_ERROR, cfgfile);
             break;
         default:

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -469,22 +469,11 @@ void PrintErrorAcordingToModules(int modules, const char *cfgfile) {
 
     switch (BITMASK(modules)) {
         case CSYSCHECK:
-            mwarn(CONFIG_ERROR, cfgfile);
-            break;
-        case CCLIENT:
-            merror(CONFIG_ERROR, cfgfile);
-            break;
         case CROOTCHECK:
             mwarn(CONFIG_ERROR, cfgfile);
             break;
-        case CWMODULE:
-            /*syscollector*/
-            merror(CONFIG_ERROR, cfgfile);
-            break;
-        case CBUFFER|CLABELS:
-            merror(CONFIG_ERROR, cfgfile);
-            break;
         default:
+            merror(CONFIG_ERROR, cfgfile);
             break;
     }
 }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -38,6 +38,16 @@
 
 #define MAX_NEEDED_TAGS 4
 
+#define BITMASK(modules)   (\
+                            (modules & CGLOBAL       ) | (modules & CRULES        ) | (modules & CSYSCHECK     ) |\
+                            (modules & CROOTCHECK    ) | (modules & CALERTS       ) | (modules & CLOCALFILE    ) |\
+                            (modules & CREMOTE       ) | (modules & CCLIENT       ) | (modules & CMAIL         ) |\
+                            (modules & CAR           ) | (modules & CDBD          ) | (modules & CSYSLOGD      ) |\
+                            (modules & CAGENT_CONFIG ) | (modules & CAGENTLESS    ) | (modules & CREPORTS      ) |\
+                            (modules & CINTEGRATORD  ) | (modules & CWMODULE      ) | (modules & CLABELS       ) |\
+                            (modules & CAUTHD        ) | (modules & CBUFFER       ) | (modules & CCLUSTER      ) |\
+                            (modules & CSOCKET       ) | (modules & CLOGTEST      ) | (modules & WAZUHDB       ) )
+
 typedef enum needed_tags {
     JSONOUT_OUTPUT = 0,
     ALERTS_LOG,
@@ -45,12 +55,14 @@ typedef enum needed_tags {
     LOGALL_JSON
 } NeededTags;
 
+
 #include "os_xml/os_xml.h"
 #include "config/wazuh_db-config.h"
 #include "time.h"
 
 /* Main function to read the config */
 int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2);
+void PrintErrorAcordingToModules(int modules, const char *cfgfile);
 
 int Read_Global(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
 int Read_GlobalSK(XML_NODE node, void *configp, void *mailp);

--- a/src/config/rootcheck-config.c
+++ b/src/config/rootcheck-config.c
@@ -72,17 +72,17 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
 
     while (node[i]) {
         if (!node[i]->element) {
-            merror(XML_ELEMNULL);
+            mwarn(XML_ELEMNULL);
             return (OS_INVALID);
         } else if (!node[i]->content) {
-            merror(XML_VALUENULL, node[i]->element);
+            mwarn(XML_VALUENULL, node[i]->element);
             return (OS_INVALID);
         }
 
         /* Get frequency */
         else if (strcmp(node[i]->element, xml_time) == 0) {
             if (!OS_StrIsNum(node[i]->content)) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
 
@@ -92,13 +92,13 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
         else if (strcmp(node[i]->element, xml_scanall) == 0) {
             rootcheck->scanall = eval_bool(node[i]->content);
             if (rootcheck->scanall == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, xml_disabled) == 0) {
             rootcheck->disabled = eval_bool(node[i]->content);
             if (rootcheck->disabled == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         }
@@ -107,7 +107,7 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
             rootcheck->skip_nfs = eval_bool(node[i]->content);
             if (rootcheck->skip_nfs == OS_INVALID)
             {
-                merror(XML_VALUEERR,node[i]->element,node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element,node[i]->content);
                 return(OS_INVALID);
             }
         }
@@ -115,7 +115,7 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
         {
             rootcheck->readall = eval_bool(node[i]->content);
             if (rootcheck->readall == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, xml_rootkit_files) == 0) {
@@ -158,10 +158,10 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
 
             if (node[i]->attributes && node[i]->values && *node[i]->attributes && *node[i]->values) {
                 if (strcmp(*node[i]->attributes, "type")) {
-                    merror("Invalid attribute for '%s': '%s'.", node[i]->element, *node[i]->attributes);
+                    mwarn("Invalid attribute for '%s': '%s'.", node[i]->element, *node[i]->attributes);
                     return OS_INVALID;
                 } else if (strcmp(*node[i]->values, "sregex")) {
-                    merror("Invalid value for '%s': '%s'.", *node[i]->attributes, *node[i]->values);
+                    mwarn("Invalid value for '%s': '%s'.", *node[i]->attributes, *node[i]->values);
                     return OS_INVALID;
                 }
                 os_calloc(1, sizeof(OSMatch), rootcheck->ignore_sregex[j]);
@@ -170,7 +170,7 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
 #else
                 if (!OSMatch_Compile(rootcheck->ignore[j], rootcheck->ignore_sregex[j], OS_CASE_SENSITIVE)) {
 #endif
-                    merror(REGEX_COMPILE, rootcheck->ignore[j], rootcheck->ignore_sregex[j]->error);
+                    mwarn(REGEX_COMPILE, rootcheck->ignore[j], rootcheck->ignore_sregex[j]->error);
                     return OS_INVALID;
                 }
             }
@@ -189,50 +189,50 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
         } else if (strcmp(node[i]->element, xml_check_dev) == 0) {
             rootcheck->checks.rc_dev = eval_bool(node[i]->content);
             if (rootcheck->checks.rc_dev == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, xml_check_files) == 0) {
             rootcheck->checks.rc_files = eval_bool(node[i]->content);
             if (rootcheck->checks.rc_files == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, xml_check_if) == 0) {
             rootcheck->checks.rc_if = eval_bool(node[i]->content);
             if (rootcheck->checks.rc_if == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, xml_check_pids) == 0) {
             rootcheck->checks.rc_pids = eval_bool(node[i]->content);
             if (rootcheck->checks.rc_pids == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, xml_check_ports) == 0) {
             rootcheck->checks.rc_ports = eval_bool(node[i]->content);
             if (rootcheck->checks.rc_ports == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, xml_check_sys) == 0) {
             rootcheck->checks.rc_sys = eval_bool(node[i]->content);
             if (rootcheck->checks.rc_sys == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, xml_check_trojans) == 0) {
             rootcheck->checks.rc_trojans = eval_bool(node[i]->content);
             if (rootcheck->checks.rc_trojans == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, xml_check_unixaudit) == 0) {
 #ifndef WIN32
             rootcheck->checks.rc_unixaudit = eval_bool(node[i]->content);
             if (rootcheck->checks.rc_unixaudit == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
 #endif
@@ -240,7 +240,7 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
 #ifdef WIN32
             rootcheck->checks.rc_winapps = eval_bool(node[i]->content);
             if (rootcheck->checks.rc_winapps == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
 #endif
@@ -248,7 +248,7 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
 #ifdef WIN32
             rootcheck->checks.rc_winaudit = eval_bool(node[i]->content);
             if (rootcheck->checks.rc_winaudit == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
 #endif
@@ -256,12 +256,12 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
 #ifdef WIN32
             rootcheck->checks.rc_winmalware = eval_bool(node[i]->content);
             if (rootcheck->checks.rc_winmalware == OS_INVALID) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
 #endif
         } else {
-            merror(XML_INVELEM, node[i]->element);
+            mwarn(XML_INVELEM, node[i]->element);
             return (OS_INVALID);
         }
         i++;

--- a/src/config/rootcheck-config.c
+++ b/src/config/rootcheck-config.c
@@ -170,7 +170,7 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
 #else
                 if (!OSMatch_Compile(rootcheck->ignore[j], rootcheck->ignore_sregex[j], OS_CASE_SENSITIVE)) {
 #endif
-                    mwarn(REGEX_COMPILE, rootcheck->ignore[j], rootcheck->ignore_sregex[j]->error);
+                    merror(REGEX_COMPILE, rootcheck->ignore[j], rootcheck->ignore_sregex[j]->error);
                     return OS_INVALID;
                 }
             }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -421,7 +421,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                 os_free(tag);
 
                 if (tag = os_strip_char(values[i], ' '), !tag) {
-                    merror("Processing tag for registry entry '%s'.", entries);
+                    mwarn("Processing tag for registry entry '%s'.", entries);
                 }
             } else if (strcmp(attributes[i], xml_arch) == 0) {
                 if (strcmp(values[i], xml_32bit) == 0) {
@@ -430,12 +430,12 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                 } else if (strcmp(values[i], xml_both) == 0) {
                     arch = ARCH_BOTH;
                 } else {
-                    merror(XML_INVATTR, attributes[i], entries);
+                    mwarn(XML_INVATTR, attributes[i], entries);
                     goto clean_reg;
                 }
             } else if (strcmp(attributes[i], xml_recursion_level) == 0) {
                 if (!OS_StrIsNum(values[i])) {
-                    merror(XML_VALUEERR, xml_recursion_level, entries);
+                    mwarn(XML_VALUEERR, xml_recursion_level, entries);
                     goto clean_reg;
                 }
                 recursion_level = atoi(values[i]);
@@ -574,7 +574,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                 }
 
             } else {
-                merror(XML_INVATTR, attributes[i], entries);
+                mwarn(XML_INVATTR, attributes[i], entries);
                 goto clean_reg;
             }
         }
@@ -962,7 +962,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         /* Check recursion limit */
         else if (strcmp(*attrs, xml_recursion_level) == 0) {
             if (!OS_StrIsNum(*values)) {
-                merror(XML_VALUEERR, xml_recursion_level, *values);
+                mwarn(XML_VALUEERR, xml_recursion_level, *values);
                 goto out_free;
             }
             recursion_limit = (unsigned int) atoi(*values);
@@ -1368,7 +1368,7 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
             os_calloc(2048, sizeof(char), new_nodiff);
 
             if (!ExpandEnvironmentStrings(node[i]->content, new_nodiff, 2047)){
-                merror("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
+                mwarn("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
                 free(new_nodiff);
                 continue;
             }
@@ -1404,12 +1404,12 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
 
                     if (!OSMatch_Compile(node[i]->content, syscheck->nodiff_regex[nodiff_size], 0)) {
                         mt_pt = (OSMatch *)syscheck->nodiff_regex[nodiff_size];
-                        merror(REGEX_COMPILE, node[i]->content, mt_pt->error);
+                        mwarn(REGEX_COMPILE, node[i]->content, mt_pt->error);
                         return;
                     }
                 }
                 else {
-                    merror(FIM_INVALID_ATTRIBUTE, node[i]->attributes[0], node[i]->element);
+                    mwarn(FIM_INVALID_ATTRIBUTE, node[i]->attributes[0], node[i]->element);
                     return;
                 }
             }
@@ -1441,7 +1441,7 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
             os_calloc(2048, sizeof(char), new_nodiff);
 
             if (!ExpandEnvironmentStrings(node[i]->content, new_nodiff, 2047)){
-                merror("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
+                mwarn("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
                 free(new_nodiff);
                 continue;
             }
@@ -1468,11 +1468,11 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
                         else if (strcmp(node[i]->values[j], xml_both) == 0)
                             arch = ARCH_BOTH;
                         else {
-                            merror(XML_INVATTR, node[i]->attributes[j], node[i]->content);
+                            mwarn(XML_INVATTR, node[i]->attributes[j], node[i]->content);
                             return;
                         }
                     } else {
-                        merror(XML_INVATTR, node[i]->attributes[j], node[i]->content);
+                        mwarn(XML_INVATTR, node[i]->attributes[j], node[i]->content);
                         return;
                     }
                 }
@@ -1510,7 +1510,7 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
                         syscheck->disk_quota_enabled = false;
                     }
                     else {
-                        merror(XML_VALUEERR, children[j]->element, children[j]->content);
+                        mwarn(XML_VALUEERR, children[j]->element, children[j]->content);
                         OS_ClearNode(children);
                         return;
                     }
@@ -1520,7 +1520,7 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
                         syscheck->disk_quota_limit = read_data_unit(children[j]->content);
 
                         if (syscheck->disk_quota_limit == -1) {
-                            merror(XML_VALUEERR, children[j]->element, children[j]->content);
+                            mwarn(XML_VALUEERR, children[j]->element, children[j]->content);
                             OS_ClearNode(children);
                             return;
                         }
@@ -1530,7 +1530,7 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
                         }
                     }
                     else {
-                        merror(XML_VALUEERR, children[j]->element, "");     // Null children[j]->content
+                        mwarn(XML_VALUEERR, children[j]->element, "");     // Null children[j]->content
                         OS_ClearNode(children);
                         return;
                     }
@@ -1553,7 +1553,7 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
                         syscheck->file_size_enabled = false;
                     }
                     else {
-                        merror(XML_VALUEERR, children[j]->element, children[j]->content);
+                        mwarn(XML_VALUEERR, children[j]->element, children[j]->content);
                         OS_ClearNode(children);
                         return;
                     }
@@ -1563,7 +1563,7 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
                         syscheck->file_size_limit = read_data_unit(children[j]->content);
 
                         if (syscheck->file_size_limit == -1) {
-                            merror(XML_VALUEERR, children[j]->element, children[j]->content);
+                            mwarn(XML_VALUEERR, children[j]->element, children[j]->content);
                             OS_ClearNode(children);
                             return;
                         }
@@ -1573,7 +1573,7 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
                         }
                     }
                     else {
-                        merror(XML_VALUEERR, children[j]->element, "");     // Null children[j]->content
+                        mwarn(XML_VALUEERR, children[j]->element, "");     // Null children[j]->content
                         OS_ClearNode(children);
                         return;
                     }
@@ -1802,14 +1802,14 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         syscheck->registry_limit_enabled = false;
                     }
                     else {
-                        merror(XML_VALUEERR, children[j]->element, children[j]->content);
+                        mwarn(XML_VALUEERR, children[j]->element, children[j]->content);
                         OS_ClearNode(children);
                         return (OS_INVALID);
                     }
                 }
                 else if (strcmp(children[j]->element, xml_entries) == 0) {
                     if (!OS_StrIsNum(children[j]->content)) {
-                        merror(XML_VALUEERR, children[j]->element, children[j]->content);
+                        mwarn(XML_VALUEERR, children[j]->element, children[j]->content);
                         OS_ClearNode(children);
                         return (OS_INVALID);
                     }
@@ -2273,7 +2273,7 @@ int Test_Syscheck(const char * path){
     }
 
     if (ReadConfig(CAGENT_CONFIG | CSYSCHECK, path, &test_syscheck, NULL) < 0) {
-		mwarn(RCONFIG_ERROR,"Syscheckk", path);
+		merror(RCONFIG_ERROR,"Syscheck", path);
 		fail = 1;
 	}
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -421,7 +421,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                 os_free(tag);
 
                 if (tag = os_strip_char(values[i], ' '), !tag) {
-                    mwarn("Processing tag for registry entry '%s'.", entries);
+                    merror("Processing tag for registry entry '%s'.", entries);
                 }
             } else if (strcmp(attributes[i], xml_arch) == 0) {
                 if (strcmp(values[i], xml_32bit) == 0) {
@@ -1368,7 +1368,7 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
             os_calloc(2048, sizeof(char), new_nodiff);
 
             if (!ExpandEnvironmentStrings(node[i]->content, new_nodiff, 2047)){
-                mwarn("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
+                merror("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
                 free(new_nodiff);
                 continue;
             }
@@ -1404,7 +1404,7 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
 
                     if (!OSMatch_Compile(node[i]->content, syscheck->nodiff_regex[nodiff_size], 0)) {
                         mt_pt = (OSMatch *)syscheck->nodiff_regex[nodiff_size];
-                        mwarn(REGEX_COMPILE, node[i]->content, mt_pt->error);
+                        merror(REGEX_COMPILE, node[i]->content, mt_pt->error);
                         return;
                     }
                 }
@@ -1441,7 +1441,7 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node) {
             os_calloc(2048, sizeof(char), new_nodiff);
 
             if (!ExpandEnvironmentStrings(node[i]->content, new_nodiff, 2047)){
-                mwarn("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
+                merror("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
                 free(new_nodiff);
                 continue;
             }
@@ -2006,7 +2006,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
 #ifdef WIN32
             if(!ExpandEnvironmentStrings(node[i]->content, prefilter_cmd, sizeof(prefilter_cmd) - 1)){
-                mwarn("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
+                merror("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
                 continue;
             }
             str_lowercase(prefilter_cmd);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1664,10 +1664,10 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     }
     for (i = 0; node && node[i]; i++) {
         if (!node[i]->element) {
-            merror(XML_ELEMNULL);
+            mwarn(XML_ELEMNULL);
             return (OS_INVALID);
         } else if (!node[i]->content) {
-            merror(XML_VALUENULL, node[i]->element);
+            mwarn(XML_VALUENULL, node[i]->element);
             return (OS_INVALID);
         }
 
@@ -1697,7 +1697,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
         else if (strcmp(node[i]->element, xml_windows_audit_interval) == 0) {
 #ifdef WIN32
             if (!OS_StrIsNum(node[i]->content)) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
 
@@ -1720,7 +1720,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
         /* Get frequency */
         else if (strcmp(node[i]->element, xml_time) == 0) {
             if (!OS_StrIsNum(node[i]->content)) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
 
@@ -1730,7 +1730,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
         else if (strcmp(node[i]->element, xml_scantime) == 0) {
             syscheck->scan_time = OS_IsValidUniqueTime(node[i]->content);
             if (!syscheck->scan_time) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         }
@@ -1739,8 +1739,8 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
         else if (strcmp(node[i]->element, xml_scanday) == 0) {
             syscheck->scan_day = OS_IsValidDay(node[i]->content);
             if (!syscheck->scan_day) {
-                merror(INVALID_DAY, node[i]->content);
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(INVALID_DAY, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         }
@@ -1759,14 +1759,14 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         syscheck->file_limit_enabled = false;
                     }
                     else {
-                        merror(XML_VALUEERR, children[j]->element, children[j]->content);
+                        mwarn(XML_VALUEERR, children[j]->element, children[j]->content);
                         OS_ClearNode(children);
                         return (OS_INVALID);
                     }
                 }
                 else if (strcmp(children[j]->element, xml_entries) == 0) {
                     if (!OS_StrIsNum(children[j]->content)) {
-                        merror(XML_VALUEERR, children[j]->element, children[j]->content);
+                        mwarn(XML_VALUEERR, children[j]->element, children[j]->content);
                         OS_ClearNode(children);
                         return (OS_INVALID);
                     }
@@ -1838,7 +1838,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             } else if (strcmp(node[i]->content, "no") == 0) {
                 syscheck->scan_on_start = 0;
             } else {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         }
@@ -1850,7 +1850,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             } else if (strcmp(node[i]->content, "no") == 0) {
                 syscheck->disabled = 0;
             } else {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR "%d", node[i]->element, node[i]->content,__LINE__);
                 return (OS_INVALID);
             }
         }
@@ -1864,7 +1864,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 syscheck->skip_fs.nfs = 0;
             else
             {
-                merror(XML_VALUEERR,node[i]->element,node[i]->content);
+                mwarn(XML_VALUEERR,node[i]->element,node[i]->content);
                 return(OS_INVALID);
             }
         }
@@ -1878,7 +1878,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 syscheck->skip_fs.dev = 0;
             else
             {
-                merror(XML_VALUEERR,node[i]->element,node[i]->content);
+                mwarn(XML_VALUEERR,node[i]->element,node[i]->content);
                 return(OS_INVALID);
             }
         }
@@ -1892,7 +1892,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 syscheck->skip_fs.sys = 0;
             else
             {
-                merror(XML_VALUEERR,node[i]->element,node[i]->content);
+                mwarn(XML_VALUEERR,node[i]->element,node[i]->content);
                 return(OS_INVALID);
             }
         }
@@ -1906,7 +1906,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 syscheck->skip_fs.proc = 0;
             else
             {
-                merror(XML_VALUEERR,node[i]->element,node[i]->content);
+                mwarn(XML_VALUEERR,node[i]->element,node[i]->content);
                 return(OS_INVALID);
             }
         }
@@ -1921,7 +1921,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         return result;
                     }
                 } else {
-                    merror(FIM_INVALID_ATTRIBUTE, node[i]->attributes[0], node[i]->element);
+                    mwarn(FIM_INVALID_ATTRIBUTE, node[i]->attributes[0], node[i]->element);
                     return (OS_INVALID);
                 }
             } else {
@@ -1952,11 +1952,11 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         else if (strcmp(node[i]->values[j], xml_both) == 0)
                             arch = ARCH_BOTH;
                         else {
-                            merror(XML_INVATTR, node[i]->attributes[j], node[i]->content);
+                            mwarn(XML_INVATTR, node[i]->attributes[j], node[i]->content);
                             return OS_INVALID;
                         }
                     } else {
-                        merror(XML_INVATTR, node[i]->attributes[j], node[i]->content);
+                        mwarn(XML_INVATTR, node[i]->attributes[j], node[i]->content);
                         return OS_INVALID;
                     }
                 }
@@ -1990,7 +1990,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         return result;
                     }
                 } else {
-                    merror(FIM_INVALID_ATTRIBUTE, node[i]->attributes[0], node[i]->element);
+                    mwarn(FIM_INVALID_ATTRIBUTE, node[i]->attributes[0], node[i]->element);
                     return (OS_INVALID);
                 }
             } else {
@@ -2006,7 +2006,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
 #ifdef WIN32
             if(!ExpandEnvironmentStrings(node[i]->content, prefilter_cmd, sizeof(prefilter_cmd) - 1)){
-                merror("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
+                mwarn("Could not expand the environment variable %s (%ld)", node[i]->content, GetLastError());
                 continue;
             }
             str_lowercase(prefilter_cmd);
@@ -2024,7 +2024,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                     *ix = '\0';
                 }
                 if (stat(statcmd, &statbuf) != 0) {
-                    merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                    mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                     return (OS_INVALID);
                 }
             }
@@ -2038,7 +2038,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 syscheck->restart_audit = 0;
             else
             {
-                merror(XML_VALUEERR,node[i]->element,node[i]->content);
+                mwarn(XML_VALUEERR,node[i]->element,node[i]->content);
                 return(OS_INVALID);
             }
         }
@@ -2074,7 +2074,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         syscheck->audit_healthcheck = 0;
                     else
                     {
-                        merror(XML_VALUEERR,children[j]->element,children[j]->content);
+                        mwarn(XML_VALUEERR,children[j]->element,children[j]->content);
                         OS_ClearNode(children);
                         return(OS_INVALID);
                     }
@@ -2085,12 +2085,12 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         syscheck->restart_audit = 0;
                     else
                     {
-                        merror(XML_VALUEERR,children[j]->element,children[j]->content);
+                        mwarn(XML_VALUEERR,children[j]->element,children[j]->content);
                         OS_ClearNode(children);
                         return(OS_INVALID);
                     }
                 } else {
-                    merror(XML_ELEMNULL);
+                    mwarn(XML_ELEMNULL);
                     OS_ClearNode(children);
                     return OS_INVALID;
                 }
@@ -2102,7 +2102,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             long value = strtol(node[i]->content, &end, 10);
 
             if (value < -20 || value > 19 || *end) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             } else {
                 syscheck->process_priority = value;
@@ -2149,13 +2149,13 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             else if(strcmp(node[i]->content, "no") == 0)
                 syscheck->allow_remote_prefilter_cmd = 0;
             else {
-                merror(XML_VALUEERR,node[i]->element,node[i]->content);
+                mwarn(XML_VALUEERR,node[i]->element,node[i]->content);
                 return(OS_INVALID);
             }
         }
         else if (strcmp(node[i]->element, xml_max_files_per_second) == 0) {
             if (!OS_StrIsNum(node[i]->content)) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
             syscheck->max_files_per_second = atoi(node[i]->content);
@@ -2273,7 +2273,7 @@ int Test_Syscheck(const char * path){
     }
 
     if (ReadConfig(CAGENT_CONFIG | CSYSCHECK, path, &test_syscheck, NULL) < 0) {
-		merror(RCONFIG_ERROR,"Syscheck", path);
+		mwarn(RCONFIG_ERROR,"Syscheckk", path);
 		fail = 1;
 	}
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1850,7 +1850,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             } else if (strcmp(node[i]->content, "no") == 0) {
                 syscheck->disabled = 0;
             } else {
-                mwarn(XML_VALUEERR "%d", node[i]->element, node[i]->content,__LINE__);
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
         }

--- a/src/config/wmodules-agent-upgrade.c
+++ b/src/config/wmodules-agent-upgrade.c
@@ -224,7 +224,7 @@ static int wm_agent_upgrade_read_ca_verification(xml_node **nodes, unsigned int 
             } else if (strcasecmp(nodes[i]->content, "no") == 0) {
                 *verification_flag = 0;
             } else {
-                mwarn("Invalid content for tag <%s>", nodes[i]->element);
+                merror("Invalid content for tag <%s>", nodes[i]->element);
                 return OS_INVALID;
             }
         } else if (!strcmp(nodes[i]->element, XML_CA_STORE)) {
@@ -262,7 +262,7 @@ static int wm_agent_upgrade_read_ca_verification_old(unsigned int *verification_
                 *verification_flag = 0;
             }
             else {
-                mwarn("Invalid content for tag <%s>: '%s'", caverify[2], ca_verification[i]);
+                merror("Invalid content for tag <%s>: '%s'", caverify[2], ca_verification[i]);
                 free_strarray(ca_verification);
                 return OS_INVALID;
             }

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -70,7 +70,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
     wm_aws_service *cur_service = NULL;
 
     if (!nodes) {
-        mwarn("Tag <%s> not found at module '%s'.", XML_BUCKET, WM_AWS_CONTEXT.name);
+        merror("Tag <%s> not found at module '%s'.", XML_BUCKET, WM_AWS_CONTEXT.name);
         return OS_INVALID;
     }
 

--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -75,7 +75,7 @@ int wm_azure_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
     module->data = azure;
 
     if (!nodes) {
-        mwarn("Empty configuration at module '%s'.", WM_AZURE_CONTEXT.name);
+        merror("Empty configuration at module '%s'.", WM_AZURE_CONTEXT.name);
         return OS_INVALID;
     }
 

--- a/src/config/wmodules-command.c
+++ b/src/config/wmodules-command.c
@@ -34,7 +34,7 @@ int wm_command_read(xml_node **nodes, wmodule *module, int agent_cfg)
     char * command_tag = NULL;
 
     if (!nodes) {
-        mwarn("Tag <%s> not found at module '%s'.", XML_COMMAND, WM_COMMAND_CONTEXT.name);
+        merror("Tag <%s> not found at module '%s'.", XML_COMMAND, WM_COMMAND_CONTEXT.name);
         return OS_INVALID;
     }
 
@@ -177,7 +177,7 @@ int wm_command_read(xml_node **nodes, wmodule *module, int agent_cfg)
     }
 
     if (!command->command) {
-        mwarn("Tag <%s> not found at module '%s'.", XML_COMMAND, WM_COMMAND_CONTEXT.name);
+        merror("Tag <%s> not found at module '%s'.", XML_COMMAND, WM_COMMAND_CONTEXT.name);
         return OS_INVALID;
     }
 

--- a/src/config/wmodules-gcp.c
+++ b/src/config/wmodules-gcp.c
@@ -77,7 +77,7 @@ int wm_gcp_pubsub_read(xml_node **nodes, wmodule *module) {
     gcp = module->data;
 
     if (!nodes) {
-        mwarn("Empty configuration at module '%s'.", WM_GCP_PUBSUB_CONTEXT.name);
+        merror("Empty configuration at module '%s'.", WM_GCP_PUBSUB_CONTEXT.name);
         return OS_INVALID;
     }
 
@@ -133,7 +133,7 @@ int wm_gcp_pubsub_read(xml_node **nodes, wmodule *module) {
 
             // Beware of IsFile inverted, twisted logic.
             if (IsFile(realpath_buffer)) {
-                mwarn("File '%s' not found. Check your configuration.", realpath_buffer);
+                merror("File '%s' not found. Check your configuration.", realpath_buffer);
                 return OS_INVALID;
             }
 
@@ -237,7 +237,7 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
     gcp = module->data;
 
     if (!nodes) {
-        mwarn("Empty configuration at module '%s'.", WM_GCP_BUCKET_CONTEXT.name);
+        merror("Empty configuration at module '%s'.", WM_GCP_BUCKET_CONTEXT.name);
         return OS_INVALID;
     }
 
@@ -370,7 +370,7 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
                     } else {
                         const char * const realpath_buffer_ref = realpath(children[j]->content, realpath_buffer);
                         if (!realpath_buffer_ref) {
-                            mwarn("File '%s' from tag '%s' not found.", realpath_buffer, XML_CREDENTIALS_FILE);
+                            merror("File '%s' from tag '%s' not found.", realpath_buffer, XML_CREDENTIALS_FILE);
                             OS_ClearNode(children);
                             return OS_INVALID;
                         }
@@ -378,7 +378,7 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
 
                     // Beware of IsFile inverted, twisted logic.
                     if (IsFile(realpath_buffer)) {
-                        mwarn("File '%s' not found. Check your configuration.", realpath_buffer);
+                        merror("File '%s' not found. Check your configuration.", realpath_buffer);
                         OS_ClearNode(children);
                         return OS_INVALID;
                     }
@@ -416,7 +416,7 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
         return OS_INVALID;
     }
     if (!gcp->buckets) {
-        mwarn("No buckets or services definitions found at module '%s'.", WM_GCP_BUCKET_CONTEXT.name);
+        merror("No buckets or services definitions found at module '%s'.", WM_GCP_BUCKET_CONTEXT.name);
         return OS_INVALID;
     }
 

--- a/src/config/wmodules-gcp.c
+++ b/src/config/wmodules-gcp.c
@@ -126,7 +126,7 @@ int wm_gcp_pubsub_read(xml_node **nodes, wmodule *module) {
             } else {
                 const char * const realpath_buffer_ref = realpath(nodes[i]->content, realpath_buffer);
                 if (!realpath_buffer_ref) {
-                    mwarn("File '%s' from tag '%s' not found.", realpath_buffer, XML_CREDENTIALS_FILE);
+                    merror("File '%s' from tag '%s' not found.", realpath_buffer, XML_CREDENTIALS_FILE);
                     return OS_INVALID;
                 }
             }

--- a/src/config/wmodules-syscollector.c
+++ b/src/config/wmodules-syscollector.c
@@ -127,7 +127,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.enabled = 1;
             else {
-                mwarn("Invalid content for tag '%s' at module '%s'.", XML_DISABLED, WM_SYS_CONTEXT.name);
+                merror("Invalid content for tag '%s' at module '%s'.", XML_DISABLED, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_NETWORK)) {
@@ -136,7 +136,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.netinfo = 0;
             else {
-                mwarn("Invalid content for tag '%s' at module '%s'.", XML_NETWORK, WM_SYS_CONTEXT.name);
+                merror("Invalid content for tag '%s' at module '%s'.", XML_NETWORK, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_OS_SCAN)) {
@@ -145,7 +145,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.osinfo = 0;
             else {
-                mwarn("Invalid content for tag '%s' at module '%s'.", XML_OS_SCAN, WM_SYS_CONTEXT.name);
+                merror("Invalid content for tag '%s' at module '%s'.", XML_OS_SCAN, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_HARDWARE)) {
@@ -154,7 +154,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.hwinfo = 0;
             else {
-                mwarn("Invalid content for tag '%s' at module '%s'.", XML_HARDWARE, WM_SYS_CONTEXT.name);
+                merror("Invalid content for tag '%s' at module '%s'.", XML_HARDWARE, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_PACKAGES)) {
@@ -163,7 +163,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.programinfo = 0;
             else {
-                mwarn("Invalid content for tag '%s' at module '%s'.", XML_PACKAGES, WM_SYS_CONTEXT.name);
+                merror("Invalid content for tag '%s' at module '%s'.", XML_PACKAGES, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_HOTFIXES)) {
@@ -173,11 +173,11 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
                 else if (!strcmp(node[i]->content, "no"))
                     syscollector->flags.hotfixinfo = 0;
                 else {
-                    mwarn("Invalid content for tag '%s' at module '%s'.", XML_HOTFIXES, WM_SYS_CONTEXT.name);
+                    merror("Invalid content for tag '%s' at module '%s'.", XML_HOTFIXES, WM_SYS_CONTEXT.name);
                     return OS_INVALID;
                 }
 #else
-                mwarn("The '%s' option is only available on Windows systems. Ignoring it.", XML_HOTFIXES);
+                merror("The '%s' option is only available on Windows systems. Ignoring it.", XML_HOTFIXES);
 #endif
         } else if (!strcmp(node[i]->element, XML_PROCS)) {
             if (!strcmp(node[i]->content, "yes"))
@@ -185,7 +185,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.procinfo = 0;
             else {
-                mwarn("Invalid content for tag '%s' at module '%s'.", XML_PROCS, WM_SYS_CONTEXT.name);
+                merror("Invalid content for tag '%s' at module '%s'.", XML_PROCS, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_PORTS)) {
@@ -196,11 +196,11 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
                     } else if (!strcmp(node[i]->values[0], "yes")) {
                         syscollector->flags.allports = 1;
                     } else {
-                        mwarn("Invalid content for attribute '%s' at module '%s'.", node[i]->attributes[0], WM_SYS_CONTEXT.name);
+                        merror("Invalid content for attribute '%s' at module '%s'.", node[i]->attributes[0], WM_SYS_CONTEXT.name);
                         return OS_INVALID;
                     }
                 } else {
-                    mwarn("Invalid attribute for tag '%s' at module '%s'.", XML_PORTS, WM_SYS_CONTEXT.name);
+                    merror("Invalid attribute for tag '%s' at module '%s'.", XML_PORTS, WM_SYS_CONTEXT.name);
                     return OS_INVALID;
                 }
             }
@@ -209,7 +209,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.portsinfo = 0;
             else {
-                mwarn("Invalid content for tag '%s' at module '%s'.", XML_PORTS, WM_SYS_CONTEXT.name);
+                merror("Invalid content for tag '%s' at module '%s'.", XML_PORTS, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_SYNC)) {
@@ -221,7 +221,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
                 OS_ClearNode(children);
             }
         } else {
-            mwarn("No such tag '%s' at module '%s'.", node[i]->element, WM_SYS_CONTEXT.name);
+            merror("No such tag '%s' at module '%s'.", node[i]->element, WM_SYS_CONTEXT.name);
             return OS_INVALID;
         }
     }

--- a/src/config/wmodules-syscollector.c
+++ b/src/config/wmodules-syscollector.c
@@ -127,7 +127,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.enabled = 1;
             else {
-                merror("Invalid content for tag '%s' at module '%s'.", XML_DISABLED, WM_SYS_CONTEXT.name);
+                mwarn("Invalid content for tag '%s' at module '%s'.", XML_DISABLED, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_NETWORK)) {
@@ -136,7 +136,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.netinfo = 0;
             else {
-                merror("Invalid content for tag '%s' at module '%s'.", XML_NETWORK, WM_SYS_CONTEXT.name);
+                mwarn("Invalid content for tag '%s' at module '%s'.", XML_NETWORK, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_OS_SCAN)) {
@@ -145,7 +145,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.osinfo = 0;
             else {
-                merror("Invalid content for tag '%s' at module '%s'.", XML_OS_SCAN, WM_SYS_CONTEXT.name);
+                mwarn("Invalid content for tag '%s' at module '%s'.", XML_OS_SCAN, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_HARDWARE)) {
@@ -154,7 +154,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.hwinfo = 0;
             else {
-                merror("Invalid content for tag '%s' at module '%s'.", XML_HARDWARE, WM_SYS_CONTEXT.name);
+                mwarn("Invalid content for tag '%s' at module '%s'.", XML_HARDWARE, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_PACKAGES)) {
@@ -163,7 +163,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.programinfo = 0;
             else {
-                merror("Invalid content for tag '%s' at module '%s'.", XML_PACKAGES, WM_SYS_CONTEXT.name);
+                mwarn("Invalid content for tag '%s' at module '%s'.", XML_PACKAGES, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_HOTFIXES)) {
@@ -173,7 +173,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
                 else if (!strcmp(node[i]->content, "no"))
                     syscollector->flags.hotfixinfo = 0;
                 else {
-                    merror("Invalid content for tag '%s' at module '%s'.", XML_HOTFIXES, WM_SYS_CONTEXT.name);
+                    mwarn("Invalid content for tag '%s' at module '%s'.", XML_HOTFIXES, WM_SYS_CONTEXT.name);
                     return OS_INVALID;
                 }
 #else
@@ -185,7 +185,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.procinfo = 0;
             else {
-                merror("Invalid content for tag '%s' at module '%s'.", XML_PROCS, WM_SYS_CONTEXT.name);
+                mwarn("Invalid content for tag '%s' at module '%s'.", XML_PROCS, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_PORTS)) {
@@ -196,11 +196,11 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
                     } else if (!strcmp(node[i]->values[0], "yes")) {
                         syscollector->flags.allports = 1;
                     } else {
-                        merror("Invalid content for attribute '%s' at module '%s'.", node[i]->attributes[0], WM_SYS_CONTEXT.name);
+                        mwarn("Invalid content for attribute '%s' at module '%s'.", node[i]->attributes[0], WM_SYS_CONTEXT.name);
                         return OS_INVALID;
                     }
                 } else {
-                    merror("Invalid attribute for tag '%s' at module '%s'.", XML_PORTS, WM_SYS_CONTEXT.name);
+                    mwarn("Invalid attribute for tag '%s' at module '%s'.", XML_PORTS, WM_SYS_CONTEXT.name);
                     return OS_INVALID;
                 }
             }
@@ -209,7 +209,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             else if (!strcmp(node[i]->content, "no"))
                 syscollector->flags.portsinfo = 0;
             else {
-                merror("Invalid content for tag '%s' at module '%s'.", XML_PORTS, WM_SYS_CONTEXT.name);
+                mwarn("Invalid content for tag '%s' at module '%s'.", XML_PORTS, WM_SYS_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(node[i]->element, XML_SYNC)) {
@@ -221,7 +221,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
                 OS_ClearNode(children);
             }
         } else {
-            merror("No such tag '%s' at module '%s'.", node[i]->element, WM_SYS_CONTEXT.name);
+            mwarn("No such tag '%s' at module '%s'.", node[i]->element, WM_SYS_CONTEXT.name);
             return OS_INVALID;
         }
     }

--- a/src/config/wmodules-syscollector.c
+++ b/src/config/wmodules-syscollector.c
@@ -177,7 +177,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
                     return OS_INVALID;
                 }
 #else
-                merror("The '%s' option is only available on Windows systems. Ignoring it.", XML_HOTFIXES);
+                mwarn("The '%s' option is only available on Windows systems. Ignoring it.", XML_HOTFIXES);
 #endif
         } else if (!strcmp(node[i]->element, XML_PROCS)) {
             if (!strcmp(node[i]->content, "yes"))

--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -52,6 +52,7 @@
 #define mtferror(tag, msg, ...) _mtferror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define merror_exit(msg, ...) _merror_exit(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define mterror_exit(tag, msg, ...) _mterror_exit(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+#define mlerror_exit(level, msg, ...) _mlerror_exit(level, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 
 void _mdebug1(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull));
 void _mtdebug1(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
@@ -71,6 +72,7 @@ void _mferror(const char * file, int line, const char * func, const char *msg, .
 void _mtferror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
 void _merror_exit(const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 4, 5))) __attribute__((nonnull)) __attribute__ ((noreturn));
 void _mterror_exit(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull)) __attribute__ ((noreturn));
+void _mlerror_exit(const int level, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull)) __attribute__ ((noreturn));
 
 /**
  * @brief Logging module initializer

--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -131,7 +131,7 @@ int main(int argc, char **argv)
 
     /* Read config file */
     if (LogCollectorConfig(cfg) < 0) {
-        merror_exit(CONFIG_ERROR, cfg);
+        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
     }
 
     /* Exit if test config */

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -511,7 +511,7 @@ int WinExecdStart()
 
     /* Read config */
     if ((c = ExecdConfig(cfg)) < 0) {
-        merror_exit(CONFIG_ERROR, cfg);
+        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
     }
 
     /* Active response disabled */

--- a/src/os_execd/main.c
+++ b/src/os_execd/main.c
@@ -124,7 +124,7 @@ int main(int argc, char **argv)
 
     /* Read config */
     if ((c = ExecdConfig(cfg)) < 0) {
-        merror_exit(CONFIG_ERROR, cfg);
+        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
     }
 
     /* Exit if test_config */

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -174,7 +174,7 @@ int rootcheck_init(int test_config)
 
     /* Read configuration  --function specified twice (check makefile) */
     if (Read_Rootcheck_Config(cfg) < 0) {
-        merror(RCONFIG_ERROR, ARGV0, cfg);
+        mwarn(RCONFIG_ERROR, ARGV0, cfg);
         return (1);
     }
 

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -239,7 +239,7 @@ void os_logging_config(){
     flags.log_plain = 1;
     flags.log_json = 0;
     OS_ClearXML(&xml);
-    merror_exit(XML_ERROR, OSSECCONF, xml.err, xml.err_line);
+    mlerror_exit(LOGLEVEL_ERROR, XML_ERROR, OSSECCONF, xml.err, xml.err_line);
   }
 
   logformat = OS_GetOneContentforElement(&xml, xmlf);
@@ -485,6 +485,25 @@ void _mterror_exit(const char *tag, const char * file, int line, const char * fu
 {
     va_list args;
     int level = LOGLEVEL_CRITICAL;
+
+    va_start(args, msg);
+    _log(level, tag, file, line, func, msg, args);
+    va_end(args);
+
+#ifdef WIN32
+    /* If not MA */
+#ifndef MA
+    WinSetError();
+#endif
+#endif
+
+    exit(1);
+}
+
+void _mlerror_exit(const int level, const char * file, int line, const char * func, const char *msg, ...)
+{
+    va_list args;
+    const char *tag = __local_name;
 
     va_start(args, msg);
     _log(level, tag, file, line, func, msg, args);

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -267,7 +267,7 @@ void os_logging_config(){
         }else{
           flags.log_plain = 1;
           flags.log_json = 0;
-          merror_exit(XML_VALUEERR, "log_format", part);
+          mlerror_exit(LOGLEVEL_ERROR, XML_VALUEERR, "log_format", part);
         }
       }
       for (i=0; parts[i]; i++){

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
 
     /* Read syscheck config */
     if ((r = Read_Syscheck_Config(cfg)) < 0) {
-        merror(RCONFIG_ERROR, SYSCHECK, cfg);
+        mwarn(RCONFIG_ERROR, SYSCHECK, cfg);
         syscheck.disabled = 1;
     } else if ((r == 1) || (syscheck.disabled == 1)) {
         if (syscheck.directories == NULL || OSList_GetFirstNode(syscheck.directories) == NULL) {

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -134,7 +134,7 @@ int Start_win32_Syscheck() {
 
     /* Read syscheck config */
     if ((r = Read_Syscheck_Config(cfg)) < 0) {
-        merror(RCONFIG_ERROR, SYSCHECK, cfg);
+        mwarn(RCONFIG_ERROR, SYSCHECK, cfg);
         syscheck.disabled = 1;
     } else if ((r == 1) || (syscheck.disabled == 1)) {
         /* Disabled */

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -202,7 +202,7 @@ void test_Start_win32_Syscheck_corrupted_config_file(void **state) {
 
     expect_string(__wrap_Read_Syscheck_Config, file, "ossec.conf");
     will_return(__wrap_Read_Syscheck_Config, -1);
-    expect_string(__wrap__merror, formatted_msg, "(1207): syscheck remote configuration in 'ossec.conf' is corrupted.");
+    expect_string(__wrap__mwarn, formatted_msg, "(1207): syscheck remote configuration in 'ossec.conf' is corrupted.");
 
     will_return(__wrap_rootcheck_init, 1);
 

--- a/src/unit_tests/wazuh_modules/gcp/test_wmodules_gcp.c
+++ b/src/unit_tests/wazuh_modules/gcp/test_wmodules_gcp.c
@@ -746,7 +746,7 @@ static void test_wm_gcp_pubsub_read_credentials_file_tag_realpath_error(void **s
 
     will_return(__wrap_realpath, (char *) NULL);   //  realpath failed
 
-    expect_string(__wrap__mwarn, formatted_msg, "File '' from tag 'credentials_file' not found.");
+    expect_string(__wrap__merror, formatted_msg, "File '' from tag 'credentials_file' not found.");
 
     ret = wm_gcp_pubsub_read(data->nodes, data->module);
 
@@ -763,7 +763,7 @@ static void test_wm_gcp_pubsub_read_credentials_file_tag_file_not_found(void **s
     expect_string(__wrap_IsFile, file, "credentials.json");
     will_return(__wrap_IsFile, 1);
 
-    expect_string(__wrap__mwarn, formatted_msg, "File 'credentials.json' not found. Check your configuration.");
+    expect_string(__wrap__merror, formatted_msg, "File 'credentials.json' not found. Check your configuration.");
 
     ret = wm_gcp_pubsub_read(data->nodes, data->module);
 
@@ -915,7 +915,7 @@ static void test_wm_gcp_pubsub_read_invalid_nodes(void **state) {
     group_data_t *data = *state;
     int ret;
 
-    expect_string(__wrap__mwarn, formatted_msg, "Empty configuration at module 'gcp-pubsub'.");
+    expect_string(__wrap__merror, formatted_msg, "Empty configuration at module 'gcp-pubsub'.");
 
     ret = wm_gcp_pubsub_read(NULL, data->module);
 
@@ -1009,7 +1009,7 @@ static void test_wm_gcp_bucket_read_no_bucket(void **state) {
     expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
     will_return(__wrap_sched_scan_read, 0);
 
-    expect_string(__wrap__mwarn, formatted_msg, "No buckets or services definitions found at module 'gcp-bucket'.");
+    expect_string(__wrap__merror, formatted_msg, "No buckets or services definitions found at module 'gcp-bucket'.");
 
     ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
 
@@ -1271,7 +1271,7 @@ static void test_wm_gcp_bucket_read_credentials_file_tag_realpath_error(void **s
 
     will_return(__wrap_realpath, (char *) NULL);   //  realpath failed
 
-    expect_string(__wrap__mwarn, formatted_msg, "File '' from tag 'credentials_file' not found.");
+    expect_string(__wrap__merror, formatted_msg, "File '' from tag 'credentials_file' not found.");
 
     ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
 
@@ -1291,7 +1291,7 @@ static void test_wm_gcp_bucket_read_credentials_file_tag_file_not_found(void **s
     expect_string(__wrap_IsFile, file, "credentials.json");
     will_return(__wrap_IsFile, 1);
 
-    expect_string(__wrap__mwarn, formatted_msg, "File 'credentials.json' not found. Check your configuration.");
+    expect_string(__wrap__merror, formatted_msg, "File 'credentials.json' not found. Check your configuration.");
 
     ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
 
@@ -1369,7 +1369,7 @@ static void test_wm_gcp_bucket_read_invalid_nodes(void **state) {
     group_data_t *data = *state;
     int ret;
 
-    expect_string(__wrap__mwarn, formatted_msg, "Empty configuration at module 'gcp-bucket'.");
+    expect_string(__wrap__merror, formatted_msg, "Empty configuration at module 'gcp-bucket'.");
 
     ret = wm_gcp_bucket_read(data->xml, NULL, data->module);
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -152,7 +152,7 @@ int local_start()
     } else {
         /* Check auth keys */
         if (!OS_CheckKeys()) {
-            mlerror_exit(LOGLEVEL_ERROR, AG_NOKEYS_EXIT);
+            merror_exit(AG_NOKEYS_EXIT);
         }
     }
     /* Read keys */
@@ -282,7 +282,7 @@ int local_start()
         mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
     }
 
-    if (!wm_config() && !wm_check()) {
+    if (!wm_check()) {
         wmodule * cur_module;
 
         for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -107,17 +107,17 @@ int local_start()
     /* Read agent config */
     mdebug1("Reading agent configuration.");
     if (ClientConf(cfg) < 0) {
-        merror_exit(CLIENT_ERROR);
+        mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 
     if (!Validate_Address(agt->server)){
         merror(AG_INV_MNGIP, agt->server[0].rip);
-        merror_exit(CLIENT_ERROR);
+        mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 
     if (!Validate_IPv6_Link_Local_Interface(agt->server)){
         merror(AG_INV_INT);
-        merror_exit(CLIENT_ERROR);
+        mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 
     if (agt->notify_time == 0) {
@@ -143,7 +143,7 @@ int local_start()
     w_msg_hash_queues_init();
 
     if (LogCollectorConfig(cfg) < 0) {
-        merror_exit(CONFIG_ERROR, cfg);
+        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
     }
 
     if(agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
@@ -152,7 +152,7 @@ int local_start()
     } else {
         /* Check auth keys */
         if (!OS_CheckKeys()) {
-            merror_exit(AG_NOKEYS_EXIT);
+            mlerror_exit(LOGLEVEL_ERROR, AG_NOKEYS_EXIT);
         }
     }
     /* Read keys */

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -278,6 +278,10 @@ int local_start()
 
     // Read wodle configuration and start modules
 
+    if (wm_config() < 0) {
+        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
+    }
+
     if (!wm_config() && !wm_check()) {
         wmodule * cur_module;
 


### PR DESCRIPTION
|Related issue|Manual testing|Integration tests|
|---|---|---|
|https://github.com/wazuh/wazuh/issues/15576|wazuh/wazuh-qa#4067|https://github.com/wazuh/wazuh-qa/pull/4094|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR resolves the issue https://github.com/wazuh/wazuh/issues/15576, the proposed solution was to add an error message when wazuh-agent does not start, a warning message when wazuh-agent starts and fixes some modules on Windows that start but should not start when there are invalid configurations, should have the same behavior as Linux (see [table](https://github.com/wazuh/wazuh/issues/assigned/thejbte#issuecomment- 1421287296)).
<!--
Add a clear description of how the problem has been solved.
-->


## Tests
- Open `ossec.conf` and modify these [modules](https://github.com/wazuh/wazuh/issues/assigned/thejbte#issuecomment- 1421287296) with invalid configuration.
- Start/restart agent
- Validate wazuh-agent status.

Note:
The Windows GUI does not update the state to stop when there is an invalid configuration.
![Screenshot from 2023-02-22 22-06-41](https://user-images.githubusercontent.com/17997755/220817137-9018286c-763c-4379-8091-e89e55065bfc.png)

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
