### PR TITLE
Engine integrate server metrics

### DIFF
--- a/src/engine/source/cmds/src/start.cpp
+++ b/src/engine/source/cmds/src/start.cpp
@@ -211,7 +211,7 @@ void runStart(ConfHandler confManager, const std::shared_ptr<metrics_manager::IM
         api::catalog::handlers::registerHandlers(catalog, server->getRegistry());
         WAZUH_LOG_DEBUG("Catalog API registered.")
 
-        router = std::make_shared<router::Router>(builder, store, threads);
+        router = std::make_shared<router::Router>(builder, store, metricsManager, threads);
         router->run(server->getEventQueue());
         g_exitHanlder.add([router]() { router->stop(); });
         WAZUH_LOG_INFO("Router initialized.");

--- a/src/engine/source/router/CMakeLists.txt
+++ b/src/engine/source/router/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(router
     base
     json
     store::istore
+    metrics
 )
 
 target_include_directories(router

--- a/src/engine/source/router/include/router/router.hpp
+++ b/src/engine/source/router/include/router/router.hpp
@@ -17,6 +17,9 @@
 #include "environmentManager.hpp"
 #include "route.hpp"
 
+#include <metrics/iMetricsManager.hpp>
+#include <metrics/iMetricsScope.hpp>
+
 namespace router
 {
 constexpr auto ROUTES_TABLE_NAME = "internal/router_table/0"; ///< Name of the routes table in the store
@@ -80,6 +83,9 @@ private:
      */
     void dumpTableToStorage();
 
+    std::shared_ptr<metrics_manager::IMetricsScope> m_spMetricsScope;
+    std::shared_ptr<metrics_manager::IMetricsScope> m_spMetricsScopeDelta;
+
 public:
     using Entry = std::tuple<std::string, std::size_t, std::string, std::string>; ///< Entry of the routes table (name,
                                                                                   ///< priority, filter, target)
@@ -91,7 +97,8 @@ public:
      * @param store Store to get/save the routes table
      * @param threads Number of threads for the pool
      */
-    Router(std::shared_ptr<builder::Builder> builder, std::shared_ptr<store::IStore> store, std::size_t threads = 1);
+    Router(std::shared_ptr<builder::Builder> builder, std::shared_ptr<store::IStore> store,
+            const std::shared_ptr<metrics_manager::IMetricsManager>& metricsManager, std::size_t threads = 1);
 
     /**
      * @brief Get the list of route names, priority and target

--- a/src/engine/test/source/router/router_test.cpp
+++ b/src/engine/test/source/router/router_test.cpp
@@ -8,26 +8,30 @@
 
 #include "testAuxiliar/routerAuxiliarFunctions.hpp"
 
+#include <metrics/metricsManager.hpp>
+using namespace metrics_manager;
+
 TEST(Router, build_ok)
 {
+    std::shared_ptr<IMetricsManager> manager = std::make_shared<MetricsManager>();
     auto registry = std::make_shared<builder::internals::Registry>();
     builder::internals::registerBuilders(registry);
     auto builder = aux::getFakeBuilder();
     auto store = aux::getFakeStore();
 
-    router::Router router(builder, store);
+    router::Router router(builder, store, manager);
 }
 // Add more test
 TEST(Router, build_fail)
 {
-
+    std::shared_ptr<IMetricsManager> manager = std::make_shared<MetricsManager>();
     auto registry = std::make_shared<builder::internals::Registry>();
     builder::internals::registerBuilders(registry);
     auto builder = aux::getFakeBuilder();
     auto store = aux::getFakeStore();
 
     try {
-        router::Router router(builder, store, 0);
+        router::Router router(builder, store, manager, 0);
         FAIL() << "Router: The router was created with 0 threads";
     } catch (const std::runtime_error& e) {
         ASSERT_STREQ(e.what(), "Router: The number of threads must be between 1 and 128");
@@ -36,7 +40,7 @@ TEST(Router, build_fail)
     }
 
     try {
-        router::Router router(nullptr, store, 1);
+        router::Router router(nullptr, store, manager, 1);
         FAIL() << "Router: The router was created with a null builder";
     } catch (const std::runtime_error& e) {
         ASSERT_STREQ(e.what(), "Router: Builder cannot be null");
@@ -45,7 +49,7 @@ TEST(Router, build_fail)
     }
 
     try {
-        router::Router router(builder, nullptr, 1);
+        router::Router router(builder, nullptr, manager, 1);
         FAIL() << "Router: The router was created with a null store";
     } catch (const std::runtime_error& e) {
         ASSERT_STREQ(e.what(), "Router: Store cannot be null");
@@ -56,12 +60,13 @@ TEST(Router, build_fail)
 
 TEST(Router, add_list_remove_routes)
 {
+    std::shared_ptr<IMetricsManager> manager = std::make_shared<MetricsManager>();
     auto registry = std::make_shared<builder::internals::Registry>();
     builder::internals::registerBuilders(registry);
     auto builder = aux::getFakeBuilder();
     auto store = aux::getFakeStore();
 
-    router::Router router(builder, store);
+    router::Router router(builder, store, manager);
 
     ASSERT_EQ(router.getRouteTable().size(), 0);
 
@@ -111,12 +116,13 @@ TEST(Router, add_list_remove_routes)
 }
 
 TEST(Router, priorityChanges) {
+    std::shared_ptr<IMetricsManager> manager = std::make_shared<MetricsManager>();
     auto registry = std::make_shared<builder::internals::Registry>();
     builder::internals::registerBuilders(registry);
     auto builder = aux::getFakeBuilder();
     auto store = aux::getFakeStore();
 
-    router::Router router(builder, store);
+    router::Router router(builder, store, manager);
 
     // Add a route
     auto error = router.addRoute("e_wazuh_queue", 2,"filter/e_wazuh_queue/0", "environment/env_1/0");
@@ -221,6 +227,7 @@ TEST(Router, checkRouting) {
     const auto ENV_C3 = "deco_C3";
     const auto PATH_DECODER = json::Json::formatJsonPath("~decoder");
 
+    std::shared_ptr<IMetricsManager> manager = std::make_shared<MetricsManager>();
     auto registry = std::make_shared<builder::internals::Registry>();
     builder::internals::registerBuilders(registry);
     auto builder = aux::getFakeBuilder();
@@ -229,7 +236,7 @@ TEST(Router, checkRouting) {
     // Run the router
     auto testQueue = aux::testQueue{};
 
-    router::Router router(builder, store);
+    router::Router router(builder, store, manager);
     router.run(testQueue.getQueue());
 
     /*************************************************************************************


### PR DESCRIPTION
|Related issue| Documentation| Testing issue|
|---|---|---|
| #16273| link to docu, user manual or design doc| Testing issue |

## Server metrics
Research and list Server metrics. Each metric must be clearly defined and documented, so its meaning and usage is clear. 
These metrics must help the administrator with capacity planning and debugging performance issues:



Each module of the engine needs appropriate metrics as well. We must complete each module metrics after carefully considering its value.