### PR TITLE
Rework of PUT active-response

### DIFF
--- a/api/api/models/active_response_model.py
+++ b/api/api/models/active_response_model.py
@@ -18,8 +18,6 @@ class ActiveResponseModel(Body):
         command : str
             Command running in the agent. If this value starts by !, then it refers to a script name instead of a
             command name.
-        custom : bool
-            Whether the specified command is a custom command or not.
         arguments : list
             Command arguments.
         alert : dict
@@ -27,20 +25,17 @@ class ActiveResponseModel(Body):
         """
         self.swagger_types = {
             'command': str,
-            'custom': bool,
             'arguments': List[str],
             'alert': dict
         }
 
         self.attribute_map = {
             'command': 'command',
-            'custom': 'custom',
             'arguments': 'arguments',
             'alert': 'alert'
         }
 
         self._command = command
-        self._custom = custom
         self._arguments = arguments
         self._alert = alert
 
@@ -63,26 +58,6 @@ class ActiveResponseModel(Body):
             Command to run in the agent.
         """
         self._command = command
-
-    @property
-    def custom(self) -> bool:
-        """
-        Returns
-        -------
-        bool
-            Whether the specified command is a custom command or not.
-        """
-        return self._custom
-
-    @custom.setter
-    def custom(self, custom: bool):
-        """
-        Parameters
-        ----------
-        custom : bool
-            Whether the specified command is a custom command or not.
-        """
-        self._custom = custom
 
     @property
     def arguments(self) -> list:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1376,10 +1376,6 @@ components:
           instead of a command name"
           type: string
           format: active_response_command
-        custom:
-          description: "Whether the specified command is a custom command or not"
-          type: boolean
-          default: false
         alert:
           type: object
           properties:

--- a/api/test/integration/test_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_active_response_endpoints.tavern.yaml
@@ -12,8 +12,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "custom"
-        custom: True
+        command: "!custom"
       params:
         agents_list: '001'
     response:
@@ -36,8 +35,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "custom"
-        custom: True
+        command: "!custom"
       params:
         agents_list: '006'
     response:
@@ -60,8 +58,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "custom"
-        custom: True
+        command: "!custom"
       params:
         agents_list: 002,004,005,007,010,012
     response:

--- a/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
@@ -30,8 +30,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "custom"
-        custom: True
+        command: "!custom"
       params:
         agents_list: '002'
     response:
@@ -54,8 +53,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "custom"
-        custom: True
+        command: "!custom"
       params:
         agents_list: 002,004,005,007,010,011
     response:

--- a/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
@@ -12,8 +12,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "custom"
-        custom: True
+        command: "!custom"
       params:
         agents_list: '001'
     response:
@@ -57,8 +56,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "custom"
-        custom: True
+        command: "!custom"
       params:
         agents_list: 002,004,005,007,010,011
     response:

--- a/framework/wazuh/active_response.py
+++ b/framework/wazuh/active_response.py
@@ -12,7 +12,7 @@ from wazuh.rbac.decorators import expose_resources
 
 @expose_resources(actions=['active-response:command'], resources=['agent:id:{agent_list}'],
                   post_proc_kwargs={'exclude_codes': [1701, 1703]})
-def run_command(agent_list: list = None, command: str = '', arguments: list = None, custom: bool = False,
+def run_command(agent_list: list = None, command: str = '', arguments: list = None,
                 alert: dict = None) -> AffectedItemsWazuhResult:
     """Run AR command in a specific agent.
 
@@ -48,7 +48,7 @@ def run_command(agent_list: list = None, command: str = '', arguments: list = No
                         raise WazuhResourceNotFound(1701)
                     if agent_id == "000":
                         raise WazuhError(1703)
-                    active_response.send_ar_message(agent_id, wq, command, arguments, custom, alert)
+                    active_response.send_ar_message(agent_id, wq, command, arguments, alert)
                     result.affected_items.append(agent_id)
                     result.total_affected_items += 1
                 except WazuhException as e:

--- a/framework/wazuh/core/active_response.py
+++ b/framework/wazuh/core/active_response.py
@@ -107,7 +107,7 @@ class ARMessageBuilder:
 
         Raises
         ------
-        ValueError
+        WazuhError(1000)
             If no suitable message builder is found for the agent version.
         """
 
@@ -115,7 +115,7 @@ class ARMessageBuilder:
             if subclass.can_handle(agent_version):
                 return subclass()
 
-        raise WazuhError(1000 ,"No suitable message builder found for agent version: {}".format(agent_version))
+        raise WazuhError(1000, "No suitable message builder found for agent version: {}".format(agent_version))
 
 
 class ARStrMessage(ARMessageBuilder):

--- a/framework/wazuh/core/active_response.py
+++ b/framework/wazuh/core/active_response.py
@@ -13,80 +13,221 @@ from wazuh.core.wazuh_queue import WazuhQueue
 from wazuh.core.wazuh_socket import create_wazuh_socket_message
 
 
-def create_message(command: str = '', custom: bool = False, arguments: list = None) -> str:
-    """Create the message that will be sent.
+def get_commands() -> list:
+    """Get the available commands.
+
+    Returns
+    -------
+    list
+        List with the available commands.
+    """
+    commands = list()
+    with open(common.AR_CONF) as f:
+        for line in f:
+            cmd = line.split(" - ")[0]
+            commands.append(cmd)
+
+    return commands
+
+
+def shell_escape(command: str = '') -> str:
+    """Escape some characters in the command before sending it.
 
     Parameters
     ----------
     command : str
-        Command running in the agent. If this value starts with !, then it refers to a script name instead of a command
-        name.
-    custom : bool
-        Whether the specified command is a custom command or not.
-    arguments : list
-        Command arguments.
-
-    Raises
-    ------
-    WazuhError(1650)
-        If the command is not specified.
-    WazuhError(1652)
-        If the command is not custom and the command is not one of the available commands.
+        Command running in the agent. If this value starts with !, then it refers to a script name instead of a
+        command name.
 
     Returns
     -------
     str
-        Message that will be sent to the socket.
+        Command with escape characters.
     """
-    if not command:
-        raise WazuhError(1650)
+    shell_escapes = \
+        ['"', '\'', '\t', ';', '`', '>', '<', '|', '#', '*', '[', ']', '{', '}', '&', '$', '!', ':', '(', ')']
+    for shell_esc_char in shell_escapes:
+        command = command.replace(shell_esc_char, "\\" + shell_esc_char)
 
-    commands = get_commands()
-    if not custom and command not in commands:
-        raise WazuhError(1652)
-
-    msg_queue = "!{}".format(command) if custom else command
-    msg_queue += " " + " ".join(shell_escape(str(x)) for x in arguments) if arguments else " - -"
-
-    return msg_queue
+    return command
 
 
-def create_json_message(command: str = '', arguments: list = None, alert: dict = None) -> str:
-    """Create the JSON message that will be sent. Function used when Wazuh agent version is >= 4.2.0.
+class ARMessageBuilder:
+    @staticmethod
+    def can_handle(agent_version: str) -> bool:
+        """Check if the message builder can handle the given agent version.
 
-    Parameters
-    ----------
-    command : str
-        Command running in the agent. If this value starts by !, then it refers to a script name instead of a command
-        name.
-    arguments : list
-        Command arguments.
-    alert : dict
-        Alert data that will be sent with the AR command.
+        Parameters
+        ----------
+        agent_version : str
+            The version of the agent.
 
-    Raises
-    ------
-    WazuhError(1650)
-        If the command is not specified.
+        Returns
+        -------
+        bool
+            True if the message builder can handle the agent version, False otherwise.
+        """
+        raise NotImplementedError
 
-    Returns
-    -------
-    str
-        Message that will be sent to the socket.
-    """
-    if not command:
-        raise WazuhError(1650)
+    def create_message(self, command: str = '', custom: bool = False, arguments: list = None, alert: dict = None) -> str:
+        """Create the message with the Active Response format that will be sent to the socket.
 
-    cluster_enabled = not read_cluster_config()['disabled']
-    node_name = get_node().get('node') if cluster_enabled else None
+        Parameters
+        ----------
+        command : str
+            Command running in the agent. If this value starts with !, then it refers to a script name instead of a
+            command name.
+        custom : bool
+            Whether the specified command is a custom command or not.
+        arguments : list
+            Command arguments.
+        alert : dict
+            Alert data that will be sent with the AR command.
 
-    msg_queue = json.dumps(
-        create_wazuh_socket_message(origin={'name': node_name, 'module': common.origin_module.get()},
-                                    command=command,
-                                    parameters={'extra_args': arguments if arguments else [],
-                                                'alert': alert if alert else {}}))
+        Returns
+        -------
+        str
+            Message that will be sent to the socket.
+        """
+        raise NotImplementedError
 
-    return msg_queue
+    @classmethod
+    def choose_builder(cls, agent_version: str):
+        """Choose the appropriate message builder based on the agent version.
+
+        Parameters
+        ----------
+        agent_version : str
+            The version of the agent.
+
+        Returns
+        -------
+        ARMessageBuilder
+            An instance of the chosen message builder.
+
+        Raises
+        ------
+        ValueError
+            If no suitable message builder is found for the agent version.
+        """
+
+        for subclass in cls.__subclasses__():
+            if subclass.can_handle(agent_version):
+                return subclass()
+
+        raise ValueError("No suitable message builder found for agent version: {}".format(agent_version))
+
+
+class ARStrMessage(ARMessageBuilder):
+    @staticmethod
+    def can_handle(agent_version: str) -> bool:
+        """Check if the ARStrMessage can handle the given agent version.
+
+        Parameters
+        ----------
+        agent_version : str
+            The version of the agent.
+
+        Returns
+        -------
+        bool
+            True if ARStrMessage can handle the agent version, False otherwise.
+        """
+        return WazuhVersion(agent_version) < WazuhVersion(common.AR_LEGACY_VERSION)
+
+    def create_message(self, command: str = '', custom: bool = False, arguments: list = None, alert: dict = None) -> str:
+        """Create the message with the Active Response format that will be sent to the socket.
+
+        Parameters
+        ----------
+        command : str
+            Command running in the agent. If this value starts with !, then it refers to a script name instead of a command
+            name.
+        custom : bool
+            Whether the specified command is a custom command or not.
+        arguments : list
+            Command arguments.
+        alert : dict
+            Alert data that will be sent with the AR command.
+
+        Raises
+        ------
+        WazuhError(1650)
+            If the command is not specified.
+        WazuhError(1652)
+            If the command is not custom and the command is not one of the available commands.
+
+        Returns
+        -------
+        str
+            Message that will be sent to the socket.
+        """
+        if not command:
+            raise WazuhError(1650)
+
+        commands = get_commands()
+        if not custom and command not in commands:
+            raise WazuhError(1652)
+
+        msg_queue = "!{}".format(command) if custom else command
+        msg_queue += " " + " ".join(shell_escape(str(x)) for x in arguments) if arguments else " - -"
+
+        return msg_queue
+
+
+class ARJsonMessage(ARMessageBuilder):
+    @staticmethod
+    def can_handle(agent_version: str) -> bool:
+        """Check if the ARJsonMessage can handle the given agent version.
+
+        Parameters
+        ----------
+        agent_version : str
+            The version of the agent.
+
+        Returns
+        -------
+        bool
+            True if ARJsonMessage can handle the agent version, False otherwise.
+        """
+        return WazuhVersion(agent_version) >= WazuhVersion(common.AR_LEGACY_VERSION)
+
+    def create_message(self, command: str = '', custom: bool = False, arguments: list = None, alert: dict = None) -> str:
+        """Create the message with the Active Response format that will be sent to the socket.
+
+        Parameters
+        ----------
+        command : str
+            Command running in the agent. If this value starts by !, then it refers to a script name instead of a command
+            name.
+        arguments : list
+            Command arguments.
+        alert : dict
+            Alert data that will be sent with the AR command.
+
+        Raises
+        ------
+        WazuhError(1650)
+            If the command is not specified.
+
+        Returns
+        -------
+        str
+            Message that will be sent to the socket.
+        """
+        if not command:
+            raise WazuhError(1650)
+
+        cluster_enabled = not read_cluster_config()['disabled']
+        node_name = get_node().get('node') if cluster_enabled else None
+
+        msg_queue = json.dumps(
+            create_wazuh_socket_message(origin={'name': node_name, 'module': common.origin_module.get()},
+                                        command=command,
+                                        parameters={'extra_args': arguments if arguments else [],
+                                                    'alert': alert if alert else {}}))
+
+        return msg_queue
 
 
 def send_ar_message(agent_id: str = '', wq: WazuhQueue = None, command: str = '', arguments: list = None,
@@ -132,48 +273,10 @@ def send_ar_message(agent_id: str = '', wq: WazuhQueue = None, command: str = ''
         raise WazuhError(1750)
 
     # Create classic msg or JSON msg depending on the agent version
-    if WazuhVersion(agent_version) >= WazuhVersion(common.AR_LEGACY_VERSION):
-        msg_queue = create_json_message(command=command, arguments=arguments, alert=alert)
-    else:
-        msg_queue = create_message(command=command, arguments=arguments, custom=custom)
+    message_builder = ARMessageBuilder.choose_builder(agent_version)
+    msg_queue = message_builder.create_message(command=command, custom=custom, arguments=arguments, alert=alert)
 
     wq.send_msg_to_agent(msg=msg_queue, agent_id=agent_id, msg_type=WazuhQueue.AR_TYPE)
 
 
-def get_commands() -> list:
-    """Get the available commands.
 
-    Returns
-    -------
-    list
-        List with the available commands.
-    """
-    commands = list()
-    with open(common.AR_CONF) as f:
-        for line in f:
-            cmd = line.split(" - ")[0]
-            commands.append(cmd)
-
-    return commands
-
-
-def shell_escape(command: str = '') -> str:
-    """Escape some characters in the command before sending it.
-
-    Parameters
-    ----------
-    command : str
-        Command running in the agent. If this value starts with !, then it refers to a script name instead of a
-        command name.
-
-    Returns
-    -------
-    str
-        Command with escape characters.
-    """
-    shell_escapes = \
-        ['"', '\'', '\t', ';', '`', '>', '<', '|', '#', '*', '[', ']', '{', '}', '&', '$', '!', ':', '(', ')']
-    for shell_esc_char in shell_escapes:
-        command = command.replace(shell_esc_char, "\\" + shell_esc_char)
-
-    return command

--- a/framework/wazuh/core/active_response.py
+++ b/framework/wazuh/core/active_response.py
@@ -115,7 +115,7 @@ class ARMessageBuilder:
             if subclass.can_handle(agent_version):
                 return subclass()
 
-        raise ValueError("No suitable message builder found for agent version: {}".format(agent_version))
+        raise WazuhError(1000 ,"No suitable message builder found for agent version: {}".format(agent_version))
 
 
 class ARStrMessage(ARMessageBuilder):

--- a/framework/wazuh/core/active_response.py
+++ b/framework/wazuh/core/active_response.py
@@ -30,7 +30,7 @@ def get_commands() -> list:
     return commands
 
 
-def shell_escape(command: str = '') -> str:
+def shell_escape(command: str) -> str:
     """Escape some characters in the command before sending it.
 
     Parameters
@@ -46,8 +46,10 @@ def shell_escape(command: str = '') -> str:
     """
     shell_escapes = \
         ['"', '\'', '\t', ';', '`', '>', '<', '|', '#', '*', '[', ']', '{', '}', '&', '$', '!', ':', '(', ')']
-    for shell_esc_char in shell_escapes:
-        command = command.replace(shell_esc_char, "\\" + shell_esc_char)
+
+    if any(special_char in command for special_char in shell_escapes):
+        for shell_esc_char in shell_escapes:
+            command = command.replace(shell_esc_char, "\\" + shell_esc_char)
 
     return command
 

--- a/framework/wazuh/core/active_response.py
+++ b/framework/wazuh/core/active_response.py
@@ -46,10 +46,8 @@ def shell_escape(command: str) -> str:
     """
     shell_escapes = \
         ['"', '\'', '\t', ';', '`', '>', '<', '|', '#', '*', '[', ']', '{', '}', '&', '$', '!', ':', '(', ')']
-
-    if any(special_char in command for special_char in shell_escapes):
-        for shell_esc_char in shell_escapes:
-            command = command.replace(shell_esc_char, "\\" + shell_esc_char)
+    for shell_esc_char in shell_escapes:
+        command = command.replace(shell_esc_char, "\\" + shell_esc_char)
 
     return command
 
@@ -237,12 +235,10 @@ def send_ar_message(agent_id: str = '', wq: WazuhQueue = None, command: str = ''
     agent_id : str
         ID specifying the agent where the msg_queue will be sent to.
     wq : WazuhQueue
-        WazuhQueue used for the active response messages.
+        Used for the active response messages.
     command : str
         Command running in the agents. If this value starts with !, then it refers to a script name instead of a
         command name.
-    custom : bool
-        Whether the specified command is a custom command or not.
     arguments : list
         Command arguments.
     alert : dict

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -216,7 +216,11 @@ class WazuhException(Exception):
         1603: 'Invalid status. Valid statuses are: all, solved and outstanding',
         1650: 'Active response - Command not specified',
 
-        1652: 'Active response - Unable to run command',
+        1652: {'message': 'The command used is not defined in the configuration.',
+               'remediation': f'Please, visit the official documentation (https://documentation.wazuh.com/'
+                              f'{DOCU_VERSION}/user-manual/capabilities/active-response/how-to-configure.html)'
+                              'to get more information'
+               },
 
         # Agents: 1700 - 1799
         1701: {'message': 'Agent does not exist',

--- a/framework/wazuh/core/tests/test_active_response.py
+++ b/framework/wazuh/core/tests/test_active_response.py
@@ -69,6 +69,25 @@ def agent_config(expected_exception):
 
 # Tests
 
+@pytest.mark.parametrize('agent_version, builder_type', [
+    ('Wazuh v4.2.0', active_response.ARJsonMessage),
+    ('Wazuh v4.3.0', active_response.ARJsonMessage),
+    ('Wazuh v4.1.0', active_response.ARStrMessage)
+])
+def test_correct_builder_is_used(agent_version, builder_type):
+    """Test if the correct builder is used based on the agent version.
+
+    Parameters
+    ----------
+    agent_version : str
+        The version of the agent.
+    builder_type : Type[active_response.ARMessageBuilder]
+        The expected type of the builder based on the agent version.
+    """
+    builder = active_response.ARMessageBuilder.choose_builder(agent_version)
+    assert isinstance(builder, builder_type)
+
+
 @pytest.mark.parametrize('expected_exception, command, arguments, custom', [
     (1650, None, [], False),
     (1652, 'random', [], False),

--- a/framework/wazuh/core/tests/test_active_response.py
+++ b/framework/wazuh/core/tests/test_active_response.py
@@ -97,9 +97,9 @@ def test_create_message(expected_exception, command, arguments, custom):
     """
     if expected_exception:
         with pytest.raises(WazuhError, match=f'.* {expected_exception} .*'):
-            active_response.create_message(command=command, arguments=arguments, custom=custom)
+            active_response.ARStrMessage().create_message(command=command, arguments=arguments, custom=custom)
     else:
-        ret = active_response.create_message(command=command, arguments=arguments, custom=custom)
+        ret = active_response.ARStrMessage().create_message(command=command, arguments=arguments, custom=custom)
         assert command in ret, f'Command not being returned'
         if arguments:
             assert (arg in ret for arg in arguments), f'Arguments not being added'
@@ -134,9 +134,9 @@ def test_create_json_message(expected_exception, command, arguments, alert):
     """
     if expected_exception:
         with pytest.raises(WazuhError, match=f'.* {expected_exception} .*'):
-            active_response.create_json_message(command=command, arguments=arguments, alert=alert)
+            active_response.ARJsonMessage().create_message(command=command, arguments=arguments, alert=alert)
     else:
-        ret = json.loads(active_response.create_json_message(command=command, arguments=arguments, alert=alert))
+        ret = json.loads(active_response.ARJsonMessage().create_message(command=command, arguments=arguments, alert=alert))
         assert ret["version"] == 1, f'Wrong message version'
         assert command in ret["command"], f'Command not being returned'
         if arguments:

--- a/framework/wazuh/core/tests/test_active_response.py
+++ b/framework/wazuh/core/tests/test_active_response.py
@@ -196,6 +196,19 @@ def test_shell_escape(command, expected_escape):
                              ('agent001', 'ls', ['arg1', 'arg2'], {'type': 'Firewall', 'src_ip': '192.168.1.1'})
                          ])
 def test_send_ar_message(agent_id, command, arguments, alert):
+    """ Checks if the functions behaves as expected
+
+    Parameters
+    ----------
+    agent_id : str
+        Agent id
+    command : str
+        Command to be used
+    arguments : List[str]
+        List of arguments for the command
+    alert : Dict[str, str]
+        Alert information
+    """
     mock_agent_info = {'status': 'active', 'version': '3.0'}
     mock_agent_conf = {'active-response': {'disabled': 'no'}}
 
@@ -227,6 +240,18 @@ def test_send_ar_message(agent_id, command, arguments, alert):
                              ({'status': 'active', 'version': '3.0'}, {'active-response': {'disabled': 'yes'}}, 1750),
                          ])
 def test_send_ar_message_nok(mock_agent_info, mock_agent_conf, expected_error_code):
+    """ Checks if the function raises the expected exceptions
+
+    Parameters
+    ----------
+    mock_agent_info : Dict[str, Any]
+        Agent information
+    mock_agent_conf : Dict[str, Any]
+        Agent configuration
+    expected_error_code : int
+        Expected error code
+
+    """
     agent_id = 'agent001'
     command = 'ls'
     arguments = ['arg1', 'arg2']

--- a/framework/wazuh/core/tests/test_active_response.py
+++ b/framework/wazuh/core/tests/test_active_response.py
@@ -130,7 +130,7 @@ def test_create_message(expected_exception, command, arguments):
     (None, 'restart-wazuh0', [], None),
     (None, 'restart-wazuh0', [], None),
     (None, 'restart-wazuh0', ["arg1", "arg2"], None),
-    (None, 'custom-ar', ["arg1", "arg2"], {"data": {"srcip": "1.1.1.1"}})
+    (1652, 'custom-ar', ["arg1", "arg2"], {"data": {"srcip": "1.1.1.1"}})
 ])
 @patch('wazuh.core.common.AR_CONF', new=test_data_path)
 def test_create_json_message(expected_exception, command, arguments, alert):

--- a/framework/wazuh/core/tests/test_active_response.py
+++ b/framework/wazuh/core/tests/test_active_response.py
@@ -88,16 +88,16 @@ def test_correct_builder_is_used(agent_version, builder_type):
     assert isinstance(builder, builder_type)
 
 
-@pytest.mark.parametrize('expected_exception, command, arguments, custom', [
-    (1650, None, [], False),
-    (1652, 'random', [], False),
-    (1652, 'invalid_cmd', [], False),
-    (None, 'restart-wazuh0', [], False),
-    (None, 'restart-wazuh0', [], True),
-    (None, 'restart-wazuh0', ["arg1", "arg2"], False)
+@pytest.mark.parametrize('expected_exception, command, arguments', [
+    (1650, None, []),
+    (1652, 'random', []),
+    (1652, 'invalid_cmd', []),
+    (None, 'restart-wazuh0', []),
+    (None, '!restart-wazuh0', []),
+    (None, 'restart-wazuh0', ["arg1", "arg2"])
 ])
 @patch('wazuh.core.common.AR_CONF', new=test_data_path)
-def test_create_message(expected_exception, command, arguments, custom):
+def test_create_message(expected_exception, command, arguments):
     """Check if the returned message is correct.
 
     Checks if message returned by create_message(...) contains the command, arguments and '!' symbol
@@ -116,14 +116,12 @@ def test_create_message(expected_exception, command, arguments, custom):
     """
     if expected_exception:
         with pytest.raises(WazuhError, match=f'.* {expected_exception} .*'):
-            active_response.ARStrMessage().create_message(command=command, arguments=arguments, custom=custom)
+            active_response.ARStrMessage().create_message(command=command, arguments=arguments)
     else:
-        ret = active_response.ARStrMessage().create_message(command=command, arguments=arguments, custom=custom)
+        ret = active_response.ARStrMessage().create_message(command=command, arguments=arguments)
         assert command in ret, f'Command not being returned'
         if arguments:
             assert (arg in ret for arg in arguments), f'Arguments not being added'
-        if custom:
-            assert '!' in ret, f'! symbol not being added when custom command'
 
 
 @pytest.mark.parametrize('expected_exception, command, arguments, alert', [

--- a/framework/wazuh/tests/test_active_response.py
+++ b/framework/wazuh/tests/test_active_response.py
@@ -27,19 +27,19 @@ full_agent_list = ['000', '001', '002', '003', '004', '005', '006', '007', '008'
 
 # Tests
 
-@pytest.mark.parametrize('message_exception, send_exception, agent_id, command, arguments, custom, alert, version', [
-    (1701, None, ['999'], 'restart-wazuh0', [], False, None, 'Wazuh v4.0.0'),
-    (1703, None, ['000'], 'restart-wazuh0', [], False, None, 'Wazuh v4.0.0'),
-    (1650, None, ['001'], None, [], False, None, 'Wazuh v4.0.0'),
-    (1652, None, ['002'], 'random', [], False, None, 'Wazuh v4.0.0'),
-    (None, 1707, ['003'], 'restart-wazuh0', [], False, None, None),
-    (None, 1750, ['004'], 'restart-wazuh0', [], False, None, 'Wazuh v4.0.0'),
-    (None, None, ['005'], 'restart-wazuh0', [], False, None, 'Wazuh v4.0.0'),
-    (None, None, ['006'], 'custom-ar', [], True, None, 'Wazuh v4.0.0'),
-    (None, None, ['007'], 'restart-wazuh0', ["arg1", "arg2"], False, None, 'Wazuh v4.0.0'),
-    (None, None, ['001', '002', '003', '004', '005', '006'], 'restart-wazuh0', [], False, None, 'Wazuh v4.0.0'),
-    (None, None, ['001'], 'restart-wazuh0', ["arg1", "arg2"], False, None, 'Wazuh v4.2.0'),
-    (None, None, ['002'], 'restart-wazuh0', [], False, None, 'Wazuh v4.2.1'),
+@pytest.mark.parametrize('message_exception, send_exception, agent_id, command, arguments, alert, version', [
+    (1701, None, ['999'], 'restart-wazuh0', [], None, 'Wazuh v4.0.0'),
+    (1703, None, ['000'], 'restart-wazuh0', [], None, 'Wazuh v4.0.0'),
+    (1650, None, ['001'], None, [], None, 'Wazuh v4.0.0'),
+    (1652, None, ['002'], 'random', [], None, 'Wazuh v4.0.0'),
+    (None, 1707, ['003'], 'restart-wazuh0', [], None, None),
+    (None, 1750, ['004'], 'restart-wazuh0', [], None, 'Wazuh v4.0.0'),
+    (None, None, ['005'], 'restart-wazuh0', [], None, 'Wazuh v4.0.0'),
+    (None, None, ['006'], '!custom-ar', [], None, 'Wazuh v4.0.0'),
+    (None, None, ['007'], 'restart-wazuh0', ["arg1", "arg2"], None, 'Wazuh v4.0.0'),
+    (None, None, ['001', '002', '003', '004', '005', '006'], 'restart-wazuh0', [], None, 'Wazuh v4.0.0'),
+    (None, None, ['001'], 'restart-wazuh0', ["arg1", "arg2"], None, 'Wazuh v4.2.0'),
+    (None, None, ['002'], 'restart-wazuh0', [], None, 'Wazuh v4.2.1'),
 ])
 @patch("wazuh.core.wazuh_queue.WazuhQueue._connect")
 @patch("wazuh.syscheck.WazuhQueue._send", return_value='1')
@@ -47,7 +47,7 @@ full_agent_list = ['000', '001', '002', '003', '004', '005', '006', '007', '008'
 @patch('wazuh.core.common.AR_CONF', new=test_data_path)
 @patch('wazuh.active_response.get_agents_info', return_value=full_agent_list)
 def test_run_command(mock_get_agents_info, mock_close, mock_send, mock_conn, message_exception,
-                     send_exception, agent_id, command, arguments, custom, alert, version):
+                     send_exception, agent_id, command, arguments, alert, version):
     """Verify the proper operation of active_response module.
 
     Parameters
@@ -71,10 +71,10 @@ def test_run_command(mock_get_agents_info, mock_close, mock_send, mock_conn, mes
                return_value=agent_info_exception_and_version(send_exception, version)):
         with patch('wazuh.core.agent.Agent.get_config', return_value=agent_config(send_exception)):
             if message_exception:
-                ret = run_command(agent_list=agent_id, command=command, arguments=arguments, custom=custom, alert=alert)
+                ret = run_command(agent_list=agent_id, command=command, arguments=arguments, alert=alert)
                 assert ret.render()['data']['failed_items'][0]['error']['code'] == message_exception
             else:
-                ret = run_command(agent_list=agent_id, command=command, arguments=arguments, custom=custom, alert=alert)
+                ret = run_command(agent_list=agent_id, command=command, arguments=arguments, alert=alert)
                 if send_exception:
                     assert ret.render()['message'] == 'AR command was not sent to any agent'
                     assert ret.render()['data']['failed_items'][0]['error']['code'] == send_exception


### PR DESCRIPTION
|Related issue|
|---|
|[15990](https://github.com/wazuh/wazuh/issues/15990)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill in the table above. Feel free to extend it at your convenience.
-->

## Description

The functions related to the `PUT /active-response` endpoint were refactored.
The create_message function was moved to the `ARMessageBuilder` base class The subclasses `ARStrMessage` and `ARJsonMessage` now override this function to provide their specific implementations.
Depending on the `agent-version` it initializes one of the two new classes for handling the creation of the active-response message. Also, the tests for these modules were updated and new ones were created.


<!--
Add a clear description of how the problem has been solved.
-->


