### PR TITLE
[4.4] Update setuptools in the embedded Python interpreter

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -4,7 +4,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 # To install the library, run the following
 #
@@ -22,7 +22,7 @@ setup(
     url="https://github.com/wazuh",
     keywords=["Wazuh API"],
     install_requires=[],
-    packages=find_packages(exclude=["*.test", "*.test.*", "test.*", "test"]),
+    packages=find_namespace_packages(exclude=["*.test", "*.test.*", "test.*", "test"]),
     package_data={'': ['spec/spec.yaml']},
     include_package_data=True,
     zip_safe=False,

--- a/framework/setup.py
+++ b/framework/setup.py
@@ -10,7 +10,7 @@ import json
 import os
 from datetime import datetime, timezone
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 from setuptools.command.install import install
 
 
@@ -47,7 +47,7 @@ setup(name='wazuh',
       author='Wazuh',
       author_email='hello@wazuh.com',
       license='GPLv2',
-      packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+      packages=find_namespace_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
       package_data={'wazuh': ['core/wazuh.json', 'core/cluster/cluster.json', 'rbac/default/*.yaml']},
       include_package_data=True,
       install_requires=[],


### PR DESCRIPTION
|Related issue|
|---|
| #16473 |


## Description

This PR closes https://github.com/wazuh/wazuh/issues/16473. It updates the `setuptools` dependency in the Wazuh Python embedded interpreter to version `65.5.1` due to [a vulnerability](https://github.com/advisories/GHSA-r9hx-vwmv-q579) of the package. This update also required a modification in the `api/setup.py` and `framework/setup.py` files needed to build the `api` and `wazuh` packages.
