### PR TITLE
Use environment variable `windir` on Windows agent uninstall

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -146,7 +146,7 @@ function uninstall_wazuh {
 
 	if ($UninstallString -ne $null) {
 		write-output "$(Get-Date -format u) - Performing the Wazuh-Agent uninstall using: `"$UninstallString`"." >> .\upgrade\upgrade.log
-		& "C:\Windows\SYSTEM32\cmd.exe" /c $UninstallString
+		& "$env:windir\System32\cmd.exe"/c $UninstallString
 
 		# registry takes some time to refresh (e.g.: NT 6.3)
 		Start-Sleep 5


### PR DESCRIPTION
|Related issue|
|---|
|Closes #16659|

## Description

This PR uses the environment variable windir to refer to the Windows installation directory when the upgrade script need to  perform the Windows agent uninstall during rollback of a failed upgrade. It was previously using a hardcoded path to the C: drive.

## Logs example

### Succesful rollback
![rollback with windir](https://github.com/wazuh/wazuh/assets/7939712/911e9f2f-75ab-4c84-b9cb-4259ead01feb)

### Succesful upgrade
![windir upgrade ok](https://github.com/wazuh/wazuh/assets/7939712/aa64fe78-7ec7-449d-ad30-5fab87672024)

## Tests
- [ ] Package upgrade
