### PR TITLE
Validated the region passed before instantiating the service class

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3672,7 +3672,7 @@ def main(argv):
                 try:
                     service_type.check_region(region)
                 except ValueError:
-                    print(f"+++ WARNING: The region '{region}' is not a valid one.", 1)
+                    debug(f"+++ WARNING: The region '{region}' is not a valid one.", 1)
                     continue
 
                 debug('+++ Getting alerts from "{}" region.'.format(region), 1)

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -87,6 +87,10 @@ THROTTLING_EXCEPTION_ERROR_MESSAGE = "The '{name}' request was denied due to req
                                      " check the following link to learn how to use the Retry configuration to avoid it: " \
                                      f"'{RETRY_CONFIGURATION_URL}'"
 
+ALL_REGIONS = [
+    'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2', 'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-2',
+    'ap-south-1', 'eu-central-1', 'eu-west-1'
+]
 
 ################################################################################
 # Classes
@@ -2804,6 +2808,11 @@ class AWSService(WazuhIntegration):
 
         return {'integration': 'aws', 'aws': msg}
 
+    @staticmethod
+    def check_region(region: str) -> None:
+        if region not in ALL_REGIONS:
+            raise ValueError(f"Invalid region '{region}'")
+
 
 class AWSInspector(AWSService):
     """
@@ -3657,11 +3666,15 @@ def main(argv):
                     options.regions.append(aws_config.get(aws_profile, "region"))
                 else:
                     debug("+++ Warning: No regions were specified, trying to get events from all regions", 1)
-                    options.regions = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',
-                                       'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-2', 'ap-south-1',
-                                       'eu-central-1', 'eu-west-1']
+                    options.regions = ALL_REGIONS
 
             for region in options.regions:
+                try:
+                    service_type.check_region(region)
+                except ValueError:
+                    print(f"+++ WARNING: The region '{region}' is not a valid one.", 1)
+                    continue
+
                 debug('+++ Getting alerts from "{}" region.'.format(region), 1)
                 service = service_type(reparse=options.reparse,
                                        access_key=options.access_key,

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -26,6 +26,7 @@
 #   17 - Invalid key format
 #   18 - Invalid prefix
 #   19 - The server datetime and datetime of the AWS environment differ
+#   20 - Invalid region
 
 import argparse
 import configparser
@@ -3672,8 +3673,8 @@ def main(argv):
                 try:
                     service_type.check_region(region)
                 except ValueError:
-                    debug(f"+++ WARNING: The region '{region}' is not a valid one.", 1)
-                    continue
+                    debug(f"+++ ERROR: The region '{region}' is not a valid one.", 1)
+                    exit(20)
 
                 debug('+++ Getting alerts from "{}" region.'.format(region), 1)
                 service = service_type(reparse=options.reparse,


### PR DESCRIPTION
|Related issue|
|---|
| #16301 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #16301. Adds validation for the region passed to the service classes, in order to prevent requesting inexistent endpoints.

## Tests

```python
root@ubuntu-jammy:/home/vagrant/qa/tests/integration/test_aws# pytest -k 'cloudwatchlogs or inspector' --disable-warnings --tb=line --tier 0 test_regions.py
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vagrant/qa/tests/integration, configfile: pytest.ini
plugins: metadata-2.0.2, html-3.1.1, testinfra-5.0.0
collected 24 items / 18 deselected / 6 selected

test_regions.py ......                                                                                                                                                                                        [100%]

============================================================================= 6 passed, 18 deselected, 2 warnings in 132.06s (0:02:12) ==============================================================================
```