### PR TITLE
Limit syscollector github actions for specific folders.

### DIFF
--- a/.github/workflows/macos-syscollector-tests.yml
+++ b/.github/workflows/macos-syscollector-tests.yml
@@ -2,7 +2,12 @@ name: Syscollector test on macOS
 
 on:
   pull_request:
-    branches: ["*"]
+    paths:
+        - ".github/workflows/macos-syscollector-tests.yml"
+        - "src/data_provider/**"
+        - "src/shared_modules/**"
+        - "src/wazuh_modules/syscollector/**"
+        - "src/Makefile"
 
 jobs:
   build:

--- a/.github/workflows/ubuntu-syscollector-tests.yml
+++ b/.github/workflows/ubuntu-syscollector-tests.yml
@@ -2,7 +2,12 @@ name: Syscollector test on Ubuntu
 
 on:
   pull_request:
-    branches: ["*"]
+    paths:
+        - ".github/workflows/ubuntu-syscollector-tests.yml"
+        - "src/data_provider/**"
+        - "src/shared_modules/**"
+        - "src/wazuh_modules/syscollector/**"
+        - "src/Makefile"
 
 jobs:
   build:

--- a/.github/workflows/windows-syscollector-tests.yml
+++ b/.github/workflows/windows-syscollector-tests.yml
@@ -2,7 +2,12 @@ name: Syscollector test on Windows
 
 on:
   pull_request:
-    branches: ["*"]
+    paths:
+      - ".github/workflows/windows-syscollector-tests.yml"
+      - "src/data_provider/**"
+      - "src/shared_modules/**"
+      - "src/wazuh_modules/syscollector/**"
+      - "src/Makefile"
 
 jobs:
   build:


### PR DESCRIPTION
|Related issue|
|---|
|Closes #16991|

**Description**
This PR modifies GitHub Actions workflows to limit the checks and tests to specific directories only. Currently, Syscollector checks and tests are executed for every push or pull request, even if the changes made were not related to those directories. This can be time-consuming and unnecessary.

The workflow is triggered only if the changes are made to the directories specified in the `paths` parameter. This parameter is a comma-separated list of directory paths that should trigger the workflow.

**Changes Made**
- Modify GitHub Actions workflow.
- Modified the `on` parameter to only trigger the workflow if changes are made to the directories specified in the `paths` parameter.
- Added the `paths` parameter to the new workflow.

