### PR TITLE
Don't report a solved vulnerability when the package is updated and still vulnerable

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -8580,7 +8580,7 @@ void test_wm_vuldet_send_cve_report_error_alert_create(void **state)
 
     will_return(__wrap_cJSON_CreateObject, NULL);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_INVALID);
 }
@@ -8594,7 +8594,7 @@ void test_wm_vuldet_send_cve_report_error_alert_cve_create(void **state)
     will_return(__wrap_cJSON_CreateObject, NULL);
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_INVALID);
 }
@@ -8613,7 +8613,7 @@ void test_wm_vuldet_send_cve_report_error_j_package_create(void **state)
     will_return(__wrap_cJSON_CreateObject, NULL);
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_INVALID);
 }
@@ -8653,7 +8653,7 @@ void test_wm_vuldet_send_cve_report_error_j_cvss_create(void **state)
     will_return(__wrap_cJSON_CreateObject, NULL);
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_INVALID);
 }
@@ -8697,7 +8697,7 @@ void test_wm_vuldet_send_cve_report_error_j_cvss_node_create(void **state)
     will_return(__wrap_cJSON_CreateObject, NULL);
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_INVALID);
 }
@@ -8829,7 +8829,7 @@ void test_wm_vuldet_send_cve_report_error_j_advisories_create(void **state)
     will_return(__wrap_cJSON_CreateArray, NULL);
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_INVALID);
 }
@@ -8970,7 +8970,7 @@ void test_wm_vuldet_send_cve_report_error_j_bug_references_create(void **state)
     will_return(__wrap_cJSON_CreateArray, NULL);
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_INVALID);
 }
@@ -9119,7 +9119,7 @@ void test_wm_vuldet_send_cve_report_error_j_references_create(void **state)
     will_return(__wrap_cJSON_CreateArray, NULL);
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_INVALID);
 }
@@ -9290,7 +9290,7 @@ void test_wm_vuldet_send_cve_report_without_title(void **state)
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_SUCCESS);
 }
@@ -9460,7 +9460,7 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_SUCCESS);
 }
@@ -9631,7 +9631,7 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_SUCCESS);
 }
@@ -9802,7 +9802,7 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_SUCCESS);
 }
@@ -9987,7 +9987,7 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    int retval = wm_vuldet_send_cve_report(report);
+    int retval = wm_vuldet_send_cve_report(report, false);
 
     assert_int_equal(retval, OS_SUCCESS);
 

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -9465,6 +9465,193 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
     assert_int_equal(retval, OS_SUCCESS);
 }
 
+void test_wm_vuldet_send_cve_report_check_title(void **state)
+{
+    vu_report* report = state[REPORT_CVE_REPORT_POS];
+
+    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1))
+        return;
+
+    cJSON* alert = (cJSON *)1;
+    cJSON* alert_cve = (cJSON *)1;
+    cJSON* j_package = (cJSON *)1;
+    cJSON* j_cvss = (cJSON *)1;
+    cJSON* j_cvss_node = (cJSON *)1;
+    cJSON* cvss_json = (cJSON *)1;
+    cJSON* j_advisories = (cJSON *)1;
+
+    char *json_text = NULL;
+    os_strdup("{\"title\": \"vulnerability detector alert json\"}", json_text);
+
+    will_return_always(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    will_return(__wrap_cJSON_CreateObject, alert);
+    will_return(__wrap_cJSON_CreateObject, alert_cve);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    // Adding package information
+    will_return(__wrap_cJSON_CreateObject, j_package);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "name");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->software);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "source");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->source);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->condition);
+    // Adding cvss information
+    will_return(__wrap_cJSON_CreateObject, j_cvss);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    will_return(__wrap_cJSON_CreateObject, j_cvss_node);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    will_return(__wrap_cJSON_CreateObject, cvss_json);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "attack_vector");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "network");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "access_complexity");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "medium");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "authentication");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "none");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "confidentiality_impact");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "none");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "integrity_impact");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "none");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "availability");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "complete");
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    expect_value(__wrap_cJSON_CreateNumber, num, 7.1);
+    will_return(__wrap_cJSON_CreateNumber, NULL);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    expect_value(__wrap_cJSON_CreateNumber, num, 8.6);
+    will_return(__wrap_cJSON_CreateNumber, NULL);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    expect_value(__wrap_cJSON_CreateNumber, num, 6.9);
+    will_return(__wrap_cJSON_CreateNumber, NULL);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    will_return(__wrap_cJSON_CreateObject, j_cvss_node);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    will_return(__wrap_cJSON_CreateObject, cvss_json);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "attack_vector");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "network");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "access_complexity");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "high");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "privileges_required");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "none");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "user_interaction");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "none");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "scope");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "unchanged");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "confidentiality_impact");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "none");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "integrity_impact");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "none");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "availability");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "high");
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    expect_value(__wrap_cJSON_CreateNumber, num, 5.9);
+    will_return(__wrap_cJSON_CreateNumber, NULL);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    expect_value(__wrap_cJSON_CreateNumber, num, 2.2);
+    will_return(__wrap_cJSON_CreateNumber, NULL);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    expect_value(__wrap_cJSON_CreateNumber, num, 3.6);
+    will_return(__wrap_cJSON_CreateNumber, NULL);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    // Adding CVE information
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->cve);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "title");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "Version of package nettle affected by CVE-2016-6489 was updated but it is still vulnerable");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "rationale");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
+    expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "published");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->type);
+    // Adding advisories data
+    will_return(__wrap_cJSON_CreateArray, j_advisories);
+    expect_string(__wrap_cJSON_CreateString, string, "RHSA-2020:0975");
+    will_return(__wrap_cJSON_CreateString, NULL);
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    // Adding bugzilla references data
+    will_return(__wrap_cJSON_CreateArray, j_advisories);
+    expect_string(__wrap_cJSON_CreateString, string, "http://rhn.redhat.org/cgi-bin/bugreport.cgi?bug=925286");
+    will_return(__wrap_cJSON_CreateString, NULL);
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    // Adding references data
+    will_return(__wrap_cJSON_CreateArray, j_advisories);
+    expect_string(__wrap_cJSON_CreateString, string, "http://rhn.redhat.com/errata/RHSA-2016-2582.html");
+    will_return(__wrap_cJSON_CreateString, NULL);
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "assigner");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->assigner);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cve_version");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->cve_version);
+    will_return(__wrap_cJSON_PrintUnformatted, json_text);
+
+    will_return(__wrap_wm_sendmsg, OS_INVALID);
+    expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
+    expect_value(__wrap_wm_sendmsg, queue, 1);
+    expect_string(__wrap_wm_sendmsg, message, "1:vulnerability-detector:{\"title\": \"vulnerability detector alert json\"}");
+    expect_string(__wrap_wm_sendmsg, locmsg, "[001] (Ubuntu_WAgent) 192.168.0.125");
+    expect_value(__wrap_wm_sendmsg, loc, SECURE_MQ);
+
+    char* strerr = NULL;
+    os_strdup("Error sending message", strerr);
+    will_return(__wrap_strerror, strerr);
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Error sending message'");
+
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQ, type, WRITE);
+    will_return(__wrap_StartMQ, -1);
+
+    expect_string(__wrap__mterror_exit, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror_exit, formatted_msg, "(1211): Unable to access queue: 'queue/sockets/queue'. Giving up.");
+
+    expect_function_call(__wrap_cJSON_Delete);
+
+    int retval = wm_vuldet_send_cve_report(report, true);
+
+    assert_int_equal(retval, OS_SUCCESS);
+
+    os_free(strerr);
+}
+
 void test_wm_vuldet_send_cve_report_without_ip(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
@@ -23391,6 +23578,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_references_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_without_title, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_without_condition, setup_cve_report, teardown_cve_report),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_check_title, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_without_ip, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_without_hotfix, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_sendmsg_error, setup_cve_report, teardown_cve_report),

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -276,7 +276,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_BY_PK] = "DELETE FROM sys_osinfo WHERE os_name = ?;",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_CLEAR] = "DELETE FROM sys_osinfo;",
     [WDB_STMT_VULN_CVES_INSERT] = "INSERT INTO vuln_cves (name, version, architecture, cve, reference, type, status, severity, cvss2_score, cvss3_score, detection_time, external_references, condition, title, published, updated) VALUES (?,?,?,?,?,?,?,?,?,?,strftime('%s', 'now'),?,?,?,?,?)"
-                                  "ON CONFLICT (reference, cve) DO UPDATE SET type = excluded.type, status = excluded.status, severity = excluded.severity, cvss2_score = excluded.cvss2_score, cvss3_score = excluded.cvss3_score, detection_time = detection_time, external_references = excluded.external_references, condition = excluded.condition, title = excluded.title, published = excluded.published, updated = excluded.updated;",
+                                  "ON CONFLICT (reference, cve) DO UPDATE SET version = excluded.version, type = excluded.type, status = excluded.status, severity = excluded.severity, cvss2_score = excluded.cvss2_score, cvss3_score = excluded.cvss3_score, detection_time = detection_time, external_references = excluded.external_references, condition = excluded.condition, title = excluded.title, published = excluded.published, updated = excluded.updated;",
     [WDB_STMT_VULN_CVES_UPDATE] = "UPDATE vuln_cves SET status = ? WHERE status = ?;",
     [WDB_STMT_VULN_CVES_UPDATE_BY_TYPE] = "UPDATE vuln_cves SET status = ? WHERE type = ?;",
     [WDB_STMT_VULN_CVES_UPDATE_ALL] = "UPDATE vuln_cves SET status = ?",

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -333,7 +333,7 @@ constexpr auto PACKAGES_SQL_STATEMENT
     item_id TEXT,
     PRIMARY KEY (name,version,architecture,format,location)) WITHOUT ROWID;)"
 };
-static const std::vector<std::string> PACKAGES_ITEM_ID_FIELDS{"name", "version", "architecture", "format", "location"};
+static const std::vector<std::string> PACKAGES_ITEM_ID_FIELDS{"name", "architecture", "format", "location"};
 
 constexpr auto PACKAGES_SYNC_CONFIG_STATEMENT
 {

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -151,7 +151,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -183,7 +183,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -407,7 +407,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -435,7 +435,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -580,7 +580,7 @@ TEST_F(SyscollectorImpTest, noOs)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult11
     {
@@ -608,7 +608,7 @@ TEST_F(SyscollectorImpTest, noOs)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -740,7 +740,7 @@ TEST_F(SyscollectorImpTest, noNetwork)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -760,7 +760,7 @@ TEST_F(SyscollectorImpTest, noNetwork)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -1075,7 +1075,7 @@ TEST_F(SyscollectorImpTest, noPorts)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1103,7 +1103,7 @@ TEST_F(SyscollectorImpTest, noPorts)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -1252,7 +1252,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1284,7 +1284,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -1428,7 +1428,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1456,7 +1456,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -1606,7 +1606,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1638,7 +1638,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -1809,7 +1809,7 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
     };
     const auto expectedResult5
     {
-        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
     };
     const auto expectedResult6
     {
@@ -1857,7 +1857,7 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
     };
     const auto expectedResult17
     {
-        R"({"data":{"architecture":"amd64","checksum":"c1a125f40a70bab20a252f42ea4ec0dcf90733e8","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","os_patch":null,"priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c1a125f40a70bab20a252f42ea4ec0dcf90733e8","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","os_patch":null,"priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult18
     {
@@ -2305,7 +2305,7 @@ TEST_F(SyscollectorImpTest, PackagesDuplicated)
 
     const auto expectedResult1
     {
-        R"({"data":{"architecture":"amd64","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
 
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1792,7 +1792,7 @@ int wm_vuldet_send_cve_report(vu_report *report, bool updated) {
             if (!updated)
                 cJSON_AddStringToObject(alert_cve, "title", report->title);
             else {
-                char *title;
+                char title[100];
                 sprintf(title, "Version of package %s affected by %s was updated but it is still vulnerable", report->source, report->cve);
                 cJSON_AddStringToObject(alert_cve, "title", title);
             }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1688,20 +1688,19 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
                     "exists");
             }
 
-            if (!update) {
-                // Sending CVE report
-                if (wm_vuldet_send_cve_report(report)) {
-                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve ? report->cve : "", report->software ? report->software : "" , scan_ctx->agent_id);
-                } else {
-                    if (pkg->feed & VU_SRC_NVD) {
-                        vuln_reported_nvd++;
-                    }
-                    if (pkg->feed & VU_SRC_OVAL) {
-                        vuln_reported_vendor++;
-                    }
-                    vuln_reported++;
+            // Sending CVE report
+            if (wm_vuldet_send_cve_report(report, update)) {
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve ? report->cve : "", report->software ? report->software : "" , scan_ctx->agent_id);
+            } else {
+                if (pkg->feed & VU_SRC_NVD) {
+                    vuln_reported_nvd++;
                 }
+                if (pkg->feed & VU_SRC_OVAL) {
+                    vuln_reported_vendor++;
+                }
+                vuln_reported++;
             }
+            
             wm_vuldet_free_report(report);
 
             pkg = next;
@@ -1729,7 +1728,7 @@ error:
     return OS_INVALID;
 }
 
-int wm_vuldet_send_cve_report(vu_report *report) {
+int wm_vuldet_send_cve_report(vu_report *report, bool updated) {
     cJSON *alert = NULL;
     cJSON *alert_cve = NULL;
     int retval = OS_INVALID;
@@ -1790,7 +1789,13 @@ int wm_vuldet_send_cve_report(vu_report *report) {
         // Set the alert body
         cJSON_AddStringToObject(alert_cve, "cve", report->cve);
         if (report->title) {
-            cJSON_AddStringToObject(alert_cve, "title", report->title);
+            if (!updated)
+                cJSON_AddStringToObject(alert_cve, "title", report->title);
+            else {
+                char *title;
+                sprintf(title, "Version of package %s affected by %s was updated but it is still vulnerable", report->source, report->cve);
+                cJSON_AddStringToObject(alert_cve, "title", title);
+            }
         }
         if (report->rationale) {
             cJSON_AddStringToObject(alert_cve, "rationale", report->rationale);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -1039,7 +1039,7 @@ int wm_checks_package_vulnerability(char *version_a, const char *operation, cons
  * @param report An already generated report that must be parsed and sent.
  * @return 0 on success, -1 otherwise.
  */
-int wm_vuldet_send_cve_report(vu_report *report);
+int wm_vuldet_send_cve_report(vu_report *report, bool updated);
 
 /**
  * @brief Send a report for a removed CVE and the affected package.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2426,7 +2426,7 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
         if (!update) {
             // No report should be generated for vulnerabilities already reported
             // Sending CVE report
-            wm_vuldet_send_cve_report(report);
+            wm_vuldet_send_cve_report(report,update);
         }
 
         wm_vuldet_free_nvd_report(f_report_node);


### PR DESCRIPTION
|Related issue|
|---|
|#13354|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This pull request aims to change the Vuln-Detector alerts flow. Before this PR when updating the version of a vulnerable package to a certain CVE, Wazuh reported an alert as this vulnerability would have been first encountered. 

Now, when the version of a certain package is updated but remains vulnerable, the system checks if this new version solves the vulnerability or not, and change the description of the alert in order to correctly inform that the package is still vulnerable, but its version has been updated. If the new version really solves the vulnerability, a different alert is shown informing that the vulnerability has been totally solved.

## Configuration options
To test this PR, there are some configuration requirements.

This PR must be tested using an ubuntu20 agent, the server is not mandatory to be this version.
First of all, it's mandatory to load a custom CVE in the manager which checks the vulnerability of a fictitious package called `dummy-fixed`. 

<details><summary>custom_ubuntu_focal_oval_feed.xml</summary>

``` xml
<oval_definitions
    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
    xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
    xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
    xmlns:linux-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#macos linux-definitions-schema.xsd">

    <generator>
        <oval:product_name>Canonical CVE OVAL Generator</oval:product_name>
        <oval:product_version>1.1</oval:product_version>
        <oval:schema_version>5.11.1</oval:schema_version>
        <oval:timestamp>2021-11-16T15:30:28</oval:timestamp>
    </generator>
    <definitions>
        <definition class="vulnerability" id="oval:com.ubuntu.focal:def:200224390000000" version="1">
            <metadata>
                <title>CVE-2022-2022 on Ubuntu 20.04 (focal) - low.</title>
                <description>Dummy description</description>
                <affected family="unix">
                    <platform>Ubuntu 20.04</platform>
                </affected>
                <reference source="CVE" ref_id="CVE-2022-2022" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2022" />
                <advisory>
                    <severity>Low</severity>
                    <rights>Copyright (C) 2015 Canonical Ltd.</rights>
                    <public_date>2022-05-04</public_date>
                    <ref>http://people.canonical.com/~ubuntu-security/cve/2002/CVE-2022-2022.html</ref>
                </advisory>
            </metadata>
            <criteria>
                <extend_definition definition_ref="oval:com.ubuntu.focal:def:100" comment="Ubuntu 20.04 (focal) is installed." applicability_check="true" />
                <criteria operator="OR">
                    <criterion test_ref="oval:com.ubuntu.focal:tst:200224390000040" comment="dummy-fixed package in focal, is related to the CVE in some way and has been fixed (note: '10.0.0-0ubuntu1')." />
                </criteria>
            </criteria>
        </definition>
    </definitions>
    <tests>
        <linux-def:dpkginfo_test id="oval:com.ubuntu.focal:tst:200224390000040" version="1" check_existence="at_least_one_exists" check="at least one" comment="Does the 'dummy-fixed' package exist and is the version less than '10.0.0-0ubuntu1'?">
            <linux-def:object object_ref="oval:com.ubuntu.focal:obj:200224390000040"/>
            <linux-def:state state_ref="oval:com.ubuntu.focal:ste:200224390000040" />
        </linux-def:dpkginfo_test>
    </tests>
    <objects>
        <linux-def:dpkginfo_object id="oval:com.ubuntu.focal:obj:200224390000040" version="1" comment="The 'dummy-fixed' package binary.">
            <linux-def:name var_ref="oval:com.ubuntu.focal:var:200224390000040" var_check="at least one" />
            <linux-def:name>dummy-fixed</linux-def:name>
        </linux-def:dpkginfo_object>
    </objects>
    <states>
        <linux-def:dpkginfo_state id="oval:com.ubuntu.focal:ste:200224390000040" version="1" comment="The package version is less than '0:10.0.0-0ubuntu1'.">
            <linux-def:evr datatype="debian_evr_string" operation="less than">0:10.0.0-0ubuntu1</linux-def:evr>
        </linux-def:dpkginfo_state>
    </states>
    <variables>
        <constant_variable id="oval:com.ubuntu.focal:var:200224390000040" version="1" datatype="string" comment="'dummy-fixed' package binaries">
            <value>dummy-fixed</value>
        </constant_variable>
    </variables>
</oval_definitions>

```

</details>

Then, the new CVE must be loaded, here is an example of the ossec.conf Vulnerability-detector configuration block.

<details><summary>ossec.conf Vulnerability-detector example block</summary>

``` xml
<vulnerability-detector>
    <enabled>yes</enabled>
    <interval>1m</interval>
    <min_full_scan_interval>2m</min_full_scan_interval>
    <run_on_start>yes</run_on_start>

    <!-- Ubuntu OS vulnerabilities -->
    <provider name="canonical">
      <enabled>yes</enabled>
      <os path="/home/vagrant/custom_ubuntu_focal_oval_feed.xml">focal</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Debian OS vulnerabilities -->
    <provider name="debian">
      <enabled>no</enabled>
      <os>buster</os>
      <os>bullseye</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- RedHat OS vulnerabilities -->
    <provider name="redhat">
      <enabled>no</enabled>
      <os>5</os>
      <os>6</os>
      <os>7</os>
      <os>8</os>
      <os>9</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Amazon Linux OS vulnerabilities -->
    <provider name="alas">
      <enabled>no</enabled>
      <os>amazon-linux</os>
      <os>amazon-linux-2</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- SUSE OS vulnerabilities -->
    <provider name="suse">
      <enabled>no</enabled>
      <os>11-server</os>
      <os>11-desktop</os>
      <os>12-server</os>
      <os>12-desktop</os>
      <os>15-server</os>
      <os>15-desktop</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Arch OS vulnerabilities -->
    <provider name="arch">
      <enabled>no</enabled>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Windows OS vulnerabilities -->
    <provider name="msu">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Aggregate vulnerabilities -->
    <provider name="nvd">
      <enabled>yes</enabled>
      <update_from_year>2022</update_from_year>
      <update_interval>1h</update_interval>
    </provider>

</vulnerability-detector>

```

</details>

And finally in the `/var/lib/dpkg/status` file in the agent, a new entry for the `dummy-fixed` must be added.

<details><summary>dummy-fixed entry</summary>

```
Package: dummy-fixed
Status: install ok installed
Priority: required
Section: libs
Installed-Size: 164
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Architecture: amd64
Multi-Arch: same
Source: dummy-fixed
Version: 1.0.0-0ubuntu1
Provides: libz1
Depends: libc6 (>= 2.14)
Breaks: libxml2 (<< 2.7.6.dfsg-2), texlive-binaries (<< 2009-12)
Conflicts: zlib1 (<= 1:1.0.4-7)
Description: compression library - runtime
 zlib is a library implementing the deflate compression method found
 in gzip and PKZIP.  This package includes the shared library.
Homepage: http://zlib.net/
Original-Maintainer: Mark Brown <broonie@debian.org>
```

</details>

To check the behavior of this implementation, the version can be changed, as for example: `Version: 2.0.0-0ubuntu1` and rerun a vuln-detector scan.

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<details><summary>First detection alert</summary>

```
** Alert 1683725699.59884: - vulnerability-detector,gdpr_IV_35.7.d,pci_dss_11.2.1,pci_dss_11.2.3,tsc_CC7.1,tsc_CC7.2,
2023 May 10 13:34:59 (agent1-ubu20) any->vulnerability-detector
Rule: 23504 (level 7) -> 'CVE-2022-2022 affects dummy-fixed'
{"vulnerability":{"package":{"name":"dummy-fixed","source":"dummy-fixed","version":"1.0.0-0ubuntu1","architecture":"amd64","condition":"Package less than 10.0.0-0ubuntu1"},"cvss":{"cvss2":{"vector":{"attack_vector":"network","access_complexity":"medium","authentication":"single","confidentiality_impact":"none","integrity_impact":"partial","availability":"none"},"base_score":3.5},"cvss3":{"vector":{"attack_vector":"network","access_complexity":"low","privileges_required":"low","user_interaction":"required","scope":"changed","confidentiality_impact":"low","integrity_impact":"low","availability":"none"},"base_score":5.4}},"cve":"CVE-2022-2022","title":"CVE-2022-2022 affects dummy-fixed","rationale":"Cross-site Scripting (XSS) - Stored in GitHub repository nocodb/nocodb prior to 0.91.7.","severity":"Medium","published":"2022-06-07","updated":"2022-06-16","cwe_reference":"CWE-79","status":"Active","type":"PACKAGE","references":["https://github.com/nocodb/nocodb/commit/ffad5a318ad60d1da1c75dd28152827b94c92e9d","https://huntr.dev/bounties/f6082949-40d3-411c-b613-23ada2691913","https://nvd.nist.gov/vuln/detail/CVE-2022-2022","http://people.canonical.com/~ubuntu-security/cve/2002/CVE-2022-2022.html","https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2022"],"assigner":"security@huntr.dev","cve_version":"4.0"}}
vulnerability.package.name: dummy-fixed
vulnerability.package.source: dummy-fixed
vulnerability.package.version: 1.0.0-0ubuntu1
vulnerability.package.architecture: amd64
vulnerability.package.condition: Package less than 10.0.0-0ubuntu1
vulnerability.cvss.cvss2.vector.attack_vector: network
vulnerability.cvss.cvss2.vector.access_complexity: medium
vulnerability.cvss.cvss2.vector.authentication: single
vulnerability.cvss.cvss2.vector.confidentiality_impact: none
vulnerability.cvss.cvss2.vector.integrity_impact: partial
vulnerability.cvss.cvss2.vector.availability: none
vulnerability.cvss.cvss2.base_score: 3.500000
vulnerability.cvss.cvss3.vector.attack_vector: network
vulnerability.cvss.cvss3.vector.access_complexity: low
vulnerability.cvss.cvss3.vector.privileges_required: low
vulnerability.cvss.cvss3.vector.user_interaction: required
vulnerability.cvss.cvss3.vector.scope: changed
vulnerability.cvss.cvss3.vector.confidentiality_impact: low
vulnerability.cvss.cvss3.vector.integrity_impact: low
vulnerability.cvss.cvss3.vector.availability: none
vulnerability.cvss.cvss3.base_score: 5.400000
vulnerability.cve: CVE-2022-2022
vulnerability.title: CVE-2022-2022 affects dummy-fixed
vulnerability.rationale: Cross-site Scripting (XSS) - Stored in GitHub repository nocodb/nocodb prior to 0.91.7.
vulnerability.severity: Medium
vulnerability.published: 2022-06-07
vulnerability.updated: 2022-06-16
vulnerability.cwe_reference: CWE-79
vulnerability.status: Active
vulnerability.type: PACKAGE
vulnerability.references: ["https://github.com/nocodb/nocodb/commit/ffad5a318ad60d1da1c75dd28152827b94c92e9d", "https://huntr.dev/bounties/f6082949-40d3-411c-b613-23ada2691913", "https://nvd.nist.gov/vuln/detail/CVE-2022-2022", "http://people.canonical.com/~ubuntu-security/cve/2002/CVE-2022-2022.html", "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2022"]
vulnerability.assigner: security@huntr.dev
vulnerability.cve_version: 4.0
```

</details>

<details><summary>Update (still vulnerable) version alert</summary>

```
** Alert 1683733388.70674: - vulnerability-detector,gdpr_IV_35.7.d,pci_dss_11.2.1,pci_dss_11.2.3,tsc_CC7.1,tsc_CC7.2,
2023 May 10 15:43:08 (agent1-ubu20) any->vulnerability-detector
Rule: 23504 (level 7) -> 'CVE-2022-2022 affects dummy-fixed'
{"vulnerability":{"package":{"name":"dummy-fixed","source":"dummy-fixed","version":"3.0.0-0ubuntu1","architecture":"amd64","condition":"Package less than 10.0.0-0ubuntu1"},"cvss":{"cvss2":{"vector":{"attack_vector":"network","access_complexity":"medium","authentication":"single","confidentiality_impact":"none","integrity_impact":"partial","availability":"none"},"base_score":3.5},"cvss3":{"vector":{"attack_vector":"network","access_complexity":"low","privileges_required":"low","user_interaction":"required","scope":"changed","confidentiality_impact":"low","integrity_impact":"low","availability":"none"},"base_score":5.4}},"cve":"CVE-2022-2022","title":"Version of package dummy-fixed affected by CVE-2022-2022 was updated but it is still vulnerable","rationale":"Cross-site Scripting (XSS) - Stored in GitHub repository nocodb/nocodb prior to 0.91.7.","severity":"Medium","published":"2022-06-07","updated":"2022-06-16","cwe_reference":"CWE-79","status":"Active","type":"PACKAGE","references":["https://github.com/nocodb/nocodb/commit/ffad5a318ad60d1da1c75dd28152827b94c92e9d","https://huntr.dev/bounties/f6082949-40d3-411c-b613-23ada2691913","https://nvd.nist.gov/vuln/detail/CVE-2022-2022","http://people.canonical.com/~ubuntu-security/cve/2002/CVE-2022-2022.html","https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2022"],"assigner":"security@huntr.dev","cve_version":"4.0"}}
vulnerability.package.name: dummy-fixed
vulnerability.package.source: dummy-fixed
vulnerability.package.version: 3.0.0-0ubuntu1
vulnerability.package.architecture: amd64
vulnerability.package.condition: Package less than 10.0.0-0ubuntu1
vulnerability.cvss.cvss2.vector.attack_vector: network
vulnerability.cvss.cvss2.vector.access_complexity: medium
vulnerability.cvss.cvss2.vector.authentication: single
vulnerability.cvss.cvss2.vector.confidentiality_impact: none
vulnerability.cvss.cvss2.vector.integrity_impact: partial
vulnerability.cvss.cvss2.vector.availability: none
vulnerability.cvss.cvss2.base_score: 3.500000
vulnerability.cvss.cvss3.vector.attack_vector: network
vulnerability.cvss.cvss3.vector.access_complexity: low
vulnerability.cvss.cvss3.vector.privileges_required: low
vulnerability.cvss.cvss3.vector.user_interaction: required
vulnerability.cvss.cvss3.vector.scope: changed
vulnerability.cvss.cvss3.vector.confidentiality_impact: low
vulnerability.cvss.cvss3.vector.integrity_impact: low
vulnerability.cvss.cvss3.vector.availability: none
vulnerability.cvss.cvss3.base_score: 5.400000
vulnerability.cve: CVE-2022-2022
vulnerability.title: Version of package dummy-fixed affected by CVE-2022-2022 was updated but it is still vulnerable
vulnerability.rationale: Cross-site Scripting (XSS) - Stored in GitHub repository nocodb/nocodb prior to 0.91.7.
vulnerability.severity: Medium
vulnerability.published: 2022-06-07
vulnerability.updated: 2022-06-16
vulnerability.cwe_reference: CWE-79
vulnerability.status: Active
vulnerability.type: PACKAGE
vulnerability.references: ["https://github.com/nocodb/nocodb/commit/ffad5a318ad60d1da1c75dd28152827b94c92e9d", "https://huntr.dev/bounties/f6082949-40d3-411c-b613-23ada2691913", "https://nvd.nist.gov/vuln/detail/CVE-2022-2022", "http://people.canonical.com/~ubuntu-security/cve/2002/CVE-2022-2022.html", "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2022"]
vulnerability.assigner: security@huntr.dev
vulnerability.cve_version: 4.0
```

</details>

<details><summary>Update (solved vulnerability) version alert</summary>

```
** Alert 1683725398.57353: - vulnerability-detector,gdpr_IV_35.7.d,pci_dss_11.2.1,pci_dss_11.2.3,tsc_CC7.1,tsc_CC7.2,
2023 May 10 13:29:58 (agent1-ubu20) any->vulnerability-detector
Rule: 23502 (level 3) -> 'The CVE-2022-2022 that affected dummy-fixed was solved due to a package removal/update or a system upgrade'
{"vulnerability":{"package":{"name":"dummy-fixed","version":"8.0.0-0ubuntu1","architecture":"amd64"},"cve":"CVE-2022-2022","status":"Solved","type":"PACKAGE","title":"CVE-2022-2022 affecting dummy-fixed was solved","severity":"Medium","published":"2022-06-07","updated":"2022-06-16","cvss":{"cvss2":{"base_score":3.5},"cvss3":{"base_score":5.4}},"references":["https://github.com/nocodb/nocodb/commit/ffad5a318ad60d1da1c75dd28152827b94c92e9d","https://huntr.dev/bounties/f6082949-40d3-411c-b613-23ada2691913","https://nvd.nist.gov/vuln/detail/CVE-2022-2022","http://people.canonical.com/~ubuntu-security/cve/2002/CVE-2022-2022.html","https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2022"]}}
vulnerability.package.name: dummy-fixed
vulnerability.package.version: 8.0.0-0ubuntu1
vulnerability.package.architecture: amd64
vulnerability.cve: CVE-2022-2022
vulnerability.status: Solved
vulnerability.type: PACKAGE
vulnerability.title: CVE-2022-2022 affecting dummy-fixed was solved
vulnerability.severity: Medium
vulnerability.published: 2022-06-07
vulnerability.updated: 2022-06-16
vulnerability.cvss.cvss2.base_score: 3.500000
vulnerability.cvss.cvss3.base_score: 5.400000
vulnerability.references: ["https://github.com/nocodb/nocodb/commit/ffad5a318ad60d1da1c75dd28152827b94c92e9d", "https://huntr.dev/bounties/f6082949-40d3-411c-b613-23ada2691913", "https://nvd.nist.gov/vuln/detail/CVE-2022-2022", "http://people.canonical.com/~ubuntu-security/cve/2002/CVE-2022-2022.html", "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2022"]
```

</details>


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
