### PR TITLE
Change cluster status default date type

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1602,7 +1602,8 @@ class SyncWazuhdb(SyncTask):
         return True
 
 
-def end_sending_agent_information(logger, start_time, response) -> Tuple[bytes, bytes]:
+def end_sending_agent_information(logger: logging.Logger, start_time: datetime.datetime,
+                                  response: str) -> Tuple[bytes, bytes]:
     """Function called when the master/worker sends the "syn_m_a_e" or "syn_w_g_e" command.
 
     This method is called once the master finishes processing the agent-info/agent-groups. It logs
@@ -1610,10 +1611,10 @@ def end_sending_agent_information(logger, start_time, response) -> Tuple[bytes, 
 
     Parameters
     ----------
-    logger : Logger object
+    logger : logging.Logger
         Logger to use during synchronization process.
-    start_time : float
-        Timestamp collected at the start of the end process of a task of type agent-information.
+    start_time : datetime.datetime
+        Time collected at the start of the end process of an agent-information task.
     response : str
         JSON containing information about agent-info/agent-groups sync status.
 
@@ -1625,7 +1626,9 @@ def end_sending_agent_information(logger, start_time, response) -> Tuple[bytes, 
         Response message.
     """
     data = json.loads(response)
-    msg = f"Finished in {(utils.get_utc_now().timestamp() - start_time):.3f}s. Updated {data['updated_chunks']} chunks."
+    msg = f"Finished in {(utils.get_utc_now().timestamp() - start_time.timestamp()):.3f}s. " + \
+    f"Updated {data['updated_chunks']} chunks."
+
     logger.info(msg) if not data['error_messages'] else logger.error(
         msg + f" There were {len(data['error_messages'])} chunks with errors: {data['error_messages']}")
 

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -304,10 +304,7 @@ class LocalServerHandlerMaster(LocalServerHandler):
         dict
             Dict object containing nodes information.
         """
-        return b'ok', json.dumps(self.server.node.get_health(json.loads(filter_nodes)),
-                                 default=lambda o: "n/a" if
-                                 isinstance(o, datetime) and o == get_date_from_timestamp(0)
-                                 else (o.__str__() if isinstance(o, datetime) else None)).encode()
+        return b'ok', json.dumps(self.server.node.get_health(json.loads(filter_nodes))).encode()
 
     def send_file_request(self, path, node_name):
         """Send a file from the API to the cluster.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -193,11 +193,11 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                       'total_files': {'missing': 0, 'shared': 0, 'extra': 0, 'extra_valid': 0}}
         self.sync_agent_info_status = {'date_start_master': DEFAULT_DATE, 'date_end_master': DEFAULT_DATE,
                                        'n_synced_chunks': 0}
-        self.send_agent_groups_status = {'date_start': default_date,
-                                         'date_end': default_date,
+        self.send_agent_groups_status = {'date_start': DEFAULT_DATE,
+                                         'date_end': DEFAULT_DATE,
                                          'n_synced_chunks': 0}
-        self.send_full_agent_groups_status = {'date_start': default_date,
-                                              'date_end': default_date,
+        self.send_full_agent_groups_status = {'date_start': DEFAULT_DATE,
+                                              'date_end': DEFAULT_DATE,
                                               'n_synced_chunks': 0}
 
         # Variables which will be filled when the worker sends the hello request.
@@ -267,14 +267,20 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             logger = self.task_loggers['Agent-groups send']
             start_time = self.send_agent_groups_status['date_start']
             if isinstance(start_time, str):
-                start_time = datetime.strptime(start_time, DECIMALS_DATE_FORMAT)
+                if start_time == DEFAULT_DATE:
+                    start_time = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
+                else:
+                    start_time = datetime.strptime(start_time, DECIMALS_DATE_FORMAT)
             start_time = start_time.timestamp()
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_wgc_e':
             logger = self.task_loggers['Agent-groups send full']
             start_time = self.send_full_agent_groups_status['date_start']
             if isinstance(start_time, str):
-                start_time = datetime.strptime(start_time, DECIMALS_DATE_FORMAT)
+                if start_time == DEFAULT_DATE:
+                    start_time = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
+                else:
+                    start_time = datetime.strptime(start_time, DECIMALS_DATE_FORMAT)
             start_time = start_time.timestamp()
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_w_g_err':

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -21,7 +21,7 @@ from wazuh.core.cluster import server, cluster, common as c_common
 from wazuh.core.cluster.dapi import dapi
 from wazuh.core.cluster.utils import context_tag
 from wazuh.core.common import DECIMALS_DATE_FORMAT
-from wazuh.core.utils import get_utc_now, get_utc_strptime
+from wazuh.core.utils import get_utc_now
 from wazuh.core.wdb import AsyncWazuhDBConnection
 
 DEFAULT_DATE: str = 'n/a'
@@ -265,23 +265,11 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             return self.process_sync_error_from_worker(data)
         elif command == b'syn_w_g_e':
             logger = self.task_loggers['Agent-groups send']
-            start_time = self.send_agent_groups_status['date_start']
-            if isinstance(start_time, str):
-                if start_time == DEFAULT_DATE:
-                    start_time = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
-                else:
-                    start_time = datetime.strptime(start_time, DECIMALS_DATE_FORMAT)
-            start_time = start_time.timestamp()
+            start_time = datetime.strptime(self.send_agent_groups_status['date_start'], DECIMALS_DATE_FORMAT)
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_wgc_e':
             logger = self.task_loggers['Agent-groups send full']
-            start_time = self.send_full_agent_groups_status['date_start']
-            if isinstance(start_time, str):
-                if start_time == DEFAULT_DATE:
-                    start_time = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
-                else:
-                    start_time = datetime.strptime(start_time, DECIMALS_DATE_FORMAT)
-            start_time = start_time.timestamp()
+            start_time = datetime.strptime(self.send_full_agent_groups_status['date_start'], DECIMALS_DATE_FORMAT)
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_w_g_err':
             logger = self.task_loggers['Agent-groups send']

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -702,15 +702,11 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             Logger to use.
         """
         date_end_master = utils.get_utc_now()
-        if self.integrity_sync_status['tmp_date_start_master'] == DEFAULT_DATE:
-            # This should only be a case in tests where the value has not been set beforehand
-            tmp_date_start_master = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
-        else:
-            tmp_date_start_master = datetime.strptime(self.integrity_sync_status['tmp_date_start_master'],
-                                                      DECIMALS_DATE_FORMAT)
+        tmp_date_start_master = self.integrity_sync_status['tmp_date_start_master']
 
         logger.info("Finished in {:.3f}s.".format((date_end_master - tmp_date_start_master).total_seconds()))
-        self.integrity_sync_status['date_start_master'] = self.integrity_sync_status['tmp_date_start_master']
+        self.integrity_sync_status['date_start_master'] = \
+            self.integrity_sync_status['tmp_date_start_master'].strftime(DECIMALS_DATE_FORMAT)
         self.integrity_sync_status['date_end_master'] = date_end_master.strftime(DECIMALS_DATE_FORMAT)
 
     async def integrity_check(self, task_id: str, received_file: asyncio.Event):

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -1478,13 +1478,21 @@ def test_end_sending_agent_information(perf_counter_mock, json_loads_mock):
     logger = logging.getLogger('testing')
     with patch('wazuh.core.cluster.common.utils.get_utc_now', side_effect=get_utc_now_mock):
         with patch.object(logger, "info") as logger_info_mock:
-            assert cluster_common.end_sending_agent_information(logger, 0, "response") == (b'ok', b'Thanks')
+            assert cluster_common.end_sending_agent_information(
+                logger,
+                datetime.fromtimestamp(0),
+                "response"
+                ) == (b'ok', b'Thanks')
             json_loads_mock.assert_called_once_with("response")
             logger_info_mock.assert_called_once_with("Finished in 0.000s. Updated 10 chunks.")
 
         with patch.object(logger, "error") as logger_error_mock:
             json_loads_mock.return_value = {"updated_chunks": 10, "error_messages": "error"}
-            assert cluster_common.end_sending_agent_information(logger, 0, "response") == (b'ok', b'Thanks')
+            assert cluster_common.end_sending_agent_information(
+                logger,
+                datetime.fromtimestamp(0),
+                "response"
+                ) == (b'ok', b'Thanks')
             logger_error_mock.assert_called_once_with(
                 "Finished in 0.000s. Updated 10 chunks. There were 5 chunks with errors: error")
 

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -16,7 +16,6 @@ import uvloop
 from freezegun import freeze_time
 
 from wazuh.core import exception
-from wazuh.core.cluster.master import DEFAULT_DATE
 
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
@@ -28,6 +27,7 @@ with patch('wazuh.core.common.wazuh_uid'):
 
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
         from wazuh.core.cluster import common as cluster_common, client, master
+        from wazuh.core.cluster.master import DEFAULT_DATE
         from wazuh.core import common
         from wazuh.core.cluster.dapi import dapi
         from wazuh.core.utils import get_utc_strptime

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -31,6 +31,7 @@ with patch('wazuh.core.common.wazuh_uid'):
         from wazuh.core import common
         from wazuh.core.cluster.dapi import dapi
         from wazuh.core.utils import get_utc_strptime
+        from wazuh.core.common import DECIMALS_DATE_FORMAT
 
 # Global variables
 
@@ -412,16 +413,23 @@ def test_master_handler_process_request(logger_mock):
     with patch("wazuh.core.cluster.common.end_sending_agent_information",
                return_value=b'ok') as end_sending_agent_information_mock:
         master_handler.task_loggers['Agent-groups send'] = logging.getLogger('Agent-groups send')
+        master_handler.send_agent_groups_status['date_start'] = '1970-01-01T00:00:00.0Z'
+
         assert master_handler.process_request(command=b'syn_w_g_e', data=b"data") == b"ok"
-        end_sending_agent_information_mock.assert_called_once_with(logging.getLogger('Agent-groups send'), 0.0, "data")
+        end_sending_agent_information_mock.assert_called_once_with(
+            logging.getLogger('Agent-groups send'), 
+            datetime.strptime(master_handler.send_agent_groups_status['date_start'], DECIMALS_DATE_FORMAT), "data")
 
     # Test the sixth condition
     with patch("wazuh.core.cluster.common.end_sending_agent_information",
                return_value=b'ok') as end_sending_agent_information_mock:
         master_handler.task_loggers['Agent-groups send full'] = logging.getLogger('Agent-groups send full')
+        master_handler.send_full_agent_groups_status['date_start'] = '1970-01-01T00:00:00.0Z'
+
         assert master_handler.process_request(command=b'syn_wgc_e', data=b"data") == b"ok"
         end_sending_agent_information_mock.assert_called_once_with(
-            logging.getLogger('Agent-groups send full'), 0.0, "data")
+            logging.getLogger('Agent-groups send full'),
+            datetime.strptime(master_handler.send_full_agent_groups_status['date_start'], DECIMALS_DATE_FORMAT), "data")
 
     # Test the seventh condition
     with patch("wazuh.core.cluster.common.error_receiving_agent_information",

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -6,6 +6,7 @@ import json
 import logging
 import sys
 from unittest.mock import patch, MagicMock, AsyncMock, call, ANY
+import datetime
 
 import pytest
 import uvloop
@@ -377,7 +378,8 @@ def test_worker_handler_process_request_ok(logger_mock):
             assert worker_handler.process_request(
                 command=b"syn_m_a_e", data=b'{"updated_chunks": 4, "error_messages": []}') == b"ok"
             sync_mock.assert_called_once_with(setup_task_logger_mock,
-                                              0.0, b'{"updated_chunks": 4, "error_messages": []}'.decode())
+                                              datetime.datetime(1970, 1, 1, 0, 0),
+                                              b'{"updated_chunks": 4, "error_messages": []}'.decode())
             logger_mock.assert_called_with("Command received: 'b'syn_m_a_e''")
     # Test the seventh condition
     with patch("wazuh.core.cluster.worker.c_common.error_receiving_agent_information",

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -206,7 +206,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             return self.setup_sync_integrity(command, data)
         elif command == b'syn_m_a_e':
             logger = self.task_loggers['Agent-info sync']
-            start_time = self.agent_info_sync_status['date_start']
+            start_time = datetime.utcfromtimestamp(self.agent_info_sync_status['date_start'])
             return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_m_a_err':
             logger = self.task_loggers['Agent-info sync']


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/16995 |

## Description

Changed the default date string from a `datetime` at the unix epoch to a string `"n/a"`.

## Tests

Cluster unit and integration tests were executed successfully.

```console
(venv2) gasti@pop-os:~/work/wazuh$ python3 -m pytest framework/wazuh/core/cluster/tests/test_master.py
================================================================ test session starts =================================================================
platform linux -- Python 3.9.16, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/gasti/work/wazuh/framework
plugins: aiohttp-0.3.0, tavern-1.2.2, trio-0.7.0, html-2.1.1, asyncio-0.15.1, metadata-2.0.4
collected 47 items                                                                                                                                   

framework/wazuh/core/cluster/tests/test_master.py ...............................................                                              [100%]

=========================================================== 47 passed, 5 warnings in 0.55s ===========================================================
```

```console
(venv2) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_cluster_endpoints.tavern.yaml
================================================================ test session starts =================================================================
platform linux -- Python 3.9.16, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/gasti/work/wazuh/venv2/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.6-76060206-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '5.4.3', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '0.3.0', 'tavern': '1.2.2', 'trio': '0.7.0', 'html': '2.1.1', 'asyncio': '0.15.1', 'metadata': '2.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration, inifile: pytest.ini
plugins: aiohttp-0.3.0, tavern-1.2.2, trio-0.7.0, html-2.1.1, asyncio-0.15.1, metadata-2.0.4
collected 49 items                                                                                                                                   

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                           [  2%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                            [  4%]
test_cluster_endpoints.tavern.yaml::GET /cluster/ruleset/synchronization PASSED                                                                [  6%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                             [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                  [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                     [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                         [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                         [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                       [ 18%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                     [ 20%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                     [ 22%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                  [ 24%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                 [ 26%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                [ 28%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                               [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                             [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                    [ 34%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                            [ 36%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                [ 38%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                [ 40%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                            [ 42%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                [ 44%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                [ 46%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                        [ 48%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                        [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[master-node] PASSED                                                   [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker1] PASSED                                                       [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker2] PASSED                                                       [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                           [ 59%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                               [ 61%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                               [ 63%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                       [ 65%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                                                 [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                                     [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                                     [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                    [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                        [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                        [ 77%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                   [ 79%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                       [ 81%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                       [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                    [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                        [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                        [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                          [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                              [ 93%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                              [ 95%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                [ 97%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                [100%]

==================================================== 49 passed, 62 warnings in 453.31s (0:07:33) =====================================================

