### PR TITLE
Added plus symbol to macOS ULS timestamp

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -150,7 +150,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
             (pieces[13] == ':') &&
             (pieces[16] == ':') &&
             (pieces[19] == '.') &&
-            (pieces[26] == '-') &&
+            (pieces[26] == '-' || pieces[26] == '+') &&
             (pieces[31] == ' ') && (lf->log += 32)
         )
 


### PR DESCRIPTION
|Related issue|
|---|
|#15669|

Fixed a problem with the `+` symbol in the macOS ULS timestamp, which was not accepted.

We can check the correct performance of the PR with `wazuh-logtest`:
```bash
#wazuh-logtest
Starting wazuh-logtest v4.6.0
Type one log per line

2022-12-13 14:19:30.429319+0200  localhost sshd[1115]: Failed password for invalid user hacker from 192.168.56.1 port 50384 ssh2

**Phase 1: Completed pre-decoding.
	full event: '2022-12-13 14:19:30.429319+0200  localhost sshd[1115]: Failed password for invalid user hacker from 192.168.56.1 port 50384 ssh2'
	timestamp: '2022-12-13 14:19:30.429319+0200'
	program_name: 'sshd'

**Phase 2: Completed decoding.
	name: 'sshd'
	parent: 'sshd'
	srcip: '192.168.56.1'
	srcuser: 'hacker'

**Phase 3: Completed filtering (rules).
	id: '5710'
	level: '5'
	description: 'sshd: Attempt to login using a non-existent user'
	groups: '['syslog', 'sshd', 'authentication_failed', 'invalid_login']'
	firedtimes: '1'
	gdpr: '['IV_35.7.d', 'IV_32.2']'
	gpg13: '['7.1']'
	hipaa: '['164.312.b']'
	mail: 'False'
	mitre.id: '['T1110.001', 'T1021.004', 'T1078']'
	mitre.tactic: '['Credential Access', 'Lateral Movement', 'Defense Evasion', 'Persistence', 'Privilege Escalation', 'Initial Access']'
	mitre.technique: '['Password Guessing', 'SSH', 'Valid Accounts']'
	nist_800_53: '['AU.14', 'AC.7', 'AU.6']'
	pci_dss: '['10.2.4', '10.2.5', '10.6.1']'
	tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']'
**Alert to be generated.

```