### PR TITLE
Support variable use in the ruleset

### DIFF
--- a/framework/wazuh/core/rule.py
+++ b/framework/wazuh/core/rule.py
@@ -130,7 +130,7 @@ def load_rules_from_file(rule_filename: str, rule_relative_path: str, rule_statu
         # Get variables in dict format {varname: value} (will only be used for id and level for now)
         variables = {}
         for vari in root.findall('var'):
-            name = "$"+vari.attrib.get('name')
+            name = "$" + vari.attrib.get('name')
             value = vari.text
             variables[name] = value
 
@@ -142,7 +142,7 @@ def load_rules_from_file(rule_filename: str, rule_relative_path: str, rule_statu
                     if xml_rule.tag.lower() == "rule":
                         groups = list()
 
-                        #Replace values of id and level if variables exist
+                        # Replace values of id and level if variables exist
                         id_value = int(variables.get(xml_rule.attrib['id'], xml_rule.attrib['id']))
                         level_value = int(variables.get(xml_rule.attrib['level'], xml_rule.attrib['level']))
 

--- a/framework/wazuh/core/rule.py
+++ b/framework/wazuh/core/rule.py
@@ -127,6 +127,13 @@ def load_rules_from_file(rule_filename: str, rule_relative_path: str, rule_statu
         rules = list()
         root = load_wazuh_xml(os.path.join(common.WAZUH_PATH, rule_relative_path, rule_filename))
 
+        # Get variables in dict format {varname: value} (will only be used for id and level for now)
+        variables = {}
+        for vari in root.findall('var'):
+            name = "$"+vari.attrib.get('name')
+            value = vari.text
+            variables[name] = value
+
         for xml_group in list(root):
             if xml_group.tag.lower() == "group":
                 general_groups = xml_group.attrib['name'].split(',')
@@ -134,10 +141,15 @@ def load_rules_from_file(rule_filename: str, rule_relative_path: str, rule_statu
                     # New rule
                     if xml_rule.tag.lower() == "rule":
                         groups = list()
+
+                        #Replace values of id and level if variables exist
+                        id_value = int(variables.get(xml_rule.attrib['id'], xml_rule.attrib['id']))
+                        level_value = int(variables.get(xml_rule.attrib['level'], xml_rule.attrib['level']))
+
                         rule = {'filename': rule_filename, 'relative_dirname': rule_relative_path,
-                                'id': int(xml_rule.attrib['id']), 'level': int(xml_rule.attrib['level']),
-                                'status': rule_status, 'details': dict(), 'pci_dss': list(), 'gpg13': list(),
-                                'gdpr': list(), 'hipaa': list(), 'nist_800_53': list(), 'tsc': list(), 'mitre': list(),
+                                'id': id_value, 'level': level_value, 'status': rule_status,
+                                'details': dict(), 'pci_dss': list(), 'gpg13': list(), 'gdpr': list(),
+                                'hipaa': list(), 'nist_800_53': list(), 'tsc': list(), 'mitre': list(),
                                 'groups': list(), 'description': ''}
                         for k in xml_rule.attrib:
                             if k != 'id' and k != 'level':


### PR DESCRIPTION
|Related issue|
|---|
|#16032|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This fix provides the possibility to set the **ID** and **Level** options of a rule (inside the ruleset) with variables. The rules then can be consulted by API and the error _ValueError: invalid literal for int() with base 10: '$LEVEL'_ will not appear anymore. All variables must be defined at root level for them to work, not inside any tag. 
## Example

Using the following configuration on _/var/ossec/etc/rules/local_rules.xml_:

```
<var name="LEVEL">0</var>
<var name="ID">100001</var>

<!-- Example -->
<group name="local,syslog,sshd,">
  <rule id="$ID" level="$LEVEL">
    <if_sid>5716</if_sid>
    <srcip>1.1.1.1</srcip>
    <description>sshd: authentication failed from IP 1.1.1.1.</description>
    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>

</group>
```
and by consulting the API endpoint GET /rules we get the following response:

```
{
    "data": {
        "affected_items": [
            {
                "filename": "local_rules.xml",
                "relative_dirname": "etc/rules",
                "id": 100001,
                "level": 0,
                "status": "enabled",
                "details": {
                    "if_sid": "5716",
                    "srcip": "1.1.1.1"
                },
                "pci_dss": [
                    "10.2.4",
                    "10.2.5"
                ],
                "gpg13": [],
                "gdpr": [],
                "hipaa": [],
                "nist_800_53": [],
                "tsc": [],
                "mitre": [],
                "groups": [
                    "authentication_failed",
                    "local",
                    "syslog",
                    "sshd"
                ],
                "description": "sshd: authentication failed from IP 1.1.1.1."
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected rules were returned",
    "error": 0
}
```

confirming the ID and Level were replaced correctly by their variable values.
An issue for the documentation will be created in order to specify that variables must be defined at a root level, not inside any tag.


## Tests


<details><summary>Unit Tests 🟢 </summary>

```
              ============================= test session starts ==============================
                  platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
                  rootdir: /home/testuser/git/wazuh/framework
                  plugins: cov-3.0.0, aiohttp-1.0.4, trio-0.7.0, anyio-3.6.2, metadata-2.0.2, html-3.0.0, asyncio-0.18.1
                  asyncio: mode=auto
                  collected 2094 items
                  
                  framework/scripts/tests/test_agent_groups.py ..............              [  0%]
                  framework/scripts/tests/test_agent_upgrade.py ..............             [  1%]
                  framework/scripts/tests/test_cluster_control.py ......                   [  1%]
                  framework/scripts/tests/test_rbac_control.py .........                   [  2%]
                  framework/scripts/tests/test_wazuh_clusterd.py .......                   [  2%]
                  framework/scripts/tests/test_wazuh_logtest.py ......................     [  3%]
                  framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................... [  4%]
                  .............                                                            [  4%]
                  framework/wazuh/core/cluster/tests/test_client.py ................       [  5%]
                  framework/wazuh/core/cluster/tests/test_cluster.py ..................... [  6%]
                  ..............                                                           [  7%]
                  framework/wazuh/core/cluster/tests/test_common.py ...................... [  8%]
                  ............................................................             [ 11%]
                  framework/wazuh/core/cluster/tests/test_control.py ......                [ 11%]
                  framework/wazuh/core/cluster/tests/test_local_client.py ..............   [ 12%]
                  framework/wazuh/core/cluster/tests/test_local_server.py ................ [ 13%]
                  ........                                                                 [ 13%]
                  framework/wazuh/core/cluster/tests/test_master.py ...................... [ 14%]
                  ..........................                                               [ 15%]
                  framework/wazuh/core/cluster/tests/test_server.py ...................... [ 16%]
                  .......                                                                  [ 17%]
                  framework/wazuh/core/cluster/tests/test_utils.py ...........             [ 17%]
                  framework/wazuh/core/cluster/tests/test_worker.py ...................... [ 18%]
                  ............                                                             [ 19%]
                  framework/wazuh/core/tests/test_active_response.py ..............        [ 19%]
                  framework/wazuh/core/tests/test_agent.py ............................... [ 21%]
                  ........................................................................ [ 24%]
                  ............................................                             [ 26%]
                  framework/wazuh/core/tests/test_cdb_list.py ............................ [ 28%]
                  ..........                                                               [ 28%]
                  framework/wazuh/core/tests/test_common.py .........                      [ 29%]
                  framework/wazuh/core/tests/test_configuration.py ....................... [ 30%]
                  ................................................                         [ 32%]
                  framework/wazuh/core/tests/test_database.py .............                [ 33%]
                  framework/wazuh/core/tests/test_decoder.py ................              [ 33%]
                  framework/wazuh/core/tests/test_exception.py ...                         [ 34%]
                  framework/wazuh/core/tests/test_input_validator.py ...                   [ 34%]
                  framework/wazuh/core/tests/test_logtest.py ..                            [ 34%]
                  framework/wazuh/core/tests/test_manager.py ................              [ 35%]
                  framework/wazuh/core/tests/test_mitre.py .............                   [ 35%]
                  framework/wazuh/core/tests/test_pyDaemonModule.py .....                  [ 35%]
                  framework/wazuh/core/tests/test_results.py ............................. [ 37%]
                  ...........                                                              [ 37%]
                  framework/wazuh/core/tests/test_rootcheck.py .............               [ 38%]
                  framework/wazuh/core/tests/test_rule.py ......................           [ 39%]
                  framework/wazuh/core/tests/test_sca.py ........................          [ 40%]
                  framework/wazuh/core/tests/test_security.py .............                [ 41%]
                  framework/wazuh/core/tests/test_stats.py .................               [ 42%]
                  framework/wazuh/core/tests/test_syscheck.py .......                      [ 42%]
                  framework/wazuh/core/tests/test_syscollector.py ...                      [ 42%]
                  framework/wazuh/core/tests/test_task.py ........                         [ 42%]
                  framework/wazuh/core/tests/test_utils.py ............................... [ 44%]
                  ........................................................................ [ 47%]
                  ........................................................................ [ 51%]
                  ...................................................................      [ 54%]
                  framework/wazuh/core/tests/test_vulnerability.py ..                      [ 54%]
                  framework/wazuh/core/tests/test_wazuh_queue.py ....................      [ 55%]
                  framework/wazuh/core/tests/test_wazuh_socket.py ....................     [ 56%]
                  framework/wazuh/core/tests/test_wdb.py ...............................   [ 58%]
                  framework/wazuh/core/tests/test_wlogging.py ............                 [ 58%]
                  framework/wazuh/rbac/tests/test_auth_context.py ..                       [ 58%]
                  framework/wazuh/rbac/tests/test_decorators.py .......................... [ 59%]
                  ........................................................................ [ 63%]
                  ...........                                                              [ 63%]
                  framework/wazuh/rbac/tests/test_default_configuration.py ............... [ 64%]
                  .........................................                                [ 66%]
                  framework/wazuh/rbac/tests/test_orm.py ................................. [ 68%]
                  ................................                                         [ 69%]
                  framework/wazuh/rbac/tests/test_preprocessor.py ...........              [ 70%]
                  framework/wazuh/tests/test_active_response.py ............               [ 70%]
                  framework/wazuh/tests/test_agent.py .................................... [ 72%]
                  ........................................................................ [ 75%]
                  ..........                                                               [ 76%]
                  framework/wazuh/tests/test_cdb_list.py ................................. [ 77%]
                  ....................                                                     [ 78%]
                  framework/wazuh/tests/test_ciscat.py .................................   [ 80%]
                  framework/wazuh/tests/test_cluster.py ..........                         [ 80%]
                  framework/wazuh/tests/test_decoder.py .................................. [ 82%]
                  .                                                                        [ 82%]
                  framework/wazuh/tests/test_group.py .......                              [ 82%]
                  framework/wazuh/tests/test_logtest.py ......                             [ 83%]
                  framework/wazuh/tests/test_manager.py .................................. [ 84%]
                  ..                                                                       [ 85%]
                  framework/wazuh/tests/test_mitre.py .......                              [ 85%]
                  framework/wazuh/tests/test_rootcheck.py ................................ [ 86%]
                  ..................                                                       [ 87%]
                  framework/wazuh/tests/test_rule.py ..................................... [ 89%]
                  ..................                                                       [ 90%]
                  framework/wazuh/tests/test_sca.py ...........                            [ 90%]
                  framework/wazuh/tests/test_security.py ................................. [ 92%]
                  ......................................                                   [ 94%]
                  framework/wazuh/tests/test_stats.py ...............                      [ 94%]
                  framework/wazuh/tests/test_syscheck.py .........................         [ 96%]
                  framework/wazuh/tests/test_syscollector.py ............                  [ 96%]
                  framework/wazuh/tests/test_task.py ............................          [ 98%]
                  framework/wazuh/tests/test_vulnerability.py ............................ [ 99%]
                  ............                                                             [100%]
                  
                  =============================== warnings summary ===============================
                  ../../venv/unittest-env/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28
                    /home/testuser/venv/unittest-env/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
                      config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)
                  
                  framework/wazuh/core/utils.py:928
                    /home/testuser/git/wazuh/framework/wazuh/core/utils.py:928: DeprecationWarning: invalid escape sequence \g
                      data = re.sub(r'^&backslash;<(.*[^>])$', '&backslash;&lt;\g<1>', data)
                  
                  ../../venv/unittest-env/lib/python3.9/site-packages/jsonschema/compat.py:6
                  ../../venv/unittest-env/lib/python3.9/site-packages/jsonschema/compat.py:6
                    /home/testuser/venv/unittest-env/lib/python3.9/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
                      from collections import MutableMapping, Sequence  # noqa
                  
                  framework/wazuh/core/InputValidator.py:18
                    /home/testuser/git/wazuh/framework/wazuh/core/InputValidator.py:18: DeprecationWarning: invalid escape sequence \w
                      """Abstract function to check a name matches a regex (\\w+ by default).
                  
                  ../../venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:48
                    /home/testuser/venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:48: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
                      def problems_middleware(request, handler):
                  
                  ../../venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:169
                    /home/testuser/venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:169: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
                      def _get_openapi_json(self, request):
                  
                  ../../venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:177
                    /home/testuser/venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:177: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
                      def _get_openapi_yaml(self, request):
                  
                  ../../venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:236
                    /home/testuser/venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:236: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
                      def _get_swagger_ui_home(self, req):
                  
                  ../../venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:246
                    /home/testuser/venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:246: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
                      def _get_swagger_ui_config(self, req):
                  
                  ../../venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:295
                    /home/testuser/venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:295: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
                      def get_request(cls, req):
                  
                  ../../venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:324
                    /home/testuser/venv/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:324: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
                      def get_response(cls, response, mimetype=None, request=None):
                  
                  framework/wazuh/core/cluster/dapi/tests/test_dapi.py:67
                    /home/testuser/git/wazuh/framework/wazuh/core/cluster/dapi/tests/test_dapi.py:67: PytestCollectionWarning: cannot collect test class 'TestingLoggerParent' because it has a __init__ constructor (from: wazuh/core/cluster/dapi/tests/test_dapi.py)
                      class TestingLoggerParent:
                  
                  framework/wazuh/core/cluster/dapi/tests/test_dapi.py:73
                    /home/testuser/git/wazuh/framework/wazuh/core/cluster/dapi/tests/test_dapi.py:73: PytestCollectionWarning: cannot collect test class 'TestingLogger' because it has a __init__ constructor (from: wazuh/core/cluster/dapi/tests/test_dapi.py)
                      class TestingLogger:
                  
                  framework/wazuh/core/cluster/tests/test_local_client.py:7
                    /home/testuser/git/wazuh/framework/wazuh/core/cluster/tests/test_local_client.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
                      from collections import Callable
                  
                  scripts/tests/test_agent_groups.py::test_show_groups
                    /home/testuser/git/wazuh/framework/scripts/tests/test_agent_groups.py:42: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      forward_mock.has_calls([call(func=agent.get_agent_groups, kwargs={}),
                  
                  scripts/tests/test_agent_groups.py::test_show_group
                    /home/testuser/git/wazuh/framework/scripts/tests/test_agent_groups.py:69: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      forward_mock.has_calls(call(func=agent.get_agents, f_kwargs={'agent_list': agent_id}))
                  
                  scripts/tests/test_agent_groups.py::test_show_synced_agent
                    /home/testuser/git/wazuh/framework/scripts/tests/test_agent_groups.py:98: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      forward_mock.has_calls(call(func=agent.get_agents_sync_group, f_kwargs={'agent_list': [agent_id]}))
                  
                  scripts/tests/test_agent_groups.py::test_show_agents_with_group
                    /home/testuser/git/wazuh/framework/scripts/tests/test_agent_groups.py:125: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      forward_mock.has_calls(call(func=agent.get_agents_in_group, f_kwargs={'group_list': 'testing'}))
                  
                  scripts/tests/test_agent_groups.py::test_show_group_files
                    /home/testuser/git/wazuh/framework/scripts/tests/test_agent_groups.py:152: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      forward_mock.has_calls(call(func=agent.get_group_files, f_kwargs={'group_list': 'testing'}))
                  
                  scripts/tests/test_agent_groups.py::test_unset_group
                    /home/testuser/git/wazuh/framework/scripts/tests/test_agent_groups.py:181: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      forward_mock.has_calls(call(func=agent.remove_agent_from_groups,
                  
                  scripts/tests/test_agent_groups.py::test_remove_group
                    /home/testuser/git/wazuh/framework/scripts/tests/test_agent_groups.py:217: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      forward_mock.has_calls(call(func=agent.delete_groups, f_kwargs={'group_list': ['testing']}))
                  
                  scripts/tests/test_agent_groups.py::test_set_group
                    /home/testuser/git/wazuh/framework/scripts/tests/test_agent_groups.py:252: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      forward_mock.has_calls(call(func=agent.assign_agents_to_group,
                  
                  scripts/tests/test_agent_groups.py::test_create_group
                    /home/testuser/git/wazuh/framework/scripts/tests/test_agent_groups.py:291: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      forward_mock.has_calls(call(func=agent.create_group, f_kwargs={'group_id': group_id}))
                  
                  scripts/tests/test_cluster_control.py::test_main
                    /usr/lib/python3.9/unittest/mock.py:328: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      self.__dict__[_the_name] = value
                  
                  wazuh/core/cluster/tests/test_client.py::test_ac_connection_lost
                    /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'Handler.send_request' was never awaited
                      self.name = name
                  
                  wazuh/core/cluster/tests/test_client.py::test_ac_connection_lost
                    /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'Handler.log_exceptions' was never awaited
                      self.name = name
                  
                  wazuh/core/cluster/tests/test_common.py::test_rst_done_callback
                    /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'test_run_in_pool.<locals>.LoopMock.run_in_executor' was never awaited
                      self.name = name
                  
                  wazuh/core/cluster/tests/test_common.py::test_rst_done_callback
                    wazuh/core/cluster/tests/test_common.py:261: PytestWarning: The test <Function test_rst_done_callback> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
                      @pytest.mark.asyncio
                  
                  wazuh/core/cluster/tests/test_common.py::test_wazuh_common_setup_send_info
                    /usr/lib/python3.9/inspect.py:3052: RuntimeWarning: coroutine 'Event.wait' was never awaited
                      return self._bind(args, kwargs, partial=True)
                  
                  wazuh/core/cluster/tests/test_common.py::test_wazuh_common_error_receiving_file_ok
                  wazuh/core/cluster/tests/test_master.py::test_master_handler_execute_ko
                  wazuh/core/tests/test_agent.py::test_agent_get_agent_os_name[0-Ubuntu]
                    /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'Event.wait' was never awaited
                      setattr(_type, entry, MagicProxy(entry, self))
                  
                  wazuh/core/cluster/tests/test_local_client.py::test_localclient_execute
                    /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      self.name = name
                  
                  wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_process_request
                    /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'test_LocalServerHandler_get_send_file_response.<locals>.func_mock' was never awaited
                      setattr(_type, entry, MagicProxy(entry, self))
                  
                  wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_process_request
                  wazuh/core/cluster/tests/test_master.py::test_rit_init
                  wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_integrity_ok_from_master
                  wazuh/core/tests/test_agent.py::test_agent_get_agent_os_name[0-Ubuntu]
                    /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'Handler.log_exceptions' was never awaited
                      setattr(_type, entry, MagicProxy(entry, self))
                  
                  wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_process_request
                  wazuh/core/cluster/tests/test_master.py::test_rit_init
                  wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_integrity_ok_from_master
                  wazuh/core/tests/test_agent.py::test_agent_get_agent_os_name[0-Ubuntu]
                    /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
                      setattr(_type, entry, MagicProxy(entry, self))
                  
                  wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerWorker_process_request
                    /usr/lib/python3.9/unittest/mock.py:328: RuntimeWarning: coroutine 'Handler.log_exceptions' was never awaited
                      self.__dict__[_the_name] = value
                  
                  wazuh/core/cluster/tests/test_master.py::test_master_handler_execute_ok
                    /home/testuser/venv/unittest-env/lib/python3.9/site-packages/pytest_asyncio/plugin.py:375: RuntimeWarning: coroutine 'test_LocalServerHandlerMaster_send_file_request.<locals>.func_mock' was never awaited
                      old_loop.close()
                  
                  wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_worker_files_ok
                    /usr/lib/python3.9/unittest/mock.py:566: RuntimeWarning: coroutine 'MasterHandler.send_agent_groups_information' was never awaited
                      self._mock_side_effect = value
                  
                  wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_worker_files_ok
                    /usr/lib/python3.9/unittest/mock.py:566: RuntimeWarning: coroutine 'Handler.forward_dapi_response' was never awaited
                      self._mock_side_effect = value
                  
                  wazuh/core/cluster/tests/test_worker.py::test_sync_wazuh_db_sync_ok
                    /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'WorkerHandler.process_files_from_master' was never awaited
                      setattr(_type, entry, MagicProxy(entry, self))
                  
                  wazuh/core/tests/test_agent.py::test_agent_get_agent_os_name[0-Ubuntu]
                    /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'Response.read' was never awaited
                      setattr(_type, entry, MagicProxy(entry, self))
                  
                  wazuh/rbac/tests/test_auth_context.py::test_auth_roles
                    /home/testuser/git/wazuh/framework/wazuh/rbac/auth_context.py:225: FutureWarning: Possible nested set at position 2
                      regex = re.compile(regex)
                  
                  -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
                  ================ 2094 passed, 50 warnings in 221.26s (0:03:41) =================
```

</details>

<details><summary>Integration Tests 🟢</summary>

```
================================================================================================ test session starts =================================================================================================
platform darwin -- Python 3.9.7, pytest-5.0.0, py-1.11.0, pluggy-0.13.1 -- /Users/mateo/.pyenv/versions/3.9.7/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.7', 'Platform': 'macOS-13.2.1-arm64-arm-64bit', 'Packages': {'pytest': '5.0.0', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.2.2', 'html': '2.1.1', 'metadata': '2.0.2'}}
rootdir: /Users/mateo/Laburo/Wazuh/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.2.2, html-2.1.1, metadata-2.0.2
collected 15 items

test_rule_endpoints.tavern.yaml::GET /rules PASSED                                                                                                                                                             [  6%]
test_rule_endpoints.tavern.yaml::GET /rules filters PASSED                                                                                                                                                     [ 13%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/pci_dss PASSED                                                                                                                                         [ 20%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/gdpr PASSED                                                                                                                                            [ 26%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/gpg13 PASSED                                                                                                                                           [ 33%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/hipaa PASSED                                                                                                                                           [ 40%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/nist-800-53 PASSED                                                                                                                                     [ 46%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/tsc PASSED                                                                                                                                             [ 53%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/mitre PASSED                                                                                                                                           [ 60%]
test_rule_endpoints.tavern.yaml::GET /rules/groups PASSED                                                                                                                                                      [ 66%]
test_rule_endpoints.tavern.yaml::GET /rules/files PASSED                                                                                                                                                       [ 73%]
test_rule_endpoints.tavern.yaml::GET /rules/files/{filename} PASSED                                                                                                                                            [ 80%]
test_rule_endpoints.tavern.yaml::PUT /rule/files/{filename} PASSED                                                                                                                                             [ 86%]
test_rule_endpoints.tavern.yaml::DELETE /rules/files/{filename} PASSED                                                                                                                                         [ 93%]
test_rule_endpoints.tavern.yaml::GET /rules?rule_ids PASSED                                                                                                                                                    [100%]

============================================================================================ 15 passed in 953.75 seconds =============================================================================================
```
</details>