### PR TITLE
Changes to compile new CURL library v7.88.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,28 +128,30 @@ Here you can find all the automation tools maintained by the Wazuh team.
 
 |Software|Version|Author|License|
 |---|---|---|---|
-|bzip2|1.0.8|Julian Seward|BSD License|
-|cJSON|1.7.12|Dave Gamble|MIT License|
-|cPython|3.9.9|Guido van Rossum|Python Software Foundation License version 2|
-|cURL|7.88.1|Daniel Stenberg|MIT License|
-|GoogleTest|1.11.0|Google Inc.|3-Clause "New" BSD License|
-|jemalloc|5.2.1|Jason Evans|2-Clause "Simplified" BSD License|
-|libarchive|3.5.1|Tim Kientzle|3-Clause "New" BSD License|
-|libdb|18.1.40|Oracle Corporation|Affero GPL v3|
-|libffi|3.2.1|Anthony Green|MIT License|
-|libpcre2|10.34|Philip Hazel|BSD License|
-|libplist|2.2.0|Aaron Burghardt et al.|GNU Lesser General Public License version 2.1|
-|libYAML|0.1.7|Kirill Simonov|MIT License|
-|Linux Audit userspace|2.8.4|Rik Faith|LGPL (copyleft)|
-|msgpack|3.1.1|Sadayuki Furuhashi|Boost Software License version 1.0|
-|nlohmann|3.7.3|Niels Lohmann|MIT License|
-|OpenSSL|1.1.1t|OpenSSL Software Foundation|Apache 2.0 License|
-|pacman|5.2.2|Judd Vinet|GNU Public License version 2 (copyleft)|
-|popt|1.16|Jeff Johnson & Erik Troan|MIT License|
-|procps|2.8.3|Brian Edmonds et al.|LGPL (copyleft)|
-|rpm|4.16.1.3|Marc Ewing & Erik Troan|GNU Public License version 2 (copyleft)|
-|sqlite|3.36.0|D. Richard Hipp|Public Domain (no restrictions)|
-|zlib|1.2.11|Jean-loup Gailly & Mark Adler|zlib/libpng License|
+|[bzip2](https://github.com/libarchive/bzip2)|1.0.8|Julian Seward|BSD License|
+|[cJSON](https://github.com/DaveGamble/cJSON)|1.7.12|Dave Gamble|MIT License|
+|[cPython](https://github.com/python/cpython)|3.9.9|Guido van Rossum|Python Software Foundation License version 2|
+|[cURL](https://github.com/curl/curl)|7.88.1|Daniel Stenberg|MIT License|
+|[GoogleTest](https://github.com/google/googletest)|1.11.0|Google Inc.|3-Clause "New" BSD License|
+|[jemalloc](https://github.com/jemalloc/jemalloc)|5.2.1|Jason Evans|2-Clause "Simplified" BSD License|
+|[libarchive](https://github.com/libarchive/libarchive)|3.5.1|Tim Kientzle|3-Clause "New" BSD License|
+|[libdb](https://github.com/yasuhirokimura/db18)|18.1.40|Oracle Corporation|Affero GPL v3|
+|[libffi](https://github.com/libffi/libffi)|3.2.1|Anthony Green|MIT License|
+|[libpcre2](https://github.com/PCRE2Project/pcre2)|10.34|Philip Hazel|BSD License|
+|[libplist](https://github.com/libimobiledevice/libplist)|2.2.0|Aaron Burghardt et al.|GNU Lesser General Public License version 2.1|
+|[libYAML](https://github.com/yaml/libyaml)|0.1.7|Kirill Simonov|MIT License|
+|[Linux Audit userspace](https://github.com/linux-audit/audit-userspace)|2.8.4|Rik Faith|LGPL (copyleft)|
+|[msgpack](https://github.com/msgpack/msgpack-c)|3.1.1|Sadayuki Furuhashi|Boost Software License version 1.0|
+|[nlohmann](https://github.com/nlohmann/json)|3.7.3|Niels Lohmann|MIT License|
+|[OpenSSL](https://github.com/openssl/openssl)|1.1.1t|OpenSSL Software Foundation|Apache 2.0 License|
+|[pacman](https://gitlab.archlinux.org/pacman/pacman)|5.2.2|Judd Vinet|GNU Public License version 2 (copyleft)|
+|[popt](https://github.com/rpm-software-management/popt)|1.16|Jeff Johnson & Erik Troan|MIT License|
+|[procps](https://gitlab.com/procps-ng/procps)|2.8.3|Brian Edmonds et al.|LGPL (copyleft)|
+|[rpm](https://github.com/rpm-software-management/rpm)|4.16.1.3|Marc Ewing & Erik Troan|GNU Public License version 2 (copyleft)|
+|[sqlite](https://github.com/sqlite/sqlite)|3.36.0|D. Richard Hipp|Public Domain (no restrictions)|
+|[zlib](https://github.com/madler/zlib)|1.2.11|Jean-loup Gailly & Mark Adler|zlib/libpng License|
+
+* [PyPi packages](framework/requirements.txt)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -126,20 +126,30 @@ Here you can find all the automation tools maintained by the Wazuh team.
 
 ## Software and libraries used
 
-* Modified version of Zlib and a embedded part of OpenSSL (SHA1, SHA256, SHA512, AES and Blowfish libraries).
-* OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/).
-* Cryptographic software written by Eric Young (eay@cryptsoft.com).
-* Software developed by the Zlib project (Jean-loup Gailly and Mark Adler).
-* Software developed by the cJSON project (Dave Gamble).
-* Software developed by the MessagePack project (https://msgpack.org/).
-* Software developed by the CURL project (https://curl.haxx.se/).
-* Software developed by the bzip2 project (Julian Seward).
-* Software developed by the libYAML project (Kirill Simonov).
-* The Linux audit userspace project (https://github.com/linux-audit/audit-userspace).
-* A embedded part of the Berkeley DB library (https://github.com/berkeleydb/libdb).
-* CPython interpreter by Guido van Rossum and the Python Software Foundation (https://www.python.org).
-* PyPi packages: [azure-storage-blob](https://github.com/Azure/azure-storage-python), [boto3](https://github.com/boto/boto3), [cryptography](https://github.com/pyca/cryptography), [docker](https://github.com/docker/docker-py), [pytz](https://pythonhosted.org/pytz/), [requests](http://python-requests.org/) and [uvloop](http://github.com/MagicStack/uvloop).
-* PCRE2 library by Philip Hazel (https://www.pcre.org/).
+|Software|Version|Author|License|
+|---|---|---|---|
+|bzip2|1.0.8|Julian Seward|BSD License|
+|cJSON|1.7.12|Dave Gamble|MIT License|
+|cPython|3.9.9|Guido van Rossum|Python Software Foundation License version 2|
+|cURL|7.88.1|Daniel Stenberg|MIT License|
+|GoogleTest|1.11.0|Google Inc.|3-Clause "New" BSD License|
+|jemalloc|5.2.1|Jason Evans|2-Clause "Simplified" BSD License|
+|libarchive|3.5.1|Tim Kientzle|3-Clause "New" BSD License|
+|libdb|18.1.40|Oracle Corporation|Affero GPL v3|
+|libffi|3.2.1|Anthony Green|MIT License|
+|libpcre2|10.34|Philip Hazel|BSD License|
+|libplist|2.2.0|Aaron Burghardt et al.|GNU Lesser General Public License version 2.1|
+|libYAML|0.1.7|Kirill Simonov|MIT License|
+|Linux Audit userspace|2.8.4|Rik Faith|LGPL (copyleft)|
+|msgpack|3.1.1|Sadayuki Furuhashi|Boost Software License version 1.0|
+|nlohmann|3.7.3|Niels Lohmann|MIT License|
+|OpenSSL|1.1.1t|OpenSSL Software Foundation|Apache 2.0 License|
+|pacman|5.2.2|Judd Vinet|GNU Public License version 2 (copyleft)|
+|popt|1.16|Jeff Johnson & Erik Troan|MIT License|
+|procps|2.8.3|Brian Edmonds et al.|LGPL (copyleft)|
+|rpm|4.16.1.3|Marc Ewing & Erik Troan|GNU Public License version 2 (copyleft)|
+|sqlite|3.36.0|D. Richard Hipp|Public Domain (no restrictions)|
+|zlib|1.2.11|Jean-loup Gailly & Mark Adler|zlib/libpng License|
 
 ## Documentation
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -233,7 +233,7 @@ ifeq (${uname_S},Darwin)
 		AR_LDFLAGS+=-pthread
 		AR_LDFLAGS+=-Xlinker -rpath -Xlinker "@executable_path/../../lib"
 		SHARED=dylib
-		OSSEC_LIBS+=-framework Security -framework CoreFoundation
+		OSSEC_LIBS+=-framework Security -framework CoreFoundation -framework SystemConfiguration
 		PRECOMPILED_OS:=darwin
 else
 ifeq (${uname_S},FreeBSD)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1020,11 +1020,11 @@ ${LIBCURL_LIB}: $(EXTERNAL_CURL)Makefile
 
 ifeq (${TARGET},winagent)
 $(EXTERNAL_CURL)Makefile:
-	cd $(EXTERNAL_CURL) && CFLAGS=-fPIC CC=${MING_BASE}${CC} ./configure --host=${MINGW_HOST} PREFIX=${MING_BASE} --enable-static=yes --disable-shared --with-winssl --disable-ldap --without-libidn2 && ${MAKE}
+	cd $(EXTERNAL_CURL) && CFLAGS=-fPIC CC=${MING_BASE}${CC} ./configure --host=${MINGW_HOST} PREFIX=${MING_BASE} --enable-static=yes --disable-shared --with-schannel --disable-ldap --without-libidn2 && ${MAKE}
 else
 ifeq (${uname_S},Darwin)
 $(EXTERNAL_CURL)Makefile:
-	cd $(EXTERNAL_CURL) && ./configure --with-darwinssl --disable-ldap --without-libidn2
+	cd $(EXTERNAL_CURL) && ./configure --with-secure-transport --disable-ldap --without-libidn2
 else
 $(EXTERNAL_CURL)Makefile: $(OPENSSL_LIB)
 ifeq (${uname_S},Linux)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1022,16 +1022,11 @@ ifeq (${TARGET},winagent)
 $(EXTERNAL_CURL)Makefile:
 	cd $(EXTERNAL_CURL) && CFLAGS=-fPIC CC=${MING_BASE}${CC} ./configure --host=${MINGW_HOST} PREFIX=${MING_BASE} --enable-static=yes --disable-shared --with-schannel --disable-ldap --without-libidn2 && ${MAKE}
 else
-ifeq (${uname_S},Darwin)
-$(EXTERNAL_CURL)Makefile:
-	cd $(EXTERNAL_CURL) && ./configure --with-secure-transport --disable-ldap --without-libidn2
-else
 $(EXTERNAL_CURL)Makefile: $(OPENSSL_LIB)
 ifeq (${uname_S},Linux)
 	cd $(EXTERNAL_CURL) && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LIBS="-ldl -lpthread" ./configure --with-ssl="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" --disable-ldap --without-libidn2 --without-libpsl --without-brotli
 else
 	cd $(EXTERNAL_CURL) && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LIBS="-lpthread" ./configure --with-ssl="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" --disable-ldap --without-libidn2
-endif
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -233,7 +233,7 @@ ifeq (${uname_S},Darwin)
 		AR_LDFLAGS+=-pthread
 		AR_LDFLAGS+=-Xlinker -rpath -Xlinker "@executable_path/../../lib"
 		SHARED=dylib
-		OSSEC_LIBS+=-framework Security
+		OSSEC_LIBS+=-framework Security -framework CoreFoundation
 		PRECOMPILED_OS:=darwin
 else
 ifeq (${uname_S},FreeBSD)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1028,9 +1028,9 @@ $(EXTERNAL_CURL)Makefile:
 else
 $(EXTERNAL_CURL)Makefile: $(OPENSSL_LIB)
 ifeq (${uname_S},Linux)
-	cd $(EXTERNAL_CURL) && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LIBS="-ldl -lpthread" ./configure --disable-ldap --without-libidn2 --without-libpsl --without-brotli
+	cd $(EXTERNAL_CURL) && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LIBS="-ldl -lpthread" ./configure --with-ssl="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" --disable-ldap --without-libidn2 --without-libpsl --without-brotli
 else
-	cd $(EXTERNAL_CURL) && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LIBS="-lpthread" ./configure --disable-ldap --without-libidn2
+	cd $(EXTERNAL_CURL) && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LIBS="-lpthread" ./configure --with-ssl="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" --disable-ldap --without-libidn2
 endif
 endif
 endif


### PR DESCRIPTION
|Related issue|Manual testing|
|---|---|
|closes https://github.com/wazuh/wazuh/issues/16279|https://github.com/wazuh/wazuh-qa/issues/4007|

## Description

This PR includes the changes required in the Makefile for all the OS to compile the new CURL library (v7.88.1).

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
