### PR TITLE
Fix memory leaks in wazuh-analysisd when parsing and matching rules

### DIFF
--- a/ruleset/testing/ruleset/test_rules.xml
+++ b/ruleset/testing/ruleset/test_rules.xml
@@ -477,4 +477,46 @@
   <description>Wrong ifsid test.</description>
 </rule>
 
+<!-- Check that no memmory leak appears in nested if_matched_sid -->
+<!-- device="SFW" date=2000-12-01 time=17:19:06 timezone="+01" device_name="XXXX" device_id=1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Denied" status="Deny"' -->
+
+<rule id="999280" level="3">
+  <if_sid>70021</if_sid>
+  <field name="device_id">^1234567$</field>
+  <description>Traffic Denied</description>
+  <options>no_full_log</options>
+</rule>
+
+<rule id="999281" level="5" timeframe="3600">
+  <if_matched_sid>999280</if_matched_sid>
+  <description>Traffic Denied (SID level-1)</description>
+</rule>
+
+<rule id="999282" level="7" timeframe="3600">
+  <if_matched_sid>999281</if_matched_sid>
+  <description>Traffic Denied (SID level-2)</description>
+</rule>
+
+<!-- Check that no memmory leak appears in nested if_matched_group -->
+<!-- device="SFW" date=2000-12-01 time=17:19:06 timezone="+01" device_name="XXXX" device_id=12345678 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Denied" status="Deny"' -->
+
+<rule id="999283" level="3">
+  <if_sid>70021</if_sid>
+  <field name="device_id">^12345678$</field>
+  <description>Traffic Denied</description>
+  <options>no_full_log</options>
+  <group>test_if_group_1,</group>
+</rule>
+
+<rule id="999284" level="5" timeframe="3600">
+  <if_matched_group>test_if_group_1</if_matched_group>
+  <description>Traffic Denied (group level-1)</description>
+  <group>test_if_group_2,</group>
+</rule>
+
+<rule id="999285" level="7" timeframe="3600">
+  <if_matched_group>test_if_group_2</if_matched_group>
+  <description>Traffic Denied (group level-2)</description>
+</rule>
+
 </group>

--- a/ruleset/testing/tests/test_features.ini
+++ b/ruleset/testing/tests/test_features.ini
@@ -36,3 +36,19 @@ log 1 pass = Sep  5 13:14:00 User test_wrong_ifsid[12345]:Test
 rule = 999275
 alert = 3
 decoder = test_wrong_ifsid
+
+[nested if_matched_sid]
+log 1 pass = device="SFW" date=2000-12-01 time=17:19:06 timezone="+01" device_name="XXXX" device_id=1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Denied" status="Deny"
+log 1 pass = device="SFW" date=2000-12-01 time=17:19:06 timezone="+01" device_name="XXXX" device_id=1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Denied" status="Deny"
+log 1 pass = device="SFW" date=2000-12-01 time=17:19:06 timezone="+01" device_name="XXXX" device_id=1234567 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Denied" status="Deny"
+rule = 999282
+alert = 7
+decoder = sophos-fw
+
+[nested if_matched_group]
+log 1 pass = device="SFW" date=2000-12-01 time=17:19:06 timezone="+01" device_name="XXXX" device_id=12345678 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Denied" status="Deny"
+log 1 pass = device="SFW" date=2000-12-01 time=17:19:06 timezone="+01" device_name="XXXX" device_id=12345678 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Denied" status="Deny"
+log 1 pass = device="SFW" date=2000-12-01 time=17:19:06 timezone="+01" device_name="XXXX" device_id=12345678 log_id=010101010101 log_type="Firewall" log_component="Firewall Rule" log_subtype="Denied" status="Deny"
+rule = 999285
+alert = 7
+decoder = sophos-fw

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -677,6 +677,8 @@ int main_analysisd(int argc, char **argv)
                 char * msg;
                 OSList * list_msg = OSList_Create();
                 OSList_SetMaxSize(list_msg, ERRORLIST_MAXSIZE);
+                OSList_SetFreeDataPointer(list_msg, (void (*)(void *))os_analysisd_free_log_msg);
+
                 OSListNode * node_log_msg;
                 int error_exit = 0;
 
@@ -715,7 +717,7 @@ int main_analysisd(int argc, char **argv)
 
                     rulesfiles++;
                 }
-                os_free(list_msg);
+                OSList_Destroy(list_msg);
             }
 
             /* Find all rules that require list lookups and attache the the

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -577,7 +577,7 @@ int main_analysisd(int argc, char **argv)
                             merror("%s", msg);
                         }
                         os_free(msg);
-                        os_analysisd_free_log_msg(&data_msg);
+                        os_analysisd_free_log_msg(data_msg);
                         OSList_DeleteCurrentlyNode(list_msg);
                         node_log_msg = OSList_GetFirstNode(list_msg);
                     }
@@ -603,7 +603,7 @@ int main_analysisd(int argc, char **argv)
                     error_exit = 1;
                 }
                 os_free(msg);
-                os_analysisd_free_log_msg(&data_msg);
+                os_analysisd_free_log_msg(data_msg);
                 OSList_DeleteCurrentlyNode(list_msg);
                 node_log_msg = OSList_GetFirstNode(list_msg);
             }
@@ -645,7 +645,7 @@ int main_analysisd(int argc, char **argv)
                             merror("%s", msg);
                         }
                         os_free(msg);
-                        os_analysisd_free_log_msg(&data_msg);
+                        os_analysisd_free_log_msg(data_msg);
                         OSList_DeleteCurrentlyNode(list_msg);
                         node_log_msg = OSList_GetFirstNode(list_msg);
                     }
@@ -704,7 +704,7 @@ int main_analysisd(int argc, char **argv)
                             merror("%s", msg);
                         }
                         os_free(msg);
-                        os_analysisd_free_log_msg(&data_msg);
+                        os_analysisd_free_log_msg(data_msg);
                         OSList_DeleteCurrentlyNode(list_msg);
                         node_log_msg = OSList_GetFirstNode(list_msg);
                     }

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -228,7 +228,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, __attribute__((unused)) EventList *
         }
 
         /* Check if the number of matches worked */
-        if (frequency_count <= 10) {
+        if (frequency_count <= 10 && (my_lf->last_events == NULL || my_lf->last_events[frequency_count] == NULL)) {
             add_lastevt(my_lf->last_events, frequency_count, lf->full_log);
         }
 
@@ -411,7 +411,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, __attribute__((unused)) EventList
 
 
         /* Check if the number of matches worked */
-        if (frequency_count <= 10) {
+        if (frequency_count <= 10 && (my_lf->last_events == NULL || my_lf->last_events[frequency_count] == NULL)) {
             add_lastevt(my_lf->last_events, frequency_count, lf->full_log);
         }
 
@@ -593,7 +593,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, EventList *last_events, RuleInfo 
 
         /* Check if the number of matches worked */
         if (frequency_count < rule->frequency) {
-            if (frequency_count <= 10) {
+            if (frequency_count <= 10 && (my_lf->last_events == NULL || my_lf->last_events[frequency_count] == NULL)) {
                 add_lastevt(my_lf->last_events, frequency_count, lf->full_log);
             }
 

--- a/src/analysisd/logmsg.c
+++ b/src/analysisd/logmsg.c
@@ -10,7 +10,7 @@
 
 #include "logmsg.h"
 
-void _os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func, 
+void _os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func,
                                 const char * file, char * msg, ...) {
 
     va_list args;
@@ -74,14 +74,14 @@ char * os_analysisd_string_log_msg(os_analysisd_log_msg_t * log_msg) {
     return str;
 }
 
-void os_analysisd_free_log_msg(os_analysisd_log_msg_t ** log_msg) {
+void os_analysisd_free_log_msg(os_analysisd_log_msg_t * log_msg) {
 
-    if (!*log_msg) {
+    if (!log_msg) {
         return;
     }
 
-    os_free((*log_msg)->file);
-    os_free((*log_msg)->func);
-    os_free((*log_msg)->msg);
-    os_free(*log_msg);
+    os_free(log_msg->file);
+    os_free(log_msg->func);
+    os_free(log_msg->msg);
+    os_free(log_msg);
 }

--- a/src/analysisd/logmsg.h
+++ b/src/analysisd/logmsg.h
@@ -40,8 +40,8 @@ typedef struct os_analysisd_log_msg_t {
  * @param ...    additional arguments following format are formatted and inserted in the
  *                   resulting string replacing their respective specifiers.
  */
-void _os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func, 
-                                const char * file, char * msg, ...) __attribute__ ((format (_PRINTF_FORMAT, 6, 7))) 
+void _os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func,
+                                const char * file, char * msg, ...) __attribute__ ((format (_PRINTF_FORMAT, 6, 7)))
                                                                     __attribute__((nonnull (4, 5, 6)));
 
 /**
@@ -55,6 +55,6 @@ char * os_analysisd_string_log_msg(os_analysisd_log_msg_t * log_msg);
  * @brief Free \ref os_analysisd_log_msg_t
  * @param log_msg elements to free.
  */
-void os_analysisd_free_log_msg(os_analysisd_log_msg_t ** log_msg);
+void os_analysisd_free_log_msg(os_analysisd_log_msg_t * log_msg);
 
 #endif

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -439,7 +439,7 @@ w_logtest_session_t * w_logtest_initialize_session(OSList * list_msg) {
         files++;
     }
 
-    if (SetDecodeXML(list_msg, &session->decoder_store, &session->decoderlist_nopname, 
+    if (SetDecodeXML(list_msg, &session->decoder_store, &session->decoderlist_nopname,
                      &session->decoderlist_forpname) == 0) {
         goto cleanup;
     }
@@ -983,7 +983,7 @@ void w_logtest_add_msg_response(cJSON * response, OSList * list_msg, int * error
         /* Cleanup */
         os_free(raw_msg);
         os_free(json_str_msj);
-        os_analysisd_free_log_msg(&data_msg);
+        os_analysisd_free_log_msg(data_msg);
         OSList_DeleteCurrentlyNode(list_msg);
 
         node_log_msg = OSList_GetFirstNode(list_msg);
@@ -1267,7 +1267,7 @@ bool w_logtest_ruleset_load_config(OS_XML * xml, XML_NODE conf_section_nodes, _C
         }
 
         /* Load ruleset */
-        if (strcmp(conf_section_nodes[i]->element, XML_RULESET) == 0 
+        if (strcmp(conf_section_nodes[i]->element, XML_RULESET) == 0
             && Read_Rules(options_node, ruleset_config, list_msg) < 0) {
 
             OS_ClearNode(options_node);

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -1012,6 +1012,7 @@ char * w_logtest_process_request(char * raw_request, w_logtest_connection_t * co
     }
 
     OSList_SetMaxSize(list_msg, ERRORLIST_MAXSIZE);
+    OSList_SetFreeDataPointer(list_msg, (void (*)(void *))os_analysisd_free_log_msg);
 
     /* Check message and generate a request */
     json_response = cJSON_CreateObject();
@@ -1044,7 +1045,7 @@ char * w_logtest_process_request(char * raw_request, w_logtest_connection_t * co
     str_response = cJSON_PrintUnformatted(json_response);
     cJSON_Delete(json_response);
     cJSON_Delete(json_request);
-    os_free(list_msg);
+    OSList_Destroy(list_msg);
 
     return str_response;
 }

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -254,7 +254,7 @@ int main(int argc, char **argv)
                             msg = os_analysisd_string_log_msg(data_msg);
                             merror("%s", msg);
                             os_free(msg);
-                            os_analysisd_free_log_msg(&data_msg);
+                            os_analysisd_free_log_msg(data_msg);
                             OSList_DeleteCurrentlyNode(list_msg);
                             node_log_msg = OSList_GetFirstNode(list_msg);
                         }
@@ -281,7 +281,7 @@ int main(int argc, char **argv)
                         merror("%s", msg);
                     }
                     os_free(msg);
-                    os_analysisd_free_log_msg(&data_msg);
+                    os_analysisd_free_log_msg(data_msg);
                     OSList_DeleteCurrentlyNode(list_msg);
                     node_log_msg = OSList_GetFirstNode(list_msg);
                 }
@@ -313,7 +313,7 @@ int main(int argc, char **argv)
                             msg = os_analysisd_string_log_msg(data_msg);
                             merror("%s", msg);
                             os_free(msg);
-                            os_analysisd_free_log_msg(&data_msg);
+                            os_analysisd_free_log_msg(data_msg);
                             OSList_DeleteCurrentlyNode(list_msg);
                             node_log_msg = OSList_GetFirstNode(list_msg);
                         }
@@ -338,7 +338,7 @@ int main(int argc, char **argv)
                     error_exit = 1;
                 }
                 os_free(msg);
-                os_analysisd_free_log_msg(&data_msg);
+                os_analysisd_free_log_msg(data_msg);
                 OSList_DeleteCurrentlyNode(list_msg);
                 node_log_msg = OSList_GetFirstNode(list_msg);
             }
@@ -369,7 +369,7 @@ int main(int argc, char **argv)
                             msg = os_analysisd_string_log_msg(data_msg);
                             merror("%s", msg);
                             os_free(msg);
-                            os_analysisd_free_log_msg(&data_msg);
+                            os_analysisd_free_log_msg(data_msg);
                             OSList_DeleteCurrentlyNode(list_msg);
                             node_log_msg = OSList_GetFirstNode(list_msg);
                         }
@@ -418,7 +418,7 @@ int main(int argc, char **argv)
                             error_exit = 1;
                         }
                         os_free(msg);
-                        os_analysisd_free_log_msg(&data_msg);
+                        os_analysisd_free_log_msg(data_msg);
                         OSList_DeleteCurrentlyNode(list_msg);
                         node_log_msg = OSList_GetFirstNode(list_msg);
                     }

--- a/src/unit_tests/analysisd/test_logmsg.c
+++ b/src/unit_tests/analysisd/test_logmsg.c
@@ -19,7 +19,7 @@
 void _os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func,
                                 const char * file, char * msg, ...) __attribute__((nonnull));
 char * os_analysisd_string_log_msg(os_analysisd_log_msg_t * log_msg);
-void os_analysisd_free_log_msg(os_analysisd_log_msg_t ** log_msg);
+void os_analysisd_free_log_msg(os_analysisd_log_msg_t * log_msg);
 
 /* setup/teardown */
 
@@ -71,7 +71,7 @@ void test_os_analysisd_free_log_msg_NULL(void **state)
 
     os_analysisd_log_msg_t * message = NULL;
 
-    os_analysisd_free_log_msg(&message);
+    os_analysisd_free_log_msg(message);
 
 }
 
@@ -88,7 +88,7 @@ void test_os_analysisd_free_log_msg_OK(void **state)
     message->func = strdup("TestFunction");
 
 
-    os_analysisd_free_log_msg(&message);
+    os_analysisd_free_log_msg(message);
 
 }
 

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -2938,6 +2938,12 @@ void test_w_logtest_process_request_error_check_input(void ** state) {
 
     will_return(__wrap_cJSON_PrintUnformatted, "{json response}");
 
+    will_return(__wrap_pthread_rwlock_wrlock, 0);
+    will_return(__wrap_pthread_mutex_lock, 0);
+    will_return(__wrap_pthread_mutex_unlock, 0);
+    will_return(__wrap_pthread_rwlock_unlock, 0);
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
     retval = w_logtest_process_request(input_raw_json, &connection);
 
     assert_string_equal(retval, "{json response}");
@@ -3033,6 +3039,12 @@ void test_w_logtest_process_request_type_remove_session_ok(void ** state) {
     expect_string(__wrap_cJSON_AddItemToObject, string, "data");
 
     will_return(__wrap_cJSON_PrintUnformatted, "{json response}");
+
+    will_return(__wrap_pthread_rwlock_wrlock, 0);
+    will_return(__wrap_pthread_mutex_lock, 0);
+    will_return(__wrap_pthread_mutex_unlock, 0);
+    will_return(__wrap_pthread_rwlock_unlock, 0);
+    will_return(__wrap_pthread_mutex_destroy, 0);
 
     retval = w_logtest_process_request(input_raw_json, &connection);
 
@@ -3193,6 +3205,12 @@ void test_w_logtest_process_request_type_log_processing(void ** state) {
     expect_string(__wrap_cJSON_AddItemToObject, string, "data");
 
     will_return(__wrap_cJSON_PrintUnformatted, "{json response}");
+
+    will_return(__wrap_pthread_rwlock_wrlock, 0);
+    will_return(__wrap_pthread_mutex_lock, 0);
+    will_return(__wrap_pthread_mutex_unlock, 0);
+    will_return(__wrap_pthread_rwlock_unlock, 0);
+    will_return(__wrap_pthread_mutex_destroy, 0);
 
     retval = w_logtest_process_request(input_raw_json, &connection);
 
@@ -4722,6 +4740,12 @@ void test_w_logtest_clients_handler_ok(void ** state)
     expect_string(__wrap_cJSON_AddItemToObject, string, "data");
 
     will_return(__wrap_cJSON_PrintUnformatted, strdup("{json response}"));
+
+    will_return(__wrap_pthread_rwlock_wrlock, 0);
+    will_return(__wrap_pthread_mutex_lock, 0);
+    will_return(__wrap_pthread_mutex_unlock, 0);
+    will_return(__wrap_pthread_rwlock_unlock, 0);
+    will_return(__wrap_pthread_mutex_destroy, 0);
 
     will_return(__wrap_OS_SendSecureTCP, 0);
 

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -496,11 +496,11 @@ char *__wrap_Eventinfo_to_jsonstr(const Eventinfo *lf, bool force_full_log){
     return mock_type(char *);
 }
 
-void __wrap_os_analysisd_free_log_msg(os_analysisd_log_msg_t ** log_msg) {
-    os_free((*log_msg)->file);
-    os_free((*log_msg)->func);
-    os_free((*log_msg)->msg);
-    os_free(*log_msg);
+void __wrap_os_analysisd_free_log_msg(os_analysisd_log_msg_t * log_msg) {
+    os_free(log_msg->file);
+    os_free(log_msg->func);
+    os_free(log_msg->msg);
+    os_free(log_msg);
     return;
 }
 


### PR DESCRIPTION
|Related issue|QA|
|---|---|
|Closes #16304|https://github.com/wazuh/wazuh-qa/issues/3993|

This PR aims to fix 27 memory leaks detected in _wazuh-analysisd_. They're detailed in the related issue.

## Changes

### Fixed

1. Memory leaks when parsing nested frequency rules:
  a. `<if_matched_sid>`
  b. `<if_matched_group>`
2. Memory leaks when closing Logtest sessions.
3. Memory leaks when the ruleset parser produced more than 50 warnings.

### Changed

1. Refactor `os_analysisd_free_log_msg()` to receive `os_analysisd_log_msg_t *` instead of `os_analysisd_log_msg_t **`.
2. Adapt unit tests to the changes above.

### Added

1. Extend the ruleset test suite to cover the first memory leak. **It will need _wazuh-analysisd_ to be running on Valgrind.**

## Artifacts

- These changes affect _wazuh-analysisd_ only.

## Tests

- [x] Launch the ruleset test suite while _wazuh-analysisd_ running on Valgrind.
- [x] Run the server's unit tests.
- [x] Coverity.

### Ruleset test

```sh
python2 runtests.py -t tests/test_features.ini -s
```

```
- [ File = ./tests/test_features.ini ] ---------
.......


|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |    7     |   4248   |  0.16%   |
| Decoders |    4     |   165    |  2.42%   |


|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/test_features.ini|    7     |    0     |   ✅    |
```

### Valgrind report

```sh
valgrind --num-callers=20 --leak-check=full --show-leak-kinds=definite,indirect /var/ossec/bin/wazuh-analysisd -f
```

```
LEAK SUMMARY:
   definitely lost: 0 bytes in 0 blocks
   indirectly lost: 0 bytes in 0 blocks
     possibly lost: 45,216 bytes in 157 blocks
   still reachable: 23,194,732 bytes in 132,651 blocks
        suppressed: 0 bytes in 0 blocks
```

### Coverity report

|Build ID|New defects found|
|---|---|
|516726|0|