### PR TITLE
Fix check_md5sum setting in FIM events

### DIFF
--- a/src/syscheckd/src/db/src/file.cpp
+++ b/src/syscheckd/src/db/src/file.cpp
@@ -105,7 +105,7 @@ nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohman
         jsonEvent["data"]["attributes"]["mtime"] = data.at("mtime");
     }
 
-    if (ctx->config->options & CHECK_SHA1SUM)
+    if (ctx->config->options & CHECK_MD5SUM)
     {
         jsonEvent["data"]["attributes"]["hash_md5"] = data.at("hash_md5");
     }


### PR DESCRIPTION
|Related issue|
|---|
|#16625|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hello team,

This PR fixes the bug found related to the configuration of the `check_md5sum`, which was wrongly coded, and was only activated when we set the `check_sha1sum` tag.

## Configuration options

`<directories check_all="no" check_md5sum="yes" realtime="yes">/test</directories>`

## Logs/Alerts example

Before fix:
```
** Alert 1681464848.692837: - ossec,syscheck,syscheck_entry_added,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2023 Apr 14 09:34:08 (centos9) any->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/test/file1' added
Mode: realtime

Attributes:

** Alert 1681464854.693219: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2023 Apr 14 09:34:14 (centos9) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/test/file1' modified
Mode: realtime
Changed attributes: md5
Old md5sum was: 'd41d8cd98f00b204e9800998ecf8427e'
New md5sum is : ''

Attributes:

** Alert 1681464857.693703: - ossec,syscheck,syscheck_entry_deleted,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2023 Apr 14 09:34:17 (centos9) any->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/test/file1' deleted
Mode: realtime

Attributes:
 - MD5: 5c9597f3c8245907ea71a89d9d39d08e
```
It can be observed that neither in the added event nor in the modified event the md5 attribute appears correctly (the deleted events use a different function that was correct).

After fix:
```
** Alert 1681464751.690792: - ossec,syscheck,syscheck_entry_added,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2023 Apr 14 09:32:31 (centos9) any->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/test/file1' added
Mode: realtime

Attributes:
 - MD5: d41d8cd98f00b204e9800998ecf8427e

** Alert 1681464756.691215: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2023 Apr 14 09:32:36 (centos9) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/test/file1' modified
Mode: realtime
Changed attributes: md5
Old md5sum was: 'd41d8cd98f00b204e9800998ecf8427e'
New md5sum is : '5c9597f3c8245907ea71a89d9d39d08e'

Attributes:
 - MD5: 5c9597f3c8245907ea71a89d9d39d08e

** Alert 1681464760.691772: - ossec,syscheck,syscheck_entry_deleted,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2023 Apr 14 09:32:40 (centos9) any->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/test/file1' deleted
Mode: realtime

Attributes:
 - MD5: 5c9597f3c8245907ea71a89d9d39d08e
```
