### PR TITLE
Increase timeout for waiting agent reconnection on Windows WPK upgrade

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -268,13 +268,17 @@ write-output "$(Get-Date -format u) - Process ID: $($process_id)." >> .\upgrade\
 Start-Sleep 10
 
 # Check status file
-$status = Select-String -Path '.\wazuh-agent.state' -Pattern "^status='(.+)'" | %{$_.Matches[0].Groups[1].value}
+function Get-AgentStatus {
+    Select-String -Path '.\wazuh-agent.state' -Pattern "^status='(.+)'" | %{$_.Matches[0].Groups[1].value}
+}
+
+$status = Get-AgentStatus
 $counter = 30
 while($status -ne "connected"  -And $counter -gt 0)
 {
     $counter--
     Start-Sleep 2
-    $status = Select-String -Path '.\wazuh-agent.state' -Pattern "^status='(.+)'" | %{$_.Matches[0].Groups[1].value}
+    $status = Get-AgentStatus
 }
 Write-Output "$(Get-Date -Format u) - Reading status file: status='$status'." >> .\upgrade\upgrade.log
 

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -254,7 +254,7 @@ write-output "$(Get-Date -format u) - Installation finished." >> .\upgrade\upgra
 
 # Check process status
 $process_id = (Get-Process wazuh-agent).id
-$counter = 5
+$counter = 10
 while($process_id -eq $null -And $counter -gt 0)
 {
     $counter--
@@ -268,17 +268,17 @@ write-output "$(Get-Date -format u) - Process ID: $($process_id)." >> .\upgrade\
 Start-Sleep 10
 
 # Check status file
-$status = Get-Content .\wazuh-agent.state | select-string "status='connected'" -SimpleMatch
-$counter = 5
-while($status -eq $null -And $counter -gt 0)
+$status = Select-String -Path '.\wazuh-agent.state' -Pattern "^status='(.+)'" | %{$_.Matches[0].Groups[1].value}
+$counter = 30
+while($status -ne "connected"  -And $counter -gt 0)
 {
     $counter--
     Start-Sleep 2
-    $status = Get-Content .\wazuh-agent.state | select-string "status='connected'" -SimpleMatch
+    $status = Select-String -Path '.\wazuh-agent.state' -Pattern "^status='(.+)'" | %{$_.Matches[0].Groups[1].value}
 }
-write-output "$(Get-Date -format u) - Reading status file: $($status)." >> .\upgrade\upgrade.log
+Write-Output "$(Get-Date -Format u) - Reading status file: status='$status'." >> .\upgrade\upgrade.log
 
-If ($status -eq $null)
+If ($status -ne "connected")
 {
     Get-Service -Name "Wazuh" | Stop-Service
     write-output "$(Get-Date -format u) - Upgrade failed: Restoring former installation." >> .\upgrade\upgrade.log


### PR DESCRIPTION
|Related issue|
|---|
|closes #17046|

## Description

This PR aims to fix the reported problems upgrading Windows agents to v4.4.0 via WPK by increasing the timeouts used in the upgrade script after the new version is installed:
 - Timeout for process status check: increased from 10 seconds to `20 seconds`.
 - Timeout for agent reconnection: increased from 20 seconds to `60 seconds`.
 - The 10 seconds wait between these two events remains unchanged.

(Rationale for increasing timeout: see [comment](https://github.com/wazuh/wazuh/pull/17076#issuecomment-1583046370))

In addition, this PR improves the `Reading status file` message of the `upgrade.log` to show the actual value of the status field of the `wazuh-agent.state` file. Previously, this line showed `"Reading status file: ."` whenever the status was different than `connected`, that made it impossible to distinguish between the different states of the connection or even if the state file was not present.
Now this line will be like this: 
- `Reading status file: status='connected'.`
- `Reading status file: status='pending'.`
- `Reading status file: status='disconnected'.`
- `Reading status file: status=''.` (only if it was not possible to read the `wazuh-agent.state` file)

## Manual tests

Tests performed with manager `v4.5.1`. 
Custom WPK used in these tests: [wazuh_agent_v4.5.1_pr17076.zip](https://github.com/wazuh/wazuh/files/11981864/wazuh_agent_v4.5.1_pr17076.zip) (Updated to bd91f746ae3d4100e649ac5eb3f634eaac12c31a)

<details><summary>Windows Server 16 - 64 bits - English - Failed upgrade</summary>

#### The following screenshot shows:
- The installed agent at the start of the test is `v4.4.1`.
- Upgrade to `4.5.1` failed (*): `Upgrade failed: Restoring former installation.`
- The rollback with the backed-up MSI was done correctly:
   - `Performing the Wazuh-Agent uninstall using: "MsiExec.exe /X{A9A1109D-29A1-450A-A7AE-EF43FCDFA3C7}
 /quiet".`
   - `Excecuting former Wazuh-Agent MSI: ".\backup\21770.msi".`
- The reported version after the upgrade is 4.4.1 by both the VERSION file and Windows registry.
- Other observations:
  - The log shows the message `Reading status file: status='pending'.` 
  - There is a 70 seconds difference between the messages `Process ID: 3324.` and `Reading status file: status='pending'.`. This time corresponds to `10` seconds of waiting for the agent state to be cleaned and `60` seconds waiting for the agent to reconnect to the manager.
![win16-failed-rollback ok](https://github.com/wazuh/wazuh/assets/7939712/b3df1851-31dd-4ede-a433-020d1a3fcb53)

*(To make the upgrade fail, the connection between manager and agent was deliberately blocked after the agent received the WPK file)
</details>

<details><summary>Windows Server 16 - 64 bits - English - Succesful upgrade</summary>

#### The following screenshot shows:
- The installed agent at the start of the test is `v4.4.0`.
- Upgrade to `4.5.1` was successful.
- The reported version after the upgrade is `4.5.1` by both the VERSION file and Windows registry.
- Other observations:
  - The log shows the message `Reading status file: status='connected'.`
![win16-ok](https://github.com/wazuh/wazuh/assets/7939712/0423af7e-4fe3-4c88-89f0-3e0f7e3595ee)

</details>



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- [x] Package upgrade
- [x] Review logs syntax and correct language
