### PR TITLE
Fix UI launch after successfull installation

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -351,6 +351,10 @@ public function config()
         remUserPerm = "icacls """ & install_dir & """ /remove *S-1-5-32-545 /q"
         WshShell.run remUserPerm, 0, True
 
+        userSID = GetUserSID()
+        grantUserPerm = "icacls """ & install_dir & """ /grant *" & userSID & ":(RX) /t"
+        WshShell.run grantUserPerm, 0, True
+
         ' Remove Everyone group for ossec.conf
         remEveryonePerms = "icacls """ & home_dir & "ossec.conf" & """ /remove *S-1-1-0 /q"
         WshShell.run remEveryonePerms, 0, True
@@ -403,4 +407,18 @@ Public Function StartWazuhSvc()
 	Set WshShell = CreateObject("WScript.Shell")
     StartSvc = "NET START WazuhSvc"
     WshShell.run StartSvc, 0, True
+End Function
+
+Private Function GetUserSID()
+    GetUserSID = ""
+    Dim sDomain, oWMI, sDomUser
+
+    sDomain = CreateObject("WScript.Network").UserDomain
+    sDomUser = CreateObject( "WScript.Shell" ).ExpandEnvironmentStrings( "%USERNAME%" )
+
+    On Error Resume Next
+    Set oWMI = GetObject("winmgmts:{impersonationlevel=impersonate}!" & "/root/cimv2:Win32_UserAccount.Domain='" & sDomain & "'" & ",Name='" & sDomUser & "'")
+    If Err.Number = 0 Then
+        GetUserSID = oWMI.SID
+    End If
 End Function

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -63,7 +63,8 @@
             <RegistrySearch Id="WazuhInstallDirProperty" Type="raw" Root="HKLM" Key="Software\[Manufacturer]\[ProductName]" Name="WazuhInstallDir" />
         </Property>
 
-        <CustomAction Id="LaunchUI" Directory="APPLICATIONFOLDER" ExeCommand="[APPLICATIONFOLDER]win32ui.exe" Return="asyncNoWait" />
+        <Property Id="WixShellExecTarget" Value="[APPLICATIONFOLDER]win32ui.exe" />
+        <CustomAction Id="LaunchUI" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
         <Property Id="OSSECINSTALLED">
             <RegistrySearch Id="OssecInstalled" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Services\OssecSvc" Name="DisplayName" />


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12906|

This PR aims to fix the situation where a user requests the agent UI to be launched after installation but the UI won't be launched, failing silently.

## Description

The problem was caused by 2 different situations
- Access to the agent installation folder is completely closed, so the installer had no access to it to execute it
- The agent UI requires elevated privileges to be executed, even with access to the folder, the execution would not occur.

The first situation was solved from the VB script, allowing the currently logged user to access the folder.

The second situation was solved from the Wix script, by allowing impersonation, thus allowing the user to execute the UI (after elevated privileges are granted).

## Configuration options

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
