### PR TITLE
Show explicit messages when there aren't logs to process

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -792,10 +792,12 @@ class AWSBucket(WazuhIntegration):
                 filter_marker = self.marker_only_logs_after(aws_region, aws_account_id) if self.only_logs_after \
                     else self.marker_custom_date(aws_region, aws_account_id, self.default_date)
 
+        prefix = self.get_full_prefix(aws_account_id, aws_region) or (filter_marker if not self.only_logs_after else '')
+
         filter_args = {
             'Bucket': self.bucket,
             'MaxKeys': 1000,
-            'Prefix': self.get_full_prefix(aws_account_id, aws_region)
+            'Prefix': prefix
         }
 
         # if nextContinuationToken is not used for processing logs in a bucket
@@ -1012,7 +1014,11 @@ class AWSBucket(WazuhIntegration):
 
             while True:
                 if 'Contents' not in bucket_files:
-                    debug(f"+++ No logs to process in bucket: {aws_account_id}/{aws_region}", 1)
+                    base_message = '+++ No logs to process in bucket:'
+                    if aws_account_id is not None and aws_region is not None:
+                        debug(f"{base_message} {aws_account_id}/{aws_region}", 1)
+                    else:
+                        debug(f"{base_message} {self.bucket}", 1)
                     return
 
                 for bucket_file in bucket_files['Contents']:

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2629,8 +2629,8 @@ class AWSServerAccess(AWSCustomBucket):
     def check_bucket(self):
         """Check if the bucket is empty or the credentials are wrong."""
         try:
-            bucket_objects = self.client.list_objects_v2(Bucket=self.bucket, Delimiter='/')
-            if not 'CommonPrefixes' in bucket_objects and not bucket_objects['Contents']:
+            bucket_objects = self.client.list_objects_v2(Bucket=self.bucket, Prefix=self.prefix, Delimiter='/')
+            if not 'CommonPrefixes' in bucket_objects and not 'Contents' in bucket_objects:
                 print("ERROR: No files were found in '{0}'. No logs will be processed.".format(self.bucket_path))
                 exit(14)
         except botocore.exceptions.ClientError as error:


### PR DESCRIPTION
|Related issue|
|---|
| #16290 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #16290. 
It fixes some issues related to missing log messages in order to improve the understanding of what is going on.  

## Tests

### UT

```python
============================= test session starts ==============================
platform linux -- Python 3.9.9, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/nstefani/git/wazuh
plugins: tavern-1.2.2, html-3.1.1, aiohttp-0.3.0, trio-0.7.0, sugar-0.9.6, metadata-2.0.2, asyncio-0.15.1, cov-2.12.0
collected 39 items

wodles/aws/tests/test_aws.py .......................................     [100%]

============================== 39 passed in 0.25s ==============================


```
### IT 

```python
root@ubuntu-jammy:/home/vagrant/qa/tests/integration/test_aws# pytest -k 'waf or server_access' --disable-warnings --tier 0
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vagrant/qa/tests/integration, configfile: pytest.ini
plugins: metadata-2.0.2, html-3.1.1, testinfra-5.0.0
collected 195 items / 179 deselected / 16 selected

test_basic.py ..                                                                                                                                                                                              [ 12%]
test_discard_regex.py ..                                                                                                                                                                                      [ 25%]
test_only_logs_after.py ....                                                                                                                                                                                  [ 50%]
test_path.py ......                                                                                                                                                                                           [ 87%]
test_remove_from_bucket.py ..                                                                                                                                                                                 [100%]

============================================================================ 16 passed, 179 deselected, 2 warnings in 331.63s (0:05:31) =============================================================================

root@ubuntu-jammy:/home/vagrant/qa/tests/integration/test_aws# pytest -k 'waf or server_access' --disable-warnings --tier 1 --tb=no
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vagrant/qa/tests/integration, configfile: pytest.ini
plugins: metadata-2.0.2, html-3.1.1, testinfra-5.0.0
collected 195 items / 193 deselected / 2 selected

test_only_logs_after.py FF                                                                                                                                                                                    [100%]

============================================================================================== short test summary info ==============================================================================================
FAILED test_only_logs_after.py::test_bucket_multiple_calls[waf_only_logs_after_multiple_calls] - wazuh_testing.modules.aws.cli_utils.OutputAnalysisError: The AWS module did not use the correct marker
FAILED test_only_logs_after.py::test_bucket_multiple_calls[server_access_only_logs_after_multiple_calls] - wazuh_testing.modules.aws.cli_utils.OutputAnalysisError: The AWS module did not use the correct marker
============================================================================= 2 failed, 193 deselected, 3 warnings in 67.56s (0:01:07) ==============================================================================
```
Because the tier 1 tests continued with their execution, I found new fails in the next steps of the test. This should be handled in #16246
