### PR TITLE
Logcollector modified to collect normal logs as json objects

### DIFF
--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -36,6 +36,8 @@
 #define OS_LOGCOLLECTOR_JSON_HASH       "hash"
 #define OS_LOGCOLLECTOR_JSON_OFFSET     "offset"
 
+///< JSON field name which will contain a log that is originally not a json object
+#define LOGCOLLECTOR_JSON_EVENT_FIELD   "log"
 
 #include "shared.h"
 #include "config/localfile-config.h"

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -36,8 +36,8 @@
 #define OS_LOGCOLLECTOR_JSON_HASH       "hash"
 #define OS_LOGCOLLECTOR_JSON_OFFSET     "offset"
 
-///< JSON field name which will contain a log that is originally not a json object
-#define LOGCOLLECTOR_JSON_EVENT_FIELD   "log"
+///< JSON field which will contain a non-json event, notice that "event" is an object that contains the field "original"
+#define LOGCOLLECTOR_JSON_EVENT_FIELD   "event.original"
 
 #include "shared.h"
 #include "config/localfile-config.h"

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -18,11 +18,8 @@
 void *read_json(logreader *lf, int *rc, int drop_it) {
     int __ms = 0;
     int __ms_reported = 0;
-    int i;
-    char *jsonParsed;
     char str[OS_MAXSTR + 1];
     int lines = 0;
-    cJSON * obj;
     int64_t offset = 0;
     int64_t rbytes = 0;
 
@@ -101,21 +98,33 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
             continue;
         }
 
-        const char *jsonErrPtr;
-        if (obj = cJSON_ParseWithOpts(str, &jsonErrPtr, 0), obj && cJSON_IsObject(obj)) {
-          for (i = 0; lf->labels && lf->labels[i].key; i++) {
-              W_JSON_AddField(obj, lf->labels[i].key, lf->labels[i].value);
-          }
+        const char * jsonErrPtr;
+        cJSON * obj = cJSON_ParseWithOpts(str, &jsonErrPtr, 0);
 
-          jsonParsed = cJSON_PrintUnformatted(obj);
-          cJSON_Delete(obj);
-        } else {
-          cJSON_Delete(obj);
-          mdebug1("Line '%.*s'%s read from '%s' is not a JSON object.", sample_log_length, str, rbytes > sample_log_length ? "..." : "", lf->file);
-          continue;
+        if (!cJSON_IsObject(obj)) {
+            mdebug2("JSON input is not a json object.");
+            if (NULL != obj) {
+                cJSON_Delete(obj);
+            }
+            obj = cJSON_CreateObject();
+            W_JSON_AddField(obj, LOGCOLLECTOR_JSON_EVENT_FIELD, str);
         }
 
-        mdebug2("Reading json message: '%.*s'%s", sample_log_length, jsonParsed, strlen(jsonParsed) > (size_t)sample_log_length ? "..." : "");
+        if (NULL == obj) {
+            mdebug1("Line '%.*s'%s read from '%s' could not be converted to a JSON object.",
+                                            sample_log_length, str, rbytes > sample_log_length ? "..." : "", lf->file);
+            continue;
+        }
+
+        for (int i = 0; lf->labels && lf->labels[i].key; i++) {
+            W_JSON_AddField(obj, lf->labels[i].key, lf->labels[i].value);
+        }
+
+        char * jsonParsed = cJSON_PrintUnformatted(obj);
+        cJSON_Delete(obj);
+
+        mdebug2("Reading json message: '%.*s'%s",
+                            sample_log_length, jsonParsed, strlen(jsonParsed) > (size_t)sample_log_length ? "..." : "");
 
         /* Send message to queue */
         if (drop_it == 0) {


### PR DESCRIPTION
|Related issue|
|---|
|#16263|

## Description

As required on issue #16263, this PR modifies `logcollector` to collect logs that are not JSON objects when the `log_format` is set to `json`. To do so, such a log is embedded in a JSON object under a field called `LOGCOLLECTOR_JSON_EVENT_FIELD` which at this time is translated to `"event.original"` (this is a field called `original` contained by an object called `event`).

## Configuration example

```xml
  <localfile>
    <location>/root/test.log</location>
    <log_format>json</log_format>
    <label key="purpose">test</label>
    <label key="event.module">test-json</label>
    <label key="agent.nickname">Test nickname</label>
  </localfile>
```

## Expected examples
It must be taken into account that some additional fields may be present according to the nature of the engine and the order of the parameters cannot be the one displayed in the examples.
### Example 1
#### Input
```json
{"log": "Testing event"}
```
#### Output
```json
{
  "wazuh": {
    "queue": 49
  },
  "event": {
    "original": "{\"log\":\"Testing event\",\"purpose\":\"test\",\"event\":{\"module\":\"test-json\"},\"agent\":{\"nickname\":\"Test nickname\"}}"
  }
}
```
### Example 2
#### Input
```
Testing event
```
#### Output
```json
{
  "wazuh": {
    "queue": 49
  },
  "event": {
    "original": "{\"event\":{\"original\":\"Testing event\",\"module\":\"test-json\"},\"purpose\":\"test\",\"agent\":{\"nickname\":\"Test nickname\"}}"
  }
}
```

## Valgrind report

### Valgrind report reference before changes
```
==19860== Memcheck, a memory error detector
==19860== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==19860== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==19860== Command: /var/ossec/bin/wazuh-logcollector -fdd
==19860== Parent PID: 1518
==19860== 
==19860== 
==19860== HEAP SUMMARY:
==19860==     in use at exit: 18,473 bytes in 126 blocks
==19860==   total heap usage: 2,908,422 allocs, 2,908,296 frees, 1,074,955,458 bytes allocated
==19860== 
==19860== LEAK SUMMARY:
==19860==    definitely lost: 0 bytes in 0 blocks
==19860==    indirectly lost: 0 bytes in 0 blocks
==19860==      possibly lost: 2,016 bytes in 7 blocks
==19860==    still reachable: 16,457 bytes in 119 blocks
==19860==         suppressed: 0 bytes in 0 blocks
==19860== Reachable blocks (those to which a pointer was found) are not shown.
==19860== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==19860== 
==19860== For lists of detected and suppressed errors, rerun with: -s
==19860== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
```

### Valgrind report after changes
```
==60002== Memcheck, a memory error detector
==60002== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==60002== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==60002== Command: /var/ossec/bin/wazuh-logcollector -fdd
==60002== Parent PID: 58254
==60002==
==60002==
==60002== HEAP SUMMARY:
==60002==     in use at exit: 18,441 bytes in 124 blocks
==60002==   total heap usage: 4,806,502 allocs, 4,806,378 frees, 1,628,553,727 bytes allocated
==60002==
==60002== LEAK SUMMARY:
==60002==    definitely lost: 0 bytes in 0 blocks
==60002==    indirectly lost: 0 bytes in 0 blocks
==60002==      possibly lost: 2,016 bytes in 7 blocks
==60002==    still reachable: 16,425 bytes in 117 blocks
==60002==         suppressed: 0 bytes in 0 blocks
==60002== Reachable blocks (those to which a pointer was found) are not shown.
==60002== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==60002==
==60002== For lists of detected and suppressed errors, rerun with: -s
==60002== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
```