### PR TITLE
Fix custom bucket markers

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -788,7 +788,7 @@ class AWSBucket(WazuhIntegration):
                     'bucket_path': self.bucket_path,
                     'aws_region': aws_region,
                     'prefix': f'{self.prefix}%',
-                    'aws_account_id': aws_account_id
+                    'aws_account_id': aws_account_id or self.aws_account_id
                 })
             try:
                 filter_marker = query_last_key.fetchone()[0]
@@ -2196,7 +2196,7 @@ class AWSCustomBucket(AWSBucket):
         return cursor.fetchone()[0] > 0
 
     def mark_complete(self, aws_account_id, aws_region, log_file):
-        AWSBucket.mark_complete(self, self.aws_account_id, aws_region, log_file)
+        AWSBucket.mark_complete(self, aws_account_id or self.aws_account_id, aws_region, log_file)
 
     def db_count_custom(self, aws_account_id=None):
         """Counts the number of rows in DB for a region

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2616,6 +2616,7 @@ class AWSServerAccess(AWSCustomBucket):
                         debug(f"+++ Remove file from S3 Bucket:{bucket_file['Key']}", 2)
                         self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                     self.mark_complete(aws_account_id, aws_region, bucket_file)
+                    processed_logs += 1
 
                 if processed_logs == 0:
                     self._print_not_logs_to_prcess_message(self.bucket, aws_account_id, aws_region)

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1010,7 +1010,7 @@ class AWSBucket(WazuhIntegration):
                 self.send_event(event_msg)
 
     @staticmethod
-    def _print_not_logs_to_prcess_message(bucket, aws_account_id, aws_region):
+    def _print_no_logs_to_process_message(bucket, aws_account_id, aws_region):
         base_message = '+++ No logs to process in bucket:'
         if aws_account_id is not None and aws_region is not None:
             debug(f"{base_message} {aws_account_id}/{aws_region}", 1)
@@ -1069,7 +1069,7 @@ class AWSBucket(WazuhIntegration):
                     processed_logs += 1
 
                 # This is a workaround in order to work with custom buckets that don't have
-                # base prefix to serach the logs
+                # base prefix to search the logs
                 if processed_logs == 0:
                     self._print_not_logs_to_prcess_message(self.bucket, aws_account_id, aws_region)
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1028,7 +1028,7 @@ class AWSBucket(WazuhIntegration):
 
             while True:
                 if 'Contents' not in bucket_files:
-                    self._print_not_logs_to_prcess_message(self.bucket, aws_account_id, aws_region)
+                    self._print_no_logs_to_process_message(self.bucket, aws_account_id, aws_region)
                     return
 
                 processed_logs = 0
@@ -1071,7 +1071,7 @@ class AWSBucket(WazuhIntegration):
                 # This is a workaround in order to work with custom buckets that don't have
                 # base prefix to search the logs
                 if processed_logs == 0:
-                    self._print_not_logs_to_prcess_message(self.bucket, aws_account_id, aws_region)
+                    self._print_no_logs_to_process_message(self.bucket, aws_account_id, aws_region)
 
                 if bucket_files['IsTruncated']:
                     new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region, True)
@@ -2571,7 +2571,7 @@ class AWSServerAccess(AWSCustomBucket):
                                                                                    custom_delimiter='-'))
             while True:
                 if 'Contents' not in bucket_files:
-                    self._print_not_logs_to_prcess_message(self.bucket, aws_account_id, aws_region)
+                    self._print_no_logs_to_process_message(self.bucket, aws_account_id, aws_region)
                     return
 
                 processed_logs = 0
@@ -2619,7 +2619,7 @@ class AWSServerAccess(AWSCustomBucket):
                     processed_logs += 1
 
                 if processed_logs == 0:
-                    self._print_not_logs_to_prcess_message(self.bucket, aws_account_id, aws_region)
+                    self._print_no_logs_to_process_message(self.bucket, aws_account_id, aws_region)
 
                 if bucket_files['IsTruncated']:
                     new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region, True)


### PR DESCRIPTION
|Related issue|
|---|
| #16246 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #16246. Fixes the marker that the custom buckets were displaying.

## Tests

```python
root@ubuntu-jammy:/home/vagrant/qa/tests/integration/test_aws# pytest -k 'guardduty or waf or server_access or umbrella' --disable-warnings --tier 1 --tb=line
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vagrant/qa/tests/integration, configfile: pytest.ini
plugins: metadata-2.0.2, html-3.1.1, testinfra-5.0.0
collected 195 items / 190 deselected / 5 selected

test_only_logs_after.py .....                                                                                                                                                                                 [100%]

============================================================================= 5 passed, 190 deselected, 2 warnings in 163.92s (0:02:43) =============================================================================
```