### PR TITLE
Improved information displayed in report_changes field in alerts

### DIFF
--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -316,11 +316,6 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
     directory_t *configuration = NULL;
     fim_txn_context_t *txn_context = (fim_txn_context_t *) user_data;
 
-    // Do not process if it's the first scan
-    if (_base_line == 0) {
-        return; // LCOV_EXCL_LINE
-    }
-
     // In case of deletions, latest_entry is NULL, so we need to get the path from the json event
     if (resultType == DELETED) {
         cJSON *path_cjson = cJSON_GetObjectItem(result_json, "path");
@@ -340,6 +335,11 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
 
     if (configuration->options & CHECK_SEECHANGES && resultType != DELETED) {
         diff = fim_file_diff(path, configuration);
+    }
+
+    // Do not process if it's the first scan
+    if (_base_line == 0) {
+        goto end; // LCOV_EXCL_LINE
     }
 
     switch (resultType) {
@@ -415,7 +415,7 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
         }
     }
 
-    if (diff != NULL) {
+    if (diff != NULL && resultType == MODIFIED) {
         cJSON_AddStringToObject(data, "content_changes", diff);
     }
 
@@ -836,7 +836,7 @@ void fim_event_callback(void* data, void * ctx)
             char* diff;
 
             diff = fim_file_diff(path, ctx_data->config);
-            if (diff != NULL) {
+            if (diff != NULL && ctx_data->event->type == FIM_MODIFICATION) {
                 cJSON_AddStringToObject(data_json, "content_changes", diff);
             }
             os_free(diff);

--- a/src/syscheckd/src/fim_diff_changes.c
+++ b/src/syscheckd/src/fim_diff_changes.c
@@ -234,11 +234,11 @@ char *fim_registry_value_diff(const char *key_name,
     // Check for file limit and disk quota
     if (ret = fim_diff_check_limits(diff), ret == 1) {
         mdebug2(FIM_BIG_FILE_REPORT_CHANGES, full_value_name);
-        os_strdup("Unable to calculate diff due to 'file_size' limit has been reached", diff_changes);
+        os_strdup("Unable to calculate diff due to 'file_size' limit has been reached.", diff_changes);
         goto cleanup;
     } else if (ret == 2){
         mdebug2(FIM_DISK_QUOTA_LIMIT_REACHED, "estimation", full_value_name);
-        os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached", diff_changes);
+        os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached.", diff_changes);
         goto cleanup;
     }
 
@@ -249,7 +249,7 @@ char *fim_registry_value_diff(const char *key_name,
             save_compress_file(diff);
             os_strdup("Unable to calculate diff due to no previous data stored for this registry value.", diff_changes);
         } else if (ret == -2){
-            os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached", diff_changes);
+            os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached.", diff_changes);
         }
         goto cleanup;
     }
@@ -257,10 +257,10 @@ char *fim_registry_value_diff(const char *key_name,
     // If it exists, estimate the new compressed file
     float backup_file_size = (FileSize(diff->compress_file) / 1024.0f);
     syscheck.diff_folder_size -= backup_file_size;
-    if (ret = fim_diff_create_compress_file(diff), ret == -1) {
+    if (ret = fim_diff_create_compress_file(diff), ret != 0) {
         syscheck.diff_folder_size += backup_file_size;
         if (ret == -2){
-            os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached", diff_changes);
+            os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached.", diff_changes);
         }
         goto cleanup;
     }
@@ -273,7 +273,7 @@ char *fim_registry_value_diff(const char *key_name,
     }
 
     if (is_registry_nodiff(key_name, value_name, configuration->arch)) {
-        os_strdup("Diff truncated due to 'nodiff' configuration detected for this registry value", diff_changes);
+        os_strdup("Diff truncated due to 'nodiff' configuration detected for this registry value.", diff_changes);
         syscheck.diff_folder_size += backup_file_size;
         goto cleanup;
     }

--- a/src/syscheckd/src/fim_diff_changes.c
+++ b/src/syscheckd/src/fim_diff_changes.c
@@ -204,7 +204,7 @@ char *fim_registry_value_diff(const char *key_name,
                               const registry_t *configuration) {
 
     char *diff_changes = NULL;
-    int limits_reached;
+    int ret;
 
     // Invalid types for report_changes
     if (!(data_type == REG_SZ ||
@@ -232,19 +232,24 @@ char *fim_registry_value_diff(const char *key_name,
     snprintf(full_value_name, PATH_MAX, "%s\\%s", key_name, value_name);
 
     // Check for file limit and disk quota
-    if (limits_reached = fim_diff_check_limits(diff), limits_reached == 1) {
+    if (ret = fim_diff_check_limits(diff), ret == 1) {
         mdebug2(FIM_BIG_FILE_REPORT_CHANGES, full_value_name);
+        os_strdup("Unable to calculate diff due to 'file_size' limit has been reached", diff_changes);
         goto cleanup;
-    } else if (limits_reached == 2){
+    } else if (ret == 2){
         mdebug2(FIM_DISK_QUOTA_LIMIT_REACHED, "estimation", full_value_name);
+        os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached", diff_changes);
         goto cleanup;
     }
 
     // If the file is not there, create compressed file and return.
     if (w_uncompress_gzfile(diff->compress_file, diff->uncompress_file) != 0) {
-        if (fim_diff_create_compress_file(diff) == 0){
+        if (ret = fim_diff_create_compress_file(diff), ret == 0){
             mkdir_ex(diff->compress_folder);
             save_compress_file(diff);
+            os_strdup("Unable to calculate diff due to no previous data stored for this registry value.", diff_changes);
+        } else if (ret == -2){
+            os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached", diff_changes);
         }
         goto cleanup;
     }
@@ -252,19 +257,23 @@ char *fim_registry_value_diff(const char *key_name,
     // If it exists, estimate the new compressed file
     float backup_file_size = (FileSize(diff->compress_file) / 1024.0f);
     syscheck.diff_folder_size -= backup_file_size;
-    if (fim_diff_create_compress_file(diff) == -1) {
+    if (ret = fim_diff_create_compress_file(diff), ret == -1) {
         syscheck.diff_folder_size += backup_file_size;
+        if (ret == -2){
+            os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached", diff_changes);
+        }
         goto cleanup;
     }
 
     if (fim_diff_compare(diff) == -1) {
         mdebug2(FIM_DIFF_IDENTICAL_MD5_FILES);
         syscheck.diff_folder_size += backup_file_size;
+        os_strdup("No content changes were found for this registry value.", diff_changes);
         goto cleanup;
     }
 
     if (is_registry_nodiff(key_name, value_name, configuration->arch)) {
-        os_strdup("<Diff truncated because nodiff option>", diff_changes);
+        os_strdup("Diff truncated due to 'nodiff' configuration detected for this registry value", diff_changes);
         syscheck.diff_folder_size += backup_file_size;
         goto cleanup;
     }
@@ -396,7 +405,7 @@ int fim_diff_registry_tmp(const char *value_data,
 char *fim_file_diff(const char *filename, const directory_t *configuration) {
 
     char *diff_changes = NULL;
-    int limits_reached;
+    int ret;
 
     // Generate diff structure
     diff_data *diff = initialize_file_diff_data(filename, configuration);
@@ -407,19 +416,24 @@ char *fim_file_diff(const char *filename, const directory_t *configuration) {
     mkdir_ex(diff->tmp_folder);
 
     // Check for file limit and disk quota
-    if (limits_reached = fim_diff_check_limits(diff), limits_reached == 1) {
+    if (ret = fim_diff_check_limits(diff), ret == 1) {
         mdebug2(FIM_BIG_FILE_REPORT_CHANGES, filename);
+        os_strdup("Unable to calculate diff due to 'file_size' limit has been reached.", diff_changes);
         goto cleanup;
-    } else if (limits_reached == 2){
+    } else if (ret == 2){
         mdebug2(FIM_DISK_QUOTA_LIMIT_REACHED, "estimation", filename);
+        os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached.", diff_changes);
         goto cleanup;
     }
 
     // If the file is not there, create compressed file and return.
     if (w_uncompress_gzfile(diff->compress_file, diff->uncompress_file) != 0) {
-        if (fim_diff_create_compress_file(diff) == 0){
+        if (ret = fim_diff_create_compress_file(diff), ret == 0){
             mkdir_ex(diff->compress_folder);
             save_compress_file(diff);
+            os_strdup("Unable to calculate diff due to no previous data stored for this file.", diff_changes);
+        } else if (ret == -2){
+            os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached.", diff_changes);
         }
         goto cleanup;
     }
@@ -427,19 +441,23 @@ char *fim_file_diff(const char *filename, const directory_t *configuration) {
     // If it exists, estimate the new compressed file
     float backup_file_size = (FileSize(diff->compress_file) / 1024.0f);
     syscheck.diff_folder_size -= backup_file_size;
-    if (fim_diff_create_compress_file(diff) == -1) {
+    if (ret = fim_diff_create_compress_file(diff), ret != 0) {
         syscheck.diff_folder_size += backup_file_size;
+        if (ret == -2){
+            os_strdup("Unable to calculate diff due to 'disk_quota' limit has been reached.", diff_changes);
+        }
         goto cleanup;
     }
 
     if (fim_diff_compare(diff) == -1) {
         mdebug2(FIM_DIFF_IDENTICAL_MD5_FILES);
         syscheck.diff_folder_size += backup_file_size;
+        os_strdup("No content changes were found for this file.", diff_changes);
         goto cleanup;
     }
 
     if (is_file_nodiff(diff->file_origin)) {
-        os_strdup("<Diff truncated because nodiff option>", diff_changes);
+        os_strdup("Diff truncated due to 'nodiff' configuration detected for this file.", diff_changes);
         syscheck.diff_folder_size += backup_file_size;
         goto cleanup;
     }
@@ -604,7 +622,7 @@ int fim_diff_create_compress_file(const diff_data *diff) {
                 mdebug2(FIM_DISK_QUOTA_LIMIT_REACHED, "calculate", diff->file_origin);
             }
             fim_diff_modify_compress_estimation(zip_size, diff->file_size);
-            return -1;
+            return -2;
         }
     }
 

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -331,7 +331,7 @@ static void registry_value_transaction_callback(ReturnTypeCallback resultType,
         cJSON_AddStringToObject(data, "tags", configuration->tag);
     }
 
-    if (diff != NULL) {
+    if (diff != NULL && resultType == MODIFIED) {
         cJSON_AddStringToObject(data, "content_changes", diff);
     }
 

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -4020,9 +4020,9 @@ static void test_fim_event_callback(void **state) {
 
     fim_event_callback(json_event, &callback_ctx);
 #ifndef TEST_WINAGENT
-    char* test_event = "{\"data\":{\"path\":\"/path/to/file\",\"content_changes\":\"diff\",\"audit\":{\"user_name\":\"audit_user_name\",\"process_id\":0,\"ppid\":0},\"tags\":\"tag_name\"}}";
+    char* test_event = "{\"data\":{\"path\":\"/path/to/file\",\"audit\":{\"user_name\":\"audit_user_name\",\"process_id\":0,\"ppid\":0},\"tags\":\"tag_name\"}}";
 #else
-    char* test_event = "{\"data\":{\"path\":\"/path/to/file\",\"content_changes\":\"diff\",\"audit\":{\"user_name\":\"audit_user_name\",\"process_id\":0},\"tags\":\"tag_name\"}}";
+    char* test_event = "{\"data\":{\"path\":\"/path/to/file\",\"audit\":{\"user_name\":\"audit_user_name\",\"process_id\":0},\"tags\":\"tag_name\"}}";
 #endif
     char* string_event = cJSON_PrintUnformatted(json_event);
     assert_string_equal(string_event, test_event);

--- a/src/unit_tests/syscheckd/test_fim_diff_changes.c
+++ b/src/unit_tests/syscheckd/test_fim_diff_changes.c
@@ -797,7 +797,7 @@ void test_fim_diff_create_compress_file_quota_reached(void **state) {
 
     int ret = fim_diff_create_compress_file(diff);
 
-    assert_int_equal(ret, -1);
+    assert_int_equal(ret, -2);
 }
 
 void test_fim_diff_modify_compress_estimation_small_compresion_rate(void **state) {
@@ -1276,7 +1276,9 @@ void test_fim_registry_value_diff_wrong_too_big_file(void **state) {
 
     char *diff_str = fim_registry_value_diff(key_name, value_name, value_data, data_type, configuration);
 
-    assert_ptr_equal(diff_str, NULL);
+    assert_string_equal(diff_str, "Unable to calculate diff due to 'file_size' limit has been reached.");
+    
+    free(diff_str);
 }
 
 void test_fim_registry_value_diff_wrong_quota_reached(void **state) {
@@ -1299,7 +1301,9 @@ void test_fim_registry_value_diff_wrong_quota_reached(void **state) {
 
     char *diff_str = fim_registry_value_diff(key_name, value_name, value_data, data_type, configuration);
 
-    assert_ptr_equal(diff_str, NULL);
+    assert_string_equal(diff_str, "Unable to calculate diff due to 'disk_quota' limit has been reached.");
+    
+    free(diff_str);
 }
 
 void test_fim_registry_value_diff_uncompress_fail(void **state) {
@@ -1326,7 +1330,9 @@ void test_fim_registry_value_diff_uncompress_fail(void **state) {
 
     char *diff_str = fim_registry_value_diff(key_name, value_name, value_data, data_type, configuration);
 
-    assert_ptr_equal(diff_str, NULL);
+    assert_string_equal(diff_str, "Unable to calculate diff due to no previous data stored for this registry value.");
+    
+    free(diff_str);
 }
 
 void test_fim_registry_value_diff_create_compress_fail(void **state) {
@@ -1384,7 +1390,9 @@ void test_fim_registry_value_diff_compare_fail(void **state) {
 
     char *diff_str = fim_registry_value_diff(key_name, value_name, value_data, data_type, configuration);
 
-    assert_ptr_equal(diff_str, NULL);
+    assert_string_equal(diff_str, "No content changes were found for this registry value.");
+    
+    free(diff_str);
 }
 
 void test_fim_registry_value_diff_nodiff(void **state) {
@@ -1413,7 +1421,9 @@ void test_fim_registry_value_diff_nodiff(void **state) {
 
     char *diff_str = fim_registry_value_diff(key_name, value_name, value_data, data_type, configuration);
 
-    assert_string_equal(diff_str, "<Diff truncated because nodiff option>");
+    assert_string_equal(diff_str, "Diff truncated due to 'nodiff' configuration detected for this registry value.");
+
+    free(diff_str);
 }
 
 void test_fim_registry_value_diff_generate_fail(void **state) {
@@ -1525,7 +1535,9 @@ void test_fim_file_diff_wrong_too_big_file(void **state) {
 
     char *diff_str = fim_file_diff(filename, &configuration);
 
-    assert_ptr_equal(diff_str, NULL);
+    assert_string_equal(diff_str, "Unable to calculate diff due to 'file_size' limit has been reached.");
+    
+    free(diff_str);
 }
 
 void test_fim_file_diff_wrong_quota_reached(void **state) {
@@ -1550,7 +1562,9 @@ void test_fim_file_diff_wrong_quota_reached(void **state) {
 
     char *diff_str = fim_file_diff(filename, &configuration);
 
-    assert_ptr_equal(diff_str, NULL);
+    assert_string_equal(diff_str, "Unable to calculate diff due to 'disk_quota' limit has been reached.");
+    
+    free(diff_str);
 }
 
 void test_fim_file_diff_uncompress_fail(void **state) {
@@ -1578,7 +1592,9 @@ void test_fim_file_diff_uncompress_fail(void **state) {
 
     char *diff_str = fim_file_diff(filename, &configuration);
 
-    assert_ptr_equal(diff_str, NULL);
+    assert_string_equal(diff_str, "Unable to calculate diff due to no previous data stored for this file.");
+    
+    free(diff_str);
 }
 
 void test_fim_file_diff_create_compress_fail(void **state) {
@@ -1643,7 +1659,9 @@ void test_fim_file_diff_compare_fail(void **state) {
 
     char *diff_str = fim_file_diff(filename, &configuration);
 
-    assert_ptr_equal(diff_str, NULL);
+    assert_string_equal(diff_str, "No content changes were found for this file.");
+    
+    free(diff_str);
 }
 
 #ifdef TEST_WINAGENT
@@ -1675,7 +1693,9 @@ void test_fim_file_diff_nodiff(void **state) {
 
     char *diff_str = fim_file_diff(filename, &configuration);
 
-    assert_string_equal(diff_str, "<Diff truncated because nodiff option>");
+    assert_string_equal(diff_str, "Diff truncated due to 'nodiff' configuration detected for this file.");
+    
+    free(diff_str);
 }
 #else
 void test_fim_file_diff_nodiff(void **state) {
@@ -1706,7 +1726,7 @@ void test_fim_file_diff_nodiff(void **state) {
 
     char *diff_str = fim_file_diff(filename, &configuration);
 
-    assert_string_equal(diff_str, "<Diff truncated because nodiff option>");
+    assert_string_equal(diff_str, "Diff truncated due to 'nodiff' configuration detected for this file.");
 
     free(diff_str);
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/9448|


## Description

Hi team, this PR is to improve the report_changes functionality, so that when it is not possible to calculate the differences of a file, the corresponding messages are correctly displayed in the alerts. Messages have been added or modified for the following cases (just modified events display this information):

- `disk_quota` limit reached:
```
What changed:
Unable to calculate diff due to 'disk_quota' limit has been reached.
```
- `file_size` limit reached:
```
What changed:
Unable to calculate diff due to 'file_size' limit has been reached.
```
- nodiff option:
```
What changed:
Diff truncated due to 'nodiff' configuration detected for this file.
```
- No changes found in the file:
```
What changed:
No content changes were found for this file.
```
- No previous data to generate diff (for example, due to added file with `file_size` limit reached):
```
What changed:
Unable to calculate diff due to no previous data stored for this file.
```

Also, fixed functionality for FIM baseline to correctly save report_changes information.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
