### PR TITLE
Add Support for GCC & GCC High to the Office365 Module

### DIFF
--- a/src/config/wmodules-office365.c
+++ b/src/config/wmodules-office365.c
@@ -21,6 +21,7 @@ static const char *XML_TENANT_ID            = "tenant_id";
 static const char *XML_CLIENT_ID            = "client_id";
 static const char *XML_CLIENT_SECRET_PATH   = "client_secret_path";
 static const char *XML_CLIENT_SECRET        = "client_secret";
+static const char *XML_API_TYPE             = "api_type";
 
 static const char *XML_SUBSCRIPTIONS                = "subscriptions";
 static const char *XML_SUBSCRIPTION                 = "subscription";
@@ -136,6 +137,35 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
                     }
                     os_free(office365_auth->client_secret);
                     os_strdup(children[j]->content, office365_auth->client_secret);
+                } else if (!strcmp(children[j]->element, XML_API_TYPE)) {
+                    if (strlen(children[j]->content) == 0) {
+                        merror("Empty content for tag '%s' at module '%s'.", XML_API_TYPE, WM_OFFICE365_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+                    else if (!strcmp(children[j]->content, "commercial")) {
+                        os_free(office365_auth->login_fqdn);
+                        os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, office365_auth->login_fqdn);
+                        os_free(office365_auth->management_fqdn);
+                        os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, office365_auth->management_fqdn);
+                    }
+                    else if (!strcmp(children[j]->content, "gcc")) {
+                        os_free(office365_auth->login_fqdn);
+                        os_strdup(WM_OFFICE365_GCC_API_LOGIN_FQDN, office365_auth->login_fqdn);
+                        os_free(office365_auth->management_fqdn);
+                        os_strdup(WM_OFFICE365_GCC_API_MANAGEMENT_FQDN, office365_auth->management_fqdn);
+                    }
+                    else if (!strcmp(children[j]->content, "gcc-high")) {
+                        os_free(office365_auth->login_fqdn);
+                        os_strdup(WM_OFFICE365_GCC_HIGH_API_LOGIN_FQDN, office365_auth->login_fqdn);
+                        os_free(office365_auth->management_fqdn);
+                        os_strdup(WM_OFFICE365_GCC_HIGH_API_MANAGEMENT_FQDN, office365_auth->management_fqdn);
+                    }
+                    else {
+                        merror("Invalid content for tag '%s' at module '%s'.", XML_API_TYPE, WM_OFFICE365_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
                 } else {
                     merror("No such tag '%s' at module '%s'.", children[j]->element, WM_OFFICE365_CONTEXT.name);
                     OS_ClearNode(children);
@@ -150,7 +180,7 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
                     return OS_INVALID;
                 }
                 if(access(office365_auth->client_secret_path, F_OK) != 0 ) {
-                    merror("At module '%s': The path cannot be opened.", WM_OFFICE365_CONTEXT.name);
+                    merror("Invalid content for tag '%s' at module '%s': The path cannot be opened.", XML_CLIENT_SECRET_PATH, WM_OFFICE365_CONTEXT.name);
                     return OS_INVALID;
                 }
             } else if (!office365_auth->client_secret) {
@@ -164,6 +194,14 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
             } else if (!office365_auth->tenant_id) {
                 merror("'%s' is missing at module '%s'.", XML_TENANT_ID, WM_OFFICE365_CONTEXT.name);
                 return OS_INVALID;
+            }
+
+            // Keep retrocompatibility with configs made prior to GCC (High) support
+            if (!office365_auth->login_fqdn && !office365_auth->management_fqdn) {
+                os_free(office365_auth->login_fqdn);
+                os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, office365_auth->login_fqdn);
+                os_free(office365_auth->management_fqdn);
+                os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, office365_auth->management_fqdn);
             }
 
         } else if (!strcmp(nodes[i]->element, XML_SUBSCRIPTIONS)) {

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -95,11 +95,24 @@ static int teardown_test_read(void **state) {
             os_free(((wm_office365*)test->module->data)->auth->client_id);
             os_free(((wm_office365*)test->module->data)->auth->client_secret_path);
             os_free(((wm_office365*)test->module->data)->auth->client_secret);
+            os_free(((wm_office365*)test->module->data)->auth->login_fqdn);
+            os_free(((wm_office365*)test->module->data)->auth->management_fqdn);
             if (((wm_office365*)test->module->data)->auth->next) {
                 os_free(((wm_office365*)test->module->data)->auth->next->tenant_id);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_id);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_secret_path);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_secret);
+                os_free(((wm_office365*)test->module->data)->auth->next->login_fqdn);
+                os_free(((wm_office365*)test->module->data)->auth->next->management_fqdn);
+                if (((wm_office365*)test->module->data)->auth->next->next) {
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->tenant_id);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->client_id);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->client_secret_path);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->client_secret);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->login_fqdn);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->management_fqdn);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->next);
+                }
                 os_free(((wm_office365*)test->module->data)->auth->next->next);
             }
             os_free(((wm_office365*)test->module->data)->auth->next);
@@ -163,6 +176,8 @@ void test_read_configuration(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
+    assert_string_equal(module_data->auth->login_fqdn, WM_OFFICE365_DEFAULT_API_LOGIN_FQDN); // retrocompatability test
+    assert_string_equal(module_data->auth->management_fqdn, WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN); // retrocompatability test
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -180,11 +195,19 @@ void test_read_configuration_1(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<api_auth>"
             "<tenant_id>your_tenant_id_1</tenant_id>"
             "<client_id>your_client_id_1</client_id>"
+            "<client_secret>your_secret_1</client_secret>"
+            "<api_type>gcc</api_type>"
+        "</api_auth>"
+        "<api_auth>"
+            "<tenant_id>your_tenant_id_2</tenant_id>"
+            "<client_id>your_client_id_2</client_id>"
             "<client_secret_path>/path/to/secret</client_secret_path>"
+            "<api_type>gcc-high</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -207,9 +230,18 @@ void test_read_configuration_1(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
+    assert_string_equal(module_data->auth->login_fqdn, WM_OFFICE365_DEFAULT_API_LOGIN_FQDN);
+    assert_string_equal(module_data->auth->management_fqdn, WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN);
     assert_string_equal(module_data->auth->next->tenant_id, "your_tenant_id_1");
     assert_string_equal(module_data->auth->next->client_id, "your_client_id_1");
-    assert_string_equal(module_data->auth->next->client_secret_path, "/path/to/secret");
+    assert_string_equal(module_data->auth->next->client_secret, "your_secret_1");
+    assert_string_equal(module_data->auth->next->login_fqdn, WM_OFFICE365_GCC_API_LOGIN_FQDN);
+    assert_string_equal(module_data->auth->next->management_fqdn, WM_OFFICE365_GCC_API_MANAGEMENT_FQDN);
+    assert_string_equal(module_data->auth->next->next->tenant_id, "your_tenant_id_2");
+    assert_string_equal(module_data->auth->next->next->client_id, "your_client_id_2");
+    assert_string_equal(module_data->auth->next->next->client_secret_path, "/path/to/secret");
+    assert_string_equal(module_data->auth->next->next->login_fqdn, WM_OFFICE365_GCC_HIGH_API_LOGIN_FQDN);
+    assert_string_equal(module_data->auth->next->next->management_fqdn, WM_OFFICE365_GCC_HIGH_API_MANAGEMENT_FQDN);
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -223,6 +255,7 @@ void test_read_default_configuration(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
     ;
     test_structure *test = *state;
@@ -241,6 +274,7 @@ void test_read_interval(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -261,6 +295,8 @@ void test_read_interval(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
+    assert_string_equal(module_data->auth->login_fqdn, WM_OFFICE365_DEFAULT_API_LOGIN_FQDN);
+    assert_string_equal(module_data->auth->management_fqdn, WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN);
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -278,6 +314,7 @@ void test_read_interval_s(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -304,6 +341,7 @@ void test_read_interval_s_fail(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -329,6 +367,7 @@ void test_read_interval_m(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -355,6 +394,7 @@ void test_read_interval_m_fail(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -380,6 +420,7 @@ void test_read_interval_h(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -406,6 +447,7 @@ void test_read_interval_h_fail(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -431,6 +473,7 @@ void test_read_interval_d(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -457,6 +500,7 @@ void test_read_interval_d_fail(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -482,6 +526,7 @@ void test_read_curl_max_size(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -502,6 +547,8 @@ void test_read_curl_max_size(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
+    assert_string_equal(module_data->auth->login_fqdn, WM_OFFICE365_DEFAULT_API_LOGIN_FQDN);
+    assert_string_equal(module_data->auth->management_fqdn, WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN);
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -519,6 +566,7 @@ void test_read_curl_max_size_invalid_1(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -544,6 +592,7 @@ void test_read_curl_max_size_invalid_2(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -569,6 +618,7 @@ void test_read_curl_max_size_invalid_3(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -591,6 +641,7 @@ void test_secret_path_and_secret(void **state) {
             "<client_id>your_client_id</client_id>"
             "<client_secret_path>/path/to/secret</client_secret_path>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
     ;
     test_structure *test = *state;
@@ -609,6 +660,7 @@ void test_fake_tag(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -635,6 +687,7 @@ void test_fake_tag_1(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -661,6 +714,7 @@ void test_invalid_content_1(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription></subscription>"
@@ -686,6 +740,7 @@ void test_invalid_content_2(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -711,6 +766,7 @@ void test_invalid_content_3(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -736,6 +792,7 @@ void test_invalid_content_4(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -759,6 +816,7 @@ void test_invalid_interval(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -800,6 +858,7 @@ void test_error_api_auth_1(void **state) {
             "<invalid>your_tenant_id</invalid>"
             "<invalid>your_client_id</invalid>"
             "<invalid>your_secret</invalid>"
+            "<invalid>commercial</invalid>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -823,6 +882,7 @@ void test_error_tenant_id(void **state) {
             "<tenant_id></tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -845,6 +905,7 @@ void test_error_tenant_id_1(void **state) {
         "<api_auth>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -868,6 +929,7 @@ void test_error_client_id(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id></client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -890,6 +952,7 @@ void test_error_client_id_1(void **state) {
         "<api_auth>"
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -913,6 +976,7 @@ void test_error_client_secret(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret></client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -935,6 +999,7 @@ void test_error_client_secret_1(void **state) {
         "<api_auth>"
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -950,7 +1015,7 @@ void test_error_client_secret_1(void **state) {
     assert_int_equal(wm_office365_read(&(test->xml), test->nodes, test->module),-1);
 }
 
-void test_error_client_secret_path (void **state) {
+void test_error_client_secret_path(void **state) {
     const char *string =
         "<enabled>yes</enabled>\n"
         "<interval>10</interval>"
@@ -958,6 +1023,7 @@ void test_error_client_secret_path (void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret_path>/path/to/secret</client_secret_path>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -970,7 +1036,7 @@ void test_error_client_secret_path (void **state) {
     test_structure *test = *state;
     expect_string(__wrap_access, __name, "/path/to/secret");
     will_return(__wrap_access, -1);
-    expect_string(__wrap__merror, formatted_msg, "At module 'office365': The path cannot be opened.");
+    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'client_secret_path' at module 'office365': The path cannot be opened.");
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(wm_office365_read(&(test->xml), test->nodes, test->module),-1);
 }
@@ -983,6 +1049,7 @@ void test_error_client_secret_path_1(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret_path></client_secret_path>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -994,6 +1061,54 @@ void test_error_client_secret_path_1(void **state) {
     ;
     test_structure *test = *state;
     expect_string(__wrap__merror, formatted_msg, "Empty content for tag 'client_secret_path' at module 'office365'.");
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    assert_int_equal(wm_office365_read(&(test->xml), test->nodes, test->module),-1);
+}
+
+void test_error_api_type(void **state) {
+    const char *string =
+        "<enabled>yes</enabled>\n"
+        "<interval>10</interval>"
+        "<api_auth>"
+            "<tenant_id>your_tenant_id</tenant_id>"
+            "<client_id>your_client_id</client_id>"
+            "<client_secret>your_secret</client_secret>"
+            "<api_type>invalid</api_type>"
+        "</api_auth>"
+        "<subscriptions>"
+            "<subscription>Audit.AzureActiveDirectory</subscription>"
+            "<subscription>Audit.Exchange</subscription>"
+            "<subscription>Audit.SharePoint</subscription>"
+            "<subscription>Audit.General</subscription>"
+            "<subscription>DLP.All</subscription>"
+        "</subscriptions>"
+    ;
+    test_structure *test = *state;
+    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'api_type' at module 'office365'.");
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    assert_int_equal(wm_office365_read(&(test->xml), test->nodes, test->module),-1);
+}
+
+void test_error_api_type_1(void **state) {
+    const char *string =
+        "<enabled>yes</enabled>\n"
+        "<interval>10</interval>"
+        "<api_auth>"
+            "<tenant_id>your_tenant_id</tenant_id>"
+            "<client_id>your_client_id</client_id>"
+            "<client_secret>your_secret</client_secret>"
+            "<api_type></api_type>"
+        "</api_auth>"
+        "<subscriptions>"
+            "<subscription>Audit.AzureActiveDirectory</subscription>"
+            "<subscription>Audit.Exchange</subscription>"
+            "<subscription>Audit.SharePoint</subscription>"
+            "<subscription>Audit.General</subscription>"
+            "<subscription>DLP.All</subscription>"
+        "</subscriptions>"
+    ;
+    test_structure *test = *state;
+    expect_string(__wrap__merror, formatted_msg, "Empty content for tag 'api_type' at module 'office365'.");
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(wm_office365_read(&(test->xml), test->nodes, test->module),-1);
 }
@@ -1043,11 +1158,13 @@ void test_wm_office365_dump_yes_options(void **state) {
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret_path", data->office365_config->auth->client_secret_path);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
 
-    char *test = "{\"office365\":{\"enabled\":\"yes\",\"only_future_events\":\"yes\",\"interval\":10,\"api_auth\":[{\"tenant_id\":\"test_tenant_id\",\"client_id\":\"test_client_id\",\"client_secret_path\":\"test_client_secret_path\",\"client_secret\":\"test_client_secret\"}],\"subscriptions\":[\"test_subscription_name\"]}}";
+    char *test = "{\"office365\":{\"enabled\":\"yes\",\"only_future_events\":\"yes\",\"interval\":10,\"api_auth\":[{\"tenant_id\":\"test_tenant_id\",\"client_id\":\"test_client_id\",\"client_secret_path\":\"test_client_secret_path\",\"client_secret\":\"test_client_secret\",\"api_type\":\"commercial\"}],\"subscriptions\":[\"test_subscription_name\"]}}";
 
     cJSON *root = wm_office365_dump(data->office365_config);
     data->root_c = cJSON_PrintUnformatted(root);
@@ -1092,6 +1209,8 @@ void test_wm_office365_main_enable(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 1;
@@ -1150,6 +1269,8 @@ void test_wm_office365_get_access_token_with_auth_secret(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -1185,6 +1306,8 @@ void test_wm_office365_get_access_token_with_auth_secret_path(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret_path", data->office365_config->auth->client_secret_path);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -1217,6 +1340,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_400(void **sta
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1259,6 +1384,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_null(void **st
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1298,6 +1425,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_max_size_reach
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1340,6 +1469,8 @@ void test_wm_office365_get_access_token_with_auth_secret_error_json_response(voi
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1381,6 +1512,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_200(void **sta
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 200;
@@ -1419,12 +1552,15 @@ void test_wm_office365_manage_subscription_start_response_null(void **state) {
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 1;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1452,7 +1588,7 @@ void test_wm_office365_manage_subscription_start_response_null(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
     expect_string(__wrap__mtdebug1, formatted_msg, "Unknown error while managing subscription.");
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_INVALID);
     assert_null(error_msg);
@@ -1470,12 +1606,15 @@ void test_wm_office365_manage_subscription_start_code_200(void **state) {
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 1;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1503,7 +1642,7 @@ void test_wm_office365_manage_subscription_start_code_200(void **state) {
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_SUCCESS);
     assert_null(error_msg);
@@ -1521,12 +1660,15 @@ void test_wm_office365_manage_subscription_stop_error_json_response(void **state
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1556,7 +1698,7 @@ void test_wm_office365_manage_subscription_stop_error_json_response(void **state
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_INVALID);
     assert_null(error_msg);
@@ -1574,12 +1716,15 @@ void test_wm_office365_manage_subscription_stop_error_max_size_reached(void **st
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1610,7 +1755,7 @@ void test_wm_office365_manage_subscription_stop_error_max_size_reached(void **st
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_INVALID);
     assert_null(error_msg);
@@ -1628,12 +1773,15 @@ void test_wm_office365_manage_subscription_stop_code_400_error_AF20024(void **st
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1661,7 +1809,7 @@ void test_wm_office365_manage_subscription_stop_code_400_error_AF20024(void **st
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_SUCCESS);
     assert_null(error_msg);
@@ -1679,12 +1827,15 @@ void test_wm_office365_manage_subscription_stop_code_400_error_different_AF20024
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1714,7 +1865,7 @@ void test_wm_office365_manage_subscription_stop_code_400_error_different_AF20024
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_INVALID);
     assert_string_equal(error_msg, data->response->body);
@@ -2404,6 +2555,8 @@ void test_wm_office365_execute_scan_all(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     data->office365_config->auth->next = NULL;
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
@@ -2442,7 +2595,8 @@ void test_wm_office365_execute_scan_all(void **state) {
     will_return(__wrap_wurl_http_request, data->response);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API access token URL: 'https://login.microsoftonline.com/test_tenant_id/oauth2/v2.0/token'");
+    const char expected_token_url[] = "Office 365 API access token URL: 'https://" WM_OFFICE365_DEFAULT_API_LOGIN_FQDN "/test_tenant_id/oauth2/v2.0/token'";
+    expect_string(__wrap__mtdebug1, formatted_msg, expected_token_url);
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
@@ -2467,7 +2621,8 @@ void test_wm_office365_execute_scan_all(void **state) {
     will_return(__wrap_wurl_http_request, data->response);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API subscription URL: 'https://manage.office.com/api/v1.0/test_client_id/activity/feed/subscriptions/start?contentType=test_subscription_name'");
+    const char expected_subscription_url[] = "Office 365 API subscription URL: 'https://" WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN "/api/v1.0/test_client_id/activity/feed/subscriptions/start?contentType=test_subscription_name'";
+    expect_string(__wrap__mtdebug1, formatted_msg, expected_subscription_url);
 
     #ifndef WIN32
         will_return(__wrap_gmtime_r, 1);
@@ -2496,7 +2651,8 @@ void test_wm_office365_execute_scan_all(void **state) {
     expect_any(__wrap__mdebug1, formatted_msg);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API content blobs URL: 'https://manage.office.com/api/v1.0/test_client_id/activity/feed/subscriptions/content?contentType=test_subscription_name&startTime=2021-05-07 12:24:56&endTime=2021-05-07 12:24:56'");
+    const char expected_blob_url[] = "Office 365 API content blobs URL: 'https://" WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN "/api/v1.0/test_client_id/activity/feed/subscriptions/content?contentType=test_subscription_name&startTime=2021-05-07 12:24:56&endTime=2021-05-07 12:24:56'";
+    expect_string(__wrap__mtdebug1, formatted_msg, expected_blob_url);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
     expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API content URI: 'https://contentUri1.com'");
@@ -2556,6 +2712,8 @@ void test_wm_office365_execute_scan_initial_scan_only_future_events(void **state
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 1;
@@ -2598,6 +2756,8 @@ void test_wm_office365_execute_scan_access_token_null(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 1;
@@ -2643,6 +2803,8 @@ void test_wm_office365_execute_scan_manage_subscription_error(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 0;
@@ -2708,6 +2870,8 @@ void test_wm_office365_execute_scan_saving_running_state_error(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -2767,6 +2931,8 @@ void test_wm_office365_execute_scan_content_blobs_fail(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     data->office365_config->only_future_events = 0;
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
@@ -2868,6 +3034,8 @@ void test_wm_office365_execute_scan_get_logs_from_blob_response_null(void **stat
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 0;
@@ -3027,6 +3195,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_error_client_secret_1, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_error_client_secret_path, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_error_client_secret_path_1, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_error_api_type, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_error_api_type_1, setup_test_read, teardown_test_read),
     };
     const struct CMUnitTest tests_functionality[] = {
         cmocka_unit_test_setup_teardown(test_wm_office365_main_disabled, setup_conf, teardown_conf),

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -60,6 +60,7 @@ STATIC char* wm_office365_get_access_token(wm_office365_auth* auth, size_t max_s
 /**
  * @brief Start/stop a subscription through Office365 API
  * @param subscription Office365 subscription node
+ * @param management_fqdn Office365 management API endpoint domain
  * @param client_id Client ID
  * @param token Authentication token
  * @param start Whether to start/end a subscription
@@ -67,7 +68,7 @@ STATIC char* wm_office365_get_access_token(wm_office365_auth* auth, size_t max_s
  * @param error_msg Error message to complete in case of failure
  * @return 0 if no error, -1 otherwise
  */
-STATIC int wm_office365_manage_subscription(wm_office365_subscription* subscription, const char* client_id, const char* token, int start, size_t max_size, char **error_msg);
+STATIC int wm_office365_manage_subscription(wm_office365_subscription* subscription, const char* management_fqdn, const char* client_id, const char* token, int start, size_t max_size, char **error_msg);
 
 /**
  * @brief Get a content blob through Office365 API
@@ -179,6 +180,8 @@ void wm_office365_auth_destroy(wm_office365_auth* office365_auth) {
         os_free(current->client_id);
         os_free(current->client_secret_path);
         os_free(current->client_secret);
+        os_free(current->login_fqdn);
+        os_free(current->management_fqdn);
         os_free(current);
         current = next;
     }
@@ -248,6 +251,18 @@ cJSON *wm_office365_dump(const wm_office365* office365_config) {
             }
             if (iter->client_secret) {
                 cJSON_AddStringToObject(api_auth, "client_secret", iter->client_secret);
+            }
+            // The management API FQDN is unique between API types, so the login FQDN can be safely ignored
+            if (iter->management_fqdn) {
+                if (!strncmp(iter->management_fqdn, WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, 17)) {
+                    cJSON_AddStringToObject(api_auth, "api_type", "commercial");
+                }
+                if (!strncmp(iter->management_fqdn, WM_OFFICE365_GCC_API_MANAGEMENT_FQDN, 21)) {
+                    cJSON_AddStringToObject(api_auth, "api_type", "gcc");
+                }
+                if (!strncmp(iter->management_fqdn, WM_OFFICE365_GCC_HIGH_API_MANAGEMENT_FQDN, 19)) {
+                    cJSON_AddStringToObject(api_auth, "api_type", "gcc-high");
+                }
             }
             cJSON_AddItemToArray(arr_auth, api_auth);
         }
@@ -358,7 +373,7 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
             }
 
             // Start subscription
-            if (wm_office365_manage_subscription(current_subscription, current_auth->client_id, access_token, 1, office365_config->curl_max_size, &error_msg)) {
+            if (wm_office365_manage_subscription(current_subscription, current_auth->management_fqdn, current_auth->client_id, access_token, 1, office365_config->curl_max_size, &error_msg)) {
                 wm_office365_scan_failure_action(&office365_config->fails, current_auth->tenant_id,
                     current_subscription->subscription_name, error_msg, office365_config->queue_fd);
                 current_subscription = next_subscription;
@@ -394,7 +409,7 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                 strftime(end_time_str, sizeof(end_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
 
                 memset(url, '\0', OS_SIZE_8192);
-                snprintf(url, OS_SIZE_8192 -1, WM_OFFICE365_API_CONTENT_BLOB_URL, current_auth->client_id, current_subscription->subscription_name,
+                snprintf(url, OS_SIZE_8192 -1, WM_OFFICE365_API_CONTENT_BLOB_URL, current_auth->management_fqdn, current_auth->client_id, current_subscription->subscription_name,
                     start_time_str, end_time_str);
 
                 scan_finished = 0;
@@ -531,10 +546,10 @@ STATIC char* wm_office365_get_access_token(wm_office365_auth* auth, size_t max_s
     }
 
     memset(auth_payload, '\0', OS_SIZE_8192);
-    snprintf(auth_payload, OS_SIZE_8192 -1, WM_OFFICE365_API_ACCESS_TOKEN_PAYLOAD, auth->client_id, auth_secret);
+    snprintf(auth_payload, OS_SIZE_8192 -1, WM_OFFICE365_API_ACCESS_TOKEN_PAYLOAD, auth->client_id, auth->management_fqdn, auth_secret);
 
     memset(url, '\0', OS_SIZE_8192);
-    snprintf(url, OS_SIZE_8192 -1, WM_OFFICE365_API_ACCESS_TOKEN_URL, auth->tenant_id);
+    snprintf(url, OS_SIZE_8192 -1, WM_OFFICE365_API_ACCESS_TOKEN_URL, auth->login_fqdn, auth->tenant_id);
 
     mtdebug1(WM_OFFICE365_LOGTAG, "Office 365 API access token URL: '%s'", url);
 
@@ -575,7 +590,7 @@ STATIC char* wm_office365_get_access_token(wm_office365_auth* auth, size_t max_s
     return access_token;
 }
 
-STATIC int wm_office365_manage_subscription(wm_office365_subscription* subscription, const char* client_id, const char* token, int start, size_t max_size, char **error_msg) {
+STATIC int wm_office365_manage_subscription(wm_office365_subscription* subscription, const char* management_fqdn, const char* client_id, const char* token, int start, size_t max_size, char **error_msg) {
     char **headers = NULL;
     char url[OS_SIZE_8192];
     curl_response *response;
@@ -583,9 +598,9 @@ STATIC int wm_office365_manage_subscription(wm_office365_subscription* subscript
 
     memset(url, '\0', OS_SIZE_8192);
     if (start) {
-        snprintf(url, OS_SIZE_8192 -1, WM_OFFICE365_API_SUBSCRIPTION_URL, client_id, WM_OFFICE365_API_SUBSCRIPTION_START, subscription->subscription_name);
+        snprintf(url, OS_SIZE_8192 -1, WM_OFFICE365_API_SUBSCRIPTION_URL, management_fqdn, client_id, WM_OFFICE365_API_SUBSCRIPTION_START, subscription->subscription_name);
     } else {
-        snprintf(url, OS_SIZE_8192 -1, WM_OFFICE365_API_SUBSCRIPTION_URL, client_id, WM_OFFICE365_API_SUBSCRIPTION_STOP, subscription->subscription_name);
+        snprintf(url, OS_SIZE_8192 -1, WM_OFFICE365_API_SUBSCRIPTION_URL, management_fqdn, client_id, WM_OFFICE365_API_SUBSCRIPTION_STOP, subscription->subscription_name);
     }
 
     mtdebug1(WM_OFFICE365_LOGTAG, "Office 365 API subscription URL: '%s'", url);

--- a/src/wazuh_modules/wm_office365.h
+++ b/src/wazuh_modules/wm_office365.h
@@ -25,7 +25,7 @@
 #define WM_OFFICE365_GCC_API_LOGIN_FQDN "login.microsoftonline.com"
 #define WM_OFFICE365_GCC_API_MANAGEMENT_FQDN "manage-gcc.office.com"
 
-#define WM_OFFICE365_GGC_HIGH_API_LOGIN_FQDN "login.microsoftonline.us"
+#define WM_OFFICE365_GCC_HIGH_API_LOGIN_FQDN "login.microsoftonline.us"
 #define WM_OFFICE365_GCC_HIGH_API_MANAGEMENT_FQDN "manage.office365.us"
 
 #define WM_OFFICE365_MSG_DELAY 1000000 / wm_max_eps

--- a/src/wazuh_modules/wm_office365.h
+++ b/src/wazuh_modules/wm_office365.h
@@ -19,16 +19,24 @@
 #define WM_OFFICE365_DEFAULT_INTERVAL 60
 #define WM_OFFICE365_DEFAULT_CURL_MAX_SIZE 1048576L
 #define WM_OFFICE365_DEFAULT_CURL_REQUEST_TIMEOUT 60L
+#define WM_OFFICE365_DEFAULT_API_LOGIN_FQDN "login.microsoftonline.com"
+#define WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN "manage.office.com"
+
+#define WM_OFFICE365_GCC_API_LOGIN_FQDN "login.microsoftonline.com"
+#define WM_OFFICE365_GCC_API_MANAGEMENT_FQDN "manage-gcc.office.com"
+
+#define WM_OFFICE365_GGC_HIGH_API_LOGIN_FQDN "login.microsoftonline.us"
+#define WM_OFFICE365_GCC_HIGH_API_MANAGEMENT_FQDN "manage.office365.us"
 
 #define WM_OFFICE365_MSG_DELAY 1000000 / wm_max_eps
 #define WM_OFFICE365_RETRIES_TO_SEND_ERROR 3
 #define WM_OFFICE365_NEXT_PAGE_REGEX "NextPageUri:\\s*(\\S+)"
 
-#define WM_OFFICE365_API_ACCESS_TOKEN_URL "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
-#define WM_OFFICE365_API_SUBSCRIPTION_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/%s?contentType=%s"
-#define WM_OFFICE365_API_CONTENT_BLOB_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/content?contentType=%s&startTime=%s&endTime=%s"
+#define WM_OFFICE365_API_ACCESS_TOKEN_URL "https://%s/%s/oauth2/v2.0/token"
+#define WM_OFFICE365_API_SUBSCRIPTION_URL "https://%s/api/v1.0/%s/activity/feed/subscriptions/%s?contentType=%s"
+#define WM_OFFICE365_API_CONTENT_BLOB_URL "https://%s/api/v1.0/%s/activity/feed/subscriptions/content?contentType=%s&startTime=%s&endTime=%s"
 
-#define WM_OFFICE365_API_ACCESS_TOKEN_PAYLOAD "client_id=%s&scope=https://manage.office.com/.default&grant_type=client_credentials&client_secret=%s"
+#define WM_OFFICE365_API_ACCESS_TOKEN_PAYLOAD "client_id=%s&scope=https://%s/.default&grant_type=client_credentials&client_secret=%s"
 
 #define WM_OFFICE365_API_SUBSCRIPTION_START "start"
 #define WM_OFFICE365_API_SUBSCRIPTION_STOP "stop"
@@ -38,6 +46,8 @@ typedef struct wm_office365_auth {
     char *client_id;
     char *client_secret_path;
     char *client_secret;
+    char *login_fqdn;
+    char *management_fqdn;
     struct wm_office365_auth *next;
 } wm_office365_auth;
 


### PR DESCRIPTION
|Related issue|Manual testing|Integration tests|Documentation|
|---|---|---|---|
|Resolves #14029|https://github.com/wazuh/wazuh-qa/issues/4062|https://github.com/wazuh/wazuh-qa/pull/4065|https://github.com/wazuh/wazuh-documentation/pull/6000|

@S-Bryce 

To provide additional context on the related issue, the Office365 module has several hard-coded API endpoints that are used to communicate with Microsoft 365/Azure tenants:
https://github.com/wazuh/wazuh/blob/6d972907c90cdfe709fa021d384519c02dd0b24a/src/wazuh_modules/wm_office365.h#L27-L31
However, these endpoints change depending on the MS 365 tenant's type/plan, e.g., commercial, government community cloud (GCC), or government community cloud high (GCC High). This makes it difficult for users to receive logs from GCC or GCC High tenants, as these endpoints cannot be changed without modifying the corresponding header file and rebuilding the Wazuh server from source. References on how these endpoints change between subscription plans can be found [here for the API endpoints](https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-reference) and [here for the authentication endpoint](https://learn.microsoft.com/en-us/azure/active-directory/develop/authentication-national-cloud).


## Description

This PR extends the Office365 module's functionality by providing a new configuration option, `api_type`, within the existing `api_auth` block. This new `api_type` parameter allows users to specify what kind of tenant they are using, from which the server can automatically select the appropriate endpoint FQDNs on a per-tenant basis. In the case that the `api_type` parameter is not provided in a tenant's `api_auth` block, the default value `commercial` is used, as its endpoints are the same as the current hard-coded ones, providing retrocompatibility.

Forks of the [wazuh-documentation](https://github.com/S-Bryce/wazuh-documentation/tree/dev-office365-gcc-support) and [wazuh-qa](https://github.com/S-Bryce/wazuh-qa/tree/dev-office365-gcc-support) repositories that update them vis-à-vis the new parameter have also been created. If this PR ends up being to everyone's liking, I would be happy to make additional PRs for those as well.

## Configuration options

|Parameter|Allowed Values|
|---|---|
|api_auth\api_type|commercial, gcc, gcc-high|

## Logs/Alerts example

The examples below used an `api_type` of `gcc-high` and were connected to a GCC High tenant for testing:
```
# tail /var/ossec/logs/ossec.log | grep office365
2022/09/27 08:57:15 wazuh-modulesd:office365[2788] wm_office365.c:498 at wm_office365_execute_scan(): DEBUG: Bookmark updated to '2022-09-27T13:57:15Z' for tenant 'xxxx-xxxx-xxxx-xxxx-xxxx' and subscription 'Audit.AzureActiveDirectory', waiting '60' seconds to run next scan.
2022/09/27 08:57:15 wazuh-modulesd:office365[2788] wm_office365.c:604 at wm_office365_manage_subscription(): DEBUG: Office 365 API subscription URL: 'https://manage.office365.us/api/v1.0/xxxx-xxxx-xxxx-xxxx-xxxx/activity/feed/subscriptions/start?contentType=Audit.Exchange'
2022/09/27 08:57:15 wazuh-modulesd:office365[2788] wm_office365.c:654 at wm_office365_get_content_blobs(): DEBUG: Office 365 API content blobs URL: 'https://manage.office365.us/api/v1.0/xxxx-xxxx-xxxx-xxxx-xxxx/activity/feed/subscriptions/content?contentType=Audit.Exchange&startTime=2022-09-27T13:56:13Z&endTime=2022-09-27T13:57:15Z'
```

```
{
  "_index": "wazuh-alerts-4.x-2022.09.20",
  "_type": "_doc",
  "_id": "NzQtXIMBGHI76S58Hc6p",
  "_version": 1,
  "_score": null,
  "_source": {
    "input": {
      "type": "log"
    },
    "agent": {
      "name": "IDUSLABGCC",
      "id": "000"
    },
    "manager": {
      "name": "IDUSLABGCC"
    },
    "data": {
      "integration": "office365",
      "office365": {
        "AzureActiveDirectoryEventType": "1",
        "UserKey": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "ActorIpAddress": "xxx.xxx.xxx.xxx",
        "Operation": "UserLoggedIn",
        "OrganizationId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "ExtendedProperties": [
          {
            "Value": "Success",
            "Name": "ResultStatusDetail"
          },
          {
            "Value": "true",
            "Name": "KeepMeSignedIn"
          },
          {
            "Value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
            "Name": "UserAgent"
          },
          {
            "Value": "SAS:ProcessAuth",
            "Name": "RequestType"
          }
        ],
        "IntraSystemId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "Target": [
          {
            "Type": 0,
            "ID": "xxxx-xxxx-xxxx-xxxx-xxxx"
          }
        ],
        "RecordType": "15",
        "Version": "1",
        "ModifiedProperties": [],
        "Actor": [
          {
            "Type": 0,
            "ID": "xxxx-xxxx-xxxx-xxxx-xxxx"
          },
          {
            "Type": 5,
            "ID": "xxxx@xxxx.xxxx"
          }
        ],
        "DeviceProperties": [
          {
            "Value": "Windows 10",
            "Name": "OS"
          },
          {
            "Value": "Chrome",
            "Name": "BrowserType"
          },
          {
            "Value": "False",
            "Name": "IsCompliantAndManaged"
          },
          {
            "Value": "xxxx-xxxx-xxxx-xxxx-xxxx",
            "Name": "SessionId"
          }
        ],
        "Subscription": "Audit.AzureActiveDirectory",
        "ActorContextId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "ResultStatus": "Success",
        "ObjectId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "ErrorNumber": "50140",
        "ClientIP": "xxx.xxx.xxx.xxxx",
        "Workload": "AzureActiveDirectory",
        "UserId": "xxxx@xxxx.xxxx",
        "TargetContextId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "CreationTime": "2022-09-20T18:28:46",
        "Id": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "InterSystemsId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "ApplicationId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "UserType": "0"
      }
    },
    "rule": {
      "firedtimes": 1,
      "mail": false,
      "level": 3,
      "hipaa": [
        "164.312.a.2.I",
        "164.312.b",
        "164.312.d",
        "164.312.e.2.II"
      ],
      "pci_dss": [
        "8.3",
        "10.6.1"
      ],
      "description": "Office 365: Secure Token Service (STS) logon events in Azure Active Directory.",
      "groups": [
        "office365",
        "AzureActiveDirectoryStsLogon"
      ],
      "id": "91545"
    },
    "location": "office365",
    "decoder": {
      "name": "json"
    },
    "id": "1663698801.564178",
    "GeoLocation": {
      "city_name": "xxxx",
      "country_name": "xxxx",
      "region_name": "xxxx",
      "location": {
        "lon": xxxx,
        "lat": xxxx
      }
    },
    "timestamp": "2022-09-20T13:33:21.447-0500"
  },
  "fields": {
    "timestamp": [
      "2022-09-20T18:33:21.447Z"
    ]
  },
  "highlight": {
    "data.office365.Operation": [
      "@opensearch-dashboards-highlighted-field@UserLoggedIn@/opensearch-dashboards-highlighted-field@"
    ],
    "data.integration": [
      "@opensearch-dashboards-highlighted-field@office365@/opensearch-dashboards-highlighted-field@"
    ]
  },
  "sort": [
    1663698801447
  ]
}
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)

## Test Validation
### Unit Testing
![image](https://user-images.githubusercontent.com/89558443/221645933-f49670d2-9178-4f10-b2f9-686b0373fc97.png)
![image](https://user-images.githubusercontent.com/89558443/221645973-41b269fb-32c4-4f5a-a381-edf99a397c86.png)
![image](https://user-images.githubusercontent.com/89558443/221645996-3a6484ad-8c43-4234-9428-bbc8e89b59d9.png)
![image](https://user-images.githubusercontent.com/89558443/221646010-c8a1c898-d460-4611-8559-71f2ff6f333a.png)

### Valgrind (memory leak testing)
![image](https://user-images.githubusercontent.com/89558443/221646063-71aa22cf-ec55-4c3b-a570-10ad92a942b7.png)

### Coverage Report
![image](https://user-images.githubusercontent.com/89558443/221646119-20963686-839c-44f2-859b-a56c81cf25b3.png)
