### PR TITLE
Fix windows integration

### DIFF
--- a/src/engine/ruleset/integrations/windows/windows-base/decoders/windows-event-decoder.yml
+++ b/src/engine/ruleset/integrations/windows/windows-base/decoders/windows-event-decoder.yml
@@ -26,7 +26,6 @@ parse:
 normalize:
  - map:
    - wazuh.decoders: +array_append/windows-event-decoder
-   - event.module: windows
    - event.dataset: base
    - event.start: $~windows.Event.System.TimeCreated.@SystemTime
    - event.code: $~windows.Event.System.EventID.#text

--- a/src/engine/ruleset/integrations/windows/windows-base/decoders/windows-json.yml
+++ b/src/engine/ruleset/integrations/windows/windows-base/decoders/windows-json.yml
@@ -17,7 +17,7 @@ sources:
   - decoder/integrations/0
 
 check:
-  - wazuh.origin: EventChannel
+  - event.module: windows
 
 parse:
   logpar:

--- a/src/engine/ruleset/wazuh-core/decoders/core-windows.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-windows.yml
@@ -23,5 +23,6 @@ check:
 
 normalize:
   - map:
+      - event.module: windows
       - wazuh.source: logcollector
       - wazuh.decoders: +array_append/core-windows


### PR DESCRIPTION
|Related issue|
|---|
||

## Description

This PR fixes an issue were  Windows integration wasn't ingesting logs correctly
This change identifies windows logs using event.module field so that they can correctly be parsed by Windows integration decoders

Correct decoding present in UI
![image](https://github.com/wazuh/wazuh/assets/7738867/80e7882e-a465-40db-b5fa-6b83c4c32883)


## Configuration options

A windows Wazuh agent with event channel collection is required

## Logs/Alerts example

![image](https://github.com/wazuh/wazuh/assets/7738867/fc3cca9e-d157-43bf-a169-11519e76d97e)
