### PR TITLE
Backport fixes in the vulnerability detector AIT

### DIFF
--- a/api/test/integration/env/configurations/vulnerability/manager/configuration_files/nvd_providers.sh
+++ b/api/test/integration/env/configurations/vulnerability/manager/configuration_files/nvd_providers.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
+nvd_year=$(date -d "3 months ago" +%Y)
+
 # Remove providers
 sed -i '/<os>xenial<\/os>/d' /var/ossec/etc/ossec.conf
 sed -i '/<os>trusty<\/os>/d' /var/ossec/etc/ossec.conf
 sed -i '/<os>bionic<\/os>/d' /var/ossec/etc/ossec.conf
+sed -i "s/NVD_FEED_YEAR/$nvd_year/g" /var/ossec/etc/ossec.conf

--- a/api/test/integration/env/configurations/vulnerability/manager/configuration_files/ossec_module.conf
+++ b/api/test/integration/env/configurations/vulnerability/manager/configuration_files/ossec_module.conf
@@ -19,7 +19,7 @@
         </provider>
         <provider name="nvd">
             <enabled>yes</enabled>
-            <update_from_year>2023</update_from_year>
+            <update_from_year>NVD_FEED_YEAR</update_from_year>
         </provider>
     </vulnerability-detector>
 </root>

--- a/api/test/integration/env/configurations/vulnerability/manager/configuration_files/ossec_module.conf
+++ b/api/test/integration/env/configurations/vulnerability/manager/configuration_files/ossec_module.conf
@@ -19,7 +19,7 @@
         </provider>
         <provider name="nvd">
             <enabled>yes</enabled>
-            <update_from_year>2021</update_from_year>
+            <update_from_year>2023</update_from_year>
         </provider>
     </vulnerability-detector>
 </root>

--- a/api/test/integration/test_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_vulnerability_endpoints.tavern.yaml
@@ -29,8 +29,8 @@ stages:
               name: !anystr
               type: !anystr
               status: !anystr
-              cvss2_score: !anyfloat
-              cvss3_score: !anyfloat
+              cvss2_score: !anything
+              cvss3_score: !anything
               detection_time: !anystr
               severity: !anystr
               external_references: !anylist

--- a/api/test/integration/test_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_vulnerability_endpoints.tavern.yaml
@@ -37,7 +37,6 @@ stages:
               condition: !anystr
               title: !anystr
               published: !anystr
-              updated: !anystr
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -57,7 +56,6 @@ stages:
           expected_condition: data.affected_items[0].condition
           expected_title: data.affected_items[0].title
           expected_published: data.affected_items[0].published
-          expected_updated: data.affected_items[0].updated
 
   - name: Get agent's vulnerabilities (filter by Type)
     request:
@@ -228,19 +226,6 @@ stages:
           extra_kwargs:
             key: "published"
             expected_values: "{expected_published}"
-
-  - name: Get agent's vulnerabilities (filter by update date)
-    request:
-      <<: *vulnerability_request_001
-      params:
-        q: "updated={expected_updated}"
-    response:
-      status_code: 200
-      verify_response_with:
-        - function: tavern_utils:test_expected_value
-          extra_kwargs:
-            key: "updated"
-            expected_values: "{expected_updated}"
 
   - name: Try to get agent's vulnerabilities (filter by an unexistent CVSS3 score)
     request:


### PR DESCRIPTION
|Related issue|
|---|
| Closes #16809 |

## Description

This PR backports the fixes developed here:
- https://github.com/wazuh/wazuh/pull/16239

Also, it changes the `<update_from_year>` configuration for the `NVD` feed. The year of the date 3 months prior is now used. For example, in February the previous year will be used but in April it will be the current year. This prevents downloading too big feeds (so the test could fail because the environment is never healthy). 

## Tests
```
$ pytest -vv test_vulnerability_endpoints.tavern.yaml
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.6, pytest-7.2.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.15.0-69-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.2.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '2.0.2', 'metadata': '2.0.4'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, tavern-2.0.2, metadata-2.0.4
collected 3 items                                                                                                                                                                                           

test_vulnerability_endpoints.tavern.yaml::GET /vulnerability/{agent_id} PASSED                                                                                                                        [ 33%]
test_vulnerability_endpoints.tavern.yaml::GET /vulnerability/001/last_scan PASSED                                                                                                                     [ 66%]
test_vulnerability_endpoints.tavern.yaml::GET /vulnerability/{agent_id}/summary/{field} PASSED                                                                                                        [100%]

================================================================================= 3 passed, 3 warnings in 147.05s (0:02:27) =================================================================================
```