### PR TITLE
Fixed error when assigning the 'upgrade_custom' command to a task.

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1142,7 +1142,7 @@ def upgrade_agents(agent_list: list = None, wpk_repo: str = None, version: str =
         eligible_agents = [int(agent) for agent in eligible_agents]
 
         tasks_results = create_upgrade_tasks(eligible_agents=eligible_agents, chunk_size=UPGRADE_CHUNK_SIZE,
-                                             command='upgrade' if not installer or file_path else 'upgrade_custom',
+                                             command='upgrade' if not (installer or file_path) else 'upgrade_custom',
                                              wpk_repo=wpk_repo, version=version, force=force, use_http=use_http,
                                              file_path=file_path, installer=installer)
 


### PR DESCRIPTION
|Related issue|
|---|
|[16186](https://github.com/wazuh/wazuh/issues/16186)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Fixed logic that decides if a task is an 'upgrade' or 'upgrade_custom' command, fixing the issue [16186](https://github.com/wazuh/wazuh/issues/16186)
https://github.com/wazuh/wazuh/blob/d39f8f5cbdaf7170fee9faf37fa59cd2026d6a7d/framework/wazuh/agent.py#L1155-L1158.

<!--
Add a clear description of how the problem has been solved.
-->


