### PR TITLE
Refactor default_config method to take into account user config found in .aws/config file

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -251,18 +251,22 @@ class WazuhIntegration:
                 self.db_connector.execute(self.sql_drop_table.format(table='trail_progress'))
 
     @staticmethod
-    def default_config(profile: str):
-        """Sets a default configuration in case retry parameters are missing.
+    def default_config(profile: str = 'default'):
+        """Sets the parameters found in .aws/config as a default configuration for client.
 
-        This method is called when Wazuh Integration is instantiated and sets the configuration for received param
+        This method is called when Wazuh Integration is instantiated and sets a default config using .aws/config file
+        using the profile received from parameter.
 
-        If there is no configuration in config path a Config object is created and default configuration is set.
-    Else, if max_attempts and mode configuration are not within the param configuration dict
+        If .aws/config file exist the file is retrieved and read to check for the existence of retry parameters mode and
+         max attempts if they exist and empty dictionary is returned and config is handled by botocore but if they dont
+         exist a botocore Config object is created and default configuration is set using user config for received
+         profile and retry parameters are set to avoid a throttling exception
 
         Parameters
         ----------
         profile : string
                 Aws profile configuration to use
+
         Returns
         -------
         dict
@@ -270,11 +274,47 @@ class WazuhIntegration:
 
         Raises
         ------
-
-
+        KeyError
+             KeyError when there is no region declared in .aws/config file
         """
         args = {}
-        if not path.exists(DEFAULT_AWS_CONFIG_PATH):
+
+        if path.exists(DEFAULT_AWS_CONFIG_PATH):
+            # Get User Aws Config
+            aws_config = get_aws_config_params()
+
+            # Set profile
+            profile = profile if profile is not None else 'default'
+
+            user_config = aws_config._sections[profile]
+
+            # Checks if retries config have the necessary parameters to avoid a throttling exception
+            if 'retries' in user_config:
+                retries = user_config['retries']
+                retries.setdefault('max_attempts', 10)
+                retries.setdefault('mode', 'standard')
+            else:
+                return args
+
+            # Get region name in the config file or raised a key error
+            region_name = user_config.get('region') or user_config['region_name']
+
+            # Get primary botocore Config parameters
+            signature_version = user_config.get('signature_version', 'v4')
+            s3 = user_config.get('s3')
+            proxies = user_config.get('proxies')
+            proxies_config = user_config.get('proxies_config')
+
+            args['config'] = botocore.config.Config(
+                region_name,
+                retries,
+                signature_version,
+                **s3,
+                **proxies,
+                **proxies_config
+            )
+
+        else:
             args['config'] = botocore.config.Config(
                 retries={
                     'max_attempts': 10,
@@ -284,29 +324,6 @@ class WazuhIntegration:
             debug(
                 f"Generating default configuration for retries: mode {args['config'].retries['mode']} - max_attempts {args['config'].retries['max_attempts']}",
                 2)
-        else:
-            aws_config = get_aws_config_params()
-
-            config_dict = dict(aws_config.items(profile))
-
-            if config_dict['retry_mode'] and config_dict['max_attempts']:
-                debug(
-                    f'Found configuration for connection retries in {path.join(path.expanduser("~"), ".aws", "config")}',
-                    2)
-            else:
-
-                if not config_dict['max_attempts']:
-                    config_dict['retries'].update({
-                        'max_attempts': 10
-                    })
-                    debug("")
-
-                if not config_dict['retry_mode']:
-                    config_dict['retries'].update({
-                        'mode': 'standard'
-                    })
-
-                args['config'] = botocore.config.Config(config_dict)
 
         return args
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -412,7 +412,7 @@ class WazuhIntegration:
                                         profile_config=profile_config)
 
             except (KeyError, ValueError) as e:
-                print('Invalid key, value found in config '.format(e))
+                print('Invalid key or value found in config '.format(e))
                 sys.exit(17)
 
             debug(

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # Import AWS S3
 #
 # Copyright (C) 2015, Wazuh Inc.
@@ -76,7 +75,8 @@ if sys.version_info[0] == 3:
 ################################################################################
 
 CREDENTIALS_URL = 'https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html'
-RETRY_CONFIGURATION_URL = 'https://documentation.wazuh.com/current/amazon/services/prerequisites/considerations.html#Connection-configuration-for-retries'
+RETRY_CONFIGURATION_URL = 'https://documentation.wazuh.com/current/amazon/services/prerequisites/considerations.html' \
+                          '#Connection-configuration-for-retries'
 DEPRECATED_MESSAGE = 'The {name} authentication parameter was deprecated in {release}. ' \
                      'Please use another authentication method instead. Check {url} for more information.'
 GUARDDUTY_URL = 'https://documentation.wazuh.com/current/amazon/services/supported-services/guardduty.html'
@@ -93,9 +93,13 @@ THROTTLING_EXCEPTION_ERROR_CODE = "ThrottlingException"
 
 INVALID_CREDENTIALS_ERROR_MESSAGE = "Invalid credentials to access S3 Bucket"
 INVALID_REQUEST_TIME_ERROR_MESSAGE = "The server datetime and datetime of the AWS environment differ"
-THROTTLING_EXCEPTION_ERROR_MESSAGE = "The '{name}' request was denied due to request throttling. If the problem persists" \
-                                     " check the following link to learn how to use the Retry configuration to avoid it: " \
-                                     f"'{RETRY_CONFIGURATION_URL}'"
+THROTTLING_EXCEPTION_ERROR_MESSAGE = "The '{name}' request was denied due to request throttling. If the problem " \
+                                     "persists check the following link to learn how to use the Retry configuration " \
+                                     f"to avoid it: {RETRY_CONFIGURATION_URL}'"
+RETRY_ATTEMPTS_KEY: str = "max_attempts"
+RETRY_MODE_CONFIG_KEY: str = "retry_mode"
+RETRY_MODE_BOTO_KEY: str = "mode"
+
 
 ALL_REGIONS = [
     'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2', 'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-2',
@@ -107,8 +111,7 @@ ALL_REGIONS = [
 # Helpers functions
 ################################################################################
 
-
-def set_profile_dict_config(boto_config: dict,profile:str, profile_config):
+def set_profile_dict_config(boto_config: dict, profile: str, profile_config: dict):
     """Creates a botocore.config.Config object with the specified profile and profile_config.
 
     This function reads the profile configuration from the provided profile_config object and extracts the necessary
@@ -127,46 +130,36 @@ def set_profile_dict_config(boto_config: dict,profile:str, profile_config):
 
     profile_config : dict
         The user config dict containing the profile configuration.
-
-    Raises
-    ------
-    ValueError
-        ValueError when there is an error parsing a value in config file
     """
-    try:
+    # Set s3 config
+    if f'{profile}.s2' in str(profile_config):
+        s3_config = {
+            "max_concurrent_requests": int(profile_config.get(f'{profile}.s2.max_concurrent_requests', 10)),
+            "max_queue_size": int(profile_config.get(f'{profile}.s2.max_queue_size', 10)),
+            "multipart_threshold": profile_config.get(f'{profile}.s2.multipart_threshold', '8MB'),
+            "multipart_chunksize": profile_config.get(f'{profile}.s2.multipart_chunksize', '8MB'),
+            "max_bandwidth": profile_config.get(f'{profile}.s2.max_bandwidth'),
+            "use_accelerate_endpoint": bool(profile_config.get(f'{profile}.s2.use_accelerate_endpoint', False)),
+            "addressing_style": profile_config.get(f'{profile}.s2.addressing_style', 'auto'),
+        }
+        boto_config['config'].s3 = s3_config
 
-        # Set s2 Config
-        if f'{profile}.s2' in str(profile_config):
-            s3_config = {
-                "max_concurrent_requests": int(profile_config.get(f'{profile}.s2.max_concurrent_requests', 10)),
-                "max_queue_size": int(profile_config.get(f'{profile}.s2.max_queue_size', 10)),
-                "multipart_threshold": profile_config.get(f'{profile}.s2.multipart_threshold', '8MB'),
-                "multipart_chunksize": profile_config.get(f'{profile}.s2.multipart_chunksize', '8MB'),
-                "max_bandwidth": profile_config.get(f'{profile}.s2.max_bandwidth'),
-                "use_accelerate_endpoint": bool(profile_config.get(f'{profile}.s2.use_accelerate_endpoint', False)),
-                "addressing_style": profile_config.get(f'{profile}.s2.addressing_style', 'auto'),
-                }
-            boto_config['config'].s3 = s3_config
+    # Set Proxies configuration
+    if f'{profile}.proxy' in str(profile_config):
+        proxy_config = {
+            "host": profile_config.get(f'{profile}.proxy.host'),
+            "port": int(profile_config.get(f'{profile}.proxy.port')),
+            "username": profile_config.get(f'{profile}.proxy.username'),
+            "password": profile_config.get(f'{profile}.proxy.password'),
+        }
+        boto_config['config'].proxies = proxy_config
 
-        # Set Proxies configuration
-        if f'{profile}.proxy' in str(profile_config):
-            proxy_config = {
-                "host": profile_config.get(f'{profile}.proxy.host'),
-                "port": int(profile_config.get(f'{profile}.proxy.port')),
-                "username": profile_config.get(f'{profile}.proxy.username'),
-                "password": profile_config.get(f'{profile}.proxy.password'),
-            }
-            boto_config['config'].proxies = proxy_config
-
-            proxies_config = {
-                "ca_bundle": profile_config.get(f'{profile}.proxy.ca_bundle'),
-                "client_cert": profile_config.get(f'{profile}.proxy.client_cert'),
-                "use_forwarding_for_https": bool(profile_config.get(f'{profile}.proxy.use_forwarding_for_https', False))
-                }
-            boto_config['config'].proxies_config = proxies_config
-
-    except ValueError:
-        raise ValueError
+        proxies_config = {
+            "ca_bundle": profile_config.get(f'{profile}.proxy.ca_bundle'),
+            "client_cert": profile_config.get(f'{profile}.proxy.client_cert'),
+            "use_forwarding_for_https": bool(profile_config.get(f'{profile}.proxy.use_forwarding_for_https', False))
+        }
+        boto_config['config'].proxies_config = proxies_config
 
 
 ################################################################################
@@ -255,8 +248,7 @@ class WazuhIntegration:
         # GovCloud regions
         self.gov_regions = {'us-gov-east-1', 'us-gov-west-1'}
 
-        self.connection_config = self.default_config(profile=aws_profile,
-                                                     region=region)
+        self.connection_config = self.default_config(profile=aws_profile)
 
         self.client = self.get_client(access_key=access_key,
                                       secret_key=secret_key,
@@ -319,24 +311,22 @@ class WazuhIntegration:
                 self.db_connector.execute(self.sql_drop_table.format(table='trail_progress'))
 
     @staticmethod
-    def default_config(profile: str, region: str):
+    def default_config(profile: str):
         """Sets the parameters found in user config file as a default configuration for client.
 
         This method is called when Wazuh Integration is instantiated and sets a default config using .aws/config file
         using the profile received from parameter.
 
         If .aws/config file exist the file is retrieved and read to check for the existence of retry parameters mode and
-         max attempts if they exist and empty dictionary is returned and config is handled by botocore but if they don't
-         exist a botocore Config object is created and default configuration is set using user config for received
-         profile and retries parameters are set to avoid a throttling exception
+        max attempts if they exist and empty dictionary is returned and config is handled by botocore but if they don't
+        exist a botocore Config object is created and default configuration is set using user config for received
+        profile and retries parameters are set to avoid a throttling exception
 
         Parameters
         ----------
         profile : string
                 Aws profile configuration to use
 
-        region : string
-                Aws region to use
         Returns
         -------
         dict
@@ -363,41 +353,26 @@ class WazuhIntegration:
             profile = profile if profile is not None else 'default'
 
             # Get profile config dictionary
-            profile_config = aws_config._sections[profile]
-
-            # Get region name in the config file or raised a key error
-            try:
-                config_file_region = profile_config.get('region') or profile_config['region_name']
-
-                # If Region is passed as parameter check if matches user config
-                if region is not None and region != config_file_region:
-                    debug(f'Region passed as parameter does not match region found in {profile} config file', 2)
-                    sys.exit(20)
-
-                args['config'].region_name = config_file_region
-
-            except KeyError:
-                print(f'No region found in {profile} profile config)')
-                sys.exit(17)
+            profile_config = {option: aws_config.get(profile, option) for option in aws_config.options(profile)}
 
             # Map Primary Botocore Config parameters with profile config file
             try:
                 # Checks for retries config in profile config and sets it if not found to avoid throttling exception
-                if 'max_attempts' in profile_config \
-                        or 'retry_mode' in profile_config:
+                if RETRY_ATTEMPTS_KEY in profile_config \
+                        or RETRY_MODE_CONFIG_KEY in profile_config:
                     retries = {
-                        'max_attempts': int(profile_config.get('max_attempts', 10)),
-                        'mode': profile_config.get('retry_mode', 'standard')
+                        RETRY_ATTEMPTS_KEY: int(profile_config.get(RETRY_ATTEMPTS_KEY, 10)),
+                        RETRY_MODE_BOTO_KEY: profile_config.get(RETRY_MODE_CONFIG_KEY, 'standard')
                     }
                 else:
                     # Set retry config
                     retries = {
-                        'max_attempts': 10,
-                        'mode': 'standard'
+                        RETRY_ATTEMPTS_KEY: 10,
+                        RETRY_MODE_BOTO_KEY: 'standard'
                     }
                     debug(
                         "No retries configuration found in profile config generating default configuration for "
-                        f"retries: mode {retries['mode']} - max_attempts {retries['max_attempts']}",
+                        f"retries: mode: {retries['mode']} - max_attempts: {retries['max_attempts']}",
                         2)
 
                 args['config'].retries = retries
@@ -423,12 +398,13 @@ class WazuhIntegration:
             # Set default config
             args['config'] = botocore.config.Config(
                 retries={
-                    'max_attempts': 10,
-                    'mode': 'standard'
+                    RETRY_ATTEMPTS_KEY: 10,
+                    RETRY_MODE_BOTO_KEY: 'standard'
                 }
             )
             debug(
-                f"Generating default configuration for retries: mode {args['config'].retries['mode']} - max_attempts {args['config'].retries['max_attempts']}",
+                f"Generating default configuration for retries: {RETRY_MODE_BOTO_KEY} {args['config'].retries[RETRY_MODE_BOTO_KEY]} - "
+                f"{RETRY_ATTEMPTS_KEY} {args['config'].retries[RETRY_ATTEMPTS_KEY]}",
                 2)
 
         return args

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -352,9 +352,6 @@ class WazuhIntegration:
         """
         args = {}
 
-        import pydevd_pycharm
-        pydevd_pycharm.settrace('172.19.0.1', port=10000, stdoutToServer=True, stderrToServer=True)
-
         if path.exists(DEFAULT_AWS_CONFIG_PATH):
             # Create boto Config object
             args['config'] = botocore.config.Config()

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -112,13 +112,13 @@ ALL_REGIONS = [
 ################################################################################
 
 def set_profile_dict_config(boto_config: dict, profile: str, profile_config: dict):
-    """Creates a botocore.config.Config object with the specified profile and profile_config.
+    """Create a botocore.config.Config object with the specified profile and profile_config.
 
     This function reads the profile configuration from the provided profile_config object and extracts the necessary
     parameters to create a botocore.config.Config object.
     It handles the signature version, s3, proxies, and proxies_config settings found in the .aws/config file for the
     specified profile. If a setting is not found, a default value is used based on the boto3 documentation and config is
-    set into the boto_config
+    set into the boto_config.
 
     Parameters
     ----------
@@ -316,7 +316,7 @@ class WazuhIntegration:
 
     @staticmethod
     def default_config(profile: str) -> dict:
-        """Sets the parameters found in user config file as a default configuration for client.
+        """Set the parameters found in user config file as a default configuration for client.
 
         This method is called when Wazuh Integration is instantiated and sets a default config using .aws/config file
         using the profile received from parameter.
@@ -324,28 +324,28 @@ class WazuhIntegration:
         If .aws/config file exist the file is retrieved and read to check for the existence of retry parameters mode and
         max attempts if they exist and empty dictionary is returned and config is handled by botocore but if they don't
         exist a botocore Config object is created and default configuration is set using user config for received
-        profile and retries parameters are set to avoid a throttling exception
+        profile and retries parameters are set to avoid a throttling exception.
 
         Parameters
         ----------
         profile : string
-                Aws profile configuration to use
+                Aws profile configuration to use.
 
         Returns
         -------
         dict
-            Configuration dictionary
+            Configuration dictionary.
 
         Raises
         ------
         KeyError
-            KeyError when there is no region in user config file
+            KeyError when there is no region in user config file.
 
         ValueError
-            ValueError when there is an error parsing config file
+            ValueError when there is an error parsing config file.
 
         NoSectionError
-            configparser error when given profile does not exist in user config file
+            configparser error when given profile does not exist in user config file.
         """
         args = {}
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -29,7 +29,7 @@
 #   20 - Unable to find SQS
 #   21 - Failed fetch/delete from SQS
 #   22 - Invalid region
-#   23 - Matching regions error
+#   23 - Profile not found
 
 import argparse
 import configparser
@@ -132,15 +132,17 @@ def set_profile_dict_config(boto_config: dict, profile: str, profile_config: dic
         The user config dict containing the profile configuration.
     """
     # Set s3 config
-    if f'{profile}.s2' in str(profile_config):
+    if f'{profile}.s3' in str(profile_config):
         s3_config = {
-            "max_concurrent_requests": int(profile_config.get(f'{profile}.s2.max_concurrent_requests', 10)),
-            "max_queue_size": int(profile_config.get(f'{profile}.s2.max_queue_size', 10)),
-            "multipart_threshold": profile_config.get(f'{profile}.s2.multipart_threshold', '8MB'),
-            "multipart_chunksize": profile_config.get(f'{profile}.s2.multipart_chunksize', '8MB'),
-            "max_bandwidth": profile_config.get(f'{profile}.s2.max_bandwidth'),
-            "use_accelerate_endpoint": bool(profile_config.get(f'{profile}.s2.use_accelerate_endpoint', False)),
-            "addressing_style": profile_config.get(f'{profile}.s2.addressing_style', 'auto'),
+            "max_concurrent_requests": int(profile_config.get(f'{profile}.s3.max_concurrent_requests', 10)),
+            "max_queue_size": int(profile_config.get(f'{profile}.s3.max_queue_size', 10)),
+            "multipart_threshold": profile_config.get(f'{profile}.s3.multipart_threshold', '8MB'),
+            "multipart_chunksize": profile_config.get(f'{profile}.s3.multipart_chunksize', '8MB'),
+            "max_bandwidth": profile_config.get(f'{profile}.s3.max_bandwidth'),
+            "use_accelerate_endpoint": (
+                True if profile_config.get(f'{profile}.s3.use_accelerate_endpoint') == 'true' else False
+            ),
+            "addressing_style": profile_config.get(f'{profile}.s3.addressing_style', 'auto'),
         }
         boto_config['config'].s3 = s3_config
 
@@ -157,7 +159,9 @@ def set_profile_dict_config(boto_config: dict, profile: str, profile_config: dic
         proxies_config = {
             "ca_bundle": profile_config.get(f'{profile}.proxy.ca_bundle'),
             "client_cert": profile_config.get(f'{profile}.proxy.client_cert'),
-            "use_forwarding_for_https": bool(profile_config.get(f'{profile}.proxy.use_forwarding_for_https', False))
+            "use_forwarding_for_https": (
+                True if profile_config.get(f'{profile}.proxy.use_forwarding_for_https') == 'true' else False
+            )
         }
         boto_config['config'].proxies_config = proxies_config
 
@@ -311,7 +315,7 @@ class WazuhIntegration:
                 self.db_connector.execute(self.sql_drop_table.format(table='trail_progress'))
 
     @staticmethod
-    def default_config(profile: str):
+    def default_config(profile: str) -> dict:
         """Sets the parameters found in user config file as a default configuration for client.
 
         This method is called when Wazuh Integration is instantiated and sets a default config using .aws/config file
@@ -339,6 +343,9 @@ class WazuhIntegration:
 
         ValueError
             ValueError when there is an error parsing config file
+
+        NoSectionError
+            configparser error when given profile does not exist in user config file
         """
         args = {}
 
@@ -352,8 +359,13 @@ class WazuhIntegration:
             # Set profile
             profile = profile if profile is not None else 'default'
 
-            # Get profile config dictionary
-            profile_config = {option: aws_config.get(profile, option) for option in aws_config.options(profile)}
+            try:
+                # Get profile config dictionary
+                profile_config = {option: aws_config.get(profile, option) for option in aws_config.options(profile)}
+
+            except configparser.NoSectionError:
+                print(f"No profile named: '{profile}' was found in the user config file")
+                sys.exit(23)
 
             # Map Primary Botocore Config parameters with profile config file
             try:
@@ -364,6 +376,10 @@ class WazuhIntegration:
                         RETRY_ATTEMPTS_KEY: int(profile_config.get(RETRY_ATTEMPTS_KEY, 10)),
                         RETRY_MODE_BOTO_KEY: profile_config.get(RETRY_MODE_CONFIG_KEY, 'standard')
                     }
+                    debug(
+                        f"Retries parameters found in user profile. Using profile '{profile}' retries configuration",
+                        2)
+
                 else:
                     # Set retry config
                     retries = {
@@ -371,7 +387,7 @@ class WazuhIntegration:
                         RETRY_MODE_BOTO_KEY: 'standard'
                     }
                     debug(
-                        "No retries configuration found in profile config generating default configuration for "
+                        "No retries configuration found in profile config. Generating default configuration for "
                         f"retries: mode: {retries['mode']} - max_attempts: {retries['max_attempts']}",
                         2)
 
@@ -391,11 +407,11 @@ class WazuhIntegration:
                 sys.exit(17)
 
             debug(
-                f'Created Config object using profile: {profile} parameters',
+                f"Created Config object using profile: '{profile}' configuration",
                 2)
 
         else:
-            # Set default config
+            # Set retries parameters to avoid a throttling exception
             args['config'] = botocore.config.Config(
                 retries={
                     RETRY_ATTEMPTS_KEY: 10,

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -120,7 +120,7 @@ def set_profile_dict_config(boto_config: dict,profile:str, profile_config):
     Parameters
     ----------
     boto_config: dict
-        The config dictionary where the Boto Config will be set.8
+        The config dictionary where the Boto Config will be set.
 
     profile : str
         The AWS profile name to use for the configuration.

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -30,6 +30,7 @@
 #   20 - Unable to find SQS
 #   21 - Failed fetch/delete from SQS
 #   22 - Invalid region
+#   23 - Matching regions error
 
 import argparse
 import configparser
@@ -100,6 +101,72 @@ ALL_REGIONS = [
     'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2', 'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-2',
     'ap-south-1', 'eu-central-1', 'eu-west-1'
 ]
+
+
+################################################################################
+# Helpers functions
+################################################################################
+
+
+def set_profile_dict_config(boto_config: dict,profile:str, profile_config):
+    """Creates a botocore.config.Config object with the specified profile and profile_config.
+
+    This function reads the profile configuration from the provided profile_config object and extracts the necessary
+    parameters to create a botocore.config.Config object.
+    It handles the signature version, s3, proxies, and proxies_config settings found in the .aws/config file for the
+    specified profile. If a setting is not found, a default value is used based on the boto3 documentation and config is
+    set into the boto_config
+
+    Parameters
+    ----------
+    boto_config: dict
+        The config dictionary where the Boto Config will be set.8
+
+    profile : str
+        The AWS profile name to use for the configuration.
+
+    profile_config : dict
+        The user config dict containing the profile configuration.
+
+    Raises
+    ------
+    ValueError
+        ValueError when there is an error parsing a value in config file
+    """
+    try:
+
+        # Set s2 Config
+        if f'{profile}.s2' in str(profile_config):
+            s3_config = {
+                "max_concurrent_requests": int(profile_config.get(f'{profile}.s2.max_concurrent_requests', 10)),
+                "max_queue_size": int(profile_config.get(f'{profile}.s2.max_queue_size', 10)),
+                "multipart_threshold": profile_config.get(f'{profile}.s2.multipart_threshold', '8MB'),
+                "multipart_chunksize": profile_config.get(f'{profile}.s2.multipart_chunksize', '8MB'),
+                "max_bandwidth": profile_config.get(f'{profile}.s2.max_bandwidth'),
+                "use_accelerate_endpoint": bool(profile_config.get(f'{profile}.s2.use_accelerate_endpoint', False)),
+                "addressing_style": profile_config.get(f'{profile}.s2.addressing_style', 'auto'),
+                }
+            boto_config['config'].s3 = s3_config
+
+        # Set Proxies configuration
+        if f'{profile}.proxy' in str(profile_config):
+            proxy_config = {
+                "host": profile_config.get(f'{profile}.proxy.host'),
+                "port": int(profile_config.get(f'{profile}.proxy.port')),
+                "username": profile_config.get(f'{profile}.proxy.username'),
+                "password": profile_config.get(f'{profile}.proxy.password'),
+            }
+            boto_config['config'].proxies = proxy_config
+
+            proxies_config = {
+                "ca_bundle": profile_config.get(f'{profile}.proxy.ca_bundle'),
+                "client_cert": profile_config.get(f'{profile}.proxy.client_cert'),
+                "use_forwarding_for_https": bool(profile_config.get(f'{profile}.proxy.use_forwarding_for_https', False))
+                }
+            boto_config['config'].proxies_config = proxies_config
+
+    except ValueError:
+        raise ValueError
 
 
 ################################################################################
@@ -188,7 +255,8 @@ class WazuhIntegration:
         # GovCloud regions
         self.gov_regions = {'us-gov-east-1', 'us-gov-west-1'}
 
-        self.connection_config = self.default_config(profile=aws_profile)
+        self.connection_config = self.default_config(profile=aws_profile,
+                                                     region=region)
 
         self.client = self.get_client(access_key=access_key,
                                       secret_key=secret_key,
@@ -251,22 +319,24 @@ class WazuhIntegration:
                 self.db_connector.execute(self.sql_drop_table.format(table='trail_progress'))
 
     @staticmethod
-    def default_config(profile: str = 'default'):
-        """Sets the parameters found in .aws/config as a default configuration for client.
+    def default_config(profile: str, region: str):
+        """Sets the parameters found in user config file as a default configuration for client.
 
         This method is called when Wazuh Integration is instantiated and sets a default config using .aws/config file
         using the profile received from parameter.
 
         If .aws/config file exist the file is retrieved and read to check for the existence of retry parameters mode and
-         max attempts if they exist and empty dictionary is returned and config is handled by botocore but if they dont
+         max attempts if they exist and empty dictionary is returned and config is handled by botocore but if they don't
          exist a botocore Config object is created and default configuration is set using user config for received
-         profile and retry parameters are set to avoid a throttling exception
+         profile and retries parameters are set to avoid a throttling exception
 
         Parameters
         ----------
         profile : string
                 Aws profile configuration to use
 
+        region : string
+                Aws region to use
         Returns
         -------
         dict
@@ -275,46 +345,85 @@ class WazuhIntegration:
         Raises
         ------
         KeyError
-             KeyError when there is no region declared in .aws/config file
+            KeyError when there is no region in user config file
+
+        ValueError
+            ValueError when there is an error parsing config file
         """
         args = {}
 
+        import pydevd_pycharm
+        pydevd_pycharm.settrace('172.19.0.1', port=10000, stdoutToServer=True, stderrToServer=True)
+
         if path.exists(DEFAULT_AWS_CONFIG_PATH):
+            # Create boto Config object
+            args['config'] = botocore.config.Config()
+
             # Get User Aws Config
             aws_config = get_aws_config_params()
 
             # Set profile
             profile = profile if profile is not None else 'default'
 
-            user_config = aws_config._sections[profile]
-
-            # Checks if retries config have the necessary parameters to avoid a throttling exception
-            if 'retries' in user_config:
-                retries = user_config['retries']
-                retries.setdefault('max_attempts', 10)
-                retries.setdefault('mode', 'standard')
-            else:
-                return args
+            # Get profile config dictionary
+            profile_config = aws_config._sections[profile]
 
             # Get region name in the config file or raised a key error
-            region_name = user_config.get('region') or user_config['region_name']
+            try:
+                config_file_region = profile_config.get('region') or profile_config['region_name']
 
-            # Get primary botocore Config parameters
-            signature_version = user_config.get('signature_version', 'v4')
-            s3 = user_config.get('s3')
-            proxies = user_config.get('proxies')
-            proxies_config = user_config.get('proxies_config')
+                # If Region is passed as parameter check if matches user config
+                if region is not None and region != config_file_region:
+                    debug(f'Region passed as parameter does not match region found in {profile} config file', 2)
+                    sys.exit(20)
 
-            args['config'] = botocore.config.Config(
-                region_name,
-                retries,
-                signature_version,
-                **s3,
-                **proxies,
-                **proxies_config
-            )
+                args['config'].region_name = config_file_region
+
+            except KeyError:
+                print(f'No region found in {profile} profile config)')
+                sys.exit(17)
+
+            # Map Primary Botocore Config parameters with profile config file
+            try:
+                # Checks for retries config in profile config and sets it if not found to avoid throttling exception
+                if 'max_attempts' in profile_config \
+                        or 'retry_mode' in profile_config:
+                    retries = {
+                        'max_attempts': int(profile_config.get('max_attempts', 10)),
+                        'mode': profile_config.get('retry_mode', 'standard')
+                    }
+                else:
+                    # Set retry config
+                    retries = {
+                        'max_attempts': 10,
+                        'mode': 'standard'
+                    }
+                    debug(
+                        "No retries configuration found in profile config generating default configuration for "
+                        f"retries: mode {retries['mode']} - max_attempts {retries['max_attempts']}",
+                        2)
+
+                args['config'].retries = retries
+
+                # Set signature version
+                signature_version = profile_config.get('signature_version', 's3v4')
+                args['config'].signature_version = signature_version
+
+                # Set profile dictionaries configuration
+                set_profile_dict_config(boto_config=args,
+                                        profile=profile,
+                                        profile_config=profile_config)
+
+            except (KeyError, ValueError) as e:
+                print('Invalid key, value found in config '.format(e))
+                sys.exit(17)
+
+            debug(
+                f'Created Config object using profile: {profile} parameters',
+                2)
 
         else:
+            # Set default config
             args['config'] = botocore.config.Config(
                 retries={
                     'max_attempts': 10,
@@ -894,7 +1003,8 @@ class AWSBucket(WazuhIntegration):
         # turn some list fields into dictionaries
         single_element_list_to_dictionary(event)
 
-        # in order to support both old and new index pattern, change data.aws.sourceIPAddress fieldname and parse that one with type ip
+        # in order to support both old and new index pattern,
+        # change data.aws.sourceIPAddress fieldname and parse that one with type ip
         # Only add this field if the sourceIPAddress is an IP and not a DNS.
         if 'sourceIPAddress' in event['aws'] and re.match(r'\d+\.\d+.\d+.\d+', event['aws']['sourceIPAddress']):
             event['aws']['source_ip_address'] = event['aws']['sourceIPAddress']


### PR DESCRIPTION
|Related issue|
|---|
|Closes #14978|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
## Description

The default_config was not taken into consideration that the _.aws/config_ file could not have the necessary retries parameters to avoid a throttling error a solution was made to not only look for the retry parameter but also all primary botocore parameters and set them into a botocore Config object.

More information on the solution is described here:
- #14978 

<!--
Add a clear description of how the problem has been solved.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

Now after running the module it will always check for the retries parameters on the config file if the file exists:

- No Retry Parameters
```
root@wazuh-master:/# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-kms -t custom -p dev -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: No retries configuration found in profile config generating default configuration for retries: mode standard - max_attempts 10
DEBUG: Created Config object using profile: dev parameters
DEBUG: +++ Marker: 2023/03/29
```
 
- With retry parameters

```
root@wazuh-master:/# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-kms -t custom -p dev -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Created Config object using profile: dev parameters
DEBUG: +++ Marker: 2023/03/29
DEBUG: +++ DB Maintenance
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

- Latest Test results:

| **Test name** | **Pass** | **XPass** | **Skip** | **XFail** | **Fail** | **Status** |
|--|--|--|--|--|--|--|
| Wodles UTs | 277 | 0 | 0 | 0 | 1 | 🟢 |
| AWS ITs | 191 | 0 | 3 | 1 | 0 | 🟢  |
 |ASL Manual execution|-|-|-|-|-|  🟢 |

Some scenarios were tested to ensure the module was functioning properly
Ex:

- No regions matching

```
root@wazuh-master:/# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-kms -t custom -r us-west-1 -p dev -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Region passed as parameter does not match region found in dev config file
```


- Api unit test:

```
(ut-3.9-venv) eduardoleon@pop-os:~/git/wazuh$ PYTHONPATH=/home/eduardoleon/git/wazuh/api:/home/eduardoleon/git/wazuh/framework python3 -m pytest api/api --disable-warnings
========================================== test session starts ===========================================
platform linux -- Python 3.9.9, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/eduardoleon/git/wazuh/api
plugins: asyncio-0.18.1, aiohttp-1.0.4, trio-0.7.0, cov-3.0.0, anyio-3.6.2, metadata-2.0.2, html-3.0.0
asyncio: mode=auto
collected 544 items                                                                                      

api/api/controllers/test/test_active_response_controller.py .                                      [  0%]
api/api/controllers/test/test_agent_controller.py ...........................................      [  8%]
api/api/controllers/test/test_cdb_list_controller.py ......                                        [  9%]
api/api/controllers/test/test_ciscat_controller.py .                                               [  9%]
api/api/controllers/test/test_cluster_controller.py ........................                       [ 13%]
api/api/controllers/test/test_decoder_controller.py .......                                        [ 15%]
api/api/controllers/test/test_default_controller.py .                                              [ 15%]
api/api/controllers/test/test_experimental_controller.py ...............                           [ 18%]
api/api/controllers/test/test_manager_controller.py ..................                             [ 21%]
api/api/controllers/test/test_mitre_controller.py .......                                          [ 22%]
api/api/controllers/test/test_overview_controller.py .                                             [ 22%]
api/api/controllers/test/test_rootcheck_controller.py ....                                         [ 23%]
api/api/controllers/test/test_rule_controller.py ........                                          [ 25%]
api/api/controllers/test/test_sca_controller.py ..                                                 [ 25%]
api/api/controllers/test/test_security_controller.py ............................................. [ 33%]
......                                                                                             [ 34%]
api/api/controllers/test/test_syscheck_controller.py ....                                          [ 35%]
api/api/controllers/test/test_syscollector_controller.py .........                                 [ 37%]
api/api/controllers/test/test_task_controller.py .                                                 [ 37%]
api/api/controllers/test/test_vulnerability_controller.py ....                                     [ 38%]
api/api/models/test/test_model.py ...........................                                      [ 43%]
api/api/test/test_alogging.py ..................                                                   [ 46%]
api/api/test/test_authentication.py ...........                                                    [ 48%]
api/api/test/test_configuration.py ............................................                    [ 56%]
api/api/test/test_encoder.py ...                                                                   [ 56%]
api/api/test/test_middlewares.py ............                                                      [ 59%]
api/api/test/test_uri_parser.py ...                                                                [ 59%]
api/api/test/test_util.py ..............................................                           [ 68%]
api/api/test/test_validator.py ................................................................... [ 80%]
.................................................................................................. [ 98%]
........                                                                                           [100%]

==================================== 544 passed, 15 warnings in 2.23s ====================================
```


