### PR TITLE
Fix/16468 api executor subprocess broke

### DIFF
--- a/framework/wazuh/core/tests/test_exception.py
+++ b/framework/wazuh/core/tests/test_exception.py
@@ -3,6 +3,31 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from wazuh.core.exception import WazuhException, WazuhError
+import pytest
+
+
+@pytest.mark.parametrize('code, extra_message, extra_remediation, cmd_error, dapi_errors, title, type, exc_string', [
+        # code not found in ERRORS - use extra_message
+        (9999, "External exception", None, None, None, None, None, "Error 9999 - External exception"),
+        # code found in ERRORS - cmd_error True
+        (999, "Code found with cmd_error", None, True, None, None, None, "Error 999 - Code found with cmd_error"),
+        # code found in ERRORS - dictionary entry of string type
+        (999, None, None, None, None, None, None, "Error 999 - Incompatible version of Python"),
+        # code found in ERRORS - dictionary entry of dictionary type - withouth remediation key
+        (4018, None, None, None, None, None, None, "Error 4018 - Level cannot be a negative number"),
+        # code found in ERRORS - dictionary entry of dictionary type - with remediation key
+        (4019, None, None, None, None, None, None, "Error 4019 - Invalid resource specified"),
+        # code found in ERRORS - extra_message parameter of string type
+        (4018, "extra message", None, None, None, None, None, "Error 4018 - Level cannot be a negative number: extra message"),
+        # code found in ERRORS - extra_message parameter of dictionary type
+        (1017, {'node_name': 'Node Name', 'not_ready_daemons': 'not ready daemons'}, None, None, None, None, None, 
+            'Error 1017 - Some Wazuh daemons are not ready yet in node "Node Name" (not ready daemons)'),        
+    ])
+def test_wazuh_exception_to_string(code, extra_message, extra_remediation, cmd_error, dapi_errors, title , type, exc_string):
+    """Check object constructor """
+    exc = WazuhException(code, extra_message, extra_remediation, cmd_error, dapi_errors, title, type)
+    assert str(exc) == exc_string
+
 
 def test_wazuh_exception__or__():
     """Check that WazuhException's | operator performs the join of dapi errors properly."""


### PR DESCRIPTION
|Related issue|
|---|
|[16468](https://github.com/wazuh/wazuh/issues/16468)|

## Description
This PR fixes the bug reported in the issue [16468](https://github.com/wazuh/wazuh/issues/16468) and adds a new unit test to check several test cases of the corrected source code.

## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors