### PR TITLE
Fix Windows unit test hangs in nanosleep for Jenkins environment

### DIFF
--- a/src/unit_tests/shared/test_rwlock_op.c
+++ b/src/unit_tests/shared/test_rwlock_op.c
@@ -20,8 +20,6 @@
 #define N_READERS 4
 #define READ_CYCLES 10000
 #define WRITE_CYCLES 1000
-#define READER_DELAY_NSEC 10000
-#define WRITER_DELAY_NSEC 1000000
 
 typedef struct {
     rwlock_t * rwlock;
@@ -40,15 +38,11 @@ int test_rwlock_teardown(void ** state) {
 
 static void * reader(thread_args_t * thread_args) {
     char target[BUFFER_LEN];
-    struct timespec delay = {
-        .tv_sec = 0,
-        .tv_nsec = READER_DELAY_NSEC,
-    };
 
     for (int i = 0; i < READ_CYCLES; i++) {
         RWLOCK_LOCK_READ(thread_args->rwlock, {
             memcpy(target, thread_args->buffer, BUFFER_LEN);
-            nanosleep(&delay, NULL);
+            sched_yield();
         })
     }
 
@@ -57,17 +51,13 @@ static void * reader(thread_args_t * thread_args) {
 
 static void * writer(thread_args_t * thread_args) {
     int i = 0;
-     struct timespec delay = {
-        .tv_sec = 0,
-        .tv_nsec = WRITER_DELAY_NSEC,
-    };
 
     for (int i = 0; i < WRITE_CYCLES; i++) {
         RWLOCK_LOCK_WRITE(thread_args->rwlock, {
             snprintf(thread_args->buffer, BUFFER_LEN, "%d", i);
         })
 
-        nanosleep(&delay, NULL);
+        sched_yield();
     }
 
     return NULL;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/16736|


## Description
Hello team, 
this PR is to prevent Windows unit tests from hanging during execution in Jenkins.

After further investigation, the `test_rwlock_op` was getting stuck when calling the `nanosleep` function on this line:
https://github.com/wazuh/wazuh/blob/cea61fa45848539219481fd52d1c587f610d23e8/src/unit_tests/shared/test_rwlock_op.c#L70

By testing, we have come to the conclusion that it happens exclusively for values equal to or greater than 1000000 nanoseconds (1 millisecond).

I have tried to simplify the test to the maximum, calling only the nanosleep function:
```
void test_rwlock_threads(void ** state) {
    struct timespec delay = {
        .tv_sec = 0,
        .tv_nsec = 1000000,
    };
    nanosleep(&delay, NULL);
}

int main() {
    const struct CMUnitTest tests[] = {
        cmocka_unit_test(test_rwlock_threads),
    };

    return cmocka_run_group_tests(tests, NULL, NULL);
}
```

Checking in this way that the test was hanging.
However, modifying the value of `tv_nsec` to 999999, the test works correctly and consistently.
I also checked values like:

- Test passing:
```
    struct timespec delay = {
        .tv_sec = 0,
        .tv_nsec = 0,
    };
```
- Test hanging:
```
    struct timespec delay = {
        .tv_sec = 1,
        .tv_nsec = 0,
    };
```


Unfortunately we have not found the root cause of the problem, since it occurs exclusively during jenkins executions, it has not been possible to reproduce this behavior on local machines or docker.

## Conclusions

The proposed solution is to replace `nanosleep` with `sched_yield`.
We have launched a run with this modification branch and found that it worked correctly:
https://ci.wazuh.info/job/Test_unit/40967/
