### PR TITLE
Engine - Upgrade_MQ analysis and decoder development

### DIFF
--- a/src/engine/ruleset/decoders/wazuh-agent/syscollector/syscollector-dbsync.yml
+++ b/src/engine/ruleset/decoders/wazuh-agent/syscollector/syscollector-dbsync.yml
@@ -24,9 +24,9 @@ sources:
   - decoder/syscollector-base/0
 
 check:
-  - ~json.type: +s_starts/dbsync_
-  - ~json.operation: +t_is_string
-  - ~json.data: +t_is_object
+  - ~json.type: +starts_with/dbsync_
+  - ~json.operation: +is_string
+  - ~json.data: +is_object
 
 # processes
 # {"data":{"argvs":null,"checksum":"71ece4e42dd41b4b06df00e3f5c4fab33aacc1c5","cmd":null,"egroup":"root","euser":"root","fgroup":"root","name":"kworker/1:2-eve","nice":0,"nlwp":1,"pgrp":0,"pid":"4188","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","scan_time":"2023/03/10 03:27:12","session":0,"sgroup":"root","share":0,"size":0,"start_time":1678418235,"state":"R","stime":14,"suser":"root","tgid":4188,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"}
@@ -48,62 +48,62 @@ check:
 # {"data":{"scan_time":"2021/10/29 14:26:24","hotfix":"KB123456","checksum":"abcdef0123456789"}, "type":"dbsync_hotfixes","operation":"MODIFIED"}
 
 normalize:
-  - check: +ef_exists/~json.data.address OR +ef_exists/~json.data.mac OR +ef_exists/~json.data.os_version OR +ef_exists/~json.data.release OR +s_ne/~json.data.hostname/ OR +s_ne/~json.data.os_name/ OR +s_ne/~json.data.os_platform/ OR +s_ne/~json.data.sysname/
+  - check: +exists/~json.data.address OR +exists/~json.data.mac OR +exists/~json.data.os_version OR +exists/~json.data.release OR +string_not_equal/~json.data.hostname/ OR +string_not_equal/~json.data.os_name/ OR +string_not_equal/~json.data.os_platform/ OR +string_not_equal/~json.data.sysname/
     map:
       - ~do_update_kvdb: true
 
   # Avoid updating when architecture field not from osinfo
-  - check: +s_ne/~json.data.architecture/ AND +s_eq/~json.type/osinfo
+  - check: +string_not_equal/~json.data.architecture/ AND +string_equal/~json.type/osinfo
     map:
       - ~do_update_kvdb: true
 
   - map:
-      - ~json.type: +s_replace/dbsync_/
-      - ~tmp.query: +s_concat/agent /$agent.id/ dbsync /$~json.type/ /$~json.operation/ /$~json.data
+      - ~json.type: +replace/dbsync_/
+      - ~tmp.query: +concat/agent /$agent.id/ dbsync /$~json.type/ /$~json.operation/ /$~json.data
       - ~tmp.query_response: +wdb_update/$~tmp.query
-      - ~json.data.checksum: +ef_delete
+      - ~json.data.checksum: +delete
 
   - check:
-      - ~tmp.query_response: +t_is_false
+      - ~tmp.query_response: +is_false
     map:
       - ~do_update_kvdb: false
 
     # Mapping result fields to wazuh.syscollector
-  - check: +t_is_true/~tmp.query_response AND +s_eq/~json.type/processes
+  - check: +is_true/~tmp.query_response AND +string_equal/~json.type/processes
     map:
       - wazuh.syscollector.process: $~json.data
 
-  - check: +t_is_true/~tmp.query_response AND +s_eq/~json.type/ports
+  - check: +is_true/~tmp.query_response AND +string_equal/~json.type/ports
     map:
       - wazuh.syscollector.port: $~json.data
 
-  - check: +t_is_true/~tmp.query_response AND +s_eq/~json.type/hotfixes
+  - check: +is_true/~tmp.query_response AND +string_equal/~json.type/hotfixes
     map:
       - wazuh.syscollector.hotfix: $~json.data
 
-  - check: +t_is_true/~tmp.query_response AND +s_eq/~json.type/hwinfo
+  - check: +is_true/~tmp.query_response AND +string_equal/~json.type/hwinfo
     map:
       - wazuh.syscollector.hardware: $~json.data
 
-  - check: +t_is_true/~tmp.query_response AND +s_eq/~json.type/network_address
+  - check: +is_true/~tmp.query_response AND +string_equal/~json.type/network_address
     map:
       - wazuh.syscollector.netinfo.addr: $~json.data
 
-  - check: +t_is_true/~tmp.query_response AND +s_eq/~json.type/network_protocol
+  - check: +is_true/~tmp.query_response AND +string_equal/~json.type/network_protocol
     map:
       - wazuh.syscollector.netinfo.proto: $~json.data
 
-  - check: +t_is_true/~tmp.query_response AND +s_eq/~json.type/network_iface
+  - check: +is_true/~tmp.query_response AND +string_equal/~json.type/network_iface
     map:
       - wazuh.syscollector.netinfo.iface: $~json.data
 
-  - check: +t_is_true/~tmp.query_response AND +s_eq/~json.type/osinfo
+  - check: +is_true/~tmp.query_response AND +string_equal/~json.type/osinfo
     map:
       - wazuh.syscollector.os: $~json.data
 
-  - check: +t_is_true/~tmp.query_response AND +s_eq/~json.type/packages
+  - check: +is_true/~tmp.query_response AND +string_equal/~json.type/packages
     map:
       - wazuh.syscollector.program: $~json.data
 
   - map:
-      - ~tmp: +ef_delete
+      - ~tmp: +delete

--- a/src/engine/ruleset/decoders/wazuh-agent/upgrade/queue-upgrade.yml
+++ b/src/engine/ruleset/decoders/wazuh-agent/upgrade/queue-upgrade.yml
@@ -1,0 +1,22 @@
+---
+name: decoder/queue-upgrade/0
+
+metadata:
+  module: wazuh-agent/upgrade
+  title: Upgrade queue events
+  description: Exclusive parent decoder for events from upgrade queue (UPGRADE_MQ)
+  compatibility: >
+    This decoder has been tested on Wazuh version 4.4.0
+  versions:
+    - "4.4.0"
+  author:
+    name: Wazuh, Inc.
+    date: 2023/03/22
+  references:
+    - https://www.json.org
+
+sources:
+  - decoder/agent-event-enrichment/0
+
+check:
+  - wazuh.queue: 117 # UPGRADE_MQ 'u'

--- a/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
+++ b/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
@@ -15,6 +15,7 @@ metadata:
         url: https://wazuh.com
         date: 2023/03/22
     references:
+      # TODO
         - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
 
 sources:
@@ -22,6 +23,7 @@ sources:
 
 check:
   - event.original: +s_starts/{
+  - agent.id: +ef_exists
 
 parse:
   logpar:
@@ -30,7 +32,6 @@ parse:
 normalize:
   - check:
       - ~json.parameters: +t_is_object
-      - agent.id: +ef_exists
     map:
       - ~json.parameters.agents: +a_append/$agent.id
       - ~tmp.send_result: +upgrade_confirmation_send/$~json

--- a/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
+++ b/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
@@ -1,0 +1,43 @@
+---
+name: decoder/upgrade/0
+
+metadata:
+    module: wazuh-agent/upgrade
+    title: Upgrade Confirmation events
+    description: >
+        Decodes Upgrade confirmation messages
+    compatibility: >
+        This decoder has been tested on Wazuh version 4.4.0
+    versions:
+      - "4.4.0"
+    author:
+        name: Wazuh, Inc.
+        url: https://wazuh.com
+        date: 2023/03/22
+    references:
+        - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+
+sources:
+  - decoder/queue-upgrade/0
+
+check:
+  - event.original: +s_starts/{
+
+parse:
+  logpar:
+    - event.original: <~json/json>
+
+normalize:
+  - check:
+      - ~json.parameters: +t_is_object
+      - agent.id: +ef_exists
+    map:
+      - ~json.parameters.agents: +a_append/$agent.id
+      - ~tmp.send_result: +upgrade_confirmation_send/$~json
+
+  - check:
+      - ~tmp.send_result: +t_is_true
+    map:
+      - ~tmp.result: success
+      # - ~tmp: +ef_delete
+

--- a/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
+++ b/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
@@ -15,8 +15,8 @@ metadata:
         url: https://wazuh.com
         date: 2023/03/22
     references:
-      # TODO
-        - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+        - https://documentation.wazuh.com/current/user-manual/agents/remote-upgrading/upgrading-agent.html#upgrading-agent
+        - https://documentation.wazuh.com/current/user-manual/agents/remote-upgrading/agent-upgrade-module.html
 
 sources:
   - decoder/queue-upgrade/0
@@ -24,6 +24,12 @@ sources:
 check:
   - event.original: +s_starts/{
   - agent.id: +ef_exists
+
+# Examples:
+# https://github.com/wazuh/wazuh/issues/5406
+# {"origin":{"module":"api"},"command":"upgrade","parameters":{"agents":[5,6],"wpk_repo":"packages.wazuh.com/4.x/wpk/","version":"v4.0.0","use_http":false,"force_upgrade":false}}
+# {"origin":{"module":"api"},"command":"upgrade_custom","parameters":{"agents":[20,23],"file_path":"/home/user/agent.wpk","installer":"custom-upgrade-script.sh"}}
+# {"origin":{"module":"upgrade_module"},"command":"upgrade_update_status","parameters":{"agents":[20],"error":0,"data":"Upgrade Successful","status":"Done"}}
 
 parse:
   logpar:
@@ -40,5 +46,9 @@ normalize:
       - ~tmp.send_result: +t_is_true
     map:
       - ~tmp.result: success
-      # - ~tmp: +ef_delete
+
+  # Cleanup
+  - map:
+      - ~tmp: +ef_delete
+      - ~json: +ef_delete
 

--- a/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
+++ b/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
@@ -22,14 +22,13 @@ sources:
   - decoder/queue-upgrade/0
 
 check:
-  - event.original: +s_starts/{
-  - agent.id: +ef_exists
+  - event.original: +starts_with/{
+  - agent.id: +exists
 
 # Examples:
 # https://github.com/wazuh/wazuh/issues/5406
-# {"origin":{"module":"api"},"command":"upgrade","parameters":{"agents":[5,6],"wpk_repo":"packages.wazuh.com/4.x/wpk/","version":"v4.0.0","use_http":false,"force_upgrade":false}}
-# {"origin":{"module":"api"},"command":"upgrade_custom","parameters":{"agents":[20,23],"file_path":"/home/user/agent.wpk","installer":"custom-upgrade-script.sh"}}
-# {"origin":{"module":"upgrade_module"},"command":"upgrade_update_status","parameters":{"agents":[20],"error":0,"data":"Upgrade Successful","status":"Done"}}
+# {"command":"upgrade_update_status","parameters":{"error":0,"message":"Upgrade was successful","status":"Done"}}
+# {"command":"upgrade_update_status","parameters":{"error":2,"message":"Upgrade Failed","status":"Failed"}}
 
 parse:
   logpar:
@@ -37,18 +36,18 @@ parse:
 
 normalize:
   - check:
-      - ~json.parameters: +t_is_object
+      - ~json.parameters: +is_object
     map:
-      - ~json.parameters.agents: +a_append/$agent.id
+      - ~json.parameters.agents: +array_append/$agent.id
       - ~tmp.send_result: +upgrade_confirmation_send/$~json
 
   - check:
-      - ~tmp.send_result: +t_is_true
+      - ~tmp.send_result: +is_true
     map:
       - ~tmp.result: success
 
   # Cleanup
-  - map:
-      - ~tmp: +ef_delete
-      - ~json: +ef_delete
+  # - map:
+      # - ~tmp: +delete
+      # - ~json: +delete
 

--- a/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
+++ b/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
@@ -47,7 +47,7 @@ normalize:
       - ~tmp.result: success
 
   # Cleanup
-  # - map:
-      # - ~tmp: +delete
-      # - ~json: +delete
+  - map:
+      - ~tmp: +delete
+      - ~json: +delete
 

--- a/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
+++ b/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
@@ -38,13 +38,14 @@ normalize:
   - check:
       - ~json.parameters: +is_object
     map:
-      - ~json.parameters.agents: +array_append/$agent.id
+      - ~tmp.agent_id_int: +parse_long/$agent.id
+      - ~json.parameters.agents: +array_append/$~tmp.agent_id_int
       - ~tmp.send_result: +upgrade_confirmation_send/$~json
 
   - check:
       - ~tmp.send_result: +is_true
     map:
-      - ~tmp.result: success
+      - event.outcome: success
 
   # Cleanup
   - map:

--- a/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
+++ b/src/engine/ruleset/decoders/wazuh-agent/upgrade/upgrade.yml
@@ -21,10 +21,6 @@ metadata:
 sources:
   - decoder/queue-upgrade/0
 
-check:
-  - event.original: +starts_with/{
-  - agent.id: +exists
-
 # Examples:
 # https://github.com/wazuh/wazuh/issues/5406
 # {"command":"upgrade_update_status","parameters":{"error":0,"message":"Upgrade was successful","status":"Done"}}
@@ -40,7 +36,7 @@ normalize:
     map:
       - ~tmp.agent_id_int: +parse_long/$agent.id
       - ~json.parameters.agents: +array_append/$~tmp.agent_id_int
-      - ~tmp.send_result: +upgrade_confirmation_send/$~json
+      - ~tmp.send_result: +send_upgrade_confirmation/$~json
 
   - check:
       - ~tmp.send_result: +is_true

--- a/src/engine/ruleset/environments/wazuh-environment.yml
+++ b/src/engine/ruleset/environments/wazuh-environment.yml
@@ -10,6 +10,7 @@ decoders:
   - decoder/queue-localfile/0
   - decoder/queue-rootcheck/0
   - decoder/queue-ciscat/0
+  - decoder/queue-upgrade/0
 
   # General format decoders
   - decoder/json/0
@@ -40,6 +41,9 @@ decoders:
   - decoder/syscollector-program/0
   - decoder/syscollector-program-del/0
   - decoder/syscollector-program-save/0
+
+  # Upgrade confirmation
+  - decoder/upgrade/0
 
   # Enrich events with host info
   - decoder/agent-event-enrichment/0

--- a/src/engine/source/base/utils/socketInterface/unixDatagram.hpp
+++ b/src/engine/source/base/utils/socketInterface/unixDatagram.hpp
@@ -18,7 +18,7 @@ class unixDatagram : public unixInterface
 
 public:
     /**
-     * @brief Create a unixSecureStream object linked to a UNIX socket located at `path`.
+     * @brief Create a unixDatagram object linked to a UNIX socket located at `path`.
      *
      * Set the socket size to the maximum message size (default=2^16).
      * @param path UNIX domain socket pathname

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(builders OBJECT
   builders/opBuilderHelperFilter.cpp
   builders/opBuilderHelperMap.cpp
   builders/opBuilderHelperNetInfoAddress.cpp
+  builders/opBuilderHelperUpgradeConfirmation.cpp
   builders/opBuilderKVDB.cpp
   builders/opBuilderLogParser.cpp
   builders/opBuilderSCAdecoder.cpp

--- a/src/engine/source/builder/builders/baseHelper.cpp
+++ b/src/engine/source/builder/builders/baseHelper.cpp
@@ -64,12 +64,6 @@ std::vector<Parameter> processParameters(const std::string name,
                                                "Json pointer path: {}",
                                                parameter,
                                                e.what()));
-
-                               throw(std::runtime_error(
-                                   fmt::format("Cannot format parameter \"{}\" to Json "
-                                               "pointer path: {}",
-                                               parameter,
-                                               e.what())));
                            }
                            return {Parameter::Type::REFERENCE, pointerPath};
                        }

--- a/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.cpp
@@ -1,0 +1,115 @@
+/* Copyright (C) 2015-2023, Wazuh Inc.
+ * All rights reserved.
+ *
+ */
+
+#include "opBuilderHelperUpgradeConfirmation.hpp"
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+
+#include "syntax.hpp"
+
+#include <baseHelper.hpp>
+#include <utils/socketInterface/unixSecureStream.hpp>
+#include <utils/stringUtils.hpp>
+
+namespace sint = base::utils::socketInterface;
+using helper::base::Parameter;
+
+namespace builder::internals::builders
+{
+
+// field: +upgrade_confirmation_send/ar_message
+base::Expression opBuilderHelperSendUpgradeConfirmation(const std::any& definition)
+{
+    // Extract parameters from any
+    auto [targetField, name, raw_parameters] =
+        helper::base::extractDefinition(definition);
+    // Identify references and build JSON pointer paths
+    auto parameters {helper::base::processParameters(name, raw_parameters)};
+    // Assert expected number of parameters
+    helper::base::checkParametersSize(name, parameters, 1);
+    // Format name for the tracer
+    name = helper::base::formatHelperName(name, targetField, parameters);
+
+    std::shared_ptr<sint::unixSecureStream> socketUC {
+        std::make_shared<sint::unixSecureStream>(WM_UPGRADE_SOCK)};
+
+    std::string rValue {};
+    const helper::base::Parameter rightParameter {parameters[0]};
+    const auto rValueType {rightParameter.m_type};
+    rValue = rightParameter.m_value;
+
+    // Tracing
+    const auto successTrace {fmt::format("[{}] -> Success", name)};
+
+    const std::string failureTrace1 {
+        fmt::format("[{}] -> Failure: Query reference \"{}\" not found",
+                    name,
+                    parameters[0].m_value)};
+    const std::string failureTrace2 {
+        fmt::format("[{}] -> Failure: The query is empty", name)};
+    const std::string failureTrace3 {
+        fmt::format("[{}] -> Failure: Upgrade Confirmation message could not be send", name)};
+    const std::string failureTrace4 {
+        fmt::format("[{}] -> Failure: Error trying to send Update Confirmation message: ", name)};
+
+    // Function that implements the helper
+    return base::Term<base::EngineOp>::create(
+        name,
+        [=, targetField = std::move(targetField), name = std::move(name)](
+            base::Event event) -> base::result::Result<base::Event>
+        {
+            std::string query {};
+            bool messageSent {false};
+
+            // Check if the value comes from a reference
+            if (Parameter::Type::REFERENCE == rValueType)
+            {
+                auto resolvedRValue {event->getString(rValue)};
+
+                if (!resolvedRValue.has_value())
+                {
+                    return base::result::makeFailure(event, failureTrace1);
+                }
+                else
+                {
+                    query = resolvedRValue.value();
+                }
+            }
+            else // Direct value
+            {
+                query = rValue;
+            }
+
+            if (query.empty())
+            {
+                return base::result::makeFailure(event, failureTrace2);
+            }
+            else
+            {
+                try
+                {
+                    if (sint::SendRetval::SUCCESS == socketUC->sendMsg(query))
+                    {
+                        event->setBool(true, targetField);
+                        return base::result::makeSuccess(event, successTrace);
+                    }
+                    else
+                    {
+                        return base::result::makeFailure(event, failureTrace3);
+                    }
+                }
+                catch (const std::exception& e)
+                {
+                    return base::result::makeFailure(event, failureTrace4 + e.what());
+                }
+            }
+        });
+}
+
+} // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.cpp
@@ -23,8 +23,7 @@ namespace builder::internals::builders
 base::Expression opBuilderHelperSendUpgradeConfirmation(const std::any& definition)
 {
     // Extract parameters from any
-    auto [targetField, name, raw_parameters] =
-        helper::base::extractDefinition(definition);
+    auto [targetField, name, raw_parameters] = helper::base::extractDefinition(definition);
     // Identify references and build JSON pointer paths
     auto parameters {helper::base::processParameters(name, raw_parameters)};
     // Assert expected number of parameters
@@ -32,8 +31,8 @@ base::Expression opBuilderHelperSendUpgradeConfirmation(const std::any& definiti
     // Format name for the tracer
     name = helper::base::formatHelperName(name, targetField, parameters);
 
-    std::shared_ptr<sint::unixSecureStream> socketUC {
-        std::make_shared<sint::unixSecureStream>(WM_UPGRADE_SOCK)};
+    // Socket instance
+    std::shared_ptr<sint::unixSecureStream> socketUC {std::make_shared<sint::unixSecureStream>(WM_UPGRADE_SOCK)};
 
     std::string rValue {};
     const helper::base::Parameter rightParameter {parameters[0]};
@@ -44,11 +43,8 @@ base::Expression opBuilderHelperSendUpgradeConfirmation(const std::any& definiti
     const auto successTrace {fmt::format("[{}] -> Success", name)};
 
     const std::string failureTrace1 {
-        fmt::format("[{}] -> Failure: Query reference \"{}\" not found",
-                    name,
-                    parameters[0].m_value)};
-    const std::string failureTrace2 {
-        fmt::format("[{}] -> Failure: The query is empty", name)};
+        fmt::format("[{}] -> Failure: Message reference \"{}\" not found", name, parameters[0].m_value)};
+    const std::string failureTrace2 {fmt::format("[{}] -> Failure: The message is empty", name)};
     const std::string failureTrace3 {
         fmt::format("[{}] -> Failure: Upgrade confirmation message could not be send", name)};
     const std::string failureTrace4 {

--- a/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.cpp
@@ -19,7 +19,7 @@ using helper::base::Parameter;
 namespace builder::internals::builders
 {
 
-// field: +upgrade_confirmation_send/ar_message
+// field: +send_upgrade_confirmation/ar_message
 base::Expression opBuilderHelperSendUpgradeConfirmation(const std::any& definition)
 {
     // Extract parameters from any
@@ -70,7 +70,7 @@ base::Expression opBuilderHelperSendUpgradeConfirmation(const std::any& definiti
             query = event->str(rValue).value();
 
             //Verify that its a non-empty object
-            if (query.empty() || query == "{}")
+            if (query.empty() || "{}" == query)
             {
                 return base::result::makeFailure(event, failureTrace2);
             }

--- a/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.cpp
@@ -5,17 +5,13 @@
 
 #include "opBuilderHelperUpgradeConfirmation.hpp"
 
-#include <algorithm>
 #include <optional>
 #include <string>
-#include <string_view>
-#include <variant>
 
 #include "syntax.hpp"
 
 #include <baseHelper.hpp>
 #include <utils/socketInterface/unixSecureStream.hpp>
-#include <utils/stringUtils.hpp>
 
 namespace sint = base::utils::socketInterface;
 using helper::base::Parameter;
@@ -54,9 +50,9 @@ base::Expression opBuilderHelperSendUpgradeConfirmation(const std::any& definiti
     const std::string failureTrace2 {
         fmt::format("[{}] -> Failure: The query is empty", name)};
     const std::string failureTrace3 {
-        fmt::format("[{}] -> Failure: Upgrade Confirmation message could not be send", name)};
+        fmt::format("[{}] -> Failure: Upgrade confirmation message could not be send", name)};
     const std::string failureTrace4 {
-        fmt::format("[{}] -> Failure: Error trying to send Update Confirmation message: ", name)};
+        fmt::format("[{}] -> Failure: Error trying to send upgrade confirmation message: ", name)};
 
     // Function that implements the helper
     return base::Term<base::EngineOp>::create(

--- a/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.hpp
+++ b/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.hpp
@@ -18,8 +18,12 @@ namespace builder::internals::builders
 
 constexpr const char* WM_UPGRADE_SOCK {"/var/ossec/queue/tasks/upgrade"};
 
-
-//TODO
+/**
+ * @brief Sends upgrade confirmation throug UPGRADE_MQ socket
+ *
+ * @param definition The transformation definition.
+ * @return base::Expression The ifter with the transformation.
+ */
 base::Expression opBuilderHelperSendUpgradeConfirmation(const std::any& definition);
 
 } // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.hpp
+++ b/src/engine/source/builder/builders/opBuilderHelperUpgradeConfirmation.hpp
@@ -1,0 +1,27 @@
+/* Copyright (C) 2015-2023, Wazuh Inc.
+ * All rights reserved.
+ *
+ */
+
+#ifndef _OP_BUILDER_HELPER_UPGRADE_CONFIRMATION_H
+#define _OP_BUILDER_HELPER_UPGRADE_CONFIRMATION_H
+
+#include <any>
+
+#include <baseTypes.hpp>
+
+#include "expression.hpp"
+#include <utils/stringUtils.hpp>
+
+namespace builder::internals::builders
+{
+
+constexpr const char* WM_UPGRADE_SOCK {"/var/ossec/queue/tasks/upgrade"};
+
+
+//TODO
+base::Expression opBuilderHelperSendUpgradeConfirmation(const std::any& definition);
+
+} // namespace builder::internals::builders
+
+#endif // _OP_BUILDER_HELPER_UPGRADE_CONFIRMATION_H

--- a/src/engine/source/builder/register.hpp
+++ b/src/engine/source/builder/register.hpp
@@ -9,6 +9,7 @@
 #include "builders/opBuilderHelperFilter.hpp"
 #include "builders/opBuilderHelperMap.hpp"
 #include "builders/opBuilderHelperNetInfoAddress.hpp"
+#include "builders/opBuilderHelperUpgradeConfirmation.hpp"
 #include "builders/opBuilderKVDB.hpp"
 #include "builders/opBuilderLogParser.hpp"
 #include "builders/opBuilderSCAdecoder.hpp"
@@ -159,6 +160,9 @@ static void registerBuilders(std::shared_ptr<Registry> registry, const dependenc
     registry->registerBuilder(builders::opBuilderSpecificHLPQuotedParse, "helper.parse_quoted");
     registry->registerBuilder(builders::opBuilderSpecificHLPBetweenParse, "helper.parse_between");
     registry->registerBuilder(builders::opBuilderSpecificHLPAlphanumericParse, "helper.parse_alphanumeric");
+
+    // Update Confirmation
+    registry->registerBuilder(builders::opBuilderHelperSendUpgradeConfirmation, "helper.upgrade_confirmation_send");
 }
 } // namespace builder::internals
 

--- a/src/engine/source/builder/register.hpp
+++ b/src/engine/source/builder/register.hpp
@@ -161,8 +161,8 @@ static void registerBuilders(std::shared_ptr<Registry> registry, const dependenc
     registry->registerBuilder(builders::opBuilderSpecificHLPBetweenParse, "helper.parse_between");
     registry->registerBuilder(builders::opBuilderSpecificHLPAlphanumericParse, "helper.parse_alphanumeric");
 
-    // Update Confirmation
-    registry->registerBuilder(builders::opBuilderHelperSendUpgradeConfirmation, "helper.upgrade_confirmation_send");
+    // Upgrade Confirmation
+    registry->registerBuilder(builders::opBuilderHelperSendUpgradeConfirmation, "helper.send_upgrade_confirmation");
 }
 } // namespace builder::internals
 

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -168,7 +168,6 @@ add_executable(opBuilderHelperMap_test
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderKVDBDelete_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderKVDBGet_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderKVDBSet_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperUpgradeConfirmation_test.cpp
 )
 gtest_discover_tests(opBuilderHelperMap_test)
 
@@ -221,3 +220,9 @@ add_executable(opBuilderHelperNetInfoAddress_test
   ${TEST_SOURCE_DIR}/base/socketInterface/testAuxiliar/socketAuxiliarFunctions.cpp
 )
 gtest_discover_tests(opBuilderHelperNetInfoAddress_test)
+
+add_executable(opBuilderHelperUpdateConfirmation_test
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperUpgradeConfirmation_test.cpp
+  ${TEST_SOURCE_DIR}/base/socketInterface/testAuxiliar/socketAuxiliarFunctions.cpp
+)
+gtest_discover_tests(opBuilderHelperUpdateConfirmation_test)

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -221,8 +221,8 @@ add_executable(opBuilderHelperNetInfoAddress_test
 )
 gtest_discover_tests(opBuilderHelperNetInfoAddress_test)
 
-add_executable(opBuilderHelperUpdateConfirmation_test
+add_executable(opBuilderHelperUpgradeConfirmation_test
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperUpgradeConfirmation_test.cpp
   ${TEST_SOURCE_DIR}/base/socketInterface/testAuxiliar/socketAuxiliarFunctions.cpp
 )
-gtest_discover_tests(opBuilderHelperUpdateConfirmation_test)
+gtest_discover_tests(opBuilderHelperUpgradeConfirmation_test)

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -168,6 +168,7 @@ add_executable(opBuilderHelperMap_test
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderKVDBDelete_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderKVDBGet_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderKVDBSet_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperUpgradeConfirmation_test.cpp
 )
 gtest_discover_tests(opBuilderHelperMap_test)
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperActiveResponse_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperActiveResponse_test.cpp
@@ -11,7 +11,6 @@
 
 #include <baseTypes.hpp>
 #include <utils/socketInterface/unixDatagram.hpp>
-#include <utils/socketInterface/unixSecureStream.hpp>
 #include <wdb/wdb.hpp>
 
 #include <logging/logging.hpp>

--- a/src/engine/test/source/builder/builders/opBuilderHelperUpgradeConfirmation_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperUpgradeConfirmation_test.cpp
@@ -1,0 +1,102 @@
+/* Copyright (C) 2015-2023, Wazuh Inc.
+ * All rights reserved.
+ *
+ */
+
+#include <any>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <baseTypes.hpp>
+#include <utils/socketInterface/unixSecureStream.hpp>
+
+#include "opBuilderHelperUpgradeConfirmation.hpp"
+#include "socketAuxiliarFunctions.hpp"
+
+using namespace base;
+using namespace builder::internals::builders;
+
+const std::string targetField {"/result"};
+const std::string arSendHFName {"upgrade_confirmation_send"};
+
+
+TEST(opBuilderUpgradeConfirmationTestSuite, Builds)
+{
+    auto tuple {std::make_tuple(targetField, arSendHFName, std::vector<std::string> {"query params"})};
+
+    ASSERT_NO_THROW(opBuilderHelperSendUpgradeConfirmation(tuple));
+}
+
+TEST(opBuilderUpgradeConfirmationTestSuite, BuildsNoParameterError)
+{
+    auto tuple {std::make_tuple(targetField, arSendHFName, std::vector<std::string> {})};
+
+    ASSERT_THROW(opBuilderHelperSendUpgradeConfirmation(tuple), std::runtime_error);
+}
+
+TEST(opBuilderUpgradeConfirmationTestSuite, Send)
+{
+    // auto tuple {std::make_tuple(targetField, arSendHFName, std::vector<std::string> {"test\n123"})};
+    // auto op {opBuilderHelperSendUpgradeConfirmation(tuple)->getPtr<Term<EngineOp>>()->getFn()};
+
+    // auto serverSocketFD = testBindUnixSocket(AR_QUEUE_PATH, SOCK_DGRAM);
+    // ASSERT_GT(serverSocketFD, 0);
+
+    // auto event {make_shared<json::Json>(R"({"agent_id": "007"})")};
+    // auto result {op(event)};
+    // ASSERT_TRUE(result);
+    // ASSERT_TRUE(result.payload()->isBool(targetField));
+    // ASSERT_TRUE(result.payload()->getBool(targetField));
+
+    // // Check received command on the AR's queue
+    // ASSERT_STREQ(testRecvString(serverSocketFD, SOCK_DGRAM).c_str(), "test\n123");
+
+    // close(serverSocketFD);
+    // unlink(AR_QUEUE_PATH);
+}
+
+TEST(opBuilderUpgradeConfirmationTestSuite, SendFromReference)
+{
+    // auto tuple {
+    //     std::make_tuple(targetField, arSendHFName, std::vector<std::string> {"$wdb.query_params"})};
+    // auto op {opBuilderHelperSendUpgradeConfirmation(tuple)->getPtr<Term<EngineOp>>()->getFn()};
+
+    // auto serverSocketFD = testBindUnixSocket(AR_QUEUE_PATH, SOCK_DGRAM);
+    // ASSERT_GT(serverSocketFD, 0);
+
+    // auto event {
+    //     make_shared<json::Json>(R"({"wdb": {"query_params": "reference_test"}})")};
+    // auto result {op(event)};
+    // ASSERT_TRUE(result);
+    // ASSERT_TRUE(result.payload()->isBool(targetField));
+    // ASSERT_TRUE(result.payload()->getBool(targetField));
+
+    // // Check received command on the AR's queue
+    // ASSERT_STREQ(testRecvString(serverSocketFD, SOCK_DGRAM).c_str(), "reference_test");
+
+    // close(serverSocketFD);
+    // unlink(AR_QUEUE_PATH);
+}
+
+TEST(opBuilderUpgradeConfirmationTestSuite, SendEmptyReferencedValueError)
+{
+    // auto tuple {
+    //     std::make_tuple(targetField, arSendHFName, std::vector<std::string> {"$wdb.query_params"})};
+    // auto op {opBuilderHelperSendUpgradeConfirmation(tuple)->getPtr<Term<EngineOp>>()->getFn()};
+
+    // auto event {make_shared<json::Json>(R"({"wdb": {"query_params": ""}})")};
+    // auto result {op(event)};
+    // ASSERT_FALSE(result);
+}
+
+TEST(opBuilderUpgradeConfirmationTestSuite, SendEmptyReferenceError)
+{
+    // auto tuple {
+    //     std::make_tuple(targetField, arSendHFName, std::vector<std::string> {"$wdb.query_params"})};
+    // auto op {opBuilderHelperSendUpgradeConfirmation(tuple)->getPtr<Term<EngineOp>>()->getFn()};
+
+    // auto event {make_shared<json::Json>(R"({"wdb": {"NO_query_params": "123"}})")};
+    // auto result {op(event)};
+    // ASSERT_FALSE(result);
+}

--- a/src/engine/test/source/builder/builders/opBuilderHelperUpgradeConfirmation_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperUpgradeConfirmation_test.cpp
@@ -26,7 +26,7 @@ const std::string messageReferenceObject {"$fieldReferenceObject"};
 
 TEST(opBuilderUpgradeConfirmationTestSuite, Build)
 {
-    auto tuple {std::make_tuple(targetField, upgradeConfirmationHelperName, std::vector<std::string> {"query params"})};
+    auto tuple {std::make_tuple(targetField, upgradeConfirmationHelperName, std::vector<std::string> {messageReferenceObject})};
 
     ASSERT_NO_THROW(opBuilderHelperSendUpgradeConfirmation(tuple));
 }
@@ -46,21 +46,10 @@ TEST(opBuilderUpgradeConfirmationTestSuite, ErrorBuildWithMoreParameters)
     ASSERT_THROW(opBuilderHelperSendUpgradeConfirmation(tuple), std::runtime_error);
 }
 
-TEST(opBuilderUpgradeConfirmationTestSuite, SendMessageFromValue)
+TEST(opBuilderUpgradeConfirmationTestSuite, ErrorBuildMessageNotReference)
 {
     auto tuple {std::make_tuple(targetField, upgradeConfirmationHelperName, std::vector<std::string> {testMessage})};
-    auto op {opBuilderHelperSendUpgradeConfirmation(tuple)->getPtr<Term<EngineOp>>()->getFn()};
-
-    auto serverSocketFD = testBindUnixSocket(WM_UPGRADE_SOCK, SOCK_STREAM);
-    ASSERT_GT(serverSocketFD, 0);
-
-    auto event {std::make_shared<json::Json>(R"({})")};
-    auto result {op(event)};
-
-    ASSERT_FALSE(result);
-
-    close(serverSocketFD);
-    unlink(WM_UPGRADE_SOCK);
+    ASSERT_THROW(opBuilderHelperSendUpgradeConfirmation(tuple), std::runtime_error);
 }
 
 TEST(opBuilderUpgradeConfirmationTestSuite, SendFromReferenceString)

--- a/src/engine/test/source/builder/builders/opBuilderHelperUpgradeConfirmation_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperUpgradeConfirmation_test.cpp
@@ -80,7 +80,8 @@ TEST(opBuilderUpgradeConfirmationTestSuite, SendAndReceivedMessage)
 
 TEST(opBuilderUpgradeConfirmationTestSuite, SendFromReference)
 {
-    auto tuple {std::make_tuple(targetField, upgradeConfirmationHelperName, std::vector<std::string> {messageReference})};
+    auto tuple {
+        std::make_tuple(targetField, upgradeConfirmationHelperName, std::vector<std::string> {messageReference})};
     auto op {opBuilderHelperSendUpgradeConfirmation(tuple)->getPtr<Term<EngineOp>>()->getFn()};
 
     auto serverSocketFD = testBindUnixSocket(WM_UPGRADE_SOCK, SOCK_STREAM);
@@ -113,7 +114,8 @@ TEST(opBuilderUpgradeConfirmationTestSuite, SendFromReference)
 
 TEST(opBuilderUpgradeConfirmationTestSuite, SendEmptyReferencedValueError)
 {
-    auto tuple {std::make_tuple(targetField, upgradeConfirmationHelperName, std::vector<std::string> {messageReference})};
+    auto tuple {
+        std::make_tuple(targetField, upgradeConfirmationHelperName, std::vector<std::string> {messageReference})};
     auto op {opBuilderHelperSendUpgradeConfirmation(tuple)->getPtr<Term<EngineOp>>()->getFn()};
 
     auto serverSocketFD = testBindUnixSocket(WM_UPGRADE_SOCK, SOCK_STREAM);
@@ -130,7 +132,8 @@ TEST(opBuilderUpgradeConfirmationTestSuite, SendEmptyReferencedValueError)
 
 TEST(opBuilderUpgradeConfirmationTestSuite, SendWrongReferenceError)
 {
-    auto tuple {std::make_tuple(targetField, upgradeConfirmationHelperName, std::vector<std::string> {"$NonExistentReference"})};
+    auto tuple {std::make_tuple(
+        targetField, upgradeConfirmationHelperName, std::vector<std::string> {"$NonExistentReference"})};
     auto op {opBuilderHelperSendUpgradeConfirmation(tuple)->getPtr<Term<EngineOp>>()->getFn()};
 
     auto serverSocketFD = testBindUnixSocket(WM_UPGRADE_SOCK, SOCK_STREAM);

--- a/src/engine/test/source/builder/builders/opBuilderHelperUpgradeConfirmation_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperUpgradeConfirmation_test.cpp
@@ -19,7 +19,7 @@ using namespace base;
 using namespace builder::internals::builders;
 
 const std::string targetField {"/result"};
-const std::string upgradeConfirmationHelperName {"upgrade_confirmation_send"};
+const std::string upgradeConfirmationHelperName {"send_upgrade_confirmation"};
 const std::string testMessage {"{\"fieldReference\":\"test String Sent\"}"};
 const std::string messageReferenceString {"$fieldReference"};
 const std::string messageReferenceObject {"$fieldReferenceObject"};

--- a/src/engine/test/source/builder/builders/opBuilderSCAdecoder_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderSCAdecoder_test.cpp
@@ -15,7 +15,6 @@
 
 #include <baseTypes.hpp>
 #include <utils/socketInterface/unixDatagram.hpp>
-#include <utils/socketInterface/unixSecureStream.hpp>
 
 #include <logging/logging.hpp>
 #include <wdb/wdb.hpp>

--- a/src/engine/test/source/builder/builders/opBuilderWdbQuery_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderWdbQuery_test.cpp
@@ -15,7 +15,6 @@
 
 #include <baseTypes.hpp>
 #include <utils/socketInterface/unixDatagram.hpp>
-#include <utils/socketInterface/unixSecureStream.hpp>
 
 #include <logging/logging.hpp>
 #include <wdb/wdb.hpp>

--- a/src/engine/test/source/builder/builders/opBuilderWdbUpdate_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderWdbUpdate_test.cpp
@@ -11,7 +11,6 @@
 
 #include <baseTypes.hpp>
 #include <utils/socketInterface/unixDatagram.hpp>
-#include <utils/socketInterface/unixSecureStream.hpp>
 
 #include <logging/logging.hpp>
 #include <wdb/wdb.hpp>

--- a/src/engine/test/source/wdb/wdb_test.cpp
+++ b/src/engine/test/source/wdb/wdb_test.cpp
@@ -6,7 +6,6 @@
 #include <logging/logging.hpp>
 
 #include "socketAuxiliarFunctions.hpp"
-#include <utils/socketInterface/unixSecureStream.hpp>
 
 using namespace wazuhdb;
 


### PR DESCRIPTION
|Related issue|
|---|
|#16467|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

One important component of analysisD process is the UPGRADE_MQ 'u' queue, which is responsible for handling messages related to upgrades. To ensure that all incoming messages are correctly processed by the engine, it is necessary to conduct a detailed study of this queue and how it's handled.
After the analysis is complete, it becomes necessary to create a new decoder that can handle all incoming messages from the UPGRADE_MQ 'u' queue, ensuring that they are properly processed by the engine.

Upgrade MQ communicates through the socket using the UNIX secure stream protocol, so it was mandatory to develop a new helper function. It couldn't be possible to update or modify the one that we already have (used by the active response module) because it uses another protocol, it would have been an unnecessary complexity to the end user.

- Analysis
  - [x] Test on agent receiving messages on manager

- Helper development
  - [x] Code development
  - [x] UT
  
- Decoder
  - [x] Development
  - [x] Additional test cases
  
- Documentation
  - [x] Headers and in-code
  - [x] Outside docs containing helpers
  