### PR TITLE
Handle case where the "date_start" is a str

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -261,11 +261,19 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             return self.process_sync_error_from_worker(data)
         elif command == b'syn_w_g_e':
             logger = self.task_loggers['Agent-groups send']
-            start_time = self.send_agent_groups_status['date_start'].timestamp()
+            start_time = self.send_agent_groups_status['date_start']
+            if isinstance(start_time, str):
+                start_time = datetime.strptime(start_time, DECIMALS_DATE_FORMAT)
+
+            start_time = start_time.timestamp()
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_wgc_e':
             logger = self.task_loggers['Agent-groups send full']
-            start_time = self.send_agent_groups_status['date_start'].timestamp()
+            start_time = self.send_agent_groups_status['date_start']
+            if isinstance(start_time, str):
+                start_time = datetime.strptime(start_time, DECIMALS_DATE_FORMAT)
+
+            start_time = start_time.timestamp()
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_w_g_err':
             logger = self.task_loggers['Agent-groups send']

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -269,7 +269,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_wgc_e':
             logger = self.task_loggers['Agent-groups send full']
-            start_time = self.send_agent_groups_status['date_start']
+            start_time = self.send_full_agent_groups_status['date_start']
             if isinstance(start_time, str):
                 start_time = datetime.strptime(start_time, DECIMALS_DATE_FORMAT)
 


### PR DESCRIPTION
|Related issue|
|---|
| [#16981](https://github.com/wazuh/wazuh/issues/16981) |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

All the status properties inside the `MasterHandler` are saved as a `String` containing the date of the event.
Example:
https://github.com/wazuh/wazuh/blob/13228ade7786495fd6d75f34775efcfc30eeee64/framework/wazuh/core/cluster/master.py#L693-L696

The data from `send_full_agent_groups_status` and `sync_agent_info_status` is used in the `process_request` method as a `start_date`, so it needs to be converted to a `date` type. The following code was added to use a type guard in case the value is an `String` and convert it to the desired `date` type:

https://github.com/wazuh/wazuh/blob/13228ade7786495fd6d75f34775efcfc30eeee64/framework/wazuh/core/cluster/master.py#L262-L277
<!--
Add a clear description of how the problem has been solved.
-->
