### PR TITLE
Fix a crash in Analysisd when parsing an invalid decoder

### DIFF
--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -811,8 +811,16 @@ int ReadDecodeXML(const char *file, OSDecoderNode **decoderlist_pn,
         }
 
         /* Add osdecoder to the list */
-        if (!OS_AddOSDecoder(pi, decoderlist_pn, decoderlist_nopn, log_msg)) {
+
+        int r;
+
+        if ((r = OS_AddOSDecoder(pi, decoderlist_pn, decoderlist_nopn, log_msg)) < 1) {
             smerror(log_msg, DECODER_ERROR);
+
+            if (r == -1) {
+                pi = NULL;
+            }
+
             goto cleanup;
         }
 

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -111,13 +111,13 @@ struct deltas_fields_match_list {
 
 /**
  * @brief Generic function to handle value mapping
- * 
+ *
  */
 typedef bool (*mapping_t)(cJSON*,const char*);
 
 /**
  * @brief Struct to map a field name their custom value mapper function
- * 
+ *
  */
 struct delta_values_mapping {
     char *key;
@@ -126,7 +126,7 @@ struct delta_values_mapping {
 
 /**
  * @brief Linked list of deltas values mappers
- * 
+ *
  */
 struct delta_values_mapping_list {
     struct delta_values_mapping current;
@@ -176,7 +176,10 @@ void OS_CreateOSDecoderList(void);
  * @param pi decoder to add in decoder list
  * @param pn_osdecodernode decoder list for events with program name
  * @param npn_osdecodernode decoder list for events without program name
- * @return 1 on success, otherwise 0
+ * @return status code
+ * @retval 1 success
+ * @retval 0 failure, the decoder has not been added to the list
+ * @retval -1 failure, but the decoder has already been added to the list
  */
 int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode,
                     OSDecoderNode **npn_osdecodernode, OSList* log_msg);

--- a/src/analysisd/decoders/decoders_list.c
+++ b/src/analysisd/decoders/decoders_list.c
@@ -82,7 +82,7 @@ STATIC OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi,
                     goto error;
                 }
 
-                if ((tmp_node->osdecoder->regex || tmp_node->osdecoder->plugindecoder) 
+                if ((tmp_node->osdecoder->regex || tmp_node->osdecoder->plugindecoder)
                     && (pi->regex || pi->plugindecoder)) {
                     tmp_node->osdecoder->get_next = 1;
                 } else {
@@ -155,7 +155,7 @@ int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode,
                 tmp_node->child = _OS_AddOSDecoder(tmp_node->child, pi, log_msg);
                 if (!tmp_node->child) {
                     smerror(log_msg, DEC_PLUGIN_ERR);
-                    return (0);
+                    return -added;
                 }
                 added = 1;
             }
@@ -169,7 +169,7 @@ int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode,
                 tmp_node->child = _OS_AddOSDecoder(tmp_node->child, pi, log_msg);
                 if (!tmp_node->child) {
                     smerror(log_msg, DEC_PLUGIN_ERR);
-                    return (0);
+                    return -added;
                 }
                 added = 1;
             }

--- a/src/analysisd/decoders/decoders_list.c
+++ b/src/analysisd/decoders/decoders_list.c
@@ -152,11 +152,12 @@ int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode,
         /* List with p_name */
         while (tmp_node) {
             if (strcmp(tmp_node->osdecoder->name, pi->parent) == 0) {
-                tmp_node->child = _OS_AddOSDecoder(tmp_node->child, pi, log_msg);
-                if (!tmp_node->child) {
+                OSDecoderNode *new_node = _OS_AddOSDecoder(tmp_node->child, pi, log_msg);
+                if (!new_node) {
                     smerror(log_msg, DEC_PLUGIN_ERR);
                     return -added;
                 }
+                tmp_node->child = new_node;
                 added = 1;
             }
             tmp_node = tmp_node->next;
@@ -166,11 +167,12 @@ int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode,
         tmp_node = *npn_osdecodernode;
         while (tmp_node) {
             if (strcmp(tmp_node->osdecoder->name, pi->parent) == 0) {
-                tmp_node->child = _OS_AddOSDecoder(tmp_node->child, pi, log_msg);
-                if (!tmp_node->child) {
+                OSDecoderNode *new_node = _OS_AddOSDecoder(tmp_node->child, pi, log_msg);
+                if (!new_node) {
                     smerror(log_msg, DEC_PLUGIN_ERR);
                     return -added;
                 }
+                tmp_node->child = new_node;
                 added = 1;
             }
             tmp_node = tmp_node->next;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17135|

This PR aims to fix the following issues in _wazuh-analysisd_ which happen when parsing a child decoder with an invalid option:

|Bug|Fix|
|---|---|
|Double free|Do not clean memory if the decoder was already added to the list.|
|Memory leak|Do not overwrite a child object with an invalid result (null pointer).|

### Critical decoder

```xml
<decoder name="sudo-fields">
  <parent>sudo</parent>
  <regex offset="after_regex">(\S+)</regex>
  <order>boom</order>
</decoder>
```

## Affected artifacts

- wazuh-analysisd
- wazuh-logtest-legacy

## Tests

- [x] Valgrind
- [x] Coverity
- [ ] Add an integration test that checks a controlled failure.

### Valgrind report

```
==127104== HEAP SUMMARY:
==127104==     in use at exit: 6,773,331 bytes in 35,753 blocks
==127104==   total heap usage: 187,155 allocs, 151,402 frees, 444,063,456 bytes allocated
==127104==
==127104== LEAK SUMMARY:
==127104==    definitely lost: 0 bytes in 0 blocks
==127104==    indirectly lost: 0 bytes in 0 blocks
==127104==      possibly lost: 0 bytes in 0 blocks
==127104==    still reachable: 6,773,331 bytes in 35,753 blocks
==127104==         suppressed: 0 bytes in 0 blocks
```

### Coverity report

New defects have been reported, but the list matches https://github.com/wazuh/wazuh/issues/17011#issuecomment-1536073478.

No bugs related to the affected files have been detected.

