### PR TITLE
Fix/16526 rewrite async tests and abstractclienttest and functions

### DIFF
--- a/framework/wazuh/core/cluster/client.py
+++ b/framework/wazuh/core/cluster/client.py
@@ -163,18 +163,21 @@ class AbstractClient(common.Handler):
     def connection_result(self, future_result):
         """Callback function called when the master sends a response to the hello command sent by the worker.
 
+            If the coroutine raises an exception, future_result.result() will raise the exception in this 
+            callback
+
         Parameters
         ----------
         future_result : asyncio.Future object
             Result of the hello request.
         """
-        response_msg = future_result.result()[0]
-        if isinstance(response_msg, Exception):
-            self.logger.error(f"Could not connect to master: {response_msg}.")
-            self.transport.close()
-        else:
+        try:
+            future_result.result()
             self.logger.info("Successfully connected to master.")
             self.connected = True
+        except Exception as e:        
+            self.logger.error(f"Could not connect to master: {str(e)}.")
+            self.transport.close()
 
     def connection_made(self, transport):
         """Define process of connecting to the server.
@@ -185,7 +188,7 @@ class AbstractClient(common.Handler):
             Socket to write data on.
         """
         self.transport = transport
-        future = asyncio.gather(self.log_exceptions(self.send_request(command=b'hello', data=self.client_data)))
+        future = asyncio.gather(self.send_request(command=b'hello', data=self.client_data))
         future.add_done_callback(self.connection_result)
 
     def connection_lost(self, exc):

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -499,7 +499,7 @@ class Handler(asyncio.Protocol):
                 break
             parsed = self.msg_parse()
 
-    async def send_request(self, command: bytes, data: bytes) -> Union[exception.WazuhClusterError, Any]:
+    async def send_request(self, command: bytes, data: bytes) -> Any:
         """Send a request to peer and wait for the response to be received and processed.
 
         Parameters

--- a/framework/wazuh/core/cluster/tests/test_client.py
+++ b/framework/wazuh/core/cluster/tests/test_client.py
@@ -23,6 +23,8 @@ with patch('wazuh.common.wazuh_uid'):
         import wazuh.core.cluster.client as client
         from wazuh import WazuhException
 
+from wazuh.core.exception import WazuhClusterError
+
 fernet_key = "00000000000000000000000000000000"
 
 cluster_items = {'intervals': {'worker': {'keep_alive': 1, 'max_failed_keepalive_attempts': 0, "connection_retry": 2}}}
@@ -188,57 +190,70 @@ def test_ac_connection_result():
     """Check that once an asyncio.Future object is received, a connection is established if no problems were found, or
     closed if and Exception was received."""
 
-    class MultipleMock:
-        def __init__(self):
-            self.result_output = None
-
+    class MockClose():
         def close(self):
             pass
 
-        def result(self):
-            return self.result_output
-
-    m_mock = MultipleMock()
-
     # Check first condition
     with patch.object(logging.getLogger('wazuh'), "error") as logger_mock:
-        m_mock.result_output = [WazuhException(1001)]
-        abstract_client.transport = m_mock
+        abstract_client.transport = MockClose()
 
-        with patch.object(MultipleMock, "close") as close_mock:
-            abstract_client.connection_result(m_mock)
-            logger_mock.assert_called_once_with(f"Could not connect to master: {WazuhException(1001)}.")
+        with patch.object(abstract_client.transport, "close") as close_mock:
+            future = asyncio.Future()
+            future.set_exception(WazuhClusterError(3020))
+            abstract_client.connection_result(future)
+            logger_mock.assert_called_once_with(f"Could not connect to master: {str(WazuhClusterError(3020))}.")
             close_mock.assert_called_once()
 
     # Check second condition
     with patch.object(logging.getLogger('wazuh'), "info") as logger_mock:
-        m_mock.result_output = ["OK"]
-        abstract_client.transport = m_mock
+        
+        abstract_client.transport = MockClose()
+        future = asyncio.Future()
+        future.set_result(['OK'])
 
-        abstract_client.connection_result(m_mock)
+        abstract_client.connection_result(future)
         logger_mock.assert_called_once_with("Successfully connected to master.")
         assert abstract_client.connected is True
 
+@pytest.mark.asyncio
+async def test_ac_connection_made():
+    """Check that the process of connection to the manager is correctly performed.
 
-@patch('asyncio.gather')
-def test_ac_connection_made(gather_mock):
-    """Check that the process of connection to the manager is correctly performed."""
+        1. asyncio.gather must call send_request(b'hello', self.client_data) coroutine
+        2. The done_callback of the future returned by asyncio.gatheris set to 
+           connection_made inside connection_made
+        3. In connection_result function, a message to the log is written
+           and abstract_client.connected is set to True
 
-    class TaskMock:
+    """
+    async def check_connected(abs_cli):
+        # coroutine to wait for connected set to True
+        while not abs_cli.connected:
+            await asyncio.sleep(0.01)
 
-        def __init__(self):
-            pass
+    coro = abstract_client.send_request(b'hello', abstract_client.client_data)
+    msg = abstract_client.msg_build(b'return', 1, b'ok')
+    future = asyncio.Future()
+    with patch('wazuh.core.cluster.client.asyncio.gather', return_value=future) as g_mock:
+        with patch.object(abstract_client.logger, 'info') as log_mock:
+            abstract_client.connection_made(asyncio.Transport())
+            # check coroutine function called and arguments
+            assert coro.cr_code == g_mock.call_args.args[0].cr_code \
+                and coro.cr_frame.f_locals == g_mock.call_args.args[0].cr_frame.f_locals
+            
+            # coro.close() called to avoid not awaited warning
+            coro.close()
 
-        def add_done_callback(self, param=None):
-            pass
+            # set the value that will be received by connection_result
+            future.set_result(msg)
 
-    gather_mock.return_value = TaskMock()
-
-    with patch.object(TaskMock, "add_done_callback") as add_done_callback_mock:
-        abstract_client.connection_made("transport")
-        gather_mock.assert_called_once()
-        add_done_callback_mock.assert_called_once()
-
+            # wait that abstract_client.connected is set to True for 10 seconds
+            await asyncio.wait_for(check_connected(abstract_client), 10)
+ 
+            # check assertions
+            log_mock.assert_called_with("Successfully connected to master.")
+            assert abstract_client.connected is True
 
 @patch('wazuh.core.cluster.client.AbstractClient._cancel_all_tasks')
 def test_ac_connection_lost(cancel_tasks_mock):


### PR DESCRIPTION
|Related issue|
|---|
|epic [#16526]|

## Description
This PR fixes the warning messages generated by test_ac_connection_made [#16495] and implements several corrections described by the epic [epic #16526](https://github.com/wazuh/wazuh/issues/16526) required to make the test work.


## Tests
Framework and API Unit Test executed without failures