### PR TITLE
fix(integration test): use docker compose v2

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -34,7 +34,7 @@ cluster_env_mode = 'cluster'
 
 
 def pytest_addoption(parser):
-    parser.addoption('--nobuild', action='store_false', help='Do not run docker-compose build.')
+    parser.addoption('--nobuild', action='store_false', help='Do not run docker compose build.')
 
 
 def pytest_collection_modifyitems(items: list):
@@ -111,12 +111,12 @@ def build_and_up(env_mode: str, interval: int = 10, interval_build_env: int = 10
         while values_build_env['retries'] < values_build_env['max_retries']:
             if build:
                 current_process = subprocess.Popen(
-                    ["docker-compose", "--profile", env_mode,
+                    ["docker", "compose", "--profile", env_mode,
                      "build", "--build-arg", f"WAZUH_BRANCH={current_branch}", "--build-arg", f"ENV_MODE={env_mode}"],
                     stdout=f_docker, stderr=subprocess.STDOUT, universal_newlines=True)
                 current_process.wait()
             current_process = subprocess.Popen(
-                ["docker-compose", "--profile", env_mode, "up", "-d"], env=dict(os.environ, ENV_MODE=env_mode),
+                ["docker", "compose", "--profile", env_mode, "up", "-d"], env=dict(os.environ, ENV_MODE=env_mode),
                 stdout=f_docker, stderr=subprocess.STDOUT, universal_newlines=True)
             current_process.wait()
 
@@ -135,7 +135,7 @@ def down_env():
     """Stop and remove all Docker containers."""
     os.chdir(env_path)
     with open(docker_log_path, mode='a') as f_docker:
-        current_process = subprocess.Popen(["docker-compose", "down", "-t0"], stdout=f_docker,
+        current_process = subprocess.Popen(["docker", "compose", "down", "-t0"], stdout=f_docker,
                                            stderr=subprocess.STDOUT, universal_newlines=True)
         current_process.wait()
     os.chdir(current_path)
@@ -167,14 +167,14 @@ def check_health(interval: int = 10, node_type: str = 'manager', agents: list = 
         nodes_to_check = ['master'] if only_check_master_health else env_cluster_nodes
         for node in nodes_to_check:
             health = subprocess.check_output(
-                f"docker inspect env_wazuh-{node}_1 -f '{{{{json .State.Health.Status}}}}'", shell=True)
+                f"docker inspect env-wazuh-{node}-1 -f '{{{{json .State.Health.Status}}}}'", shell=True)
             if not health.startswith(b'"healthy"'):
                 return False
         return True
     elif node_type == 'agent':
         for agent in agents:
             health = subprocess.check_output(
-                f"docker inspect env_wazuh-agent{agent}_1 -f '{{{{json .State.Health.Status}}}}'", shell=True)
+                f"docker inspect env-wazuh-agent{agent}-1 -f '{{{{json .State.Health.Status}}}}'", shell=True)
             if not health.startswith(b'"healthy"'):
                 return False
         return True
@@ -308,7 +308,7 @@ def save_logs(test_name: str):
         for log in logs:
             try:
                 subprocess.check_output(
-                    f"docker cp env_wazuh-{node}_1:{os.path.join(logs_path, log)} "
+                    f"docker cp env-wazuh-{node}-1:{os.path.join(logs_path, log)} "
                     f"{os.path.join(test_logs_path, f'test_{test_name}-{node}-{log}')}",
                     shell=True)
             except subprocess.CalledProcessError:
@@ -318,7 +318,7 @@ def save_logs(test_name: str):
     for agent in agent_names:
         try:
             subprocess.check_output(
-                f"docker cp env_wazuh-{agent}_1:{os.path.join(logs_path, 'ossec.log')} "
+                f"docker cp env-wazuh-{agent}-1:{os.path.join(logs_path, 'ossec.log')} "
                 f"{os.path.join(test_logs_path, f'test_{test_name}-{agent}-ossec.log')}",
                 shell=True)
         except subprocess.CalledProcessError:
@@ -379,7 +379,7 @@ def api_test(request: _pytest.fixtures.SubRequest):
         agents_health = check_health(interval=values['interval'], node_type='agent', agents=list(range(1, 9)))
         # Check if entrypoint was successful
         try:
-            error_message = subprocess.check_output(["docker", "exec", "-t", "env_wazuh-master_1", "sh", "-c",
+            error_message = subprocess.check_output(["docker", "exec", "-t", "env-wazuh-master-1", "sh", "-c",
                                                      "cat /entrypoint_error"]).decode().strip()
             pytest.fail(error_message)
         except subprocess.CalledProcessError:
@@ -402,7 +402,7 @@ def get_health():
     """
     health = "\nEnvironment final status\n"
     health += subprocess.check_output(
-        "docker ps --format 'table {{.Names}}\t{{.RunningFor}}\t{{.Status}}' --filter name=^env_wazuh",
+        "docker ps --format 'table {{.Names}}\t{{.RunningFor}}\t{{.Status}}' --filter name=^env-wazuh",
         shell=True).decode()
     health += '\n'
 

--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -135,7 +135,7 @@ def down_env():
     """Stop and remove all Docker containers."""
     os.chdir(env_path)
     with open(docker_log_path, mode='a') as f_docker:
-        current_process = subprocess.Popen(["docker", "compose", "down", "-t0"], stdout=f_docker,
+        current_process = subprocess.Popen(["docker", "compose", "down", "--remove-orphans", "-t0"], stdout=f_docker,
                                            stderr=subprocess.STDOUT, universal_newlines=True)
         current_process.wait()
     os.chdir(current_path)

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -2,9 +2,6 @@ version: '3.7'
 
 services:
   wazuh-master:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/manager/manager.Dockerfile
@@ -38,6 +35,8 @@ services:
       - wazuh-master
       - worker1
       - worker
+    depends_on:
+      - wazuh-master
 
   wazuh-worker2:
     profiles:
@@ -55,11 +54,10 @@ services:
       - wazuh-master
       - worker2
       - worker
+    depends_on:
+      - wazuh-master
 
   wazuh-agent1:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/new.Dockerfile
@@ -76,9 +74,6 @@ services:
       - nginx-lb
 
   wazuh-agent2:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/new.Dockerfile
@@ -96,9 +91,6 @@ services:
       - nginx-lb
 
   wazuh-agent3:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/new.Dockerfile
@@ -116,9 +108,6 @@ services:
       - nginx-lb
 
   wazuh-agent4:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/new.Dockerfile
@@ -136,9 +125,6 @@ services:
       - nginx-lb
 
   wazuh-agent5:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/old.Dockerfile
@@ -157,9 +143,6 @@ services:
       - nginx-lb
 
   wazuh-agent6:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/old.Dockerfile
@@ -178,9 +161,6 @@ services:
       - nginx-lb
 
   wazuh-agent7:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/old.Dockerfile
@@ -199,9 +179,6 @@ services:
       - nginx-lb
 
   wazuh-agent8:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/old.Dockerfile
@@ -220,9 +197,6 @@ services:
       - nginx-lb
 
   nginx-lb:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: ./base/nginx-lb
     image: integration_test_nginx-lb

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -441,7 +441,7 @@ def check_agentd_started(response, agents_list):
         while tries < 80:
             try:
                 # Save agentd logs in a list
-                command = f"docker exec env_wazuh-agent{int(agent_id)}_1 grep agentd /var/ossec/logs/ossec.log"
+                command = f"docker exec env-wazuh-agent{int(agent_id)}-1 grep agentd /var/ossec/logs/ossec.log"
                 output = subprocess.check_output(command.split()).decode().strip().split('\n')
             except subprocess.SubprocessError as exc:
                 raise subprocess.SubprocessError(f"Error while trying to get logs from agent {agent_id}") from exc
@@ -475,7 +475,7 @@ def check_agent_active_status(agents_list):
     while tries < 25:
         try:
             # Get active agents
-            output = subprocess.check_output(f"docker exec env_wazuh-master_1 /var/ossec/framework/python/bin/python3 "
+            output = subprocess.check_output(f"docker exec env-wazuh-master-1 /var/ossec/framework/python/bin/python3 "
                                              f"{active_agents_script_path}".split()).decode().strip()
         except subprocess.SubprocessError as exc:
             raise subprocess.SubprocessError("Error while trying to get agents") from exc


### PR DESCRIPTION

|Related issue|
|---|
|#16812|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
### Context
[As announced in January](https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/), from the end of June (two months after originally planned) Docker will drop support for Compose V1 and as a result Docker Desktop will no longer include Compose V1 (`docker-compose`). As part of our integration testing runs, a cluster is brought up. This cluster is managed via Compose V1. 

### Solution
This PR fixes #16812 by introducing the necessary changes to manage said cluster via Compose V2. This update should also somewhat speed the cluster creation, since
Compose V2 uses Buildkit by default.
- Replace `docker-compose` with `docker compose`.
- Replace _ with - as word separator in container names, following the new default.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components