### PR TITLE
Fix bug in agent_groups script when deleting groups

### DIFF
--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -190,12 +190,7 @@ async def remove_group(group_id, quiet=False):
         if result.total_affected_items == 0:
             msg = list(result.failed_items.keys())[0]
         else:
-            affected_agents = next(iter(result.affected_items[0].values()))
             msg = f'Group {group_id} removed.'
-            if len(affected_agents) == 0:
-                msg += "\nNo affected agents."
-            else:
-                msg += "\nAffected agents: {0}.".format(', '.join(affected_agents))
     else:
         msg = 'Cancelled.'
 

--- a/framework/scripts/tests/test_agent_groups.py
+++ b/framework/scripts/tests/test_agent_groups.py
@@ -209,14 +209,14 @@ async def test_remove_group(print_mock):
             AffectedItems.called = True
 
     def forward_function(func, f_kwargs):
-        return AffectedItems(affected_items=[{'testing': ['a', 'b']}], failed_items={'a': 'b'})
+        return AffectedItems(affected_items=['testing'], failed_items={'a': 'b'})
 
     with patch('scripts.agent_groups.cluster_utils.forward_function', side_effect=forward_function) as forward_mock:
         with patch('scripts.agent_groups.get_stdin', return_value='y') as get_stdin_mock:
             await agent_groups.remove_group(group_id='testing')
             forward_mock.has_calls(call(func=agent.delete_groups, f_kwargs={'group_list': ['testing']}))
             get_stdin_mock.assert_has_calls([call("Do you want to remove the 'testing' group? [y/N]: ")])
-            print_mock.assert_has_calls([call('Group testing removed.\nAffected agents: a, b.')])
+            print_mock.assert_has_calls([call('Group testing removed.')])
             print_mock.reset_mock()
             get_stdin_mock.reset_mock()
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #16483 |

## Description

This PR fixes a problem in the `agent_groups` CLI when deleting any group:
```
# /var/ossec/bin/agent_groups -r -g test_group3
Do you want to remove the 'test_group3' group? [y/N]: y
Internal error: 'str' object has no attribute 'values'
```

As it was explained in #16483, the problem was that [after this PR](https://github.com/wazuh/wazuh/pull/16231), the `agent.delete_groups` framework function no longer returns a dictionary (`{'<group_name>': ['affected_agent_A', affected_agent_B', ...]}`) but a list where the affected agents are not considered (`[<group_name>]`).

The CLI was not updated so it still expected a dict in the response. It now works correctly:
```
# /var/ossec/bin/agent_groups -r -g test_group3
Do you want to remove the 'test_group3' group? [y/N]: y
Group test_group3 removed.
```

## Tests

```
$ PYTHONPATH=/home/selu/Git/wazuh/api:/home/selu/Git/wazuh/framework python3 -m pytest framework -x --disable-warnings
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1, aiohttp-1.0.4, cov-4.0.0
asyncio: mode=auto
collected 2047 items                                                                                                                                                                                        

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                                                                         [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                                                                [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                 [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                                [  7%]
framework/wazuh/core/cluster/tests/test_common.py ...........................................................................                                                                         [ 10%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                                             [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                 [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                      [ 12%]
framework/wazuh/core/cluster/tests/test_master.py .............................................                                                                                                       [ 15%]
framework/wazuh/core/cluster/tests/test_server.py ...................                                                                                                                                 [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                          [ 16%]
framework/wazuh/core/cluster/tests/test_worker.py ....................................                                                                                                                [ 18%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [ 19%]
framework/wazuh/core/tests/test_agent.py ................................................................................................................................................             [ 26%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 27%]
framework/wazuh/core/tests/test_common.py .......                                                                                                                                                     [ 28%]
framework/wazuh/core/tests/test_configuration.py ......................................................................                                                                               [ 31%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 32%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 33%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 33%]
framework/wazuh/core/tests/test_manager.py ...............                                                                                                                                            [ 34%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 34%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 35%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 37%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 38%]
framework/wazuh/core/tests/test_sca.py ........................                                                                                                                                       [ 39%]
framework/wazuh/core/tests/test_security.py ............                                                                                                                                              [ 40%]
framework/wazuh/core/tests/test_stats.py .................                                                                                                                                            [ 41%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 42%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 49%]
.....................................................................................                                                                                                                 [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                                                [ 57%]
framework/wazuh/core/tests/test_wlogging.py .........                                                                                                                                                 [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 58%]
framework/wazuh/rbac/tests/test_decorators.py .............................................................................................................                                           [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py ........................................................                                                                                     [ 66%]
framework/wazuh/rbac/tests/test_orm.py ......................................................                                                                                                         [ 68%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 69%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [ 69%]
framework/wazuh/tests/test_agent.py .....................................................................................................................                                             [ 75%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 79%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 80%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 82%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 82%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 84%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 84%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 87%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                           [ 89%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                         [ 90%]
framework/wazuh/tests/test_security.py .........................................................................                                                                                      [ 94%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                   [ 94%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                     [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................................                                                                                                                  [100%]

=============================================================================== 2047 passed, 47 warnings in 345.99s (0:05:45) ===============================================================================
```