### PR TITLE
Add AggregationType to context and + counter UT

### DIFF
--- a/src/engine/source/metrics/include/metricsContext.hpp
+++ b/src/engine/source/metrics/include/metricsContext.hpp
@@ -46,6 +46,7 @@ struct MetricsContext
     ProcessorsTypes processorType;
     ProviderTypes providerType;
     opentelemetry::sdk::metrics::InstrumentType instrumentType;
+    opentelemetry::sdk::metrics::AggregationType aggregationType;
     std::vector<double> histogramVector;
     std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter;
     std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> metricExporter;

--- a/src/engine/source/metrics/src/providerHandler.cpp
+++ b/src/engine/source/metrics/src/providerHandler.cpp
@@ -33,6 +33,7 @@ void ProviderHandler::create(std::shared_ptr<MetricsContext> data)
             auto provider = std::shared_ptr<opentelemetry::metrics::MeterProvider>(new opentelemetry::sdk::metrics::MeterProvider());
             data->meterProvider = std::static_pointer_cast<opentelemetry::sdk::metrics::MeterProvider>(provider);
             data->meterProvider->AddMetricReader(std::move(data->reader));
+
             switch (data->instrumentType)
             {
                 case opentelemetry::sdk::metrics::InstrumentType::kHistogram:
@@ -58,7 +59,7 @@ void ProviderHandler::create(std::shared_ptr<MetricsContext> data)
                     auto instrumentSelector = std::unique_ptr<opentelemetry::sdk::metrics::InstrumentSelector>(new opentelemetry::sdk::metrics::InstrumentSelector(data->instrumentType, name));
                     auto meterSelector = std::unique_ptr<opentelemetry::sdk::metrics::MeterSelector>(new opentelemetry::sdk::metrics::MeterSelector(data->counterName, version, schema));
                     std::unique_ptr<opentelemetry::sdk::metrics::View> counterView{new opentelemetry::sdk::metrics::View{
-                    data->counterName, "description", opentelemetry::sdk::metrics::AggregationType::kDefault}};
+                    data->counterName, "description", data->aggregationType }};
                     data->meterProvider->AddView(std::move(instrumentSelector), std::move(meterSelector), std::move(counterView));
                     opentelemetry::metrics::Provider::SetMeterProvider(provider);
                     break;

--- a/src/engine/test/source/metrics/counter_test.cpp
+++ b/src/engine/test/source/metrics/counter_test.cpp
@@ -36,12 +36,6 @@ protected:
 
 TEST_F(MetricsInstrumentationTest, CounterTest)
 {
-    /*
-    Initialize an exporter and a reader.
-    In this case, we initialize an OStream Exporter which will print to stdout by
-    default. The reader periodically collects metrics from the Aggregation Store and
-    exports them.
-    */
     m_spContext->exporterType = ExportersTypes::Logging;
     m_spContext->loggingFileExport = true;
     m_spContext->outputFile = "counter.txt";
@@ -50,6 +44,101 @@ TEST_F(MetricsInstrumentationTest, CounterTest)
     m_spContext->export_interval_millis = std::chrono::milliseconds(1000);
     m_spContext->export_timeout_millis = std::chrono::milliseconds(500);
     m_spContext->counterName = "example";
+    auto exporter = std::make_shared<ExporterHandler>();
+    auto reader = std::make_shared<ReaderHandler>();
+    auto provider = std::make_shared<ProviderHandler>();
+    exporter->setNext(reader)->setNext(provider);
+    exporter->handleRequest(m_spContext);
+    counterExample(m_spContext->counterName);
+}
+
+TEST_F(MetricsInstrumentationTest, counterDefaultExample)
+{
+    m_spContext->exporterType = ExportersTypes::Logging;
+    m_spContext->loggingFileExport = true;
+    m_spContext->outputFile = "counter-kDefault.txt";
+    m_spContext->providerType = ProviderTypes::Meter;
+    m_spContext->instrumentType = opentelemetry::sdk::metrics::InstrumentType::kCounter;
+    m_spContext->aggregationType = opentelemetry::sdk::metrics::AggregationType::kDefault;
+    m_spContext->export_interval_millis = std::chrono::milliseconds(500);
+    m_spContext->export_timeout_millis = std::chrono::milliseconds(250);
+    m_spContext->counterName = "counter-kDefault";
+    auto exporter = std::make_shared<ExporterHandler>();
+    auto reader = std::make_shared<ReaderHandler>();
+    auto provider = std::make_shared<ProviderHandler>();
+    exporter->setNext(reader)->setNext(provider);
+    exporter->handleRequest(m_spContext);
+    counterExample(m_spContext->counterName);
+}
+
+TEST_F(MetricsInstrumentationTest, counterkDropExample)
+{
+    m_spContext->exporterType = ExportersTypes::Logging;
+    m_spContext->loggingFileExport = true;
+    m_spContext->outputFile = "counter-kDrop.txt";
+    m_spContext->providerType = ProviderTypes::Meter;
+    m_spContext->instrumentType = opentelemetry::sdk::metrics::InstrumentType::kCounter;
+    m_spContext->aggregationType = opentelemetry::sdk::metrics::AggregationType::kDrop;
+    m_spContext->export_interval_millis = std::chrono::milliseconds(500);
+    m_spContext->export_timeout_millis = std::chrono::milliseconds(250);
+    m_spContext->counterName = "counter-kDrop";
+    auto exporter = std::make_shared<ExporterHandler>();
+    auto reader = std::make_shared<ReaderHandler>();
+    auto provider = std::make_shared<ProviderHandler>();
+    exporter->setNext(reader)->setNext(provider);
+    exporter->handleRequest(m_spContext);
+    counterExample(m_spContext->counterName);
+}
+
+TEST_F(MetricsInstrumentationTest, counterkHistogramExample)
+{
+    m_spContext->exporterType = ExportersTypes::Logging;
+    m_spContext->loggingFileExport = true;
+    m_spContext->outputFile = "counter-kHistogram.txt";
+    m_spContext->providerType = ProviderTypes::Meter;
+    m_spContext->instrumentType = opentelemetry::sdk::metrics::InstrumentType::kCounter;
+    m_spContext->aggregationType = opentelemetry::sdk::metrics::AggregationType::kHistogram;
+    m_spContext->export_interval_millis = std::chrono::milliseconds(500);
+    m_spContext->export_timeout_millis = std::chrono::milliseconds(250);
+    m_spContext->counterName = "counter-kHistogram";
+    auto exporter = std::make_shared<ExporterHandler>();
+    auto reader = std::make_shared<ReaderHandler>();
+    auto provider = std::make_shared<ProviderHandler>();
+    exporter->setNext(reader)->setNext(provider);
+    exporter->handleRequest(m_spContext);
+    counterExample(m_spContext->counterName);
+}
+
+TEST_F(MetricsInstrumentationTest, counterkLastValueExample)
+{
+    m_spContext->exporterType = ExportersTypes::Logging;
+    m_spContext->loggingFileExport = true;
+    m_spContext->outputFile = "counter-kLastValue.txt";
+    m_spContext->providerType = ProviderTypes::Meter;
+    m_spContext->instrumentType = opentelemetry::sdk::metrics::InstrumentType::kCounter;
+    m_spContext->aggregationType = opentelemetry::sdk::metrics::AggregationType::kLastValue;
+    m_spContext->export_interval_millis = std::chrono::milliseconds(500);
+    m_spContext->export_timeout_millis = std::chrono::milliseconds(250);
+    m_spContext->counterName = "counter-kLastValue";
+    auto exporter = std::make_shared<ExporterHandler>();
+    auto reader = std::make_shared<ReaderHandler>();
+    auto provider = std::make_shared<ProviderHandler>();
+    exporter->setNext(reader)->setNext(provider);
+    exporter->handleRequest(m_spContext);
+    counterExample(m_spContext->counterName);
+}
+
+TEST_F(MetricsInstrumentationTest, counterkSumExample)
+{
+    m_spContext->exporterType = ExportersTypes::Logging;
+    m_spContext->loggingFileExport = true;
+    m_spContext->outputFile = "counter-kSum.txt";
+    m_spContext->providerType = ProviderTypes::Meter;
+    m_spContext->instrumentType = opentelemetry::sdk::metrics::InstrumentType::kCounter;
+    m_spContext->aggregationType = opentelemetry::sdk::metrics::AggregationType::kSum;
+    m_spContext->export_interval_millis = std::chrono::milliseconds(500);
+    m_spContext->export_timeout_millis = std::chrono::milliseconds(250);
+    m_spContext->counterName = "counter-kSum";
     auto exporter = std::make_shared<ExporterHandler>();
     auto reader = std::make_shared<ReaderHandler>();
     auto provider = std::make_shared<ProviderHandler>();


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors