### PR TITLE
Fix Infinite loop of test command

### DIFF
--- a/src/engine/ruleset/wazuh-core/manifest.yml
+++ b/src/engine/ruleset/wazuh-core/manifest.yml
@@ -30,4 +30,5 @@ filters:
 - filter/allow-all/0
 name: integration/wazuh-core/0
 outputs:
-- output/file-output/0
+- output/file-output-wazuh-core/0
+- output/file-output-integrations/0

--- a/src/engine/ruleset/wazuh-core/outputs/file-output-integrations.yml
+++ b/src/engine/ruleset/wazuh-core/outputs/file-output-integrations.yml
@@ -1,13 +1,16 @@
-name: output/file-output/0
+name: output/file-output-integrations/0
 
 metadata:
   title: file output event
-  description: Output events to a file
+  description: Output integrations events to a file
   compatibility: >
     This decoder has been tested on Wazuh version 4.3
   author:
     name: Wazuh, Inc.
     date: 2022/11/08
+
+check:
+  - wazuh.decoders: +array_contains/integrations
 
 outputs:
   - file:

--- a/src/engine/ruleset/wazuh-core/outputs/file-output-wazuh-core.yml
+++ b/src/engine/ruleset/wazuh-core/outputs/file-output-wazuh-core.yml
@@ -1,0 +1,17 @@
+name: output/file-output-wazuh-core/0
+
+metadata:
+  title: file output event
+  description: Output wazuh events to a file
+  compatibility: >
+    This decoder has been tested on Wazuh version 4.3
+  author:
+    name: Wazuh, Inc.
+    date: 2022/11/08
+
+check:
+  - wazuh.decoders: +array_not_contains/integrations
+
+outputs:
+  - file:
+      path: /var/ossec/logs/alerts/alerts-wazuh.json

--- a/src/engine/source/builder/builders/opBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/builders/opBuilderHelperFilter.hpp
@@ -376,6 +376,23 @@ base::Expression opBuilderHelperContainsString(const std::string& targetField,
                                                const std::vector<std::string>& rawParameters,
                                                std::shared_ptr<defs::IDefinitions> definitions);
 
+/**
+ * @brief Create `array_not_contains` helper function that filters events if the field
+ * is an array and does not contains any of the specified values.
+ *
+ * @param targetField target field of the helper
+ * @param rawName name of the helper as present in the raw definition
+ * @param rawParameters vector of parameters as present in the raw definition
+ * @param definitions handler with definitions
+ * @return base::Expression
+ *
+ * @throws std::runtime_error if cannot create the filter.
+ */
+base::Expression opBuilderHelperNotContainsString(const std::string& targetField,
+                                               const std::string& rawName,
+                                               const std::vector<std::string>& rawParameters,
+                                               std::shared_ptr<defs::IDefinitions> definitions);
+
 //*************************************************
 //*                Type filters                   *
 //*************************************************

--- a/src/engine/source/builder/register.hpp
+++ b/src/engine/source/builder/register.hpp
@@ -38,6 +38,7 @@ static void registerHelperBuilders(std::shared_ptr<Registry<HelperBuilder>> help
 {
     // Filter Helpers
     helperRegistry->registerBuilder(builders::opBuilderHelperContainsString, "array_contains");
+    helperRegistry->registerBuilder(builders::opBuilderHelperNotContainsString, "array_not_contains");
     helperRegistry->registerBuilder(builders::opBuilderHelperIntEqual, "int_equal");
     helperRegistry->registerBuilder(builders::opBuilderHelperIntGreaterThan, "int_greater");
     helperRegistry->registerBuilder(builders::opBuilderHelperIntGreaterThanEqual, "int_greater_or_equal");

--- a/src/engine/source/cmds/src/test.cpp
+++ b/src/engine/source/cmds/src/test.cpp
@@ -350,7 +350,10 @@ void run(const Options& options)
 
     }
 
-    clear_icanon(false);
+    if (isatty(fileno(stdin)))
+    {
+        clear_icanon(false);
+    }
     g_exitHanlder.execute();
 }
 

--- a/src/engine/source/cmds/src/test.cpp
+++ b/src/engine/source/cmds/src/test.cpp
@@ -252,14 +252,17 @@ void run(const Options& options)
 
     std::cout << std::endl << std::endl << "Enter a log in single line (Crtl+C to exit):" << std::endl << std::endl;
 
-    // Stdin loop
-    std::string line;
-
-    if(!clear_icanon(true))
+    // Only set non-canonical mode when connected to terminal
+    if (isatty(fileno(stdin)))
     {
-        std::cout << "WARNING: Failed to set non-canonical mode, only logs shorter than 4095 characters will be processed correctly." << std::endl << std::endl;
+        if(!clear_icanon(true))
+        {
+            std::cout << "WARNING: Failed to set non-canonical mode, only logs shorter than 4095 characters will be processed correctly." << std::endl << std::endl;
+        }
     }
 
+    // Stdin loop
+    std::string line;
     while (gs_doRun && std::getline(std::cin, line))
     {
         if (!line.empty())

--- a/src/engine/source/cmds/src/test.cpp
+++ b/src/engine/source/cmds/src/test.cpp
@@ -49,7 +49,7 @@ int clear_icanon(bool flag)
         return 0;
     }
 
-    if (true == flag)
+    if (flag)
     {
         settings.c_lflag &= ~ICANON;
     }

--- a/src/engine/source/cmds/src/test.cpp
+++ b/src/engine/source/cmds/src/test.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <memory>
 #include <thread>
+#include <termios.h>
 
 #include <re2/re2.h>
 
@@ -38,6 +39,33 @@ void sigint_handler(const int signum)
 
 namespace cmd::test
 {
+
+int clear_icanon(bool flag)
+{
+    struct termios settings;
+
+    if (tcgetattr(STDIN_FILENO, &settings) < 0)
+    {
+        return 0;
+    }
+
+    if (true == flag)
+    {
+        settings.c_lflag &= ~ICANON;
+    }
+    else
+    {
+        settings.c_lflag |= ICANON;
+    }
+
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &settings) < 0)
+    {
+        return 0;
+    }
+
+    return 1;
+}
+
 void run(const Options& options)
 {
     // Logging init
@@ -226,6 +254,12 @@ void run(const Options& options)
 
     // Stdin loop
     std::string line;
+
+    if(!clear_icanon(true))
+    {
+        std::cout << "WARNING: Failed to set non-canonical mode, only logs shorter than 4095 characters will be processed correctly." << std::endl << std::endl;
+    }
+
     while (gs_doRun && std::getline(std::cin, line))
     {
         if (!line.empty())
@@ -313,6 +347,7 @@ void run(const Options& options)
 
     }
 
+    clear_icanon(false);
     g_exitHanlder.execute();
 }
 

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -124,6 +124,7 @@ add_executable(opBuilderHelperCheck_test
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntNotEqual_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIPCIDRCheck_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperNotExists_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperNotContainsString_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperRegexMatch_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperRegexNotMatch_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringEqual_test.cpp

--- a/src/engine/test/source/builder/builders/opBuilderHelperNotContainsString_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperNotContainsString_test.cpp
@@ -1,0 +1,97 @@
+#include <any>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include <baseTypes.hpp>
+#include <defs/mocks/failDef.hpp>
+
+#include "opBuilderHelperFilter.hpp"
+
+using namespace base;
+namespace bld = builder::internals::builders;
+
+TEST(OpBuilderHelperNotContainsString, Builds)
+{
+    auto tuple = std::make_tuple(std::string {"/field"},
+                                 std::string {"+array_not_contains"},
+                                 std::vector<std::string> {"1", "$ref", "3"},
+                                 std::make_shared<defs::mocks::FailDef>());
+    ASSERT_NO_THROW(std::apply(bld::opBuilderHelperNotContainsString, tuple));
+}
+
+TEST(OpBuilderHelperNotContainsString, EmptyParameters)
+{
+    auto tuple = std::make_tuple(std::string {"/field"},
+                                 std::string {"+array_not_contains"},
+                                 std::vector<std::string> {},
+                                 std::make_shared<defs::mocks::FailDef>());
+    ASSERT_THROW(std::apply(bld::opBuilderHelperNotContainsString, tuple), std::runtime_error);
+}
+
+TEST(OpBuilderHelperNotContainsString, Success)
+{
+    auto tuple = std::make_tuple(std::string {"/field"},
+                                 std::string {"+array_not_contains"},
+                                 std::vector<std::string> {"1", "$ref", "3"},
+                                 std::make_shared<defs::mocks::FailDef>());
+    auto event1 = std::make_shared<json::Json>(R"({"field": ["0"]})");
+    auto event2 = std::make_shared<json::Json>(R"({"field": ["4","5","6"], "ref": "2"})");
+    auto event3 = std::make_shared<json::Json>(R"({"field": [2]})");
+
+    auto op = std::apply(bld::opBuilderHelperNotContainsString, tuple)->getPtr<Term<EngineOp>>()->getFn();
+
+    result::Result<Event> result = op(event1);
+    ASSERT_TRUE(result.success());
+    result = op(event2);
+    ASSERT_TRUE(result.success());
+    result = op(event3);
+    ASSERT_TRUE(result.success());
+}
+
+TEST(OpBuilderHelperNotContainsString, FailureParametersNotFound)
+{
+    auto tuple = std::make_tuple(std::string {"/field"},
+                                 std::string {"+array_not_contains"},
+                                 std::vector<std::string> {"1", "$ref", "3"},
+                                 std::make_shared<defs::mocks::FailDef>());
+    auto event1 = std::make_shared<json::Json>(R"({"field": ["1"]})");
+    auto event2 = std::make_shared<json::Json>(R"({"field": ["0","5","2"], "ref": "2"})");
+    auto event3 = std::make_shared<json::Json>(R"({"field": ["3"]})");
+
+    auto op = std::apply(bld::opBuilderHelperNotContainsString, tuple)->getPtr<Term<EngineOp>>()->getFn();
+
+    result::Result<Event> result = op(event1);
+    ASSERT_FALSE(result.success());
+    result = op(event2);
+    ASSERT_FALSE(result.success());
+    result = op(event3);
+    ASSERT_FALSE(result.success());
+}
+
+TEST(OpBuilderHelperNotContainsString, FailureTargetNotFound)
+{
+    auto tuple = std::make_tuple(std::string {"/field"},
+                                 std::string {"+array_not_contains"},
+                                 std::vector<std::string> {"1"},
+                                 std::make_shared<defs::mocks::FailDef>());
+    auto event = std::make_shared<json::Json>(R"({"Otherfield": ["1"]})");
+
+    auto op = std::apply(bld::opBuilderHelperNotContainsString, tuple)->getPtr<Term<EngineOp>>()->getFn();
+
+    result::Result<Event> result = op(event);
+    ASSERT_FALSE(result.success());
+}
+
+TEST(OpBuilderHelperNotContainsString, FailureTargetNotArray)
+{
+    auto tuple = std::make_tuple(std::string {"/field"},
+                                 std::string {"+array_not_contains"},
+                                 std::vector<std::string> {"1"},
+                                 std::make_shared<defs::mocks::FailDef>());
+    auto event = std::make_shared<json::Json>(R"({"field": "1"})");
+
+    auto op = std::apply(bld::opBuilderHelperNotContainsString, tuple)->getPtr<Term<EngineOp>>()->getFn();
+
+    result::Result<Event> result = op(event);
+    ASSERT_FALSE(result.success());
+}


### PR DESCRIPTION
|Related issue|
|---|
|#17147|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

With this change the test command is able to be used with redirection (from a single line like using echo command, or with several lines like cat to a several-lines file) and with the user keyboard input as it's mainly used.

`╰─# cat file.txt | wazuh-engine test` 
Will print an output and assets result for each line in file.txt

`╰─# echo 'some event' | wazuh-engine test`
Prints the output and assets involved in event containing "some event" as log line.

`╰─# wazuh-engine test`
Will start a test session, waiting for the user to enter a log line.

As described on issue #17147, it is required to improve the `test` command to be able to process large example logs.
To achieve this goal it's necesary disable temporaly the canonical mode. [documentation](https://man7.org/linux/man-pages/man3/termios.3.html)



