### PR TITLE
fixed osqueryd bug for version higher than 5.4.0

### DIFF
--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -416,15 +416,15 @@ char * wm_osquery_already_running(char * text) {
     char * end;
 
     // Find "osqueryd (xxxx) is already running"
-   if (text != NULL) {
-       if (begin = strstr(text, PATTERNS[0]), begin && (end = strstr(begin += strlen(PATTERNS[0]), PATTERNS[1]), end)) {
-           *end = '\0';
-           os_strdup(begin, text);
-           *end = *PATTERNS[1];
+    if (text != NULL) {
+        if (begin = strstr(text, PATTERNS[0]), begin && (end = strstr(begin += strlen(PATTERNS[0]), PATTERNS[1]), end)) {
+            *end = '\0';
+            os_strdup(begin, text);
+            *end = *PATTERNS[1];
 
-           // Find "Pidfile::Error::Busy"
+            // Find "Pidfile::Error::Busy"
         } else if (strstr(text, PATTERNS[2]) != NULL) {
-           os_strdup("unknown", text);
+            os_strdup("unknown", text);
         }
     }
     return text;


### PR DESCRIPTION
|Related issue|
|---|
|#15654|


## Description

This PR includes a fix to issue #15654, which presented an error when already running `osquery.service` or `user/bin/osqueryd` and wazuh try launch osquery . The function `wm_osquery_already_running` is modified to be able compatibility to higher than 5.4.0 osquery version.

## Configuration options

```xml

  <!-- Osquery integration -->
  <wodle name="osquery">
    <disabled>no</disabled>
    <run_daemon>yes</run_daemon>
    <log_path>/var/log/osquery/osqueryd.results.log</log_path>
    <config_path>/etc/osquery/osquery.conf</config_path>
    <add_labels>yes</add_labels>
  </wodle>
```


<!--
Paste here related logs and alerts
-->

## Tests

### Osquery higher than 5.4.0

1. Enable and start osquery.service (systemctl start osqueryd.service)
2. Config osquery block in `ossec.conf` file
3. Wazuh restart 
4. Checking `ossec.log` file:
```vim
2023/05/04 11:11:04 wazuh-modulesd:osquery: INFO: osqueryd is already running with pid unknown. Will run again in 1 minutes

2023/05/04 11:22:04 wazuh-modulesd:osquery: INFO: osqueryd is already running with pid unknown. Will run again in 10 minutes
```

***

### Osquery lower or equal than 5.4.0

1. Enable and start osquery.service (systemctl start osqueryd.service)
2. Config osquery block in `ossec.conf` file
3. Wazuh restart 
4. Checking `ossec.log` file:
```vim
2023/05/04 09:44:38 wazuh-modulesd:osquery: INFO: osqueryd is already running with pid 27367. Will run again in 1 minutes.

2023/05/04 09:55:38 wazuh-modulesd:osquery: INFO: osqueryd is already running with pid 27367. Will run again in 10 minutes.
```

***

### Osqueryd.service (OFF) / Run_daemon (ON)

1. Stop osquery.service (systemctl stop osqueryd.service)
2. Config osquery block in `ossec.conf` file
3. Wazuh restart 
4. Checking `ossec.log` file:
```vim
2023/05/04 12:51:03 wazuh-modulesd:osquery: INFO: Module started.
2023/05/04 12:51:03 wazuh-modulesd:task-manager: INFO: (8200): Module Task Manager started.
2023/05/04 12:51:03 sca: INFO: Module started.
2023/05/04 12:51:03 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2023/05/04 12:51:03 wazuh-modulesd:osquery: INFO: Following osquery results file '/var/log/osquery/osqueryd.results.log'.
```


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X