### PR TITLE
PCRE2 regex for SCA policies

### DIFF
--- a/src/headers/expression.h
+++ b/src/headers/expression.h
@@ -109,6 +109,13 @@ bool w_expression_match(w_expression_t * expression, const char * str_test, cons
                         regex_matching * regex_match);
 
 /**
+ * @brief Frees regex_matching object
+ * @param expression expression with compiled pattern
+  * @param regex_match Structure to manage pattern matches.
+ */
+void w_free_expression_match(w_expression_t * expression, regex_matching **reg);
+
+/**
  * @brief Fill a match_data with PCRE2 result
  * @param captured_groups number of matches of PCRE2 execute
  * @param str_test string to test

--- a/src/os_regex/os_match_free_pattern.c
+++ b/src/os_regex/os_match_free_pattern.c
@@ -20,26 +20,23 @@
 /* Release all the memory created by the compilation/execution phases */
 void OSMatch_FreePattern(OSMatch *reg)
 {
+    if(reg == NULL)
+        return;
+
     /* Free the patterns */
     if (reg->patterns) {
         char **pattern = reg->patterns;
         while (*pattern) {
-            if (*pattern) {
-                os_free(*pattern);
-            }
+            os_free(*pattern);
             pattern++;
         }
 
         os_free(reg->patterns);
-        reg->patterns = NULL;
     }
 
     os_free(reg->size);
     os_free(reg->match_fp);
     os_free(reg->raw);
-
-    reg->size = NULL;
-    reg->match_fp = NULL;
 
     return;
 }

--- a/src/os_regex/os_regex.h
+++ b/src/os_regex/os_regex.h
@@ -15,6 +15,7 @@
 
 /* size_t */
 #include <stddef.h>
+#include <stdbool.h>
 #include <pthread.h>
 
 /* OSRegex_Compile flags */
@@ -56,6 +57,7 @@ typedef struct _OSRegex {
     char **patterns;
     const char ** *prts_closure;
     pthread_mutex_t mutex;
+    bool mutex_initialised;
     // Dynamic variables
     char **d_sub_strings;
     const char ***d_prts_str;

--- a/src/os_regex/os_regex.h
+++ b/src/os_regex/os_regex.h
@@ -111,7 +111,7 @@ const char *OSRegex_Execute(const char *str, OSRegex *reg) __attribute__((nonnul
  const char *OSRegex_Execute_ex(const char *str, OSRegex *reg, regex_matching *regex_match) __attribute__((nonnull(2)));
 
 /* Release all the memory created by the compilation/execution phases */
-void OSRegex_FreePattern(OSRegex *reg) __attribute__((nonnull));
+void OSRegex_FreePattern(OSRegex *reg);
 
 /* This function is a wrapper around the compile/execute
  * functions. It should only be used when the pattern is
@@ -135,7 +135,7 @@ int OSMatch_Compile(const char *pattern, OSMatch *reg, int flags);
 int OSMatch_Execute(const char *str, size_t str_len, OSMatch *reg);
 
 /* Release all the memory created by the compilation/execution phases */
-void OSMatch_FreePattern(OSMatch *reg) __attribute__((nonnull));
+void OSMatch_FreePattern(OSMatch *reg);
 
 int OS_Match2(const char *pattern, const char *str)  __attribute__((nonnull(2)));
 

--- a/src/os_regex/os_regex_compile.c
+++ b/src/os_regex/os_regex_compile.c
@@ -52,6 +52,7 @@ int OSRegex_Compile(const char *pattern, OSRegex *reg, int flags)
     reg->raw = NULL;
     memset(&reg->d_size, 0, sizeof(regex_dynamic_size));
     w_mutex_init(&reg->mutex, NULL);
+    reg->mutex_initialised = true;
 
     /* The pattern can't be null */
     if (pattern == NULL) {

--- a/src/os_regex/os_regex_free_pattern.c
+++ b/src/os_regex/os_regex_free_pattern.c
@@ -65,7 +65,8 @@ void OSRegex_FreePattern(OSRegex *reg)
     }
 
     os_free(reg->d_size.prts_str_size);
-    w_mutex_destroy(&reg->mutex);
+    if (reg->mutex_initialised)
+        w_mutex_destroy(&reg->mutex);
 
     return;
 }

--- a/src/os_regex/os_regex_free_pattern.c
+++ b/src/os_regex/os_regex_free_pattern.c
@@ -17,14 +17,14 @@
 void OSRegex_FreePattern(OSRegex *reg)
 {
     int i = 0;
+    if(reg == NULL)
+        return;
 
     /* Free the patterns */
     if (reg->patterns) {
         char **pattern = reg->patterns;
         while (*pattern) {
-            if (*pattern) {
-                os_free(*pattern);
-            }
+            os_free(*pattern);
             pattern++;
         }
 
@@ -56,14 +56,12 @@ void OSRegex_FreePattern(OSRegex *reg)
             i++;
         }
         os_free(reg->d_prts_str);
-        reg->d_prts_str = NULL;
     }
 
     /* Free the sub strings */
     if (reg->d_sub_strings) {
         w_FreeArray(reg->d_sub_strings);
         os_free(reg->d_sub_strings);
-        reg->d_sub_strings = NULL;
     }
 
     os_free(reg->d_size.prts_str_size);

--- a/src/shared/expression.c
+++ b/src/shared/expression.c
@@ -184,8 +184,8 @@ bool w_expression_match(w_expression_t * expression, const char * str_test, cons
                 retval = true;
             }
 
-            if (status_match.sub_strings != NULL) {
-                OSRegex_free_regex_matching(&status_match);
+            if (regex_match->sub_strings != NULL) {
+                OSRegex_free_regex_matching(regex_match);
             }
             break;
 

--- a/src/shared/expression.c
+++ b/src/shared/expression.c
@@ -88,6 +88,38 @@ void w_free_expression(w_expression_t * var) {
     w_free_expression_t(&var);
 }
 
+void w_free_expression_match(w_expression_t * expression, regex_matching **reg){
+    if (expression == NULL) {
+        return;
+    }
+
+    switch (expression->exp_type) {
+         case EXP_TYPE_OSMATCH:
+            OSRegex_free_regex_matching(*reg);
+            os_free(*reg);
+            break;
+
+        case EXP_TYPE_OSREGEX:
+            OSRegex_free_regex_matching(*reg);
+            os_free(*reg);
+            break;
+
+        case EXP_TYPE_PCRE2:
+            OSRegex_free_regex_matching(*reg);
+            os_free(*reg);
+            break;
+
+        case EXP_TYPE_STRING:
+            break;
+
+        case EXP_TYPE_OSIP_ARRAY:
+            break;
+
+        default:
+            break;
+    }
+}
+
 bool w_expression_add_osip(w_expression_t ** var, char * ip) {
 
     unsigned int ip_s = 0;
@@ -185,8 +217,8 @@ bool w_expression_match(w_expression_t * expression, const char * str_test, cons
                 retval = true;
             }
 
-            if (regex_match->sub_strings != NULL) {
-                OSRegex_free_regex_matching(regex_match);
+            if (status_match.sub_strings != NULL) {
+                OSRegex_free_regex_matching(&status_match);
             }
             break;
 

--- a/src/shared/expression.c
+++ b/src/shared/expression.c
@@ -31,6 +31,7 @@ void w_calloc_expression_t(w_expression_t ** var, w_exp_type_t type) {
 
         case EXP_TYPE_PCRE2:
             os_calloc(1, sizeof(w_pcre2_code_t), (*var)->pcre2);
+            break;
 
         default:
             break;

--- a/src/unit_tests/wazuh_modules/sca/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/sca/CMakeLists.txt
@@ -9,7 +9,8 @@
 list(APPEND tests_names "test_wm_sca")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=FOREVER,--wrap=IsFile,--wrap=getDefine_Int \
-                         -Wl,--wrap=StartMQ,--wrap=CreateThread,--wrap=wm_exec,--wrap=wm_sendmsg,--wrap=opendir,--wrap=realpath,--wrap=atexit")
+                         -Wl,--wrap=StartMQ,--wrap=CreateThread,--wrap=wm_exec,--wrap=wm_sendmsg,--wrap=opendir,--wrap=realpath,--wrap=atexit \
+                         -Wl,--wrap=w_expression_compile -Wl,--wrap=w_expression_match")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1786,6 +1786,14 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
     else if (strcmp(w_expression_get_regex_type(regex_engine), PCRE2_STR) == 0) {
             w_calloc_expression_t(&regex, EXP_TYPE_PCRE2);
     }
+    else{
+        if (*reason == NULL) {
+            os_malloc(snprintf(NULL, 0, "Invalid regex type.") + 1, *reason);
+            sprintf(*reason, "Invalid regex type.");
+        }
+        return RETURN_INVALID;
+    }
+
     if (!w_expression_compile(regex, "(\\d+)", OS_RETURN_SUBSTRING)) {
         if (*reason == NULL) {
             os_malloc(snprintf(NULL, 0, "Cannot compile regex.") + 1, *reason);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1067,7 +1067,7 @@ static int wm_sca_do_scan(cJSON * checks,
             if(!rule_ref->valuestring) {
                 mdebug1("Field 'rule' must be a string.");
                 ret_val = 1;
-                w_free_expression_t(&regex_engine);
+                os_free(regex_engine);
                 goto clean_return;
             }
 
@@ -1103,7 +1103,7 @@ static int wm_sca_do_scan(cJSON * checks,
                 merror("Invalid rule: '%s'. Skipping policy.", rule_ref->valuestring);
                 os_free(rule_cp);
                 ret_val = 1;
-                w_free_expression_t(&regex_engine);
+                os_free(regex_engine);
                 goto clean_return;
             }
 
@@ -1320,6 +1320,7 @@ static int wm_sca_do_scan(cJSON * checks,
                 free(data->alert_msg[i]);
                 data->alert_msg[i] = NULL;
             }
+            os_free(regex_engine);
             goto clean_return;
         }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1320,7 +1320,6 @@ static int wm_sca_do_scan(cJSON * checks,
                 free(data->alert_msg[i]);
                 data->alert_msg[i] = NULL;
             }
-            w_free_expression_t(&regex_engine);
             goto clean_return;
         }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1320,7 +1320,7 @@ static int wm_sca_do_scan(cJSON * checks,
                 free(data->alert_msg[i]);
                 data->alert_msg[i] = NULL;
             }
-            os_free(regex_engine);
+            w_free_expression_t(&regex_engine);
             goto clean_return;
         }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -827,7 +827,7 @@ static int wm_sca_resolve_symlink(const char * const file, char * realpath_buffe
 
         mdebug2("Could not resolve the real path of '%s': %s", file, strerror(realpath_errno));
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Could not resolve the real path of '%s': %s", file, strerror(realpath_errno)) + 1, *reason);
             sprintf(*reason, "Could not resolve the real path of '%s': %s", file, strerror(realpath_errno));
         }
 
@@ -858,8 +858,8 @@ static int wm_sca_check_dir_list(wm_sca_t * const data,
         if(data->skip_nfs && is_nfs == 1) {
             mdebug2("Directory '%s' flagged as NFS and skip_nfs is enabled.", dir);
             if (*reason == NULL) {
-                os_malloc(OS_MAXSTR, *reason);
-                sprintf(*reason,"Directory '%s' flagged as NFS and skip_nfs is enabled", dir);
+                os_malloc(snprintf(NULL, 0, "Directory '%s' flagged as NFS and skip_nfs is enabled", dir) + 1, *reason);
+                sprintf(*reason, "Directory '%s' flagged as NFS and skip_nfs is enabled", dir);
             }
             found = RETURN_INVALID;
         } else {
@@ -1158,7 +1158,7 @@ static int wm_sca_do_scan(cJSON * checks,
                 if (!data->remote_commands && remote_policy) {
                     mwarn("Ignoring check for policy '%s'. The internal option 'sca.remote_commands' is disabled.", cJSON_GetObjectItem(policy, "name")->valuestring);
                     if (reason == NULL) {
-                        os_malloc(OS_MAXSTR, reason);
+                        os_malloc(snprintf(NULL, 0, "Ignoring check for running command '%s'. The internal option 'sca.remote_commands' is disabled", rule_location) + 1, reason);
                         sprintf(reason, "Ignoring check for running command '%s'. The internal option 'sca.remote_commands' is disabled", rule_location);
                     }
                     found = RETURN_INVALID;
@@ -1341,7 +1341,7 @@ static int wm_sca_do_scan(cJSON * checks,
             message_ref = invalid;
 
             if (reason == NULL) {
-                os_malloc(OS_MAXSTR, reason);
+                os_malloc(snprintf(NULL, 0, "Unknown reason") + 1, reason);
                 sprintf(reason, "Unknown reason");
                 mdebug1("A check returned INVALID for an unknown reason.");
             }
@@ -1504,7 +1504,7 @@ static int wm_sca_check_file_existence(const char * const file, char **reason)
             return RETURN_NOT_FOUND;
         }
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Could not open '%s': %s", file, strerror(lstat_errno)) + 1, *reason);
             sprintf(*reason, "Could not open '%s': %s", file, strerror(lstat_errno));
         }
         mdebug2("FILE_EXISTS(%s) -> RETURN_INVALID: %s", file, strerror(lstat_errno));
@@ -1517,7 +1517,7 @@ static int wm_sca_check_file_existence(const char * const file, char **reason)
     }
 
     if (*reason == NULL) {
-        os_malloc(OS_MAXSTR, *reason);
+        os_malloc(snprintf(NULL, 0, "FILE_EXISTS(%s) -> RETURN_INVALID: Not a regular file.", file) + 1, *reason);
         sprintf(*reason, "FILE_EXISTS(%s) -> RETURN_INVALID: Not a regular file.", file);
     }
 
@@ -1539,7 +1539,7 @@ static int wm_sca_check_file_contents(const char * const file,
     const int wm_sca_resolve_symlink_result = wm_sca_resolve_symlink(file, realpath_buffer, reason);
     if (wm_sca_resolve_symlink_result != RETURN_FOUND) {
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Could not open file '%s'", file) + 1, *reason);
             sprintf(*reason, "Could not open file '%s'", file);
         }
 
@@ -1553,7 +1553,7 @@ static int wm_sca_check_file_contents(const char * const file,
     const int fopen_errno = errno;
     if (!fp) {
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Could not open file '%s': %s", file, strerror(fopen_errno)) + 1, *reason);
             sprintf(*reason, "Could not open file '%s': %s", file, strerror(fopen_errno));
         }
         mdebug2("Could not open file '%s': %s", file, strerror(fopen_errno));
@@ -1653,7 +1653,7 @@ static int wm_sca_check_file_list_for_contents(const char * const file_list,
             /* a file that does not exist produces an INVALID check */
             result_accumulator = RETURN_INVALID;
             if (*reason == NULL) {
-                os_malloc(OS_MAXSTR, *reason);
+                os_malloc(snprintf(NULL, 0, "Could not open file '%s'",  file) + 1, *reason);
                 sprintf(*reason, "Could not open file '%s'",  file);
             }
             mdebug2("Could not open file '%s'. Skipping.", file);
@@ -1709,7 +1709,7 @@ static int wm_sca_read_command(char * command,
         os_free(cmd_output);
         mdebug1("Timeout overtaken running command '%s'", command);
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Timeout overtaken running command '%s'", command) + 1, *reason);
             sprintf(*reason, "Timeout overtaken running command '%s'", command);
         }
         os_free(cmd_output);
@@ -1718,13 +1718,13 @@ static int wm_sca_read_command(char * command,
         if (result_code == EXECVE_ERROR) {
             mdebug1("Invalid path or wrong permissions to run command '%s'", command);
             if (*reason == NULL) {
-                os_malloc(OS_MAXSTR, *reason);
+                os_malloc(snprintf(NULL, 0, "Invalid path or wrong permissions to run command '%s'", command) + 1, *reason);
                 sprintf(*reason, "Invalid path or wrong permissions to run command '%s'", command);
             }
         } else {
             mdebug1("Failed to run command '%s'. Returned code %d", command, result_code);
             if (*reason == NULL) {
-                os_malloc(OS_MAXSTR, *reason);
+                os_malloc(snprintf(NULL, 0, "Failed to run command '%s'. Returned code %d", command, result_code) + 1, *reason);
                 sprintf(*reason, "Failed to run command '%s'. Returned code %d", command, result_code);
             }
         }
@@ -1770,7 +1770,7 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
 {
     if (!partial_comparison) {
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "No comparison provided.") + 1, *reason);
             sprintf(*reason, "No comparison provided.");
         }
         mwarn("No comparison provided.");
@@ -1788,7 +1788,7 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
     }
     if (!w_expression_compile(regex, "(\\d+)", OS_RETURN_SUBSTRING)) {
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Cannot compile regex.") + 1, *reason);
             sprintf(*reason, "Cannot compile regex.");
         }
         mwarn("Cannot compile regex");
@@ -1800,7 +1800,7 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
 
     if (!w_expression_match(regex, partial_comparison, NULL, regex_match)) {
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "No integer was found within the comparison '%s' ", partial_comparison) + 1, *reason);
             sprintf(*reason, "No integer was found within the comparison '%s' ", partial_comparison);
         }
         mwarn("No integer was found within the comparison '%s' ", partial_comparison);
@@ -1815,7 +1815,7 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
 
     if (!regex_match->sub_strings || !regex_match->sub_strings[0]) {
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "No number was captured.") + 1, *reason);
             sprintf(*reason, "No number was captured.");
         }
         mwarn("No number was captured.");
@@ -1832,7 +1832,7 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
 
     if (errno != 0 || strtol_end_ptr == regex_match->sub_strings[0]) {
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Conversion error. Cannot convert '%s' to integer.", regex_match->sub_strings[0]) + 1, *reason);
             sprintf(*reason, "Conversion error. Cannot convert '%s' to integer.", regex_match->sub_strings[0]);
         }
         mwarn("Conversion error. Cannot convert '%s' to integer.", regex_match->sub_strings[0]);
@@ -1875,7 +1875,7 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
         return number > value_given ? RETURN_FOUND : RETURN_NOT_FOUND;
     }
     if (*reason == NULL) {
-        os_malloc(OS_MAXSTR, *reason);
+        os_malloc(snprintf(NULL, 0, "Unrecognized operation: '%s'", partial_comparison) + 1, *reason);
         sprintf(*reason, "Unrecognized operation: '%s'", partial_comparison);
     }
     mdebug2("Unrecognized operation: '%s'", partial_comparison);
@@ -1895,7 +1895,7 @@ static int wm_sca_regex_numeric_comparison (const char * const pattern,
     if (!partial_comparison_ref) {
         mdebug2("Keyword 'compare' not found. Did you forget adding 'compare COMPARATOR VALUE' to your rule?' %s'", pattern_copy_ref);
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Keyword 'compare' not found. Did you forget adding 'compare COMPARATOR VALUE' to your rule?' %s'", pattern_copy_ref) + 1, *reason);
             sprintf(*reason, "Keyword 'compare' not found. Did you forget adding 'compare COMPARATOR VALUE' to your rule?' %s'", pattern_copy_ref);
         }
         os_free(pattern_copy);
@@ -1909,7 +1909,7 @@ static int wm_sca_regex_numeric_comparison (const char * const pattern,
     if (!w_expression_compile(regex_engine, pattern_copy_ref, OS_RETURN_SUBSTRING)) {
         mdebug2("Cannot compile regex '%s'", pattern_copy_ref);
         if (!*reason) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Cannot compile regex '%s'", pattern_copy_ref) + 1, *reason);
             sprintf(*reason, "Cannot compile regex '%s'", pattern_copy_ref);
         }
         os_free(pattern_copy);
@@ -1928,7 +1928,7 @@ static int wm_sca_regex_numeric_comparison (const char * const pattern,
     if (!regex_match->sub_strings || !regex_match->sub_strings[0]) {
         mdebug2("Regex '%s' matched, but no string was captured by it. Did you forget specifying a capture group?", pattern_copy_ref);
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Regex '%s' matched, but no string was captured by it. Did you forget specifying a capture group?", pattern_copy_ref) + 1, *reason);
             sprintf(*reason, "Regex '%s' matched, but no string was captured by it. Did you forget specifying a capture group?", pattern_copy_ref);
         }
         w_free_expression_t(&regex_engine);
@@ -1946,7 +1946,7 @@ static int wm_sca_regex_numeric_comparison (const char * const pattern,
     if (errno != 0 || strtol_end_ptr == regex_match->sub_strings[0]) {
         mdebug2("Conversion error. Cannot convert '%s' to integer.", regex_match->sub_strings[0]);
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Conversion error. Cannot convert '%s' to integer.", regex_match->sub_strings[0]) + 1, *reason);
             sprintf(*reason, "Conversion error. Cannot convert '%s' to integer.", regex_match->sub_strings[0]);
         }
         os_free(pattern_copy);
@@ -2066,7 +2066,7 @@ static int wm_sca_check_dir_existence(const char * const dir, char **reason)
     }
 
     if (*reason == NULL) {
-        os_malloc(OS_MAXSTR, *reason);
+        os_malloc(snprintf(NULL, 0, "Could not check directory existence for '%s': %s", dir, strerror(open_dir_errno)) + 1, *reason);
         sprintf(*reason, "Could not check directory existence for '%s': %s", dir, strerror(open_dir_errno));
     }
 
@@ -2091,7 +2091,7 @@ static int wm_sca_check_dir(const char * const dir,
     const int wm_sca_resolve_symlink_result = wm_sca_resolve_symlink(dir, realpath_buffer, reason);
     if (wm_sca_resolve_symlink_result != RETURN_FOUND) {
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Could not open dir '%s'", dir) + 1, *reason);
             sprintf(*reason, "Could not open dir '%s'", dir);
         }
 
@@ -2105,7 +2105,7 @@ static int wm_sca_check_dir(const char * const dir,
     if (!dp) {
         const int open_dir_errno = errno;
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Could not open '%s': %s", dir, strerror(open_dir_errno)) + 1, *reason);
             sprintf(*reason, "Could not open '%s': %s", dir, strerror(open_dir_errno));
         }
         mdebug2("Could not open '%s': %s", dir, strerror(open_dir_errno));
@@ -2133,7 +2133,7 @@ static int wm_sca_check_dir(const char * const dir,
         if (lstat(f_name, &statbuf_local) != 0) {
             mdebug2("Cannot check directory entry '%s'", f_name);
             if (*reason == NULL){
-                os_malloc(OS_MAXSTR, *reason);
+                os_malloc(snprintf(NULL, 0, "Cannot check directory entry '%s", f_name) + 1, *reason);
                 sprintf(*reason, "Cannot check directory entry '%s", f_name);
             }
             result_accumulator = RETURN_INVALID;
@@ -2174,7 +2174,7 @@ static int wm_sca_check_process_is_running(OSList * p_list,
 {
     if (p_list == NULL) {
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Process list is empty.") + 1, *reason);
             sprintf(*reason, "Process list is empty.");
         }
         return RETURN_INVALID;
@@ -2215,7 +2215,7 @@ static int wm_sca_is_registry(char * entry_name,
 
     if (wm_sca_sub_tree == NULL || rk == NULL) {
          if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Invalid registry entry: '%s'", entry_name) + 1, *reason);
             sprintf(*reason, "Invalid registry entry: '%s'", entry_name);
         }
 
@@ -2303,7 +2303,7 @@ static int wm_sca_test_key(char * subkey,
     LSTATUS err = RegOpenKeyEx(wm_sca_sub_tree, subkey, 0, KEY_READ | arch, &oshkey);
     if (err == ERROR_ACCESS_DENIED) {
         if (*reason == NULL) {
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Access denied for registry '%s'", full_key_name) + 1, *reason);
             sprintf(*reason, "Access denied for registry '%s'", full_key_name);
         }
         merror("Access denied for registry '%s'", full_key_name);
@@ -2325,7 +2325,7 @@ static int wm_sca_test_key(char * subkey,
         }
 
         if (*reason == NULL){
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Unable to read registry '%s' (%s)", full_key_name, error_msg) + 1, *reason);
             sprintf(*reason, "Unable to read registry '%s' (%s)", full_key_name, error_msg);
         }
         return RETURN_INVALID;
@@ -2394,7 +2394,7 @@ static int wm_sca_winreg_querykey(HKEY hKey,
                     (LPTSTR) &error_msg, OS_SIZE_1024, NULL);
 
         if (*reason == NULL){
-            os_malloc(OS_MAXSTR, *reason);
+            os_malloc(snprintf(NULL, 0, "Unable to read registry '%s' (%s)", full_key_name, error_msg) + 1, *reason);
             sprintf(*reason, "Unable to read registry '%s' (%s)", full_key_name, error_msg);
         }
 
@@ -2433,7 +2433,7 @@ static int wm_sca_winreg_querykey(HKEY hKey,
                             (LPTSTR) &error_msg, OS_SIZE_1024, NULL);
 
                 if (*reason == NULL){
-                    os_malloc(OS_MAXSTR, *reason);
+                    os_malloc(snprintf(NULL, 0, "Unable to enumerate values of registry '%s' (%s)", full_key_name, error_msg) + 1, *reason);
                     sprintf(*reason, "Unable to enumerate values of registry '%s' (%s)", full_key_name, error_msg);
                 }
 
@@ -2515,7 +2515,7 @@ static int wm_sca_winreg_querykey(HKEY hKey,
     }
 
     if (*reason == NULL && reg_value){
-        os_malloc(OS_MAXSTR, *reason);
+        os_malloc(snprintf(NULL, 0, "Key '%s' not found for registry '%s'", reg_option, full_key_name) + 1, *reason);
         sprintf(*reason, "Key '%s' not found for registry '%s'", reg_option, full_key_name);
     }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1745,7 +1745,7 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
 
     mdebug2("Partial comparison '%s'", partial_comparison);
 
-    w_expression_t * regex;
+    w_expression_t * regex = NULL;
     if (strcmp(w_expression_get_regex_type(regex_engine), OSREGEX_STR) == 0) {
             w_calloc_expression_t(&regex, EXP_TYPE_OSREGEX);
     }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1804,13 +1804,9 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
             sprintf(*reason, "No integer was found within the comparison '%s' ", partial_comparison);
         }
         mwarn("No integer was found within the comparison '%s' ", partial_comparison);
-        os_free(regex_match);
+        w_free_expression_match(regex, &regex_match);
         w_free_expression_t(&regex);
         return RETURN_INVALID;
-    }
-
-    if(regex_match->d_size.prts_str_size){
-        os_free(regex_match->d_size.prts_str_size);
     }
 
     if (!regex_match->sub_strings || !regex_match->sub_strings[0]) {
@@ -1819,7 +1815,7 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
             sprintf(*reason, "No number was captured.");
         }
         mwarn("No number was captured.");
-        os_free(regex_match);
+        w_free_expression_match(regex, &regex_match);
         w_free_expression_t(&regex);
         return RETURN_INVALID;
     }
@@ -1836,7 +1832,7 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
             sprintf(*reason, "Conversion error. Cannot convert '%s' to integer.", regex_match->sub_strings[0]);
         }
         mwarn("Conversion error. Cannot convert '%s' to integer.", regex_match->sub_strings[0]);
-        os_free(regex_match);
+        w_free_expression_match(regex, &regex_match);
         w_free_expression_t(&regex);
         return RETURN_INVALID;
     }
@@ -1848,8 +1844,9 @@ static int wm_sca_apply_numeric_partial_comparison(const char * const partial_co
             }
             os_free(regex_match->sub_strings);
         }
-        os_free(regex_match);
     }
+
+    w_free_expression_match(regex, &regex_match);
     w_free_expression_t(&regex);
 
 
@@ -1921,7 +1918,7 @@ static int wm_sca_regex_numeric_comparison (const char * const pattern,
     if (!w_expression_match(regex_engine, str, NULL, regex_match)) {
         mdebug2("No match found for regex '%s'", pattern_copy_ref);
         os_free(pattern_copy);
-        os_free(regex_match);
+        w_free_expression_match(regex_engine, &regex_match);
         return RETURN_NOT_FOUND;
     }
 
@@ -1933,7 +1930,7 @@ static int wm_sca_regex_numeric_comparison (const char * const pattern,
         }
         w_free_expression_t(&regex_engine);
         os_free(pattern_copy);
-        os_free(regex_match);
+        w_free_expression_match(regex_engine, &regex_match);
         return RETURN_INVALID;
     }
 
@@ -1950,7 +1947,7 @@ static int wm_sca_regex_numeric_comparison (const char * const pattern,
             sprintf(*reason, "Conversion error. Cannot convert '%s' to integer.", regex_match->sub_strings[0]);
         }
         os_free(pattern_copy);
-        os_free(regex_match);
+        w_free_expression_match(regex_engine, &regex_match);
         return RETURN_INVALID;
     }
 
@@ -1967,7 +1964,7 @@ static int wm_sca_regex_numeric_comparison (const char * const pattern,
             }
             os_free(regex_match->sub_strings);
         }
-        os_free(regex_match);
+        w_free_expression_match(regex_engine, &regex_match);
     }
 
     return result;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1928,7 +1928,6 @@ static int wm_sca_regex_numeric_comparison (const char * const pattern,
             os_malloc(snprintf(NULL, 0, "Regex '%s' matched, but no string was captured by it. Did you forget specifying a capture group?", pattern_copy_ref) + 1, *reason);
             sprintf(*reason, "Regex '%s' matched, but no string was captured by it. Did you forget specifying a capture group?", pattern_copy_ref);
         }
-        w_free_expression_t(&regex_engine);
         os_free(pattern_copy);
         w_free_expression_match(regex_engine, &regex_match);
         return RETURN_INVALID;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1926,10 +1926,6 @@ static int wm_sca_regex_numeric_comparison (const char * const pattern,
         return RETURN_NOT_FOUND;
     }
 
-    if(regex_match->d_size.prts_str_size){
-        os_free(regex_match->d_size.prts_str_size);
-    }
-
     if (!regex_match->sub_strings || !regex_match->sub_strings[0]) {
         mdebug2("Regex '%s' matched, but no string was captured by it. Did you forget specifying a capture group?", pattern_copy_ref);
         if (*reason == NULL) {

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -398,7 +398,7 @@ static void wm_sca_read_files(wm_sca_t * data) {
                 goto next;
             }
 
-            const cJSON * const policy_regex_type = cJSON_GetObjectItem(policy, "regex_type");
+            cJSON * policy_regex_type = cJSON_GetObjectItem(policy, "regex_type");
 
             if (!policy_regex_type) {
                 data->policies[i]->policy_regex_type = OSREGEX_STR;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2023,7 +2023,6 @@ int wm_sca_pattern_matches(const char * const str,
             minterm++;
             negated = 1;
         }
-        OSRegex_FreePattern(regex_engine->regex);
 
         const int minterm_result = negated ^ wm_sca_test_positive_minterm (minterm, str, reason, regex_engine);
         OSMatch_FreePattern(regex_engine->match);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2027,6 +2027,9 @@ int wm_sca_pattern_matches(const char * const str,
         else if (strcmp(w_expression_get_regex_type(regex_engine), PCRE2_STR) == 0) {
             w_calloc_expression_t(&regex, EXP_TYPE_PCRE2);
         }
+        if(regex == NULL)
+            break;
+
         const int minterm_result = negated ^ wm_sca_test_positive_minterm (minterm, str, reason, regex);
         w_free_expression_t(&regex);
         

--- a/src/wazuh_modules/wm_sca.h
+++ b/src/wazuh_modules/wm_sca.h
@@ -34,6 +34,7 @@ typedef struct wm_sca_policy_t {
     unsigned int remote:1;
     char *policy_path;
     char *policy_id;
+    char *policy_regex_type;
 } wm_sca_policy_t;
 
 typedef struct wm_sca_t {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13931|

## Description
Hello team, this PR aims to add the possibility in SCA to use the PCRE2 regex engine to test the policies.
In this first step we have added a new tag inside the SCA ruleset to have the possibility to test the rules in PCRE2 adding the `regex_type` tag that takes as default value `os_regex`.
We have two possibilities to configure the engine, the first one is to configure a global engine by adding in the policy section the configuration `regex_type: "<engine>"` by default the regex_type will be `os_regex`. We can also configure a particular check with a different engine than the global engine by adding in the check `regex_type: "<engine>"`. 
So we can have the following combination of policies and controls with different or the same engines:

| Tags | PCRE2 engine global setting | OS_regex engine global setting||
| -------- | ----------- | ---------------- |----------|
|Policy|x|x|PCRE2 engine local check|
|Check|x|x| OS_regex engine local check|

## Configuration options
This is a fragment of the cis_ubuntu20.04.yml policy in the rule adding a change in the 19045 check's regex.
``` yml
policy:
  id: "cis_ubuntu20-04"
  file: "cis_ubuntu20-04.yml"
  name: "CIS benchmark for Ubuntu Linux 20.04 LTS"
  description: "This document provides prescriptive guidance for establishing a secure configuration posture for Ubuntu Linux 20.04 LTS."
  references:
    - https://www.cisecurity.org/cis-benchmarks/

requirements:
  title: "Check Ubuntu version."
  description: "Requirements for running the SCA scan against Ubuntu Linux 20.04 LTS"
  condition: all
  rules:
    - 'f:/etc/os-release -> r:Ubuntu'
    - 'f:/proc/sys/kernel/ostype -> Linux'

checks:

- id: 19040
    title: "Ensure all AppArmor Profiles are enforcing."
    description: "AppArmor profiles define what resources applicatons are able to access."
    rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that any policies that exist on the system are activated.."
    remediation: "Run the following command to set all profiles to enforce mode: # aa-enforce /etc/apparmor.d/* Any unconfined processes may need to have a profile created or activated for them and then be restarted."
    compliance:
      - cis: ["1.6.1.4"]
      - cis_csc: ["14.6"]
      - pci_dss: ["2.2.4"]
      - nist_800_53: ["CM.1"]
      - tsc: ["CC5.2"]
    condition: all
    rules:
      - 'c:apparmor_status -> n:^(\d+)\s*profiles are loaded compare > 0'
      - 'c:apparmor_status -> r:^0\s*profiles are in complain mode'
      - 'c:apparmor_status -> r:^0\s*processes are unconfined'

- id: 19045
    title: "Ensure permissions on /etc/issue are configured."
    description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
    rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
    remediation: "Run the following commands to set permissions on /etc/issue: # chown root:root /etc/issue # chmod u-x,go-wx /etc/issue"
    compliance:
      - cis: ["1.7.5"]
      - cis_csc: ["5.1"]
      - pci_dss: ["10.2.5"]
      - hipaa: ["164.312.b"]
      - nist_800_53: ["AU.14", "AC.7"]
      - gpg_13: ["7.8"]
      - gdpr_IV: ["35.7","32.2"]
      - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
    condition: all
    rules:
      - 'c:stat /etc/issue -> r:^Access:\s*\(0644\/.{0,10}\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root\)$'  
    regex_type: "PCRE2"
```

## Logs/Alerts example
This is an example of SCA operation using the OS_regex engine:
``` Logtalk
2022/09/27 06:23:11 sca[13134] wm_sca.c:1004 at wm_sca_do_scan(): DEBUG: Beginning evaluation of check id: 19045 'Ensure permissions on /etc/issue are configured.'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1005 at wm_sca_do_scan(): DEBUG: Rule aggregation strategy for this check is 'all'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1006 at wm_sca_do_scan(): DEBUG: Initial rule-aggregator value por this type of rule is '1'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1007 at wm_sca_do_scan(): DEBUG: Beginning rules evaluation.
2022/09/27 06:23:11 sca[13134] wm_sca.c:1017 at wm_sca_do_scan(): DEBUG: SCA will use 'osregex' engine to check the rules.
2022/09/27 06:23:11 sca[13134] wm_sca.c:1041 at wm_sca_do_scan(): DEBUG: Considering rule: 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)
'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1154 at wm_sca_do_scan(): DEBUG: Running command: 'stat /etc/issue'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1665 at wm_sca_read_command(): DEBUG: Executing command 'stat /etc/issue', and testing output with pattern 'r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)
\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1671 at wm_sca_read_command(): DEBUG: Command 'stat /etc/issue' returned code 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\))(  File: /etc/
issue) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\))(  File: 
/etc/issue) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\))(  Size: 26   
             Blocks: 8          IO Block: 4096   regular file) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\))(  Size: 
26           Blocks: 8          IO Block: 4096   regular file) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\))(Device: fd00h/64768d      Inode: 1049278     Links: 1) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\))(Device: fd00h/64768d Inode: 1049278     Links: 1) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\))(Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\))(Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1727 at wm_sca_read_command(): DEBUG: Result for (r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\))(stat /etc/issue) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1157 at wm_sca_do_scan(): DEBUG: Command output matched.
2022/09/27 06:23:11 sca[13134] wm_sca.c:1246 at wm_sca_do_scan(): DEBUG: Result for rule 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)': 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1157 at wm_sca_do_scan(): DEBUG: Command output matched.
2022/09/27 06:23:11 sca[13134] wm_sca.c:1246 at wm_sca_do_scan(): DEBUG: Result for rule 'c:stat /etc/issue -> r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root
\)$': 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1041 at wm_sca_do_scan(): DEBUG: Considering rule: 'c:apparmor_status -> n:^(\d+)\s*profiles are loaded compare > 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1154 at wm_sca_do_scan(): DEBUG: Running command: 'apparmor_status'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1665 at wm_sca_read_command(): DEBUG: Executing command 'apparmor_status', and testing output with pattern 'n:^(\d+)\s*profiles are loaded compare > 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1671 at wm_sca_read_command(): DEBUG: Command 'apparmor_status' returned code 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1859 at wm_sca_regex_numeric_comparison(): DEBUG: REGEX: '^(\d+)\s*profiles are loaded'. Partial comparison: '> 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1874 at wm_sca_regex_numeric_comparison(): DEBUG: No match found for regex '^(\d+)\s*profiles are loaded'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (n:^(\d+)\s*profiles are loaded compare > 0)(apparmor module is loaded.) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (n:^(\d+)\s*profiles are loaded compare > 0)(apparmor module is loaded.) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1859 at wm_sca_regex_numeric_comparison(): DEBUG: REGEX: '^(\d+)\s*profiles are loaded'. Partial comparison: '> 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1891 at wm_sca_regex_numeric_comparison(): DEBUG: Captured value: '11'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1908 at wm_sca_regex_numeric_comparison(): DEBUG: Converted value: '11'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1745 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Partial comparison '> 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1787 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Value given for comparison: '0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1808 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Value converted: '0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1826 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Operation is '11 > 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1911 at wm_sca_regex_numeric_comparison(): DEBUG: Comparison result '11 > 0' -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (n:^(\d+)\s*profiles are loaded compare > 0)(11 profiles are loaded.) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (n:^(\d+)\s*profiles are loaded compare > 0)(11 profiles are loaded.) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1727 at wm_sca_read_command(): DEBUG: Result for (n:^(\d+)\s*profiles are loaded compare > 0)(apparmor_status) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1157 at wm_sca_do_scan(): DEBUG: Command output matched.
2022/09/27 06:23:11 sca[13134] wm_sca.c:1246 at wm_sca_do_scan(): DEBUG: Result for rule 'c:apparmor_status -> n:^(\d+)\s*profiles are loaded compare > 0': 1
```
This is an example of SCA operation using the PCRE2 engine:

``` Logtalk
2022/09/27 06:23:11 sca[13134] wm_sca.c:1004 at wm_sca_do_scan(): DEBUG: Beginning evaluation of check id: 19046 'Ensure permissions on /etc/issue are configured.'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1005 at wm_sca_do_scan(): DEBUG: Rule aggregation strategy for this check is 'all'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1006 at wm_sca_do_scan(): DEBUG: Initial rule-aggregator value por this type of rule is '1'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1007 at wm_sca_do_scan(): DEBUG: Beginning rules evaluation.
2022/09/27 06:23:11 sca[13134] wm_sca.c:1017 at wm_sca_do_scan(): DEBUG: SCA will use 'pcre2' engine to check the rules.
2022/09/27 06:23:11 sca[13134] wm_sca.c:1041 at wm_sca_do_scan(): DEBUG: Considering rule: 'c:stat /etc/issue -> r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*ro
ot\)$'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1154 at wm_sca_do_scan(): DEBUG: Running command: 'stat /etc/issue'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1665 at wm_sca_read_command(): DEBUG: Executing command 'stat /etc/issue', and testing output with pattern 'r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*roo
t\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root\)$'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1671 at wm_sca_read_command(): DEBUG: Command 'stat /etc/issue' returned code 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root\)$)(  File: 
/etc/issue) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root\)$)(  F
ile: /etc/issue) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root\)$)(  Size: 
26           Blocks: 8          IO Block: 4096   regular file) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root\)$)(  S
ize: 26              Blocks: 8          IO Block: 4096   regular file) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root\)$)(Device: 
fd00h/64768d Inode: 1049278     Links: 1) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root\)$)(Dev
ice: fd00h/64768d    Inode: 1049278     Links: 1) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root\)$)(Access: 
(0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root\)$)(Acc
ess: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1727 at wm_sca_read_command(): DEBUG: Result for (r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root\)$)(stat /etc/issue)
 -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1157 at wm_sca_do_scan(): DEBUG: Command output matched.
2022/09/27 06:23:11 sca[13134] wm_sca.c:1246 at wm_sca_do_scan(): DEBUG: Result for rule 'c:stat /etc/issue -> r:^Access:\s*\(0644\/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0\/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0\/\s*\t*root
\)$': 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1041 at wm_sca_do_scan(): DEBUG: Considering rule: 'c:apparmor_status -> n:^(\d+)\s*profiles are loaded compare > 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1154 at wm_sca_do_scan(): DEBUG: Running command: 'apparmor_status'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1665 at wm_sca_read_command(): DEBUG: Executing command 'apparmor_status', and testing output with pattern 'n:^(\d+)\s*profiles are loaded compare > 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1671 at wm_sca_read_command(): DEBUG: Command 'apparmor_status' returned code 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1859 at wm_sca_regex_numeric_comparison(): DEBUG: REGEX: '^(\d+)\s*profiles are loaded'. Partial comparison: '> 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1874 at wm_sca_regex_numeric_comparison(): DEBUG: No match found for regex '^(\d+)\s*profiles are loaded'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (n:^(\d+)\s*profiles are loaded compare > 0)(apparmor module is loaded.) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (n:^(\d+)\s*profiles are loaded compare > 0)(apparmor module is loaded.) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1859 at wm_sca_regex_numeric_comparison(): DEBUG: REGEX: '^(\d+)\s*profiles are loaded'. Partial comparison: '> 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1891 at wm_sca_regex_numeric_comparison(): DEBUG: Captured value: '11'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1908 at wm_sca_regex_numeric_comparison(): DEBUG: Converted value: '11'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1745 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Partial comparison '> 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1787 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Value given for comparison: '0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1808 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Value converted: '0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1826 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Operation is '11 > 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1911 at wm_sca_regex_numeric_comparison(): DEBUG: Comparison result '11 > 0' -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (n:^(\d+)\s*profiles are loaded compare > 0)(11 profiles are loaded.) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (n:^(\d+)\s*profiles are loaded compare > 0)(11 profiles are loaded.) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1727 at wm_sca_read_command(): DEBUG: Result for (n:^(\d+)\s*profiles are loaded compare > 0)(apparmor_status) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1157 at wm_sca_do_scan(): DEBUG: Command output matched.
2022/09/27 06:23:11 sca[13134] wm_sca.c:1246 at wm_sca_do_scan(): DEBUG: Result for rule 'c:apparmor_status -> n:^(\d+)\s*profiles are loaded compare > 0': 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1041 at wm_sca_do_scan(): DEBUG: Considering rule: 'c:apparmor_status -> n:^(\d+)\s*profiles are loaded compare > 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1154 at wm_sca_do_scan(): DEBUG: Running command: 'apparmor_status'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1665 at wm_sca_read_command(): DEBUG: Executing command 'apparmor_status', and testing output with pattern 'n:^(\d+)\s*profiles are loaded compare > 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1671 at wm_sca_read_command(): DEBUG: Command 'apparmor_status' returned code 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1859 at wm_sca_regex_numeric_comparison(): DEBUG: REGEX: '^(\d+)\s*profiles are loaded'. Partial comparison: '> 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1874 at wm_sca_regex_numeric_comparison(): DEBUG: No match found for regex '^(\d+)\s*profiles are loaded'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (n:^(\d+)\s*profiles are loaded compare > 0)(apparmor module is loaded.) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (n:^(\d+)\s*profiles are loaded compare > 0)(apparmor module is loaded.) -> 0
2022/09/27 06:23:11 sca[13134] wm_sca.c:1859 at wm_sca_regex_numeric_comparison(): DEBUG: REGEX: '^(\d+)\s*profiles are loaded'. Partial comparison: '> 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1891 at wm_sca_regex_numeric_comparison(): DEBUG: Captured value: '11'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1908 at wm_sca_regex_numeric_comparison(): DEBUG: Converted value: '11'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1745 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Partial comparison '> 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1787 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Value given for comparison: '0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1808 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Value converted: '0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1826 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Operation is '11 > 0'
2022/09/27 06:23:11 sca[13134] wm_sca.c:1911 at wm_sca_regex_numeric_comparison(): DEBUG: Comparison result '11 > 0' -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1966 at wm_sca_pattern_matches(): DEBUG: Testing minterm (n:^(\d+)\s*profiles are loaded compare > 0)(11 profiles are loaded.) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1969 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (n:^(\d+)\s*profiles are loaded compare > 0)(11 profiles are loaded.) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1727 at wm_sca_read_command(): DEBUG: Result for (n:^(\d+)\s*profiles are loaded compare > 0)(apparmor_status) -> 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1157 at wm_sca_do_scan(): DEBUG: Command output matched.
2022/09/27 06:23:11 sca[13134] wm_sca.c:1246 at wm_sca_do_scan(): DEBUG: Result for rule 'c:apparmor_status -> n:^(\d+)\s*profiles are loaded compare > 0': 1
2022/09/27 06:23:11 sca[13134] wm_sca.c:1269 at wm_sca_do_scan(): DEBUG: Result for check id: 19046 'Ensure permissions on /etc/issue are configured.' -> 1
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report