### PR TITLE
Add AWS parser validations

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -447,7 +447,9 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     }
                 } else if (!strcmp(children[j]->element, XML_LOG_GROUP)) {
                     if (strlen(children[j]->content) == 0) {
-                            mwarn("Empty content for tag '%s' at module '%s'.", XML_LOG_GROUP, WM_AWS_CONTEXT.name);
+                            merror("Empty content for tag '%s' at module '%s'.", XML_LOG_GROUP, WM_AWS_CONTEXT.name);
+                            OS_ClearNode(children);
+                            return OS_INVALID;
                         }
                     else if (strlen(children[j]->content) != 0) {
                         free(cur_service->aws_log_groups);

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -270,22 +270,34 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                             os_strdup(children[j]->content, cur_bucket->iam_role_duration);
                         }
                     } else if (!strcmp(children[j]->element, XML_TRAIL_PREFIX)) {
-                        if (strlen(children[j]->content) != 0) {
+                        if (strlen(children[j]->content) == 0) {
+                            mwarn("Empty content for tag '%s' at module '%s'.", XML_TRAIL_PREFIX, WM_AWS_CONTEXT.name);
+                        }
+                        else if (strlen(children[j]->content) != 0) {
                             free(cur_bucket->trail_prefix);
                             os_strdup(children[j]->content, cur_bucket->trail_prefix);
                         }
                     } else if (!strcmp(children[j]->element, XML_TRAIL_SUFFIX)) {
-                        if (strlen(children[j]->content) != 0) {
+                        if (strlen(children[j]->content) == 0) {
+                            mwarn("Empty content for tag '%s' at module '%s'.", XML_TRAIL_SUFFIX, WM_AWS_CONTEXT.name);
+                        }
+                        else if (strlen(children[j]->content) != 0) {
                             free(cur_bucket->trail_suffix);
                             os_strdup(children[j]->content, cur_bucket->trail_suffix);
                         }
                     } else if (!strcmp(children[j]->element, XML_ONLY_LOGS_AFTER)) {
-                        if (strlen(children[j]->content) != 0) {
+                        if (strlen(children[j]->content) == 0) {
+                            mwarn("Empty content for tag '%s' at module '%s'.", XML_ONLY_LOGS_AFTER, WM_AWS_CONTEXT.name);
+                        }
+                        else if (strlen(children[j]->content) != 0) {
                             free(cur_bucket->only_logs_after);
                             os_strdup(children[j]->content, cur_bucket->only_logs_after);
                         }
                     } else if (!strcmp(children[j]->element, XML_REGION)) {
-                        if (strlen(children[j]->content) != 0) {
+                        if (strlen(children[j]->content) == 0) {
+                            mwarn("Empty content for tag '%s' at module '%s'.", XML_REGION, WM_AWS_CONTEXT.name);
+                        }
+                        else if (strlen(children[j]->content) != 0) {
                             free(cur_bucket->regions);
                             os_strdup(children[j]->content, cur_bucket->regions);
                         }
@@ -418,17 +430,26 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                             os_strdup(children[j]->content, cur_service->iam_role_duration);
                         }
                 } else if (!strcmp(children[j]->element, XML_ONLY_LOGS_AFTER)) {
-                    if (strlen(children[j]->content) != 0) {
+                    if (strlen(children[j]->content) == 0) {
+                            mwarn("Empty content for tag '%s' at module '%s'.", XML_ONLY_LOGS_AFTER, WM_AWS_CONTEXT.name);
+                    }
+                    else if (strlen(children[j]->content) != 0) {
                         free(cur_service->only_logs_after);
                         os_strdup(children[j]->content, cur_service->only_logs_after);
                     }
                 } else if (!strcmp(children[j]->element, XML_REGION)) {
-                    if (strlen(children[j]->content) != 0) {
+                    if (strlen(children[j]->content) == 0) {
+                            mwarn("Empty content for tag '%s' at module '%s'.", XML_REGION, WM_AWS_CONTEXT.name);
+                    }
+                    else if (strlen(children[j]->content) != 0) {
                         free(cur_service->regions);
                         os_strdup(children[j]->content, cur_service->regions);
                     }
                 } else if (!strcmp(children[j]->element, XML_LOG_GROUP)) {
-                    if (strlen(children[j]->content) != 0) {
+                    if (strlen(children[j]->content) == 0) {
+                            mwarn("Empty content for tag '%s' at module '%s'.", XML_LOG_GROUP, WM_AWS_CONTEXT.name);
+                        }
+                    else if (strlen(children[j]->content) != 0) {
                         free(cur_service->aws_log_groups);
                         os_strdup(children[j]->content, cur_service->aws_log_groups);
                     }

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3118,8 +3118,8 @@ def arg_valid_date(arg_string):
         raise argparse.ArgumentTypeError("Argument not a valid date in format YYYY-MMM-DD: '{0}'.".format(arg_string))
 
 
-def arg_valid_prefix(arg_string):
-    CHARACTERS_TO_AVOID = "{}^%`[]'<>~#|"
+def arg_valid_key(arg_string):
+    CHARACTERS_TO_AVOID = "\\{}^%`[]'\"<>~#|"
     XML_CONSTRAINTS = ["&apos;", "&quot;", "&amp;", "&lt;", "&gt;", "&#13;", "&#10;"]
 
     # Validate against the naming guidelines https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
@@ -3129,7 +3129,7 @@ def arg_valid_prefix(arg_string):
             f" Avoid to use '{CHARACTERS_TO_AVOID}' or '{''.join(XML_CONSTRAINTS)}'."
         )
 
-    if arg_string and arg_string[-1] != '/' and arg_string[-1] != "\\":
+    if arg_string and arg_string[-1] != '/':
         return '{arg_string}/'.format(arg_string=arg_string)
     return arg_string
 
@@ -3258,10 +3258,10 @@ def get_script_arguments():
                         help='AWS Account ID Alias', default='')
     parser.add_argument('-l', '--trail_prefix', dest='trail_prefix',
                         help='Log prefix for S3 key',
-                        default='', type=arg_valid_prefix)
+                        default='', type=arg_valid_key)
     parser.add_argument('-L', '--trail_suffix', dest='trail_suffix',
                         help='Log suffix for S3 key',
-                        default='', type=arg_valid_prefix)
+                        default='', type=arg_valid_key)
     parser.add_argument('-s', '--only_logs_after', dest='only_logs_after',
                         help='Only parse logs after this date - format YYYY-MMM-DD',
                         default=None, type=arg_valid_date)
@@ -3273,7 +3273,7 @@ def get_script_arguments():
                         help='Parse the log file, even if its been parsed before', default=False)
     parser.add_argument('-t', '--type', dest='type', type=str, help='Bucket type.', default='cloudtrail')
     parser.add_argument('-g', '--aws_log_groups', dest='aws_log_groups', help='Name of the log group to be parsed',
-                        default='', type=arg_valid_prefix)
+                        default='', type=arg_valid_key)
     parser.add_argument('-P', '--remove-log-streams', action='store_true', dest='deleteLogStreams',
                         help='Remove processed log streams from the log group', default=False)
     parser.add_argument('-df', '--discard-field', type=str, dest='discard_field', default=None,

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3152,13 +3152,14 @@ def arg_valid_regions(arg_string):
     final_regions = []
     regions = arg_string.split(',')
     for arg_region in regions:
-        if not re.match(r'(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d', arg_region):
+        if not re.match(r'^([a-z]{2}(-gov)?)-([a-z]{4,7})-\d$', arg_region):
             raise argparse.ArgumentTypeError(
                 f"WARNING: The region '{arg_region}' has not a valid format.'"
             )
         if arg_region.strip():
             final_regions.append(arg_region.strip())
-    return final_regions
+
+    return list(set(final_regions))
 
 
 def arg_valid_iam_role_duration(arg_string):

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3205,7 +3205,7 @@ def arg_valid_bucket_name(arg: str) -> str:
     argparse.ArgumentTypeError
         If the bucket name is not valid.
     """
-    if not re.match(r'(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$', arg):
+    if not re.match(r'(?!(^xn--|.+-s3alias$|.+--ol-s3$))^[a-z0-9][a-z0-9-.]{1,61}[a-z0-9]$', arg):
         raise argparse.ArgumentTypeError(f"'{arg}' isn't a valid bucket name.")
     return arg
 


### PR DESCRIPTION
|Related issue|
|---|
| #16383 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #16383. Add validations for parameters in case of empty or invalid values.

## Tests

```python
root@ubuntu-jammy:/home/vagrant/qa/tests/integration/test_aws# pytest --disable-warnings --tb=line test_parser.py
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vagrant/qa/tests/integration, configfile: pytest.ini
plugins: metadata-2.0.2, html-3.1.1, testinfra-5.0.0
collected 26 items

test_parser.py ..........................                                                                                                                                                                     [100%]

==================================================================================== 26 passed, 2 warnings in 261.90s (0:04:21) =====================================================================================
```
