### PR TITLE
Fix manager configuration validation

### DIFF
--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1721,9 +1721,8 @@ def test_validate_wazuh_xml_ko_2(effect, expected_exception):
     expected_exception
         Expected code when triggering the exception.
     """
-    with patch('wazuh.core.utils.load_wazuh_xml', side_effect=effect):
-        with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
-            utils.validate_wazuh_xml('{"body": "<ossec_config></ossec_config>}')
+    with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
+        utils.validate_wazuh_xml('{"body": "<ossec_config></ossec_config>}')
 
 
 @patch('wazuh.core.utils.full_copy')

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1709,6 +1709,22 @@ def test_validate_wazuh_xml_ko(effect, expected_exception):
         with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
             utils.validate_wazuh_xml(input_file)
 
+@pytest.mark.parametrize('effect, expected_exception', [
+    (utils.WazuhError, 1113)
+])
+def test_validate_wazuh_xml_ko_2(effect, expected_exception):
+    """Tests validate_wazuh_xml function works when an invalid configuration raises an exception.
+    Parameters
+    ----------
+    effect : Exception
+        Exception to be triggered.
+    expected_exception
+        Expected code when triggering the exception.
+    """
+    with patch('wazuh.core.utils.load_wazuh_xml', side_effect=effect):
+        with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
+            utils.validate_wazuh_xml('{"body": "<ossec_config></ossec_config>}')
+
 
 @patch('wazuh.core.utils.full_copy')
 def test_delete_file_with_backup(mock_full_copy):

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1692,10 +1692,12 @@ def test_validate_wazuh_xml(mock_remote_commands, mock_unchanged_limits):
 
 
 @pytest.mark.parametrize('effect, expected_exception', [
-    (utils.ExpatError, 1113)
+    (utils.ExpatError, 1113),
+    (None, 1113)
 ])
 def test_validate_wazuh_xml_ko(effect, expected_exception):
-    """Tests validate_wazuh_xml function works when open function raises an exception.
+    """Check all errors that can be raised by the function validate_wazuh_xml.
+
     Parameters
     ----------
     effect : Exception
@@ -1703,24 +1705,13 @@ def test_validate_wazuh_xml_ko(effect, expected_exception):
     expected_exception
         Expected code when triggering the exception.
     """
-    input_file = os.path.join(test_files_path, 'test_rules.xml')
+    if effect is not None:
+        input_file = os.path.join(test_files_path, 'test_rules.xml')
 
-    with patch('wazuh.core.utils.load_wazuh_xml', side_effect=effect):
-        with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
-            utils.validate_wazuh_xml(input_file)
+        with patch('wazuh.core.utils.load_wazuh_xml', side_effect=effect):
+            with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
+                utils.validate_wazuh_xml(input_file)
 
-@pytest.mark.parametrize('effect, expected_exception', [
-    (utils.WazuhError, 1113)
-])
-def test_validate_wazuh_xml_ko_2(effect, expected_exception):
-    """Tests validate_wazuh_xml function works when an invalid configuration raises an exception.
-    Parameters
-    ----------
-    effect : Exception
-        Exception to be triggered.
-    expected_exception
-        Expected code when triggering the exception.
-    """
     with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
         utils.validate_wazuh_xml('{"body": "<ossec_config></ossec_config>}')
 

--- a/framework/wazuh/tests/test_decoder.py
+++ b/framework/wazuh/tests/test_decoder.py
@@ -193,13 +193,13 @@ def test_upload_file(mock_remote_commands, mock_safe_move, mock_remove, mock_ful
         True for updating existing files, False otherwise.
     """
     with patch('wazuh.decoder.exists', return_value=overwrite):
-        result = decoder.upload_decoder_file(filename=file, content='test', overwrite=overwrite)
+        result = decoder.upload_decoder_file(filename=file, content='<test></test>', overwrite=overwrite)
 
         # Assert data match what was expected, type of the result and correct parameters in delete() method.
         assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
         decoder_path = os.path.join('etc', 'decoders', file)
         assert result.affected_items[0] == decoder_path, 'Expected item not found'
-        mock_xml.assert_called_once_with('test', decoder_path)
+        mock_xml.assert_called_once_with('<test></test>', decoder_path)
         if overwrite:
             mock_delete.assert_called_once_with(filename=file), 'delete_decoder_file method not called with expected ' \
                                                                 'parameter'
@@ -215,7 +215,7 @@ def test_upload_file_ko(mock_remote_commands, mock_safe_move, mock_xml, mock_del
     """Test exceptions on upload function."""
     # Error when file exists and overwrite is not True
     with patch('wazuh.decoder.exists'):
-        result = decoder.upload_decoder_file(filename='test_decoders.xml', content='test', overwrite=False)
+        result = decoder.upload_decoder_file(filename='test_decoders.xml', content='<test></test>', overwrite=False)
         assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
         assert result.render()['data']['failed_items'][0]['error']['code'] == 1905, 'Error code not expected.'
 
@@ -226,7 +226,7 @@ def test_upload_file_ko(mock_remote_commands, mock_safe_move, mock_xml, mock_del
 
     # Error doing backup
     with patch('wazuh.decoder.exists'):
-        result = decoder.upload_decoder_file(filename='test_decoders.xml', content='test', overwrite=True)
+        result = decoder.upload_decoder_file(filename='test_decoders.xml', content='<test></test>', overwrite=True)
         assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
         assert result.render()['data']['failed_items'][0]['error']['code'] == 1019, 'Error code not expected.'
 

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -288,13 +288,13 @@ def test_upload_file(mock_remote_commands, mock_safe_move, mock_remove, mock_ful
         True for updating existing files, False otherwise.
     """
     with patch('wazuh.rule.exists', return_value=overwrite):
-        result = rule.upload_rule_file(filename=file, content='test', overwrite=overwrite)
+        result = rule.upload_rule_file(filename=file, content='<test></test>', overwrite=overwrite)
 
         # Assert data match what was expected, type of the result and correct parameters in delete() method.
         assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
         rule_path = os.path.join('etc', 'rules', file)
         assert result.affected_items[0] == rule_path, 'Expected item not found'
-        mock_xml.assert_called_once_with('test', rule_path)
+        mock_xml.assert_called_once_with('<test></test>', rule_path)
         if overwrite:
             mock_delete.assert_called_once_with(filename=file), 'delete_rule_file method not called with expected ' \
                                                                 'parameter'
@@ -310,7 +310,7 @@ def test_upload_file_ko(mock_remote_commands, mock_safe_move, mock_xml, mock_del
     """Test exceptions on upload function."""
     # Error when file exists and overwrite is not True
     with patch('wazuh.rule.exists'):
-        result = rule.upload_rule_file(filename='test_rules.xml', content='test', overwrite=False)
+        result = rule.upload_rule_file(filename='test_rules.xml', content='<test></test>', overwrite=False)
         assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
         assert result.render()['data']['failed_items'][0]['error']['code'] == 1905, 'Error code not expected.'
 
@@ -321,7 +321,7 @@ def test_upload_file_ko(mock_remote_commands, mock_safe_move, mock_xml, mock_del
 
     # Error doing backup
     with patch('wazuh.rule.exists'):
-        result = rule.upload_rule_file(filename='test_rules.xml', content='test', overwrite=True)
+        result = rule.upload_rule_file(filename='test_rules.xml', content='<test></test>', overwrite=True)
         assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
         assert result.render()['data']['failed_items'][0]['error']['code'] == 1019, 'Error code not expected.'
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/16341|

## Description

During the validation of configuration files (ossec.conf), non-xml formatted data was accepted.

### Expected behavior

Return an error and not allow the users to save invalid content to the configuration file.  

### Steps to reproduce

UI steps:

- Log in to the dashboard
- Switch to Management → Configuration
- Edit configuration: put some malformed data inside the form (non-xml, see examples).
- Save the configuration - no error.

Similarly, we could reproduce the issue using the API by submitting the same payload inside the body of a PUT request to the endpoint `/manager/configuration`.

## Logs/Alerts example

The following content was considered valid:

```
{"body": {"<ossec_config></ossec_config>"}}
```

## Tests

```
====================================== test session starts ======================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/gasti/work/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1
asyncio: mode=legacy
collected 2045 items                                                                            

framework/scripts/tests/test_agent_groups.py ..............                               [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                             [  1%]
framework/scripts/tests/test_cluster_control.py ......                                    [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                    [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                      [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ..............................ss     [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                        [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ..........................ss.......    [  7%]
framework/wazuh/core/cluster/tests/test_common.py ....................................... [  9%]
....................................                                                      [ 10%]
framework/wazuh/core/cluster/tests/test_control.py ......                                 [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .......ss....                     [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................          [ 12%]
framework/wazuh/core/cluster/tests/test_master.py ....................................... [ 14%]
......                                                                                    [ 15%]
framework/wazuh/core/cluster/tests/test_server.py ...................                     [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                              [ 16%]
framework/wazuh/core/cluster/tests/test_worker.py ....................................    [ 18%]
framework/wazuh/core/tests/test_active_response.py ..............                         [ 19%]
framework/wazuh/core/tests/test_agent.py ................................................ [ 21%]
......................................................................................... [ 25%]
.......                                                                                   [ 26%]
framework/wazuh/core/tests/test_cdb_list.py ......................................        [ 27%]
framework/wazuh/core/tests/test_common.py .......                                         [ 28%]
framework/wazuh/core/tests/test_configuration.py ........................................ [ 30%]
..............................                                                            [ 31%]
framework/wazuh/core/tests/test_database.py .............                                 [ 32%]
framework/wazuh/core/tests/test_decoder.py ................                               [ 33%]
framework/wazuh/core/tests/test_exception.py ...                                          [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                    [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                                             [ 33%]
framework/wazuh/core/tests/test_manager.py ...............                                [ 34%]
framework/wazuh/core/tests/test_mitre.py .............                                    [ 34%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                   [ 35%]
framework/wazuh/core/tests/test_results.py ........................................       [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                                [ 37%]
framework/wazuh/core/tests/test_rule.py ......................                            [ 38%]
framework/wazuh/core/tests/test_sca.py ........................                           [ 40%]
framework/wazuh/core/tests/test_security.py ............                                  [ 40%]
framework/wazuh/core/tests/test_stats.py .................                                [ 41%]
framework/wazuh/core/tests/test_syscheck.py .......                                       [ 41%]
framework/wazuh/core/tests/test_syscollector.py ...                                       [ 41%]
framework/wazuh/core/tests/test_task.py ........                                          [ 42%]
framework/wazuh/core/tests/test_utils.py ................................................ [ 44%]
......................................................................................... [ 48%]
......................................................................................... [ 53%]
.............                                                                             [ 53%]
framework/wazuh/core/tests/test_vulnerability.py ..                                       [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                       [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                      [ 56%]
framework/wazuh/core/tests/test_wdb.py .s.ssssss......................                    [ 57%]
framework/wazuh/core/tests/test_wlogging.py .........                                     [ 57%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                        [ 58%]
framework/wazuh/rbac/tests/test_decorators.py ........................................... [ 60%]
..................................................................                        [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py ................................ [ 64%]
........................                                                                  [ 66%]
framework/wazuh/rbac/tests/test_orm.py .................................................. [ 68%]
....                                                                                      [ 68%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                               [ 69%]
framework/wazuh/tests/test_active_response.py ............                                [ 69%]
framework/wazuh/tests/test_agent.py ..................................................... [ 72%]
.................................................................                         [ 75%]
framework/wazuh/tests/test_cdb_list.py .................................................. [ 78%]
...                                                                                       [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                    [ 79%]
framework/wazuh/tests/test_cluster.py ..........                                          [ 80%]
framework/wazuh/tests/test_decoder.py ...................................                 [ 82%]
framework/wazuh/tests/test_group.py .......                                               [ 82%]
framework/wazuh/tests/test_logtest.py ......                                              [ 82%]
framework/wazuh/tests/test_manager.py ....................................                [ 84%]
framework/wazuh/tests/test_mitre.py .......                                               [ 84%]
framework/wazuh/tests/test_rootcheck.py ................................................. [ 87%]
.                                                                                         [ 87%]
framework/wazuh/tests/test_rule.py ...................................................... [ 89%]
..                                                                                        [ 90%]
framework/wazuh/tests/test_sca.py ...........                                             [ 90%]
framework/wazuh/tests/test_security.py .................................................. [ 93%]
.......................                                                                   [ 94%]
framework/wazuh/tests/test_stats.py ...............                                       [ 94%]
framework/wazuh/tests/test_syscheck.py .........................                          [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                   [ 96%]
framework/wazuh/tests/test_task.py ............................                           [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................................      [100%]

=================== 2032 passed, 13 skipped, 79 warnings in 213.41s (0:03:33) ===================
```

> I ran the tests in `api/api` just in case and they all pass as well.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors