### PR TITLE
Fix OSHash_GetIndex() function signature

### DIFF
--- a/src/headers/hash_op.h
+++ b/src/headers/hash_op.h
@@ -98,6 +98,6 @@ void OSHash_It_ex(const OSHash *hash, char mode, void *data, void (*iterating_fu
 /*
  * Returns the index of the key.
 */
-int OSHash_GetIndex(OSHash *self, const char *key);
+unsigned int OSHash_GetIndex(OSHash *self, const char *key);
 
 #endif /* OS_HASHOP */

--- a/src/shared/hash_op.c
+++ b/src/shared/hash_op.c
@@ -671,11 +671,11 @@ void OSHash_It_ex(const OSHash *hash, char mode, void *data, void (*iterating_fu
 }
 
 
-/** int OSHash_GetIndex(OSHash *self, char *key)
- * Returns -1 on error (not found).
+/*
+ * Returns the index of the key.
  * Key must not be NULL.
  */
-int OSHash_GetIndex(OSHash *self, const char *key)
+unsigned int OSHash_GetIndex(OSHash *self, const char *key)
 {
     unsigned int hash_key;
     unsigned int index;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #16654|

According to the comment by @lihanhui, `OSHash_GetIndex()` is documented to return `-1` if the key does not exist. This is not possible as `OSHash_GetIndex()` actually does not find a key in the hash table, but calculates the target row according to the key.

In fact, the result is a module on `_os_genhash()` which returns `unsigned int`. Hence, `OSHash_GetIndex()` should always return an `unsigned int` type.

## Impact

None, as `OSHash_GetIndex()` is not being called by any function at this moment.