### PR TITLE
Skip agent if they don't exist while scan is in progress

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1650,6 +1650,16 @@ int wdb_remove_database(const char * agent_id) {
     return result;
 }
 
+/* Verify if database file exists*/
+int wdb_exists_database(const int agent_id) {
+    char path[PATH_MAX];
+    struct stat stats;
+
+    snprintf(path, PATH_MAX, "%s/%03d.db", WDB2_DIR, agent_id);
+
+    return stat(path, &stats);
+}
+
 cJSON *wdb_remove_multiple_agents(char *agent_list) {
     cJSON *response = NULL;
     cJSON *json_agents = NULL;

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -881,6 +881,8 @@ void wdb_close_old();
 
 int wdb_remove_database(const char * agent_id);
 
+int wdb_exists_database(const int agent_id);
+
 /**
  * @brief Checks and vacuums (if necessary) the databases in the DB pool.
  */

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -208,9 +208,10 @@ STATIC int wm_vuldet_collect_agent_software(scan_agent *agent, sqlite3 *db, scan
  * @param agent Pointer to an agent node.
  * @param flags Flag list for Windows agents
  * @param scan_ctx Context of the scan in progress
+ * @param skip Flag to skip agent.
  * @return 0 on success, -1 otherwise.
  */
-STATIC int wm_vuldet_find_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags, scan_ctx_t* scan_ctx);
+STATIC int wm_vuldet_find_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags, scan_ctx_t* scan_ctx, bool* skip);
 
 /**
  * @brief Eliminate and report every obsolete vulnerability.
@@ -2643,7 +2644,7 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, scan_agent *agents_it, OSH
     return 0;
 }
 
-int wm_vuldet_find_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags, scan_ctx_t* scan_ctx) {
+int wm_vuldet_find_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags, scan_ctx_t* scan_ctx, bool* skip) {
 
     int retval = OS_INVALID;
     OSHash *cve_table = NULL;
@@ -2693,6 +2694,14 @@ int wm_vuldet_find_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuld
         if (wm_vuldet_linux_rm_false_positives(db, agent, cve_table)) {
             goto end;
         }
+
+        if (wdb_exists_database(scan_ctx->agent_id)) {
+            *skip = true;
+            retval = 0;
+            mwarn("Couldn't read agent id '%03d' database: %s. Skipping.", scan_ctx->agent_id, strerror(errno));
+            goto end;
+        }
+
         if (wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, scan_ctx)) {
             goto end;
         }
@@ -2776,6 +2785,11 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
             scan_ctx.agent_name = agents_it->agent_name;
             scan_ctx.agent_ip = agents_it->agent_ip;
 
+            if (wdb_exists_database(scan_ctx.agent_id)) {
+                mwarn("Couldn't read agent id '%03d' database: %s. Skipping.", scan_ctx.agent_id, strerror(errno));
+                continue;
+            }
+
             if (agents_it->pending_attempts == 0) continue;
 
             time_t start = time(NULL);
@@ -2835,11 +2849,21 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
 
             mtinfo(WM_VULNDETECTOR_LOGTAG, VU_START_AG_AN, scan_ctx.agent_id);
 
+            bool skip = false;
             // Find and report agent vulnerabilities
-            if (OS_SUCCESS != wm_vuldet_find_agent_vulnerabilities(db, agents_it, &vuldet->flags, &scan_ctx)) {
+            if (OS_SUCCESS != wm_vuldet_find_agent_vulnerabilities(db, agents_it, &vuldet->flags, &scan_ctx, &skip)) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_REPORT_ERROR, scan_ctx.agent_id, sqlite3_errmsg(db));
                 abort_scan = true;
                 break;
+            }
+
+            if (skip) {
+                continue;
+            }
+
+            if (wdb_exists_database(scan_ctx.agent_id)) {
+                mwarn("Couldn't read agent id '%03d' database: %s. Skipping.", scan_ctx.agent_id, strerror(errno));
+                continue;
             }
 
             // Find and report obsolete vulnerabilities
@@ -2847,6 +2871,11 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
                 mterror(WM_VULNDETECTOR_LOGTAG, "The agent '%.3d' obsolete vulnerability could not be processed", scan_ctx.agent_id);
                 abort_scan = true;
                 break;
+            }
+
+            if (wdb_exists_database(scan_ctx.agent_id)) {
+                mwarn("Couldn't read agent id '%03d' database: %s. Skipping.", scan_ctx.agent_id, strerror(errno));
+                continue;
             }
 
             // Update the time of the last scan


### PR DESCRIPTION
|Related issue|
|---|
|#15037|

## Description

This PR mitigates the flooding described here https://github.com/wazuh/wazuh/issues/15037 when an agent is removed prior inserted its vulnerabilities in the database. 
It is important to notice that the reported case is just a particular situation but the problems may occur in many places. 

## Configuration options

Tested with Jammy manager and Focal agent. 

```xml
  <vulnerability-detector>
    <enabled>yes</enabled>
    <interval>5m</interval>
    <min_full_scan_interval>6h</min_full_scan_interval>
    <run_on_start>yes</run_on_start>

    <!-- Ubuntu OS vulnerabilities -->
    <provider name="canonical">
      <enabled>yes</enabled>
      <os>focal</os>
      <os>jammy</os>
      <update_interval>1h</update_interval>
    </provider>
...
```

## Logs/Alerts example

The error reported in the issue is easily reproduced with this script. 

```sh
#!/usr/bin/env bash

wazuh-control stop
echo "" > /var/ossec/logs/ossec.log
sqlite3 /var/ossec/queue/db/000.db 'update vuln_metadata set last_full_scan = 0' --line
sqlite3 /var/ossec/queue/db/001.db 'update vuln_metadata set last_full_scan = 0' --line
wazuh-control start && echo done

while : ; do
  grep -E "Collecting agent.*001" /var/ossec/logs/ossec.log
  [ $? -eq 0 ] && break
done

manage_agents -r 001
```

We can see that is not necessary to have several agents to reproduce this error, but it is more prone to happen with more agents 

![image](https://user-images.githubusercontent.com/13010397/236559305-6871ca21-f05f-4410-a49c-fb23f57f94e1.png)

If we edit the bash script to remove the agent when we are collecting the software for the manager. 
`grep -E "Collecting agent.*001" /var/ossec/logs/ossec.log`

This other issue occurs. 

![image](https://user-images.githubusercontent.com/13010397/236559622-333ba730-dab2-4a5e-9378-b3c664d5c27a.png)

Multiple errors may occur during the scan because there're many functions that query the agent database. 

## DoD 

The solution is to verify if the database file exists prior to querying the agent database.

![image](https://user-images.githubusercontent.com/13010397/236560210-f0593c2a-049d-4c44-86f4-d26b2c698519.png)

The log is no longer flooded with error logs, but the final solution requires to do verification in all places where this may occur and ensure that the scan keeps working for the rest of the agents.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors