### PR TITLE
wazuh control options

### DIFF
--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -309,6 +309,7 @@ restart)
     ;;
 reload)
     DAEMONS=$(echo $DAEMONS | sed 's/wazuh-execd//')
+    testconfig
     lock
     stop_service
     sleep 1

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -390,6 +390,7 @@ restart)
     ;;
 reload)
     DAEMONS=$(echo $DAEMONS | sed 's/wazuh-execd//')
+    testconfig
     lock
     stop_service
     start_service

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -582,6 +582,7 @@ restart)
     ;;
 reload)
     DAEMONS=$(echo $DAEMONS | sed 's/wazuh-execd//')
+    testconfig
     lock
     stop_service
     start_service


### PR DESCRIPTION
|Related issue|Manual testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/15577|-|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR resolves the issue https://github.com/wazuh/wazuh/issues/15577, the proposed solution was to add `testconfig` to wazuh-control reload options.


## Tests
Setting an invalid configuration for Sycollector on an agent that is already running and attempting a reload. This action will not be possible because this option is checked before stopping the agent. In this case, the agent should continue working with the previous valid configuration.

It can be seen that no wazuh process is restarted when there is an invalid configuration.
`watch -n 0.1 "COLUMNS= ps aux | grep -v \"ssh\|bash\|ps\|grep\" | grep wazuh"`





<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
