### PR TITLE
Use environment variable windir on Windows agent uninstall

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -146,7 +146,7 @@ function uninstall_wazuh {
 
 	if ($UninstallString -ne $null) {
 		write-output "$(Get-Date -format u) - Performing the Wazuh-Agent uninstall using: `"$UninstallString`"." >> .\upgrade\upgrade.log
-		& "C:\Windows\SYSTEM32\cmd.exe" /c $UninstallString
+		& "$env:windir\System32\cmd.exe"/c $UninstallString
 
 		# registry takes some time to refresh (e.g.: NT 6.3)
 		Start-Sleep 5


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17071|

## Description

This PR uses the environment variable `windir` to refer to the Windows installation directory when the upgrade script needs to perform the Windows agent uninstall during the rollback of a failed upgrade. It was previously using a hardcoded path to the `C:` drive.

### Note 1
During testing of this PR several unsuccessful attempts were made to install Windows on a drive with a letter different than C. However, the solution applied by this fix is to use the [Windows environment variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.3#long-description) `windir`: 

> the WINDIR environment variable contains the location of the Windows installation directory.

This removes from the script any hardcoded reference to the Windows installation directory and instead relies on the information provided by Windows itself. 

### Note 2
In order for the rollback to work correctly the locale of the Windows OS must be English, otherwise the rollback could fail by the problem described on #15196.

## Manual tests

Tests performed with manager `v4.5.1`.
Custom WPK used in this test: [wazuh_agent_v4.5.1_pr17176.zip](https://github.com/wazuh/wazuh/files/11951038/wazuh_agent_v4.5.1_pr17176.zip)

### Windows Server 16 - 64 bits - English

The change in this PR is part of the rollback process when the upgrade fails. The following test shows that the rollback procedure keeps working correctly with this change.

#### The following screenshot shows:
- The installed agent at the start of the test is `v4.4.0`.
- Upgrade to `4.5.1` failed(*): `Upgrade failed: Restoring former installation.`
- The rollback with the backed-up MSI was done correctly:
   - `Performing the Wazuh-Agent uninstall using: "MsiExec.exe /X{A9A1109D-29A1-450A-A7AE-EF43FCDFA3C7}
 /quiet".`
   - `Excecuting former Wazuh-Agent MSI: ".\backup\3fd2d9.msi".`
- The reported version after the upgrade is 4.4.0 by both the VERSION file and Windows registry.

![Win16 - 64 bits - failed upgrade - correct rollback](https://github.com/wazuh/wazuh/assets/7939712/7895ca86-eeff-4e21-baa8-10c92222c64b)

*(To make the upgrade fail, the connection between manager and agent was deliberately blocked after the agent received the WPK file)

For completeness, a test with a successful upgrade is included:
<details><summary>Windows 16 - 64 bits - English - Succesful upgrade</summary>

#### The following screenshot shows:
- The installed agent at the start of the test is `v4.1.1`.
- Upgrade to `4.5.1` was successful.
- The reported version after the upgrade is 4.4.1 by both the VERSION file and Windows registry.

![2023-07-04_14-04](https://github.com/wazuh/wazuh/assets/7939712/21cd9502-2050-4f65-91d2-1e23074ec873)

</details>


## Tests
- [x] Package upgrade