### PR TITLE
Store agent group data 

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1992,22 +1992,32 @@ components:
               properties:
                 last_keep_alive:
                   type: string
-                last_sync_agent_groups:
-                  type: object
-                  properties:
-                    date_start_master:
-                      type: string
-                    date_end_master:
-                      type: string
-                    total_agentgroups:
-                      type: integer
-                      format: int32
                 last_sync_agentinfo:
                   type: object
                   properties:
                     date_start_master:
                       type: string
                     date_end_master:
+                      type: string
+                    n_synced_chunks:
+                      type: integer
+                      format: int32
+                last_sync_agentgroup:
+                  type: object
+                  properties:
+                    date_start:
+                      type: string
+                    date_end:
+                      type: string
+                    n_synced_chunks:
+                      type: integer
+                      format: int32
+                last_sync_full_agentgroup:
+                  type: object
+                  properties:
+                    date_start:
+                      type: string
+                    date_end:
                       type: string
                     n_synced_chunks:
                       type: integer
@@ -9608,6 +9618,14 @@ paths:
                             extra_valid: 0
                             shared: 0
                         sync_agent_info_free: true
+                        last_sync_agentgroup:
+                            date_start: 2021-05-27T10:48:54.086973Z
+                            date_end: 2021-05-27T10:49:52.075794Z
+                            n_synced_chunks: 1
+                        last_sync_full_agentgroup:
+                            date_start: 2021-05-27T10:52:48.038573Z
+                            date_end: 2021-05-27T10:53:23.057795Z
+                            n_synced_chunks: 2
                         last_sync_agentinfo:
                           date_start_master: 2021-05-27T10:50:49.174463Z
                           date_end_master: 2021-05-27T10:50:49.175921Z
@@ -9635,6 +9653,14 @@ paths:
                             extra_valid: 0
                             shared: 0
                         sync_agent_info_free: true
+                        last_sync_agentgroup:
+                          date_start: 2021-05-27T10:48:54.086973Z
+                          date_end: 2021-05-27T10:49:52.075794Z
+                          n_synced_chunks: 1
+                        last_sync_full_agentgroup:
+                          date_start: 2021-05-27T10:52:48.038573Z
+                          date_end: 2021-05-27T10:53:23.057795Z
+                          n_synced_chunks: 2
                         last_sync_agentinfo:
                           date_start_master: 2021-05-27T10:50:48.832800Z
                           date_end_master: 2021-05-27T10:50:48.833854Z

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -170,6 +170,8 @@ async def print_health(config, more, filter_node):
             msg2 += f"                Last synchronization: {total} " \
                     f"({node_info['status']['last_sync_agentgroup']['date_start']} - " \
                     f"{node_info['status']['last_sync_agentgroup']['date_end']}).\n"
+            msg2 += f"                Number of synchronized chunks: " \
+                    f"{node_info['status']['last_sync_agentgroup']['n_synced_chunks']}.\n"
 
             # Agent groups full
             total = calculate_seconds(node_info['status']['last_sync_full_agentgroup']['date_start'],
@@ -178,7 +180,8 @@ async def print_health(config, more, filter_node):
             msg2 += f"                Last synchronization: {total} " \
                     f"({node_info['status']['last_sync_full_agentgroup']['date_start']} - " \
                     f"{node_info['status']['last_sync_full_agentgroup']['date_end']}).\n"
-
+            msg2 += f"                Number of synchronized chunks: " \
+                    f"{node_info['status']['last_sync_full_agentgroup']['n_synced_chunks']}.\n"
     print(msg1)
     more and print(msg2)
 

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -120,7 +120,9 @@ async def print_health(config, more, filter_node):
                         f"Integrity check: {node_info['status']['last_check_integrity']['date_end_master']} | " \
                         f"Integrity sync: {node_info['status']['last_sync_integrity']['date_end_master']} | " \
                         f"Agents-info: {node_info['status']['last_sync_agentinfo']['date_end_master']} | " \
-                        f"Last keep alive: {node_info['status']['last_keep_alive']}.\n"
+                        f"Last keep alive: {node_info['status']['last_keep_alive']} | " \
+                        f"Agent-groups: {node_info['status']['last_sync_agentgroup']['date_end']} | " \
+                        f"Agent-groups full: {node_info['status']['last_sync_full_agentgroup']['date_end']}.\n"
 
             msg2 += "        Status:\n"
 

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -120,9 +120,9 @@ async def print_health(config, more, filter_node):
                         f"Integrity check: {node_info['status']['last_check_integrity']['date_end_master']} | " \
                         f"Integrity sync: {node_info['status']['last_sync_integrity']['date_end_master']} | " \
                         f"Agents-info: {node_info['status']['last_sync_agentinfo']['date_end_master']} | " \
-                        f"Last keep alive: {node_info['status']['last_keep_alive']} | " \
                         f"Agent-groups: {node_info['status']['last_sync_agentgroup']['date_end']} | " \
-                        f"Agent-groups full: {node_info['status']['last_sync_full_agentgroup']['date_end']}.\n"
+                        f"Agent-groups full: {node_info['status']['last_sync_full_agentgroup']['date_end']} | " \
+                        f"Last keep alive: {node_info['status']['last_keep_alive']}.\n"
 
             msg2 += "        Status:\n"
 

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -163,6 +163,22 @@ async def print_health(config, more, filter_node):
             msg2 += f"                Permission to synchronize agent-info: " \
                     f"{node_info['status']['sync_agent_info_free']}.\n"
 
+            # Agent groups
+            total = calculate_seconds(node_info['status']['last_sync_agentgroup']['date_start'],
+                                      node_info['status']['last_sync_agentgroup']['date_end'])
+            msg2 += "            Agents-groups:\n"
+            msg2 += f"                Last synchronization: {total} " \
+                    f"({node_info['status']['last_sync_agentgroup']['date_start']} - " \
+                    f"{node_info['status']['last_sync_agentgroup']['date_end']}).\n"
+
+            # Agent groups full
+            total = calculate_seconds(node_info['status']['last_sync_full_agentgroup']['date_start'],
+                                      node_info['status']['last_sync_full_agentgroup']['date_end'])
+            msg2 += "            Agents-groups full:\n"
+            msg2 += f"                Last synchronization: {total} " \
+                    f"({node_info['status']['last_sync_full_agentgroup']['date_start']} - " \
+                    f"{node_info['status']['last_sync_full_agentgroup']['date_end']}).\n"
+
     print(msg1)
     more and print(msg2)
 

--- a/framework/scripts/tests/test_cluster_control.py
+++ b/framework/scripts/tests/test_cluster_control.py
@@ -94,6 +94,10 @@ async def test_print_nodes(local_client_mock, get_agents_mock, print_table_mock,
                                     'sync_integrity_free': 'True',
                                     'last_sync_agentinfo': {'date_start_master': '0', 'date_end_master': '0',
                                                             'n_synced_chunks': 0},
+                                    'last_sync_agentgroup': {'date_start': 0, 'date_end': 0,
+                                                             'n_synced_chunks': 0},
+                                    'last_sync_full_agentgroup': {'date_start': 0, 'date_end': 0,
+                                                                  'n_synced_chunks': 0},
                                     'sync_agent_info_free': 'True'}}}})
 async def test_print_health(get_health_mock, get_nodes_mock, local_client_mock, get_utc_strptime_mock, print_mock):
     """Test if the current status of the cluster is properly printed."""
@@ -148,6 +152,18 @@ async def test_print_health(get_health_mock, get_nodes_mock, local_client_mock, 
                                           f"{worker_status['last_sync_agentinfo']['n_synced_chunks']}."
                                           f"\n                Permission to synchronize agent-info: "
                                           f"{worker_status['sync_agent_info_free']}.\n"
+                                          "            Agents-groups:\n"
+                                          f"                Last synchronization: 0.001s "
+                                          f"({worker_status['last_sync_agentgroup']['date_start']} - "
+                                          f"{worker_status['last_sync_agentgroup']['date_end']}).\n"
+                                          f"                Number of synchronized chunks: "
+                                          f"{worker_status['last_sync_agentgroup']['n_synced_chunks']}.\n"
+                                          "            Agents-groups full:\n"
+                                          f"                Last synchronization: 0.001s "
+                                          f"({worker_status['last_sync_full_agentgroup']['date_start']} - "
+                                          f"{worker_status['last_sync_full_agentgroup']['date_end']}).\n"
+                                          f"                Number of synchronized chunks: "
+                                          f"{worker_status['last_sync_full_agentgroup']['n_synced_chunks']}.\n"
                                           )])
 
         # Common assertions
@@ -177,6 +193,8 @@ async def test_print_health(get_health_mock, get_nodes_mock, local_client_mock, 
                                        f"Integrity check: {worker_status['last_check_integrity']['date_end_master']} "
                                        f"| Integrity sync: {worker_status['last_sync_integrity']['date_end_master']} |"
                                        f" Agents-info: {worker_status['last_sync_agentinfo']['date_end_master']} | "
+                                       f"Agent-groups: {worker_status['last_sync_agentgroup']['date_end']} | "
+                                       f"Agent-groups full: {worker_status['last_sync_full_agentgroup']['date_end']} | "
                                        f"Last keep alive: {worker_status['last_keep_alive']}.\n")
 
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -194,9 +194,11 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         self.sync_agent_info_status = {'date_start_master': default_date, 'date_end_master': default_date,
                                        'n_synced_chunks': 0}
         self.send_agent_groups_status = {'date_start': default_date,
-                                         'date_end': default_date}
+                                         'date_end': default_date,
+                                         'n_synced_chunks': 0}
         self.send_full_agent_groups_status = {'date_start': default_date,
-                                              'date_end': default_date}
+                                              'date_end': default_date,
+                                              'n_synced_chunks': 0}
 
         # Variables which will be filled when the worker sends the hello request.
         self.version = ""
@@ -661,6 +663,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         # Updates Agent groups full status
         self.send_full_agent_groups_status['date_start'] = start_time.strftime(DECIMALS_DATE_FORMAT)
         self.send_full_agent_groups_status['date_end'] = end_time.strftime(DECIMALS_DATE_FORMAT)
+        self.send_agent_groups_status['n_synced_chunks'] = len(local_agent_groups_information)
 
     async def send_agent_groups_information(self):
         """Function in charge of sending the group information to the worker node.
@@ -681,6 +684,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     logger.info('Starting.')
                     self.send_agent_groups_status['date_start'] = get_utc_now().strftime(DECIMALS_DATE_FORMAT)
                     await sync_object.sync(start_time=self.send_agent_groups_status['date_start'], chunks=info)
+                    self.send_agent_groups_status['n_synced_chunks'] = len(info)
                     self.send_agent_groups_status['date_end'] = get_utc_now().strftime(DECIMALS_DATE_FORMAT)
                 except Exception as e:
                     logger.error(f'Error sending agent-groups information to {self.name}: {e}')

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -261,11 +261,11 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             return self.process_sync_error_from_worker(data)
         elif command == b'syn_w_g_e':
             logger = self.task_loggers['Agent-groups send']
-            start_time = datetime.strptime(self.send_agent_groups_status['date_start'], DECIMALS_DATE_FORMAT).timestamp()
+            start_time = self.send_agent_groups_status['date_start'].timestamp()
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_wgc_e':
             logger = self.task_loggers['Agent-groups send full']
-            start_time = datetime.strptime(self.send_agent_groups_status['date_start'], DECIMALS_DATE_FORMAT).timestamp()
+            start_time = self.send_agent_groups_status['date_start'].timestamp()
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_w_g_err':
             logger = self.task_loggers['Agent-groups send']

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -663,7 +663,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         # Updates Agent groups full status
         self.send_full_agent_groups_status['date_start'] = start_time.strftime(DECIMALS_DATE_FORMAT)
         self.send_full_agent_groups_status['date_end'] = end_time.strftime(DECIMALS_DATE_FORMAT)
-        self.send_agent_groups_status['n_synced_chunks'] = len(local_agent_groups_information)
+        self.send_full_agent_groups_status['n_synced_chunks'] = len(local_agent_groups_information)
 
     async def send_agent_groups_information(self):
         """Function in charge of sending the group information to the worker node.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -22,7 +22,7 @@ from wazuh.core.cluster import server, cluster, common as c_common
 from wazuh.core.cluster.dapi import dapi
 from wazuh.core.cluster.utils import context_tag
 from wazuh.core.common import DECIMALS_DATE_FORMAT
-from wazuh.core.utils import get_utc_now
+from wazuh.core.utils import get_utc_now, get_utc_strptime
 from wazuh.core.wdb import AsyncWazuhDBConnection
 
 
@@ -261,11 +261,11 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             return self.process_sync_error_from_worker(data)
         elif command == b'syn_w_g_e':
             logger = self.task_loggers['Agent-groups send']
-            start_time = self.send_agent_groups_status['date_start']
+            start_time = datetime.strptime(self.send_agent_groups_status['date_start'], DECIMALS_DATE_FORMAT).timestamp()
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_wgc_e':
             logger = self.task_loggers['Agent-groups send full']
-            start_time = self.send_agent_groups_status['date_start']
+            start_time = datetime.strptime(self.send_agent_groups_status['date_start'], DECIMALS_DATE_FORMAT).timestamp()
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_w_g_err':
             logger = self.task_loggers['Agent-groups send']


### PR DESCRIPTION
|Related issue|
|---|
[16069](https://github.com/wazuh/wazuh/issues/16069)



## Description

Added `Agent groups` and `Agent groups full` status data to the `MasterHandler` and changed log of the `cluster_control.py` script.

## Example 

```
Cluster name: wazuh

Connected nodes (1):

    master-node (wazuh-master)
        Version: 4.4.1
        Type: master
        Active agents: 0

    worker (172.18.0.4)
        Version: 4.4.1
        Type: worker
        Active agents: 1
        Status:
            Last keep Alive:
                Last received: 2023-03-16T11:58:05.985666Z.
            Integrity check:
                Last integrity check: 0.007s (2023-03-16T11:58:13.274594Z - 2023-03-16T11:58:13.281172Z).
                Permission to check integrity: True.
            Integrity sync:
                Last integrity synchronization: n/a (n/a - n/a).
                Synchronized files: Shared: 0 | Missing: 0 | Extra: 0.
            Agents-info:
                Last synchronization: 0.001s (2023-03-16T11:58:16.613794Z - 2023-03-16T11:58:16.615173Z).
                Number of synchronized chunks: 1.
                Permission to synchronize agent-info: True.
            Agents-groups:
                Last synchronization: 0.001s (2023-03-16T11:58:16.822680Z - 2023-03-16T11:58:16.823920Z).
                Number of synchronized chunks: 1.
            Agents-groups full:
                Last synchronization: n/a (n/a - n/a).
                Number of synchronized chunks: 0.
```