### PR TITLE
Fix typo on configuration template file

### DIFF
--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -17,7 +17,7 @@
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
     <agents_disconnection_time>10m</agents_disconnection_time>
-    <agents_disconnection_alert_time>0</agents_disconnection_alert_time
+    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
   </global>
 
   <alerts>

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -935,6 +935,7 @@ InstallCommon()
         if [ -f  ../etc/ossec.mc ]; then
             ${INSTALL} -m 0660 -o root -g ${WAZUH_GROUP} ../etc/ossec.mc ${INSTALLDIR}/etc/ossec.conf
         else
+            echo "ERROR: unable to generate ossec.conf file with desired configurations, using default configurations from ${OSSEC_CONF_SRC}"
             ${INSTALL} -m 0660 -o root -g ${WAZUH_GROUP} ${OSSEC_CONF_SRC} ${INSTALLDIR}/etc/ossec.conf
         fi
     fi

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -935,7 +935,7 @@ InstallCommon()
         if [ -f  ../etc/ossec.mc ]; then
             ${INSTALL} -m 0660 -o root -g ${WAZUH_GROUP} ../etc/ossec.mc ${INSTALLDIR}/etc/ossec.conf
         else
-            echo "ERROR: unable to generate ossec.conf file with desired configurations, using default configurations from ${OSSEC_CONF_SRC}"
+            echo "WARNING: unable to generate ossec.conf file with desired configurations, using default configurations from ${OSSEC_CONF_SRC}"
             ${INSTALL} -m 0660 -o root -g ${WAZUH_GROUP} ${OSSEC_CONF_SRC} ${INSTALLDIR}/etc/ossec.conf
         fi
     fi


### PR DESCRIPTION
|Related issue|
|---|
|#16657|

## Description
This PR aims to fix a badly formatted configuration file involved in the installation process.

All the analysis is on [the issue](https://github.com/wazuh/wazuh/issues/16657#issuecomment-1504130828).

## CL
- Fixed typo on the `etc/ossec-local.conf`
- Added warning message to indicate that the configurations provided on the script were not successfully applied (using default configurations on `etc/ossec-local.conf`)

## Tests
- [ ] Source installation
  - [x] Linux
  - [ ] MAC OS X