### PR TITLE
CPE Helper update

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/cpe_helper.json
+++ b/src/wazuh_modules/vulnerability_detector/cpe_helper.json
@@ -1,8 +1,61 @@
 {
     "version": "1.0",
     "format_version": "1.0",
-    "update_date": "2019-10-02T10:56Z",
+    "update_date": "2023-04-21T11:43Z",
     "dictionary": [
+	    {
+    "target": "windows",
+    "source": {
+        "vendor": [
+            "Microsoft Corporation"
+        ],
+        "product": [
+            "^Microsoft ASP.NET Core ([0-9]\\.*[0-9]*\\.*[0-9]*)"
+        ],
+        "version": [
+	    "^Microsoft ASP.NET Core ([0-9]\\.*[0-9]*\\.*[0-9]*)"
+	]
+    },
+    "translation": {
+        "vendor": [
+            "microsoft"
+        ],
+        "product": [
+            "asp.net_core"
+        ],
+        "version": []
+    },
+    "action": [
+        "replace_vendor",
+	"set_version_if_product_matches",
+        "replace_product"
+    ]
+},
+	   {
+    "target": "windows",
+    "source": {
+        "vendor": [
+            "Microsoft Corporation"
+        ],
+        "product": [
+            "Microsoft Edge"
+        ],
+        "version": []
+    },
+    "translation": {
+        "vendor": [
+            "microsoft"
+        ],
+        "product": [
+            "edge_chromium"
+        ],
+        "version": []
+    },
+    "action": [
+        "replace_vendor",
+        "replace_product"
+    ]
+},
         {
             "target": "windows",
             "source": {
@@ -36,11 +89,11 @@
                     "^Sun"
                 ],
                 "product": [
-                    "Java .* Development Kit",
+                    "Java.* Development Kit",
                     "^Oracle.*VirtualBox [0-9]",
                     "^Java.*Update"
                 ],
-                "version": []
+                "version":[]
             },
             "translation": {
                 "vendor": [
@@ -55,8 +108,8 @@
                 "version": []
             },
             "action": [
-                "replace_vendor_if_matches",
-                "replace_product_if_matches"
+                "replace_vendor",
+                "replace_product"
             ]
         },
         {
@@ -561,9 +614,11 @@
                     "^Python"
                 ],
                 "product": [
-                    "^Python [0-9]\\.[0-9]\\.*[0-9]* \\("
+                    "^Python [0-9]\\.[0-9]+\\.*[0-9]* \\("
                 ],
-                "version": [],
+                "version": [
+			"^Python ([0-9]\\.[0-9]+\\.[0-9])"
+		],
                 "target_hw" : [
                     "^Python [0-9]+\\.*[0-9]*\\.*[0-9]* \\(([6432]{2}-bit)\\)"
                 ]
@@ -580,6 +635,7 @@
             "action": [
                 "replace_vendor",
                 "replace_product",
+		"set_version_if_product_matches",
                 "set_targethw_if_product_matches"
             ]
         },


### PR DESCRIPTION
|Related issue|
|---|
|CPE Helper dictionary update #16687|

This PR aims to update the `cpe_helper.json` file, with the purpose of correcting some entries that have an incomplete **Regex** and adding some new entries, which solve some false negatives that were being generated on **Windows OS**.
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description of the new feature

Once the `cpe_helper` dictionary is updated, vulnerabilities caused by `Python` with more than two digits in its version number (for example: `V 3.10.5150`) and `Java SE Development Kit` in its different versions can be detected. In the case of `Python` and `JDK`, their respective entries were corrected since the **Regex** was not appropriate.

Also, vulnerabilities caused by `Microsoft Edge` and M`icrosoft ASP.NET Core Shared Framework` can now be detected, for which a new entry had to be created from scratch in the `cpe_helper` (for versions that are vulnerable according to the **NVD**).
<!--
Add a clear description of how the problem has been solved.
-->

## Changes to the CPE Helper 

1. Python

<details>
  <summary> Before </summary>

```c
{
            "target": "windows",
            "source": {
                "vendor": [
                    "^Python"
                ],
                "product": [
                    "^Python [0-9]\\.[0-9]\\.*[0-9]* \\("
                ],
                "version": [],
                "target_hw" : [
                    "^Python [0-9]+\\.*[0-9]*\\.*[0-9]* \\(([6432]{2}-bit)\\)"
                ]
            },
            "translation": {
                "vendor": [
                    "python"
                ],
                "product": [
                    "python"
                ],
                "version": []
            },
            "action": [
                "replace_vendor",
                "replace_product",
                "set_targethw_if_product_matches"
            ]
        },
``` 
</details>
<details>
  <summary> After </summary>

```c
{
            "target": "windows",
            "source": {
                "vendor": [
                    "^Python"
                ],
                "product": [
                    "^Python [0-9]\\.[0-9]+\\.*[0-9]* \\("
                ],
                "version": [
                     "^Python ([0-9]\\.[0-9]+\\.*[0-9]*)"
                ],
                "target_hw" : [
                    "^Python [0-9]+\\.*[0-9]*\\.*[0-9]* \\(([6432]{2}-bit)\\)"
                ]
            },
            "translation": {
                "vendor": [
                    "python"
                ],
                "product": [
                    "python"
                ],
                "version": []
            },
            "action": [
                "replace_vendor",
                "replace_product",
                "set_version_if_product_matches",
                "set_targethw_if_product_matches"
            ]
        },
``` 
</details>

2. Java SE Development kit

<details>
  <summary> Before </summary>

```c
{
            "target": "windows",
            "source": {
                "vendor": [
                    "^Oracle",
                    "^Sun"
                ],
                "product": [
                    "Java .* Development Kit",
                    "^Oracle.*VirtualBox [0-9]",
                    "^Java.*Update"
                ],
                "version": []
            },
            "translation": {
                "vendor": [
                    "oracle",
                    "sun"
                ],
                "product": [
                    "jdk",
                    "vm_virtualbox",
                    "jre"
                ],
                "version": []
            },
            "action": [
                "replace_vendor_if_matches",
                "replace_product_if_matches"
            ]
        },
``` 
</details>
<details>
  <summary> After </summary>

```c
{
            "target": "windows",
            "source": {
                "vendor": [
                    "^Oracle",
                    "^Sun"
                ],
                "product": [
                    "Java.* Development Kit",
                    "^Oracle.*VirtualBox [0-9]",
                    "^Java.*Update"
                ],
                "version": [
                    "Java.* Development Kit ([0-9]+\\.*[0-9]*\\.*[0-9]*)"
                ]
            },
            "translation": {
                "vendor": [
                    "oracle",
                    "sun"
                ],
                "product": [
                    "jdk",
                    "vm_virtualbox",
                    "jre"
                ],
                "version": []
            },
            "action": [
                "replace_vendor",
                "replace_product",
                "set_version_if_product_matches"
            ]
        },

``` 
</details>

3. Microsoft Edge WebView2 Runtime

<details>
  <summary> CPE Helper entry </summary>

```c
{
    "target": "windows",
    "source": {
        "vendor": [
            "Microsoft Corporation"
        ],
        "product": [
            "Microsoft Edge"
        ],
        "version": []
    },
    "translation": {
        "vendor": [
            "microsoft"
        ],
        "product": [
            "edge_chromium"
        ],
        "version": []
    },
    "action": [
        "replace_vendor",
        "replace_product"
    ]
},
``` 
</details>

3. Microsoft ASP.NET Core

<details>
  <summary> CPE Helper entry </summary>

```c
{
    "target": "windows",
    "source": {
        "vendor": [
            "Microsoft Corporation"
        ],
        "product": [
            "^Microsoft ASP.NET Core ([0-9]\\.*[0-9]*\\.*[0-9]*)"
        ],
        "version": [
            "^Microsoft ASP.NET Core ([0-9]\\.*[0-9]*\\.*[0-9]*)"
        ]
    },
    "translation": {
        "vendor": [
            "microsoft"
        ],
        "product": [
            "asp.net_core"
        ],
        "version": []
    },
    "action": [
        "replace_vendor",
        "set_version_if_product_matches",
        "replace_product"
    ]
},
``` 
</details>


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors