### PR TITLE
Fix RBAC white agent integration tests

### DIFF
--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -1659,6 +1659,32 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
+  # Agent assignment below requires the agent not to be in the group to succeed
+  - name: Remove agent 008 from group default (Allowed)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '008'
+        group_id: 'default'
+    response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["008"]
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - '008'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
   - name: Assign agent 008 to default (Allowed)
     request:
       verify: False

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -1406,8 +1406,9 @@ stages:
               id:
                 - "002"
                 - "006"
+                - "008"
                 - "010"
-          total_failed_items: 3
+          total_failed_items: 4
         message: !anystr
 
 ---


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/16750|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

Added a missing failed item in one of the tests and removed an agent from the default group before attempting the assignment (otherwise it would fail) in another one.

## Tests

```console
(venv2) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_rbac_white_agent_endpoints.tavern.yaml
====================================================== test session starts ======================================================
platform linux -- Python 3.9.16, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/gasti/work/wazuh/venv2/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.6-76060206-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '5.4.3', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '0.3.0', 'tavern': '1.2.2', 'trio': '0.7.0', 'html': '2.1.1', 'asyncio': '0.15.1', 'metadata': '2.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration, inifile: pytest.ini
plugins: aiohttp-0.3.0, tavern-1.2.2, trio-0.7.0, html-2.1.1, asyncio-0.15.1, metadata-2.0.4
collected 42 items                                                                                                              

test_rbac_white_agent_endpoints.tavern.yaml::GET /agents PASSED                                                           [  2%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents?agents_list=agent_id PASSED                                      [  4%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED             [  7%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                  [  9%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                            [ 11%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                  [ 14%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                              [ 16%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups PASSED                                                           [ 19%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                         [ 21%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                  [ 23%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                          [ 26%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                          [ 28%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                           [ 30%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                           [ 33%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                  [ 35%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                  [ 38%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                            [ 40%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                            [ 42%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                [ 45%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                            [ 47%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                       [ 50%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/group?group_id={group_id} PASSED                              [ 52%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /groups?groups_list={group_id} PASSED                                 [ 54%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /groups PASSED                                                        [ 57%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents?agents_list=agent_id&status=all PASSED                        [ 59%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents PASSED                                                        [ 61%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents PASSED                                                          [ 64%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents/insert PASSED                                                   [ 66%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                             [ 69%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /groups PASSED                                                          [ 71%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/group PASSED                                                     [ 73%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                  [ 76%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                  [ 78%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/reconnect PASSED                                                 [ 80%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                   [ 83%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                               [ 85%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                        [ 88%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                   [ 90%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                            [ 92%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                            [ 95%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents (deny cluster:read) PASSED                                       [ 97%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                    [100%]

======================================================= warnings summary ========================================================
/home/gasti/work/wazuh/venv2/lib/python3.9/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/gasti/work/wazuh/venv2/lib/python3.9/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/gasti/work/wazuh/venv2/lib/python3.9/site-packages/tavern/testutils/pytesthook/file.py:233: 42 tests with warnings
  /home/gasti/work/wazuh/venv2/lib/python3.9/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================== 42 passed, 43 warnings in 734.30s (0:12:14) ==========================================
```