### PR TITLE
SafeWow64DisableWow64FsRedirection wrapper to make safe call for WoW64DisableWoW64FsRedirection

### DIFF
--- a/src/headers/os_utils.h
+++ b/src/headers/os_utils.h
@@ -30,4 +30,9 @@ int w_is_file(const char * const file);
 /* Delete the process list */
 int w_del_plist(OSList *p_list);
 
+#ifdef WIN32
+/* Executes Wow64DisableWow64FsRedirection if the OS version supports it */
+void SafeWow64DisableWow64FsRedirection(PVOID *oldValue);
+#endif
+
 #endif /* OS_UTILS_OP_H */

--- a/src/shared/os_utils.c
+++ b/src/shared/os_utils.c
@@ -14,6 +14,7 @@
 #ifdef WIN32
 #include <tlhelp32.h>
 #include <psapi.h>
+#include <windows.h>
 #endif
 
 #ifndef WIN32
@@ -323,4 +324,19 @@ OSList *w_os_get_process_list()
     CloseHandle(hsnap);
     return (p_list);
 }
+
+typedef BOOL (WINAPI *LPFN_WOW64DISABLEWOW64FSREDIRECTION)(PVOID *OldValue);
+ 
+void SafeWow64DisableWow64FsRedirection(PVOID *oldValue) {
+    LPFN_WOW64DISABLEWOW64FSREDIRECTION Wow64DisableWow64FsRedirection = NULL;
+    HMODULE kernel32 = GetModuleHandle(TEXT("kernel32.dll"));
+    if (kernel32) {
+        Wow64DisableWow64FsRedirection = (LPFN_WOW64DISABLEWOW64FSREDIRECTION)GetProcAddress(kernel32, "Wow64DisableWow64FsRedirection");
+    }
+    if (Wow64DisableWow64FsRedirection) {
+        // The Wow64DisableWow64FsRedirection function is supported
+        Wow64DisableWow64FsRedirection(oldValue);
+    }
+}
+
 #endif

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -499,7 +499,7 @@ time_t fim_scan() {
 #endif
 
 #ifdef WIN32
-    Wow64DisableWow64FsRedirection(NULL); //Disable virtual redirection to 64bits folder due this is a x86 process
+    SafeWow64DisableWow64FsRedirection(NULL); //Disable virtual redirection to 64bits folder due this is a x86 process
 #endif
     cputime_start = clock();
     gettime(&start);

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -402,7 +402,7 @@ DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args) {
     OSListNode *node_it;
     int watches;
 
-    Wow64DisableWow64FsRedirection(NULL); //Disable virtual redirection to 64bits folder due this is a x86 process
+    SafeWow64DisableWow64FsRedirection(NULL); //Disable virtual redirection to 64bits folder due this is a x86 process
     set_priority_windows_thread();
     // Directories in Windows configured with real-time add recursive watches
     w_rwlock_wrlock(&syscheck.directories_lock);

--- a/src/syscheckd/src/whodata/win_whodata.c
+++ b/src/syscheckd/src/whodata/win_whodata.c
@@ -740,7 +740,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
     unsigned long mask = 0;
     directory_t *configuration;
 
-    Wow64DisableWow64FsRedirection(NULL); //Disable virtual redirection to 64bits folder due this is a x86 process
+    SafeWow64DisableWow64FsRedirection(NULL); //Disable virtual redirection to 64bits folder due this is a x86 process
     if (action == EvtSubscribeActionDeliver) {
         char hash_id[21];
 
@@ -1103,7 +1103,7 @@ error:
 }
 
 long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
-    Wow64DisableWow64FsRedirection(NULL); //Disable virtual redirection to 64bits folder due this is a x86 process
+   SafeWow64DisableWow64FsRedirection(NULL); //Disable virtual redirection to 64bits folder due this is a x86 process
 
     int exists;
     whodata_dir_status *d_status;


### PR DESCRIPTION
|Related issue|
|---|
|[# 16698](https://github.com/wazuh/wazuh/issues/16698)|

## Description
On Windows XP SP3, the function [WoW64DisableWoW64FsRedirection](https://learn.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-wow64disablewow64fsredirection) is not supported, making Wazuh's Windows Agent to crash (and since already on a 32 bit platform, there is no need for it to be called).

To avoid the crash, a wrapper around the function was implemented, which verifies if the function exists before attempting to call it.
