### PR TITLE
Fix missing FEED_SUSE

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -886,7 +886,7 @@ typedef struct scan_ctx_t {
 } scan_ctx_t;
 
 // Macros
-#define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN || x == FEED_REDHAT || x == FEED_ALAS)
+#define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN || x == FEED_REDHAT || x == FEED_ALAS || x == FEED_SUSE)
 #define wm_vuldet_silent_feed(x) (x == FEED_CPEW)
 #define wm_vuldet_is_product_name(bin_name) ({int ret = 0; for (; ret < PR_NOSYSTEM; ret++) \
                                             if (!strcmp(vu_os_product_name_list[ret], bin_name)) break; ret;})


### PR DESCRIPTION
|Related issue|
|---|
|#16976|

## Description
We add the missing FEED in the following code section:

https://github.com/wazuh/wazuh/blob/63a0580562007c4ba9c117f4a232ce90160481ff/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h#L889

With this fix, we allow in the configuration to include unsupported systems in SUSE systems for custom OS.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
