### PR TITLE
Non UTF8 process information

### DIFF
--- a/src/data_provider/src/ports/portWindowsWrapper.h
+++ b/src/data_provider/src/ports/portWindowsWrapper.h
@@ -182,7 +182,7 @@ class WindowsPortWrapper final : public IPortWrapper
         }
         std::string processName() const override
         {
-            return m_processName;
+            return Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_processName);
         }
 };
 

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -291,8 +291,8 @@ static nlohmann::json getProcessInfo(const PROCESSENTRY32& processEntry)
         SysInfoProcess process(pId, processHandle);
 
         // Current process information
-        jsProcessInfo["name"]       = processName(processEntry);
-        jsProcessInfo["cmd"]        = (isSystemProcess(pId)) ? "none" : process.cmd();
+        jsProcessInfo["name"]       = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(processName(processEntry));
+        jsProcessInfo["cmd"]        = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8((isSystemProcess(pId)) ? "none" : process.cmd());
         jsProcessInfo["stime"]      = process.kernelModeTime();
         jsProcessInfo["size"]       = process.pageFileUsage();
         jsProcessInfo["ppid"]       = processEntry.th32ParentProcessID;


### PR DESCRIPTION
|Related issue|
|---|
|#16682|

## Description

Convertion to UTF8 was not being considered for processes, only for packages. 

## Logs/Alerts example

Processes

![image](https://user-images.githubusercontent.com/13010397/231542592-28f65788-b145-419d-9e67-e5c6633e7f1c.png)

Ports

![image](https://user-images.githubusercontent.com/13010397/233080731-ff1dc604-8913-41a7-93ef-9e05b8aaac58.png)


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [x] Package installation