### PR TITLE
Added support for localfile blocks deployment

### DIFF
--- a/etc/templates/config/README.md
+++ b/etc/templates/config/README.md
@@ -36,6 +36,8 @@
 
         localfile-commands.template
 
+        localfile-extra.template
+
         rules.template
     </ossec_config>
 
@@ -70,6 +72,8 @@
         localfile-logs*
 
         localfile-commands.template
+
+        localfile-extra.template
 
         <active-response>
           <disabled>no</disabled>

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -401,6 +401,14 @@ WriteAgent()
     cat ${LOCALFILE_COMMANDS_TEMPLATE} >> $NEWCONFIG
     echo "" >> $NEWCONFIG
 
+    # Localfile extra
+    LOCALFILE_EXTRA_TEMPLATE=$(GetTemplate "localfile-extra.agent.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
+    if [ "$LOCALFILE_EXTRA_TEMPLATE" = "ERROR_NOT_FOUND" ]; then
+      LOCALFILE_EXTRA_TEMPLATE=$(GetTemplate "localfile-extra.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
+    fi
+    cat ${LOCALFILE_EXTRA_TEMPLATE} >> $NEWCONFIG
+    echo "" >> $NEWCONFIG
+
     echo "  <!-- Active response -->" >> $NEWCONFIG
 
     echo "  <active-response>" >> $NEWCONFIG
@@ -537,6 +545,15 @@ WriteManager()
     cat ${LOCALFILE_COMMANDS_TEMPLATE} >> $NEWCONFIG
     echo "" >> $NEWCONFIG
 
+    # Localfile extra
+    LOCALFILE_EXTRA_TEMPLATE=$(GetTemplate "localfile-extra.manager.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
+    if [ "$LOCALFILE_EXTRA_TEMPLATE" = "ERROR_NOT_FOUND" ]; then
+      LOCALFILE_EXTRA_TEMPLATE=$(GetTemplate "localfile-extra.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
+    fi
+    cat ${LOCALFILE_EXTRA_TEMPLATE} >> $NEWCONFIG
+    echo "" >> $NEWCONFIG
+
+
     # Writting rules configuration
     cat ${RULES_TEMPLATE} >> $NEWCONFIG
     echo "" >> $NEWCONFIG
@@ -656,6 +673,14 @@ WriteLocal()
       LOCALFILE_COMMANDS_TEMPLATE=$(GetTemplate "localfile-commands.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
     fi
     cat ${LOCALFILE_COMMANDS_TEMPLATE} >> $NEWCONFIG
+    echo "" >> $NEWCONFIG
+
+    # Localfile extra
+    LOCALFILE_EXTRA_TEMPLATE=$(GetTemplate "localfile-extra.manager.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
+    if [ "$LOCALFILE_EXTRA_TEMPLATE" = "ERROR_NOT_FOUND" ]; then
+      LOCALFILE_EXTRA_TEMPLATE=$(GetTemplate "localfile-extra.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
+    fi
+    cat ${LOCALFILE_EXTRA_TEMPLATE} >> $NEWCONFIG
     echo "" >> $NEWCONFIG
 
     # Writting rules configuration

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -406,7 +406,7 @@ WriteAgent()
     if [ "$LOCALFILE_EXTRA_TEMPLATE" = "ERROR_NOT_FOUND" ]; then
       LOCALFILE_EXTRA_TEMPLATE=$(GetTemplate "localfile-extra.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
     fi
-    if [ "$LOCALFILE_EXTRA_TEMPLATE" != "ERROR_NOT_FOUND" ]; then
+    if [ ! "$LOCALFILE_EXTRA_TEMPLATE" = "ERROR_NOT_FOUND" ]; then
       cat ${LOCALFILE_EXTRA_TEMPLATE} >> $NEWCONFIG
       echo "" >> $NEWCONFIG
     fi

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -406,8 +406,10 @@ WriteAgent()
     if [ "$LOCALFILE_EXTRA_TEMPLATE" = "ERROR_NOT_FOUND" ]; then
       LOCALFILE_EXTRA_TEMPLATE=$(GetTemplate "localfile-extra.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
     fi
-    cat ${LOCALFILE_EXTRA_TEMPLATE} >> $NEWCONFIG
-    echo "" >> $NEWCONFIG
+    if [ "$LOCALFILE_EXTRA_TEMPLATE" != "ERROR_NOT_FOUND" ]; then
+      cat ${LOCALFILE_EXTRA_TEMPLATE} >> $NEWCONFIG
+      echo "" >> $NEWCONFIG
+    fi
 
     echo "  <!-- Active response -->" >> $NEWCONFIG
 
@@ -550,9 +552,11 @@ WriteManager()
     if [ "$LOCALFILE_EXTRA_TEMPLATE" = "ERROR_NOT_FOUND" ]; then
       LOCALFILE_EXTRA_TEMPLATE=$(GetTemplate "localfile-extra.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
     fi
-    cat ${LOCALFILE_EXTRA_TEMPLATE} >> $NEWCONFIG
-    echo "" >> $NEWCONFIG
-
+    if [ ! "$LOCALFILE_EXTRA_TEMPLATE" = "ERROR_NOT_FOUND" ]; then
+      cat ${LOCALFILE_EXTRA_TEMPLATE} >> $NEWCONFIG
+      echo "" >> $NEWCONFIG
+    fi
+    
 
     # Writting rules configuration
     cat ${RULES_TEMPLATE} >> $NEWCONFIG
@@ -680,8 +684,10 @@ WriteLocal()
     if [ "$LOCALFILE_EXTRA_TEMPLATE" = "ERROR_NOT_FOUND" ]; then
       LOCALFILE_EXTRA_TEMPLATE=$(GetTemplate "localfile-extra.template" ${DIST_NAME} ${DIST_VER} ${DIST_SUBVER})
     fi
-    cat ${LOCALFILE_EXTRA_TEMPLATE} >> $NEWCONFIG
-    echo "" >> $NEWCONFIG
+    if [ ! "$LOCALFILE_EXTRA_TEMPLATE" = "ERROR_NOT_FOUND" ]; then
+      cat ${LOCALFILE_EXTRA_TEMPLATE} >> $NEWCONFIG
+      echo "" >> $NEWCONFIG
+    fi
 
     # Writting rules configuration
     cat ${RULES_TEMPLATE} >> $NEWCONFIG


### PR DESCRIPTION
|Related issue|
|---|
|#16751|

This solves the need to deploy extra localfile configuration blocks for ossec.conf based on OS and OS Version.
The new file is called `localfile-extra.template`. Files should be created under the `etc/template/config` folder structure.

Current problem was to add the shown localfile block on some macOS versions to use the ULS collection capabilities. 

```
<localfile>
  <location>macos</location>
  <log_format>macos</log_format>
  <query type="trace,log,activity" level="info">(process == "sudo") or (process == "sessionlogoutd" and message contains "logout is complete.") or (process == "sshd") or (process == "tccd" and message contains "Update Access Record") or (message contains "SessionAgentNotificationCenter") or (process == "screensharingd" and message contains "Authentication") or (process == "securityd" and eventMessage contains "Session" and subsystem == "com.apple.securityd")</query>
</localfile>
```

### Test - Agent with localfile-extra.template files

We have created a [macOS package](https://packages-dev.wazuh.com/warehouse/pullrequests/4.4/macos/wazuh-agent-4.4.2-0.commit89bd3d4.pkg) using this modification in https://github.com/wazuh/wazuh/pull/16078/files

After package installation, we can verify the correct localfile block is included in the wazuh-agent ossec.conf file:

```
  ...
  <!-- Log analysis -->
  <localfile>
    <log_format>full_command</log_format>
    <command>netstat -an | awk '{if ((/^(tcp|udp)/) && ($4 != "*.*") && ($5 == "*.*")) {print $1" "$4" "$5}}' | sort -u</command>
    <alias>netstat listening ports</alias>
    <frequency>360</frequency>
  </localfile>

  <localfile>
    <location>macos</location>
    <log_format>macos</log_format>
    <query type="trace,log,activity" level="info">(process == "sudo") or (process == "sessionlogoutd" and message contains "logout is complete.") or (process == "sshd") or (process == "tccd" and message contains "Update Access Record") or (message contains "SessionAgentNotificationCenter") or (process == "screensharingd" and message contains "Authentication") or (process == "securityd" and eventMessage contains "Session" and subsystem == "com.apple.securityd")</query>
  </localfile>

  <!-- Active response -->
  ...
```

### Test - Agent with NO localfile-extra.template files

We tested the packet for an RHEL 9 system with no need for localfile-extra.template configuration. Wazh-agent was installed and worked as expected.
