### PR TITLE
Use Test-Path to detect powershell path in Windows agent upgrade script

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -6,7 +6,7 @@ $Env:WAZUH_DEF_REG_START_PATH = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion
 $Env:WAZUH_PUBLISHER_VALUE    = "Wazuh, Inc."
 
 # Select powershell
-if ((Get-WmiObject Win32_OperatingSystem).OSArchitecture -eq "64-bit" -And [System.IntPtr]::Size -eq 4) {
+if (Test-Path "$env:windir\sysnative") {
     write-output "$(Get-Date -format u) Sysnative Powershell will be used to access the registry." >> .\upgrade\upgrade.log
     Set-Alias Start-NativePowerShell "$env:windir\sysnative\WindowsPowerShell\v1.0\powershell.exe"
 } else {

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -5,9 +5,12 @@ $TMP_BACKUP_DIR               = "wazuh_backup_tmp"
 $Env:WAZUH_DEF_REG_START_PATH = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\"
 $Env:WAZUH_PUBLISHER_VALUE    = "Wazuh, Inc."
 
+# Delete previous upgrade.log
+Remove-Item -Path ".\upgrade\upgrade.log" -ErrorAction SilentlyContinue
+
 # Select powershell
 if (Test-Path "$env:windir\sysnative") {
-    write-output "$(Get-Date -format u) Sysnative Powershell will be used to access the registry." >> .\upgrade\upgrade.log
+    write-output "$(Get-Date -format u) - Sysnative Powershell will be used to access the registry." >> .\upgrade\upgrade.log
     Set-Alias Start-NativePowerShell "$env:windir\sysnative\WindowsPowerShell\v1.0\powershell.exe"
 } else {
     Set-Alias Start-NativePowerShell "$env:windir\System32\WindowsPowerShell\v1.0\powershell.exe"
@@ -229,7 +232,7 @@ function install
 
 # Get current version
 $current_version = (Get-Content VERSION)
-write-output "$(Get-Date -format u) - Current version: $($current_version)." > .\upgrade\upgrade.log
+write-output "$(Get-Date -format u) - Current version: $($current_version)." >> .\upgrade\upgrade.log
 
 # Get process name
 $current_process = "wazuh-agent"


### PR DESCRIPTION
|Related issue|
|---|
|Closes #15196|

## Description

The problem was [caused by the wrong powershell selection](https://github.com/wazuh/wazuh/issues/15196#issuecomment-1474057613) for the rollback procedure when using a non-English version of Windows.
The solution is to directly check the existence of the sysnative path with `Test-Path "$env:windir\sysnative"` as suggested by a user [here](https://github.com/wazuh/wazuh/issues/15196#issuecomment-1490060171), and validated [here](https://github.com/wazuh/wazuh/issues/15196#issuecomment-1494877372).
Since the solution does not use a string comparison of a localized variable, the language of the OS is now irrelevant.

In addition, this PR fixes a small bug in the script logging that prevented the line `"Sysnative Powershell will be used to access the registry."` from being visible in the upgrade.log: the file was truncated after that line was written. This message is important to see what powershell was selected during the upgrade.

## Manual tests

Tests performed with manager `v4.5.1`, at commit adf19568c2421c61d69261558c8cf5e910ce02fe. 
Custom WPK used in these tests: [wazuh_agent_v4.5.1_pr16659.zip](https://github.com/wazuh/wazuh/files/11950673/wazuh_agent_v4.5.1_pr16659.zip)

<details><summary>Windows 11 - 64 bits - Spanish - Succesful upgrade</summary>

#### The following screenshot shows:
- The installed agent at the start of the test is `v4.3.10`.
- Upgrade to `4.5.1` was successful.
- The reported version after the upgrade is 4.5.1 by both the VERSION file and Windows registry.
- Other observations:
  - The log shows the message `"Sysnative Powershell will be used to access the registry."`. This indicates that it is a 64-bit Windows.
  - The upgrade script found and backed up the cached MSI:
    - `Backing up Wazuh-Agent cached MSI: "C:\WINDOWS\Installer\9ec41cb.msi" `
![Win11-64bits-success](https://github.com/wazuh/wazuh/assets/7939712/c6e72144-0a79-4744-98aa-9abfb18d1732)


</details>
<details><summary>Windows 11 - 64 bits - Spanish - Failed upgrade</summary>

#### The following screenshot shows:
- The installed agent at the start of the test is `v4.3.10`.
- Upgrade to `4.5.1` failed(*): `Upgrade failed: Restoring former installation.`
- The rollback with the backed-up MSI was done correctly:
   - `Performing the Wazuh-Agent uninstall using: "MsiExec.exe /X{A9A1109D-29A1-450A-A7AE-EF43FCDFA3C7} /quiet".`
   - `Excecuting former Wazuh-Agent MSI: ".\backup\a300a98.msi".`
- The reported version after the upgrade is 4.3.10 by both the VERSION file and Windows registry.
- Other observations:
  - The log shows the message `"Sysnative Powershell will be used to access the registry."`. This indicates that it is a 64-bit Windows.
  - The upgrade script found and backed up the cached MSI:
    - `Backing up Wazuh-Agent cached MSI: "C:\WINDOWS\Installer\a300a98.msi". `
![Win11-64bits-failed](https://github.com/wazuh/wazuh/assets/7939712/99fa7b20-ca04-4a8c-9a1a-5f47cc367268)

*(To make the upgrade fail, the connection between manager and agent was deliberately blocked after the agent received the WPK file)

</details>
<details><summary>Windows 10 - 32 bits - Spanish - Succesful upgrade</summary>

#### The following screenshot shows:
- The installed agent at the start of the test is `v4.3.10`.
- Upgrade to `4.5.1` was successful.
- The reported version after the upgrade is 4.5.1 by both the VERSION file and Windows registry.
- Other observations:
  - The log **does not** show the message `"Sysnative Powershell will be used to access the registry."`. This indicates that it is a 32-bit Windows.
  - The upgrade script found and backed up the cached MSI:
    - `Backing up Wazuh-Agent cached MSI: "C:\Windows\Installer\bcee5.msi".`

![Win10 - 32bits - successful](https://github.com/wazuh/wazuh/assets/7939712/66a01868-7e2d-4eb8-9602-db7e28b69bdd)

</details>
<details><summary>Windows 10 - 32 bits - Spanish - Failed upgrade</summary>

#### The following screenshot shows:
- The installed agent at the start of the test is `v4.4.0`.
- Upgrade to `4.5.1` failed(*): `Upgrade failed: Restoring former installation.`
- The rollback with the backed-up MSI was done correctly:
   - `Performing the Wazuh-Agent uninstall using: "MsiExec.exe /X{A9A1109D-29A1-450A-A7AE-EF43FCDFA3C7} /quiet".`
   - `Excecuting former Wazuh-Agent MSI: ".\backup\c0f80.msi".`
- The reported version after the upgrade is 4.4.0 by both the VERSION file and Windows registry.
- Other observations:
  - The log **does not** show the message `"Sysnative Powershell will be used to access the registry."`. This indicates that it is a 32-bit Windows.
  - The upgrade script found and backed up the cached MSI:
    - `Backing up Wazuh-Agent cached MSI: "C:\Windows\Installer\c0f80.msi".`

![Win10 - 32bits - failed](https://github.com/wazuh/wazuh/assets/7939712/d5564a86-fccd-41d2-bbfc-b78fd88ad896)

*(To make the upgrade fail, the connection between manager and agent was deliberately blocked after the agent received the WPK file)

</details>

-----

## Previous behavior

Without the changes made by this PR, this was the result of a failed upgrade on a Windows system that had a non-english language:

Upgrade from 4.3.10 to 4.4.0 failed, the rollback was done incorrectly and left the installation in an inconsistent state

- VERSION file content and Windows registry information **prior** to the attempted upgrade both show version 4.3.10:
![Captura de pantalla 2023-05-17 123344_annotated](https://github.com/wazuh/wazuh/assets/7939712/6919db70-31b9-49ba-ad62-f1ea58bd9fe4)

- upgrade.log shows:
  - No mention of the sysnative powershell being selected.
  - The cached MSI was **not** found.
  - The uninstall command was not found
![upgrade_log_before_fix_annotated](https://github.com/wazuh/wazuh/assets/7939712/cc958752-66c4-4197-8881-f3bffcec0632)

- VERSION file content and Windows registry information **after** the rollback is inconsistent:
![Captura de pantalla 2023-05-17 123430_annotated](https://github.com/wazuh/wazuh/assets/7939712/4b4fce18-5cdc-405f-a7a6-97d9fcdc3129)


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
