### PR TITLE
Create deploy script

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -212,3 +212,9 @@ add_custom_target( clean_insource
 add_custom_target( clean_build
     COMMAND rm -rf "${CMAKE_SOURCE_DIR}/build/*"
     ERROR_QUIET )
+
+add_custom_target(deploy
+    COMMAND bash ./deploy.sh
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Running Deployment Script : deploy.sh"
+)

--- a/src/engine/deploy.sh
+++ b/src/engine/deploy.sh
@@ -1,0 +1,14 @@
+echo "Current Status : Deploying current main target to current Wazuh Installation"
+echo "----------------------------------------------------------------------------"
+echo "Stopping Wazuh Manager Service..."
+sudo systemctl stop wazuh-manager.service &
+wait
+echo "Deploy new wazuh-engine binary..."
+sudo cp ./build/main /var/ossec/engine/wazuh-engine
+echo "Starting Wazuh Manager Service..."
+sudo systemctl start wazuh-manager.service &
+wait
+echo "----------------------------------------------------------------------------"
+echo "Current Status : Deploy done. Checksums (MD5) available:"
+sudo md5sum -b ./build/main
+sudo md5sum -b /var/ossec/engine/wazuh-engine


### PR DESCRIPTION
|Wazuh version|Component|Install type|Install method|Platform|
|---|---|---|---|---|
| 5.0 | Engine | Manager| - | - |

Fixes #16848 

## Implemented

  [ ] - Modify main CMakeLists.txt to add a new custom target named : "deploy"
  [ ] - Create a new bash script file in the SOURCE_DIRECTORY called deploy.sh with chmod +xX attributes.
  [ ] - Add a checksum stage to the script after execution, to help determine if the deployment was successful. 

## Basic usage workflow:

1. Modify new feature's files.
2. Run cmake and make accordingly.
3. If build is OK and the feature lies on the Engine's Server, execute `make deploy` in the build directory.
4. Now we can test the main's CLI against the new Server of our code.

