### PR TITLE
Add required square brackets arround srcip if it looks like IPv6

### DIFF
--- a/src/active-response/host-deny.c
+++ b/src/active-response/host-deny.c
@@ -85,8 +85,13 @@ int main (int argc, char **argv) {
         snprintf(hosts_deny_rule, COMMANDSIZE_4096 -1, "ALL : %s : deny", srcip);
         strcpy(hosts_deny_path, FREEBSD_HOSTS_DENY_PATH);
     } else {
-        snprintf(hosts_deny_rule, COMMANDSIZE_4096 -1, "ALL:%s", srcip);
-        strcpy(hosts_deny_path, DEFAULT_HOSTS_DENY_PATH);
+        if (strstr(srcip, ":")) { // TODO: implement proper check for IPv6 addresses.
+            snprintf(hosts_deny_rule, COMMANDSIZE_4096 -1, "ALL:[%s]", srcip);
+            strcpy(hosts_deny_path, DEFAULT_HOSTS_DENY_PATH);
+        } else {
+            snprintf(hosts_deny_rule, COMMANDSIZE_4096 -1, "ALL:%s", srcip);
+            strcpy(hosts_deny_path, DEFAULT_HOSTS_DENY_PATH);
+        }
     }
 
     memset(lock_path, '\0', COMMANDSIZE_4096);


### PR DESCRIPTION
|Related issue|
|---|
|#16460|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

/etc/hosts.deny expects square brackets around IPv6 addresses or it will silently ignore them.

<!--
Add a clear description of how the problem has been solved.
-->
Check the srcip string for a colon and add square brackets around the address if there is one. Using a proper IP version classifier like <arpa/inet.h>s inet_pton would be more reliable in corner cases but would also require a lot more code to be pulled in.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux