### PR TITLE
[4.4] Update cryptography dependency

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.4
 click==8.1.3
 clickclick==20.10.2
 connexion==2.6.0
-cryptography==3.3.2
+cryptography==39.0.2
 Cython==0.29.21
 defusedxml==0.6.0
 docker==4.2.0


### PR DESCRIPTION
|Related issue|
|---|
| #16363 |


## Description

This PR closes #16363. It updates the `cryptography` dependency to the maximum version available (`39.0.2`) due to recent patches of the package.