### PR TITLE
Add distinct parameter to API endpoints

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -106,7 +106,7 @@ async def get_agents(request, pretty: bool = False, wait_for_complete: bool = Fa
                      offset: int = 0, limit: int = DATABASE_LIMIT, select: str = None, sort: str = None,
                      search: str = None, status: str = None, q: str = None, older_than: str = None, manager: str = None,
                      version: str = None, group: str = None, node_name: str = None, name: str = None, ip: str = None,
-                     group_config_status: str = None) -> web.Response:
+                     group_config_status: str = None, distinct: bool = False) -> web.Response:
     """Get information about all agents or a list of them.
 
     Parameters
@@ -150,6 +150,8 @@ async def get_agents(request, pretty: bool = False, wait_for_complete: bool = Fa
         Filter by agent IP.
     group_config_status : str
         Filter by agent groups configuration sync status.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -174,7 +176,8 @@ async def get_agents(request, pretty: bool = False, wait_for_complete: bool = Fa
                     'registerIP': request.query.get('registerIP', None),
                     'group_config_status': group_config_status
                 },
-                'q': q
+                'q': q,
+                'distinct': distinct
                 }
     # Add nested fields to kwargs filters
     nested = ['os.version', 'os.name', 'os.platform']
@@ -1087,7 +1090,8 @@ async def delete_groups(request, groups_list: str = None, pretty: bool = False,
 
 
 async def get_list_group(request, pretty: bool = False, wait_for_complete: bool = False, groups_list: str = None,
-                         offset: int = 0, limit: int = None, sort: str = None, search: str = None) -> web.Response:
+                         offset: int = 0, limit: int = None, sort: str = None, search: str = None,
+                         distinct: bool = False) -> web.Response:
     """Get groups.
 
     Returns a list containing basic information about each agent group such as number of agents belonging to the group
@@ -1111,6 +1115,8 @@ async def get_list_group(request, pretty: bool = False, wait_for_complete: bool 
         ascending or descending order.
     search : str
         Look for elements with the specified string.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -1123,7 +1129,8 @@ async def get_list_group(request, pretty: bool = False, wait_for_complete: bool 
                 'group_list': groups_list,
                 'sort': parse_api_param(sort, 'sort'),
                 'search': parse_api_param(search, 'search'),
-                'hash_algorithm': hash_}
+                'hash_algorithm': hash_,
+                'distinct': distinct}
     dapi = DistributedAPI(f=agent.get_agent_groups,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='local_master',
@@ -1139,7 +1146,8 @@ async def get_list_group(request, pretty: bool = False, wait_for_complete: bool 
 
 async def get_agents_in_group(request, group_id: str, pretty: bool = False, wait_for_complete: bool = False,
                               offset: int = 0, limit: int = DATABASE_LIMIT, select: str = None, sort: str = None,
-                              search: str = None, status: str = None, q: str = None) -> web.Response:
+                              search: str = None, status: str = None, q: str = None,
+                              distinct: bool = False) -> web.Response:
     """Get the list of agents that belongs to the specified group.
 
     Parameters
@@ -1166,6 +1174,8 @@ async def get_agents_in_group(request, group_id: str, pretty: bool = False, wait
         Filters by agent status. Use commas to enter multiple statuses.
     q : str
         Query to filter results by. For example q&#x3D;&amp;quot;status&#x3D;active&amp;quot;
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -1181,7 +1191,8 @@ async def get_agents_in_group(request, group_id: str, pretty: bool = False, wait
                 'filters': {
                     'status': status,
                 },
-                'q': q}
+                'q': q,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=agent.get_agents_in_group,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -1315,7 +1326,8 @@ async def put_group_config(request, body: dict, group_id: str, pretty: bool = Fa
 
 
 async def get_group_files(request, group_id: str, pretty: bool = False, wait_for_complete: bool = False,
-                          offset: int = 0, limit: int = None, sort: str = None, search: str = None) -> web.Response:
+                          offset: int = 0, limit: int = None, sort: str = None, search: str = None,
+                          distinct: bool = False) -> web.Response:
     """Get the files placed under the group directory.
 
     Parameters
@@ -1336,6 +1348,8 @@ async def get_group_files(request, group_id: str, pretty: bool = False, wait_for
         ascending or descending order.
     search : str
         Look for elements with the specified string.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -1350,7 +1364,8 @@ async def get_group_files(request, group_id: str, pretty: bool = False, wait_for
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
-                'hash_algorithm': hash_}
+                'hash_algorithm': hash_,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=agent.get_group_files,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/cdb_list_controller.py
+++ b/api/api/controllers/cdb_list_controller.py
@@ -20,7 +20,7 @@ logger = logging.getLogger('wazuh-api')
 
 async def get_lists(request, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0, limit: int = None,
                     select: list = None, sort: str = None, search: str = None, filename: str = None,
-                    relative_dirname: str = None) -> web.Response:
+                    relative_dirname: str = None, distinct: bool = False) -> web.Response:
     """Get all CDB lists.
 
     Parameters
@@ -45,6 +45,8 @@ async def get_lists(request, pretty: bool = False, wait_for_complete: bool = Fal
         Filenames to filter by (separated by comma).
     relative_dirname : str
         Filter by relative dirname.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -61,6 +63,7 @@ async def get_lists(request, pretty: bool = False, wait_for_complete: bool = Fal
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
                 'filename': filename,
                 'relative_dirname': relative_dirname,
+                'distinct': distinct
                 }
 
     dapi = DistributedAPI(f=cdb_list.get_lists,

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -631,7 +631,7 @@ async def get_stats_remoted_node(request, node_id: str, pretty: bool = False,
 
 async def get_log_node(request, node_id: str, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
                        limit: int = None, sort: str = None, search: str = None, tag: str = None, level: str = None,
-                       q: str = None) -> web.Response:
+                       q: str = None, distinct: bool = False) -> web.Response:
     """Get a specified node's wazuh logs.
 
     Returns the last 2000 wazuh log entries in node {node_id}.
@@ -660,6 +660,8 @@ async def get_log_node(request, node_id: str, pretty: bool = False, wait_for_com
         Filters by log level.
     q : str
         Query to filter results by.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -675,7 +677,8 @@ async def get_log_node(request, node_id: str, pretty: bool = False, wait_for_com
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
                 'tag': tag,
                 'level': level,
-                'q': q}
+                'q': q,
+                'distinct': distinct}
 
     nodes = raise_if_exc(await get_system_nodes())
     dapi = DistributedAPI(f=manager.ossec_log,

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -59,7 +59,7 @@ async def get_cluster_node(request, pretty: bool = False, wait_for_complete: boo
 
 async def get_cluster_nodes(request, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
                             limit: int = None, sort: str = None, search: str = None, select: str = None,
-                            nodes_list: str = None, q: str = None) -> web.Response:
+                            nodes_list: str = None, q: str = None, distinct: bool = False) -> web.Response:
     """Get information about all nodes in the cluster or a list of them.
 
     Parameters
@@ -84,6 +84,8 @@ async def get_cluster_nodes(request, pretty: bool = False, wait_for_complete: bo
         List of node IDs.
     q : str
         Query to filter results by.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -100,7 +102,8 @@ async def get_cluster_nodes(request, pretty: bool = False, wait_for_complete: bo
                 'search': parse_api_param(search, 'search'),
                 'select': select,
                 'filter_type': type_,
-                'q': q}
+                'q': q,
+                'distinct': distinct}
 
     nodes = raise_if_exc(await get_system_nodes())
     dapi = DistributedAPI(f=cluster.get_nodes_info,

--- a/api/api/controllers/decoder_controller.py
+++ b/api/api/controllers/decoder_controller.py
@@ -21,7 +21,7 @@ logger = logging.getLogger('wazuh-api')
 async def get_decoders(request, decoder_names: list = None, pretty: bool = False, wait_for_complete: bool = False,
                        offset: int = 0, limit: int = None, select: list = None, sort: str = None, search: str = None,
                        q: str = None, filename: str = None, relative_dirname: str = None,
-                       status: str = None) -> web.Response:
+                       status: str = None, distinct: bool = False) -> web.Response:
     """Get all decoders.
 
     Returns information about all the decoders included in the ossec.conf file.
@@ -55,6 +55,8 @@ async def get_decoders(request, decoder_names: list = None, pretty: bool = False
         Filters by relative dirname.
     status : str
         Filters by status.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -72,7 +74,8 @@ async def get_decoders(request, decoder_names: list = None, pretty: bool = False
                 'q': q,
                 'filename': filename,
                 'status': status,
-                'relative_dirname': relative_dirname}
+                'relative_dirname': relative_dirname,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=decoder_framework.get_decoders,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -89,7 +92,7 @@ async def get_decoders(request, decoder_names: list = None, pretty: bool = False
 
 async def get_decoders_files(request, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
                              limit: int = None, sort: str = None, search: str = None, filename: str = None,
-                             relative_dirname: str = None, status: str = None) -> web.Response:
+                             relative_dirname: str = None, status: str = None, distinct: bool = False) -> web.Response:
     """Get all decoders' files.
 
     Returns information about all decoders' files used in Wazuh.
@@ -121,6 +124,8 @@ async def get_decoders_files(request, pretty: bool = False, wait_for_complete: b
         Filters by relative dirname.
     status : str
         Filters by status.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -135,7 +140,8 @@ async def get_decoders_files(request, pretty: bool = False, wait_for_complete: b
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
                 'filename': filename,
                 'relative_dirname': relative_dirname,
-                'status': status}
+                'status': status,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=decoder_framework.get_decoders_files,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -336,7 +336,7 @@ async def get_stats_remoted(request, pretty: bool = False, wait_for_complete: bo
 
 async def get_log(request, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0, limit: int = None,
                   sort: str = None, search: str = None, tag: str = None, level: str = None,
-                  q: str = None) -> web.Response:
+                  q: str = None, distinct: bool = False) -> web.Response:
     """Get manager's or local_node's last 2000 wazuh log entries.
 
     Parameters
@@ -361,6 +361,8 @@ async def get_log(request, pretty: bool = False, wait_for_complete: bool = False
         Filters by log level.
     q : str
         Query to filter agents by.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -375,7 +377,8 @@ async def get_log(request, pretty: bool = False, wait_for_complete: bool = False
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
                 'tag': tag,
                 'level': level,
-                'q': q}
+                'q': q,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=manager.ossec_log,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -85,7 +85,8 @@ async def get_info(request, pretty: bool = False, wait_for_complete: bool = Fals
 
 
 async def get_configuration(request, pretty: bool = False, wait_for_complete: bool = False, section: str = None,
-                            field: str = None, raw: bool = False) -> Union[web.Response, ConnexionResponse]:
+                            field: str = None, raw: bool = False,
+                            distinct: bool = False) -> Union[web.Response, ConnexionResponse]:
     """Get manager's or local_node's configuration (ossec.conf)
 
     Parameters
@@ -101,6 +102,8 @@ async def get_configuration(request, pretty: bool = False, wait_for_complete: bo
         Indicates a section child, e.g, fields for rule section are include, decoder_dir, etc.
     raw : bool, optional
         Whether to return the file content in raw or JSON format. Default `False`
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -112,7 +115,8 @@ async def get_configuration(request, pretty: bool = False, wait_for_complete: bo
     """
     f_kwargs = {'section': section,
                 'field': field,
-                'raw': raw}
+                'raw': raw,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=manager.read_ossec_conf,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/mitre_controller.py
+++ b/api/api/controllers/mitre_controller.py
@@ -106,7 +106,7 @@ async def get_references(request, reference_ids: list = None, pretty: bool = Fal
 
 async def get_tactics(request, tactic_ids: list = None, pretty: bool = False, wait_for_complete: bool = False,
                       offset: int = None, limit: int = None, sort: str = None, search: str = None, select: list = None,
-                      q: str = None) -> web.Response:
+                      q: str = None, distinct: bool = False) -> web.Response:
     """Get information of specified MITRE's tactics.
 
     Parameters
@@ -131,6 +131,8 @@ async def get_tactics(request, tactic_ids: list = None, pretty: bool = False, wa
         ascending or descending order.
     q : str
         Query to filter by.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -148,7 +150,8 @@ async def get_tactics(request, tactic_ids: list = None, pretty: bool = False, wa
         'search_text': parse_api_param(search, 'search')['value'] if search else None,
         'complementary_search': parse_api_param(search, 'search')['negation'] if search else None,
         'select': select,
-        'q': q
+        'q': q,
+        'distinct': distinct
     }
 
     dapi = DistributedAPI(f=mitre.mitre_tactics,
@@ -166,7 +169,7 @@ async def get_tactics(request, tactic_ids: list = None, pretty: bool = False, wa
 
 async def get_techniques(request, technique_ids: list = None, pretty: bool = False, wait_for_complete: bool = False,
                          offset: int = None, limit: int = None, sort: str = None, search: str = None,
-                         select: list = None, q: str = None) -> web.Response:
+                         select: list = None, q: str = None, distinct: bool = False) -> web.Response:
     """Get information of specified MITRE's techniques.
 
     Parameters
@@ -191,6 +194,8 @@ async def get_techniques(request, technique_ids: list = None, pretty: bool = Fal
         ascending or descending order.
     q : str
         Query to filter by.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -206,7 +211,9 @@ async def get_techniques(request, technique_ids: list = None, pretty: bool = Fal
         'sort_ascending': False if sort is None or parse_api_param(sort, 'sort')['order'] == 'desc' else True,
         'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
         'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
-        'select': select, 'q': q}
+        'select': select, 
+        'q': q,
+        'distinct': distinct}
 
     dapi = DistributedAPI(f=mitre.mitre_techniques,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -223,7 +230,7 @@ async def get_techniques(request, technique_ids: list = None, pretty: bool = Fal
 
 async def get_mitigations(request, mitigation_ids: list = None, pretty: bool = False, wait_for_complete: bool = False,
                           offset: int = None, limit: int = None, sort: str = None, search: str = None,
-                          select: list = None, q: str = None) -> web.Response:
+                          select: list = None, q: str = None, distinct: bool = False) -> web.Response:
     """Get information of specified MITRE's mitigations.
 
     Parameters
@@ -248,6 +255,8 @@ async def get_mitigations(request, mitigation_ids: list = None, pretty: bool = F
         ascending or descending order.
     q : str
         Query to filter by.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -263,7 +272,9 @@ async def get_mitigations(request, mitigation_ids: list = None, pretty: bool = F
         'sort_ascending': False if sort is None or parse_api_param(sort, 'sort')['order'] == 'desc' else True,
         'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
         'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
-        'select': select, 'q': q}
+        'select': select,
+        'q': q,
+        'distinct': distinct}
 
     dapi = DistributedAPI(f=mitre.mitre_mitigations,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -280,7 +291,7 @@ async def get_mitigations(request, mitigation_ids: list = None, pretty: bool = F
 
 async def get_groups(request, group_ids: list = None, pretty: bool = False, wait_for_complete: bool = False,
                      offset: int = None, limit: int = None, sort: str = None, search: str = None, select: list = None,
-                     q: str = None) -> web.Response:
+                     q: str = None, distinct: bool = False) -> web.Response:
     """Get information of specified MITRE's groups.
 
     Parameters
@@ -305,6 +316,8 @@ async def get_groups(request, group_ids: list = None, pretty: bool = False, wait
         ascending or descending order.
     q : str
         Query to filter by.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -322,7 +335,8 @@ async def get_groups(request, group_ids: list = None, pretty: bool = False, wait
         'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
         'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
         'select': select,
-        'q': q}
+        'q': q,
+        'distinct': distinct}
 
     dapi = DistributedAPI(f=mitre.mitre_groups,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -339,7 +353,7 @@ async def get_groups(request, group_ids: list = None, pretty: bool = False, wait
 
 async def get_software(request, software_ids: list = None, pretty: bool = False, wait_for_complete: bool = False,
                        offset: int = None, limit: int = None, sort: str = None, search: str = None, select: list = None,
-                       q: str = None) -> web.Response:
+                       q: str = None, distinct: bool = False) -> web.Response:
     """Get information of specified MITRE's software.
 
     Parameters
@@ -364,6 +378,8 @@ async def get_software(request, software_ids: list = None, pretty: bool = False,
         ascending or descending order.
     q : str
         Query to filter by.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -381,7 +397,8 @@ async def get_software(request, software_ids: list = None, pretty: bool = False,
         'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
         'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
         'select': select,
-        'q': q}
+        'q': q,
+        'distinct': distinct}
 
     dapi = DistributedAPI(f=mitre.mitre_software,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/rootcheck_controller.py
+++ b/api/api/controllers/rootcheck_controller.py
@@ -85,7 +85,7 @@ async def delete_rootcheck(request, pretty: bool = False, wait_for_complete: boo
 
 async def get_rootcheck_agent(request, pretty: bool = False, wait_for_complete: bool = False, agent_id: str = None,
                               offset: int = 0, limit: int = None, sort: str = None, search: str = None,
-                              select: str = None, q: str = '', distinct: bool = None, status: str = 'all',
+                              select: str = None, q: str = '', distinct: bool = False, status: str = 'all',
                               pci_dss: str = None, cis: str = None) -> web.Response:
     """Return a list of events from the rootcheck database.
 

--- a/api/api/controllers/rule_controller.py
+++ b/api/api/controllers/rule_controller.py
@@ -25,7 +25,7 @@ async def get_rules(request, rule_ids: list = None, pretty: bool = False, wait_f
                     offset: int = 0, select: str = None, limit: int = None, sort: str = None, search: str = None,
                     q: str = None, status: str = None, group: str = None, level: str = None, filename: list = None,
                     relative_dirname: str = None, pci_dss: str = None, gdpr: str = None, gpg13: str = None,
-                    hipaa: str = None, tsc: str = None, mitre: str = None) -> web.Response:
+                    hipaa: str = None, tsc: str = None, mitre: str = None, distinct: bool = False) -> web.Response:
     """Get information about all Wazuh rules.
 
     Parameters
@@ -72,6 +72,8 @@ async def get_rules(request, rule_ids: list = None, pretty: bool = False, wait_f
         Filters by TSC requirement.
     mitre : str
         Filters by mitre technique ID.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -95,7 +97,8 @@ async def get_rules(request, rule_ids: list = None, pretty: bool = False, wait_f
                 'hipaa': hipaa,
                 'nist_800_53': request.query.get('nist-800-53', None),
                 'tsc': tsc,
-                'mitre': mitre}
+                'mitre': mitre,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=rule_framework.get_rules,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -210,7 +213,7 @@ async def get_rules_requirement(request, requirement: str = None, pretty: bool =
 @cache(expires=api_conf['cache']['time'])
 async def get_rules_files(request, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
                           limit: int = None, sort: str = None, search: str = None, status: str = None,
-                          filename: list = None, relative_dirname: str = None) -> web.Response:
+                          filename: list = None, relative_dirname: str = None, distinct: bool = False) -> web.Response:
     """Get all the rules files.
 
     Parameters
@@ -235,6 +238,8 @@ async def get_rules_files(request, pretty: bool = False, wait_for_complete: bool
         List of filenames to filter by.
     relative_dirname : str
         Filters by relative dirname.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -249,7 +254,8 @@ async def get_rules_files(request, pretty: bool = False, wait_for_complete: bool
                 'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
                 'status': status,
                 'filename': filename,
-                'relative_dirname': relative_dirname}
+                'relative_dirname': relative_dirname,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=rule_framework.get_rules_files,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -227,7 +227,7 @@ async def logout_user(request, pretty: bool = False, wait_for_complete: bool = F
 
 async def get_users(request, user_ids: list = None, pretty: bool = False, wait_for_complete: bool = False,
                     offset: int = 0, limit: int = None, search: str = None, select: str = None,
-                    sort: str = None) -> web.Response:
+                    sort: str = None, distinct: bool = False) -> web.Response:
     """Returns information from all system users.
 
     Parameters
@@ -250,6 +250,8 @@ async def get_users(request, user_ids: list = None, pretty: bool = False, wait_f
     sort : str, optional
         Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
         ascending or descending order.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -260,7 +262,8 @@ async def get_users(request, user_ids: list = None, pretty: bool = False, wait_f
                 'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['id'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
-                'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None}
+                'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=security.get_users,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -418,7 +421,7 @@ async def delete_users(request, user_ids: list = None, pretty: bool = False,
 
 async def get_roles(request, role_ids: list = None, pretty: bool = False, wait_for_complete: bool = False,
                     offset: int = 0, limit: int = None, search: str = None, select: str = None,
-                    sort: str = None) -> web.Response:
+                    sort: str = None, distinct: bool = False) -> web.Response:
     """Get information about the security roles in the system.
 
     Parameters
@@ -441,6 +444,8 @@ async def get_roles(request, role_ids: list = None, pretty: bool = False, wait_f
     sort : str, optional
         Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
         ascending or descending order.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -451,7 +456,8 @@ async def get_roles(request, role_ids: list = None, pretty: bool = False, wait_f
                 'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['id'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
-                'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None
+                'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
+                'distinct': distinct
                 }
 
     dapi = DistributedAPI(f=security.get_roles,
@@ -728,7 +734,7 @@ async def remove_rules(request, rule_ids: list = None, pretty: bool = False,
 
 async def get_policies(request, policy_ids: list = None, pretty: bool = False, wait_for_complete: bool = False,
                        offset: int = 0, limit: int = None, search: str = None, select: str = None,
-                       sort: str = None) -> web.Response:
+                       sort: str = None, distinct: bool = False) -> web.Response:
     """Returns information from all system policies.
 
     Parameters
@@ -751,6 +757,8 @@ async def get_policies(request, policy_ids: list = None, pretty: bool = False, w
     sort : str, optional
         Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
         ascending or descending order.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -761,7 +769,8 @@ async def get_policies(request, policy_ids: list = None, pretty: bool = False, w
                 'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['id'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
-                'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None
+                'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
+                'distinct': distinct
                 }
 
     dapi = DistributedAPI(f=security.get_policies,

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -579,7 +579,7 @@ async def update_role(request, role_id: int, pretty: bool = False, wait_for_comp
 
 async def get_rules(request, rule_ids: list = None, pretty: bool = False, wait_for_complete: bool = False,
                     offset: int = 0, limit: int = None, search: str = None, select: str = None,
-                    sort: str = None) -> web.Response:
+                    sort: str = None, distinct: bool = False) -> web.Response:
     """Get information about the security rules in the system.
 
     Parameters
@@ -602,6 +602,8 @@ async def get_rules(request, rule_ids: list = None, pretty: bool = False, wait_f
     sort : str, optional
         Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
         ascending or descending order.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -612,7 +614,8 @@ async def get_rules(request, rule_ids: list = None, pretty: bool = False, wait_f
                 'sort_by': parse_api_param(sort, 'sort')['fields'] if sort is not None else ['id'],
                 'sort_ascending': True if sort is None or parse_api_param(sort, 'sort')['order'] == 'asc' else False,
                 'search_text': parse_api_param(search, 'search')['value'] if search is not None else None,
-                'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None
+                'complementary_search': parse_api_param(search, 'search')['negation'] if search is not None else None,
+                'distinct': distinct
                 }
 
     dapi = DistributedAPI(f=security.get_rules,

--- a/api/api/controllers/syscollector_controller.py
+++ b/api/api/controllers/syscollector_controller.py
@@ -53,7 +53,7 @@ async def get_hardware_info(request, agent_id: str, pretty: bool = False, wait_f
 
 async def get_hotfix_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                           offset: int = 0, limit: int = None, sort: str = None, search: str = None, select: str = None,
-                          hotfix: str = None, q: str = None) -> web.Response:
+                          hotfix: str = None, q: str = None, distinct: bool = False) -> web.Response:
     """Get info about an agent's hotfixes.
 
     Parameters
@@ -80,6 +80,8 @@ async def get_hotfix_info(request, agent_id: str, pretty: bool = False, wait_for
         Show results in human-readable format.
     wait_for_complete : bool
         Disable timeout response.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -97,7 +99,8 @@ async def get_hotfix_info(request, agent_id: str, pretty: bool = False, wait_for
                 'search': parse_api_param(search, 'search'),
                 'filters': filters,
                 'element_type': 'hotfixes',
-                'q': q}
+                'q': q,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=syscollector.get_item_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -115,7 +118,8 @@ async def get_hotfix_info(request, agent_id: str, pretty: bool = False, wait_for
 async def get_network_address_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                                    offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                                    search: str = None, iface: str = None, proto: str = None, address: str = None,
-                                   broadcast: str = None, netmask: str = None, q: str = None) -> web.Response:
+                                   broadcast: str = None, netmask: str = None, q: str = None,
+                                   distinct: bool = False) -> web.Response:
     """Get network address info of an agent.
 
     Parameters
@@ -150,6 +154,8 @@ async def get_network_address_info(request, agent_id: str, pretty: bool = False,
         Filters by broadcast direction.
     netmask : str
         Filters by netmask.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -170,7 +176,8 @@ async def get_network_address_info(request, agent_id: str, pretty: bool = False,
                 'search': parse_api_param(search, 'search'),
                 'filters': filters,
                 'element_type': 'netaddr',
-                'q': q}
+                'q': q,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=syscollector.get_item_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -188,7 +195,7 @@ async def get_network_address_info(request, agent_id: str, pretty: bool = False,
 async def get_network_interface_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                                      offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                                      search: str = None, name: str = None, adapter: str = None, state: str = None,
-                                     mtu: str = None, q: str = None) -> web.Response:
+                                     mtu: str = None, q: str = None, distinct: bool = False) -> web.Response:
     """Get network interface info of an agent.
 
     Parameters
@@ -221,6 +228,8 @@ async def get_network_interface_info(request, agent_id: str, pretty: bool = Fals
         Filters by state.
     mtu : str
         Filters by mtu.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -245,7 +254,8 @@ async def get_network_interface_info(request, agent_id: str, pretty: bool = Fals
                 'search': parse_api_param(search, 'search'),
                 'filters': filters,
                 'element_type': 'netiface',
-                'q': q}
+                'q': q,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=syscollector.get_item_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -263,7 +273,7 @@ async def get_network_interface_info(request, agent_id: str, pretty: bool = Fals
 async def get_network_protocol_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                                     offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                                     search: str = None, iface: str = None, gateway: str = None, dhcp: str = None,
-                                    q: str = None) -> web.Response:
+                                    q: str = None, distinct: bool = False) -> web.Response:
     """Get network protocol info of an agent.
 
     Parameters
@@ -294,6 +304,8 @@ async def get_network_protocol_info(request, agent_id: str, pretty: bool = False
         Filters by gateway.
     dhcp : str
         Filters by dhcp.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -313,7 +325,8 @@ async def get_network_protocol_info(request, agent_id: str, pretty: bool = False
                 'search': parse_api_param(search, 'search'),
                 'filters': filters,
                 'element_type': 'netproto',
-                'q': q}
+                'q': q,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=syscollector.get_item_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -369,7 +382,7 @@ async def get_os_info(request, agent_id: str, pretty: bool = False, wait_for_com
 async def get_packages_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                             offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                             search: str = None, vendor: str = None, name: str = None, architecture: str = None,
-                            version: str = None, q: str = None) -> web.Response:
+                            version: str = None, q: str = None, distinct: bool = False) -> web.Response:
     """Get packages info of an agent.
 
     Parameters
@@ -402,6 +415,8 @@ async def get_packages_info(request, agent_id: str, pretty: bool = False, wait_f
         Filters by architecture.
     version : str
         Filters by version.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -422,7 +437,8 @@ async def get_packages_info(request, agent_id: str, pretty: bool = False, wait_f
                 'search': parse_api_param(search, 'search'),
                 'filters': filters,
                 'element_type': 'packages',
-                'q': q}
+                'q': q,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=syscollector.get_item_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -440,7 +456,7 @@ async def get_packages_info(request, agent_id: str, pretty: bool = False, wait_f
 async def get_ports_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
                          limit: int = None, select: str = None, sort: str = None, search: str = None, pid: str = None,
                          protocol: str = None, tx_queue: str = None, state: str = None, process: str = None,
-                         q: str = None) -> web.Response:
+                         q: str = None, distinct: bool = False) -> web.Response:
     """Get ports info of an agent.
 
     Parameters
@@ -475,6 +491,8 @@ async def get_ports_info(request, agent_id: str, pretty: bool = False, wait_for_
         Filters by state.
     process : str
         Filters by process.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -499,7 +517,8 @@ async def get_ports_info(request, agent_id: str, pretty: bool = False, wait_for_
                 'search': parse_api_param(search, 'search'),
                 'filters': filters,
                 'element_type': 'ports',
-                'q': q}
+                'q': q,
+                'distinct': distinct}
 
     dapi = DistributedAPI(f=syscollector.get_item_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -519,7 +538,8 @@ async def get_processes_info(request, agent_id: str, pretty: bool = False, wait_
                              search: str = None, pid: str = None, state: str = None, ppid: str = None,
                              egroup: str = None, euser: str = None, fgroup: str = None, name: str = None,
                              nlwp: str = None, pgrp: str = None, priority: str = None, rgroup: str = None,
-                             ruser: str = None, sgroup: str = None, suser: str = None, q: str = None) -> web.Response:
+                             ruser: str = None, sgroup: str = None, suser: str = None, q: str = None,
+                             distinct: bool = False) -> web.Response:
     """Get processes info an agent.
 
     Parameters
@@ -572,6 +592,8 @@ async def get_processes_info(request, agent_id: str, pretty: bool = False, wait_
         Filters by process sgroup.
     suser : str
         Filters by process suser.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -601,7 +623,8 @@ async def get_processes_info(request, agent_id: str, pretty: bool = False, wait_
                 'search': parse_api_param(search, 'search'),
                 'filters': filters,
                 'element_type': 'processes',
-                'q': q}
+                'q': q,
+               'distinct': distinct}
 
     dapi = DistributedAPI(f=syscollector.get_item_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -105,7 +105,8 @@ async def test_get_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp
                     'registerIP': mock_request.query.get('registerIP', None),
                     'group_config_status': None
                 },
-                'q': None
+                'q': None,
+                'distinct': False
                 }
     nested = ['os.version', 'os.name', 'os.platform']
     for field in nested:
@@ -751,7 +752,8 @@ async def test_get_list_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
                 'group_list': None,
                 'sort': None,
                 'search': None,
-                'hash_algorithm': hash_
+                'hash_algorithm': hash_,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=agent.get_agent_groups,
                                       f_kwargs=mock_remove.return_value,
@@ -785,7 +787,8 @@ async def test_get_agents_in_group(mock_exc, mock_dapi, mock_remove, mock_dfunc,
                 'filters': {
                     'status': None,
                 },
-                'q': None
+                'q': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=agent.get_agents_in_group,
                                       f_kwargs=mock_remove.return_value,
@@ -899,7 +902,8 @@ async def test_get_group_files(mock_exc, mock_dapi, mock_remove, mock_dfunc, moc
                 'sort_ascending': True,
                 'search_text': None,
                 'complementary_search': None,
-                'hash_algorithm': hash_
+                'hash_algorithm': hash_,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=agent.get_group_files,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_cdb_list_controller.py
+++ b/api/api/controllers/test/test_cdb_list_controller.py
@@ -37,6 +37,7 @@ async def test_get_lists(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_requ
                 'complementary_search': None,
                 'filename': None,
                 'relative_dirname': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=cdb_list.get_lists,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_cluster_controller.py
+++ b/api/api/controllers/test/test_cluster_controller.py
@@ -486,7 +486,8 @@ async def test_get_log_node(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_r
                     'complementary_search': None,
                     'tag': None,
                     'level': None,
-                    'q': None
+                    'q': None,
+                    'distinct': False
                     }
         mock_dapi.assert_called_once_with(f=manager.ossec_log,
                                           f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_cluster_controller.py
+++ b/api/api/controllers/test/test_cluster_controller.py
@@ -66,7 +66,8 @@ async def test_get_cluster_nodes(mock_exc, mock_dapi, mock_remove, mock_dfunc, m
                     'search': None,
                     'select': None,
                     'filter_type': mock_request.query.get('type', 'all'),
-                    'q': None
+                    'q': None,
+                    'distinct': False
                     }
         mock_dapi.assert_called_once_with(f=cluster.get_nodes_info,
                                           f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_decoder_controller.py
+++ b/api/api/controllers/test/test_decoder_controller.py
@@ -40,7 +40,8 @@ async def test_get_decoders(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_r
                 'q': None,
                 'filename': None,
                 'status': None,
-                'relative_dirname': None
+                'relative_dirname': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=decoder_framework.get_decoders,
                                       f_kwargs=mock_remove.return_value,
@@ -71,7 +72,8 @@ async def test_get_decoders_files(mock_exc, mock_dapi, mock_remove, mock_dfunc, 
                 'complementary_search': None,
                 'filename': None,
                 'status': None,
-                'relative_dirname': None
+                'relative_dirname': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=decoder_framework.get_decoders_files,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_manager_controller.py
+++ b/api/api/controllers/test/test_manager_controller.py
@@ -254,7 +254,8 @@ async def test_get_log(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_reques
                 'complementary_search': None,
                 'tag': None,
                 'level': None,
-                'q': None
+                'q': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=manager.ossec_log,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_manager_controller.py
+++ b/api/api/controllers/test/test_manager_controller.py
@@ -78,7 +78,8 @@ async def test_get_configuration(mock_exc, mock_dapi, mock_remove, mock_dfunc, m
         result = await get_configuration(request=mock_request)
         f_kwargs = {'section': None,
                     'field': None,
-                    'raw': False
+                    'raw': False,
+                    'distinct': False,
                     }
         mock_dapi.assert_called_once_with(f=manager.read_ossec_conf,
                                           f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_mitre_controller.py
+++ b/api/api/controllers/test/test_mitre_controller.py
@@ -60,7 +60,8 @@ async def test_get_groups(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_req
         'search_text': None,
         'complementary_search': None,
         'select': None,
-        'q': None
+        'q': None,
+        'distinct': False
     }
     mock_dapi.assert_called_once_with(f=mitre.mitre_groups,
                                       f_kwargs=mock_remove.return_value,
@@ -94,7 +95,8 @@ async def test_get_mitigations(mock_exc, mock_dapi, mock_remove, mock_dfunc, moc
         'search_text': None,
         'complementary_search': None,
         'select': None,
-        'q': None
+        'q': None,
+        'distinct': False
     }
     mock_dapi.assert_called_once_with(f=mitre.mitre_mitigations,
                                       f_kwargs=mock_remove.return_value,
@@ -162,7 +164,8 @@ async def test_get_software(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_r
         'search_text': None,
         'complementary_search': None,
         'select': None,
-        'q': None
+        'q': None,
+        'distinct': False
     }
     mock_dapi.assert_called_once_with(f=mitre.mitre_software,
                                       f_kwargs=mock_remove.return_value,
@@ -196,7 +199,8 @@ async def test_get_tactics(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_re
         'search_text': None,
         'complementary_search': None,
         'select': None,
-        'q': None
+        'q': None,
+        'distinct': False
     }
     mock_dapi.assert_called_once_with(f=mitre.mitre_tactics,
                                       f_kwargs=mock_remove.return_value,
@@ -230,7 +234,8 @@ async def test_get_techniques(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
         'search_text': None,
         'complementary_search': None,
         'select': None,
-        'q': None
+        'q': None,
+        'distinct': False
     }
     mock_dapi.assert_called_once_with(f=mitre.mitre_techniques,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_rootcheck_controller.py
+++ b/api/api/controllers/test/test_rootcheck_controller.py
@@ -81,7 +81,7 @@ async def test_get_rootcheck_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc,
                 'search': None,
                 'select': None,
                 'q': '',
-                'distinct': None,
+                'distinct': False,
                 'filters': {
                     'status': 'all',
                     'pci_dss': None,

--- a/api/api/controllers/test/test_rule_controller.py
+++ b/api/api/controllers/test/test_rule_controller.py
@@ -51,7 +51,8 @@ async def test_get_rules(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_requ
                 'hipaa': None,
                 'nist_800_53': mock_request.query.get('nist-800-53', None),
                 'tsc': None,
-                'mitre': None
+                'mitre': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=rule_framework.get_rules,
                                       f_kwargs=mock_remove.return_value,
@@ -140,7 +141,8 @@ async def test_get_rules_files(mock_exc, mock_dapi, mock_remove, mock_dfunc, moc
                 'complementary_search': None,
                 'status': None,
                 'filename': None,
-                'relative_dirname': None
+                'relative_dirname': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=rule_framework.get_rules_files,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_security_controller.py
+++ b/api/api/controllers/test/test_security_controller.py
@@ -209,7 +209,8 @@ async def test_get_users(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_requ
                 'sort_by': ['id'],
                 'sort_ascending': True,
                 'search_text': None,
-                'complementary_search': None
+                'complementary_search': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=security.get_users,
                                       f_kwargs=mock_remove.return_value,
@@ -343,7 +344,8 @@ async def test_get_roles(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_requ
                 'sort_by': ['id'],
                 'sort_ascending': True,
                 'search_text': None,
-                'complementary_search': None
+                'complementary_search': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=security.get_roles,
                                       f_kwargs=mock_remove.return_value,
@@ -555,7 +557,8 @@ async def test_get_policies(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_r
                 'sort_by': ['id'],
                 'sort_ascending': True,
                 'search_text': None,
-                'complementary_search': None
+                'complementary_search': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=security.get_policies,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_security_controller.py
+++ b/api/api/controllers/test/test_security_controller.py
@@ -451,7 +451,8 @@ async def test_get_rules(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_requ
                 'sort_by': ['id'],
                 'sort_ascending': True,
                 'search_text': None,
-                'complementary_search': None
+                'complementary_search': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=security.get_rules,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_syscollector_controller.py
+++ b/api/api/controllers/test/test_syscollector_controller.py
@@ -63,7 +63,8 @@ async def test_get_hotfix_info(mock_exc, mock_dapi, mock_remove, mock_dfunc, moc
                 'search': None,
                 'filters': filters,
                 'element_type': 'hotfixes',
-                'q': None
+                'q': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=syscollector.get_item_agent,
                                       f_kwargs=mock_remove.return_value,
@@ -101,7 +102,8 @@ async def test_get_network_address_info(mock_exc, mock_dapi, mock_remove, mock_d
                 'search': None,
                 'filters': filters,
                 'element_type': 'netaddr',
-                'q': None
+                'q': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=syscollector.get_item_agent,
                                       f_kwargs=mock_remove.return_value,
@@ -142,7 +144,8 @@ async def test_get_network_interface_info(mock_exc, mock_dapi, mock_remove, mock
                 'search': None,
                 'filters': filters,
                 'element_type': 'netiface',
-                'q': None
+                'q': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=syscollector.get_item_agent,
                                       f_kwargs=mock_remove.return_value,
@@ -179,7 +182,8 @@ async def test_get_network_protocol_info(mock_exc, mock_dapi, mock_remove, mock_
                 'search': None,
                 'filters': filters,
                 'element_type': 'netproto',
-                'q': None
+                'q': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=syscollector.get_item_agent,
                                       f_kwargs=mock_remove.return_value,
@@ -243,7 +247,8 @@ async def test_get_packages_info(mock_exc, mock_dapi, mock_remove, mock_dfunc, m
                 'search': None,
                 'filters': filters,
                 'element_type': 'packages',
-                'q': None
+                'q': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=syscollector.get_item_agent,
                                       f_kwargs=mock_remove.return_value,
@@ -284,7 +289,8 @@ async def test_get_ports_info(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
                 'search': None,
                 'filters': filters,
                 'element_type': 'ports',
-                'q': None
+                'q': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=syscollector.get_item_agent,
                                       f_kwargs=mock_remove.return_value,
@@ -331,7 +337,8 @@ async def test_get_processes_info(mock_exc, mock_dapi, mock_remove, mock_dfunc, 
                 'search': None,
                 'filters': filters,
                 'element_type': 'processes',
-                'q': None
+                'q': None,
+                'distinct': False
                 }
     mock_dapi.assert_called_once_with(f=syscollector.get_item_agent,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -9522,6 +9522,7 @@ paths:
         - $ref: '#/components/parameters/node_type'
         - $ref: '#/components/parameters/nodes_list'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "List of connected nodes"

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -11832,6 +11832,7 @@ paths:
         - $ref: '#/components/parameters/raw'
         - $ref: '#/components/parameters/section'
         - $ref: '#/components/parameters/field'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Wazuh configuration"
@@ -17847,6 +17848,7 @@ paths:
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Return a list of security rules"

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -7204,6 +7204,7 @@ paths:
         - $ref: '#/components/parameters/ip'
         - $ref: '#/components/parameters/registerIP'
         - $ref: '#/components/parameters/group_config_status'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "List of agents or error description"
@@ -8306,6 +8307,7 @@ paths:
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/hash'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "List all groups"
@@ -8416,6 +8418,7 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/statusAgentParam'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "List of agents or error description"
@@ -8659,6 +8662,7 @@ paths:
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/hash'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Get group files"
@@ -11057,6 +11061,7 @@ paths:
         - $ref: '#/components/parameters/tag'
         - $ref: '#/components/parameters/log_level'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Wazuh node logs"
@@ -11329,6 +11334,7 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/get_dirnames_path'
         - $ref: '#/components/parameters/filename'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Successfully got all CDB lists and the files where they are defined"
@@ -12693,6 +12699,7 @@ paths:
         - $ref: '#/components/parameters/tag'
         - $ref: '#/components/parameters/log_level'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Wazuh logs"
@@ -13028,6 +13035,7 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Get MITRE groups information"
@@ -13172,6 +13180,7 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Get MITRE mitigations information"
@@ -13290,6 +13299,7 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Get MITRE software information"
@@ -13361,6 +13371,7 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Get MITRE tactics information"
@@ -13445,6 +13456,7 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Get MITRE techniques information"
@@ -13742,6 +13754,7 @@ paths:
         - $ref: '#/components/parameters/nist-800-53'
         - $ref: '#/components/parameters/tsc'
         - $ref: '#/components/parameters/mitre'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Rule"
@@ -13929,6 +13942,7 @@ paths:
         - $ref: '#/components/parameters/get_dirnames_path'
         - $ref: '#/components/parameters/xml_filename'
         - $ref: '#/components/parameters/statusRLDParam'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Rule"
@@ -14635,6 +14649,7 @@ paths:
         - $ref: '#/components/parameters/filename'
         - $ref: '#/components/parameters/get_dirnames_path'
         - $ref: '#/components/parameters/statusRLDParam'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "List of decoders included in ossec.conf"
@@ -14708,6 +14723,7 @@ paths:
         - $ref: '#/components/parameters/xml_filename'
         - $ref: '#/components/parameters/get_dirnames_path'
         - $ref: '#/components/parameters/statusRLDParam'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "List of decoders files"
@@ -16193,6 +16209,7 @@ paths:
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/hotfix'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Return an agent's hotfix results"
@@ -16253,6 +16270,7 @@ paths:
         - $ref: '#/components/parameters/broadcast'
         - $ref: '#/components/parameters/netmask'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Return a list of agent's network results"
@@ -16323,6 +16341,7 @@ paths:
         - $ref: '#/components/parameters/tx.dropped'
         - $ref: '#/components/parameters/rx.dropped'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Return a list of agent's network interfaces results"
@@ -16396,6 +16415,7 @@ paths:
         - $ref: '#/components/parameters/gateway'
         - $ref: '#/components/parameters/dhcp'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Return a list of agent's network protocol results"
@@ -16521,6 +16541,7 @@ paths:
         - $ref: '#/components/parameters/file_format'
         - $ref: '#/components/parameters/package_version'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Return a list of agent's packages results"
@@ -16624,6 +16645,7 @@ paths:
         - $ref: '#/components/parameters/state'
         - $ref: '#/components/parameters/process'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Return a list of agent's packages results"
@@ -16734,6 +16756,7 @@ paths:
         - $ref: '#/components/parameters/sgroup'
         - $ref: '#/components/parameters/suser'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Return a list of agent's processes results"
@@ -17280,6 +17303,7 @@ paths:
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Information about user"
@@ -17545,6 +17569,7 @@ paths:
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Return a list of roles"
@@ -18059,6 +18084,7 @@ paths:
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "Return a list of policies"

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -2716,6 +2716,17 @@ stages:
           total_affected_items: 2
           total_failed_items: 0
 
+  - name: Get distinct agents groups
+    request:
+      verify: False
+      <<: *get_agents_groups
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /groups filter hash
 
@@ -3111,6 +3122,17 @@ stages:
       status_code: 400
       json:
         <<: *error_spec
+
+  - name: Get distinct group agents
+    request:
+      verify: False
+      <<: *groups_id_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /groups/{group_id}/agents {sort,select}
@@ -3538,6 +3560,17 @@ stages:
       status_code: 400
       json:
         <<: *error_spec
+
+  - name: Get distinct group files
+    request:
+      verify: False
+      <<: *groups_id_files_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /groups/{group_id}/files filter hash

--- a/api/test/integration/test_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_cdb_list_endpoints.tavern.yaml
@@ -287,6 +287,17 @@ stages:
           total_affected_items: 0
           total_failed_items: 0
 
+  - name: Get distinct CDB list
+    request:
+      verify: False
+      <<: *get_lists
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /lists/files
 

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -465,6 +465,17 @@ stages:
     response:
       <<: *connexion_error
 
+  - name: Get distinct cluster nodes
+    request:
+      verify: False
+      <<: *get_cluster_nodes
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /cluster/nodes
 
@@ -1777,6 +1788,17 @@ stages:
           extra_kwargs:
             key: "level"
             expected_values: "info"
+
+  - name: Get distinct cluster node logs
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /cluster/{node_id}/logs/summary

--- a/api/test/integration/test_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoder_endpoints.tavern.yaml
@@ -316,6 +316,17 @@ stages:
           total_affected_items: 0
           total_failed_items: !anyint
 
+  - name: Get distinct decoders
+    request:
+      verify: False
+      <<: *get_decoders
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /decoders
 
@@ -730,6 +741,17 @@ stages:
       status_code: 400
       json:
         error: 1403
+
+  - name: Get distinct decoders files
+    request:
+      verify: False
+      <<: *get_decoders_files
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /decoders/files

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -250,6 +250,38 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
+  - name: Get ruleset decoder_dir section distinct configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: GET
+      headers:
+          Authorization: "Bearer {test_login_token}"
+      params:
+        section: ruleset
+        field: decoder_dir
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
+  - name: Get ruleset rule_dir section distinct configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: GET
+      headers:
+          Authorization: "Bearer {test_login_token}"
+      params:
+        section: ruleset
+        field: rule_dir
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /manager/daemons/stats
 
@@ -770,6 +802,20 @@ stages:
           failed_items: []
           total_affected_items: 0
           total_failed_items: 0
+
+  - name: Get distinct manager logs
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /manager/logs/summary

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -341,6 +341,17 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
+  - name: Get distinct mitre mitigations
+    request:
+      verify: False
+      <<: *general_mitigations_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /mitre/references
 
@@ -920,6 +931,17 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
+  - name: Get distinct mitre tactics
+    request:
+      verify: False
+      <<: *general_tactics_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /mitre/techniques
 
@@ -1227,6 +1249,17 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
+  - name: Get distinct mitre techniques
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /mitre/groups
 
@@ -1528,6 +1561,17 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
+  - name: Get distinct mitre groups
+    request:
+      verify: False
+      <<: *general_groups_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /mitre/software
 
@@ -1828,3 +1872,14 @@ stages:
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
+
+  - name: Get distinct mitre software
+    request:
+      verify: False
+      <<: *general_software_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key

--- a/api/test/integration/test_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rule_endpoints.tavern.yaml
@@ -761,6 +761,17 @@ stages:
         data:
           total_affected_items: !anyint
 
+  - name: Get distinct rules
+    request:
+      verify: False
+      <<: *general_rules_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /rules/requirement/pci_dss
 
@@ -1619,6 +1630,17 @@ stages:
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
+
+  - name: Get distinct rules files
+    request:
+      verify: False
+      <<: *files_rules_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /rules/files/{filename}

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -414,6 +414,20 @@ stages:
       json:
         error: 2007
 
+  - name: Get distinct sca agent data
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /sca/{agent_id} using select (parametrized)
 

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -351,6 +351,17 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
+  - name: Get distinct security roles
+    request:
+      verify: False
+      <<: *all_roles_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /security/policies
 
@@ -640,6 +651,17 @@ stages:
       status_code: 200
       json:
         <<: *response_error
+
+  - name: Get distinct security policies
+    request:
+      verify: False
+      <<: *all_policies_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /security/rules
@@ -968,6 +990,17 @@ stages:
                 - '999'
           total_affected_items: 1
           total_failed_items: 1
+
+  - name: Get distinct security rules
+    request:
+      verify: False
+      <<: *all_rules_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /security/user/authenticate
@@ -1430,6 +1463,17 @@ stages:
           total_affected_items: 9
           total_failed_items: 0
           failed_items: []
+
+  - name: Get distinct security users
+    request:
+      verify: False
+      <<: *all_users_request
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /security/users/me

--- a/api/test/integration/test_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscollector_endpoints.tavern.yaml
@@ -535,6 +535,17 @@ stages:
           affected_items:
             - <<: *packages_response
 
+  - name: Get distinct packages info
+    request:
+      verify: False
+      <<: *packages_request_003
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /syscollector/{agent_id}/packages?{select}
 
@@ -995,6 +1006,17 @@ stages:
     response:
       status_code: 400
 
+  - name: Get distinct processes info
+    request:
+      verify: False
+      <<: *processes_request_004
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /syscollector/{agent_id}/processes?{sort,select}
 
@@ -1266,6 +1288,17 @@ stages:
         select: wrong
     response:
       <<: *error_response_1724
+
+  - name: Get distinct ports info
+    request:
+      verify: False
+      <<: *port_request_005
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /syscollector/{agent_id}/port?{sort,select}
@@ -1660,6 +1693,17 @@ stages:
           affected_items:
             - <<: *netaddr_response
 
+  - name: Get distinct network address info
+    request:
+      verify: False
+      <<: *netaddr_request_002
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
 ---
 test_name: GET /syscollector/{agent_id}/netaddr?{sort,select}
 
@@ -1988,6 +2032,17 @@ stages:
         sort: -wrong
     response:
       <<: *error_response_1403
+
+  - name: Get distinct network protocol info
+    request:
+      verify: False
+      <<: *netproto_request_003
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /syscollector/{agent_id}/netproto?{sort,select}
@@ -2644,6 +2699,17 @@ stages:
         data:
           affected_items: []
           total_affected_items: 0
+
+  - name: Get distinct net interface info
+    request:
+      verify: False
+      <<: *netiface_request_008
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
 
 ---
 test_name: GET /syscollector/{agent_id}/netiface?{sort,select}
@@ -4228,3 +4294,14 @@ stages:
           failed_items: []
           total_affected_items: 0
           total_failed_items: 0
+
+  - name: Get distinct hotfixes info
+    request:
+      verify: False
+      <<: *hotfix_request_001
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -298,7 +298,7 @@ def restart_agents_by_group(agent_list: list = None) -> AffectedItemsWazuhResult
                   post_proc_kwargs={'exclude_codes': [1701]})
 def get_agents(agent_list: list = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort: dict = None,
                search: dict = None, select: dict = None, filters: dict = None,
-               q: str = None) -> AffectedItemsWazuhResult:
+               q: str = None, distinct: bool = False) -> AffectedItemsWazuhResult:
     """Gets a list of available agents with basic attributes.
 
     Parameters
@@ -319,6 +319,8 @@ def get_agents(agent_list: list = None, offset: int = 0, limit: int = common.DAT
         Defines required field filters. Format: {"field1":"value1", "field2":["value2","value3"]}
     q : str
         Query to filter results by.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -342,7 +344,7 @@ def get_agents(agent_list: list = None, offset: int = 0, limit: int = common.DAT
         rbac_filters = get_rbac_filters(system_resources=system_agents, permitted_resources=agent_list, filters=filters)
 
         with WazuhDBQueryAgents(offset=offset, limit=limit, sort=sort, search=search, select=select,
-                                query=q, **rbac_filters) as db_query:
+                                query=q, **rbac_filters, distinct=distinct) as db_query:
             data = db_query.run()
 
         result.affected_items.extend(data['items'])
@@ -354,7 +356,7 @@ def get_agents(agent_list: list = None, offset: int = 0, limit: int = common.DAT
 @expose_resources(actions=["group:read"], resources=["group:id:{group_list}"], post_proc_func=None)
 def get_agents_in_group(group_list: list, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort: dict = None,
                         search: dict = None, select: dict = None, filters: dict = None,
-                        q: str = None) -> AffectedItemsWazuhResult:
+                        q: str = None, distinct: bool = False) -> AffectedItemsWazuhResult:
     """Gets a list of available agents with basic attributes.
 
     Parameters
@@ -375,6 +377,8 @@ def get_agents_in_group(group_list: list, offset: int = 0, limit: int = common.D
         Defines required field filters. Format: {"field1":"value1", "field2":["value2","value3"]}
     q : str
         Query to filter results by.
+    distinct : bool
+        Look for distinct values.
 
     Raises
     ------
@@ -393,7 +397,8 @@ def get_agents_in_group(group_list: list, offset: int = 0, limit: int = common.D
 
     q = 'group=' + group_list[0] + (';' + q if q else '')
 
-    return get_agents(offset=offset, limit=limit, sort=sort, search=search, select=select, filters=filters, q=q)
+    return get_agents(offset=offset, limit=limit, sort=sort, search=search, select=select, filters=filters, q=q,
+     distinct=distinct)
 
 
 @expose_resources(actions=["agent:read"], resources=["agent:id:{agent_list}"],
@@ -551,7 +556,7 @@ def add_agent(name: str = None, agent_id: str = None, key: str = None, ip: str =
 @expose_resources(actions=["group:read"], resources=["group:id:{group_list}"],
                   post_proc_kwargs={'exclude_codes': [1710]})
 def get_agent_groups(group_list: list = None, offset: int = 0, limit: int = None, sort: dict = None,
-                     search: dict = None, hash_algorithm: str = 'md5') -> AffectedItemsWazuhResult:
+                     search: dict = None, hash_algorithm: str = 'md5', distinct: bool = False) -> AffectedItemsWazuhResult:
     """Gets the existing groups.
 
     Parameters
@@ -568,6 +573,8 @@ def get_agent_groups(group_list: list = None, offset: int = 0, limit: int = None
         Look for elements with the specified string. Format: {"fields": ["field1","field2"]}
     hash_algorithm : str
         hash algorithm used to get mergedsum and configsum. Default: 'md5'
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -579,34 +586,37 @@ def get_agent_groups(group_list: list = None, offset: int = 0, limit: int = None
                                       some_msg='Some groups information was not returned',
                                       none_msg='No group information was returned'
                                       )
-    if group_list:
+    if not group_list:
+        return result
 
-        system_groups = get_groups()
-        # Add failed items
-        for invalid_group in set(group_list) - system_groups:
-            result.add_failed_item(id_=invalid_group, error=WazuhResourceNotFound(1710))
+    system_groups = get_groups()
+    # Add failed items
+    for invalid_group in set(group_list) - system_groups:
+        result.add_failed_item(id_=invalid_group, error=WazuhResourceNotFound(1710))
 
-        rbac_filters = get_rbac_filters(system_resources=system_groups, permitted_resources=group_list)
+    rbac_filters = get_rbac_filters(system_resources=system_groups, permitted_resources=group_list)
 
-        with WazuhDBQueryGroup(offset=offset, limit=limit, sort=sort, search=search, **rbac_filters) as group_query:
-            query_data = group_query.run()
+    with WazuhDBQueryGroup(offset=offset, limit=limit, sort=sort, search=search, **rbac_filters,
+     distinct=distinct) as group_query:
+        query_data = group_query.run()
 
-        for group in query_data['items']:
-            full_entry = path.join(common.SHARED_PATH, group['name'])
+    for group in query_data['items']:
+        full_entry = path.join(common.SHARED_PATH, group['name'])
 
-            # merged.mg and agent.conf sum
-            merged_sum = get_hash(path.join(full_entry, "merged.mg"), hash_algorithm)
-            conf_sum = get_hash(path.join(full_entry, "agent.conf"), hash_algorithm)
+        # merged.mg and agent.conf sum
+        merged_sum = get_hash(path.join(full_entry, "merged.mg"), hash_algorithm)
+        conf_sum = get_hash(path.join(full_entry, "agent.conf"), hash_algorithm)
 
-            if merged_sum:
-                group['mergedSum'] = merged_sum
+        if merged_sum:
+            group['mergedSum'] = merged_sum
 
-            if conf_sum:
-                group['configSum'] = conf_sum
-            affected_groups.append(group)
+        if conf_sum:
+            group['configSum'] = conf_sum
+        
+        affected_groups.append(group)
 
-        result.affected_items = affected_groups
-        result.total_affected_items = query_data['totalItems']
+    result.affected_items = affected_groups
+    result.total_affected_items = query_data['totalItems']
 
     return result
 
@@ -614,7 +624,7 @@ def get_agent_groups(group_list: list = None, offset: int = 0, limit: int = None
 @expose_resources(actions=["group:read"], resources=["group:id:{group_list}"], post_proc_func=None)
 def get_group_files(group_list: list = None, offset: int = 0, limit: int = None, search_text: str = None,
                     search_in_fields: list = None, complementary_search: bool = False, sort_by: list = None,
-                    sort_ascending: bool = True, hash_algorithm: str = 'md5') -> WazuhResult:
+                    sort_ascending: bool = True, hash_algorithm: str = 'md5', distinct: bool = False) -> WazuhResult:
     """Gets the group files.
 
     Parameters
@@ -636,7 +646,9 @@ def get_group_files(group_list: list = None, offset: int = 0, limit: int = None,
     offset : int
         First element to return.
     limit : int
-        Maximum number of elements to return
+        Maximum number of elements to return.
+    distinct : bool
+        Look for distinct values.
 
     Raises
     ------
@@ -681,7 +693,7 @@ def get_group_files(group_list: list = None, offset: int = 0, limit: int = None,
         data.append({'filename': "ar.conf", 'hash': get_hash(ar_path, hash_algorithm)})
         data = process_array(data, search_text=search_text, search_in_fields=search_in_fields,
                              complementary_search=complementary_search, sort_by=sort_by,
-                             sort_ascending=sort_ascending, offset=offset, limit=limit)
+                             sort_ascending=sort_ascending, offset=offset, limit=limit, distinct=distinct)
         result.affected_items = data['items']
         result.total_affected_items = data['totalItems']
     except WazuhError as e:

--- a/framework/wazuh/cdb_list.py
+++ b/framework/wazuh/cdb_list.py
@@ -18,7 +18,7 @@ from wazuh.rbac.decorators import expose_resources
 def get_lists(filename: list = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, select: list = None,
               sort_by: dict = None, sort_ascending: bool = True, search_text: str = None,
               complementary_search: bool = False, search_in_fields: str = None,
-              relative_dirname: str = None) -> AffectedItemsWazuhResult:
+              relative_dirname: str = None, distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get CDB lists content.
 
     Parameters
@@ -44,6 +44,8 @@ def get_lists(filename: list = None, offset: int = 0, limit: int = common.DATABA
         Name of the field to search in for the `search_text`.
     relative_dirname : str
          Filter by relative dirname.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -66,7 +68,7 @@ def get_lists(filename: list = None, offset: int = 0, limit: int = common.DATABA
     data = process_array(lists, search_text=search_text, search_in_fields=search_in_fields,
                          complementary_search=complementary_search, sort_by=sort_by, sort_ascending=sort_ascending,
                          offset=offset, limit=limit, select=select, allowed_sort_fields=SORT_FIELDS,
-                         required_fields=REQUIRED_FIELDS, allowed_select_fields=LIST_FIELDS)
+                         required_fields=REQUIRED_FIELDS, allowed_select_fields=LIST_FIELDS, distinct=distinct)
     result.affected_items = data['items']
     result.total_affected_items = data['totalItems']
 

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -114,6 +114,8 @@ async def get_nodes_info(lc: local_client.LocalClient, filter_node: Union[str, l
         LocalClient with which to send the 'get_nodes' request.
     filter_node : str or list
         Node to return.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -114,8 +114,6 @@ async def get_nodes_info(lc: local_client.LocalClient, filter_node: Union[str, l
         LocalClient with which to send the 'get_nodes' request.
     filter_node : str or list
         Node to return.
-    distinct : bool
-        Look for distinct values.
 
     Returns
     -------

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -233,7 +233,7 @@ class WazuhDBQueryGroup(WazuhDBQuery):
     def __init__(self, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort: dict = None, search: dict = None,
                  select: list = None, get_data: bool = True, query: str = '', filters: dict = None, count: bool = True,
                  default_sort_field: str = 'name', min_select_fields: set = None, remove_extra_fields: bool = True,
-                 rbac_negate: bool = True):
+                 rbac_negate: bool = True, distinct: bool = False):
         """Class constructor.
 
         Parameters
@@ -262,6 +262,8 @@ class WazuhDBQueryGroup(WazuhDBQuery):
             Whether to return data or not.
         rbac_negate : bool
             Whether to use IN or NOT IN on RBAC resources.
+        distinct : bool
+            Look for distinct values.
         """
         if filters is None:
             filters = {}
@@ -273,7 +275,7 @@ class WazuhDBQueryGroup(WazuhDBQuery):
                               filters=filters, fields={'name': 'name'},
                               default_sort_field=default_sort_field, default_sort_order='ASC', query=query,
                               backend=backend, min_select_fields=min_select_fields, count=count, get_data=get_data,
-                              rbac_negate=rbac_negate)
+                              rbac_negate=rbac_negate, distinct=distinct)
         self.remove_extra_fields = remove_extra_fields
 
     def _add_select_to_query(self):

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -278,9 +278,6 @@ class WazuhDBQueryGroup(WazuhDBQuery):
                               rbac_negate=rbac_negate, distinct=distinct)
         self.remove_extra_fields = remove_extra_fields
 
-    def _add_select_to_query(self):
-        pass
-
     def _add_sort_to_query(self):
         """Consider the option to sort by count."""
         self.fields['count'] = 'count(id_group)'

--- a/framework/wazuh/core/cluster/control.py
+++ b/framework/wazuh/core/cluster/control.py
@@ -13,7 +13,7 @@ from wazuh.core.utils import filter_array_by_query
 
 
 async def get_nodes(lc: local_client.LocalClient, filter_node=None, offset=0, limit=common.DATABASE_LIMIT,
-                    sort=None, search=None, select=None, filter_type='all', q=''):
+                    sort=None, search=None, select=None, filter_type='all', q='', distinct: bool = False):
     """Get basic information of each of the cluster nodes.
 
     Parameters
@@ -36,6 +36,8 @@ async def get_nodes(lc: local_client.LocalClient, filter_node=None, offset=0, li
         Type of node (worker/master).
     q : str
         Query for filtering a list of results.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -45,10 +47,10 @@ async def get_nodes(lc: local_client.LocalClient, filter_node=None, offset=0, li
     if q:
         # If exists q parameter, apply limit and offset after filtering by q.
         arguments = {'filter_node': filter_node, 'offset': 0, 'limit': common.DATABASE_LIMIT, 'sort': sort,
-                     'search': search, 'select': select, 'filter_type': filter_type}
+                     'search': search, 'select': select, 'filter_type': filter_type, 'distinct': distinct}
     else:
         arguments = {'filter_node': filter_node, 'offset': offset, 'limit': limit, 'sort': sort, 'search': search,
-                     'select': select, 'filter_type': filter_type}
+                     'select': select, 'filter_type': filter_type, 'distinct': distinct}
 
     response = await lc.execute(command=b'get_nodes', data=json.dumps(arguments).encode())
     result = json.loads(response, object_hook=as_wazuh_object)

--- a/framework/wazuh/core/cluster/server.py
+++ b/framework/wazuh/core/cluster/server.py
@@ -407,7 +407,7 @@ class AbstractServer:
 
     def get_connected_nodes(self, filter_node: str = None, offset: int = 0, limit: int = common.DATABASE_LIMIT,
                             sort: Dict = None, search: Dict = None, select: Dict = None,
-                            filter_type: str = 'all') -> Dict:
+                            filter_type: str = 'all', distinct: bool = False) -> Dict:
         """Get all connected nodes, including the master node.
 
         Parameters
@@ -426,6 +426,8 @@ class AbstractServer:
             Select which fields to return (separated by comma).
         filter_type : str
             Type of node (worker/master).
+        distinct : bool
+            Look for distinct values.
 
         Returns
         -------
@@ -475,7 +477,8 @@ class AbstractServer:
                                    sort_ascending=False if sort is not None and sort['order'] == 'desc' else True,
                                    allowed_sort_fields=default_fields,
                                    offset=offset,
-                                   limit=limit)
+                                   limit=limit,
+                                   distinct=distinct)
 
     async def check_clients_keepalive(self):
         """Check date of the last received keep alive.

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -389,7 +389,8 @@ def test_AbstractServer_get_connected_nodes(mock_process_array):
                                             sort={"fields": ["nothing"], "order": "desc"}, limit=501, offset=1)
         mock_process_array.assert_called_once_with([basic_dict["info"]], search_text="wazuh", complementary_search=True,
                                                    sort_by=["nothing"], sort_ascending=False,
-                                                   allowed_sort_fields=basic_dict["info"].keys(), offset=1, limit=501)
+                                                   allowed_sort_fields=basic_dict["info"].keys(), offset=1, limit=501,
+                                                   distinct=False)
         mock_process_array.reset_mock()
 
 
@@ -405,7 +406,8 @@ def test_AbstractServer_get_connected_nodes_ko(mock_process_array):
         abstract_server.get_connected_nodes()
         mock_process_array.assert_called_once_with([basic_dict["info"]], search_text=None, complementary_search=False,
                                                    sort_by=None, sort_ascending=True,
-                                                   allowed_sort_fields=basic_dict["info"].keys(), offset=0, limit=500)
+                                                   allowed_sort_fields=basic_dict["info"].keys(), offset=0, limit=500,
+                                                   distinct=False)
         mock_process_array.reset_mock()
 
         with pytest.raises(WazuhError, match=".* 1724 .* Not a valid select field: no"):

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -584,7 +584,7 @@ def _ar_conf2json(file_path: str) -> dict:
 
 # Main functions
 def get_ossec_conf(section: str = None, field: str = None, conf_file: str = common.OSSEC_CONF,
-                   from_import: bool = False) -> dict:
+                   from_import: bool = False, distinct: bool = False) -> dict:
     """Return ossec.conf (manager) as dictionary.
 
     Parameters
@@ -597,6 +597,8 @@ def get_ossec_conf(section: str = None, field: str = None, conf_file: str = comm
         Path of the configuration file to read. Default: common.OSSEC_CONF
     from_import : bool
         This flag indicates whether this function has been called from a module load (True) or from a function (False).
+    distinct : bool
+        Look for distinct values.
 
     Raises
     ------
@@ -641,7 +643,15 @@ def get_ossec_conf(section: str = None, field: str = None, conf_file: str = comm
             if isinstance(data[section], list):
                 data = {section: [{field: item[field]} for item in data[section]]}
             else:
-                data = {section: {field: data[section][field]}}
+                field_data = data[section][field]
+                if distinct and section == 'ruleset':
+                    if field in ('decoder_dir', 'rule_dir'):
+                        # Remove duplicates
+                        values = []
+                        [values.append(x) for x in field_data if x not in values]
+                        field_data = values
+
+                data = {section: {field: field_data}}
         except KeyError:
             raise WazuhError(1103)
 

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -42,7 +42,8 @@ class WazuhDBQueryMitre(WazuhDBQuery):
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.DATABASE_LIMIT, query: str = '',
                  count: bool = True, table: str = '', sort: dict = None, default_sort_field: str = DEFAULT_PK,
                  default_sort_order: str = 'ASC', fields: dict = None, search: dict = None, select: list = None,
-                 min_select_fields: set = None, filters: dict = None, request_slice: int = DEFAULT_REQUEST_SLICE):
+                 min_select_fields: set = None, filters: dict = None, request_slice: int = DEFAULT_REQUEST_SLICE,
+                 distinct: bool = False):
         """Create an instance of the WazuhDBQueryMitre class.
 
         Parameters
@@ -75,6 +76,8 @@ class WazuhDBQueryMitre(WazuhDBQuery):
             Defines field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
         request_slice : int
             Max limit used in the WazuhDBBacked backend object.
+        distinct : bool
+            Look for distinct values.
         """
 
         if filters is None:
@@ -85,7 +88,8 @@ class WazuhDBQueryMitre(WazuhDBQuery):
                               default_sort_order=default_sort_order, filters=filters, query=query, count=count,
                               get_data=True, min_select_fields=min_select_fields,
                               date_fields={'created_time', 'modified_time'},
-                              backend=WazuhDBBackend(query_format='mitre', request_slice=request_slice))
+                              backend=WazuhDBBackend(query_format='mitre', request_slice=request_slice),
+                              distinct=distinct)
 
         self.relation_fields = set()  # This variable contains valid fields not included in the database (relations)
 
@@ -347,7 +351,7 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.DATABASE_LIMIT, query: str = '',
                  count: bool = True, sort: dict = None, default_sort_field: str = '', default_sort_order: str = 'ASC',
                  fields: dict = None, search: dict = None, select: list = None, min_select_fields: set = None,
-                 filters: dict = None):
+                 filters: dict = None, distinct: bool = False):
         """Create an instance of the WazuhDBQueryMitreMitigations class.
 
         Parameters
@@ -376,6 +380,8 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
             Fields that must always be selected because they're necessary to compute other fields.
         filters : dict
             Defines field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
+        distinct : bool
+            Look for distinct values.
         """
 
         default_sort_field = default_sort_field or MAIN_TABLES_PKS[self.TABLE_NAME]
@@ -392,7 +398,7 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
                                    count=count, sort=sort, default_sort_field=default_sort_field,
                                    default_sort_order=default_sort_order, search=search,
                                    select=list(set(self.fields.values()).intersection(set(select))),
-                                   request_slice=MITIGATIONS_REQUEST_SLICE)
+                                   request_slice=MITIGATIONS_REQUEST_SLICE, distinct=distinct)
 
         self.relation_fields = {'techniques', 'references'}
         self.extra_fields = EXTRA_FIELDS
@@ -488,7 +494,7 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.DATABASE_LIMIT, query: str = '',
                  count: bool = True, sort: dict = None, default_sort_field: str = '', default_sort_order: str = 'ASC',
                  fields: dict = None, search: dict = None, select: list = None, min_select_fields: set = None,
-                 filters: dict = None):
+                 filters: dict = None, distinct: bool = False):
         """Create an instance of the WazuhDBQueryMitreTactics class.
 
         Parameters
@@ -517,6 +523,8 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
             Fields that must always be selected because they're necessary to compute other fields.
         filters : dict
             Defines field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
+        distinct : bool
+            Look for distinct values.
         """
 
         default_sort_field = default_sort_field or MAIN_TABLES_PKS[self.TABLE_NAME]
@@ -530,7 +538,7 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
                                    fields=self.fields, filters=filters, offset=offset, limit=limit, query=query,
                                    count=count, sort=sort, default_sort_field=default_sort_field,
                                    default_sort_order=default_sort_order, search=search,
-                                   select=list(set(self.fields.values()).intersection(set(select))))
+                                   select=list(set(self.fields.values()).intersection(set(select))), distinct=distinct)
 
         self.relation_fields = {'techniques', 'references'}
         self.extra_fields = EXTRA_FIELDS
@@ -569,7 +577,7 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.DATABASE_LIMIT, query: str = '',
                  count: bool = True, sort: dict = None, default_sort_field: str = '', default_sort_order: str = 'ASC',
                  fields: dict = None, search: dict = None, select: list = None, min_select_fields: set = None,
-                 filters: dict = None):
+                 filters: dict = None, distinct: bool = False):
         """Create an instance of the WazuhDBQueryMitreTechniques class.
 
         Parameters
@@ -598,6 +606,8 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
             Fields that must always be selected because they're necessary to compute other fields.
         filters : dict
             Defines field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
+        distinct : bool
+            Look for distinct values.
         """
 
         default_sort_field = default_sort_field or MAIN_TABLES_PKS[self.TABLE_NAME]
@@ -616,7 +626,7 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
                                    count=count, sort=sort, default_sort_field=default_sort_field,
                                    default_sort_order=default_sort_order, search=search,
                                    select=list(set(self.fields.values()).intersection(set(select))),
-                                   request_slice=TECHNIQUES_REQUEST_SLICE)
+                                   request_slice=TECHNIQUES_REQUEST_SLICE, distinct=distinct)
 
         self.relation_fields = {'tactics', 'mitigations', 'software', 'groups', 'references'}
         self.extra_fields = EXTRA_FIELDS
@@ -676,7 +686,7 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.DATABASE_LIMIT, query: str = '',
                  count: bool = True, sort: dict = None, default_sort_field: str = '', default_sort_order: str = 'ASC',
                  fields: dict = None, search: dict = None, select: list = None, min_select_fields: set = None,
-                 filters: dict = None):
+                 filters: dict = None, distinct: bool = False):
         """Create an instance of the WazuhDBQueryMitreGroups class.
 
         Parameters
@@ -705,6 +715,8 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
             Fields that must always be selected because they're necessary to compute other fields.
         filters : dict
             Defines field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
+        distinct : bool
+            Look for distinct values.
         """
 
         default_sort_field = default_sort_field or MAIN_TABLES_PKS[self.TABLE_NAME]
@@ -722,7 +734,7 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
                                    count=count, sort=sort, default_sort_field=default_sort_field,
                                    default_sort_order=default_sort_order, search=search,
                                    select=list(set(self.fields.values()).intersection(set(select))),
-                                   request_slice=GROUPS_REQUEST_SLICE)
+                                   request_slice=GROUPS_REQUEST_SLICE, distinct=distinct)
 
         self.relation_fields = {'software', 'techniques', 'references'}
         self.extra_fields = EXTRA_FIELDS
@@ -773,7 +785,7 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.DATABASE_LIMIT, query: str = '',
                  count: bool = True, sort: dict = None, default_sort_field: str = '', default_sort_order: str = 'ASC',
                  fields: dict = None, search: dict = None, select: list = None, min_select_fields: set = None,
-                 filters: dict = None):
+                 filters: dict = None, distinct: bool = False):
         """Create an instance of the WazuhDBQueryMitreGroups class.
 
         Parameters
@@ -802,6 +814,8 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
             Fields that must always be selected because they're necessary to compute other fields.
         filters : dict
             Defines field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
+        distinct : bool
+            Look for distinct values.
         """
 
         default_sort_field = default_sort_field or MAIN_TABLES_PKS[self.TABLE_NAME]
@@ -818,7 +832,7 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
                                    count=count, sort=sort, default_sort_field=default_sort_field,
                                    default_sort_order=default_sort_order, search=search,
                                    select=list(set(self.fields.values()).intersection(set(select))),
-                                   request_slice=SOFTWARE_REQUEST_SLICE)
+                                   request_slice=SOFTWARE_REQUEST_SLICE, distinct=distinct)
 
         self.relation_fields = {'groups', 'techniques', 'references'}
         self.extra_fields = EXTRA_FIELDS
@@ -888,7 +902,7 @@ def get_mitre_items(mitre_class: callable) -> tuple:
 
 def get_results_with_select(mitre_class: callable, filters: str, select: list, offset: int, limit: int, sort_by: dict,
                             sort_ascending: bool, search_text: str, complementary_search: bool, search_in_fields: list,
-                            q: str) -> list:
+                            q: str, distinct: bool = False) -> list:
     """Sanitize the select parameter and processes the list of MITRE resources.
 
     Parameters
@@ -915,6 +929,8 @@ def get_results_with_select(mitre_class: callable, filters: str, select: list, o
         Fields to search in.
     q : str
         Query for filtering a list of results.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -928,4 +944,4 @@ def get_results_with_select(mitre_class: callable, filters: str, select: list, o
                          sort_ascending=sort_ascending, offset=offset, limit=limit, q=q,
                          allowed_sort_fields=fields_info['allowed_fields'],
                          allowed_select_fields=fields_info['allowed_fields'],
-                         required_fields=fields_info['min_select_fields'])
+                         required_fields=fields_info['min_select_fields'], distinct=distinct)

--- a/framework/wazuh/core/tests/data/configuration/ossec.conf
+++ b/framework/wazuh/core/tests/data/configuration/ossec.conf
@@ -21,4 +21,9 @@
         <node>wazuh-master</node>
         <node>wazuh-worker</node>
     </integration>
+	<ruleset>
+		<rule_dir>ruleset/rules</rule_dir>
+		<rule_dir>ruleset/rules</rule_dir>
+		<rule_dir>etc/rules</rule_dir>
+	</ruleset>
 </ossec_config>

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -180,6 +180,18 @@ def test_get_ossec_conf():
         conf_file=os.path.join(parent_directory, tmp_path, 'configuration/ossec.conf')
     )['integration'][0]['node'] == 'wazuh-worker'
 
+    assert configuration.get_ossec_conf(
+        conf_file=os.path.join(parent_directory, tmp_path, 'configuration/ossec.conf'),
+        section='ruleset',
+        field='rule_dir',
+        distinct=False)['ruleset']['rule_dir'] == ['ruleset/rules', 'ruleset/rules', 'etc/rules']
+
+    assert configuration.get_ossec_conf(
+        conf_file=os.path.join(parent_directory, tmp_path, 'configuration/ossec.conf'),
+        section='ruleset',
+        field='rule_dir',
+        distinct=True)['ruleset']['rule_dir'] == ['ruleset/rules', 'etc/rules']
+
 
 def test_get_agent_conf():
     with pytest.raises(WazuhError, match=".* 1710 .*"):

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -217,70 +217,83 @@ def test_cut_array_ko(limit, offset, expected_exception):
         utils.cut_array(array=['one', 'two', 'three'], limit=limit, offset=offset)
 
 
-@pytest.mark.parametrize('array, q, filters, limit, search_text, select, sort_by, expected_items, expected_total_items',
-                         [
-                             # Test cases with queries
-                             ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
-                               {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
-                              'datetime=2017-10-25T14:48:53.732000Z', None, None, None, None, None,
-                              [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}], 1),
+@pytest.mark.parametrize(
+    'array, q, filters, limit, search_text, select, sort_by, distinct, expected_items, expected_total_items',
+    [
+        # Test cases with queries
+        ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
+          {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
+         'datetime=2017-10-25T14:48:53.732000Z', None, None, None, None, None, None,
+         [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}], 1),
 
-                             ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
-                               {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
-                              'datetime<2017-10-26', None, None, None, None, None,
-                              [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}], 1),
+        ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
+          {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
+         'datetime<2017-10-26', None, None, None, None, None, None,
+         [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}], 1),
 
-                             ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
-                               {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
-                              'datetime>2019-10-26,datetime<2017-10-26', None, None, None, None, None,
-                              [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}], 1),
+        ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
+          {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
+         'datetime>2019-10-26,datetime<2017-10-26', None, None, None, None, None, None,
+         [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}], 1),
 
-                             ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
-                               {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
-                              'datetime>2017-10-26;datetime<2018-05-15T12:34:12.644000Z', None, None, None, None, None,
-                              [{'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}], 1),
+        ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
+          {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
+         'datetime>2017-10-26;datetime<2018-05-15T12:34:12.644000Z', None, None, None, None, None, None,
+         [{'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}], 1),
 
-                             ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53Z'},
-                               {'item': 'value_1', 'datetime': '2018-05-15T12:34:12Z'}],
-                              'datetime>2017-10-26;datetime<2018-05-15T12:34:12.001000Z', None, None, None, None, None,
-                              [{'item': 'value_1', 'datetime': '2018-05-15T12:34:12Z'}], 1),
+        ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53Z'},
+          {'item': 'value_1', 'datetime': '2018-05-15T12:34:12Z'}],
+         'datetime>2017-10-26;datetime<2018-05-15T12:34:12.001000Z', None, None, None, None, None, None,
+         [{'item': 'value_1', 'datetime': '2018-05-15T12:34:12Z'}], 1),
 
-                             # Test cases with filters, limit and search
-                             ([{'item': 'value_1'}, {'item': 'value_2'}, {'item': 'value_3'}],
-                              None, {'item': 'value_1'}, 1, None, None, None,
-                              [{'item': 'value_1'}], 1),
+        # Test cases with filters, limit and search
+        ([{'item': 'value_1', 'some': 't'}, {'item': 'value_2', 'some': 'a'}, {'item': 'value_3', 'some': 'b'}],
+         None, {'item': 'value_1', 'some': 't'}, 1, None, None, None, None,
+         [{'item': 'value_1', 'some': 't'}], 1),
 
-                             ([{'item': 'value_1'}, {'item': 'value_1'}, {'item': 'value_3'}],
-                              None, None, 1, 'e_1', None, None,
-                              [{'item': 'value_1'}], 2),
+        ([{'item': 'value_1'}, {'item': 'value_1'}, {'item': 'value_3'}],
+         None, None, 1, 'e_1', None, None, None,
+         [{'item': 'value_1'}], 2),
 
-                             ([{'item': 'value_1'}, {'item': 'value_1'}, {'item': 'value_3'}],
-                              None, None, 2, 'e_1', None, None,
-                              [{'item': 'value_1'}, {'item': 'value_1'}], 2),
+        ([{'item': 'value_1'}, {'item': 'value_1'}, {'item': 'value_3'}],
+         None, None, 2, 'e_1', None, None, None,
+         [{'item': 'value_1'}, {'item': 'value_1'}], 2),
 
-                             # Test cases with sort
-                             ([{'item': 'value_2'}, {'item': 'value_1'}, {'item': 'value_3'}],
-                              None, None, None, None, None, ['item'],
-                              [{'item': 'value_1'}, {'item': 'value_2'}, {'item': 'value_3'}], 3),
+        # Test cases with sort
+        ([{'item': 'value_2'}, {'item': 'value_1'}, {'item': 'value_3'}],
+         None, None, None, None, None, ['item'], None,
+         [{'item': 'value_1'}, {'item': 'value_2'}, {'item': 'value_3'}], 3),
 
-                             # Complex test cases
-                             ([{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z', 'component': 'framework'},
-                               {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z', 'component': 'API'}],
-                              'datetime~2017', {'item': 'value_1'}, 1, 'frame', None, None,
-                              [{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z',
-                                'component': 'framework'}], 1),
+        # Test cases with distinct
+        ([{'item': 'value_1', 'component': 'framework'},
+           {'item': 'value_2', 'component': 'API'},
+           {'item': 'value_1', 'component': 'framework'}],
+         None, None, None, None, None, None, True,
+         [{'item': 'value_1', 'component': 'framework'}, {'item': 'value_2', 'component': 'API'}], 2),
+         
+         (['framework', 'API', 'API'],
+         None, None, None, None, None, None, True,
+         ['framework', 'API'], 2),
 
-                             ([{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z', 'component': 'framework'},
-                               {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z', 'component': 'API'}],
-                              'datetime~2019', {'item': 'value_1'}, 1, None, None, None,
-                              [], 0),
+        # Complex test cases
+        ([{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z', 'component': 'framework'},
+          {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z', 'component': 'API'}],
+         'datetime~2017', {'item': 'value_1'}, 1, 'frame', None, None, None,
+         [{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z',
+           'component': 'framework'}], 1),
 
-                             ([{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z', 'component': 'framework'},
-                               {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z', 'component': 'API'}],
-                              'datetime~2017', {'item': 'value_1'}, 1, None, ['component', 'item'], None,
-                              [{'item': 'value_1', 'component': 'framework'}], 1),
-                         ])
-def test_process_array(array, q, filters, limit, search_text, sort_by, select, expected_items, expected_total_items):
+        ([{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z', 'component': 'framework'},
+          {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z', 'component': 'API'}],
+         'datetime~2019', {'item': 'value_1'}, 1, None, None, None, None,
+         [], 0),
+
+        ([{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z', 'component': 'framework'},
+          {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z', 'component': 'API'}],
+         'datetime~2017', {'item': 'value_1'}, 1, None, ['component', 'item'], None, None,
+         [{'item': 'value_1', 'component': 'framework'}], 1),
+    ])
+def test_process_array(array, q, filters, limit, search_text, sort_by, select, distinct, expected_items,
+                       expected_total_items):
     """Test that the process_array function is working properly with simple and complex examples.
 
     Parameters
@@ -305,7 +318,7 @@ def test_process_array(array, q, filters, limit, search_text, sort_by, select, e
         Total items expected after having applied the processing.
     """
     result = utils.process_array(array=array, filters=filters, limit=limit, offset=0, search_text=search_text,
-                                 select=select, sort_by=sort_by, q=q)
+                                 select=select, sort_by=sort_by, q=q, distinct=distinct)
 
     assert result == {'items': expected_items, 'totalItems': expected_total_items}
 

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -223,45 +223,45 @@ def test_cut_array_ko(limit, offset, expected_exception):
         # Test cases with queries
         ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
           {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
-         'datetime=2017-10-25T14:48:53.732000Z', None, None, None, None, None, None,
+         'datetime=2017-10-25T14:48:53.732000Z', None, None, None, None, None, False,
          [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}], 1),
 
         ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
           {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
-         'datetime<2017-10-26', None, None, None, None, None, None,
+         'datetime<2017-10-26', None, None, None, None, None, False,
          [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}], 1),
 
         ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
           {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
-         'datetime>2019-10-26,datetime<2017-10-26', None, None, None, None, None, None,
+         'datetime>2019-10-26,datetime<2017-10-26', None, None, None, None, None, False,
          [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}], 1),
 
         ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'},
           {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}],
-         'datetime>2017-10-26;datetime<2018-05-15T12:34:12.644000Z', None, None, None, None, None, None,
+         'datetime>2017-10-26;datetime<2018-05-15T12:34:12.644000Z', None, None, None, None, None, False,
          [{'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z'}], 1),
 
         ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53Z'},
           {'item': 'value_1', 'datetime': '2018-05-15T12:34:12Z'}],
-         'datetime>2017-10-26;datetime<2018-05-15T12:34:12.001000Z', None, None, None, None, None, None,
+         'datetime>2017-10-26;datetime<2018-05-15T12:34:12.001000Z', None, None, None, None, None, False,
          [{'item': 'value_1', 'datetime': '2018-05-15T12:34:12Z'}], 1),
 
         # Test cases with filters, limit and search
         ([{'item': 'value_1', 'some': 't'}, {'item': 'value_2', 'some': 'a'}, {'item': 'value_3', 'some': 'b'}],
-         None, {'item': 'value_1', 'some': 't'}, 1, None, None, None, None,
+         None, {'item': 'value_1', 'some': 't'}, 1, None, None, None, False,
          [{'item': 'value_1', 'some': 't'}], 1),
 
         ([{'item': 'value_1'}, {'item': 'value_1'}, {'item': 'value_3'}],
-         None, None, 1, 'e_1', None, None, None,
+         None, None, 1, 'e_1', None, None, False,
          [{'item': 'value_1'}], 2),
 
         ([{'item': 'value_1'}, {'item': 'value_1'}, {'item': 'value_3'}],
-         None, None, 2, 'e_1', None, None, None,
+         None, None, 2, 'e_1', None, None, False,
          [{'item': 'value_1'}, {'item': 'value_1'}], 2),
 
         # Test cases with sort
         ([{'item': 'value_2'}, {'item': 'value_1'}, {'item': 'value_3'}],
-         None, None, None, None, None, ['item'], None,
+         None, None, None, None, None, ['item'], False,
          [{'item': 'value_1'}, {'item': 'value_2'}, {'item': 'value_3'}], 3),
 
         # Test cases with distinct
@@ -278,18 +278,18 @@ def test_cut_array_ko(limit, offset, expected_exception):
         # Complex test cases
         ([{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z', 'component': 'framework'},
           {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z', 'component': 'API'}],
-         'datetime~2017', {'item': 'value_1'}, 1, 'frame', None, None, None,
+         'datetime~2017', {'item': 'value_1'}, 1, 'frame', None, None, False,
          [{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z',
            'component': 'framework'}], 1),
 
         ([{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z', 'component': 'framework'},
           {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z', 'component': 'API'}],
-         'datetime~2019', {'item': 'value_1'}, 1, None, None, None, None,
+         'datetime~2019', {'item': 'value_1'}, 1, None, None, None, False,
          [], 0),
 
         ([{'item': 'value_1', 'datetime': '2017-10-25T14:48:53.732000Z', 'component': 'framework'},
           {'item': 'value_1', 'datetime': '2018-05-15T12:34:12.544000Z', 'component': 'API'}],
-         'datetime~2017', {'item': 'value_1'}, 1, None, ['component', 'item'], None, None,
+         'datetime~2017', {'item': 'value_1'}, 1, None, ['component', 'item'], None, False,
          [{'item': 'value_1', 'component': 'framework'}], 1),
     ])
 def test_process_array(array, q, filters, limit, search_text, sort_by, select, distinct, expected_items,

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -112,7 +112,7 @@ def process_array(array: list, search_text: str = None, complementary_search: bo
                   search_in_fields: list = None, select: list = None, sort_by: list = None,
                   sort_ascending: bool = True, allowed_sort_fields: list = None, offset: int = 0, limit: int = None,
                   q: str = '', required_fields: list = None, allowed_select_fields: list = None,
-                  filters: dict = None) -> dict:
+                  filters: dict = None, distinct: bool = False) -> dict:
     """Process a Wazuh framework data array.
 
     Parameters
@@ -145,6 +145,8 @@ def process_array(array: list, search_text: str = None, complementary_search: bo
         List of fields allowed to select from.
     filters : dict
         Defines required field filters. Format: {"field1":"value1", "field2":["value2","value3"]}
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -152,14 +154,22 @@ def process_array(array: list, search_text: str = None, complementary_search: bo
         Dictionary: {'items': Processed array, 'totalItems': Number of items, before applying offset and limit)}
     """
     if not array:
-        return {'items': list(), 'totalItems': 0}
+        return {'items': [], 'totalItems': 0}
 
-    if isinstance(filters, dict) and len(filters.keys()) > 0:
-        new_array = list()
+    filter_items = isinstance(filters, dict) and len(filters.keys()) > 0
+    if distinct or filter_items:
+        new_array = []
         for element in array:
-            for key, value in filters.items():
-                if element[key] in value:
-                    new_array.append(element)
+            if distinct and (element in new_array):
+                continue
+
+            if filter_items:
+                for key, value in filters.items():
+                    if element[key] in value:
+                        new_array.append(element)
+                        break
+            else:
+                new_array.append(element)
 
         array = new_array
 

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -23,7 +23,7 @@ def get_decoders(names: list = None, status: str = None, filename: list = None, 
                  parents: bool = False, offset: int = 0, limit: int = common.DATABASE_LIMIT, select: list = None,
                  sort_by: list = None, sort_ascending: bool = True, search_text: str = None,
                  complementary_search: bool = False, search_in_fields: list = None,
-                 q: str = '') -> AffectedItemsWazuhResult:
+                 q: str = '', distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get a list of available decoders.
 
     Parameters
@@ -56,6 +56,8 @@ def get_decoders(names: list = None, status: str = None, filename: list = None, 
         Maximum number of elements to return.
     q : str
         Defines query to filter.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -102,7 +104,7 @@ def get_decoders(names: list = None, status: str = None, filename: list = None, 
     data = process_array(decoders, search_text=search_text, search_in_fields=search_in_fields,
                          complementary_search=complementary_search, sort_by=sort_by, sort_ascending=sort_ascending,
                          allowed_sort_fields=SORT_FIELDS, offset=offset, select=select, limit=limit, q=q,
-                         required_fields=REQUIRED_FIELDS, allowed_select_fields=DECODER_FIELDS)
+                         required_fields=REQUIRED_FIELDS, allowed_select_fields=DECODER_FIELDS, distinct=distinct)
     result.affected_items = data['items']
     result.total_affected_items = data['totalItems']
 
@@ -113,7 +115,7 @@ def get_decoders(names: list = None, status: str = None, filename: list = None, 
 def get_decoders_files(status: str = None, relative_dirname: str = None, filename: list = None, offset: int = 0,
                        limit: int = common.DATABASE_LIMIT, sort_by: list = None, sort_ascending: bool = True,
                        search_text: str = None, complementary_search: bool = False,
-                       search_in_fields: list = None) -> AffectedItemsWazuhResult:
+                       search_in_fields: list = None, distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get a list of the available decoder files.
 
     Parameters
@@ -138,6 +140,8 @@ def get_decoders_files(status: str = None, relative_dirname: str = None, filenam
         First element to return.
     limit : int
         Maximum number of elements to return.
+    distinct : bool
+        Look for distinct values.
 
     Raises
     ------
@@ -172,7 +176,7 @@ def get_decoders_files(status: str = None, relative_dirname: str = None, filenam
 
     data = process_array(decoders_files, search_text=search_text, search_in_fields=search_in_fields,
                          complementary_search=complementary_search, sort_by=sort_by, sort_ascending=sort_ascending,
-                         offset=offset, limit=limit)
+                         offset=offset, limit=limit, distinct=distinct)
     result.affected_items = data['items']
     result.total_affected_items = data['totalItems']
 

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -48,7 +48,7 @@ def get_status() -> AffectedItemsWazuhResult:
 def ossec_log(level: str = None, tag: str = None, offset: int = 0, limit: int = common.DATABASE_LIMIT,
               sort_by: dict = None, sort_ascending: bool = True, search_text: str = None,
               complementary_search: bool = False, search_in_fields: list = None,
-              q: str = '') -> AffectedItemsWazuhResult:
+              q: str = '', distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get logs from ossec.log.
 
     Parameters
@@ -73,6 +73,8 @@ def ossec_log(level: str = None, tag: str = None, offset: int = 0, limit: int = 
         Fields to search in.
     q : str
         Query to filter results by.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -95,7 +97,7 @@ def ossec_log(level: str = None, tag: str = None, offset: int = 0, limit: int = 
 
     data = process_array(logs, search_text=search_text, search_in_fields=search_in_fields,
                          complementary_search=complementary_search, sort_by=sort_by,
-                         sort_ascending=sort_ascending, offset=offset, limit=limit, q=query)
+                         sort_ascending=sort_ascending, offset=offset, limit=limit, q=query, distinct=distinct)
     result.affected_items.extend(data['items'])
     result.total_affected_items = data['totalItems']
 
@@ -281,6 +283,8 @@ def read_ossec_conf(section: str = None, field: str = None, raw: bool = False) -
         Filters by field in section (i.e. included).
     raw : bool
         Whether to return the file content in raw or JSON format.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -272,7 +272,8 @@ def get_config(component: str = None, config: str = None) -> AffectedItemsWazuhR
 
 @expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:read"],
                   resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'])
-def read_ossec_conf(section: str = None, field: str = None, raw: bool = False) -> AffectedItemsWazuhResult:
+def read_ossec_conf(section: str = None, field: str = None, raw: bool = False,
+                    distinct: bool = False) -> AffectedItemsWazuhResult:
     """Wrapper for get_ossec_conf.
 
     Parameters
@@ -283,6 +284,8 @@ def read_ossec_conf(section: str = None, field: str = None, raw: bool = False) -
         Filters by field in section (i.e. included).
     raw : bool
         Whether to return the file content in raw or JSON format.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -300,7 +303,7 @@ def read_ossec_conf(section: str = None, field: str = None, raw: bool = False) -
         if raw:
             with open(common.OSSEC_CONF) as f:
                 return f.read()
-        result.affected_items.append(get_ossec_conf(section=section, field=field))
+        result.affected_items.append(get_ossec_conf(section=section, field=field, distinct=distinct))
     except WazuhError as e:
         result.add_failed_item(id_=node_id, error=e)
     result.total_affected_items = len(result.affected_items)

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -283,8 +283,6 @@ def read_ossec_conf(section: str = None, field: str = None, raw: bool = False) -
         Filters by field in section (i.e. included).
     raw : bool
         Whether to return the file content in raw or JSON format.
-    distinct : bool
-        Look for distinct values.
 
     Returns
     -------

--- a/framework/wazuh/mitre.py
+++ b/framework/wazuh/mitre.py
@@ -32,7 +32,7 @@ def mitre_metadata() -> AffectedItemsWazuhResult:
 def mitre_mitigations(filters: dict = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, select: list = None,
                       sort_by: dict = None, sort_ascending: bool = True, search_text: str = None,
                       complementary_search: bool = False, search_in_fields: list = None,
-                      q: str = '') -> AffectedItemsWazuhResult:
+                      q: str = '', distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get information of specified MITRE's mitigations and its relations.
 
     Parameters
@@ -57,6 +57,8 @@ def mitre_mitigations(filters: dict = None, offset: int = 0, limit: int = common
         Fields to search in.
     q : str
         Query for filtering a list of results.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -122,7 +124,7 @@ def mitre_references(filters: dict = None, offset: int = 0, limit: int = common.
 def mitre_techniques(filters: dict = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, select: list = None,
                      sort_by: dict = None, sort_ascending: bool = True, search_text: str = None,
                      complementary_search: bool = False, search_in_fields: list = None,
-                     q: str = '') -> AffectedItemsWazuhResult:
+                     q: str = '', distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get information of specified MITRE's techniques and its relations.
 
     Parameters
@@ -147,6 +149,8 @@ def mitre_techniques(filters: dict = None, offset: int = 0, limit: int = common.
         Fields to search in.
     q : str
         Query for filtering a list of results.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -167,7 +171,7 @@ def mitre_techniques(filters: dict = None, offset: int = 0, limit: int = common.
 def mitre_tactics(filters: dict = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, select: list = None,
                   sort_by: dict = None, sort_ascending: bool = True, search_text: str = None,
                   complementary_search: bool = False, search_in_fields: list = None,
-                  q: str = '') -> AffectedItemsWazuhResult:
+                  q: str = '', distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get information of specified MITRE's tactics and its relations.
 
     Parameters
@@ -192,6 +196,8 @@ def mitre_tactics(filters: dict = None, offset: int = 0, limit: int = common.DAT
         Fields to search in.
     q : str
         Query for filtering a list of results.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -212,7 +218,7 @@ def mitre_tactics(filters: dict = None, offset: int = 0, limit: int = common.DAT
 def mitre_groups(filters: dict = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, select: list = None,
                  sort_by: dict = None, sort_ascending: bool = True, search_text: str = None,
                  complementary_search: bool = False, search_in_fields: list = None,
-                 q: str = '') -> AffectedItemsWazuhResult:
+                 q: str = '', distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get information of specified MITRE's groups and its relations.
 
     Parameters
@@ -237,6 +243,8 @@ def mitre_groups(filters: dict = None, offset: int = 0, limit: int = common.DATA
         Fields to search in.
     q : str
         Query for filtering a list of results.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -257,7 +265,7 @@ def mitre_groups(filters: dict = None, offset: int = 0, limit: int = common.DATA
 def mitre_software(filters: dict = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, select: list = None,
                    sort_by: dict = None, sort_ascending: bool = True, search_text: str = None,
                    complementary_search: bool = False, search_in_fields: list = None,
-                   q: str = '') -> AffectedItemsWazuhResult:
+                   q: str = '', distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get information of specified MITRE's software and its relations.
 
     Parameters
@@ -282,6 +290,8 @@ def mitre_software(filters: dict = None, offset: int = 0, limit: int = common.DA
         Fields to search in.
     q : str
         Query for filtering a list of results.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -127,7 +127,7 @@ def get_last_scan(agent_list: list) -> AffectedItemsWazuhResult:
 @expose_resources(actions=["rootcheck:read"], resources=["agent:id:{agent_list}"])
 def get_rootcheck_agent(agent_list: list = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort: str = None,
                         search: str = None, select: str = None, filters: dict = None, q: str = '',
-                        distinct: bool = None) -> AffectedItemsWazuhResult:
+                        distinct: bool = False) -> AffectedItemsWazuhResult:
     """Return a list of events from the rootcheck database.
 
     Parameters

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -30,7 +30,7 @@ def get_rules(rule_ids: list = None, status: str = None, group: str = None, pci_
               relative_dirname: str = None, filename: list = None, level: str = None, offset: int = 0,
               limit: int = common.DATABASE_LIMIT, select: str = None, sort_by: dict = None, sort_ascending: bool = True,
               search_text: str = None, complementary_search: bool = False, search_in_fields: list = None,
-              q: str = '') -> AffectedItemsWazuhResult:
+              q: str = '', distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get a list of rules.
 
     Parameters
@@ -80,6 +80,8 @@ def get_rules(rule_ids: list = None, status: str = None, group: str = None, pci_
         `search_text` will be returned.
     search_in_fields : list
         Fields to search in.
+    distinct : bool
+        Look for distinct values.
 
     Raises
     ------
@@ -134,7 +136,8 @@ def get_rules(rule_ids: list = None, status: str = None, group: str = None, pci_
     data = process_array(rules, search_text=search_text, search_in_fields=search_in_fields,
                          complementary_search=complementary_search, select=select, sort_by=sort_by,
                          sort_ascending=sort_ascending, allowed_sort_fields=SORT_FIELDS, offset=offset,
-                         limit=limit, q=q, required_fields=REQUIRED_FIELDS, allowed_select_fields=RULE_FIELDS)
+                         limit=limit, q=q, required_fields=REQUIRED_FIELDS, allowed_select_fields=RULE_FIELDS,
+                         distinct=distinct)
     result.affected_items = data['items']
     result.total_affected_items = data['totalItems']
 
@@ -145,7 +148,7 @@ def get_rules(rule_ids: list = None, status: str = None, group: str = None, pci_
 def get_rules_files(status: str = None, relative_dirname: str = None, filename: list = None, offset: int = 0,
                     limit: int = common.DATABASE_LIMIT, sort_by: dict = None, sort_ascending: bool = True,
                     search_text: str = None, complementary_search: bool = False,
-                    search_in_fields: list = None) -> AffectedItemsWazuhResult:
+                    search_in_fields: list = None, distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get a list of the rule files.
 
     Parameters
@@ -171,6 +174,8 @@ def get_rules_files(status: str = None, relative_dirname: str = None, filename: 
         `search_text` will be returned.
     search_in_fields : list
         Fields to search in.
+    distinct : bool
+        Look for distinct values.
 
     Raises
     ------
@@ -206,7 +211,7 @@ def get_rules_files(status: str = None, relative_dirname: str = None, filename: 
 
     data = process_array(rules_files, search_text=search_text, search_in_fields=search_in_fields,
                          complementary_search=complementary_search, sort_by=sort_by, sort_ascending=sort_ascending,
-                         offset=offset, limit=limit)
+                         offset=offset, limit=limit, distinct=distinct)
     result.affected_items = data['items']
     result.total_affected_items = data['totalItems']
 

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -68,7 +68,8 @@ def get_user_me(token: dict) -> AffectedItemsWazuhResult:
                   post_proc_kwargs={'exclude_codes': [5001]})
 def get_users(user_ids: list = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort_by: dict = None,
               sort_ascending: bool = True, search_text: str = None, select: str = None,
-              complementary_search: bool = False, search_in_fields: list = None) -> AffectedItemsWazuhResult:
+              complementary_search: bool = False, search_in_fields: list = None,
+              distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get the information of a specified user.
 
     Parameters
@@ -91,6 +92,8 @@ def get_users(user_ids: list = None, offset: int = 0, limit: int = common.DATABA
         Find items without the text to search.
     search_in_fields : list
         Fields to search in.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -110,7 +113,7 @@ def get_users(user_ids: list = None, offset: int = 0, limit: int = common.DATABA
     data = process_array(affected_items, search_text=search_text, search_in_fields=search_in_fields, select=select,
                          complementary_search=complementary_search, sort_by=sort_by, sort_ascending=sort_ascending,
                          offset=offset, limit=limit, allowed_sort_fields=SORT_FIELDS_GET_USERS,
-                         required_fields=REQUIRED_FIELDS)
+                         required_fields=REQUIRED_FIELDS, distinct=distinct)
     result.affected_items = data['items']
     result.total_affected_items = data['totalItems']
 
@@ -290,7 +293,8 @@ def remove_users(user_ids: list) -> AffectedItemsWazuhResult:
                   post_proc_kwargs={'exclude_codes': [4002]})
 def get_roles(role_ids: list = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort_by: dict = None,
               select: str = None, sort_ascending: bool = True, search_text: str = None,
-              complementary_search: bool = False, search_in_fields: list = None) -> AffectedItemsWazuhResult:
+              complementary_search: bool = False, search_in_fields: list = None,
+              distinct: bool = False) -> AffectedItemsWazuhResult:
     """Return information from all system roles, does not return information from its associated policies.
 
     Parameters
@@ -313,6 +317,8 @@ def get_roles(role_ids: list = None, offset: int = 0, limit: int = common.DATABA
         Find items without the text to search.
     search_in_fields : list
         Fields to search in.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -334,7 +340,8 @@ def get_roles(role_ids: list = None, offset: int = 0, limit: int = common.DATABA
 
     data = process_array(affected_items, search_text=search_text, search_in_fields=search_in_fields, select=select,
                          complementary_search=complementary_search, sort_by=sort_by, sort_ascending=sort_ascending,
-                         offset=offset, limit=limit, allowed_sort_fields=SORT_FIELDS, required_fields=REQUIRED_FIELDS)
+                         offset=offset, limit=limit, allowed_sort_fields=SORT_FIELDS, required_fields=REQUIRED_FIELDS,
+                         distinct=distinct)
     result.affected_items = data['items']
     result.total_affected_items = data['totalItems']
 
@@ -456,7 +463,8 @@ def update_role(role_id: str = None, name: str = None) -> AffectedItemsWazuhResu
                   post_proc_kwargs={'exclude_codes': [4007]})
 def get_policies(policy_ids: list, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort_by: dict = None,
                  select: str = None, sort_ascending: bool = True, search_text: str = None,
-                 complementary_search: bool = False, search_in_fields: list = None) -> AffectedItemsWazuhResult:
+                 complementary_search: bool = False, search_in_fields: list = None,
+                 distinct: bool = False) -> AffectedItemsWazuhResult:
     """Return the information of a certain policy.
 
     Parameters
@@ -479,6 +487,8 @@ def get_policies(policy_ids: list, offset: int = 0, limit: int = common.DATABASE
         Find items without the text to search.
     search_in_fields : list
         Fields to search in.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -500,7 +510,8 @@ def get_policies(policy_ids: list, offset: int = 0, limit: int = common.DATABASE
 
     data = process_array(affected_items, search_text=search_text, search_in_fields=search_in_fields, select=select,
                          complementary_search=complementary_search, sort_by=sort_by, sort_ascending=sort_ascending,
-                         offset=offset, limit=limit, allowed_sort_fields=SORT_FIELDS, required_fields=REQUIRED_FIELDS)
+                         offset=offset, limit=limit, allowed_sort_fields=SORT_FIELDS, required_fields=REQUIRED_FIELDS,
+                         distinct=distinct)
     result.affected_items = data['items']
     result.total_affected_items = data['totalItems']
 

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -640,7 +640,8 @@ def update_policy(policy_id: str = None, name: str = None, policy: dict = None) 
                   post_proc_kwargs={'exclude_codes': [4022]})
 def get_rules(rule_ids: list = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort_by: dict = None,
               select: str = None, sort_ascending: bool = True, search_text: str = None,
-              complementary_search: bool = False, search_in_fields: list = None) -> AffectedItemsWazuhResult:
+              complementary_search: bool = False, search_in_fields: list = None,
+              distinct: bool = False) -> AffectedItemsWazuhResult:
     """Return information from all the security rules. It does not return information from its associated roles.
 
     Parameters
@@ -663,6 +664,8 @@ def get_rules(rule_ids: list = None, offset: int = 0, limit: int = common.DATABA
         Find items without the text to search.
     search_in_fields : list
         Fields to search in.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -685,7 +688,8 @@ def get_rules(rule_ids: list = None, offset: int = 0, limit: int = common.DATABA
 
     data = process_array(affected_items, search_text=search_text, search_in_fields=search_in_fields, select=select,
                          complementary_search=complementary_search, sort_by=sort_by, sort_ascending=sort_ascending,
-                         offset=offset, limit=limit, allowed_sort_fields=SORT_FIELDS, required_fields=REQUIRED_FIELDS)
+                         offset=offset, limit=limit, allowed_sort_fields=SORT_FIELDS, required_fields=REQUIRED_FIELDS,
+                         distinct=distinct)
     result.affected_items = data['items']
     result.total_affected_items = data['totalItems']
 

--- a/framework/wazuh/syscollector.py
+++ b/framework/wazuh/syscollector.py
@@ -13,7 +13,7 @@ from wazuh.rbac.decorators import expose_resources
 @expose_resources(actions=['syscollector:read'], resources=['agent:id:{agent_list}'])
 def get_item_agent(agent_list: list, offset: int = 0, limit: int = common.DATABASE_LIMIT, select: dict = None,
                    search: dict = None, sort: dict = None, filters: dict = None, q: str = '', array: bool = True,
-                   nested: bool = True, element_type: str = 'os') -> AffectedItemsWazuhResult:
+                   nested: bool = True, element_type: str = 'os', distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get syscollector information about a list of agents.
 
     Parameters
@@ -40,6 +40,8 @@ def get_item_agent(agent_list: list, offset: int = 0, limit: int = common.DATABA
         Type of element to get syscollector information from. Default: 'os'
     array : bool
         Array.
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -64,7 +66,7 @@ def get_item_agent(agent_list: list, offset: int = 0, limit: int = common.DATABA
             with WazuhDBQuerySyscollector(agent_id=agent, offset=offset, limit=limit, select=select,
                                           search=search,
                                           sort=sort, filters=filters, fields=valid_select_fields, table=table,
-                                          array=array, nested=nested, query=q) as db_query:
+                                          array=array, nested=nested, query=q, distinct=distinct) as db_query:
                 data = db_query.run()
 
             for item in data['items']:

--- a/framework/wazuh/vulnerability.py
+++ b/framework/wazuh/vulnerability.py
@@ -60,7 +60,7 @@ def run_vulnerability_scan():
 
 @expose_resources(actions=["vulnerability:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)
 def get_agent_cve(agent_list: list = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort: str = None,
-                  search: str = None, select: list = None, q: str = '', distinct: bool = None,
+                  search: str = None, select: list = None, q: str = '', distinct: bool = False,
                   filters: dict = None) -> AffectedItemsWazuhResult:
     """Get agents' vulnerabilities.
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/16715|

## Description

Added the `distinct` parameter to several endpoints, updated their tests and specifications.

## Tests

<details>
  <summary>test_agent_GET_endpoints</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_agent_GET_endpoints.tavern.yaml
=================================================== test session starts ====================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.2.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 93 items                                                                                                         

test_agent_GET_endpoints.tavern.yaml::GET /agents PASSED                                                             [  1%]
test_agent_GET_endpoints.tavern.yaml::GET /agents with single agent id PASSED                                        [  2%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED               [  3%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} (only cluster configuration) PASSED [  4%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                    [  5%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                              [  6%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                    [  7%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                [  8%]
test_agent_GET_endpoints.tavern.yaml::GET /groups PASSED                                                             [  9%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED                                            [ 10%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED                                           [ 11%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED                                         [ 12%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED                                         [ 13%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED                                         [ 15%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED                                         [ 16%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED                                        [ 17%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED                                        [ 18%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED                                       [ 19%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED                                       [ 20%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED                                       [ 21%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED                                       [ 22%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                           [ 23%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED                  [ 24%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED                    [ 25%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED                      [ 26%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED                         [ 27%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED                         [ 29%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED              [ 30%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED                    [ 31%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED                  [ 32%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED                       [ 33%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED                  [ 34%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED                    [ 35%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED                   [ 36%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED                [ 37%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED                   [ 38%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED                   [ 39%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED                    [ 40%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED                [ 41%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED                   [ 43%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED                 [ 44%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED                 [ 45%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED                     [ 46%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED                    [ 47%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                    [ 48%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                            [ 49%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED                           [ 50%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED                          [ 51%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED                        [ 52%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED                        [ 53%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED                        [ 54%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED                        [ 55%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED                       [ 56%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED                       [ 58%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED                      [ 59%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED                      [ 60%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED                      [ 61%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED                      [ 62%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                            [ 63%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                             [ 64%]
test_agent_GET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                             [ 65%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                    [ 66%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED                             [ 67%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED                                  [ 68%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED                                  [ 69%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED                                [ 70%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED                           [ 72%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED                          [ 73%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED                              [ 74%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                    [ 75%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                              [ 76%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED                            [ 77%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED                                 [ 78%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED                                 [ 79%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED                      [ 80%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED                            [ 81%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED                               [ 82%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED                          [ 83%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED                            [ 84%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED                           [ 86%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED                        [ 87%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED                           [ 88%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED                           [ 89%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED                            [ 90%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED                        [ 91%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED                           [ 92%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED                         [ 93%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED                         [ 94%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED                             [ 95%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED                            [ 96%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                              [ 97%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                  [ 98%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                              [100%]

======================================== 93 passed, 2 warnings in 207.83s (0:03:27) ========================================
```
</details>

<details>
  <summary>test_decoder_endpoints</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_decoder_endpoints.tavern.yaml
==================================================== test session starts ====================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.2.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 25 items                                                                                                          

test_decoder_endpoints.tavern.yaml::GET /decoders PASSED                                                              [  4%]
test_decoder_endpoints.tavern.yaml::GET /decoders[filename] PASSED                                                    [  8%]
test_decoder_endpoints.tavern.yaml::GET /decoders[relative_dirname] PASSED                                            [ 12%]
test_decoder_endpoints.tavern.yaml::GET /decoders[name] PASSED                                                        [ 16%]
test_decoder_endpoints.tavern.yaml::GET /decoders[position] PASSED                                                    [ 20%]
test_decoder_endpoints.tavern.yaml::GET /decoders[status] PASSED                                                      [ 24%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name} PASSED                                               [ 28%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[filename] PASSED                                     [ 32%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[relative_dirname] PASSED                             [ 36%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[name] PASSED                                         [ 40%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[position] PASSED                                     [ 44%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[status] PASSED                                       [ 48%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files PASSED                                                        [ 52%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files[filename] PASSED                                              [ 56%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files[relative_dirname] PASSED                                      [ 60%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files[status] PASSED                                                [ 64%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents PASSED                                                      [ 68%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[filename] PASSED                                            [ 72%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[name] PASSED                                                [ 76%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[relative_dirname] PASSED                                    [ 80%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[position] PASSED                                            [ 84%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[status] PASSED                                              [ 88%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files/{file} PASSED                                                 [ 92%]
test_decoder_endpoints.tavern.yaml::PUT /rule/decoders/{filename} PASSED                                              [ 96%]
test_decoder_endpoints.tavern.yaml::DELETE /decoders/files/{filename} PASSED                                          [100%]
======================================== 25 passed, 2 warnings in 417.16s (0:06:57) =========================================
```
</details>

<details>
  <summary>test_mitre_endpoints</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_mitre_endpoints.tavern.yaml
=================================================== test session starts ====================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.2.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 7 items                                                                                                          

test_mitre_endpoints.tavern.yaml::GET /mitre/metadata PASSED                                                         [ 14%]
test_mitre_endpoints.tavern.yaml::GET /mitre/mitigations PASSED                                                      [ 28%]
test_mitre_endpoints.tavern.yaml::GET /mitre/references PASSED                                                       [ 42%]
test_mitre_endpoints.tavern.yaml::GET /mitre/tactics PASSED                                                          [ 57%]
test_mitre_endpoints.tavern.yaml::GET /mitre/techniques PASSED                                                       [ 71%]
test_mitre_endpoints.tavern.yaml::GET /mitre/groups PASSED                                                           [ 85%]
test_mitre_endpoints.tavern.yaml::GET /mitre/software PASSED                                                         [100%]

======================================== 7 passed, 2 warnings in 124.72s (0:02:04) =========================================
```
</details>

<details>
  <summary>test_manager_endpoints</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_manager_endpoints.tavern.yaml
=================================================== test session starts ====================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.2.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 32 items                                                                                                         

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                       [  3%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                         [  6%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                              [  9%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                [ 12%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                             [ 15%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                             [ 18%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                             [ 21%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                              [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                           [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                             [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                              [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                           [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                             [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                 [ 43%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                            [ 46%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                        [ 50%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED              [ 53%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                [ 56%]
test_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                [ 59%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                        [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                 [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                 [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                              [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                [ 75%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                         [ 78%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                 [ 81%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                   [ 84%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                [ 87%]
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED                                              [ 90%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                    [ 93%]
test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                [ 96%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                      [100%]

======================================== 32 passed, 2 warnings in 89.26s (0:01:29) =========================================
```
</details>