### PR TITLE
Avoid cluster error when agent-upgrade module sync messages fail to be sent across the cluster

### DIFF
--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -14,6 +14,9 @@
 #include "external/cJSON/cJSON.h"
 #include "config/authd-config.h"
 
+/* Attempts to send a message through the cluster */
+#define CLUSTER_SEND_MESSAGE_ATTEMPTS   10
+
 /**
  * @brief Check if syscheck is to be executed/restarted
  * @return 1 on success or 0 on failure (shouldn't be executed now).

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -841,10 +841,6 @@ int OS_RecvSecureClusterTCP(int sock, char * ret, size_t length) {
             }
     }
 
-    if (strncmp(buffer+8, "err --------", CMD_SIZE) == 0) {
-        return -2;
-    }
-
     size = wnet_order_big(*(uint32_t*)(buffer + 4));
     if (size > length) {
         mwarn("Cluster message size (%u) exceeds buffer length (%u)", (unsigned)size, (unsigned)length);
@@ -852,7 +848,13 @@ int OS_RecvSecureClusterTCP(int sock, char * ret, size_t length) {
     }
 
     /* Read the payload */
-    return os_recv_waitall(sock, ret, size);
+    int recv_size = os_recv_waitall(sock, ret, size);
+
+    if (strncmp(buffer+8, "err --------", CMD_SIZE) == 0) {
+        return -2;
+    }
+
+    return recv_size;
 }
 
 /* Receive a message from a stream socket, full message (MSG_WAITALL)

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -584,13 +584,12 @@ STATIC cJSON *assign_group_to_agent_worker(const char *agent_id, const char *md5
 
     mdebug2("Sending message to master node: '%s'", request);
 
-    w_send_clustered_message("sendsync", request, response);
+    if (w_send_clustered_message("sendsync", request, response) == 0){
+        response_json = cJSON_Parse(response);
+        data_json = cJSON_Duplicate(cJSON_GetObjectItem(response_json, "data"), 1);
+    }
 
     mdebug2("Message received from master node: '%s'", response);
-
-    response_json = cJSON_Parse(response);
-
-    data_json = cJSON_Duplicate(cJSON_GetObjectItem(response_json, "data"), 1);
 
     os_free(request);
     cJSON_Delete(payload_json);

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -584,7 +584,7 @@ STATIC cJSON *assign_group_to_agent_worker(const char *agent_id, const char *md5
 
     mdebug2("Sending message to master node: '%s'", request);
 
-    if (w_send_clustered_message("sendsync", request, response) == 0){
+    if (w_send_clustered_message("sendsync", request, response) == 0) {
         response_json = cJSON_Parse(response);
         data_json = cJSON_Duplicate(cJSON_GetObjectItem(response_json, "data"), 1);
     }

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -625,11 +625,11 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
                 if (response_length = OS_RecvSecureClusterTCP(sock, response, OS_MAXSTR), response_length <= 0) {
                     switch (response_length) {
                     case -2:
-                        merror("Cluster error detected");
+                        mwarn("Cluster error detected");
                         send_error = TRUE;
                         break;
                     case -1:
-                        merror("OS_RecvSecureClusterTCP(): %s", strerror(errno));
+                        mwarn("OS_RecvSecureClusterTCP(): %s", strerror(errno));
                         send_error = TRUE;
                         break;
                     case 0:
@@ -643,14 +643,14 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
                 }
             }
             else {
-                merror("OS_SendSecureTCPCluster(): %s", strerror(errno));
+                mwarn("OS_SendSecureTCPCluster(): %s", strerror(errno));
                 send_error = TRUE;
                 result = -2;
             }
             close(sock);
         }
         else {
-            merror("Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
+            mwarn("Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
             result = -2;
             send_error = TRUE;
         }

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -613,41 +613,57 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
     int sock = -1;
     int result = 0;
     int response_length = 0;
+    int send_attempts = 0;
+    bool send_error;
 
     strcpy(sockname, CLUSTER_SOCK);
+    for (send_attempts = 0; send_attempts < CLUSTER_SEND_MESSAGE_ATTEMPTS; ++send_attempts) {
+        send_error = FALSE;
+        if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock >= 0) {
+            if (OS_SendSecureTCPCluster(sock, command, payload, strlen(payload)) >= 0) {
+                if (response_length = OS_RecvSecureClusterTCP(sock, response, OS_MAXSTR), response_length <= 0) {
+                    switch (response_length) {
+                    case -2:
+                        merror("Cluster error detected");
+                        send_error = TRUE;
+                        break;
+                    case -1:
+                        merror("OS_RecvSecureClusterTCP(): %s", strerror(errno));
+                        send_error = TRUE;
+                        break;
 
-    if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock >= 0) {
-        if (OS_SendSecureTCPCluster(sock, command, payload, strlen(payload)) >= 0) {
-            if (response_length = OS_RecvSecureClusterTCP(sock, response, OS_MAXSTR), response_length <= 0) {
-                switch (response_length) {
-                case -2:
-                    merror("Cluster error detected");
-                    break;
-                case -1:
-                    merror("OS_RecvSecureClusterTCP(): %s", strerror(errno));
-                    break;
-
-                case 0:
-                    mdebug1("Empty message from local client.");
-                    break;
+                    case 0:
+                        mdebug1("Empty message from local client.");
+                        break;
 
 
-                case OS_MAXLEN:
-                    merror("Received message > %i", OS_MAXSTR);
-                    break;
+                    case OS_MAXLEN:
+                        merror("Received message > %i", OS_MAXSTR);
+                        break;
+                    }
+                    result = -1;
                 }
-                result = -1;
             }
+            else{
+                merror("OS_SendSecureTCPCluster(): %s", strerror(errno));
+                send_error = TRUE;
+                result = -2;
+            }
+            close(sock);
         }
-        else{
-            merror("OS_SendSecureTCPCluster(): %s", strerror(errno));
+        else {
+            merror("Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
             result = -2;
+            send_error = TRUE;
         }
-        close(sock);
-    }
-    else {
-        merror("Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
-        result = -2;
+
+        if (!send_error) {
+            break;
+        } else if (send_attempts == CLUSTER_SEND_MESSAGE_ATTEMPTS - 1) {
+            merror("Could not send message through the cluster after '%d' attempts.", CLUSTER_SEND_MESSAGE_ATTEMPTS);
+        } else {
+            sleep(1);
+        }
     }
 
     return result;

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -614,7 +614,7 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
     int result = 0;
     int response_length = 0;
     int send_attempts = 0;
-    bool send_error;
+    bool send_error = FALSE;
 
     strcpy(sockname, CLUSTER_SOCK);
     for (send_attempts = 0; send_attempts < CLUSTER_SEND_MESSAGE_ATTEMPTS; ++send_attempts) {
@@ -632,12 +632,9 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
                         merror("OS_RecvSecureClusterTCP(): %s", strerror(errno));
                         send_error = TRUE;
                         break;
-
                     case 0:
                         mdebug1("Empty message from local client.");
                         break;
-
-
                     case OS_MAXLEN:
                         merror("Received message > %i", OS_MAXSTR);
                         break;
@@ -645,7 +642,7 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
                     result = -1;
                 }
             }
-            else{
+            else {
                 merror("OS_SendSecureTCPCluster(): %s", strerror(errno));
                 send_error = TRUE;
                 result = -2;

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -618,6 +618,7 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
 
     strcpy(sockname, CLUSTER_SOCK);
     for (send_attempts = 0; send_attempts < CLUSTER_SEND_MESSAGE_ATTEMPTS; ++send_attempts) {
+        result = 0;
         send_error = FALSE;
         if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock >= 0) {
             if (OS_SendSecureTCPCluster(sock, command, payload, strlen(payload)) >= 0) {

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -600,7 +600,7 @@ void test_lookfor_agent_group_set_group_worker()
     expect_string(__wrap_w_send_clustered_message, command, "sendsync");
     expect_string(__wrap_w_send_clustered_message, payload, message);
     will_return(__wrap_w_send_clustered_message, response);
-    will_return(__wrap_w_send_clustered_message, 1);
+    will_return(__wrap_w_send_clustered_message, 0);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Message received from master node: '{\"error\":0,\"data\":{\"group\":\"test1\"}}'");
 

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -117,7 +117,9 @@ list(APPEND shared_tests_flags "-Wl,--wrap,wdb_get_agent_info -Wl,--wrap,_mdebug
                                 -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
                                 -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown ${DEBUG_OP_WRAPPERS}")
 else()
-list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
+list(APPEND shared_tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,OS_ConnectUnixDomain \
+                                -Wl,--wrap,sleep -Wl,--wrap,strerror -Wl,--wrap,getpid -Wl,--wrap,close \
+                                -Wl,--wrap,OS_SendSecureTCPCluster -Wl,--wrap,OS_RecvSecureClusterTCP ${DEBUG_OP_WRAPPERS}")
 endif()
 
 list(APPEND shared_tests_names "test_enrollment_op")

--- a/src/unit_tests/shared/test_agent_op.c
+++ b/src/unit_tests/shared/test_agent_op.c
@@ -23,6 +23,9 @@
 #include "../wrappers/common.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.h"
+#include "../wrappers/wazuh/os_net/os_net_wrappers.h"
+#include "../wrappers/libc/string_wrappers.h"
+#include "../wrappers/posix/unistd_wrappers.h"
 #include "cJSON.h"
 
 /* redefinitons/wrapping */
@@ -177,6 +180,387 @@ static void test_parse_agent_remove_response(void **state) {
     assert_int_equal(err, -2);
     assert_string_equal(err_response, "ERROR: Invalid message format");
 }
+
+/* Tests w_send_clustered_message */
+
+void test_w_send_clustered_message_connection_error(void **state) {
+    char response[OS_MAXSTR + 1];
+
+    for (int i=0; i < CLUSTER_SEND_MESSAGE_ATTEMPTS; ++i) {
+        expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+        expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+        expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+        will_return(__wrap_OS_ConnectUnixDomain, -1);
+
+        will_return(__wrap_strerror, "ERROR");
+        expect_string(__wrap__merror, formatted_msg, "Could not connect to socket 'queue/cluster/c-internal.sock': ERROR (0).");
+    }
+    expect_value_count(__wrap_sleep, seconds, 1, 9);
+
+    expect_string(__wrap__merror, formatted_msg, "Could not send message through the cluster after '10' attempts.");
+
+    assert_int_equal(w_send_clustered_message("command", "payload", response), -2);
+}
+
+void test_w_send_clustered_message_send_error(void **state) {
+    char response[OS_MAXSTR + 1];
+    char *command = "command";
+    char *payload = "payload";
+    size_t payload_size = strlen(payload);
+    int sock_num = 3;
+
+    for (int i=0; i < CLUSTER_SEND_MESSAGE_ATTEMPTS; ++i) {
+        expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+        expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+        expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+        will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+        expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+        expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+        expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+        expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+        will_return(__wrap_OS_SendSecureTCPCluster, -1);
+
+        will_return(__wrap_strerror, "ERROR");
+        expect_string(__wrap__merror, formatted_msg, "OS_SendSecureTCPCluster(): ERROR");
+    }
+    expect_value_count(__wrap_sleep, seconds, 1, 9);
+
+    expect_string(__wrap__merror, formatted_msg, "Could not send message through the cluster after '10' attempts.");
+
+    assert_int_equal(w_send_clustered_message(command, payload, response), -2);
+}
+
+void test_w_send_clustered_message_recv_cluster_error_detected(void **state) {
+    char response[OS_MAXSTR + 1];
+    char *command = "command";
+    char *payload = "payload";
+    char *recv_response = "response";
+    size_t payload_size = strlen(payload);
+    int sock_num = 3;
+
+    for (int i=0; i < CLUSTER_SEND_MESSAGE_ATTEMPTS; ++i) {
+        expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+        expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+        expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+        will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+        expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+        expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+        expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+        expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+        will_return(__wrap_OS_SendSecureTCPCluster, 1);
+
+        expect_value(__wrap_OS_RecvSecureClusterTCP, sock, sock_num);
+        expect_value(__wrap_OS_RecvSecureClusterTCP, length, OS_MAXSTR);
+        will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
+        will_return(__wrap_OS_RecvSecureClusterTCP, -2);
+
+        expect_string(__wrap__merror, formatted_msg, "Cluster error detected");
+    }
+    expect_value_count(__wrap_sleep, seconds, 1, 9);
+
+    expect_string(__wrap__merror, formatted_msg, "Could not send message through the cluster after '10' attempts.");
+
+    assert_int_equal(w_send_clustered_message(command, payload, response), -1);
+}
+
+void test_w_send_clustered_message_recv_error(void **state) {
+    char response[OS_MAXSTR + 1];
+    char *command = "command";
+    char *payload = "payload";
+    char *recv_response = "response";
+    size_t payload_size = strlen(payload);
+    int sock_num = 3;
+
+    for (int i=0; i < CLUSTER_SEND_MESSAGE_ATTEMPTS; ++i) {
+        expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+        expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+        expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+        will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+        expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+        expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+        expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+        expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+        will_return(__wrap_OS_SendSecureTCPCluster, 1);
+
+        expect_value(__wrap_OS_RecvSecureClusterTCP, sock, sock_num);
+        expect_value(__wrap_OS_RecvSecureClusterTCP, length, OS_MAXSTR);
+        will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
+        will_return(__wrap_OS_RecvSecureClusterTCP, -1);
+
+        will_return(__wrap_strerror, "ERROR");
+        expect_string(__wrap__merror, formatted_msg, "OS_RecvSecureClusterTCP(): ERROR");
+    }
+    expect_value_count(__wrap_sleep, seconds, 1, 9);
+
+    expect_string(__wrap__merror, formatted_msg, "Could not send message through the cluster after '10' attempts.");
+
+    assert_int_equal(w_send_clustered_message(command, payload, response), -1);
+}
+
+void test_w_send_clustered_message_recv_empty_message(void **state) {
+    char response[OS_MAXSTR + 1];
+    char *command = "command";
+    char *payload = "payload";
+    char *recv_response = "response";
+    size_t payload_size = strlen(payload);
+    int sock_num = 3;
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+    expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+    expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+    expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+    expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+    will_return(__wrap_OS_SendSecureTCPCluster, 1);
+
+    expect_value(__wrap_OS_RecvSecureClusterTCP, sock, sock_num);
+    expect_value(__wrap_OS_RecvSecureClusterTCP, length, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
+    will_return(__wrap_OS_RecvSecureClusterTCP, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Empty message from local client.");
+
+    assert_int_equal(w_send_clustered_message(command, payload, response), -1);
+}
+
+void test_w_send_clustered_message_recv_max_len(void **state) {
+    char response[OS_MAXSTR + 1];
+    char *command = "command";
+    char *payload = "payload";
+    char *recv_response = "response";
+    size_t payload_size = strlen(payload);
+    int sock_num = 3;
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+    expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+    expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+    expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+    expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+    will_return(__wrap_OS_SendSecureTCPCluster, 1);
+
+    expect_value(__wrap_OS_RecvSecureClusterTCP, sock, sock_num);
+    expect_value(__wrap_OS_RecvSecureClusterTCP, length, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
+    will_return(__wrap_OS_RecvSecureClusterTCP, OS_MAXLEN);
+
+    expect_string(__wrap__merror, formatted_msg, "Received message > 65536");
+
+    assert_int_equal(w_send_clustered_message(command, payload, response), -1);
+}
+
+void test_w_send_clustered_message_success(void **state) {
+    char response[OS_MAXSTR + 1];
+    char *command = "command";
+    char *payload = "payload";
+    char *recv_response = "response";
+    size_t payload_size = strlen(payload);
+    int sock_num = 3;
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+    expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+    expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+    expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+    expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+    will_return(__wrap_OS_SendSecureTCPCluster, 1);
+
+    expect_value(__wrap_OS_RecvSecureClusterTCP, sock, sock_num);
+    expect_value(__wrap_OS_RecvSecureClusterTCP, length, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
+    will_return(__wrap_OS_RecvSecureClusterTCP, strlen(recv_response));
+
+    assert_int_equal(w_send_clustered_message(command, payload, response), 0);
+    assert_string_equal(recv_response, response);
+}
+
+void test_w_send_clustered_message_success_after_connection_error(void **state) {
+    char response[OS_MAXSTR + 1];
+    char *command = "command";
+    char *payload = "payload";
+    char *recv_response = "response";
+    size_t payload_size = strlen(payload);
+    int sock_num = 3;
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, -1);
+
+    will_return(__wrap_strerror, "ERROR");
+    expect_string(__wrap__merror, formatted_msg, "Could not connect to socket 'queue/cluster/c-internal.sock': ERROR (0).");
+    expect_value(__wrap_sleep, seconds, 1);
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+    expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+    expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+    expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+    expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+    will_return(__wrap_OS_SendSecureTCPCluster, 1);
+
+    expect_value(__wrap_OS_RecvSecureClusterTCP, sock, sock_num);
+    expect_value(__wrap_OS_RecvSecureClusterTCP, length, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
+    will_return(__wrap_OS_RecvSecureClusterTCP, strlen(recv_response));
+
+    assert_int_equal(w_send_clustered_message(command, payload, response), 0);
+    assert_string_equal(recv_response, response);
+}
+
+void test_w_send_clustered_message_success_after_send_error(void **state) {
+    char response[OS_MAXSTR + 1];
+    char *command = "command";
+    char *payload = "payload";
+    char *recv_response = "response";
+    size_t payload_size = strlen(payload);
+    int sock_num = 3;
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+    expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+    expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+    expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+    expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+    will_return(__wrap_OS_SendSecureTCPCluster, -1);
+
+    will_return(__wrap_strerror, "ERROR");
+    expect_string(__wrap__merror, formatted_msg, "OS_SendSecureTCPCluster(): ERROR");
+
+    expect_value(__wrap_sleep, seconds, 1);
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+    expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+    expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+    expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+    expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+    will_return(__wrap_OS_SendSecureTCPCluster, 1);
+
+    expect_value(__wrap_OS_RecvSecureClusterTCP, sock, sock_num);
+    expect_value(__wrap_OS_RecvSecureClusterTCP, length, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
+    will_return(__wrap_OS_RecvSecureClusterTCP, strlen(recv_response));
+
+    assert_int_equal(w_send_clustered_message(command, payload, response), 0);
+    assert_string_equal(recv_response, response);
+}
+
+void test_w_send_clustered_message_success_after_cluster_error(void **state) {
+    char response[OS_MAXSTR + 1];
+    char *command = "command";
+    char *payload = "payload";
+    char *recv_response = "response";
+    size_t payload_size = strlen(payload);
+    int sock_num = 3;
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+    expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+    expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+    expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+    expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+    will_return(__wrap_OS_SendSecureTCPCluster, 1);
+
+    expect_value(__wrap_OS_RecvSecureClusterTCP, sock, sock_num);
+    expect_value(__wrap_OS_RecvSecureClusterTCP, length, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
+    will_return(__wrap_OS_RecvSecureClusterTCP, -2);
+
+    expect_string(__wrap__merror, formatted_msg, "Cluster error detected");
+    expect_value(__wrap_sleep, seconds, 1);
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+    expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+    expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+    expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+    expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+    will_return(__wrap_OS_SendSecureTCPCluster, 1);
+
+    expect_value(__wrap_OS_RecvSecureClusterTCP, sock, sock_num);
+    expect_value(__wrap_OS_RecvSecureClusterTCP, length, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
+    will_return(__wrap_OS_RecvSecureClusterTCP, strlen(recv_response));
+
+    assert_int_equal(w_send_clustered_message(command, payload, response), 0);
+    assert_string_equal(recv_response, response);
+}
+
+void test_w_send_clustered_message_success_after_recv_error(void **state) {
+    char response[OS_MAXSTR + 1];
+    char *command = "command";
+    char *payload = "payload";
+    char *recv_response = "response";
+    size_t payload_size = strlen(payload);
+    int sock_num = 3;
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+    expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+    expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+    expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+    expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+    will_return(__wrap_OS_SendSecureTCPCluster, 1);
+
+    expect_value(__wrap_OS_RecvSecureClusterTCP, sock, sock_num);
+    expect_value(__wrap_OS_RecvSecureClusterTCP, length, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
+    will_return(__wrap_OS_RecvSecureClusterTCP, -1);
+
+    will_return(__wrap_strerror, "ERROR");
+    expect_string(__wrap__merror, formatted_msg, "OS_RecvSecureClusterTCP(): ERROR");
+    expect_value(__wrap_sleep, seconds, 1);
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, sock_num);
+
+    expect_value(__wrap_OS_SendSecureTCPCluster, sock, sock_num);
+    expect_value(__wrap_OS_SendSecureTCPCluster, command, command);
+    expect_string(__wrap_OS_SendSecureTCPCluster, payload, payload);
+    expect_value(__wrap_OS_SendSecureTCPCluster, length, payload_size);
+    will_return(__wrap_OS_SendSecureTCPCluster, 1);
+
+    expect_value(__wrap_OS_RecvSecureClusterTCP, sock, sock_num);
+    expect_value(__wrap_OS_RecvSecureClusterTCP, length, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
+    will_return(__wrap_OS_RecvSecureClusterTCP, strlen(recv_response));
+
+    assert_int_equal(w_send_clustered_message(command, payload, response), 0);
+    assert_string_equal(recv_response, response);
+}
 #endif
 
 static void test_parse_agent_add_response(void **state) {
@@ -242,6 +626,18 @@ int main(void) {
         cmocka_unit_test(test_create_agent_remove_payload),
         cmocka_unit_test(test_create_sendsync_payload),
         cmocka_unit_test(test_parse_agent_remove_response),
+        // Tests w_send_clustered_message
+        cmocka_unit_test(test_w_send_clustered_message_connection_error),
+        cmocka_unit_test(test_w_send_clustered_message_send_error),
+        cmocka_unit_test(test_w_send_clustered_message_recv_cluster_error_detected),
+        cmocka_unit_test(test_w_send_clustered_message_recv_error),
+        cmocka_unit_test(test_w_send_clustered_message_recv_empty_message),
+        cmocka_unit_test(test_w_send_clustered_message_recv_max_len),
+        cmocka_unit_test(test_w_send_clustered_message_success),
+        cmocka_unit_test(test_w_send_clustered_message_success_after_connection_error),
+        cmocka_unit_test(test_w_send_clustered_message_success_after_send_error),
+        cmocka_unit_test(test_w_send_clustered_message_success_after_cluster_error),
+        cmocka_unit_test(test_w_send_clustered_message_success_after_recv_error),
         #endif
     };
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/shared/test_agent_op.c
+++ b/src/unit_tests/shared/test_agent_op.c
@@ -193,7 +193,7 @@ void test_w_send_clustered_message_connection_error(void **state) {
         will_return(__wrap_OS_ConnectUnixDomain, -1);
 
         will_return(__wrap_strerror, "ERROR");
-        expect_string(__wrap__merror, formatted_msg, "Could not connect to socket 'queue/cluster/c-internal.sock': ERROR (0).");
+        expect_string(__wrap__mwarn, formatted_msg, "Could not connect to socket 'queue/cluster/c-internal.sock': ERROR (0).");
     }
     expect_value_count(__wrap_sleep, seconds, 1, 9);
 
@@ -222,7 +222,7 @@ void test_w_send_clustered_message_send_error(void **state) {
         will_return(__wrap_OS_SendSecureTCPCluster, -1);
 
         will_return(__wrap_strerror, "ERROR");
-        expect_string(__wrap__merror, formatted_msg, "OS_SendSecureTCPCluster(): ERROR");
+        expect_string(__wrap__mwarn, formatted_msg, "OS_SendSecureTCPCluster(): ERROR");
     }
     expect_value_count(__wrap_sleep, seconds, 1, 9);
 
@@ -256,7 +256,7 @@ void test_w_send_clustered_message_recv_cluster_error_detected(void **state) {
         will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
         will_return(__wrap_OS_RecvSecureClusterTCP, -2);
 
-        expect_string(__wrap__merror, formatted_msg, "Cluster error detected");
+        expect_string(__wrap__mwarn, formatted_msg, "Cluster error detected");
     }
     expect_value_count(__wrap_sleep, seconds, 1, 9);
 
@@ -291,7 +291,7 @@ void test_w_send_clustered_message_recv_error(void **state) {
         will_return(__wrap_OS_RecvSecureClusterTCP, -1);
 
         will_return(__wrap_strerror, "ERROR");
-        expect_string(__wrap__merror, formatted_msg, "OS_RecvSecureClusterTCP(): ERROR");
+        expect_string(__wrap__mwarn, formatted_msg, "OS_RecvSecureClusterTCP(): ERROR");
     }
     expect_value_count(__wrap_sleep, seconds, 1, 9);
 
@@ -400,7 +400,7 @@ void test_w_send_clustered_message_success_after_connection_error(void **state) 
     will_return(__wrap_OS_ConnectUnixDomain, -1);
 
     will_return(__wrap_strerror, "ERROR");
-    expect_string(__wrap__merror, formatted_msg, "Could not connect to socket 'queue/cluster/c-internal.sock': ERROR (0).");
+    expect_string(__wrap__mwarn, formatted_msg, "Could not connect to socket 'queue/cluster/c-internal.sock': ERROR (0).");
     expect_value(__wrap_sleep, seconds, 1);
 
     expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
@@ -443,7 +443,7 @@ void test_w_send_clustered_message_success_after_send_error(void **state) {
     will_return(__wrap_OS_SendSecureTCPCluster, -1);
 
     will_return(__wrap_strerror, "ERROR");
-    expect_string(__wrap__merror, formatted_msg, "OS_SendSecureTCPCluster(): ERROR");
+    expect_string(__wrap__mwarn, formatted_msg, "OS_SendSecureTCPCluster(): ERROR");
 
     expect_value(__wrap_sleep, seconds, 1);
 
@@ -491,7 +491,7 @@ void test_w_send_clustered_message_success_after_cluster_error(void **state) {
     will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
     will_return(__wrap_OS_RecvSecureClusterTCP, -2);
 
-    expect_string(__wrap__merror, formatted_msg, "Cluster error detected");
+    expect_string(__wrap__mwarn, formatted_msg, "Cluster error detected");
     expect_value(__wrap_sleep, seconds, 1);
 
     expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);
@@ -539,7 +539,7 @@ void test_w_send_clustered_message_success_after_recv_error(void **state) {
     will_return(__wrap_OS_RecvSecureClusterTCP, -1);
 
     will_return(__wrap_strerror, "ERROR");
-    expect_string(__wrap__merror, formatted_msg, "OS_RecvSecureClusterTCP(): ERROR");
+    expect_string(__wrap__mwarn, formatted_msg, "OS_RecvSecureClusterTCP(): ERROR");
     expect_value(__wrap_sleep, seconds, 1);
 
     expect_string(__wrap_OS_ConnectUnixDomain, path, CLUSTER_SOCK);

--- a/src/unit_tests/wrappers/linux/socket_wrappers.c
+++ b/src/unit_tests/wrappers/linux/socket_wrappers.c
@@ -81,6 +81,9 @@ ssize_t __wrap_recv(__attribute__((unused))int __fd, __attribute__((unused))void
         char text[BUFFERSIZE];
         strcpy(text, "err --------");
         void *buffertext = &text;
+        // Set the payload buffer size to simulate the cluster message format
+        size_t payload_size = 9;
+        *(uint32_t *)(__buf+4) = wnet_order_big(payload_size);
         memcpy((char*)__buf+8, (char*)buffertext, 12);
     }
 

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
@@ -183,3 +183,21 @@ int __wrap_get_ipv6_string(__attribute__((unused)) struct in6_addr addr6,
     check_expected(address_size);
     return mock();
 }
+
+int __wrap_OS_SendSecureTCPCluster(int sock, const void *command, const void *payload, size_t length) {
+    check_expected(sock);
+    check_expected(command);
+    check_expected(payload);
+    check_expected(length);
+
+    return mock();
+}
+
+int __wrap_OS_RecvSecureClusterTCP(int sock, char *ret, size_t length) {
+    check_expected(sock);
+    check_expected(length);
+
+    strncpy(ret, mock_type(char*), length);
+
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
@@ -62,4 +62,7 @@ int __wrap_get_ipv4_string(struct in_addr addr, char *address, size_t address_si
 
 int __wrap_get_ipv6_string(struct in6_addr addr6, char *address, size_t address_size);
 
+int __wrap_OS_SendSecureTCPCluster(int sock, const void *command, const void *payload, size_t length);
+
+int __wrap_OS_RecvSecureClusterTCP(int sock, char *ret, size_t length);
 #endif

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
@@ -248,9 +248,7 @@ STATIC cJSON *wm_agent_send_task_information_worker(const cJSON *message_object)
 
     mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_TASK_SEND_CLUSTER_MESSAGE, message);
 
-    w_send_clustered_message("sendsync", message, response);
-
-    if (response[0]) {
+    if (w_send_clustered_message("sendsync", message, response) == 0 && response[0]) {
         mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_TASK_RECEIVE_MESSAGE, response);
     }
 

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
@@ -248,7 +248,9 @@ STATIC cJSON *wm_agent_send_task_information_worker(const cJSON *message_object)
 
     mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_TASK_SEND_CLUSTER_MESSAGE, message);
 
-    if (w_send_clustered_message("sendsync", message, response) == 0 && response[0]) {
+    w_send_clustered_message("sendsync", message, response);
+
+    if (response[0]) {
         mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_TASK_RECEIVE_MESSAGE, response);
     }
 


### PR DESCRIPTION
|Related issue|Manual testing|
|---|---|
|#11794|https://github.com/wazuh/wazuh-qa/issues/4101|


## Description

As part of this development, changes were made so that the function `OS_RecvSecureClusterTCP` reads the cluster response message payload when there was an error in sending the synchronization message. This would prevent clusterd from displaying the following log in cluster.log:
```
2022/03/11 13:16:33 ERROR: [Local 449601] [Main] Internal error processing request 'b'sendsync'': Error 3023 - Worker node is not connected to master
2022/03/11 13:16:33 ERROR: [Local 449601] [Main] Error during connection with '449601': [Errno 104] Connection reset by peer.
  File "/var/ossec/framework/python/lib/python3.9/asyncio/selector_events.py", line 856, in _read_ready__data_received
    data = self._sock.recv(self.max_size)
```

Retries have also been added when sending a synchronization message in the `w_send_clustered_message` function.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [x] Coverity [#report](https://github.com/wazuh/wazuh/pull/16683#issuecomment-1515277940)
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Working on cluster environments
- [x] Added unit tests (for new features)
