### PR TITLE
Update 0840-win_event_channel.xml

### DIFF
--- a/ruleset/rules/0840-win_event_channel.xml
+++ b/ruleset/rules/0840-win_event_channel.xml
@@ -92,9 +92,7 @@
       <id>T1078.002</id>
       <id>T1021.001</id>
     </mitre>
-    <group>
-      authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
-    </group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
 </group>


### PR DESCRIPTION
Just fixed an mistake in rule: 92657
 tag `<group>` had extra indents

Old:
```xml
<group>
  authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
</group>
```

![Screenshot 2023-04-03 at 11 36 45](https://user-images.githubusercontent.com/72973604/229456458-9cabf66a-684f-445b-9281-d390e9ab7caa.png)

Fixed:
```xml
<group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
```

![image](https://user-images.githubusercontent.com/72973604/229456744-43690bd9-00be-4687-8761-67164e0f4019.png)
