### PR TITLE
RTR on winagent fails during Github actions execution - Implementation

### DIFF
--- a/.github/actions/install_build_deps/action.yml
+++ b/.github/actions/install_build_deps/action.yml
@@ -23,7 +23,7 @@ runs:
       run: |
         if [[ "${{ inputs.target }}" == "winagent" ]]; then
           sudo dpkg --add-architecture i386 && sudo apt-get update
-          sudo apt-get install -y --install-recommends wine-stable
+          sudo apt-get install -y --install-recommends wine-stable wine32
         else
           echo "Skipping wine installation for this target"
         fi

--- a/.github/actions/install_build_deps/action.yml
+++ b/.github/actions/install_build_deps/action.yml
@@ -22,8 +22,12 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.target }}" == "winagent" ]]; then
-          sudo dpkg --add-architecture i386 && sudo apt-get update
-          sudo apt-get install -y --install-recommends wine-stable wine32
+          sudo dpkg --add-architecture i386
+          sudo mkdir -pm755 /etc/apt/keyrings
+          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
+          sudo apt-get update
+          sudo apt-get install -y --allow-downgrades libc6:i386 libgcc-s1:i386 libstdc++6:i386 wine-stable-i386 wine-stable-amd64 winehq-stable
         else
           echo "Skipping wine installation for this target"
         fi

--- a/.github/workflows/rtr_syscheck.yml
+++ b/.github/workflows/rtr_syscheck.yml
@@ -8,6 +8,8 @@ on:
       - "src/syscheckd/**"
       - "src/unit_tests/syscheckd/**"
       - "src/Makefile"
+      - ".github/workflows/rtr_syscheck.yml"
+      - ".github/actions/**"
 
 jobs:
   rtr:

--- a/.github/workflows/rtr_syscheck.yml
+++ b/.github/workflows/rtr_syscheck.yml
@@ -18,7 +18,8 @@ jobs:
           matrix:
               module: [syscheckd]
               target: [agent, winagent]
-    runs-on: ubuntu-latest
+    # We don't use ubuntu-latest because the install_build_deps action adds a fixed repository for Wine
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/rtr_syscollector.yml
+++ b/.github/workflows/rtr_syscollector.yml
@@ -9,6 +9,8 @@ on:
       - "src/shared_modules/**"
       - "src/wazuh_modules/syscollector/**"
       - "src/Makefile"
+      - ".github/workflows/rtr_syscollector.yml"
+      - ".github/actions/**"
 
 jobs:
   rtr:

--- a/.github/workflows/rtr_syscollector.yml
+++ b/.github/workflows/rtr_syscollector.yml
@@ -19,7 +19,8 @@ jobs:
           matrix:
               module: [wazuh_modules/syscollector, shared_modules/dbsync, shared_modules/rsync, shared_modules/utils, data_provider]
               target: [agent, winagent]
-    runs-on: ubuntu-latest
+    # We don't use ubuntu-latest because the install_build_deps action adds a fixed repository for Wine
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17144|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

As it was described in the [comment](https://github.com/wazuh/wazuh/issues/17144#issuecomment-1553115930), the **wine32** package needs to be installed explicitly because the new Github Runner image considers the recommended packages of the following command in a different way 
```
 sudo apt-get install -y --install-recommends wine-stable
``` 

### Fix

Add the **wine32** package

```
 sudo apt-get install -y --install-recommends wine-stable wine32
``` 

### Update

The proposed fix above doesn't work because some dependencies can't be found.
Instead, the whole Wine installation step was updated according to the official documentation.

Also, the proposed workaround here was used:
https://github.com/actions/runner-images/issues/4589

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

- [x] CI Pass
