### PR TITLE
Fix API to allow modifying anything inside `ossec.conf` but protected sections

### DIFF
--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -112,8 +112,9 @@ class WazuhException(Exception):
         1126: {'message': 'Error updating ossec configuration',
                'remediation': 'Please, ensure `WAZUH_PATH/etc/ossec.conf` has the proper permissions and ownership.'
                },
-        1127: {'message': 'Forbidden section detected',
-               'remediation': 'To solve this issue, please enable the section in the API settings: '
+        1127: {'message': 'Protected section was modified',
+               'remediation': 'To solve this, either revert the changes made to this section or disable the protection '
+                              'in the API settings: '
                               f"https://documentation.wazuh.com/{DOCU_VERSION}/user-manual/api/configuration.html"},
         1128: {'message': 'Invalid configuration for the given component'},
 

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1671,10 +1671,10 @@ def test_add_dynamic_detail(detail, value, attribs, details):
         assert details[detail][key] == value
 
 
-@patch('wazuh.core.utils.check_disabled_limits_in_conf')
+@patch('wazuh.core.utils.check_wazuh_limits_unchanged')
 @patch('wazuh.core.utils.check_remote_commands')
 @patch('wazuh.core.manager.common.WAZUH_PATH', new=test_files_path)
-def test_validate_wazuh_xml(mock_remote_commands, mock_disabled_limits):
+def test_validate_wazuh_xml(mock_remote_commands, mock_unchanged_limits):
     """Test validate_wazuh_xml method works and methods inside are called with expected parameters"""
 
     with open(os.path.join(test_files_path, 'test_rules.xml')) as f:
@@ -1824,22 +1824,47 @@ def test_get_utc_now():
     assert date == datetime.datetime(1970, 1, 1, 0, 1, tzinfo=datetime.timezone.utc)
 
 
-@pytest.mark.parametrize("configuration", [
-    "<global><limits><eps><whatever>yes</whatever></eps></limits></global>",
-    "<global><logall>no</logall></global><global><limits><eps><whatever>yes</whatever></eps></limits></global>"
+@pytest.mark.parametrize("new_conf, unchanged_limits_conf", [
+    ("<ossec_config><global><limits><eps><maximum>300</maximum><timeframe>5</timeframe></eps></limits></global>"
+     "</ossec_config>", False),
+    ("<ossec_config><global><logall>no</logall></global><global><limits><eps><test>yes</test></eps></limits></global>"
+     "</ossec_config>", False),
+    ("<ossec_config><global><logall>yes</logall><limits><eps><maximum>300</maximum></eps></limits></global>"
+     "</ossec_config>", True),
+    ("<ossec_config><global><logall>yes</logall><limits><eps><maximum>300</maximum></eps></limits></global>"
+     "</ossec_config><ossec_config><global><limits><eps><maximum>300</maximum></eps></limits></global></ossec_config>",
+     False)
 ])
-@pytest.mark.parametrize("limits_conf, expect_exc", [
-    ({'eps': {'allow': True}}, False),
-    ({'eps': {'allow': False}}, True)
+@pytest.mark.parametrize("original_conf", [
+    "<ossec_config><global><limits><eps><maximum>300</maximum></eps></limits></global></ossec_config>"
 ])
-def test_check_disabled_limits_in_conf(configuration, limits_conf, expect_exc):
-    """Test if forbidden limits in the API settings are blocked."""
-    new_conf = utils.configuration.api_conf
-    new_conf['upload_configuration']['limits'].update(limits_conf)
+@pytest.mark.parametrize("limits_conf", [
+    ({'eps': {'allow': True}}),
+    ({'eps': {'allow': False}})
+])
+def test_check_wazuh_limits_unchanged(new_conf, unchanged_limits_conf, original_conf, limits_conf):
+    """Test if ossec.conf limits are protected by the API.
 
-    with patch('wazuh.core.utils.configuration.api_conf', new=new_conf):
-        if expect_exc:
-            with pytest.raises(exception.WazuhError, match=".* 1127 .*"):
-                utils.check_disabled_limits_in_conf(configuration)
+    When 'eps': {'allow': False} is set in the API configuration, the limits in ossec.conf cannot be changed.
+    However, other configuration sections can be added, removed or modified.
+
+    Parameters
+    ----------
+    new_conf : str
+        New ossec.conf to be uploaded.
+    unchanged_limits_conf : bool
+        Whether the limits section in ossec.conf is the same as the original one.
+    original_conf : str
+        Original ossec.conf to be uploaded.
+    limits_conf : dict
+        API configuration for the limits section.
+    """
+    api_conf = utils.configuration.api_conf
+    api_conf['upload_configuration']['limits'].update(limits_conf)
+
+    with patch('wazuh.core.utils.configuration.api_conf', new=api_conf):
+        if limits_conf['eps']['allow'] or unchanged_limits_conf:
+            utils.check_wazuh_limits_unchanged(new_conf, original_conf)
         else:
-            utils.check_disabled_limits_in_conf(configuration)
+            with pytest.raises(exception.WazuhError, match=".* 1127 .*"):
+                utils.check_wazuh_limits_unchanged(new_conf, original_conf)

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -778,27 +778,59 @@ def check_remote_commands(data):
         check_section(command_section, section='wodle_command', split_section='<wodle name=\"command\">')
 
 
-def check_disabled_limits_in_conf(data):
-    """Check if Wazuh limits are allowed.
+def check_wazuh_limits_unchanged(new_conf, original_conf):
+    """Check if Wazuh limits remain unchanged.
 
     Parameters
     ----------
-    data : str
-        Configuration file.
+    new_conf : str
+        New configuration file.
+    original_conf : str
+        Original configuration file.
 
     Raises
     -------
     WazuhError(1127)
-        Raised if one of the disabled limits is present in the configuration to upload.
+        Raised if one of the protected limits is modified in the configuration to upload.
     """
-    def check_section(section_name):
-        if re.findall(pattern=r'<global>.*<limits>.*<{0}>.*</{0}>.*</limits>.*</global>'.format(section_name),
-                      string=data, flags=re.MULTILINE | re.DOTALL | re.IGNORECASE):
-            raise WazuhError(1127, extra_message=f"global > limits > {section_name}")
 
-    blocked_configurations = configuration.api_conf['upload_configuration']
-    for disabled_limit in [conf for conf, allowed in blocked_configurations['limits'].items() if not allowed['allow']]:
-        check_section(disabled_limit)
+    def xml_to_dict(conf, section_name):
+        """Convert XML to list of dictionaries.
+
+        Parameters
+        ----------
+        conf : str
+            XML configuration file.
+        section_name : str
+            Name of the section to extract from the configuration file.
+
+        Returns
+        -------
+        matched_configurations : list
+            Dictionaries with the configuration.
+        """
+        matched_configurations = []
+
+        for str_conf in re.findall(r'<ossec_config>.*?</ossec_config>', conf, re.MULTILINE | re.DOTALL | re.IGNORECASE):
+            ossec_config_section = fromstring(str_conf)
+            for global_section in ossec_config_section.iter('global'):
+                for limits_section in global_section.iter('limits'):
+                    for section in limits_section.iter(section_name):
+                        section_dict = {section.tag: {}}
+                        for config in section:
+                            section_dict[section.tag].update({config.tag: {'attrib': config.attrib,
+                                                                           'value': config.text.strip()}})
+                        matched_configurations.append(section_dict)
+
+        return matched_configurations
+
+    limits_configuration = configuration.api_conf['upload_configuration']['limits']
+    for disabled_limit in [conf for conf, allowed in limits_configuration.items() if not allowed['allow']]:
+        new_limits = xml_to_dict(new_conf, disabled_limit)
+        original_limits = xml_to_dict(original_conf, disabled_limit)
+
+        if len(new_limits) != len(original_limits) or any(x != y for x, y in zip(new_limits, original_limits)):
+            raise WazuhError(1127, extra_message=f"global > limits > {disabled_limit}")
 
 
 def load_wazuh_xml(xml_path, data=None):
@@ -1723,7 +1755,9 @@ def validate_wazuh_xml(content: str, config_file: bool = False):
         # Check if remote commands are allowed if it is a configuration file
         if config_file:
             check_remote_commands(final_xml)
-            check_disabled_limits_in_conf(final_xml)
+            with open(common.OSSEC_CONF, 'r') as f:
+                current_xml = f.read()
+            check_wazuh_limits_unchanged(final_xml, current_xml)
         # Check xml format
         load_wazuh_xml(xml_path='', data=final_xml)
     except ExpatError:


### PR DESCRIPTION
|Related issue|
|---|
| Closes #16520 |

## Description

This PR refactors the API limits protection according to the original request. Now, when the protection is enabled, users will be able to upload new `ossec.conf` files with any modification as long as the `<limits><eps>` section remains unchanged. 

Multiple things were taken into account during this development:
- Adding new `<limits><eps>` sections or/and tags is not allowed.
- Deleting existing `<limits><eps>` sections or/and tags is not allowed.
- Modifying existing `<limits><eps>` sections or/and tags is not allowed. This also means not commenting out existing sections, adding or removing tag attributes, etc.
- When a section is repeated, the last defined value is applied. Therefore, the API verifies that the order of the <limits> sections (if there is more than one) does not change. Its position can change as long as this does not affect the order.
- The tags' order within a section has no effect, so the API allows its modification.
- Configurations with more than one root block (`<ossec_config>...</ossec_config>`) are still allowed.

To achieve this behavior, the original and new XML configurations are converted to a list of dictionaries. In other words, a configuration like this:
<details>
<summary>ossec.conf</summary>

```XML
<ossec_config>		
		<global>
    <limits>
      <eps>
        <maximum>99999</maximum>
        <timeframe>40</timeframe>
      </eps>
    </limits>
  </global>
	
	
  <global>
    <jsonout_output>no</jsonout_output>
    <alerts_log>no</alerts_log>
    <logall>yes</logall>
    <logall_json>yes</logall_json>
    <limits>
      <eps>				
        <timeframe>30</timeframe>
        <maximum>10000</maximum>
      </eps>
    </limits>
  </global>
	
	
</ossec_config>

<ossec_config>
  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/maillog</location>
  </localfile>
</ossec_config>
```

</details>

Becomes something like this:
```JSON
[
    {
        "eps": {
            "maximum": {"attrib": {}, "value": "99999"},
            "timeframe": {"attrib": {}, "value": "40"},
        }
    },
    {
        "eps": {
            "timeframe": {"attrib": {}, "value": "30"},
            "maximum": {"attrib": {}, "value": "10000"},
        }
    },
]
```

The results of the original and new configurations are then compared. Using a list ensures that the order of the `<limits>` sections is maintained in the new `osse.conf`, while using dictionaries ensures that the content is identical regardless of the internal order of the section.

## Configuration options

The configuration options are the same as before:
```YAML
# Uploadable Wazuh configuration sections
 upload_configuration:
   limits:
     eps:
       allow: no
```

## Logs/Alerts example

Original configuration before enabling API protection for `<limits><eps>` section:
![original](https://user-images.githubusercontent.com/23361101/228877762-7ae29177-6e8a-41b3-9978-76cf66bb66a6.png)


<details>
<summary>Adding a new section (denied)</summary>

![add_new_section](https://user-images.githubusercontent.com/23361101/228881151-1ee6b34c-b133-4072-9586-3bcdffaac225.png)

</details>
<details>
<summary>Adding new tags (denied)</summary>

![add_tags1](https://user-images.githubusercontent.com/23361101/228881483-d0d851e1-75df-4c53-a8d5-63d5058f3dc0.png)

</details>
<details>
<summary>Change attributes (denied)</summary>

![change_attrib](https://user-images.githubusercontent.com/23361101/228881578-2f0de130-a188-4d7d-b7c6-96d4e3c92847.png)

</details>
<details>
<summary>Change section order (denied)</summary>

![change_order1](https://user-images.githubusercontent.com/23361101/228881660-ae42f05c-6988-471b-a9e2-b8a4e1cae9ce.png)

Adding it to a new `<ossec_config>` block won't skip the verification:
![change_order2](https://user-images.githubusercontent.com/23361101/228881817-5839af54-7000-44dc-8005-1bfc3082243a.png)

</details>
<details>
<summary>Comment out section (denied)</summary>

![commented](https://user-images.githubusercontent.com/23361101/228881892-0245446c-4a1a-4723-bc26-6c27012d008b.png)

</details>
<details>
<summary>Modify protected values (denied)</summary>

![modify_value](https://user-images.githubusercontent.com/23361101/228886073-0d371626-fddb-4b12-b056-f31b37255e66.png)

</details>
<details>
<summary>Remove section or tag (denied)</summary>

![remove1](https://user-images.githubusercontent.com/23361101/228886269-0bef5ce1-ca27-4f45-a729-0efcb5d70f93.png)
![remove3](https://user-images.githubusercontent.com/23361101/228886279-abddfc38-ad7f-4457-848c-cf3e0121b3cf.png)

</details>
<details>
<summary>Change tags order (allowed)</summary>

![change_tag_order](https://user-images.githubusercontent.com/23361101/228886387-8717466e-d88e-4e13-bb83-7f71991dcbef.png)

</details>
<details>
<summary>Change other sections (allowed)</summary>

![modify_any_other_section](https://user-images.githubusercontent.com/23361101/228886513-89f35944-17fe-4fa6-b075-8c6d032175fb.png)

</details>

## Tests
### Framework
```
$ PYTHONPATH=/home/selu/Git/wazuh/api:/home/selu/Git/wazuh/framework python3 -m pytest framework/ -x --disable-warnings
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1, aiohttp-1.0.4, cov-4.0.0
asyncio: mode=auto
collected 2051 items                                                                                                                                                                                        

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                                                                         [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                                                                [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                 [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                                [  7%]
framework/wazuh/core/cluster/tests/test_common.py ...........................................................................                                                                         [ 10%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                                             [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                 [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                      [ 12%]
framework/wazuh/core/cluster/tests/test_master.py .............................................                                                                                                       [ 15%]
framework/wazuh/core/cluster/tests/test_server.py ...................                                                                                                                                 [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                          [ 16%]
framework/wazuh/core/cluster/tests/test_worker.py ....................................                                                                                                                [ 18%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [ 19%]
framework/wazuh/core/tests/test_agent.py ................................................................................................................................................             [ 26%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 27%]
framework/wazuh/core/tests/test_common.py .......                                                                                                                                                     [ 28%]
framework/wazuh/core/tests/test_configuration.py ......................................................................                                                                               [ 31%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 32%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 33%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 33%]
framework/wazuh/core/tests/test_manager.py ...............                                                                                                                                            [ 34%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 34%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 35%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 37%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 38%]
framework/wazuh/core/tests/test_sca.py ........................                                                                                                                                       [ 39%]
framework/wazuh/core/tests/test_security.py ............                                                                                                                                              [ 40%]
framework/wazuh/core/tests/test_stats.py .................                                                                                                                                            [ 41%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 42%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 49%]
.........................................................................................                                                                                                             [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                                                [ 57%]
framework/wazuh/core/tests/test_wlogging.py .........                                                                                                                                                 [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 58%]
framework/wazuh/rbac/tests/test_decorators.py .............................................................................................................                                           [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py ........................................................                                                                                     [ 66%]
framework/wazuh/rbac/tests/test_orm.py ......................................................                                                                                                         [ 68%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 69%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [ 70%]
framework/wazuh/tests/test_agent.py .....................................................................................................................                                             [ 75%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 79%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 80%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 82%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 82%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 84%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 84%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 87%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                           [ 90%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                         [ 90%]
framework/wazuh/tests/test_security.py .........................................................................                                                                                      [ 94%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                   [ 94%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                     [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................................                                                                                                                  [100%]

=============================================================================== 2051 passed, 46 warnings in 325.08s (0:05:25) ===============================================================================
```

### API
```
$ PYTHONPATH=/home/selu/Git/wazuh/api:/home/selu/Git/wazuh/framework python3 -m pytest api/api/ -x --disable-warnings
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/api
plugins: anyio-3.6.2, asyncio-0.18.1, aiohttp-1.0.4, cov-4.0.0
asyncio: mode=auto
collected 536 items                                                                                                                                                                                         

api/api/controllers/test/test_active_response_controller.py .                                                                                                                                         [  0%]
api/api/controllers/test/test_agent_controller.py ...........................................                                                                                                         [  8%]
api/api/controllers/test/test_cdb_list_controller.py ......                                                                                                                                           [  9%]
api/api/controllers/test/test_ciscat_controller.py .                                                                                                                                                  [  9%]
api/api/controllers/test/test_cluster_controller.py ........................                                                                                                                          [ 13%]
api/api/controllers/test/test_decoder_controller.py .......                                                                                                                                           [ 15%]
api/api/controllers/test/test_default_controller.py .                                                                                                                                                 [ 15%]
api/api/controllers/test/test_experimental_controller.py ...............                                                                                                                              [ 18%]
api/api/controllers/test/test_manager_controller.py ..................                                                                                                                                [ 21%]
api/api/controllers/test/test_mitre_controller.py .......                                                                                                                                             [ 22%]
api/api/controllers/test/test_overview_controller.py .                                                                                                                                                [ 23%]
api/api/controllers/test/test_rootcheck_controller.py ....                                                                                                                                            [ 23%]
api/api/controllers/test/test_rule_controller.py ........                                                                                                                                             [ 25%]
api/api/controllers/test/test_sca_controller.py ..                                                                                                                                                    [ 25%]
api/api/controllers/test/test_security_controller.py ...................................................                                                                                              [ 35%]
api/api/controllers/test/test_syscheck_controller.py ....                                                                                                                                             [ 36%]
api/api/controllers/test/test_syscollector_controller.py .........                                                                                                                                    [ 37%]
api/api/controllers/test/test_task_controller.py .                                                                                                                                                    [ 37%]
api/api/controllers/test/test_vulnerability_controller.py ....                                                                                                                                        [ 38%]
api/api/models/test/test_model.py ...........................                                                                                                                                         [ 43%]
api/api/test/test_alogging.py ..................                                                                                                                                                      [ 47%]
api/api/test/test_authentication.py ...........                                                                                                                                                       [ 49%]
api/api/test/test_configuration.py ..........................................                                                                                                                         [ 56%]
api/api/test/test_encoder.py ...                                                                                                                                                                      [ 57%]
api/api/test/test_middlewares.py ............                                                                                                                                                         [ 59%]
api/api/test/test_uri_parser.py ...                                                                                                                                                                   [ 60%]
api/api/test/test_util.py ........................................                                                                                                                                    [ 67%]
api/api/test/test_validator.py ...................................................................................................................................................................... [ 98%]
.......                                                                                                                                                                                               [100%]

===================================================================================== 536 passed, 16 warnings in 3.12s ======================================================================================
```