### PR TITLE
Fixed JSON malformed warning

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1556,7 +1556,7 @@ static void FillCheckEventInfo(Eventinfo *lf, cJSON *scan_id, cJSON *id, cJSON *
     if(scan_id) {
         char value[OS_SIZE_128];
 
-        if(scan_id->valueint < 0){
+        if(scan_id->valueint >= 0){
             sprintf(value, "%d", scan_id->valueint);
         } else if (scan_id->valuedouble) {
              sprintf(value, "%lf", scan_id->valuedouble);
@@ -1690,7 +1690,7 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
     if(scan_id) {
         char value[OS_SIZE_128];
 
-        if(scan_id->valueint < 0){
+        if(scan_id->valueint >= 0){
             sprintf(value, "%d", scan_id->valueint);
         } else if (scan_id->valuedouble) {
             sprintf(value, "%lf", scan_id->valuedouble);

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1556,7 +1556,7 @@ static void FillCheckEventInfo(Eventinfo *lf, cJSON *scan_id, cJSON *id, cJSON *
     if(scan_id) {
         char value[OS_SIZE_128];
 
-        if(scan_id->valueint){
+        if(scan_id->valueint < 0){
             sprintf(value, "%d", scan_id->valueint);
         } else if (scan_id->valuedouble) {
              sprintf(value, "%lf", scan_id->valuedouble);
@@ -1690,7 +1690,7 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
     if(scan_id) {
         char value[OS_SIZE_128];
 
-        if(scan_id->valueint){
+        if(scan_id->valueint < 0){
             sprintf(value, "%d", scan_id->valueint);
         } else if (scan_id->valuedouble) {
             sprintf(value, "%lf", scan_id->valuedouble);

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -958,8 +958,8 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
         return;
     }
 
-    if(!pm_scan_id->valueint) {
-        merror("Malformed JSON: field 'scan_id' must be a string.");
+    if(pm_scan_id->valueint < 0) {
+        merror("Malformed JSON: field 'scan_id' cannot be negative.");
         return;
     }
 

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -958,6 +958,11 @@ static void HandleScanInfo(Eventinfo *lf,int *socket,cJSON *event) {
         return;
     }
 
+    if(!cJSON_IsNumber(pm_scan_id)){
+        merror("Malformed JSON: field 'scan_id' must be a number.");
+        return;
+    }
+
     if(pm_scan_id->valueint < 0) {
         merror("Malformed JSON: field 'scan_id' cannot be negative.");
         return;

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -24,7 +24,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_scan_info_get -Wl,--wrap,wdb_fim_upd
                         -Wl,--wrap,sqlite3_changes -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_last_insert_rowid \
                         -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave \
                         -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_open_global \
-                        -Wl,--wrap,wdb_global_agent_exists \
+                        -Wl,--wrap,wdb_global_agent_exists -Wl,--wrap,wdb_sca_find \
                         -Wl,--wrap,cJSON_PrintUnformatted \
                         -Wl,--wrap,wdb_agents_get_sys_osinfo -Wl,--wrap,wdb_osinfo_save \
                         -Wl,--wrap,wdb_agents_get_packages -Wl,--wrap,wdb_agents_get_hotfixes -Wl,--wrap,close -Wl,--wrap,getpid \

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -389,3 +389,9 @@ int __wrap_wdb_update_last_vacuum_data(__attribute__((unused))wdb_t* wdb, __attr
 int __wrap_wdb_get_db_free_pages_percentage(__attribute__((unused))wdb_t * wdb) {
     return mock();
 }
+
+int __wrap_wdb_sca_find(__attribute__((unused))wdb_t *socket, 
+                        __attribute__((unused))int pm_id, char *result_found) {
+
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -101,4 +101,6 @@ int __wrap_wdb_get_db_free_pages_percentage(__attribute__((unused))wdb_t * wdb);
 
 int __wrap_wdb_exec_stmt_send(__attribute__((unused)) sqlite3_stmt* stmt, int peer);
 
+int __wrap_wdb_sca_find(wdb_t *socket, int pm_id, char *result_found);
+
 #endif

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -2142,6 +2142,12 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             return OS_INVALID;
         }
 
+        if (!cJSON_IsNumber(scan_id)) {
+            mdebug1("Malformed JSON: field 'id' must be a number");
+            snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
+            return OS_INVALID;
+        }
+
         if (scan_id->valueint < 0) {
             mdebug1("Malformed JSON: field 'id' cannot be negative");
             snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -2142,12 +2142,6 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             return OS_INVALID;
         }
 
-        if (!scan_id->valueint) {
-            mdebug1("Malformed JSON: field 'id' must be a number");
-            snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
-            return OS_INVALID;
-        }
-
         if (policy_id = cJSON_GetObjectItem(event, "policy_id"), !policy_id) {
             mdebug1("Malformed JSON: field 'policy_id' not found");
             snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -2142,6 +2142,12 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             return OS_INVALID;
         }
 
+        if (scan_id->valueint < 0) {
+            mdebug1("Malformed JSON: field 'id' cannot be negative");
+            snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
+            return OS_INVALID;
+        }
+
         if (policy_id = cJSON_GetObjectItem(event, "policy_id"), !policy_id) {
             mdebug1("Malformed JSON: field 'policy_id' not found");
             snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -2139,55 +2139,65 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
         if (scan_id = cJSON_GetObjectItem(event, "id"), !scan_id) {
             mdebug1("Invalid Security Configuration Assessment query syntax. JSON object not found or invalid");
             snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
+            cJSON_Delete(event);
             return OS_INVALID;
         }
 
         if (!cJSON_IsNumber(scan_id)) {
             mdebug1("Malformed JSON: field 'id' must be a number");
             snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
+            cJSON_Delete(event);
             return OS_INVALID;
         }
 
         if (scan_id->valueint < 0) {
             mdebug1("Malformed JSON: field 'id' cannot be negative");
             snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
+            cJSON_Delete(event);            
             return OS_INVALID;
         }
 
         if (policy_id = cJSON_GetObjectItem(event, "policy_id"), !policy_id) {
             mdebug1("Malformed JSON: field 'policy_id' not found");
             snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
+            cJSON_Delete(event);
             return OS_INVALID;
         }
 
         if (!policy_id->valuestring) {
             mdebug1("Malformed JSON: field 'policy_id' must be a string");
             snprintf(output, OS_MAXSTR + 1, "err Invalid Security Configuration Assessment query syntax, near '%.32s'", curr);
+            cJSON_Delete(event);
             return OS_INVALID;
         }
 
         if (check = cJSON_GetObjectItem(event, "check"), !check) {
             mdebug1("Malformed JSON: field 'check' not found");
+            cJSON_Delete(event);
             return OS_INVALID;
 
         } else {
             if (id = cJSON_GetObjectItem(check, "id"), !id) {
                 mdebug1("Malformed JSON: field 'id' not found");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
             if (!id->valueint) {
                 mdebug1("Malformed JSON: field 'id' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
             if (title = cJSON_GetObjectItem(check, "title"), !title) {
                 mdebug1("Malformed JSON: field 'title' not found");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
             if (!title->valuestring) {
                 mdebug1("Malformed JSON: field 'title' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
@@ -2195,6 +2205,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
             if (description && !description->valuestring) {
                 mdebug1("Malformed JSON: field 'description' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
@@ -2202,12 +2213,14 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
             if (rationale && !rationale->valuestring) {
                 mdebug1("Malformed JSON: field 'rationale' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
             remediation = cJSON_GetObjectItem(check, "remediation");
             if (remediation && !remediation->valuestring) {
                 mdebug1("Malformed JSON: field 'remediation' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
@@ -2215,24 +2228,28 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
 
             if (reference && !reference->valuestring) {
                 mdebug1("Malformed JSON: field 'reference' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
             file = cJSON_GetObjectItem(check, "file");
             if (file && !file->valuestring) {
                 mdebug1("Malformed JSON: field 'file' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
             condition = cJSON_GetObjectItem(check, "condition");
             if (condition && !condition->valuestring) {
                 mdebug1("Malformed JSON: field 'condition' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
             directory = cJSON_GetObjectItem(check, "directory");
             if (directory && !directory->valuestring) {
                 mdebug1("Malformed JSON: field 'directory' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
@@ -2245,24 +2262,28 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
             registry = cJSON_GetObjectItem(check, "registry");
             if (registry && !registry->valuestring) {
                 mdebug1("Malformed JSON: field 'registry' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
             command = cJSON_GetObjectItem(check, "command");
             if (command && !command->valuestring) {
                 mdebug1("Malformed JSON: field 'command' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
             result_check = cJSON_GetObjectItem(check, "result");
             if (result_check && !result_check->valuestring) {
                 mdebug1("Malformed JSON: field 'result' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
 
             reason = cJSON_GetObjectItem(check, "reason");
             if (reason && !reason->valuestring) {
                 mdebug1("Malformed JSON: field 'reason' must be a string");
+                cJSON_Delete(event);
                 return OS_INVALID;
             }
         }


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/15815 |

## Description
This PR fixes scan_id validation and improves logged information when it is not valid, from a misleading text that was being output when validation failed. It also prevents dropping valid events because of invalid false negatives when scan_id is 0.

By error, validation was performed by comparing valueint to 0, but scan_id is built by a random_number, multiplying it by -1 if it is negative. Thus if scan_id is zero, it is a valid value that should not be discarded:

https://github.com/wazuh/wazuh/blob/e5d9fd47d96b00e276b3684b47e25b2ef58d4760/src/wazuh_modules/wm_sca.c#L423-L436

Also, the logged text was referring to "should be a string", which was wrong and misleading.

