### PR TITLE
Handle exception when an inexistent region was provided

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1390,6 +1390,7 @@ class AWSVPCFlowBucket(AWSLogsBucket):
     empty_bucket_message_template = (
         "+++ No logs to process for {flow_log_id} flow log ID in bucket: {aws_account_id}/{aws_region}"
     )
+    empty_bucket_message_template_without_log_id = "+++ No logs to process in bucket: {aws_account_id}/{aws_region}"
 
     def __init__(self, **kwargs):
         self.db_table_name = 'vpcflow'
@@ -1507,6 +1508,8 @@ class AWSVPCFlowBucket(AWSLogsBucket):
             return result
 
     def get_ec2_client(self, access_key, secret_key, region, profile_name=None):
+        EC2_SERVICE = 'ec2'
+
         conn_args = {}
         conn_args['region_name'] = region
 
@@ -1518,19 +1521,42 @@ class AWSVPCFlowBucket(AWSLogsBucket):
 
         boto_session = boto3.Session(**conn_args)
 
+        available_regions = [
+            *boto_session.get_available_regions(
+                service_name=EC2_SERVICE, partition_name='aws',allow_non_regional=True
+            ),
+            *boto_session.get_available_regions(
+                service_name=EC2_SERVICE, partition_name='aws-us-gov',allow_non_regional=True
+            ),
+            *boto_session.get_available_regions(
+                service_name=EC2_SERVICE, partition_name='aws-cn',allow_non_regional=True
+            )
+        ]
+
+        if region not in available_regions:
+            raise ValueError(f"Invalid region '{region}'")
+
         try:
-            ec2_client = boto_session.client(service_name='ec2', **self.connection_config)
+            ec2_client = boto_session.client(service_name=EC2_SERVICE, **self.connection_config)
         except Exception as e:
             print("Error getting EC2 client: {}".format(e))
             sys.exit(3)
 
         return ec2_client
 
-    def get_flow_logs_ids(self, access_key, secret_key, region, profile_name=None):
-        ec2_client = self.get_ec2_client(access_key, secret_key, region,
-                                         profile_name=profile_name)
-        flow_logs_ids = list(map(operator.itemgetter('FlowLogId'), ec2_client.describe_flow_logs()['FlowLogs']))
-        return flow_logs_ids
+    def get_flow_logs_ids(self, access_key, secret_key, region, account_id, profile_name=None):
+        try:
+            ec2_client = self.get_ec2_client(access_key, secret_key, region, profile_name=profile_name)
+            return list(map(operator.itemgetter('FlowLogId'), ec2_client.describe_flow_logs()['FlowLogs']))
+        except ValueError:
+            debug(
+                self.empty_bucket_message_template_without_log_id.format(aws_account_id=account_id, aws_region=region),
+                msg_level=1
+            )
+            debug(
+                f"+++ WARNING: Check the provided region: '{region}'. It's an invalid one.", msg_level=1
+            )
+            return []
 
     def already_processed(self, downloaded_file, aws_account_id, aws_region, flow_log_id):
         cursor = self.db_connector.execute(self.sql_already_processed.format(table_name=self.db_table_name), {
@@ -1554,9 +1580,9 @@ class AWSVPCFlowBucket(AWSLogsBucket):
             for aws_region in regions:
                 debug("+++ Working on {} - {}".format(aws_account_id, aws_region), 1)
                 # get flow log ids for the current region
-                flow_logs_ids = self.get_flow_logs_ids(self.access_key,
-                                                       self.secret_key,
-                                                       aws_region, profile_name=self.profile_name)
+                flow_logs_ids = self.get_flow_logs_ids(
+                    self.access_key, self.secret_key, aws_region, aws_account_id, profile_name=self.profile_name
+                )
                 # for each flow log id
                 for flow_log_id in flow_logs_ids:
                     self.iter_files_in_bucket(aws_account_id, aws_region, flow_log_id=flow_log_id)


### PR DESCRIPTION
|Related issue|
|---|
|#15763 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #15763. It handles an exception occurred when an inexistent region is passed.

## Tests

### Unit Tests

```python
============================= test session starts ==============================
platform linux -- Python 3.9.9, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/nstefani/git/wazuh
plugins: aiohttp-0.3.0, trio-0.7.0, tavern-1.0.0, sugar-0.9.6, html-2.1.1, asyncio-0.15.1, cov-2.12.0, metadata-2.0.4
collected 39 items

wodles/aws/tests/test_aws.py .......................................     [100%]

============================== 39 passed in 0.29s ==============================
```

### Integration

```python
root@ubuntu-jammy:/home/vagrant/qa/tests/integration/test_aws# pytest -k vpc --tier 0 --disable-warnings
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vagrant/qa/tests/integration, configfile: pytest.ini
plugins: metadata-2.0.2, html-3.1.1, testinfra-5.0.0
collected 160 items / 146 deselected / 14 selected

test_basic.py .                                                                                                                                                                                               [  7%]
test_discard_regex.py .                                                                                                                                                                                       [ 14%]
test_only_logs_after.py ..                                                                                                                                                                                    [ 28%]
test_path.py ...                                                                                                                                                                                              [ 50%]
test_path_suffix.py ...                                                                                                                                                                                       [ 71%]
test_regions.py ...                                                                                                                                                                                           [ 92%]
test_remove_from_bucket.py .                                                                                                                                                                                  [100%]

============================================================================ 14 passed, 146 deselected, 2 warnings in 317.11s (0:05:17) =============================================================================
```