### PR TITLE
Replace empty value with None in API specification key

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -11647,7 +11647,7 @@ paths:
                       name: "wazuh"
                       node: "master-node"
                     full_log: "ERROR"
-                    decoder:
+                    decoder: None
                     location: "/var/log/syslog"
                   alert: false
                   codemsg: 1


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/16918 |

## Description

This PR introduces a fix for the failed tests mentioned in the related issue.

## Configuration options

The testing environment must have tavern 1.2.2 and pykwalify 1.7.0 installed.

## Tests

```console
(venv2) gasti@pop-os:~/work/wazuh$ python3 -m pytest framework/wazuh/tests/test_security.py
=================================================== test session starts ====================================================
platform linux -- Python 3.9.16, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/gasti/work/wazuh/framework
plugins: aiohttp-0.3.0, tavern-1.2.2, trio-0.7.0, html-2.1.1, asyncio-0.15.1, metadata-2.0.4
collected 71 items                                                                                                         

framework/wazuh/tests/test_security.py .......................................................................       [100%]

============================================= 71 passed, 13 warnings in 43.50s =============================================
```