### PR TITLE
Engine integrate API metrics

### DIFF
--- a/src/engine/source/server/include/server/engineServer.hpp
+++ b/src/engine/source/server/include/server/engineServer.hpp
@@ -92,7 +92,7 @@ public:
 
     std::shared_ptr<metrics_manager::IMetricsScope> m_spMetricsScope;
     std::shared_ptr<metrics_manager::IMetricsScope> m_spMetricsScopeDelta;
-    std::shared_ptr<metrics_manager::IMetricsScope> m_spMetricsScopeApi;
+    std::shared_ptr<metrics_manager::IMetricsScope> m_spMetricsScopeAPI;
 };
 
 } // namespace engineserver

--- a/src/engine/source/server/include/server/engineServer.hpp
+++ b/src/engine/source/server/include/server/engineServer.hpp
@@ -92,6 +92,7 @@ public:
 
     std::shared_ptr<metrics_manager::IMetricsScope> m_spMetricsScope;
     std::shared_ptr<metrics_manager::IMetricsScope> m_spMetricsScopeDelta;
+    std::shared_ptr<metrics_manager::IMetricsScope> m_spMetricsScopeApi;
 };
 
 } // namespace engineserver

--- a/src/engine/source/server/src/endpoints/apiEndpoint.cpp
+++ b/src/engine/source/server/src/endpoints/apiEndpoint.cpp
@@ -84,7 +84,7 @@ void APIEndpoint::connectionHandler(PipeHandle& handle)
         });
 
     client->on<DataEvent>(
-        [&, timer, protocolHandler, failedResponses, responseTime](const DataEvent& event, PipeHandle& client)
+        [this, timer, protocolHandler, failedResponses, responseTime](const DataEvent& event, PipeHandle& client)
         {
             auto startTime = std::chrono::high_resolution_clock::now();
             timer->again();

--- a/src/engine/source/server/src/engineServer.cpp
+++ b/src/engine/source/server/src/engineServer.cpp
@@ -37,13 +37,14 @@ EngineServer::EngineServer(const std::string& apiEndpointPath,
 {
     try
     {
+        m_spMetricsScopeApi = metricsManager->getMetricsScope("api");
         m_spMetricsScope = metricsManager->getMetricsScope("server");
         m_spMetricsScopeDelta = metricsManager->getMetricsScope("serverRate", true);
         if (nullptr == registry)
         {
             registry = std::make_shared<api::Registry>();
         }
-        auto apiEndpoint = std::make_shared<APIEndpoint>(apiEndpointPath, registry, m_spMetricsScope);
+        auto apiEndpoint = std::make_shared<APIEndpoint>(apiEndpointPath, registry, m_spMetricsScopeApi);
         apiEndpoint->configure();
         m_endpoints.emplace(EndpointType::API, std::move(apiEndpoint));
 

--- a/src/engine/source/server/src/engineServer.cpp
+++ b/src/engine/source/server/src/engineServer.cpp
@@ -37,14 +37,14 @@ EngineServer::EngineServer(const std::string& apiEndpointPath,
 {
     try
     {
-        m_spMetricsScopeApi = metricsManager->getMetricsScope("api");
-        m_spMetricsScope = metricsManager->getMetricsScope("server");
-        m_spMetricsScopeDelta = metricsManager->getMetricsScope("serverRate", true);
+        m_spMetricsScopeAPI = metricsManager->getMetricsScope("API");
+        m_spMetricsScope = metricsManager->getMetricsScope("Server");
+        m_spMetricsScopeDelta = metricsManager->getMetricsScope("ServerRate", true);
         if (nullptr == registry)
         {
             registry = std::make_shared<api::Registry>();
         }
-        auto apiEndpoint = std::make_shared<APIEndpoint>(apiEndpointPath, registry, m_spMetricsScopeApi);
+        auto apiEndpoint = std::make_shared<APIEndpoint>(apiEndpointPath, registry, m_spMetricsScopeAPI);
         apiEndpoint->configure();
         m_endpoints.emplace(EndpointType::API, std::move(apiEndpoint));
 


### PR DESCRIPTION
|Related issue| Documentation| Testing issue|
|---|---|---|
| #16274|[Link](https://docs.google.com/document/d/1N0p7pd7XszQwFU9HBjpB7txIw2DCcAsV-BKfEZSLixw/edit#bookmark=id.89sr6lra224r) | Testing issue |

## Router metrics
Research and list Server metrics. Each metric must be clearly defined and documented, so its meaning and usage is clear. 
These metrics must help the administrator with capacity planning and debugging performance issues:


 - [x] Research and list API metrics.
   - [x] Number of request (Counter).
   - [x] Number of failed responses (Counter).
   - [x] Response latency (Histogram).
   - [x]  Total Request
  - [x] Implement API metrics.
 - [x] Update the user manual. 

Each module of the engine needs appropriate metrics as well. We must complete each module metrics after carefully considering its value.