### PR TITLE
Replace agents group column with the belongs relationship table

### DIFF
--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -4341,7 +4341,12 @@ stages:
     response:
       status_code: 200
       json:
-        <<: *basic_response
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: 27
+          total_failed_items: 0
 
   - name: Get the different combinations for os.platform
     request:
@@ -4393,6 +4398,38 @@ stages:
               os:
                 name: unknown
 
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+  
+  - name: Get the different combinations for group
+    request:
+      verify: False
+      <<: *distinct_request
+      params:
+        fields:
+          - group
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - count: !anyint
+              group:
+                - group3
+            - count: !anyint
+              group:
+                - default
+            - count: !anyint
+              group:
+                - group1
+            - count: !anyint
+              group:
+                - group2
+            - count: !anyint
+              group:
+                - unknown
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -4555,7 +4592,7 @@ stages:
             - count: 2
               node_name: 'unknown'
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: 1
           total_failed_items: 0
 
   - name: Try to show agents with wrong search

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -363,7 +363,7 @@ def get_agents_in_group(group_list: list, offset: int = 0, limit: int = common.D
     Parameters
     ----------
     group_list : list
-        List containing the group ID.
+        List containing group IDs.
     offset : int
         First element to return in the collection.
     limit : int
@@ -648,7 +648,7 @@ def get_group_files(group_list: list = None, offset: int = 0, limit: int = None,
     Parameters
     ----------
     group_list : list
-        List of Group names.
+        List of group names.
     search_text : str
         Text to search.
     complementary_search : bool
@@ -791,7 +791,7 @@ def delete_groups(group_list: list = None) -> AffectedItemsWazuhResult:
     Parameters
     ----------
     group_list : list
-        List of Group names.
+        List of group names.
 
     Returns
     -------
@@ -899,7 +899,7 @@ def remove_agent_from_group(group_list: list = None, agent_list: list = None) ->
     Parameters
     ----------
     group_list : list
-        List with the group ID.
+        List with group names.
     agent_list : list
         List with the agent ID.
 

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -83,14 +83,40 @@ class WazuhDBQueryAgents(WazuhDBQuery):
         unify_wazuh_version_format(filters)
         if min_select_fields is None:
             min_select_fields = {'id'}
+
+        joins = {
+            'belongs': {
+                'type': 'left',
+                'conditions': ['id=belongs.id_agent']
+            },
+        }
+        group_by=['id']
+
         backend = WazuhDBBackend(query_format='global')
         WazuhDBQuery.__init__(self, offset=offset, limit=limit, table='agent', sort=sort, search=search, select=select,
                               filters=filters, fields=Agent.fields, default_sort_field=default_sort_field,
                               default_sort_order='ASC', query=query, backend=backend,
                               min_select_fields=min_select_fields, count=count, get_data=get_data,
                               date_fields={'lastKeepAlive', 'dateAdd'}, extra_fields={'internal_key'},
-                              distinct=distinct, rbac_negate=rbac_negate)
+                              distinct=distinct, rbac_negate=rbac_negate, joins=joins, group_by=group_by)
         self.remove_extra_fields = remove_extra_fields
+
+    def _set_group_field_select_value(self):
+        """Wraps the field value with the GROUP_CONCAT function to join all groups in the same text field."""
+        group_field = 'group'
+        if group_field in self.fields:
+            self.fields[group_field] = 'GROUP_CONCAT(belongs.name_group)'
+
+    def _get_total_items(self):
+        self._set_group_field_select_value()
+        super()._get_total_items()
+
+    def _execute_data_query(self):
+        self._set_group_field_select_value()
+        super()._execute_data_query()
+
+    def _default_count_query(self):
+        return "SELECT COUNT(*) FROM ({0} GROUP BY id)"
 
     def _filter_date(self, date_filter: dict, filter_db_name: str):
         """Add date filter to the Wazuh query."""
@@ -214,20 +240,17 @@ class WazuhDBQueryAgents(WazuhDBQuery):
             If the operator of the filter is not valid.
         """
         if field_name == 'group' and q_filter['value'] is not None:
-            valid_group_operators = {'=', '!=', '~'}
-
-            if q_filter['operator'] == '=':
-                self.query += f"(',' || {self.fields[field_name]} || ',') LIKE :{field_filter}"
-                self.request[field_filter] = f"%,{q_filter['value']},%"
+            if q_filter['operator'] == '=' or q_filter['operator'] == 'LIKE':
+                self.query += 'id IN '
             elif q_filter['operator'] == '!=':
-                self.query += f"NOT (',' || {self.fields[field_name]} || ',') LIKE :{field_filter}"
-                self.request[field_filter] = f"%,{q_filter['value']},%"
-            elif q_filter['operator'] == 'LIKE':
-                self.query += f"{self.fields[field_name]} LIKE :{field_filter}"
-                self.request[field_filter] = f"%{q_filter['value']}%"
+                self.query += 'belongs.name_group IS NOT NULL AND id NOT IN '
             else:
+                valid_group_operators = {'=', '!=', '~'}
                 raise WazuhError(1409, f"Valid operators for 'group' field: {', '.join(valid_group_operators)}. "
                                        f"Used operator: {q_filter['operator']}")
+
+            self.query += f"(SELECT id_agent FROM belongs WHERE name_group LIKE :{field_filter})"
+            self.request[field_filter] = f"%{q_filter['value']}%"
         else:
             WazuhDBQuery._process_filter(self, field_name, field_filter, q_filter)
 
@@ -285,7 +308,7 @@ class WazuhDBQueryGroup(WazuhDBQuery):
 
     def _add_sort_to_query(self):
         """Consider the option to sort by count."""
-        self.fields['count'] = 'count(id_group)'
+        self.fields['count'] = 'count(name_group)'
         super()._add_sort_to_query()
 
     def _add_search_to_query(self):
@@ -304,7 +327,7 @@ class WazuhDBQueryGroup(WazuhDBQuery):
         str
             Default query.
         """
-        return "SELECT name, count(id_group) AS count from `group` LEFT JOIN `belongs` on id=id_group WHERE "
+        return "SELECT name, count(name_group) AS count from `group` LEFT JOIN `belongs` on name=name_group WHERE "
 
     def _get_total_items(self):
         """Get total items."""
@@ -383,8 +406,21 @@ class WazuhDBQueryGroupByAgents(WazuhDBQueryGroupBy, WazuhDBQueryAgents):
             Fields to filter by.
         """
         WazuhDBQueryAgents.__init__(self, *args, **kwargs)
+        joins = None
+        if not filter_fields or 'group' in filter_fields:
+            # Avoid joining the belongs table when it's not requested to not interfere with the count
+            joins = {
+                'belongs': {
+                    'type': 'left',
+                    'conditions': ['id=belongs.id_agent']
+                },
+            }
+        else:
+            # The belongs table is not joined, thus we can't use belongs.name_group (group field value)
+            self.fields.pop('group')
         WazuhDBQueryGroupBy.__init__(self, *args, table=self.table, fields=self.fields, filter_fields=filter_fields,
-                                     default_sort_field=self.default_sort_field, backend=self.backend, **kwargs)
+                                     default_sort_field=self.default_sort_field, backend=self.backend, joins=joins,
+                                     **kwargs)
         self.remove_extra_fields = True
 
     def _format_data_into_dictionary(self) -> str:
@@ -400,6 +436,11 @@ class WazuhDBQueryGroupByAgents(WazuhDBQueryGroupBy, WazuhDBQueryAgents):
             for field in self.filter_fields['fields']:
                 if field not in result.keys():
                     result[field] = 'unknown'
+                    continue
+
+                if field == 'group':
+                    # Skip repeated group names
+                    result[field] = result[field].split(',')[0]
 
         fields_to_nest, non_nested = get_fields_to_nest(self.fields.keys(), ['os'], '.')
 
@@ -415,6 +456,7 @@ class WazuhDBQueryGroupByAgents(WazuhDBQueryGroupBy, WazuhDBQueryAgents):
             aux.append(aux_dict)
 
         self._data = aux
+        self.total_items = len(self._data)
         self._data = [plain_dict_to_nested_dict(d, fields_to_nest, non_nested, ['os'], '.') for d in self._data]
 
         return WazuhDBQuery._format_data_into_dictionary(self)
@@ -469,7 +511,7 @@ class Agent:
     fields = {'id': 'id', 'name': 'name', 'ip': 'coalesce(ip,register_ip)', 'status': 'connection_status',
               'os.name': 'os_name', 'os.version': 'os_version', 'os.platform': 'os_platform',
               'version': 'version', 'manager': 'manager_host', 'dateAdd': 'date_add',
-              'group': '`group`', 'mergedSum': 'merged_sum', 'configSum': 'config_sum',
+              'group': 'belongs.name_group', 'mergedSum': 'merged_sum', 'configSum': 'config_sum',
               'os.codename': 'os_codename', 'os.major': 'os_major', 'os.minor': 'os_minor',
               'os.uname': 'os_uname', 'os.arch': 'os_arch', 'os.build': 'os_build',
               'node_name': 'node_name', 'lastKeepAlive': 'last_keepalive', 'internal_key': 'internal_key',
@@ -1067,8 +1109,11 @@ class Agent:
         else:
             mode = 'append' if not override else 'override'
 
-        command = f'global set-agent-groups {{"mode":"{mode}","sync_status":"syncreq","data":[{{"id":{agent_id},' \
-                  f'"groups":["{group_id}"]}}]}}'
+        command = 'global set-agent-groups {' \
+                f'"mode":"{mode}","sync_status":"syncreq","data":' \
+                '[{' \
+                f'"id":{agent_id},"groups":["{group_id}"]' \
+                '}]}'
 
         wdb = WazuhDBConnection()
         try:

--- a/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
+++ b/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
@@ -32,7 +32,6 @@ CREATE TABLE IF NOT EXISTS agent (
     connection_status TEXT NOT NULL CHECK (connection_status IN ('active', 'pending', 'disconnected', 'never_connected')) DEFAULT 'never_connected',
     fim_offset INTEGER NOT NULL DEFAULT 0,
     reg_offset INTEGER NOT NULL DEFAULT 0,
-    `group` TEXT DEFAULT 'default',
     disconnection_time INTEGER DEFAULT 0,
     group_config_status TEXT NOT NULL CHECK (group_config_status IN ('synced', 'not synced')) DEFAULT 'not synced'
 );
@@ -42,35 +41,34 @@ CREATE INDEX IF NOT EXISTS agent_ip ON agent (ip);
 
 CREATE TABLE IF NOT EXISTS `group`
     (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT
+    name TEXT PRIMARY KEY
     );
 
 CREATE TABLE IF NOT EXISTS belongs
     (
     id_agent INTEGER,
-    id_group INTEGER,
-    PRIMARY KEY (id_agent, id_group)
+    name_group TEXT,
+    PRIMARY KEY (id_agent, name_group)
 );
 
 -- manager
 INSERT INTO agent (id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_uname, os_arch,
-                   version, manager_host, node_name, date_add, last_keepalive, status, connection_status, `group`, group_config_status) VALUES
+                   version, manager_host, node_name, date_add, last_keepalive, status, connection_status, group_config_status) VALUES
                    (0,'master','127.0.0.1','Ubuntu','18.04.1 LTS','18','04','Bionic Beaver','ubuntu',
                    'Linux |master |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.9.0','master','node01',strftime('%s','now','-10 days'),253402300799,
-                    'updated','active','group-1', 'synced');
+                    'updated','active', 'synced');
 
 -- Connected agent with IP and Registered IP filled
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (1,'agent-1','172.17.0.202','any',
+                   last_keepalive, status, connection_status, group_config_status) VALUES (1,'agent-1','172.17.0.202','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Ubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v4.2.0','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-5 seconds'),'updated', 'active', 'group-2', 'synced');
+                    strftime('%s','now','-5 seconds'),'updated', 'active', 'synced');
 
 -- Connected agent with just Registered IP filled
 INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
@@ -84,14 +82,14 @@ INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_
                     strftime('%s','now','-10 minutes'),'updated','active', 'synced');
 
 -- Never connected agent
-INSERT INTO agent (id, name, register_ip, internal_key, date_add, `group`, group_config_status) VALUES (3,'nc-agent','any',
+INSERT INTO agent (id, name, register_ip, internal_key, date_add, group_config_status) VALUES (3,'nc-agent','any',
                    'f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d',
-                   strftime('%s','now','-3 days'), NULL, 'not synced');
+                   strftime('%s','now','-3 days'), 'not synced');
 
 -- Pending agent
-INSERT INTO agent (id, name, register_ip, internal_key, manager_host, date_add, last_keepalive, `group`, connection_status, group_config_status) VALUES
+INSERT INTO agent (id, name, register_ip, internal_key, manager_host, date_add, last_keepalive, connection_status, group_config_status) VALUES
                   (4,'pending-agent', 'any', '2855bcf49273c759ef5b116829cc582f153c6c199df7676e53d5937855ff5902', '',
-                   strftime('%s','now','-1 minute'), strftime('%s','now','-10 seconds'), NULL,'pending', 'not synced');
+                   strftime('%s','now','-1 minute'), strftime('%s','now','-10 seconds'), 'pending', 'not synced');
 
 
 -- Disconnected agent
@@ -133,10 +131,16 @@ INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_
                    'node01',strftime('%s','now','-3 days'),
                     strftime('%s','now','-15 minutes'),'updated','active', 'synced');
 
--- Create group-1 and group-2
-INSERT INTO `group` (id, name) VALUES (1, 'group-1');
-INSERT INTO `group` (id, name) VALUES (2, 'group-2');
+-- Create groups
+INSERT INTO `group` (name) VALUES ('group-1');
+INSERT INTO `group` (name) VALUES ('group-2');
+INSERT INTO `group` (name) VALUES ('group-3');
 
--- Add Agent1 to group-1 and agent2 to group-2
-INSERT INTO belongs (id_agent, id_group) VALUES (1, 1);
-INSERT INTO belongs (id_agent, id_group) VALUES (2, 2);
+-- Add agent-group relationships
+INSERT INTO belongs (id_agent, name_group) VALUES (0, 'group-1');
+INSERT INTO belongs (id_agent, name_group) VALUES (1, 'group-1');
+INSERT INTO belongs (id_agent, name_group) VALUES (2, 'group-2');
+INSERT INTO belongs (id_agent, name_group) VALUES (5, 'group-2');
+INSERT INTO belongs (id_agent, name_group) VALUES (6, 'group-3');
+INSERT INTO belongs (id_agent, name_group) VALUES (7, 'group-3');
+INSERT INTO belongs (id_agent, name_group) VALUES (8, 'group-3');

--- a/framework/wazuh/core/tests/data/test_database/schema_global_test.sql
+++ b/framework/wazuh/core/tests/data/test_database/schema_global_test.sql
@@ -31,8 +31,7 @@ CREATE TABLE IF NOT EXISTS agent (
     status TEXT NOT NULL CHECK (status IN ('empty', 'pending', 'updated')) DEFAULT 'empty',
     connection_status TEXT NOT NULL CHECK (connection_status IN ('active', 'pending', 'disconnected', 'never_connected')) DEFAULT 'never_connected',
     fim_offset INTEGER NOT NULL DEFAULT 0,
-    reg_offset INTEGER NOT NULL DEFAULT 0,
-    `group` TEXT DEFAULT 'default'
+    reg_offset INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);
@@ -40,35 +39,34 @@ CREATE INDEX IF NOT EXISTS agent_ip ON agent (ip);
 
 CREATE TABLE IF NOT EXISTS `group`
     (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT
+    name TEXT PRIMARY KEY
     );
 
 CREATE TABLE IF NOT EXISTS belongs
     (
     id_agent INTEGER,
-    id_group INTEGER,
-    PRIMARY KEY (id_agent, id_group)
+    name_group TEXT,
+    PRIMARY KEY (id_agent, name_group)
 );
 
 -- manager
 INSERT INTO agent (id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_uname, os_arch,
-                   version, manager_host, node_name, date_add, last_keepalive, status, connection_status, `group`) VALUES
+                   version, manager_host, node_name, date_add, last_keepalive, status, connection_status) VALUES
                    (0,'master','127.0.0.1','Ubuntu','18.04.1 LTS','18','04','Bionic Beaver','ubuntu',
                    'Linux |master |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.9.0','master','node01',strftime('%s','now','-10 days'),253402300799,
-                    'updated','active','group-1');
+                    'updated','active');
 
 -- Connected agent with IP and Registered IP filled
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`) VALUES (1,'agent-1','172.17.0.202','any',
+                   last_keepalive, status, connection_status) VALUES (1,'agent-1','172.17.0.202','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Ubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v4.2.0','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-5 seconds'),'updated', 'active', 'group-2');
+                    strftime('%s','now','-5 seconds'),'updated', 'active');
 
 -- Connected agent with just Registered IP filled
 INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
@@ -82,14 +80,14 @@ INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_
                     strftime('%s','now','-10 minutes'),'updated','active');
 
 -- Never connected agent
-INSERT INTO agent (id, name, register_ip, internal_key, date_add, `group`) VALUES (3,'nc-agent','any',
+INSERT INTO agent (id, name, register_ip, internal_key, date_add) VALUES (3,'nc-agent','any',
                    'f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d',
-                   strftime('%s','now','-3 days'), NULL);
+                   strftime('%s','now','-3 days'));
 
 -- Pending agent
-INSERT INTO agent (id, name, register_ip, internal_key, manager_host, date_add, last_keepalive, `group`, connection_status) VALUES
+INSERT INTO agent (id, name, register_ip, internal_key, manager_host, date_add, last_keepalive, connection_status) VALUES
                   (4,'pending-agent', 'any', '2855bcf49273c759ef5b116829cc582f153c6c199df7676e53d5937855ff5902', '',
-                   strftime('%s','now','-1 minute'), strftime('%s','now','-10 seconds'), NULL,'pending');
+                   strftime('%s','now','-1 minute'), strftime('%s','now','-10 seconds'),'pending');
 
 
 -- Disconnected agent
@@ -132,9 +130,9 @@ INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_
                     strftime('%s','now','-15 minutes'),'updated','active');
 
 -- Create group-1 and group-2
-INSERT INTO `group` (id, name) VALUES (1, 'group-1');
-INSERT INTO `group` (id, name) VALUES (2, 'group-2');
+INSERT INTO `group` (name) VALUES ('group-1');
+INSERT INTO `group` (name) VALUES ('group-2');
 
 -- Add Agent1 to group-1 and agent2 to group-2
-INSERT INTO belongs (id_agent, id_group) VALUES (1, 1);
-INSERT INTO belongs (id_agent, id_group) VALUES (2, 2);
+INSERT INTO belongs (id_agent, name_group) VALUES (1, 'group-1');
+INSERT INTO belongs (id_agent, name_group) VALUES (2, 'group-2');

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -378,7 +378,7 @@ def test_WazuhDBQueryGroup__add_sort_to_query(mock_socket_conn, send_mock):
     query_group = WazuhDBQueryGroup()
     query_group._add_sort_to_query()
 
-    assert 'count' in query_group.fields and query_group.fields['count'] == 'count(id_group)'
+    assert 'count' in query_group.fields and query_group.fields['count'] == 'count(name_group)'
 
 
 @patch('socket.socket.connect')
@@ -1106,8 +1106,8 @@ def test_agent_set_agent_group_relationship(socket_connect_mock, send_mock, remo
     """
     agent_id = '001'
     group_id = 'default'
-    wdb_command = r'global set-agent-groups {\"mode\":\"(.+)\",\"sync_status\":\"syncreq\",\"data\":\[{\"id\":(.+),' \
-                  r'\"groups\":\[\"(.+)\"]}]}'
+    wdb_command = r'global set-agent-groups {\"mode\":\"(.+)\",\"sync_status\":\"syncreq\",\"data\":\[{' \
+        r'\"id\":(.+),\"groups\":\[\"(.+)\"\]}]}'
 
     # Default relationship -> add an agent to a group
     Agent.set_agent_group_relationship(agent_id, group_id, remove, override)

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1540,8 +1540,8 @@ def test_WazuhDBQueryDistinct_protected_default_query(mock_socket_conn, mock_isf
     """Test utils.WazuhDBQueryDistinct._default_query function."""
     query = utils.WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
                                        query=None, select={'fields': ['name']},
-                                       fields={'name': '`group`'}, count=True,
-                                       get_data=True, default_sort_field='`group`',
+                                       fields={'name': 'group'}, count=True,
+                                       get_data=True, default_sort_field='group',
                                        backend=utils.WazuhDBBackend(agent_id=1),
                                        table='agent')
 
@@ -1562,8 +1562,8 @@ def test_WazuhDBQueryDistinct_protected_default_count_query(mock_socket_conn, mo
     """Test utils.WazuhDBQueryDistinct._default_count_query function."""
     query = utils.WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
                                        query=None, select={'name'},
-                                       fields={'name': '`group`'}, count=True,
-                                       get_data=True, default_sort_field='`group`',
+                                       fields={'name': 'group'}, count=True,
+                                       get_data=True, default_sort_field='group',
                                        backend=utils.WazuhDBBackend(agent_id=1),
                                        table='agent')
 
@@ -1585,8 +1585,8 @@ def test_WazuhDBQueryDistinct_protected_add_filters_to_query(mock_add, mock_sock
     """Test utils.WazuhDBQueryDistinct._add_filters_to_query function."""
     query = utils.WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
                                        query=None, select={'name'},
-                                       fields={'name': '`group`'}, count=True,
-                                       get_data=True, default_sort_field='`group`',
+                                       fields={'name': 'group'}, count=True,
+                                       get_data=True, default_sort_field='group',
                                        backend=utils.WazuhDBBackend(agent_id=1),
                                        table='agent')
 
@@ -1597,7 +1597,7 @@ def test_WazuhDBQueryDistinct_protected_add_filters_to_query(mock_add, mock_sock
 
 @pytest.mark.parametrize('select', [
     {'name'},
-    {'name', 'ip'}
+    {'name', 'group'}
 ])
 @patch('wazuh.core.utils.path.exists', return_value=True)
 @patch('wazuh.core.utils.glob.glob', return_value=True)
@@ -1610,10 +1610,10 @@ def test_WazuhDBQueryDistinct_protected_add_select_to_query(mock_add, mock_socke
     """Test utils.WazuhDBQueryDistinct._add_select_to_query function."""
     query = utils.WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
                                        query=None, select=select,
-                                       fields={'name': '`group`'},
+                                       fields={'name': 'group'},
                                        count=True, get_data=True,
                                        backend=utils.WazuhDBBackend(agent_id=1),
-                                       default_sort_field='`group`', table='agent')
+                                       default_sort_field='group', table='agent')
 
     if len(select) > 1:
         with pytest.raises(exception.WazuhException, match=".* 1410 .*"):
@@ -1634,10 +1634,10 @@ def test_WazuhDBQueryDistinct_protected_format_data_into_dictionary(mock_socket_
     """Test utils.WazuhDBQueryDistinct._format_data_into_dictionary function."""
     query = utils.WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
                                        query=None, select={'fields': ['name']},
-                                       fields={'name': '`group`'}, count=True,
+                                       fields={'name': 'group'}, count=True,
                                        get_data=True,
                                        backend=utils.WazuhDBBackend(agent_id=1),
-                                       default_sort_field='`group`',
+                                       default_sort_field='group',
                                        table='agent')
 
     query._data = []
@@ -1657,7 +1657,7 @@ def test_WazuhDBQueryGroupBy__init__(mock_socket_conn, mock_isfile, mock_conn_db
     """Tests utils.WazuhDBQueryGroupBy.__init__ function works"""
     utils.WazuhDBQueryGroupBy(filter_fields=None, offset=0, limit=1, table='agent',
                               sort=None, search=None, select={'fields': ['name']},
-                              filters=None, fields={'name': '`group`'},
+                              filters=None, fields={'name': 'group'},
                               default_sort_field=None, default_sort_order='ASC',
                               query=None, min_select_fields=None, count=True,
                               backend=utils.WazuhDBBackend(agent_id=0), get_data=None,
@@ -1679,7 +1679,7 @@ def test_WazuhDBQueryGroupBy_protected_get_total_items(mock_total, mock_socket_c
     query = utils.WazuhDBQueryGroupBy(filter_fields={'fields': ['name']}, offset=0,
                                       limit=1, table='agent', sort=None, search=None,
                                       select={'name'}, filters=None,
-                                      fields={'name': '`group`'}, query=None,
+                                      fields={'name': 'group'}, query=None,
                                       default_sort_field=None, get_data=None,
                                       default_sort_order='ASC',
                                       min_select_fields=None, count=True,
@@ -1704,7 +1704,7 @@ def test_WazuhDBQueryGroupBy_protected_add_select_to_query(mock_parse, mock_add,
     query = utils.WazuhDBQueryGroupBy(filter_fields={'fields': ['name']}, offset=0,
                                       limit=1, table='agent', sort=None, search=None,
                                       select={'name'}, filters=None,
-                                      fields={'name': '`group`'}, query=None,
+                                      fields={'name': 'group'}, query=None,
                                       default_sort_field=None,
                                       default_sort_order='ASC',
                                       min_select_fields=None,

--- a/framework/wazuh/tests/data/schema_global_test.sql
+++ b/framework/wazuh/tests/data/schema_global_test.sql
@@ -32,7 +32,6 @@ CREATE TABLE IF NOT EXISTS agent (
     connection_status TEXT NOT NULL CHECK (connection_status IN ('active', 'pending', 'disconnected', 'never_connected')) DEFAULT 'never_connected',
     fim_offset INTEGER NOT NULL DEFAULT 0,
     reg_offset INTEGER NOT NULL DEFAULT 0,
-    `group` TEXT DEFAULT 'default',
     disconnection_time INTEGER DEFAULT 0,
     group_config_status TEXT NOT NULL CHECK (group_config_status IN ('synced', 'not synced')) DEFAULT 'not synced'
 );
@@ -42,56 +41,55 @@ CREATE INDEX IF NOT EXISTS agent_ip ON agent (ip);
 
 CREATE TABLE IF NOT EXISTS `group`
     (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT
+    name TEXT PRIMARY KEY
     );
 
 CREATE TABLE IF NOT EXISTS belongs
     (
     id_agent INTEGER,
-    id_group INTEGER,
-    PRIMARY KEY (id_agent, id_group)
+    name_group TEXT,
+    PRIMARY KEY (id_agent, name_group)
 );
 
 -- manager
 INSERT INTO agent (id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_uname, os_arch,
-                   version, manager_host, node_name, date_add, last_keepalive, status, connection_status, `group`, group_config_status) VALUES
+                   version, manager_host, node_name, date_add, last_keepalive, status, connection_status, group_config_status) VALUES
                    (0,'master','127.0.0.1','Ubuntu','20.04.1 LTS','20','04','Bionic Beaver','ubuntu',
                    'Linux |master |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.9.0','master','node01',strftime('%s','now','-10 days'),253402300799,
-                    'updated','active',NULL, 'synced');
+                    'updated','active','synced');
 
 -- Connected agent with IP and Registered IP filled
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (1,'agent-1','172.17.0.202','any',
+                   last_keepalive, status, connection_status, group_config_status) VALUES (1,'agent-1','172.17.0.202','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Ubuntu','16.06.1 LTS','16','06',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-5 seconds'),'updated','active', 'default,group-0', 'synced');
+                    strftime('%s','now','-5 seconds'),'updated','active', 'synced');
 
 -- Connected agent with just Registered IP filled
 INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (2,'agent-2','172.17.0.201',
+                   last_keepalive, status, connection_status, group_config_status) VALUES (2,'agent-2','172.17.0.201',
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Ubuntu','16.04.1 LTS','16','04',
                    'Xenial','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.6.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
-                    strftime('%s','now','-10 minutes'),'updated','active', 'default,group-0', 'synced');
+                    strftime('%s','now','-10 minutes'),'updated','active', 'synced');
 
 -- Never connected agent
-INSERT INTO agent (id, name, register_ip, internal_key, date_add, `group`, group_config_status) VALUES (3,'nc-agent','any',
+INSERT INTO agent (id, name, register_ip, internal_key, date_add, group_config_status) VALUES (3,'nc-agent','any',
                    'f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d',
-                   strftime('%s','now','-4 days'), NULL, 'not synced');
+                   strftime('%s','now','-4 days'), 'not synced');
 
 -- Pending agent
-INSERT INTO agent (id, name, register_ip, internal_key, manager_host, date_add, last_keepalive, `group`, connection_status, group_config_status) VALUES
+INSERT INTO agent (id, name, register_ip, internal_key, manager_host, date_add, last_keepalive, connection_status, group_config_status) VALUES
                   (4,'pending-agent', 'any', '2855bcf49273c759ef5b116829cc582f153c6c199df7676e53d5937855ff5902', '',
-                   strftime('%s','now','-1 minute'), strftime('%s','now','-10 seconds'), NULL,'pending', 'not synced');
+                   strftime('%s','now','-1 minute'), strftime('%s','now','-10 seconds'),'pending', 'not synced');
 
 
 -- Disconnected agent
@@ -109,62 +107,62 @@ INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version,
 -- Connected agent in group-1
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (6,'agent-6','172.17.0.401','any',
+                   last_keepalive, status, connection_status, group_config_status) VALUES (6,'agent-6','172.17.0.401','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Xubuntu','21.04.1 LTS','21','04',
                    'Bionic Beaver','xubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-7 seconds'),'updated','active','group-1', 'synced');
+                    strftime('%s','now','-7 seconds'),'updated','active', 'synced');
 
 
 -- Connected agent in group-2
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (7,'agent-7','172.17.0.501','any',
+                   last_keepalive, status, connection_status, group_config_status) VALUES (7,'agent-7','172.17.0.501','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Ubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-4 seconds'),'updated','active','group-2', 'synced');
+                    strftime('%s','now','-4 seconds'),'updated','active', 'synced');
 
 
 -- Connected agent in group-2
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (8,'agent-8','172.17.0.502','any',
+                   last_keepalive, status, connection_status, group_config_status) VALUES (8,'agent-8','172.17.0.502','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Xubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','xubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-12 seconds'),'updated','active','group-2,group-1', 'synced');
+                    strftime('%s','now','-12 seconds'),'updated','active', 'synced');
 
 
 -- Connected agent with a different OS
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (9,'agent-9','172.17.0.503','any',
+                   last_keepalive, status, connection_status, group_config_status) VALUES (9,'agent-9','172.17.0.503','any',
                    'b3650e11eba2f27er4d160c69de533ee7ffd601636a85ba2455d53a90927747f', 'Windows','10.0.0 XP','10','00',
                    'XP classic','windows',
                    'Windows |agent-9 |3.14-45 |#46-Windows SMP Thu Dec 32 24:45:28 UTC 2022 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-5 seconds'),'updated','active','default', 'synced');
+                    strftime('%s','now','-5 seconds'),'updated','active', 'synced');
 
 
 -- Create group-1 and group-2
-INSERT INTO `group` (id, name) VALUES (1, 'group-1');
-INSERT INTO `group` (id, name) VALUES (2, 'group-2');
-INSERT INTO `group` (id, name) VALUES (3, 'group-empty');
+INSERT INTO `group` (name) VALUES ('group-1');
+INSERT INTO `group` (name) VALUES ('group-2');
+INSERT INTO `group` (name) VALUES ('group-empty');
 
+-- agent-6 -> group-1
+INSERT INTO belongs (id_agent, name_group) VALUES (006, 'group-1');
 
--- agent-6 -> group-1 and agent-7 -> group-2
-INSERT INTO belongs (id_agent, id_group) VALUES (6, 1);
-INSERT INTO belongs (id_agent, id_group) VALUES (7, 2);
-
+-- agent-7 -> group-2
+INSERT INTO belongs (id_agent, name_group) VALUES (007, 'group-2');
 
 -- agent-8 -> group-1 and group-2
-INSERT INTO belongs (id_agent, id_group) VALUES (8, 2);
-INSERT INTO belongs (id_agent, id_group) VALUES (8, 1);
+INSERT INTO belongs (id_agent, name_group) VALUES (008, 'group-2');
+INSERT INTO belongs (id_agent, name_group) VALUES (008, 'group-1');

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -304,7 +304,7 @@ def test_agent_get_agents(socket_mock, send_mock, agent_list, expected_items):
 
 
 @pytest.mark.parametrize('group, group_exists, expected_agents', [
-    ('default', True, ['001', '002', '005']),
+    ('group-1', True, ['006', '008']),
     ('not_exists_group', False, None)
 ])
 @patch('wazuh.agent.get_agents')
@@ -324,12 +324,12 @@ def test_agent_get_agents_in_group(socket_mock, send_mock, mock_get_groups, mock
     expected_agents : List of str
         List of agent ID's that belongs to a given group.
     """
-    mock_get_groups.return_value = ['default']
+    mock_get_groups.return_value = ['group-1']
     if group_exists:
         # Since the decorator is mocked, pass `group_list` using `call_args` from mock
         get_agents_in_group(group_list=[group], select=['id'])
         kwargs = mock_get_agents.call_args[1]
-        agents = get_agents(agent_list=short_agent_list, **kwargs)
+        agents = get_agents(agent_list=full_agent_list, **kwargs)
         assert agents.affected_items
         assert len(agents.affected_items) == len(expected_agents)
         for expected_agent, affected_agent in zip(expected_agents, agents.affected_items):
@@ -368,7 +368,7 @@ def test_agent_get_agents_keys(socket_mock, send_mock, agent_list, expected_item
 
 @pytest.mark.parametrize('agent_list, filters, q, error_code, expected_items', [
     (full_agent_list[1:], {'status': 'all', 'older_than': '1s'}, None, None, full_agent_list[1:]),
-    (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'group': 'group-0'}, None, 1731, ['001', '002']),
+    (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'group': 'group-0'}, None, 1731, []),
     (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'group': 'group-1'}, None, 1731, ['006', '008']),
     (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'group': 'group-2'}, None, 1731, ['007', '008']),
     (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'registerIP': 'any'}, None, 1731,


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/16285 |

## Description

Replaced the `group` column from `agents` table with the agent-group links stored in the `belongs` table. The code now refers to group names instead of group IDs.

### API call examples

Environment: integration tests

<details><summary><code>GET /agents?select=id,group</code></summary>

```json
{
    "data": {
        "affected_items": [
            {
                "id": "000"
            },
            {
                "group": [
                    "default",
                    "group1"
                ],
                "id": "001"
            },
            {
                "group": [
                    "default",
                    "group2"
                ],
                "id": "002"
            },
            {
                "group": [
                    "default",
                    "group3"
                ],
                "id": "003"
            },
            {
                "group": [
                    "default"
                ],
                "id": "004"
            },
            {
                "group": [
                    "default",
                    "group1",
                    "group2"
                ],
                "id": "005"
            },
            {
                "group": [
                    "default",
                    "group2",
                    "group3"
                ],
                "id": "006"
            },
            {
                "group": [
                    "default",
                    "group1",
                    "group3"
                ],
                "id": "007"
            },
            {
                "group": [
                    "default",
                    "group1",
                    "group2",
                    "group3"
                ],
                "id": "008"
            },
            {
                "group": [
                    "default",
                    "group1"
                ],
                "id": "009"
            },
            {
                "group": [
                    "default",
                    "group2"
                ],
                "id": "010"
            },
            {
                "id": "011"
            },
            {
                "id": "012"
            }
        ],
        "total_affected_items": 13,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected agents information was returned",
    "error": 0
}
```

</details>

<details><summary><code>GET /agents?select=id,group&q=group=group1</code></summary>

```json
{
    "data": {
        "affected_items": [
            {
                "group": [
                    "group1"
                ],
                "id": "001"
            },
            {
                "group": [
                    "group1"
                ],
                "id": "005"
            },
            {
                "group": [
                    "group1"
                ],
                "id": "007"
            },
            {
                "group": [
                    "group1"
                ],
                "id": "008"
            },
            {
                "group": [
                    "group1"
                ],
                "id": "009"
            }
        ],
        "total_affected_items": 5,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected agents information was returned",
    "error": 0
}
```

</details>

<details><summary><code>GET /groups/group2/agents?select=id,group</code></summary>

```json
{
    "data": {
        "affected_items": [
            {
                "group": [
                    "group2"
                ],
                "id": "002"
            },
            {
                "group": [
                    "group2"
                ],
                "id": "005"
            },
            {
                "group": [
                    "group2"
                ],
                "id": "006"
            },
            {
                "group": [
                    "group2"
                ],
                "id": "008"
            },
            {
                "group": [
                    "group2"
                ],
                "id": "010"
            }
        ],
        "total_affected_items": 5,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected agents information was returned",
    "error": 0
}
```

</details>

### Tests

`Integration tests for API - Tier 0 and 1` is expected to fail since they it's being executed without the changes required in the tests made [here](https://github.com/wazuh/wazuh-qa/issues/4217). I ran them manually to overcome this, the results are below.

<details><summary>Integration tests for API - Tier 0 and 1</summary>

```console
Run cd tests/integration
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.3.0
rootdir: /home/runner/work/wazuh/wazuh/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, metadata-3.0.0
collected 61 items / 3 deselected / 58 selected

test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py . [  1%]
                                                                         [  1%]
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py . [  3%]
                                                                         [  3%]
test_api/test_config/test_cache/test_cache.py ..                         [  6%]
test_api/test_config/test_cors/test_cors.py x.                           [ 10%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py ..     [ 13%]
test_api/test_config/test_experimental_features/test_experimental_features.py . [ 15%]
.                                                                        [ 17%]
test_api/test_config/test_host_port/test_host_port.py ....               [ 24%]
test_api/test_config/test_https/test_https.py ..                         [ 27%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py . [ 29%]
.                                                                        [ 31%]
test_api/test_config/test_logs/test_logs_format.py ........              [ 44%]
test_api/test_config/test_rbac/test_rbac_mode.py ..                      [ 48%]
test_api/test_config/test_request_timeout/test_request_timeout.py .      [ 50%]
test_api/test_middlewares/test_response_postprocessing.py ....           [ 56%]
test_api/test_middlewares/test_set_secure_headers.py .                   [ 58%]
test_api/test_rbac/test_add_old_resource.py ....                         [ 65%]
test_api/test_rbac/test_manage_admin_resource.py .......                 [ 77%]
test_api/test_rbac/test_policy_position.py .                             [ 79%]
test_api/test_rbac/test_remove_resource.py ....                          [ 86%]
test_api/test_rbac/test_remove_resources_relation.py ...                 [ 91%]
test_api/test_statistics/test_statistics_format.py .....                 [100%]

=========== 57 passed, 3 deselected, 1 xfailed in 826.98s (0:13:46) ============
```

</details>


<details><summary>test_agent_GET_endpoints.tavern.yaml</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_agent_GET_endpoints.tavern.yaml
================================================ test session starts ================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 93 items                                                                                                  

test_agent_GET_endpoints.tavern.yaml::GET /agents PASSED                                                      [  1%]
test_agent_GET_endpoints.tavern.yaml::GET /agents with single agent id PASSED                                 [  2%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED        [  3%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} (only cluster configuration) PASSED [  4%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                             [  5%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                       [  6%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                             [  7%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                         [  8%]
test_agent_GET_endpoints.tavern.yaml::GET /groups PASSED                                                      [  9%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED                                     [ 10%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED                                    [ 11%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED                                  [ 12%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED                                  [ 13%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED                                  [ 15%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED                                  [ 16%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED                                 [ 17%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED                                 [ 18%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED                                [ 19%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED                                [ 20%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED                                [ 21%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED                                [ 22%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                    [ 23%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED           [ 24%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED             [ 25%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED               [ 26%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED                  [ 27%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED                  [ 29%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED       [ 30%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED             [ 31%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED           [ 32%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED                [ 33%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED           [ 34%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED             [ 35%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED            [ 36%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED         [ 37%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED            [ 38%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED            [ 39%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED             [ 40%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED         [ 41%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED            [ 43%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED          [ 44%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED          [ 45%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED              [ 46%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED             [ 47%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                             [ 48%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                     [ 49%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED                    [ 50%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED                   [ 51%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED                 [ 52%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED                 [ 53%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED                 [ 54%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED                 [ 55%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED                [ 56%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED                [ 58%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED               [ 59%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED               [ 60%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED               [ 61%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED               [ 62%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                     [ 63%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                      [ 64%]
test_agent_GET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                      [ 65%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group PASSED                                             [ 66%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED                      [ 67%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED                           [ 68%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED                           [ 69%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED                         [ 70%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED                    [ 72%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED                   [ 73%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED                       [ 74%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/outdated PASSED                                             [ 75%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                       [ 76%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED                     [ 77%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED                          [ 78%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED                          [ 79%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED               [ 80%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED                     [ 81%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED                        [ 82%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED                   [ 83%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED                     [ 84%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED                    [ 86%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED                 [ 87%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED                    [ 88%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED                    [ 89%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED                     [ 90%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED                 [ 91%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED                    [ 92%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED                  [ 93%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED                  [ 94%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED                      [ 95%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED                     [ 96%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                       [ 97%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                           [ 98%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                       [100%]

==================================== 93 passed, 2 warnings in 567.71s (0:09:27) =====================================
```

</details>
