### PR TITLE
Fix memory leaks in Vulnerability Detector after disk failures

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -95,6 +95,13 @@ STATIC void wm_vuldet_add_vulnerability_info(wm_vuldet_db *ctrl_block);
  */
 STATIC vulnerability *wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node);
 
+STATIC void wm_vuldet_db_clean(wm_vuldet_db *ctrl_block);
+STATIC void wm_vuldet_clean_vulnerabilities(wm_vuldet_db *ctrl_block);
+STATIC void wm_vuldet_clean_variables(wm_vuldet_db *ctrl_block);
+STATIC void wm_vuldet_clean_info_state(wm_vuldet_db *ctrl_block);
+STATIC void wm_vuldet_clean_info_obj(wm_vuldet_db *ctrl_block);
+STATIC void wm_vuldet_clean_info_test(wm_vuldet_db *ctrl_block);
+
 /**
  * @brief Clean the CVEs linked list data structure.
  * @param ctrl_block Parsed oval data structure.
@@ -3219,6 +3226,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INS_VUL_SEC, "ALAS");
 
         if (wm_vuldet_insert_ALAS(db, alas_it, vu_feed_tag[update->dist_tag_ref])){
+            parsed_oval->alas_vuln = NULL;
             sqlite3_close_v2(db);
             return OS_INVALID;
         }
@@ -3243,91 +3251,91 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     // Adds the vulnerabilities
     if (vul_it) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INS_VUL_SEC, update->dist_ext);
-    }
+        while (vul_it) {
+            // If you do not have this field, it has been discarded by the preparser and the OS is not affected
+            if (vul_it->state_id) {
+                if (vul_it->rhsa_list) {
+                    wm_vuldet_oval_traverse_rhsa(vul_it);
+                }
 
-    while (vul_it) {
-        // If you do not have this field, it has been discarded by the preparser and the OS is not affected
-        if (vul_it->state_id) {
-            if (vul_it->rhsa_list) {
-                wm_vuldet_oval_traverse_rhsa(vul_it);
-            }
+                if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_CVE], -1, &stmt, NULL) != SQLITE_OK) {
+                    return wm_vuldet_sql_error(db, stmt);
+                }
 
-            if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_CVE], -1, &stmt, NULL) != SQLITE_OK) {
-                return wm_vuldet_sql_error(db, stmt);
-            }
-
-            sqlite3_bind_text(stmt, 1, vul_it->cve_id, -1, NULL);
-            sqlite3_bind_text(stmt, 2, parsed_oval->OS, -1, NULL);
-            sqlite3_bind_text(stmt, 3, NULL, -1, NULL);
-            sqlite3_bind_text(stmt, 5, vul_it->state_id, -1, NULL);
-            if (vul_it->package_name && vul_it->package_version) {
-                    sqlite3_bind_text(stmt, 4, vul_it->package_name, -1, NULL);
-                    sqlite3_bind_text(stmt, 6, vul_it->package_version, -1, NULL);
-            } else {
-                sqlite3_bind_text(stmt, 4, vul_it->package_name ? vul_it->package_name : vul_it->state_id, -1, NULL);
-                sqlite3_bind_text(stmt, 6, NULL, -1, NULL);
-            }
-            sqlite3_bind_int(stmt, 7, 0);
-            sqlite3_bind_int(stmt, 8, vul_it->ignore);
-            sqlite3_bind_int(stmt, 9, 0);
-            if (vul_it->deps) {
-                // Check the dependency array to avoid inserting more IDs than necessary
-                if (deps_size != vul_it->deps->elements) {
-                    deps_modified = true;
+                sqlite3_bind_text(stmt, 1, vul_it->cve_id, -1, NULL);
+                sqlite3_bind_text(stmt, 2, parsed_oval->OS, -1, NULL);
+                sqlite3_bind_text(stmt, 3, NULL, -1, NULL);
+                sqlite3_bind_text(stmt, 5, vul_it->state_id, -1, NULL);
+                if (vul_it->package_name && vul_it->package_version) {
+                        sqlite3_bind_text(stmt, 4, vul_it->package_name, -1, NULL);
+                        sqlite3_bind_text(stmt, 6, vul_it->package_version, -1, NULL);
                 } else {
-                    for (int i = 0; i < deps_size; ++i) {
-                        if (dependency[i] != vul_it->deps->test_ref[i]) {
-                            deps_modified = true;
-                            break;
+                    sqlite3_bind_text(stmt, 4, vul_it->package_name ? vul_it->package_name : vul_it->state_id, -1, NULL);
+                    sqlite3_bind_text(stmt, 6, NULL, -1, NULL);
+                }
+                sqlite3_bind_int(stmt, 7, 0);
+                sqlite3_bind_int(stmt, 8, vul_it->ignore);
+                sqlite3_bind_int(stmt, 9, 0);
+                if (vul_it->deps) {
+                    // Check the dependency array to avoid inserting more IDs than necessary
+                    if (deps_size != vul_it->deps->elements) {
+                        deps_modified = true;
+                    } else {
+                        for (int i = 0; i < deps_size; ++i) {
+                            if (dependency[i] != vul_it->deps->test_ref[i]) {
+                                deps_modified = true;
+                                break;
+                            }
                         }
                     }
-                }
-                if(deps_modified) {
-                    os_free(dependency);
-                    deps_size = vul_it->deps->elements;
-                    dependency = vul_it->deps->test_ref;
-                    ++deps_id;
+                    if(deps_modified) {
+                        os_free(dependency);
+                        deps_size = vul_it->deps->elements;
+                        dependency = vul_it->deps->test_ref;
+                        ++deps_id;
+                    } else {
+                        os_free(vul_it->deps->test_ref);
+                    }
+                    sqlite3_bind_int(stmt, 10, deps_id);
                 } else {
-                    os_free(vul_it->deps->test_ref);
+                    sqlite3_bind_int(stmt, 10, 0);
                 }
-                sqlite3_bind_int(stmt, 10, deps_id);
-            } else {
-                sqlite3_bind_int(stmt, 10, 0);
-            }
 
-            if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-                return wm_vuldet_sql_error(db, stmt);
-            }
-
-            wdb_finalize(stmt);
-
-            if (deps_modified) {
-                for(int i = 0; i < vul_it->deps->elements; ++i) {
-                    if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_PKG_DEPS], -1, &stmt, NULL) != SQLITE_OK) {
-                        return wm_vuldet_sql_error(db, stmt);
-                    }
-                    sqlite3_bind_int(stmt, 1, deps_id);
-                    sqlite3_bind_text(stmt, 2, dependency[i], -1, NULL);
-                    sqlite3_bind_text(stmt, 3, parsed_oval->OS, -1, NULL);
-
-                    if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-                        return wm_vuldet_sql_error(db, stmt);
-                    }
-
-                    wdb_finalize(stmt);
+                if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+                    return wm_vuldet_sql_error(db, stmt);
                 }
-                deps_modified = false;
+
+                wdb_finalize(stmt);
+
+                if (deps_modified) {
+                    for(int i = 0; i < vul_it->deps->elements; ++i) {
+                        if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_PKG_DEPS], -1, &stmt, NULL) != SQLITE_OK) {
+                            return wm_vuldet_sql_error(db, stmt);
+                        }
+                        sqlite3_bind_int(stmt, 1, deps_id);
+                        sqlite3_bind_text(stmt, 2, dependency[i], -1, NULL);
+                        sqlite3_bind_text(stmt, 3, parsed_oval->OS, -1, NULL);
+
+                        if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+                            return wm_vuldet_sql_error(db, stmt);
+                        }
+
+                        wdb_finalize(stmt);
+                    }
+                    deps_modified = false;
+                }
             }
+
+            vulnerability *vul_aux = vul_it;
+            vul_it = vul_it->prev;
+            os_free(vul_aux->cve_id);
+            os_free(vul_aux->state_id);
+            os_free(vul_aux->package_name);
+            os_free(vul_aux->package_version);
+            os_free(vul_aux->deps);
+            os_free(vul_aux);
         }
-
-        vulnerability *vul_aux = vul_it;
-        vul_it = vul_it->prev;
-        os_free(vul_aux->cve_id);
-        os_free(vul_aux->state_id);
-        os_free(vul_aux->package_name);
-        os_free(vul_aux->package_version);
-        os_free(vul_aux->deps);
-        os_free(vul_aux);
+        parsed_oval->vulnerabilities = NULL;
     }
 
     // Adds Debian vulnerabilities
@@ -3339,199 +3347,201 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
 
     if (test_it) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INS_TEST_SEC, update->dist_ext);
-    }
 
-    // Links vulnerabilities to their conditions
-    while (test_it) {
-        if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_CVE], -1, &stmt, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, stmt);
-        }
-
-        sqlite3_bind_text(stmt, 1, test_it->obj, -1, NULL);
-        sqlite3_bind_text(stmt, 2, test_it->state, -1, NULL);
-        sqlite3_bind_text(stmt, 3, test_it->id, -1, NULL);
-        result = wm_vuldet_step(stmt);
-
-        switch (result) {
-        case SQLITE_DONE:
-            break;
-        case SQLITE_CONSTRAINT:
-            wdb_finalize(stmt);
-
-            if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_CVE_NOT_FIXED], -1, &stmt, NULL) != SQLITE_OK) {
+        // Links vulnerabilities to their conditions
+        while (test_it) {
+            if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_CVE], -1, &stmt, NULL) != SQLITE_OK) {
                 return wm_vuldet_sql_error(db, stmt);
             }
 
             sqlite3_bind_text(stmt, 1, test_it->obj, -1, NULL);
-            sqlite3_bind_text(stmt, 2, vu_package_comp[VU_COMP_L], -1, NULL);
-            sqlite3_bind_text(stmt, 3, version_null, -1, NULL);
-            sqlite3_bind_text(stmt, 4, test_it->id, -1, NULL);
+            sqlite3_bind_text(stmt, 2, test_it->state, -1, NULL);
+            sqlite3_bind_text(stmt, 3, test_it->id, -1, NULL);
+            result = wm_vuldet_step(stmt);
 
-            if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+            switch (result) {
+            case SQLITE_DONE:
+                break;
+            case SQLITE_CONSTRAINT:
+                wdb_finalize(stmt);
+
+                if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_CVE_NOT_FIXED], -1, &stmt, NULL) != SQLITE_OK) {
+                    return wm_vuldet_sql_error(db, stmt);
+                }
+
+                sqlite3_bind_text(stmt, 1, test_it->obj, -1, NULL);
+                sqlite3_bind_text(stmt, 2, vu_package_comp[VU_COMP_L], -1, NULL);
+                sqlite3_bind_text(stmt, 3, version_null, -1, NULL);
+                sqlite3_bind_text(stmt, 4, test_it->id, -1, NULL);
+
+                if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+                    return wm_vuldet_sql_error(db, stmt);
+                }
+                break;
+            default:
                 return wm_vuldet_sql_error(db, stmt);
             }
-            break;
-        default:
-            return wm_vuldet_sql_error(db, stmt);
+
+            wdb_finalize(stmt);
+
+            info_test *test_aux = test_it;
+            test_it = test_it->prev;
+            os_free(test_aux->id);
+            os_free(test_aux->state);
+            os_free(test_aux->obj);
+            os_free(test_aux);
         }
-
-        wdb_finalize(stmt);
-
-        info_test *test_aux = test_it;
-        test_it = test_it->prev;
-        free(test_aux->id);
-        free(test_aux->state);
-        free(test_aux->obj);
-        free(test_aux);
+        parsed_oval->info_tests = NULL;
     }
 
     if (state_it) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_VU_CO, update->dist_ext);
 
         sqlite3_exec(db, vu_queries[VU_REMOVE_UNUSED_VULS], NULL, NULL, NULL);
-    }
 
-    // Sets the OVAL operators and values
-    int arch_id = 0;
+        // Sets the OVAL operators and values
+        int arch_id = 0;
 
-    while (state_it) {
-        if (state_it->operation_value != NULL) {
+        while (state_it) {
+            if (state_it->operation_value != NULL) {
 
-            // Get ID to insert architectures
-            if (state_it->arch && (update->dist_ref == FEED_REDHAT || update->dist_ref == FEED_SUSE)) {
-                arch_id++;
-            }
+                // Get ID to insert architectures
+                if (state_it->arch && (update->dist_ref == FEED_REDHAT || update->dist_ref == FEED_SUSE)) {
+                    arch_id++;
+                }
 
-            // Replace the state ID by the real values
-            query = vu_queries[VU_UPDATE_CVE_VAL];
-            if (wm_vuldet_prepare(db, query, -1, &stmt, NULL) != SQLITE_OK) {
-                return wm_vuldet_sql_error(db, stmt);
-            }
+                // Replace the state ID by the real values
+                query = vu_queries[VU_UPDATE_CVE_VAL];
+                if (wm_vuldet_prepare(db, query, -1, &stmt, NULL) != SQLITE_OK) {
+                    return wm_vuldet_sql_error(db, stmt);
+                }
 
-            sqlite3_bind_text(stmt, 1, state_it->operation, -1, NULL);
+                sqlite3_bind_text(stmt, 1, state_it->operation, -1, NULL);
 
-            // If the epoch is 0, we don't save it because it is not necessary
-            if (!strcmp(state_it->operation_value, version_null) || strncmp("0:", state_it->operation_value, 2)) {
-                sqlite3_bind_text(stmt, 2, state_it->operation_value, -1, NULL);
-            } else {
-                sqlite3_bind_text(stmt, 2, (state_it->operation_value + 2), -1, NULL);
-            }
+                // If the epoch is 0, we don't save it because it is not necessary
+                if (!strcmp(state_it->operation_value, version_null) || strncmp("0:", state_it->operation_value, 2)) {
+                    sqlite3_bind_text(stmt, 2, state_it->operation_value, -1, NULL);
+                } else {
+                    sqlite3_bind_text(stmt, 2, (state_it->operation_value + 2), -1, NULL);
+                }
 
-            sqlite3_bind_int(stmt, 3, state_it->arch ? arch_id : 0);
-            sqlite3_bind_text(stmt, 4, state_it->id, -1, NULL);
+                sqlite3_bind_int(stmt, 3, state_it->arch ? arch_id : 0);
+                sqlite3_bind_text(stmt, 4, state_it->id, -1, NULL);
 
-            if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-                return wm_vuldet_sql_error(db, stmt);
-            }
-            wdb_finalize(stmt);
+                if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+                    return wm_vuldet_sql_error(db, stmt);
+                }
+                wdb_finalize(stmt);
 
-            // Insert architecture values
-            if (arch_id && state_it->arch) {
-                for (int i = 0; state_it->arch[i]; i++) {
-                    if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_ARCH], -1, &stmt, NULL) != SQLITE_OK) {
-                        return wm_vuldet_sql_error(db, stmt);
+                // Insert architecture values
+                if (arch_id && state_it->arch) {
+                    for (int i = 0; state_it->arch[i]; i++) {
+                        if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_ARCH], -1, &stmt, NULL) != SQLITE_OK) {
+                            return wm_vuldet_sql_error(db, stmt);
+                        }
+
+                        sqlite3_bind_int(stmt, 1, arch_id);
+                        sqlite3_bind_text(stmt, 2, parsed_oval->OS, -1, NULL);
+                        sqlite3_bind_text(stmt, 3, state_it->arch[i], -1, NULL);
+
+                        if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
+                            return wm_vuldet_sql_error(db, stmt);
+                        }
+                        wdb_finalize(stmt);
                     }
-
-                    sqlite3_bind_int(stmt, 1, arch_id);
-                    sqlite3_bind_text(stmt, 2, parsed_oval->OS, -1, NULL);
-                    sqlite3_bind_text(stmt, 3, state_it->arch[i], -1, NULL);
-
-                    if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
-                        return wm_vuldet_sql_error(db, stmt);
-                    }
-                    wdb_finalize(stmt);
                 }
             }
-        }
 
-        info_state *state_aux = state_it;
-        state_it = state_it->prev;
-        os_free(state_aux->id);
-        os_free(state_aux->operation);
-        os_free(state_aux->operation_value);
-        w_FreeArray(state_aux->arch);
-        os_free(state_aux->arch);
-        os_free(state_aux);
+            info_state *state_aux = state_it;
+            state_it = state_it->prev;
+            os_free(state_aux->id);
+            os_free(state_aux->operation);
+            os_free(state_aux->operation_value);
+            w_FreeArray(state_aux->arch);
+            os_free(state_aux->arch);
+            os_free(state_aux);
+        }
+        parsed_oval->info_states = NULL;
     }
 
     if (obj_it) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_PACK_NAME, update->dist_ext);
-    }
 
-    // Sets the OVAL package name
-    while (obj_it) {
-        char *normalized_name = NULL;
+        // Sets the OVAL package name
+        while (obj_it) {
+            char *normalized_name = NULL;
 
-        if (obj_it->obj) {
-            if (result = wm_vuldet_prepare(db, vu_queries[VU_UPDATE_CVE_PACK], -1, &stmt, NULL), result != SQLITE_OK && result != SQLITE_CONSTRAINT) {
+            if (obj_it->obj) {
+                if (result = wm_vuldet_prepare(db, vu_queries[VU_UPDATE_CVE_PACK], -1, &stmt, NULL), result != SQLITE_OK && result != SQLITE_CONSTRAINT) {
+                    return wm_vuldet_sql_error(db, stmt);
+                }
+                normalized_name = w_tolower_str(obj_it->obj);
+                sqlite3_bind_text(stmt, 1, normalized_name, -1, NULL);
+                sqlite3_bind_int(stmt, 2, obj_it->need_vars);
+                sqlite3_bind_text(stmt, 3, obj_it->id, -1, NULL);
+            } else {
+                if (result = wm_vuldet_prepare(db, vu_queries[VU_REMOVE_UNUSED_ID], -1, &stmt, NULL), result != SQLITE_OK && result != SQLITE_CONSTRAINT) {
+                    return wm_vuldet_sql_error(db, stmt);
+                }
+                sqlite3_bind_text(stmt, 1, obj_it->id, -1, NULL);
+            }
+
+            if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
+                os_free(normalized_name);
                 return wm_vuldet_sql_error(db, stmt);
             }
-            normalized_name = w_tolower_str(obj_it->obj);
-            sqlite3_bind_text(stmt, 1, normalized_name, -1, NULL);
-            sqlite3_bind_int(stmt, 2, obj_it->need_vars);
-            sqlite3_bind_text(stmt, 3, obj_it->id, -1, NULL);
-        } else {
-            if (result = wm_vuldet_prepare(db, vu_queries[VU_REMOVE_UNUSED_ID], -1, &stmt, NULL), result != SQLITE_OK && result != SQLITE_CONSTRAINT) {
-                return wm_vuldet_sql_error(db, stmt);
-            }
-            sqlite3_bind_text(stmt, 1, obj_it->id, -1, NULL);
-        }
 
-        if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
+            wdb_finalize(stmt);
             os_free(normalized_name);
-            return wm_vuldet_sql_error(db, stmt);
+
+            info_obj *obj_aux = obj_it;
+            obj_it = obj_it->prev;
+            os_free(obj_aux->id);
+            os_free(obj_aux->obj);
+            os_free(obj_aux);
         }
-
-        wdb_finalize(stmt);
-        os_free(normalized_name);
-
-        info_obj *obj_aux = obj_it;
-        obj_it = obj_it->prev;
-        free(obj_aux->id);
-        free(obj_aux->obj);
-        free(obj_aux);
+        parsed_oval->info_objs = NULL;
     }
 
     if (vars_it) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INS_VARIABLES, update->dist_ext);
-    }
+        // Sets the OVAL variables
+        while (vars_it) {
+            char *normalized_id = NULL;
+            query = vu_queries[VU_INSERT_VARIABLES];
 
-    // Sets the OVAL variables
-    while (vars_it) {
-        char *normalized_id = NULL;
-        query = vu_queries[VU_INSERT_VARIABLES];
+            if (vars_it->id) {
+                int j;
+                normalized_id = w_tolower_str(vars_it->id);
 
-        if (vars_it->id) {
-            int j;
-            normalized_id = w_tolower_str(vars_it->id);
-
-            for (j = 0; vars_it->values[j]; j++) {
-                char *normalized_name = NULL;
-                if (wm_vuldet_prepare(db, query, -1, &stmt, NULL) != SQLITE_OK) {
-                    os_free(normalized_id);
-                    return wm_vuldet_sql_error(db, stmt);
-                }
-                sqlite3_bind_text(stmt, 1, normalized_id, -1, NULL);
-                normalized_name = w_tolower_str(vars_it->values[j]);
-                sqlite3_bind_text(stmt, 2, normalized_name, -1, NULL);
-                sqlite3_bind_text(stmt, 3, parsed_oval->OS, -1, NULL);
-                if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-                    os_free(normalized_id);
+                for (j = 0; vars_it->values[j]; j++) {
+                    char *normalized_name = NULL;
+                    if (wm_vuldet_prepare(db, query, -1, &stmt, NULL) != SQLITE_OK) {
+                        os_free(normalized_id);
+                        return wm_vuldet_sql_error(db, stmt);
+                    }
+                    sqlite3_bind_text(stmt, 1, normalized_id, -1, NULL);
+                    normalized_name = w_tolower_str(vars_it->values[j]);
+                    sqlite3_bind_text(stmt, 2, normalized_name, -1, NULL);
+                    sqlite3_bind_text(stmt, 3, parsed_oval->OS, -1, NULL);
+                    if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+                        os_free(normalized_id);
+                        os_free(normalized_name);
+                        return wm_vuldet_sql_error(db, stmt);
+                    }
+                    wdb_finalize(stmt);
                     os_free(normalized_name);
-                    return wm_vuldet_sql_error(db, stmt);
                 }
-                wdb_finalize(stmt);
-                os_free(normalized_name);
             }
-        }
-        os_free(normalized_id);
+            os_free(normalized_id);
 
-        variables *var_aux = vars_it;
-        vars_it = vars_it->prev;
-        free(var_aux->id);
-        w_FreeArray(var_aux->values);
-        free(var_aux->values);
-        free(var_aux);
+            variables *var_aux = vars_it;
+            vars_it = vars_it->prev;
+            os_free(var_aux->id);
+            free_strarray(var_aux->values);
+            os_free(var_aux);
+        }
+        parsed_oval->vars = NULL;
     }
 
     // Discard the CVE info from the RHEL OVALs
@@ -3570,10 +3580,10 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     }
     wdb_finalize(stmt);
 
-    free(met_it->product_name);
-    free(met_it->product_version);
-    free(met_it->schema_version);
-    free(met_it->timestamp);
+    os_free(met_it->product_name);
+    os_free(met_it->product_version);
+    os_free(met_it->schema_version);
+    os_free(met_it->timestamp);
 
     sqlite3_exec(db, vu_queries[END_T], NULL, NULL, NULL);
     sqlite3_close_v2(db);
@@ -3599,6 +3609,108 @@ void wm_vuldet_add_vulnerability_info(wm_vuldet_db *ctrl_block) {
     ctrl_block->info_cves = new;
 }
 
+void wm_vuldet_db_clean(wm_vuldet_db *ctrl_block) {
+    wm_vuldet_clean_vulnerabilities(ctrl_block);
+    wm_vuldet_clean_vulnerability_info(ctrl_block);
+    wm_vuldet_free_alas(ctrl_block->alas_vuln);
+    wm_vuldet_clean_dependencies(ctrl_block->suse_deps, NULL);
+    wm_vuldet_clean_variables(ctrl_block);
+    wm_vuldet_clean_info_state(ctrl_block); //Fail?
+    wm_vuldet_clean_info_obj(ctrl_block);
+    wm_vuldet_clean_info_test(ctrl_block);
+    os_free(ctrl_block->metadata.product_name);
+    os_free(ctrl_block->metadata.product_version);
+    os_free(ctrl_block->metadata.schema_version);
+    os_free(ctrl_block->metadata.timestamp);
+
+    os_free(ctrl_block);
+}
+
+void wm_vuldet_clean_variables(wm_vuldet_db *ctrl_block) {
+    variables *vars_it = ctrl_block->vars;
+    variables *vars_aux = NULL;
+
+    while (vars_it) {
+        vars_aux = vars_it->prev;
+        os_free(vars_it->id);
+        free_strarray(vars_it->values);
+        os_free(vars_it);
+        vars_it = vars_aux;
+    }
+
+    ctrl_block->vars = NULL;
+}
+
+void wm_vuldet_clean_info_state(wm_vuldet_db *ctrl_block) {
+    info_state *state_prev_ptr = NULL;
+
+    while (ctrl_block->info_states) {
+        state_prev_ptr = ctrl_block->info_states->prev;
+        free_strarray(ctrl_block->info_states->arch);
+        os_free(ctrl_block->info_states->operation);
+        os_free(ctrl_block->info_states->operation_value);
+        os_free(ctrl_block->info_states->id);
+        os_free(ctrl_block->info_states);
+        ctrl_block->info_states = state_prev_ptr;
+    }
+
+    ctrl_block->info_states = NULL;
+
+}
+
+void wm_vuldet_clean_info_obj(wm_vuldet_db *ctrl_block) {
+    info_obj *obj_prev_ptr = NULL;
+
+    while (ctrl_block->info_objs) {
+        obj_prev_ptr = ctrl_block->info_objs->prev;
+        os_free(ctrl_block->info_objs->obj);
+        os_free(ctrl_block->info_objs->id);
+        os_free(ctrl_block->info_objs);
+        ctrl_block->info_objs = obj_prev_ptr;
+    }
+
+    ctrl_block->info_objs = NULL;
+
+}
+
+void wm_vuldet_clean_info_test(wm_vuldet_db *ctrl_block) {
+    info_test *test_prev_ptr = NULL;
+
+    while (ctrl_block->info_tests) {
+        test_prev_ptr = ctrl_block->info_tests->prev;
+        os_free(ctrl_block->info_tests->state);
+        os_free(ctrl_block->info_tests->obj);
+        os_free(ctrl_block->info_tests->id);
+        os_free(ctrl_block->info_tests);
+        ctrl_block->info_tests = test_prev_ptr;
+    }
+
+    ctrl_block->info_tests = NULL;
+
+}
+
+void wm_vuldet_clean_vulnerabilities(wm_vuldet_db *ctrl_block) {
+    vulnerability *vul_it = ctrl_block->vulnerabilities;
+    vulnerability *vul_aux = NULL;
+
+    while (vul_it) {
+        vul_aux = vul_it->prev;
+
+        wm_vuldet_clean_dependencies(vul_it->deps, NULL); // Segfault
+        free_strarray(vul_it->rhsa_list);
+
+        os_free(vul_it->cve_id);
+        os_free(vul_it->state_id);
+        os_free(vul_it->package_name);
+        os_free(vul_it->package_version);
+        os_free(vul_it->deps);
+        os_free(vul_it);
+        vul_it = vul_aux;
+    }
+
+    ctrl_block->vulnerabilities = NULL;
+}
+
 void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block) {
     info_cve *info_aux = NULL;
     info_cve *info_it = ctrl_block->info_cves;
@@ -3614,23 +3726,25 @@ void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block) {
             free_strarray(info_it->advisories->values);
 
         info_aux = info_it->prev;
-        free(info_it->cveid);
-        free(info_it->title);
-        free(info_it->severity);
-        free(info_it->published);
-        free(info_it->updated);
-        free(info_it->refs);
-        free(info_it->description);
-        free(info_it->cvss);
-        free(info_it->cvss_vector);
-        free(info_it->cvss3);
-        free(info_it->cvss3_vector);
-        free(info_it->bugzilla_references);
-        free(info_it->advisories);
-        free(info_it->cwe);
-        free(info_it);
+        os_free(info_it->cveid);
+        os_free(info_it->title);
+        os_free(info_it->severity);
+        os_free(info_it->published);
+        os_free(info_it->updated);
+        os_free(info_it->refs);
+        os_free(info_it->description);
+        os_free(info_it->cvss);
+        os_free(info_it->cvss_vector);
+        os_free(info_it->cvss3);
+        os_free(info_it->cvss3_vector);
+        os_free(info_it->bugzilla_references);
+        os_free(info_it->advisories);
+        os_free(info_it->cwe);
+        os_free(info_it);
         info_it = info_aux;
     }
+
+    ctrl_block->info_cves = NULL;
 }
 
 vulnerability *wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node) {
@@ -3653,6 +3767,7 @@ void wm_vuldet_clean_dependencies(dependencies *deps_it, char **dependency) {
             os_free(deps_it->test_ref[i]);
         }
         os_free(deps_it->test_ref);
+        deps_it->elements = 0;
         os_free(deps_it);
         os_free(dependency);
     }
@@ -4617,20 +4732,20 @@ end:
 }
 
 int wm_vuldet_index_feed(update_node *update) {
-    wm_vuldet_db parsed_vulnerabilities;
+    wm_vuldet_db *parsed_vulnerabilities;
     const char *OS_VERSION;
     char *path;
     char success = 0;
     int compress;
 
-    memset(&parsed_vulnerabilities, 0, sizeof(wm_vuldet_db));
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_vulnerabilities);
     OS_VERSION = vu_feed_tag[update->dist_tag_ref];
-    parsed_vulnerabilities.OS = OS_VERSION;
+    parsed_vulnerabilities->OS = OS_VERSION;
 
     if (update->json_format) {
         int result;
         // It is a feed in JSON format
-        if (result = wm_vuldet_index_json(&parsed_vulnerabilities, update,
+        if (result = wm_vuldet_index_json(parsed_vulnerabilities, update,
                                 update->multi_path ? update->multi_path :
                                 (update->path && update->dist_ref == FEED_ALAS) ? update->path : VU_FIT_TEMP_FILE,
                                 update->multi_path ? 1 : 0), result == OS_INVALID) {
@@ -4658,12 +4773,12 @@ int wm_vuldet_index_feed(update_node *update) {
                 compress = 0;
             }
 
-            if (wm_vuldet_oval_process(update, compress ? VU_TEMP_FILE : path, &parsed_vulnerabilities)) {
+            if (wm_vuldet_oval_process(update, compress ? VU_TEMP_FILE : path, parsed_vulnerabilities)) {
                 goto free_mem;
             }
         }
         else if (update->dist_ref == FEED_CPED) {
-            if (wm_vuldet_nvd_cpe_parser(path, &parsed_vulnerabilities)) {
+            if (wm_vuldet_nvd_cpe_parser(path, parsed_vulnerabilities)) {
                 goto free_mem;
             }
         }
@@ -4671,7 +4786,7 @@ int wm_vuldet_index_feed(update_node *update) {
 
     mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_START_REFRESH_DB, update->dist_ext);
 
-    if (wm_vuldet_insert(&parsed_vulnerabilities, update)) {
+    if (wm_vuldet_insert(parsed_vulnerabilities, update)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_REFRESH_DB_ERROR, OS_VERSION);
         goto free_mem;
     }
@@ -4692,6 +4807,13 @@ free_mem:
     if (success) {
         return 0;
     }
+
+    // if (update->dist_ref == FEED_SUSE){
+    //     wm_vuldet_clean_dependencies(parsed_vulnerabilities->vulnerabilities->deps, NULL);
+    //     parsed_vulnerabilities->vulnerabilities->deps = NULL;
+    // }
+    wm_vuldet_db_clean(parsed_vulnerabilities);
+    parsed_vulnerabilities = NULL;
 
     return OS_INVALID;
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -110,6 +110,7 @@ STATIC void wm_vuldet_clean_info_test(wm_vuldet_db *ctrl_block);
 STATIC void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block);
 
 STATIC void wm_vuldet_clean_dependencies(dependencies *deps_it, char **dependency);
+STATIC void wm_vuldet_clean_vuln_dependencies(dependencies *deps_it);
 
 STATIC references *wm_vuldet_extract_advisories(cJSON *advisories);
 STATIC int wm_vuldet_check_db();
@@ -3206,6 +3207,12 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INS_CPES_DIC);
 
         if (wm_vuldet_insert_cpe_dic(db, w_cpes_it)){
+            free_strarray(w_cpes_it->targets_name);
+            os_free(w_cpes_it->targets);
+            os_free(w_cpes_it->update_date);
+            os_free(w_cpes_it->format_version);
+            os_free(w_cpes_it->version);
+            os_free(w_cpes_it);
             mterror(WM_VULNDETECTOR_LOGTAG, VU_CPES_INSERT_ERROR);
             sqlite3_close_v2(db);
             return OS_INVALID;
@@ -3561,6 +3568,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     wm_vuldet_clean_vulnerability_info(parsed_oval);
 
     wm_vuldet_clean_dependencies(deps_it, dependency);
+    parsed_oval->suse_deps = NULL;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_METADATA], -1, &stmt, NULL) != SQLITE_OK) {
         return wm_vuldet_sql_error(db, stmt);
@@ -3610,10 +3618,12 @@ void wm_vuldet_add_vulnerability_info(wm_vuldet_db *ctrl_block) {
 }
 
 void wm_vuldet_db_clean(wm_vuldet_db *ctrl_block) {
+    wm_vuldet_clean_dependencies(ctrl_block->suse_deps, NULL);
+    ctrl_block->suse_deps = NULL;
     wm_vuldet_clean_vulnerabilities(ctrl_block);
     wm_vuldet_clean_vulnerability_info(ctrl_block);
     wm_vuldet_free_alas(ctrl_block->alas_vuln);
-    wm_vuldet_clean_dependencies(ctrl_block->suse_deps, NULL);
+    ctrl_block->alas_vuln = NULL;
     wm_vuldet_clean_variables(ctrl_block);
     wm_vuldet_clean_info_state(ctrl_block); //Fail?
     wm_vuldet_clean_info_obj(ctrl_block);
@@ -3622,8 +3632,6 @@ void wm_vuldet_db_clean(wm_vuldet_db *ctrl_block) {
     os_free(ctrl_block->metadata.product_version);
     os_free(ctrl_block->metadata.schema_version);
     os_free(ctrl_block->metadata.timestamp);
-
-    os_free(ctrl_block);
 }
 
 void wm_vuldet_clean_variables(wm_vuldet_db *ctrl_block) {
@@ -3696,7 +3704,7 @@ void wm_vuldet_clean_vulnerabilities(wm_vuldet_db *ctrl_block) {
     while (vul_it) {
         vul_aux = vul_it->prev;
 
-        wm_vuldet_clean_dependencies(vul_it->deps, NULL); // Segfault
+        wm_vuldet_clean_vuln_dependencies(vul_it->deps);
         free_strarray(vul_it->rhsa_list);
 
         os_free(vul_it->cve_id);
@@ -3767,9 +3775,15 @@ void wm_vuldet_clean_dependencies(dependencies *deps_it, char **dependency) {
             os_free(deps_it->test_ref[i]);
         }
         os_free(deps_it->test_ref);
-        deps_it->elements = 0;
         os_free(deps_it);
         os_free(dependency);
+    }
+}
+
+void wm_vuldet_clean_vuln_dependencies(dependencies *deps_it) {
+    if (deps_it) {
+        free_strarray(deps_it->test_ref);
+        os_free(deps_it);
     }
 }
 
@@ -4029,12 +4043,13 @@ void wm_vuldet_update_dependency_list_suse(const xml_node *criterion_dep, wm_vul
     */
     if (!parsed_oval->vulnerabilities->deps) {
         os_calloc(1, sizeof(dependencies), parsed_oval->vulnerabilities->deps);
-        os_calloc(1, sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
+        os_calloc(2, sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
         parsed_oval->vulnerabilities->deps->elements = 1;
     } else {
         parsed_oval->vulnerabilities->deps->elements++;
-        os_realloc(parsed_oval->vulnerabilities->deps->test_ref, parsed_oval->vulnerabilities->deps->elements *
+        os_realloc(parsed_oval->vulnerabilities->deps->test_ref, (parsed_oval->vulnerabilities->deps->elements + 1) *
         sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
+        parsed_oval->vulnerabilities->deps->test_ref[parsed_oval->vulnerabilities->deps->elements] = NULL;
     }
 
     i = 0;
@@ -4516,7 +4531,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                         */
                         int elements = parsed_oval->vulnerabilities->prev->deps->elements;
                         os_calloc(1, sizeof(dependencies), parsed_oval->vulnerabilities->deps);
-                        os_calloc(elements, sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
+                        os_calloc(elements + 1, sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
                         for (int k = 0; k < elements; k++) {
                             parsed_oval->vulnerabilities->deps->test_ref[k] = parsed_oval->vulnerabilities->prev->deps->test_ref[k];
                         }
@@ -4813,7 +4828,7 @@ free_mem:
     //     parsed_vulnerabilities->vulnerabilities->deps = NULL;
     // }
     wm_vuldet_db_clean(parsed_vulnerabilities);
-    parsed_vulnerabilities = NULL;
+    os_free(parsed_vulnerabilities);
 
     return OS_INVALID;
 }
@@ -7752,10 +7767,12 @@ vu_msu_dep_entry *wm_vuldet_free_msu_dep_node(vu_msu_dep_entry *node) {
 
 int wm_vuldet_insert_MSU(sqlite3 *db, vu_msu_entries *msu) {
     if (wm_vulndet_insert_msu_vul_entry(db, msu->vul)) {
+        for (; msu->vul; msu->vul = wm_vuldet_free_msu_vul_node(msu->vul));
         return OS_INVALID;
     }
 
     if (wm_vulndet_insert_msu_dep_entry(db, msu->dep)) {
+        for (; msu->dep; msu->dep = wm_vuldet_free_msu_dep_node(msu->dep));
         return OS_INVALID;
     }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -110,7 +110,6 @@ STATIC void wm_vuldet_clean_info_test(wm_vuldet_db *ctrl_block);
 STATIC void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block);
 
 STATIC void wm_vuldet_clean_dependencies(dependencies *deps_it, char **dependency);
-STATIC void wm_vuldet_clean_vuln_dependencies(dependencies *deps_it);
 
 STATIC references *wm_vuldet_extract_advisories(cJSON *advisories);
 STATIC int wm_vuldet_check_db();
@@ -3266,6 +3265,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 }
 
                 if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_CVE], -1, &stmt, NULL) != SQLITE_OK) {
+                    os_free(dependency);
                     return wm_vuldet_sql_error(db, stmt);
                 }
 
@@ -3310,6 +3310,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 }
 
                 if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+                    os_free(dependency);
                     return wm_vuldet_sql_error(db, stmt);
                 }
 
@@ -3318,6 +3319,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 if (deps_modified) {
                     for(int i = 0; i < vul_it->deps->elements; ++i) {
                         if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_PKG_DEPS], -1, &stmt, NULL) != SQLITE_OK) {
+                            os_free(dependency);
                             return wm_vuldet_sql_error(db, stmt);
                         }
                         sqlite3_bind_int(stmt, 1, deps_id);
@@ -3325,6 +3327,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                         sqlite3_bind_text(stmt, 3, parsed_oval->OS, -1, NULL);
 
                         if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+                            os_free(dependency);
                             return wm_vuldet_sql_error(db, stmt);
                         }
 
@@ -3359,6 +3362,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
         // Links vulnerabilities to their conditions
         while (test_it) {
             if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_CVE], -1, &stmt, NULL) != SQLITE_OK) {
+                os_free(dependency);
                 return wm_vuldet_sql_error(db, stmt);
             }
 
@@ -3374,6 +3378,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 wdb_finalize(stmt);
 
                 if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_CVE_NOT_FIXED], -1, &stmt, NULL) != SQLITE_OK) {
+                    os_free(dependency);
                     return wm_vuldet_sql_error(db, stmt);
                 }
 
@@ -3383,10 +3388,12 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 sqlite3_bind_text(stmt, 4, test_it->id, -1, NULL);
 
                 if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+                    os_free(dependency);
                     return wm_vuldet_sql_error(db, stmt);
                 }
                 break;
             default:
+                os_free(dependency);
                 return wm_vuldet_sql_error(db, stmt);
             }
 
@@ -3421,6 +3428,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 // Replace the state ID by the real values
                 query = vu_queries[VU_UPDATE_CVE_VAL];
                 if (wm_vuldet_prepare(db, query, -1, &stmt, NULL) != SQLITE_OK) {
+                    os_free(dependency);
                     return wm_vuldet_sql_error(db, stmt);
                 }
 
@@ -3437,6 +3445,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 sqlite3_bind_text(stmt, 4, state_it->id, -1, NULL);
 
                 if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+                    os_free(dependency);
                     return wm_vuldet_sql_error(db, stmt);
                 }
                 wdb_finalize(stmt);
@@ -3445,6 +3454,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 if (arch_id && state_it->arch) {
                     for (int i = 0; state_it->arch[i]; i++) {
                         if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_ARCH], -1, &stmt, NULL) != SQLITE_OK) {
+                            os_free(dependency);
                             return wm_vuldet_sql_error(db, stmt);
                         }
 
@@ -3453,6 +3463,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                         sqlite3_bind_text(stmt, 3, state_it->arch[i], -1, NULL);
 
                         if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
+                            os_free(dependency);
                             return wm_vuldet_sql_error(db, stmt);
                         }
                         wdb_finalize(stmt);
@@ -3481,6 +3492,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
 
             if (obj_it->obj) {
                 if (result = wm_vuldet_prepare(db, vu_queries[VU_UPDATE_CVE_PACK], -1, &stmt, NULL), result != SQLITE_OK && result != SQLITE_CONSTRAINT) {
+                    os_free(dependency);
                     return wm_vuldet_sql_error(db, stmt);
                 }
                 normalized_name = w_tolower_str(obj_it->obj);
@@ -3489,6 +3501,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 sqlite3_bind_text(stmt, 3, obj_it->id, -1, NULL);
             } else {
                 if (result = wm_vuldet_prepare(db, vu_queries[VU_REMOVE_UNUSED_ID], -1, &stmt, NULL), result != SQLITE_OK && result != SQLITE_CONSTRAINT) {
+                    os_free(dependency);
                     return wm_vuldet_sql_error(db, stmt);
                 }
                 sqlite3_bind_text(stmt, 1, obj_it->id, -1, NULL);
@@ -3496,6 +3509,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
 
             if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
                 os_free(normalized_name);
+                os_free(dependency);
                 return wm_vuldet_sql_error(db, stmt);
             }
 
@@ -3526,6 +3540,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                     char *normalized_name = NULL;
                     if (wm_vuldet_prepare(db, query, -1, &stmt, NULL) != SQLITE_OK) {
                         os_free(normalized_id);
+                        os_free(dependency);
                         return wm_vuldet_sql_error(db, stmt);
                     }
                     sqlite3_bind_text(stmt, 1, normalized_id, -1, NULL);
@@ -3535,6 +3550,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                     if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
                         os_free(normalized_id);
                         os_free(normalized_name);
+                        os_free(dependency);
                         return wm_vuldet_sql_error(db, stmt);
                     }
                     wdb_finalize(stmt);
@@ -3557,6 +3573,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_VU_INFO, update->dist_ext);
         if (result = wm_vuldet_insert_cve_info(parsed_oval, db), result) {
             sqlite3_close_v2(db);
+            os_free(dependency);
             return result;
         }
     }
@@ -3619,16 +3636,20 @@ void wm_vuldet_add_vulnerability_info(wm_vuldet_db *ctrl_block) {
 }
 
 void wm_vuldet_db_clean(wm_vuldet_db *ctrl_block) {
-    wm_vuldet_clean_dependencies(ctrl_block->suse_deps, NULL);
-    ctrl_block->suse_deps = NULL;
     wm_vuldet_clean_vulnerabilities(ctrl_block);
     wm_vuldet_clean_vulnerability_info(ctrl_block);
-    wm_vuldet_free_alas(ctrl_block->alas_vuln);
-    ctrl_block->alas_vuln = NULL;
     wm_vuldet_clean_variables(ctrl_block);
     wm_vuldet_clean_info_state(ctrl_block);
     wm_vuldet_clean_info_obj(ctrl_block);
     wm_vuldet_clean_info_test(ctrl_block);
+    if (ctrl_block->alas_vuln) {
+        wm_vuldet_free_alas(ctrl_block->alas_vuln);
+        ctrl_block->alas_vuln = NULL;
+    }
+    if (ctrl_block->suse_deps) {
+        wm_vuldet_clean_dependencies(ctrl_block->suse_deps, NULL);
+        ctrl_block->suse_deps = NULL;
+    }
     os_free(ctrl_block->metadata.product_name);
     os_free(ctrl_block->metadata.product_version);
     os_free(ctrl_block->metadata.schema_version);
@@ -3705,9 +3726,9 @@ void wm_vuldet_clean_vulnerabilities(wm_vuldet_db *ctrl_block) {
     while (vul_it) {
         vul_aux = vul_it->prev;
 
-        wm_vuldet_clean_vuln_dependencies(vul_it->deps);
         free_strarray(vul_it->rhsa_list);
 
+        os_free(vul_it->deps);
         os_free(vul_it->cve_id);
         os_free(vul_it->state_id);
         os_free(vul_it->package_name);
@@ -3778,15 +3799,6 @@ void wm_vuldet_clean_dependencies(dependencies *deps_it, char **dependency) {
         deps_it->elements = 0;
         os_free(deps_it);
         os_free(dependency);
-    }
-}
-
-void wm_vuldet_clean_vuln_dependencies(dependencies *deps_it) {
-    if (deps_it) {
-        free_strarray(deps_it->test_ref);
-        deps_it->test_ref = NULL;
-        deps_it->elements = 0;
-        os_free(deps_it);
     }
 }
 
@@ -4046,13 +4058,12 @@ void wm_vuldet_update_dependency_list_suse(const xml_node *criterion_dep, wm_vul
     */
     if (!parsed_oval->vulnerabilities->deps) {
         os_calloc(1, sizeof(dependencies), parsed_oval->vulnerabilities->deps);
-        os_calloc(2, sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
+        os_calloc(1, sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
         parsed_oval->vulnerabilities->deps->elements = 1;
     } else {
         parsed_oval->vulnerabilities->deps->elements++;
-        os_realloc(parsed_oval->vulnerabilities->deps->test_ref, (parsed_oval->vulnerabilities->deps->elements + 1) *
+        os_realloc(parsed_oval->vulnerabilities->deps->test_ref, parsed_oval->vulnerabilities->deps->elements *
         sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
-        parsed_oval->vulnerabilities->deps->test_ref[parsed_oval->vulnerabilities->deps->elements] = NULL;
     }
 
     i = 0;
@@ -4534,7 +4545,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                         */
                         int elements = parsed_oval->vulnerabilities->prev->deps->elements;
                         os_calloc(1, sizeof(dependencies), parsed_oval->vulnerabilities->deps);
-                        os_calloc(elements + 1, sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
+                        os_calloc(elements, sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
                         for (int k = 0; k < elements; k++) {
                             parsed_oval->vulnerabilities->deps->test_ref[k] = parsed_oval->vulnerabilities->prev->deps->test_ref[k];
                         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3297,6 +3297,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                     }
                     if(deps_modified) {
                         os_free(dependency);
+                        deps_size = 0;
                         deps_size = vul_it->deps->elements;
                         dependency = vul_it->deps->test_ref;
                         ++deps_id;
@@ -3625,7 +3626,7 @@ void wm_vuldet_db_clean(wm_vuldet_db *ctrl_block) {
     wm_vuldet_free_alas(ctrl_block->alas_vuln);
     ctrl_block->alas_vuln = NULL;
     wm_vuldet_clean_variables(ctrl_block);
-    wm_vuldet_clean_info_state(ctrl_block); //Fail?
+    wm_vuldet_clean_info_state(ctrl_block);
     wm_vuldet_clean_info_obj(ctrl_block);
     wm_vuldet_clean_info_test(ctrl_block);
     os_free(ctrl_block->metadata.product_name);
@@ -3775,6 +3776,7 @@ void wm_vuldet_clean_dependencies(dependencies *deps_it, char **dependency) {
             os_free(deps_it->test_ref[i]);
         }
         os_free(deps_it->test_ref);
+        deps_it->elements = 0;
         os_free(deps_it);
         os_free(dependency);
     }
@@ -3783,6 +3785,8 @@ void wm_vuldet_clean_dependencies(dependencies *deps_it, char **dependency) {
 void wm_vuldet_clean_vuln_dependencies(dependencies *deps_it) {
     if (deps_it) {
         free_strarray(deps_it->test_ref);
+        deps_it->test_ref = NULL;
+        deps_it->elements = 0;
         os_free(deps_it);
     }
 }
@@ -4820,13 +4824,10 @@ free_mem:
     }
 
     if (success) {
+        os_free(parsed_vulnerabilities);
         return 0;
     }
 
-    // if (update->dist_ref == FEED_SUSE){
-    //     wm_vuldet_clean_dependencies(parsed_vulnerabilities->vulnerabilities->deps, NULL);
-    //     parsed_vulnerabilities->vulnerabilities->deps = NULL;
-    // }
     wm_vuldet_db_clean(parsed_vulnerabilities);
     os_free(parsed_vulnerabilities);
 
@@ -7768,6 +7769,7 @@ vu_msu_dep_entry *wm_vuldet_free_msu_dep_node(vu_msu_dep_entry *node) {
 int wm_vuldet_insert_MSU(sqlite3 *db, vu_msu_entries *msu) {
     if (wm_vulndet_insert_msu_vul_entry(db, msu->vul)) {
         for (; msu->vul; msu->vul = wm_vuldet_free_msu_vul_node(msu->vul));
+        for (; msu->dep; msu->dep = wm_vuldet_free_msu_dep_node(msu->dep));
         return OS_INVALID;
     }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -362,10 +362,10 @@ STATIC void wm_vuldet_run_sleep(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_init(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_update_last_scan(scan_ctx_t* scan_ctx);
 STATIC char *wm_vuldet_normalize_date(char **date);
-STATIC int wm_vulndet_insert_msu_vul_entry(sqlite3 *db, vu_msu_vul_entry *vul);
+STATIC int wm_vulndet_insert_msu_vul_entry(sqlite3 *db, vu_msu_entries *msu);
 STATIC void wm_vuldet_json_msu_parser_deps(cJSON *json_feed, vu_msu_dep_entry **msu);
 STATIC void wm_vuldet_json_msu_parser_vuln(cJSON *json_feed, vu_msu_vul_entry **msu);
-STATIC int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_dep_entry *dep);
+STATIC int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_entries *msu);
 STATIC void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs);
 STATIC int wm_vuldet_json_alas_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilities);
 STATIC int wm_vuldet_insert_ALAS(sqlite3 *db, vu_alas_vuln *alas, const char *target);
@@ -3297,12 +3297,12 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                     }
                     if(deps_modified) {
                         os_free(dependency);
-                        deps_size = 0;
                         deps_size = vul_it->deps->elements;
                         dependency = vul_it->deps->test_ref;
                         ++deps_id;
                     } else {
                         os_free(vul_it->deps->test_ref);
+                        vul_it->deps->elements = 0;
                     }
                     sqlite3_bind_int(stmt, 10, deps_id);
                 } else {
@@ -3712,7 +3712,6 @@ void wm_vuldet_clean_vulnerabilities(wm_vuldet_db *ctrl_block) {
         os_free(vul_it->state_id);
         os_free(vul_it->package_name);
         os_free(vul_it->package_version);
-        os_free(vul_it->deps);
         os_free(vul_it);
         vul_it = vul_aux;
     }
@@ -7767,13 +7766,13 @@ vu_msu_dep_entry *wm_vuldet_free_msu_dep_node(vu_msu_dep_entry *node) {
 }
 
 int wm_vuldet_insert_MSU(sqlite3 *db, vu_msu_entries *msu) {
-    if (wm_vulndet_insert_msu_vul_entry(db, msu->vul)) {
+    if (wm_vulndet_insert_msu_vul_entry(db, msu)) {
         for (; msu->vul; msu->vul = wm_vuldet_free_msu_vul_node(msu->vul));
         for (; msu->dep; msu->dep = wm_vuldet_free_msu_dep_node(msu->dep));
         return OS_INVALID;
     }
 
-    if (wm_vulndet_insert_msu_dep_entry(db, msu->dep)) {
+    if (wm_vulndet_insert_msu_dep_entry(db, msu)) {
         for (; msu->dep; msu->dep = wm_vuldet_free_msu_dep_node(msu->dep));
         return OS_INVALID;
     }
@@ -8757,29 +8756,29 @@ end:
     return *date;
 }
 
-int wm_vulndet_insert_msu_vul_entry(sqlite3 *db, vu_msu_vul_entry *vul) {
+int wm_vulndet_insert_msu_vul_entry(sqlite3 *db, vu_msu_entries *msu) {
     sqlite3_stmt *stmt = NULL;
     int result;
 
     sqlite3_exec(db, vu_queries[VU_REMOVE_MSU], NULL, NULL, NULL);
 
-    for (; vul; vul = wm_vuldet_free_msu_vul_node(vul)) {
+    for (; msu->vul; msu->vul = wm_vuldet_free_msu_vul_node(msu->vul)) {
         if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_MSU], -1, &stmt, NULL) != SQLITE_OK) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
             wdb_finalize(stmt);
             return OS_INVALID;
         }
 
-        sqlite3_bind_text(stmt, 1, vul->cveid, -1, NULL);
-        sqlite3_bind_text(stmt, 2, vul->product, -1, NULL);
-        if (vul->patch) {
-            sqlite3_bind_text(stmt, 3, strncmp(vul->patch, "KB", 2) ? vul->patch : vul->patch + 2, -1, NULL);
+        sqlite3_bind_text(stmt, 1, msu->vul->cveid, -1, NULL);
+        sqlite3_bind_text(stmt, 2, msu->vul->product, -1, NULL);
+        if (msu->vul->patch) {
+            sqlite3_bind_text(stmt, 3, strncmp(msu->vul->patch, "KB", 2) ? msu->vul->patch : msu->vul->patch + 2, -1, NULL);
         }
-        sqlite3_bind_text(stmt, 4, vul->title, -1, NULL);
-        sqlite3_bind_text(stmt, 5, vul->url, -1, NULL);
-        sqlite3_bind_text(stmt, 6, vul->subtype, -1, NULL);
-        sqlite3_bind_text(stmt, 7, vul->restart_required, -1, NULL);
-        sqlite3_bind_text(stmt, 8, vul->check_type, -1, NULL);
+        sqlite3_bind_text(stmt, 4, msu->vul->title, -1, NULL);
+        sqlite3_bind_text(stmt, 5, msu->vul->url, -1, NULL);
+        sqlite3_bind_text(stmt, 6, msu->vul->subtype, -1, NULL);
+        sqlite3_bind_text(stmt, 7, msu->vul->restart_required, -1, NULL);
+        sqlite3_bind_text(stmt, 8, msu->vul->check_type, -1, NULL);
 
         if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
@@ -8792,29 +8791,29 @@ int wm_vulndet_insert_msu_vul_entry(sqlite3 *db, vu_msu_vul_entry *vul) {
     return 0;
 }
 
-int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_dep_entry *dep) {
+int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_entries *msu) {
     sqlite3_stmt *stmt = NULL;
     int result;
 
     sqlite3_exec(db, vu_queries[VU_REMOVE_MSU_SUP], NULL, NULL, NULL);
 
-    for (; dep; dep = wm_vuldet_free_msu_dep_node(dep)) {
+    for (; msu->dep; msu->dep = wm_vuldet_free_msu_dep_node(msu->dep)) {
         int i;
-        for (i = 0; dep->supers[i]; i++) {
+        for (i = 0; msu->dep->supers[i]; i++) {
             if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_MSU_SUPER], -1, &stmt, NULL) != SQLITE_OK) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
                 wdb_finalize(stmt);
                 return OS_INVALID;
             }
-            if (dep->patch) {
-                sqlite3_bind_text(stmt, 1, strncmp(dep->patch, "KB", 2) ? dep->patch : dep->patch + 2, -1, NULL);
+            if (msu->dep->patch) {
+                sqlite3_bind_text(stmt, 1, strncmp(msu->dep->patch, "KB", 2) ? msu->dep->patch : msu->dep->patch + 2, -1, NULL);
             }
-            if (dep->supers[i]) {
-                sqlite3_bind_text(stmt, 2, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
+            if (msu->dep->supers[i]) {
+                sqlite3_bind_text(stmt, 2, strncmp(msu->dep->supers[i], "KB", 2) ? msu->dep->supers[i] : msu->dep->supers[i] + 2, -1, NULL);
 
                 // A super can be a patch too, so non-duplicated ones will be added as rows
-                sqlite3_bind_text(stmt, 3, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
-                sqlite3_bind_text(stmt, 4, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
+                sqlite3_bind_text(stmt, 3, strncmp(msu->dep->supers[i], "KB", 2) ? msu->dep->supers[i] : msu->dep->supers[i] + 2, -1, NULL);
+                sqlite3_bind_text(stmt, 4, strncmp(msu->dep->supers[i], "KB", 2) ? msu->dep->supers[i] : msu->dep->supers[i] + 2, -1, NULL);
             }
 
             if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -95,20 +95,61 @@ STATIC void wm_vuldet_add_vulnerability_info(wm_vuldet_db *ctrl_block);
  */
 STATIC vulnerability *wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node);
 
+/**
+ * @brief Clean the data structures that are not freed in case of failure of the parsed oval data.
+ *
+ * @param ctrl_block Parsed oval data structure.
+ */
 STATIC void wm_vuldet_db_clean(wm_vuldet_db *ctrl_block);
-STATIC void wm_vuldet_clean_vulnerabilities(wm_vuldet_db *ctrl_block);
-STATIC void wm_vuldet_clean_variables(wm_vuldet_db *ctrl_block);
-STATIC void wm_vuldet_clean_info_state(wm_vuldet_db *ctrl_block);
-STATIC void wm_vuldet_clean_info_obj(wm_vuldet_db *ctrl_block);
-STATIC void wm_vuldet_clean_info_test(wm_vuldet_db *ctrl_block);
 
 /**
  * @brief Clean the CVEs linked list data structure.
- * @param ctrl_block Parsed oval data structure.
  *
+ * @param ctrl_block Parsed oval data structure.
+ */
+STATIC void wm_vuldet_clean_vulnerabilities(wm_vuldet_db *ctrl_block);
+
+/**
+ * @brief Clean the linked list of variables data structure.
+ *
+ * @param ctrl_block Parsed oval data structure.
+ */
+STATIC void wm_vuldet_clean_variables(wm_vuldet_db *ctrl_block);
+
+/**
+ * @brief Clean the linked list of info states data structure.
+ *
+ * @param ctrl_block Parsed oval data structure.
+ */
+STATIC void wm_vuldet_clean_info_states(wm_vuldet_db *ctrl_block);
+
+/**
+ * @brief Clean the linked list of info objects data structure.
+ *
+ * @param ctrl_block Parsed oval data structure.
+ */
+STATIC void wm_vuldet_clean_info_objs(wm_vuldet_db *ctrl_block);
+
+/**
+ * @brief Clean the linked list of info tests data structure.
+ *
+ * @param ctrl_block Parsed oval data structure.
+ */
+STATIC void wm_vuldet_clean_info_tests(wm_vuldet_db *ctrl_block);
+
+/**
+ * @brief Clean the CVEs info linked list data structure.
+ *
+ * @param ctrl_block Parsed oval data structure.
  */
 STATIC void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block);
 
+/**
+ * @brief Clean the data structure of SUSE dependencies.
+ *
+ * @param dependencies SUSE dependencies structure.
+ * @param dependency Pointer pointing to the last list of SUSE dependencies.
+ */
 STATIC void wm_vuldet_clean_dependencies(dependencies *deps_it, char **dependency);
 
 STATIC references *wm_vuldet_extract_advisories(cJSON *advisories);
@@ -361,17 +402,51 @@ STATIC void wm_vuldet_run_sleep(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_init(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_update_last_scan(scan_ctx_t* scan_ctx);
 STATIC char *wm_vuldet_normalize_date(char **date);
+
+/**
+ * @brief Insert or update the MSU vulnerabilities in the MSU table.
+ *
+ * @param db Pointer to the cve.db database.
+ * @param msu Structure that contains all the MSU vulnerabilities.
+ * @return 0 if success, -1 otherwise.
+ */
 STATIC int wm_vulndet_insert_msu_vul_entry(sqlite3 *db, vu_msu_entries *msu);
 STATIC void wm_vuldet_json_msu_parser_deps(cJSON *json_feed, vu_msu_dep_entry **msu);
 STATIC void wm_vuldet_json_msu_parser_vuln(cJSON *json_feed, vu_msu_vul_entry **msu);
+
+/**
+ * @brief Insert or update the MSU patch dependencies in the MSU_SUPERSEDENCE table.
+ *
+ * @param db Pointer to the cve.db database.
+ * @param msu Structure that contains all the MSU patch dependencies.
+ * @return 0 if success, -1 otherwise.
+ */
 STATIC int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_entries *msu);
 STATIC void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs);
 STATIC int wm_vuldet_json_alas_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilities);
 STATIC int wm_vuldet_insert_ALAS(sqlite3 *db, vu_alas_vuln *alas, const char *target);
 STATIC vu_alas_pkg *wm_vuldet_packages_parser(char *pkg);
 STATIC int wm_vuldet_get_arch_id(sqlite3 * db, const char *cveid, const char *target, const char *pkg_name, const char *pkg_version, int *id);
+
+/**
+ * @brief Clean ALAS package data structure.
+ *
+ * @param alas_pkg ALAS package structure.
+ */
 STATIC void wm_vuldet_free_alas_pkg(vu_alas_pkg **alas_pkg);
+
+/**
+ * @brief Clean ALAS vulnerability data node.
+ *
+ * @param node ALAS vulnerability node.
+ */
 STATIC void wm_vuldet_free_alas_node(vu_alas_vuln *node);
+
+/**
+ * @brief Clean the linked list data structure of ALAS vulnerabilities.
+ *
+ * @param alas_it ALAS vulnerabilities data structure.
+ */
 STATIC void wm_vuldet_free_alas(vu_alas_vuln *alas_it);
 STATIC int wm_vuldet_insert_deps(sqlite3 *db, dependencies *deps_it, wm_vuldet_db *parsed_oval);
 
@@ -3639,13 +3714,9 @@ void wm_vuldet_db_clean(wm_vuldet_db *ctrl_block) {
     wm_vuldet_clean_vulnerabilities(ctrl_block);
     wm_vuldet_clean_vulnerability_info(ctrl_block);
     wm_vuldet_clean_variables(ctrl_block);
-    wm_vuldet_clean_info_state(ctrl_block);
-    wm_vuldet_clean_info_obj(ctrl_block);
-    wm_vuldet_clean_info_test(ctrl_block);
-    if (ctrl_block->alas_vuln) {
-        wm_vuldet_free_alas(ctrl_block->alas_vuln);
-        ctrl_block->alas_vuln = NULL;
-    }
+    wm_vuldet_clean_info_states(ctrl_block);
+    wm_vuldet_clean_info_objs(ctrl_block);
+    wm_vuldet_clean_info_tests(ctrl_block);
     if (ctrl_block->suse_deps) {
         wm_vuldet_clean_dependencies(ctrl_block->suse_deps, NULL);
         ctrl_block->suse_deps = NULL;
@@ -3671,7 +3742,7 @@ void wm_vuldet_clean_variables(wm_vuldet_db *ctrl_block) {
     ctrl_block->vars = NULL;
 }
 
-void wm_vuldet_clean_info_state(wm_vuldet_db *ctrl_block) {
+void wm_vuldet_clean_info_states(wm_vuldet_db *ctrl_block) {
     info_state *state_prev_ptr = NULL;
 
     while (ctrl_block->info_states) {
@@ -3688,7 +3759,7 @@ void wm_vuldet_clean_info_state(wm_vuldet_db *ctrl_block) {
     ctrl_block->info_states = NULL;
 }
 
-void wm_vuldet_clean_info_obj(wm_vuldet_db *ctrl_block) {
+void wm_vuldet_clean_info_objs(wm_vuldet_db *ctrl_block) {
     info_obj *obj_prev_ptr = NULL;
 
     while (ctrl_block->info_objs) {
@@ -3702,7 +3773,7 @@ void wm_vuldet_clean_info_obj(wm_vuldet_db *ctrl_block) {
     ctrl_block->info_objs = NULL;
 }
 
-void wm_vuldet_clean_info_test(wm_vuldet_db *ctrl_block) {
+void wm_vuldet_clean_info_tests(wm_vuldet_db *ctrl_block) {
     info_test *test_prev_ptr = NULL;
 
     while (ctrl_block->info_tests) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3676,7 +3676,8 @@ void wm_vuldet_clean_info_state(wm_vuldet_db *ctrl_block) {
 
     while (ctrl_block->info_states) {
         state_prev_ptr = ctrl_block->info_states->prev;
-        free_strarray(ctrl_block->info_states->arch);
+        w_FreeArray(ctrl_block->info_states->arch);
+        os_free(ctrl_block->info_states->arch);
         os_free(ctrl_block->info_states->operation);
         os_free(ctrl_block->info_states->operation_value);
         os_free(ctrl_block->info_states->id);
@@ -3685,7 +3686,6 @@ void wm_vuldet_clean_info_state(wm_vuldet_db *ctrl_block) {
     }
 
     ctrl_block->info_states = NULL;
-
 }
 
 void wm_vuldet_clean_info_obj(wm_vuldet_db *ctrl_block) {
@@ -3700,7 +3700,6 @@ void wm_vuldet_clean_info_obj(wm_vuldet_db *ctrl_block) {
     }
 
     ctrl_block->info_objs = NULL;
-
 }
 
 void wm_vuldet_clean_info_test(wm_vuldet_db *ctrl_block) {
@@ -3716,7 +3715,6 @@ void wm_vuldet_clean_info_test(wm_vuldet_db *ctrl_block) {
     }
 
     ctrl_block->info_tests = NULL;
-
 }
 
 void wm_vuldet_clean_vulnerabilities(wm_vuldet_db *ctrl_block) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
@@ -12,7 +12,7 @@
 #ifndef WM_VUNALIZER_DB
 #define WM_VUNALIZER_DB
 
-#define CVE_DBS_PATH            "queue/vulnerabilities/"
+#define CVE_DBS_PATH            "/run/lock/"
 #define CVE_DB CVE_DBS_PATH     "cve.db"
 
 #define AGENTS_TABLE            "AGENTS"

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
@@ -12,7 +12,7 @@
 #ifndef WM_VUNALIZER_DB
 #define WM_VUNALIZER_DB
 
-#define CVE_DBS_PATH            "/run/lock/"
+#define CVE_DBS_PATH            "queue/vulnerabilities/"
 #define CVE_DB CVE_DBS_PATH     "cve.db"
 
 #define AGENTS_TABLE            "AGENTS"


### PR DESCRIPTION
|Related issue|
|---|
|#16265|


## Description

This PR aims to free the memory of the structures that store the feeds when there is a problem, and it does not complete correctly.

In this case, the cause of the issue that has been investigated and found was due to disk errors, which caused the memory of the parsed feeds not to be freed, as it did not finish the flow and did not reach the end of the insert function, where these data structures are freed.

The way to replicate the problem, has been moving the path where the `cve.db` is stored, to a partition with limited storage, that way whenever I tried to insert data to this DB, it showed an error like the following one:
```
wazuh-modulesd:vulnerability-detector: ERROR: (5503): SQL error: 'database or disk is full'
```


## Configuration options

To replicate the error, it is necessary to move the DB to a path with limited storage or cause disk errors. For these tests, the following line has been modified, replacing the path with `/run/lock/`:
https://github.com/wazuh/wazuh/blob/36d17b36a732ecc4b4bffda7ddd047d60a3c79ac/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h#L15

Also, to limit that storage, a file has been created that would take up much of that space in the partition, so that it would only allow the DB to be built and the module to be started, without allowing much more information to be stored:

```
dd if=/dev/urandom of=/run/lock/test bs=1024 count=4400
```

And finally, use has been made of our [custom feeds](https://github.com/wazuh/wazuh-tools/tree/master/utils/vulnerability-detector/custom-feeds), with the configuration found in the README (which is available for _v4.4_), to allow the use of the `valgrind` tool to observe memory leaks.

## Memory report

```
==13447== LEAK SUMMARY:
==13447==    definitely lost: 0 bytes in 0 blocks
==13447==    indirectly lost: 0 bytes in 0 blocks
==13447==      possibly lost: 4,320 bytes in 14 blocks
==13447==    still reachable: 231,565 bytes in 178 blocks
==13447==         suppressed: 0 bytes in 0 blocks
==13447== 
==13447== For lists of detected and suppressed errors, rerun with: -s
==13447== ERROR SUMMARY: 40 errors from 12 contexts (suppressed: 0 from 0)
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

