### PR TITLE
"cisco-ios" decoder modified to include "SEC_LOGIN" with username and src IP

### DIFF
--- a/ruleset/decoders/0065-cisco-ios_decoders.xml
+++ b/ruleset/decoders/0065-cisco-ios_decoders.xml
@@ -270,3 +270,14 @@ Details: https://www.cisco.com/c/en/us/td/docs/routers/access/wireless/software/
   <regex>%(\w+)-(\d)-(\w+):</regex>
   <order>cisco.facility, cisco.severity, cisco.mnemonic</order>
 </decoder>
+
+<!-- Cisco IOS login success 
+  - .May 11 05:45:31.209 UTC: %SEC_LOGIN-5-LOGIN_SUCCESS: Login Success [user: johndoe] [Source: 172.16.22.101] [localport: 22] at 05:45:31 UTC Thu May 11 2023
+-->
+
+<decoder name="cisco-ios-login">
+  <parent>cisco-ios</parent>
+  <prematch>%SEC_LOGIN-5-LOGIN_SUCCESS: Login Success [user: \S+] [Source: \d+.\d+.\d+.\d+] [localport: \d+] at</prematch>
+  <regex>%(\w+)-(\d)-(\w+): Login Success [user: (\S+)] [Source: (\d+.\d+.\d+.\d+)] [localport: (\d+)] at</regex>
+  <order>cisco.facility, cisco.severity, cisco.mnemonic, srcuser, srcip, dstport</order>
+</decoder>

--- a/ruleset/testing/tests/cisco_ios.ini
+++ b/ruleset/testing/tests/cisco_ios.ini
@@ -60,3 +60,11 @@ log 2 pass = 00:00:47: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed sta
 rule = 4713
 alert = 4
 decoder = cisco-ios
+
+[cisco ios: login message]
+log 1 pass = *May 11 19:38:27.371 UTC: %SEC_LOGIN-5-LOGIN_SUCCESS: Login Success [user: autotest] [Source: 172.16.123.215] [localport: 22] at 19:38:27 UTC Thu May 11 2023
+log 2 pass = May 12 04:41:07.551 UTC: %SEC_LOGIN-5-LOGIN_SUCCESS: Login Success [user: vendor1] [Source: 10.30.116.5] [localport: 22] at 04:41:07 UTC Fri May 12 2023
+
+rule = 4722
+alert = 3
+decoder = cisco-ios


### PR DESCRIPTION
|Related issue|
|---|
|N/A|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This pull request modifies the original "cisco-ios" decoder with a new sub decoder for "SEC_LOGIN-5-LOGIN_SUCCESS" syslogs. Originally, when this type of syslog is ingested into Wazuh, only "cisco.facility, cisco.mnemonic, cisco.severity" are decoded, however, with this modified decoder I have added a new decoder named "cisco-ios-login" which further decodes the username, source IP address and the destination port.

<!--
Add a clear description of how the problem has been solved.
-->

## Logs/Alerts example
### Original Ruleset Test

```
**Messages:
	INFO: (7202): Session initialized with token 'e4998d1e'

**Phase 1: Completed pre-decoding.
	full event: '*May 11 19:38:27.371 UTC: %SEC_LOGIN-5-LOGIN_SUCCESS: Login Success [user: ansible] [Source: 172.16.23.25] [localport: 22] at 19:38:27 UTC Thu May 11 2023'

**Phase 2: Completed decoding.
	name: 'cisco-ios'
	cisco.facility: 'SEC_LOGIN'
	cisco.mnemonic: 'LOGIN_SUCCESS'
	cisco.severity: '5'

**Phase 3: Completed filtering (rules).
	id: '4722'
	level: '3'
	description: 'Cisco IOS: Successful login to the router'
	groups: '["syslog","cisco_ios","authentication_success"]'
	firedtimes: '1'
	gdpr: '["IV_32.2"]'
	gpg13: '["5.5"]'
	hipaa: '["164.312.b"]'
	mail: 'false'
	nist_800_53: '["AU.14","AC.7"]'
	pci_dss: '["10.2.5"]'
**Alert to be generated.
```

### New Ruleset Test
```
**Messages:
	INFO: (7202): Session initialized with token '564cd499'

**Phase 1: Completed pre-decoding.
	full event: '*May 11 19:38:27.371 UTC: %SEC_LOGIN-5-LOGIN_SUCCESS: Login Success [user: ansible] [Source: 172.16.23.25] [localport: 22] at 19:38:27 UTC Thu May 11 2023'

**Phase 2: Completed decoding.
	name: 'cisco-ios'
	parent: 'cisco-ios'
	cisco.facility: 'SEC_LOGIN'
	cisco.mnemonic: 'LOGIN_SUCCESS'
	cisco.severity: '5'
	dstport: '22'
	srcip: '172.16.23.25'
	srcuser: 'ansible'

**Phase 3: Completed filtering (rules).
	id: '4722'
	level: '3'
	description: 'Cisco IOS: Successful login to the router'
	groups: '["syslog","cisco_ios","authentication_success"]'
	firedtimes: '1'
	gdpr: '["IV_32.2"]'
	gpg13: '["5.5"]'
	hipaa: '["164.312.b"]'
	mail: 'false'
	nist_800_53: '["AU.14","AC.7"]'
	pci_dss: '["10.2.5"]'
**Alert to be generated.
```
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ x] Added unit testing files ".ini"
  - [ x] runtests.py executed without errors