### PR TITLE
Modifiy agent number on test stage parameter and response

### DIFF
--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -1243,7 +1243,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        agents_list: '008'
+        agents_list: '005'
         installer: upgrade.sh
         file_path: "{custom_wpk_path:s}"
     response:
@@ -1251,7 +1251,7 @@ stages:
       json:
         data:
           affected_items:
-            - agent: '008'
+            - agent: '005'
               task_id: !anyint
           total_affected_items: 1
           total_failed_items: 0


### PR DESCRIPTION
|Related issue|
|---|
|Closes #16347 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

During the launch of the integration test for #15465, it was found the integration test was failing as described here:

- #16347 

## Logs/Alerts example

Until now when launching integration tests this error showed up:

```
============================= test session starts ==============================
platform linux -- Python 3.9.9, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.9', 'Platform': 'Linux-6.1.11-76060111-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '5.4.3', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'html': '2.1.1', 'metadata': '2.0.4'}}
rootdir: /home/eduardoleon/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, html-2.1.1, metadata-2.0.4
collecting ... collected 10 items

test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/reconnect PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/restart PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/upgrade PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom FAILED

=================================== FAILURES ===================================
_ /home/eduardoleon/git/wazuh/api/test/integration/test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom _
Format variables:
  protocol:s = 'https'
  host:s = 'localhost'
  port:d = '55000'
  test_login_token = 'eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjAwMzExLCJleHAiOjE2NzgyMDEyMTEsInN1YiI6InRlc3RpbmciLCJydW5fYXMiOmZhbHNlLCJyYmFjX3JvbGVzIjpbMV0sInJiYWNfbW9kZSI6IndoaXRlIn0.ACA5cbDwOgqYZrQfEZiwlXrft_Dt0HQAJwkM_zuE0XGpVb8yZ8QFzs6MAkm8VYRlkfnxTbTOji1tpsvw1Hb8oeg2AdlCQTE5P5w6ZKLzLled_1iT4uXV47uy2D8VRHw8G99VH9upVrVTxVpJOwqAOM_Sh2q9HKCQb3EP5qJWOrZNGiCO'
  custom_wpk_path:s = '/var/ossec/test.wpk'

Source test stage (line 1237):
  - name: Try to customly upgrade an agent selecting installer (WPK does not exist)
    request:
      verify: False
      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
      method: PUT
      headers:
        Authorization: "Bearer {test_login_token}"
      params:
        agents_list: '008'
        installer: upgrade.sh
        file_path: "{custom_wpk_path:s}"
    response:
      status_code: 200
      json:
        data:
          affected_items:
            - agent: '008'
              task_id: !anyint
          total_affected_items: 1
          total_failed_items: 0
          failed_items: [ ]
        message: !anystr


Formatted stage:
  name: Try to customly upgrade an agent selecting installer (WPK does not exist)
  request:
    headers:
      Authorization: Bearer eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjAwMzExLCJleHAiOjE2NzgyMDEyMTEsInN1YiI6InRlc3RpbmciLCJydW5fYXMiOmZhbHNlLCJyYmFjX3JvbGVzIjpbMV0sInJiYWNfbW9kZSI6IndoaXRlIn0.ACA5cbDwOgqYZrQfEZiwlXrft_Dt0HQAJwkM_zuE0XGpVb8yZ8QFzs6MAkm8VYRlkfnxTbTOji1tpsvw1Hb8oeg2AdlCQTE5P5w6ZKLzLled_1iT4uXV47uy2D8VRHw8G99VH9upVrVTxVpJOwqAOM_Sh2q9HKCQb3EP5qJWOrZNGiCO
    method: PUT
    params:
      agents_list: 008
      file_path: '/var/ossec/test.wpk'
      installer: upgrade.sh
    url: 'https://localhost:55000/agents/upgrade_custom'
    verify: false
  response:
    json:
      data:
        affected_items:
        - agent: 008
          task_id: !anyint ''
        failed_items: []
        total_affected_items: 1
        total_failed_items: 0
      message: !anystr ''
    status_code: 200

Errors:
E   tavern.util.exceptions.TestFailError: Test 'Try to customly upgrade an agent selecting installer (WPK does not exist)' failed:
    - Key mismatch: (expected["data"]["total_failed_items"] = '0' (type = <class 'int'>), actual["data"]["total_failed_items"] = '1' (type = <class 'int'>))
------------------------------ Captured log call -------------------------------
WARNING  tavern._plugins.rest.response:response.py:29 Unexpected status code '200'
WARNING  tavern._plugins.rest.response:response.py:29 Unexpected status code '200'
WARNING  tavern._plugins.rest.response:response.py:29 Unexpected status code '400'
WARNING  tavern._plugins.rest.response:response.py:29 Unexpected status code '200'
WARNING  tavern._plugins.rest.response:response.py:29 Unexpected status code '200'
ERROR    tavern.response.base:base.py:41 Key mismatch: (expected["data"]["total_failed_items"] = '0' (type = <class 'int'>), actual["data"]["total_failed_items"] = '1' (type = <class 'int'>))
Traceback (most recent call last):
  File "/home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/lib/python3.9/site-packages/tavern/util/dict_util.py", line 406, in check_keys_match_recursive
    assert actual_val == expected_val
AssertionError: assert {'data': {'affected_items': [],\n          'failed_items': [{'error': {'code': 1820,\n                                      'message': 'Upgrade procedure could not '\n                                                 'start. Agent already '\n                                                 'upgrading'},\n                            'id': ['008']}],\n          'total_affected_items': 0,\n          'total_failed_items': 1},\n 'error': 1,\n 'message': 'No upgrade task was created'} == {'data': {'affected_items': [{'agent': '008',\n                              'task_id': <tavern.util.loader.IntSentinel object at 0x7f55e4a49eb0>}],\n          'failed_items': [],\n          'total_affected_items': 1,\n          'total_failed_items': 0},\n 'message': <tavern.util.loader.StrSentinel object at 0x7f55e4a49df0>}
  Differing items:
  {'data': {'affected_items': [], 'failed_items': [{'error': {'code': 1820, 'message': 'Upgrade procedure could not start. Agent already upgrading'}, 'id': ['008']}], 'total_affected_items': 0, 'total_failed_items': 1}} != {'data': {'affected_items': [{'agent': '008', 'task_id': <tavern.util.loader.IntSentinel object at 0x7f55e4a49eb0>}], 'failed_items': [], 'total_affected_items': 1, 'total_failed_items': 0}}
  {'message': 'No upgrade task was created'} != {'message': <tavern.util.loader.StrSentinel object at 0x7f55e4a49df0>}
  Left contains 1 more item:
  {'error': 1}
  Full diff:
    {
  -  'data': {'affected_items': [{'agent': '008',
  ?                              ^^^^^^^^^^^^^^^
  +  'data': {'affected_items': [],
  ?                              ^
  -                               'task_id': <tavern.util.loader.IntSentinel object at 0x7f55e4a49eb0>}],
  -           'failed_items': [],
  +           'failed_items': [{'error': {'code': 1820,
  +                                       'message': 'Upgrade procedure could not '
  +                                                  'start. Agent already '
  +                                                  'upgrading'},
  +                             'id': ['008']}],
  -           'total_affected_items': 1,
  ?                                   ^
  +           'total_affected_items': 0,
  ?                                   ^
  -           'total_failed_items': 0},
  ?                                 ^
  +           'total_failed_items': 1},
  ?                                 ^
  -  'message': <tavern.util.loader.StrSentinel object at 0x7f55e4a49df0>,
  +  'error': 1,
  +  'message': 'No upgrade task was created',
    }

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/lib/python3.9/site-packages/tavern/util/dict_util.py", line 406, in check_keys_match_recursive
    assert actual_val == expected_val
AssertionError: assert {'affected_items': [],\n 'failed_items': [{'error': {'code': 1820,\n                             'message': 'Upgrade procedure could not start. '\n                                        'Agent already upgrading'},\n                   'id': ['008']}],\n 'total_affected_items': 0,\n 'total_failed_items': 1} == {'affected_items': [{'agent': '008',\n                     'task_id': <tavern.util.loader.IntSentinel object at 0x7f55e4a49eb0>}],\n 'failed_items': [],\n 'total_affected_items': 1,\n 'total_failed_items': 0}
  Differing items:
  {'total_failed_items': 1} != {'total_failed_items': 0}
  {'total_affected_items': 0} != {'total_affected_items': 1}
  {'affected_items': []} != {'affected_items': [{'agent': '008', 'task_id': <tavern.util.loader.IntSentinel object at 0x7f55e4a49eb0>}]}
  {'failed_items': [{'error': {'code': 1820, 'message': 'Upgrade procedure could not start. Agent already upgrading'}, 'id': ['008']}]} != {'failed_items': []}
  Full diff:
    {
  -  'affected_items': [{'agent': '008',
  -                      'task_id': <tavern.util.loader.IntSentinel object at 0x7f55e4a49eb0>}],
  -  'failed_items': [],
  ?    ^^^
  +  'affected_items': [],
  ?   + ^^^^
  +  'failed_items': [{'error': {'code': 1820,
  +                              'message': 'Upgrade procedure could not start. '
  +                                         'Agent already upgrading'},
  +                    'id': ['008']}],
  -  'total_affected_items': 1,
  ?                          ^
  +  'total_affected_items': 0,
  ?                          ^
  -  'total_failed_items': 0,
  ?                        ^
  +  'total_failed_items': 1,
  ?                        ^
    }

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/lib/python3.9/site-packages/tavern/util/dict_util.py", line 406, in check_keys_match_recursive
    assert actual_val == expected_val
AssertionError: assert 1 == 0
  +1
  -0

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/lib/python3.9/site-packages/tavern/response/base.py", line 88, in recurse_check_key_match
    check_keys_match_recursive(expected_block, block, [], strict)
  File "/home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/lib/python3.9/site-packages/tavern/util/dict_util.py", line 462, in check_keys_match_recursive
    check_keys_match_recursive(
  File "/home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/lib/python3.9/site-packages/tavern/util/dict_util.py", line 462, in check_keys_match_recursive
    check_keys_match_recursive(
  File "/home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/lib/python3.9/site-packages/tavern/util/dict_util.py", line 546, in check_keys_match_recursive
    raise exceptions.KeyMismatchError(
tavern.util.exceptions.KeyMismatchError: Key mismatch: (expected["data"]["total_failed_items"] = '0' (type = <class 'int'>), actual["data"]["total_failed_items"] = '1' (type = <class 'int'>))
=============================== warnings summary ===============================
/home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/lib/python3.9/site-packages/tavern/testutils/pytesthook/hooks.py:83
  /home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/lib/python3.9/site-packages/tavern/testutils/pytesthook/hooks.py:83: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/lib/python3.9/site-packages/tavern/testutils/pytesthook/file.py:233: 10 tests with warnings
  /home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/lib/python3.9/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================== short test summary info ============================
FAILED test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom
============= 1 failed, 9 passed, 11 warnings in 623.67s (0:10:23) =============

```

After the fix described:

```
==================================================== test session starts =====================================================
platform linux -- Python 3.9.9, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.9', 'Platform': 'Linux-6.1.11-76060111-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '5.4.3', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'html': '2.1.1', 'metadata': '2.0.4'}}
rootdir: /home/eduardoleon/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, html-2.1.1, metadata-2.0.4
collected 1 item

test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom PASSED

```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->
```
==================================================== test session starts =====================================================
platform linux -- Python 3.9.9, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/eduardoleon/.pyenv/versions/3.9.9/envs/inttegration-3.9-venv/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.9', 'Platform': 'Linux-6.1.11-76060111-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '5.4.3', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'html': '2.1.1', 'metadata': '2.0.4'}}
rootdir: /home/eduardoleon/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, html-2.1.1, metadata-2.0.4
collected 10 items

test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/reconnect PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/restart PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/upgrade PASSED
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom PASSED

```
