### PR TITLE
Revert "Allow API endpoints to read between default and custom ruleset using query parameter" (PR #16033)

### DIFF
--- a/api/api/controllers/decoder_controller.py
+++ b/api/api/controllers/decoder_controller.py
@@ -204,7 +204,7 @@ async def get_decoders_parents(request, pretty: bool = False, wait_for_complete:
 
 
 async def get_file(request, pretty: bool = False, wait_for_complete: bool = False, filename: str = None,
-                   raw: bool = False, default_ruleset: bool = True) -> Union[web.Response, ConnexionResponse]:
+                   raw: bool = False) -> Union[web.Response, ConnexionResponse]:
     """Get decoder file content.
 
     Parameters
@@ -218,8 +218,6 @@ async def get_file(request, pretty: bool = False, wait_for_complete: bool = Fals
         Filename to download.
     raw : bool
         Whether to return the file content in raw or JSON format.
-    default_ruleset : bool
-        Whether to search for the rule in the default ruleset path or not. Default `True`
 
     Returns
     -------
@@ -229,7 +227,7 @@ async def get_file(request, pretty: bool = False, wait_for_complete: bool = Fals
             raw=False (default) -> web.Response (application/json)
         If any exception was raised, it will return a web.Response with details.
     """
-    f_kwargs = {'filename': filename, 'raw': raw, 'default_ruleset': default_ruleset}
+    f_kwargs = {'filename': filename, 'raw': raw}
 
     dapi = DistributedAPI(f=decoder_framework.get_decoder_file,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/rule_controller.py
+++ b/api/api/controllers/rule_controller.py
@@ -266,7 +266,7 @@ async def get_rules_files(request, pretty: bool = False, wait_for_complete: bool
 
 @cache(expires=api_conf['cache']['time'])
 async def get_file(request, pretty: bool = False, wait_for_complete: bool = False, filename: str = None,
-                   raw: bool = False, default_ruleset: bool = True) -> Union[web.Response, ConnexionResponse]:
+                   raw: bool = False) -> Union[web.Response, ConnexionResponse]:
     """Get rule file content.
 
     Parameters
@@ -280,8 +280,6 @@ async def get_file(request, pretty: bool = False, wait_for_complete: bool = Fals
         Filename to download.
     raw : bool, optional
         Whether to return the file content in raw or JSON format. Default `False`
-    default_ruleset : bool
-        Whether to search for the rule in the default ruleset path or not. Default `True`
 
     Returns
     -------
@@ -291,7 +289,7 @@ async def get_file(request, pretty: bool = False, wait_for_complete: bool = Fals
             raw=False (default) -> web.Response      (application/json)
         If any exception was raised, it will return a web.Response with details.
     """
-    f_kwargs = {'filename': filename, 'raw': raw, 'default_ruleset': default_ruleset}
+    f_kwargs = {'filename': filename, 'raw': raw}
 
     dapi = DistributedAPI(f=rule_framework.get_rule_file,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/test/test_decoder_controller.py
+++ b/api/api/controllers/test/test_decoder_controller.py
@@ -127,8 +127,7 @@ async def test_get_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_bool,
     with patch('api.controllers.decoder_controller.isinstance', return_value=mock_bool) as mock_isinstance:
         result = await get_file(request=mock_request)
         f_kwargs = {'filename': None,
-                    'raw': False,
-                    'default_ruleset': True
+                    'raw': False
                     }
         mock_dapi.assert_called_once_with(f=decoder_framework.get_decoder_file,
                                           f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_rule_controller.py
+++ b/api/api/controllers/test/test_rule_controller.py
@@ -166,8 +166,7 @@ async def test_get_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_bool,
     with patch('api.controllers.rule_controller.isinstance', return_value=mock_bool) as mock_isinstance:
         result = await get_file(request=mock_request)
         f_kwargs = {'filename': None,
-                    'raw': False,
-                    'default_ruleset': True
+                    'raw': False
                     }
         mock_dapi.assert_called_once_with(f=rule_framework.get_rule_file,
                                           f_kwargs=mock_remove.return_value,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6984,14 +6984,6 @@ components:
       schema:
         type: string
         format: xml_filename_path
-    default_ruleset_path:
-      in: query
-      name: default_ruleset
-      description: "Search for the given filename in the Wazuh default ruleset if true. Otherwise, search for it in the custom user ruleset"
-      required: false
-      schema:
-        type: boolean
-        default: true
 
 
 tags:
@@ -13994,7 +13986,6 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/xml_filename_path'
         - $ref: '#/components/parameters/raw'
-        - $ref: '#/components/parameters/default_ruleset_path'
       responses:
         '200':
           description: "Rule content"
@@ -14771,7 +14762,6 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/xml_filename_path'
         - $ref: '#/components/parameters/raw'
-        - $ref: '#/components/parameters/default_ruleset_path'
       responses:
         '200':
           description: "Decoder content"

--- a/api/test/integration/test_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoder_endpoints.tavern.yaml
@@ -1012,29 +1012,6 @@ stages:
           total_failed_items: 1
         error: 1
 
-  - name: Download a decoders file (user ruleset, decoder belongs to default ruleset)
-    request:
-      verify: False
-      method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        default_ruleset: false
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items: []
-          total_affected_items: 0
-          failed_items:
-            - error:
-                code: 1503
-              id:
-                - "0005-wazuh_decoders.xml"
-          total_failed_items: 1
-        error: 1
-
   - name: Download decoder (invalid file 1)
     request:
       verify: False

--- a/api/test/integration/test_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rule_endpoints.tavern.yaml
@@ -1675,28 +1675,6 @@ stages:
           total_failed_items: 1
         error: 1
 
-  - name: Download rule (user ruleset, rule belongs to default ruleset)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0350-amazon_rules.xml"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        default_ruleset: false
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items: []
-          total_affected_items: 0
-          failed_items:
-            - error:
-                code: 1415
-              id:
-                - "0350-amazon_rules.xml"
-          total_failed_items: 1
-        error: 1
-
   - name: Download rule (invalid file 1)
     request:
       verify: False

--- a/framework/wazuh/tests/test_decoder.py
+++ b/framework/wazuh/tests/test_decoder.py
@@ -133,7 +133,6 @@ def test_get_decoders_files_filters(status, relative_dirname, filename, expected
     'test1_decoders.xml',
     'test2_decoders.xml'
 ])
-@patch('wazuh.core.common.DECODERS_PATH', new=os.path.join(test_data_path, "tests", "data", "decoders"))
 def test_get_decoder_file(filename):
     """Test get file function.
 
@@ -161,17 +160,15 @@ def test_get_decoder_file_exceptions():
     assert result.render()['data']['failed_items'][0]['error']['code'] == 1503
 
     # Invalid XML
-    with patch('wazuh.core.common.DECODERS_PATH', new=os.path.join(test_data_path, "tests", "data", "decoders")):
-        result = decoder.get_decoder_file(filename='wrong_decoders.xml')
-        assert not result.affected_items
-        assert result.render()['data']['failed_items'][0]['error']['code'] == 1501
+    result = decoder.get_decoder_file(filename='wrong_decoders.xml')
+    assert not result.affected_items
+    assert result.render()['data']['failed_items'][0]['error']['code'] == 1501
 
     # File permissions
     with patch('builtins.open', side_effect=PermissionError):
-        with patch('wazuh.core.common.DECODERS_PATH', new=os.path.join(test_data_path, "tests", "data", "decoders")):
-            result = decoder.get_decoder_file(filename='test2_decoders.xml')
-            assert not result.affected_items
-            assert result.render()['data']['failed_items'][0]['error']['code'] == 1502
+        result = decoder.get_decoder_file(filename='test2_decoders.xml')
+        assert not result.affected_items
+        assert result.render()['data']['failed_items'][0]['error']['code'] == 1502
 
 
 @pytest.mark.parametrize('file, overwrite', [
@@ -184,7 +181,6 @@ def test_get_decoder_file_exceptions():
 @patch('wazuh.decoder.remove')
 @patch('wazuh.decoder.safe_move')
 @patch('wazuh.core.utils.check_remote_commands')
-@patch('wazuh.core.common.DECODERS_PATH', new=os.path.join(test_data_path, "tests", "data", "decoders"))
 def test_upload_file(mock_remote_commands, mock_safe_move, mock_remove, mock_full_copy, mock_xml, mock_delete, file,
                      overwrite):
     """Test uploading a decoder file.


### PR DESCRIPTION
|Related issue|
|---|
|[#15994](https://github.com/wazuh/wazuh/issues/15994)|


## Description
This PR reverts commit 439d704e04db7ee60ae8559166176b8cff30f80c.

It is a previous step required to implement what was discussed in this [issue #5176](https://github.com/wazuh/wazuh-kibana-app/issues/5176)