### PR TITLE
FTS list race condition crash

### DIFF
--- a/src/analysisd/fts.c
+++ b/src/analysisd/fts.c
@@ -306,6 +306,8 @@ char * FTS(Eventinfo *lf, OSList **fts_list, OSHash **fts_store)
         }
     }
 
+    w_mutex_lock(&fts_write_lock);
+
     /** Check if FTS is already present **/
     if (OSHash_Get_ex(*fts_store, _line)) {
         free(_line);
@@ -355,6 +357,7 @@ char * FTS(Eventinfo *lf, OSList **fts_list, OSHash **fts_store)
         if (!line_for_list) {
             merror(MEM_ERROR, errno, strerror(errno));
             free(_line);
+            w_mutex_unlock(&fts_write_lock);
             return NULL;
         }
     }
@@ -363,9 +366,11 @@ char * FTS(Eventinfo *lf, OSList **fts_list, OSHash **fts_store)
         if (fts_node) OSList_DeleteThisNode(*fts_list, fts_node);
         free(line_for_list);
         free(_line);
+        w_mutex_unlock(&fts_write_lock);
         return NULL;
     }
 
+    w_mutex_unlock(&fts_write_lock);
     return _line;
 }
 

--- a/src/analysisd/fts.c
+++ b/src/analysisd/fts.c
@@ -306,13 +306,13 @@ char * FTS(Eventinfo *lf, OSList **fts_list, OSHash **fts_store)
         }
     }
 
-    w_mutex_lock(&fts_write_lock);
-
     /** Check if FTS is already present **/
     if (OSHash_Get_ex(*fts_store, _line)) {
         free(_line);
         return NULL;
     }
+
+    w_mutex_lock(&fts_write_lock);
 
     /* Check if from the last FTS events, we had at least 3 "similars" before.
      * If yes, we just ignore it.
@@ -340,6 +340,7 @@ char * FTS(Eventinfo *lf, OSList **fts_list, OSHash **fts_store)
         if (!line_for_list) {
             merror(MEM_ERROR, errno, strerror(errno));
             free(_line);
+            w_mutex_unlock(&fts_write_lock);
             return NULL;
         }
 
@@ -347,6 +348,7 @@ char * FTS(Eventinfo *lf, OSList **fts_list, OSHash **fts_store)
         if (!fts_node) {
             free(line_for_list);
             free(_line);
+            w_mutex_unlock(&fts_write_lock);
             return NULL;
         }
     }


### PR DESCRIPTION
|Related issue|
|---|
|[#17032](https://github.com/wazuh/wazuh/issues/17032)|

## Description

When on high RPMs values, eventually a race condition might occur that generates 
crash when a thread frees a list being used by another thread.

On systems with this situation, the race condition was avoided by configuring a
single thread, with positive results.

To prevent the race condition from happening when multiple threads are allowed,
a mutex was placed to synchronize threads and prevent this from happening.

