### PR TITLE
Retries waiting for wmodules

### DIFF
--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -308,12 +308,12 @@ cJSON *getModulesConfig(void) {
 int modulesSync(char* args) {
     int ret = -1;
     wmodule *cur_module = NULL;
-    size_t retry = 0;
+    int retry = 0;
 
     do {
         if (retry > 0) {
             usleep(retry * WM_MAX_WAIT);
-            mdebug1("At modulesSync(): WModules is not ready. Retry %d", retry);
+            mdebug1("WModules is not ready. Retry %d", retry);
         }
 
         for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
@@ -334,7 +334,7 @@ int modulesSync(char* args) {
     } while (ret != 0);
 
     if (ret) {
-        merror("At modulesSync(): Unable to sync module: (%d)", ret);
+        merror("At modulesSync(): Unable to sync module '%s': (%d)", cur_module ? cur_module->tag : "",  ret);
     }
     return ret;
 }

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -23,7 +23,7 @@
 #define WM_BUFFER_MAX   1024                        // Max. static buffer size.
 #define WM_BUFFER_MIN   1024                        // Starting JSON buffer length.
 #define WM_MAX_ATTEMPTS 3                           // Max. number of attempts.
-#define WM_MAX_WAIT     1                           // Max. wait between attempts.
+#define WM_MAX_WAIT     500                           // Max. wait between attempts in milliseconds.
 #define WM_IO_WRITE     0
 #define WM_IO_READ      1
 #define WM_ERROR_TIMEOUT 1                          // Error code for timeout.


### PR DESCRIPTION
|Related issue|
|---|
|#16843|

## Description

Windows agent is receiving sync messages when the Wazuh module (currently only syscollector) is not ready. A retry logic was added to wait for Syscollector to start. 

## Logs

![image](https://user-images.githubusercontent.com/13010397/235785229-9791b398-2bb9-48f7-8717-0729e3394511.png)

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation