### PR TITLE
Add timeout and retries to VirusTotal integration

### DIFF
--- a/integrations/maltiverse.py
+++ b/integrations/maltiverse.py
@@ -74,7 +74,6 @@ except Exception as e:
 debug_enabled: bool = False
 pwd: str = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 json_alert: dict = {}
-now: str = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 
 # Set paths
 LOG_FILE: str = os.path.join(pwd, 'logs', 'integrations.log')
@@ -235,23 +234,23 @@ def main(args: list):
         bad_arguments = False
         if len(args) >= 4:
             msg = "{0} {1} {2} {3} {4}".format(
-                now,
                 args[1],
                 args[2],
                 args[3],
                 args[4] if len(args) > 4 else "",
+                args[5] if len(args) > 5 else ""
             )
             debug_enabled = len(args) > 4 and args[4] == "debug"
         else:
-            msg = f"{now} Wrong arguments"
+            msg = '# ERROR: Wrong arguments'
             bad_arguments = True
 
         # Logging the call
         with open(LOG_FILE, "a") as f:
-            f.write(msg + "\n")
+            f.write(msg + '\n')
 
         if bad_arguments:
-            debug(f"# Exiting: Bad arguments. Inputted: {args}")
+            debug("# ERROR: Exiting, bad arguments. Inputted: %s" % args)
             sys.exit(2)
 
         # Main function
@@ -328,10 +327,9 @@ def debug(msg: str):
         The debug message to print.
     """
     if debug_enabled:
-        msg = "{0}: {1}\n".format(now, msg)
         print(msg)
         with open(LOG_FILE, "a") as f:
-            f.write(msg)
+            f.write(msg + '\n')
 
 
 def get_ioc_confidence(ioc: dict) -> str:

--- a/integrations/pagerduty.py
+++ b/integrations/pagerduty.py
@@ -132,7 +132,7 @@ def debug(msg: str) -> None:
     if debug_enabled:
         print(msg)
         with open(LOG_FILE, "a") as f:
-            f.write(msg)
+            f.write(msg + '\n')
 
 
 def generate_msg(alert: any, options: any, apikey: str) -> str:

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -152,7 +152,7 @@ def debug(msg: str) -> None:
     if debug_enabled:
         print(msg)
         with open(LOG_FILE, "a") as f:
-            f.write(msg)
+            f.write(msg + '\n')
 
 
 # Skips container kills to stop self-recursion

--- a/integrations/slack.py
+++ b/integrations/slack.py
@@ -133,7 +133,7 @@ def debug(msg: str) -> None:
     if debug_enabled:
         print(msg)
         with open(LOG_FILE, "a") as f:
-            f.write(msg)
+            f.write(msg + '\n')
 
 
 def generate_msg(alert: any, options: any) -> any:

--- a/integrations/tests/test_maltiverse.py
+++ b/integrations/tests/test_maltiverse.py
@@ -469,4 +469,4 @@ def test_debug():
             patch('maltiverse.LOG_FILE', return_value='integrations.log') as log_file:
         maltiverse.debug(example_msg)
         open_mock.assert_called_with(log_file, 'a')
-        open_mock().write.assert_called_with(f"{maltiverse.now}: {example_msg}\n")
+        open_mock().write.assert_called_with(f"{example_msg}\n")

--- a/integrations/tests/test_pagerduty.py
+++ b/integrations/tests/test_pagerduty.py
@@ -138,9 +138,9 @@ def test_debug():
     with patch('pagerduty.debug_enabled', return_value=True), \
             patch("pagerduty.open", mock_open()) as open_mock, \
             patch('pagerduty.LOG_FILE', return_value='integrations.log') as log_file:
-        pagerduty.debug(msg_template)
+        pagerduty.debug(str(msg_template))
         open_mock.assert_called_with(log_file, 'a')
-        open_mock().write.assert_called_with(msg_template)
+        open_mock().write.assert_called_with(str(msg_template) + '\n')
 
 def test_send_msg_raise_exception():
     """Test that the send_msg function will raise an exception when passed the wrong webhook url."""

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -138,7 +138,7 @@ def test_debug():
             patch('shuffle.LOG_FILE', return_value='integrations.log') as log_file:
         shuffle.debug(msg_template)
         open_mock.assert_called_with(log_file, 'a')
-        open_mock().write.assert_called_with(msg_template)
+        open_mock().write.assert_called_with(f"{msg_template}\n")
 
 
 @pytest.mark.parametrize('rule_id, expected_msg', [

--- a/integrations/tests/test_slack.py
+++ b/integrations/tests/test_slack.py
@@ -135,7 +135,7 @@ def test_debug():
             patch('slack.LOG_FILE', return_value='integrations.log') as log_file:
         slack.debug(msg_template)
         open_mock.assert_called_with(log_file, 'a')
-        open_mock().write.assert_called_with(f"{msg_template}")
+        open_mock().write.assert_called_with(f"{msg_template}\n")
 
 def test_send_msg_raise_exception():
     """Test that the send_msg function will raise an exception when passed the wrong webhook url."""

--- a/integrations/tests/test_virustotal.py
+++ b/integrations/tests/test_virustotal.py
@@ -187,9 +187,9 @@ def test_debug():
     with patch('virustotal.debug_enabled', return_value=True), \
             patch("virustotal.open", mock_open()) as open_mock, \
             patch('virustotal.LOG_FILE', return_value='integrations.log') as log_file:
-        virustotal.debug(msg_template)
+        virustotal.debug(str(msg_template))
         open_mock.assert_called_with(log_file, 'a')
-        open_mock().write.assert_called_with(msg_template)
+        open_mock().write.assert_called_with(str(msg_template) + '\n')
 
 
 def test_send_msg_raise_exception():

--- a/integrations/tests/test_virustotal.py
+++ b/integrations/tests/test_virustotal.py
@@ -10,13 +10,17 @@ import os
 import pytest
 import sys
 import requests
+from requests.exceptions import Timeout
 from socket import socket, AF_UNIX, SOCK_DGRAM
 import virustotal as virustotal
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, call
 
 # Exit error codes
 ERR_NO_APIKEY           = 1
 ERR_BAD_ARGUMENTS       = 2
+ERR_BAD_MD5_SUM         = 3
+ERR_NO_RESPONSE_VT      = 4
+ERR_SOCKET_OPERATION    = 5
 ERR_FILE_NOT_FOUND      = 6
 ERR_INVALID_JSON        = 7
 
@@ -210,6 +214,7 @@ def test_send_msg():
             assert data[0].decode() != None
             s.close()
         os.remove('./socket.sock')
+
 def test_request_virustotal_info_md5_after_check_fail_1():
     """Test that the md5_after field from alerts are valid md5 hash."""
     with patch('virustotal.debug') as debug:
@@ -271,3 +276,32 @@ def test_request_virustotal_info_md5_after_check_ok():
     with patch('virustotal.query_api'), patch('virustotal.in_database', return_value=False), patch('virustotal.debug') as debug:
         response = virustotal.request_virustotal_info(alert_template_md5[8],apikey_virustotal)
         assert response == alert_output
+
+def test_request_virustotal_info_exception():
+    """Test that the query_api function fails with no retries when an Exception happens."""
+    with patch('virustotal.query_api', side_effect=[Exception(), None]), \
+            patch('virustotal.debug'), \
+            pytest.raises(SystemExit) as pytest_wrapped_e:
+        virustotal.request_virustotal_info(alert_template_md5[8],apikey_virustotal)
+    assert pytest_wrapped_e.value.code == ERR_NO_RESPONSE_VT
+
+def test_request_virustotal_info_timeout_and_retries_expired():
+    """Test that the query_api function fails with retries when an Timeout exception happens (retries expired)."""
+    virustotal.retries = 2
+    with patch('virustotal.query_api', side_effect=[Timeout(), Timeout(), Timeout(), None]), \
+            patch('virustotal.send_msg'), \
+            patch('virustotal.debug'), \
+            pytest.raises(SystemExit) as pytest_wrapped_e:
+        virustotal.request_virustotal_info(alert_template_md5[8],apikey_virustotal)
+    assert pytest_wrapped_e.value.code == ERR_NO_RESPONSE_VT
+
+def test_request_virustotal_info_timeout_and_retries_not_expired():
+    """Test that the query_api function fails with retries when an Timeout exception happens (retries not expired)."""
+    virustotal.retries = 2
+    with patch('virustotal.query_api', side_effect=[Timeout(), Timeout(), None]), \
+            patch('virustotal.in_database', return_value=False), \
+            patch('virustotal.debug') as debug:
+        response = virustotal.request_virustotal_info(alert_template_md5[8],apikey_virustotal)
+        debug.assert_has_calls([call('# Error: Request timed out. Remaining retries: 2'),
+                                call('# Error: Request timed out. Remaining retries: 1')])
+    assert response == alert_output

--- a/ruleset/rules/0490-virustotal_rules.xml
+++ b/ruleset/rules/0490-virustotal_rules.xml
@@ -57,4 +57,12 @@
         </mitre>
     </rule>
 
+    <rule id="87106" level="3">
+         <if_sid>87100</if_sid>
+         <field name="virustotal.error">408</field>
+         <description>VirusTotal: Error: API request timed out</description>
+         <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+         <options>no_full_log</options>
+     </rule>
+
 </group>

--- a/src/config/integrator-config.c
+++ b/src/config/integrator-config.c
@@ -26,6 +26,8 @@ int Read_Integrator(XML_NODE node, void *config, __attribute__((unused)) void *c
     char *xml_integrator_max_log = "max_log";
     char *xml_integrator_alert_format = "alert_format";
     char *xml_integrator_options = "options";
+    char *xml_integrator_timeout = "timeout";
+    char *xml_integrator_retries = "retries";
 
     IntegratorConfig **integrator_config = *(IntegratorConfig ***)config;
 
@@ -54,6 +56,8 @@ int Read_Integrator(XML_NODE node, void *config, __attribute__((unused)) void *c
     integrator_config[s]->level = 0;
     integrator_config[s]->enabled = 0;
     integrator_config[s]->max_log = 165;
+    integrator_config[s]->timeout = 10;
+    integrator_config[s]->retries = 3;
 
     while(node[i])
     {
@@ -172,7 +176,9 @@ int Read_Integrator(XML_NODE node, void *config, __attribute__((unused)) void *c
         else if(strcmp(node[i]->element, xml_integrator_group) == 0)
         {
             os_strdup(node[i]->content, integrator_config[s]->group);
-        } else if (strcmp(node[i]->element, xml_integrator_max_log) == 0) {
+        }
+        else if (strcmp(node[i]->element, xml_integrator_max_log) == 0)
+        {
             if (!OS_StrIsNum(node[i]->content)) {
                 merror(XML_VALUEERR,node[i]->element, node[i]->content);
                 return(OS_INVALID);
@@ -184,7 +190,28 @@ int Read_Integrator(XML_NODE node, void *config, __attribute__((unused)) void *c
                 merror(XML_VALUEERR,node[i]->element, node[i]->content);
                 return(OS_INVALID);
             }
-        } else
+        }
+        else if (strcmp(node[i]->element, xml_integrator_timeout) == 0)
+        {
+            if(!OS_StrIsNum(node[i]->content))
+            {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return(OS_INVALID);
+            }
+
+            integrator_config[s]->timeout = atoi(node[i]->content);
+        }
+        else if (strcmp(node[i]->element, xml_integrator_retries) == 0)
+        {
+            if(!OS_StrIsNum(node[i]->content))
+            {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return(OS_INVALID);
+            }
+
+            integrator_config[s]->retries = atoi(node[i]->content);
+        }
+        else
         {
             merror(XML_INVELEM, node[i]->element);
             return(OS_INVALID);

--- a/src/config/integrator-config.h
+++ b/src/config/integrator-config.h
@@ -24,6 +24,8 @@ typedef struct _IntegratorConfig
     unsigned int enabled;
     unsigned int *rule_id;
     unsigned int max_log;
+    unsigned int timeout;
+    unsigned int retries;
 
     char *name;
     char *apikey;

--- a/src/os_integrator/config.c
+++ b/src/os_integrator/config.c
@@ -62,6 +62,8 @@ cJSON *getIntegratorConfig(void) {
             }
             cJSON_AddItemToObject(cfg,"location",ids);
         }
+        cJSON_AddNumberToObject(cfg,"timeout",integrator_config[i]->timeout);
+        cJSON_AddNumberToObject(cfg,"retries",integrator_config[i]->retries);
         cJSON_AddItemToArray(integrator,cfg);
     }
 

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -429,19 +429,21 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
             }
 
             int dbg_lvl = isDebug();
-            os_snprintf(exec_full_cmd, 4095, "%s %s %s %s %s %s",
+            os_snprintf(exec_full_cmd, 4095, "%s %s %s %s %s %s %d %d",
                 INTEGRATORDIR,
                 exec_tmp_file,
                 integrator_config[s]->apikey == NULL ? "" : integrator_config[s]->apikey,
                 integrator_config[s]->hookurl == NULL ? "" : integrator_config[s]->hookurl,
                 dbg_lvl <= 0 ? "" : "debug",
-                opt_file_created == 0 ? "" : opt_tmp_file);
+                opt_file_created == 0 ? "" : opt_tmp_file,
+                integrator_config[s]->timeout,
+                integrator_config[s]->retries);
 
             if (dbg_lvl <= 0) strcat(exec_full_cmd, " > /dev/null 2>&1");
 
             mdebug1("Running script with args: %s", exec_full_cmd);
 
-            char **cmd = OS_StrBreak(' ', exec_full_cmd, 7);
+            char **cmd = OS_StrBreak(' ', exec_full_cmd, 8);
 
             if (cmd) {
                 wfd_t * wfd = wpopenv(integrator_config[s]->path, cmd, W_BIND_STDOUT | W_BIND_STDERR | W_CHECK_WRITE);

--- a/src/unit_tests/os_integrator/test_integrator.c
+++ b/src/unit_tests/os_integrator/test_integrator.c
@@ -132,7 +132,7 @@ void test_OS_IntegratorD(void **state) {
     will_return(__wrap_time, 1111);
     will_return(__wrap_os_random, 2222);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Running script with args: integrations /tmp/virustotal-1111-2222.alert 123456    > /dev/null 2>&1");
+    expect_string(__wrap__mdebug1, formatted_msg, "Running script with args: integrations /tmp/virustotal-1111-2222.alert 123456    0 0 > /dev/null 2>&1");
 
     will_return(__wrap_wpopenv, wfd);
 
@@ -174,7 +174,7 @@ void test_OS_IntegratorD(void **state) {
 
     expect_fclose((FILE *)1, 0);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Running script with args: integrations /tmp/pagerduty-1111-2222.alert 123456   /tmp/pagerduty-1111-2222.options > /dev/null 2>&1");
+    expect_string(__wrap__mdebug1, formatted_msg, "Running script with args: integrations /tmp/pagerduty-1111-2222.alert 123456   /tmp/pagerduty-1111-2222.options 0 0 > /dev/null 2>&1");
 
     will_return(__wrap_wpopenv, wfd);
 


### PR DESCRIPTION
|Related issue|Documentation|
|---|---|
|https://github.com/wazuh/wazuh/issues/16488|https://github.com/wazuh/wazuh-documentation/pull/6442|

## Description

This PR adds the ability to configure an integration with timeouts and retries to prevent API calls from hanging.

- VirusTotal script uses these parameters to control the execution of the API call and retries the request in case of the timeout expires.

Also, the logging of VirusTotal script is improved.

## Configuration options

Example:
```xml
  <integration>
    <name>virustotal</name>
    <api_key>xyz</api_key>
    <group>syscheck</group>
    <alert_format>json</alert_format>
    <retries>5</retries>
    <timeout>15</timeout>
  </integration>
```

## Logs/Alerts example

Alert example:
```
** Alert 1692133899.695844: - virustotal,gdpr_IV_35.7.d,gdpr_IV_32.2,
2023 Aug 15 21:11:39 devel->virustotal
Rule: 87106 (level 3) -> 'VirusTotal: Error: API request timed out'
{"virustotal": {"error": 408, "description": "Error: API request timed out"}, "integration": "virustotal"}
virustotal.error: 408
virustotal.description: Error: API request timed out
integration: virustotal
```

Logs example:
```
/tmp/virustotal-1692133809-1810084328.alert cfa079dd7c7c8ba311638fda953f46597957318c999324bfd3582d5f1fd50e43  debug  15 5
# Running VirusTotal script
# Opening alert file at '/tmp/virustotal-1692133809-1810084328.alert' with '{'timestamp': '2023-08-15T21:10:08.712+0000', 'rule': {'level': 7, 'description': 'File deleted.', 'id': '553', 'mitre': {'id': ['T1070.004', 'T1485'], 'tactic': ['Defense Evasion', 'Impact'], 'technique': ['File Deletion', 'Data Destruction']}, 'firedtimes': 1, 'mail': False, 'groups': ['ossec', 'syscheck', 'syscheck_entry_deleted', 'syscheck_file'], 'pci_dss': ['11.5'], 'gpg13': ['4.11'], 'gdpr': ['II_5.1.f'], 'hipaa': ['164.312.c.1', '164.312.c.2'], 'nist_800_53': ['SI.7'], 'tsc': ['PI1.4', 'PI1.5', 'CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']}, 'agent': {'id': '000', 'name': 'devel'}, 'manager': {'name': 'devel'}, 'id': '1692133808.695181', 'full_log': "File '/test/lala.txt' deleted\nMode: realtime\n", 'syscheck': {'path': '/test/lala.txt', 'mode': 'realtime', 'size_after': '69', 'perm_after': 'rw-r--r--', 'uid_after': '0', 'gid_after': '0', 'md5_after': '69630e4574ec6798239b091cda43dca0', 'sha1_after': 'cf8bd9dfddff007f75adf4c2be48005cea317c62', 'sha256_after': '131f95c51cc819465fa1797f6ccacf9d494aaaff46fa3eac73ae63ffbdfd8267', 'uname_after': 'root', 'gname_after': 'root', 'mtime_after': '2023-08-15T21:09:40', 'inode_after': 1835011, 'event': 'deleted'}, 'decoder': {'name': 'syscheck_deleted'}, 'location': 'syscheck'}'
# Requesting VirusTotal information
# Querying VirusTotal API
# Error: Request timed out. Remaining retries: 5
# Querying VirusTotal API
# Error: Request timed out. Remaining retries: 4
# Querying VirusTotal API
# Error: Request timed out. Remaining retries: 3
# Querying VirusTotal API
# Error: Request timed out. Remaining retries: 2
# Querying VirusTotal API
# Error: Request timed out. Remaining retries: 1
# Querying VirusTotal API
# Error: Request timed out. Remaining retries: 0
# Error: Request timed out and maximum number of retries was exceeded
# Request result from VT server: 1:virustotal:{"virustotal": {"error": 408, "description": "Error: API request timed out"}, "integration": "virustotal"}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language