### PR TITLE
[4.4] Update Flask and related dependencies

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -28,7 +28,7 @@ docker-pycreds==0.4.0
 docutils==0.15.2
 ecdsa==0.16.1
 envparse==0.2.0
-Flask==2.0.0
+Flask==2.2.5
 frozenlist==1.2.0
 future==0.18.3
 google-api-core==1.30.0
@@ -43,6 +43,7 @@ grpc-google-iam-v1==0.12.3
 grpcio==1.38.1
 hiredis==1.1.0
 idna==2.9
+importlib-metadata==3.10.1
 inflection==0.3.1
 itsdangerous==2.0.0
 Jinja2==3.0.0
@@ -85,3 +86,4 @@ websocket-client==0.57.0
 Werkzeug==2.2.3
 xmltodict==0.12.0
 yarl==1.6.3
+zipp==3.3.2


### PR DESCRIPTION
|Related issue|
|---|
| #17013 |

## Description

Closes #17013. It updates the Flask dependency to version `2.2.5` due to a recent patch of the package and adds two new dependencies: `importlib-metadata` and `zipp`.
Flask dependencies tree section after the update:
```
 - flask [required: >=1.0.4, installed: 2.2.5]
    - click [required: >=8.0, installed: 8.1.3]
    - importlib-metadata [required: >=3.6.0, installed: 3.10.1]
      - zipp [required: >=0.5, installed: 3.3.2]
```