### PR TITLE
Vulnerability Detector W10 & W11

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -3194,33 +3194,19 @@ void test_wm_vuldel_truncate_revision(void ** state) {
 
 void test_wm_vuldet_build_product_name(void ** state) {
     
-    scan_agent *agent = *state;
+    const char *PR_WIN[] = {"windows_10", "windows_11"};
+    char *WIN_VER[] = {"1809", "22h2"};
+    char *PR_BUILT[2][2] = {
+        {"windows_10_1809", "windows_10_22h2"},
+        {"windows_11_1809", "windows_11_22h2"}
+    };
 
-    agent->dist = FEED_WIN;
-    agent->dist_ver = FEED_W10;
-    agent->os_display_version = strdup(" ");
-    agent->os_release = strdup("1809");
-
-    const char *PR_WIN10 = "windows_10";
-    const char *PR_WIN11 = "windows_11";
-
-    char *ver_aux = NULL;    
-    char *pr_name = NULL;
-
-    if (agent->os_display_version && *agent->os_display_version != ' ') {
-        ver_aux = w_tolower_str(agent->os_display_version);
-        os_free(agent->os_display_version);
-        agent->os_display_version = ver_aux;
-    } else {
-        ver_aux = agent->os_release;
-    }
-
-    pr_name = wm_vuldet_build_product_name("windows_10", ver_aux);
-
-    assert_string_equal(pr_name,"windows_10_1809");
-
-    if(pr_name) {
-        os_free(pr_name);
+    for (int i = 0; i < 2; ++i) {
+        for (int j = 0; j < 2; ++j) {
+            char *pr_name = wm_vuldet_build_product_name(PR_WIN[i], WIN_VER[j]);
+            assert_string_equal(pr_name, PR_BUILT[i][j]);
+            os_free(pr_name);
+        }
     }
 }
 
@@ -22655,7 +22641,7 @@ int main(void)
         cmocka_unit_test(test_wm_vuldel_truncate_revision_null),
         cmocka_unit_test(test_wm_vuldel_truncate_revision),
         // Tests wm_vuldet_build_product_name
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_build_product_name, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test(test_wm_vuldet_build_product_name),
         // Tests wm_vuldet_linux_oval_vulnerabilities
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_nvd_configured_year, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_no_nvd_year, setup_scan_agent, teardown_scan_agent),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -103,6 +103,7 @@ bool wm_vuldet_update_MSU(update_node *update);
 int wm_vuldet_fetch_MSU(update_node *update, char *repo);
 int wm_vuldet_compare_vendors(char * vendor);
 void wm_vuldel_truncate_revision(char * revision);
+char *wm_vuldet_build_product_name(const char *pr, const char *ver);
 void wm_vuldet_clean_vuln_cves_db(void);
 int wm_vuldet_get_arch_id(sqlite3 * db, const char *cveid, const char *target, const char *pkg_name, const char *pkg_version, int *id);
 int wm_vuldet_insert_ALAS(sqlite3 *db, vu_alas_vuln *vul_it, const char *target);
@@ -3186,6 +3187,40 @@ void test_wm_vuldel_truncate_revision(void ** state) {
         char * rev_ptr = revision;
         wm_vuldel_truncate_revision(rev_ptr);
         assert_string_equal(rev_ptr, revisions[i][1]);
+    }
+}
+
+/* wm_vuldet_build_product_name */
+
+void test_wm_vuldet_build_product_name(void ** state) {
+    
+    scan_agent *agent = *state;
+
+    agent->dist = FEED_WIN;
+    agent->dist_ver = FEED_W10;
+    agent->os_display_version = strdup(" ");
+    agent->os_release = strdup("1809");
+
+    const char *PR_WIN10 = "windows_10";
+    const char *PR_WIN11 = "windows_11";
+
+    char *ver_aux = NULL;    
+    char *pr_name = NULL;
+
+    if (agent->os_display_version && *agent->os_display_version != ' ') {
+        ver_aux = w_tolower_str(agent->os_display_version);
+        os_free(agent->os_display_version);
+        agent->os_display_version = ver_aux;
+    } else {
+        ver_aux = agent->os_release;
+    }
+
+    pr_name = wm_vuldet_build_product_name("windows_10", ver_aux);
+
+    assert_string_equal(pr_name,"windows_10_1809");
+
+    if(pr_name) {
+        os_free(pr_name);
     }
 }
 
@@ -22619,6 +22654,8 @@ int main(void)
         // Tests wm_vuldet_truncate_revision
         cmocka_unit_test(test_wm_vuldel_truncate_revision_null),
         cmocka_unit_test(test_wm_vuldel_truncate_revision),
+        // Tests wm_vuldet_build_product_name
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_build_product_name, setup_scan_agent, teardown_scan_agent),
         // Tests wm_vuldet_linux_oval_vulnerabilities
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_nvd_configured_year, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_no_nvd_year, setup_scan_agent, teardown_scan_agent),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -8932,7 +8932,7 @@ void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
     size_t w11_patter_len = strlen(win11_pattern);
     size_t ver_patter_len = strlen(version_pattern);
 
-    if (strncmp(msu->product, win10_pattern, w10_patter_len) || strncmp(msu->product, win11_pattern, w11_patter_len)) {
+    if (strncmp(msu->product, win10_pattern, w10_patter_len) && strncmp(msu->product, win11_pattern, w11_patter_len)) {
         w_strdup("1", msu->check_type);
         return;
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -518,9 +518,9 @@ STATIC void wm_vuldel_truncate_revision(char * revision);
 
 /**
  * @brief Generates the cpe product name for Windows versions.
- * @param pr Version of the Windows distribution.
+ * @param pr Product name of the Windows distribution.
  * @param ver Display version of Windows agent (1909, 21H2, 22H2, etc).
- * @return cpe product name.
+ * @return new product name for the CPE.
  */
 STATIC char *wm_vuldet_build_product_name(const char *pr, const char *ver);
 
@@ -6553,12 +6553,16 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     }
 
     if (agent->os_display_version && *agent->os_display_version != ' ') {
+    minfo("agent->os_display_version = %s",agent->os_display_version);
         ver_aux = w_tolower_str(agent->os_display_version);
         os_free(agent->os_display_version);
         agent->os_display_version = ver_aux;
     } else {
+        minfo("agent->os_release IF");
         ver_aux = agent->os_release;
     }
+
+    minfo("agent->os_release = %s",agent->os_release);
 
     switch (agent->dist_ver) {
         case FEED_WS2003:

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6621,7 +6621,6 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
             return 1;
     }
 
-
     // We will insert a double CPE for the following systems (WS_2022)
     int os_cpes = wm_vuldet_double_os_cpe(agent->dist_ver) ? 2 : 1;
     os_calloc(os_cpes + 1, sizeof(cpe *), agent->agent_os_cpe);
@@ -8923,7 +8922,6 @@ int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_entries *msu) {
 }
 
 void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
-
     const char *win10_pattern = "Windows 10";
     const char *win11_pattern = "Windows 11";
     const char *version_pattern = " Version ";

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6505,6 +6505,16 @@ int wm_vuldet_generate_os_cpe(sqlite3 *db, scan_agent *agent, int *min_cpe_index
     return 0;
 }
 
+const char *wm_vuldet_build_product_name(const char *pr, const char *ver)
+{
+    char *ret = NULL;
+    size_t len = strlen(pr) + strlen(ver) + 2;
+    os_malloc(len, ret);
+    os_snprintf(ret, len, "%s_%s", pr, ver);
+
+    return ret;
+}
+
 int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     STATIC const char *PR_WINXP = "windows_xp";
     STATIC const char *PR_WINVISTA = "windows_vista";
@@ -6529,6 +6539,9 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     const char *ws_ver = NULL;
     char *ver_aux = NULL;
 
+    char *pr_name = NULL;
+
+    
     if (!agent->os_release && agent->dist_ver != FEED_WS2012 && agent->dist_ver != FEED_WS2012R2 &&
         agent->dist_ver != FEED_W8 && agent->dist_ver != FEED_W81) {
         mtwarn(WM_VULNDETECTOR_LOGTAG, VU_OSINFO_DISABLED, atoi(agent->agent_id));
@@ -6571,12 +6584,10 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
             win_pr = PR_WIN81;
         break;
         case FEED_W10:
-            win_pr = PR_WIN10;
-            win_ver = ver_aux;
-        break;
-        case FEED_W11:
-            win_pr = PR_WIN11;
-            win_ver = ver_aux;
+        case FEED_W11:      
+            pr_name = wm_vuldet_build_product_name(FEED_W10 == agent->dist_ver?PR_WIN10:PR_WIN11, ver_aux);
+            win_pr = pr_name;
+            win_ver = agent->os_version;            
         break;
         case FEED_WS2008:
             win_pr = PR_WIN2008;
@@ -6606,12 +6617,13 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
             win_pr = PR_WIN2022;
             win_ver = ver_aux;
             // Insert new 'windows_server' CPE to avoid false negatives
-            ws_pr = PR_WINSERVER;
+            ws_ver = PR_WINSERVER;
             ws_ver = VER_2022;
         break;
         default:
             return 1;
     }
+
 
     // We will insert a double CPE for the following systems (WS_2022)
     int os_cpes = wm_vuldet_double_os_cpe(agent->dist_ver) ? 2 : 1;
@@ -6633,6 +6645,11 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
                                                         0,
                                                         vu_feed_ext[agent->dist_ver]);
     }
+
+    if(pr_name) {
+        os_free(pr_name);
+    }
+
     return 0;
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6553,16 +6553,12 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     }
 
     if (agent->os_display_version && *agent->os_display_version != ' ') {
-    minfo("agent->os_display_version = %s",agent->os_display_version);
         ver_aux = w_tolower_str(agent->os_display_version);
         os_free(agent->os_display_version);
         agent->os_display_version = ver_aux;
     } else {
-        minfo("agent->os_release IF");
         ver_aux = agent->os_release;
     }
-
-    minfo("agent->os_release = %s",agent->os_release);
 
     switch (agent->dist_ver) {
         case FEED_WS2003:

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6505,8 +6505,7 @@ int wm_vuldet_generate_os_cpe(sqlite3 *db, scan_agent *agent, int *min_cpe_index
     return 0;
 }
 
-const char *wm_vuldet_build_product_name(const char *pr, const char *ver)
-{
+char *wm_vuldet_build_product_name(const char *pr, const char *ver) {
     char *ret = NULL;
     size_t len = strlen(pr) + strlen(ver) + 2;
     os_malloc(len, ret);
@@ -6538,10 +6537,8 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     const char *ws_pr = NULL;
     const char *ws_ver = NULL;
     char *ver_aux = NULL;
-
     char *pr_name = NULL;
 
-    
     if (!agent->os_release && agent->dist_ver != FEED_WS2012 && agent->dist_ver != FEED_WS2012R2 &&
         agent->dist_ver != FEED_W8 && agent->dist_ver != FEED_W81) {
         mtwarn(WM_VULNDETECTOR_LOGTAG, VU_OSINFO_DISABLED, atoi(agent->agent_id));
@@ -6584,10 +6581,10 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
             win_pr = PR_WIN81;
         break;
         case FEED_W10:
-        case FEED_W11:      
-            pr_name = wm_vuldet_build_product_name(FEED_W10 == agent->dist_ver?PR_WIN10:PR_WIN11, ver_aux);
+        case FEED_W11:
+            pr_name = wm_vuldet_build_product_name(FEED_W10 == agent->dist_ver ? PR_WIN10 : PR_WIN11, ver_aux);
             win_pr = pr_name;
-            win_ver = agent->os_version;            
+            win_ver = agent->os_version;
         break;
         case FEED_WS2008:
             win_pr = PR_WIN2008;
@@ -8924,42 +8921,9 @@ int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_entries *msu) {
 
     return 0;
 }
-/*
 
 void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
-    const char *win10_pattern = "Windows 10";
-    const char *version_pattern = " Version ";
 
-
-    if (strncmp(msu->product, win10_pattern, strlen(win10_pattern))) {
-        w_strdup("1", msu->check_type);
-        return;
-    }
-
-    if (!strncmp(msu->product + strlen(win10_pattern), version_pattern, strlen(version_pattern))) {
-        msu->check_type = w_tolower_str(strtok(msu->product + strlen(win10_pattern) + strlen(version_pattern), " "));
-        return;
-    }
-
-    for (; patchs; patchs = patchs->next) {
-        cJSON *product_json = cJSON_GetObjectItem(patchs, "product");
-        char *product_name;
-        if (!product_json || !(product_name = product_json->valuestring)) {
-            continue;
-        }
-
-        if (strncmp(product_name, win10_pattern, strlen(win10_pattern)) ||
-            strncmp(product_name + strlen(win10_pattern), version_pattern, strlen(version_pattern))) {
-            continue;
-        }
-        w_strdup("1", msu->check_type);
-        break;
-    }
-}
-*/
-
-void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
-    
     const char *win10_pattern = "Windows 10";
     const char *win11_pattern = "Windows 11";
     const char *version_pattern = " Version ";
@@ -8967,13 +8931,8 @@ void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
     size_t w10_patter_len = strlen(win10_pattern);
     size_t w11_patter_len = strlen(win11_pattern);
     size_t ver_patter_len = strlen(version_pattern);
-/*
-    w_strdup("1", msu->check_type);
-    minfo("wm_vuln_check_msu_type : msu->check_type:%s msu->product:%s msu->cveid:%s ", msu->check_type, msu->product, msu->cveid);
-    return;
-*/
 
-    if (strncmp(msu->product, win10_pattern, w10_patter_len) || strncmp(msu->product, win11_pattern, w11_patter_len)) {       
+    if (strncmp(msu->product, win10_pattern, w10_patter_len) || strncmp(msu->product, win11_pattern, w11_patter_len)) {
         w_strdup("1", msu->check_type);
         return;
     }
@@ -8983,16 +8942,15 @@ void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
         return;
     }
 
-    if (!strncmp(msu->product + w11_patter_len, version_pattern, ver_patter_len)) {   
+    if (!strncmp(msu->product + w11_patter_len, version_pattern, ver_patter_len)) {
         msu->check_type = w_tolower_str(strtok(msu->product + w11_patter_len + ver_patter_len, " "));
-        minfo("wm_vuln_check_msu_type :%s (version_pattern)", msu->check_type);
         return;
     }
 
     for (; patchs; patchs = patchs->next) {
         cJSON *product_json = cJSON_GetObjectItem(patchs, "product");
         char *product_name;
-        
+
         if (!product_json || !(product_name = product_json->valuestring)) {
             continue;
         }
@@ -9004,10 +8962,9 @@ void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
 
         if (strncmp(product_name, win11_pattern, w11_patter_len) ||
             strncmp(product_name + w11_patter_len, version_pattern, ver_patter_len)) {
-            minfo("wm_vuln_check_msu_type win11_pattern continue");
             continue;
         }
-       
+
         w_strdup("1", msu->check_type);
         break;
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6617,7 +6617,7 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
             win_pr = PR_WIN2022;
             win_ver = ver_aux;
             // Insert new 'windows_server' CPE to avoid false negatives
-            ws_ver = PR_WINSERVER;
+            ws_pr = PR_WINSERVER;
             ws_ver = VER_2022;
         break;
         default:
@@ -8924,10 +8924,12 @@ int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_entries *msu) {
 
     return 0;
 }
+/*
 
 void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
     const char *win10_pattern = "Windows 10";
     const char *version_pattern = " Version ";
+
 
     if (strncmp(msu->product, win10_pattern, strlen(win10_pattern))) {
         w_strdup("1", msu->check_type);
@@ -8950,6 +8952,62 @@ void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
             strncmp(product_name + strlen(win10_pattern), version_pattern, strlen(version_pattern))) {
             continue;
         }
+        w_strdup("1", msu->check_type);
+        break;
+    }
+}
+*/
+
+void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
+    
+    const char *win10_pattern = "Windows 10";
+    const char *win11_pattern = "Windows 11";
+    const char *version_pattern = " Version ";
+
+    size_t w10_patter_len = strlen(win10_pattern);
+    size_t w11_patter_len = strlen(win11_pattern);
+    size_t ver_patter_len = strlen(version_pattern);
+/*
+    w_strdup("1", msu->check_type);
+    minfo("wm_vuln_check_msu_type : msu->check_type:%s msu->product:%s msu->cveid:%s ", msu->check_type, msu->product, msu->cveid);
+    return;
+*/
+
+    if (strncmp(msu->product, win10_pattern, w10_patter_len) || strncmp(msu->product, win11_pattern, w11_patter_len)) {       
+        w_strdup("1", msu->check_type);
+        return;
+    }
+
+    if (!strncmp(msu->product + w10_patter_len, version_pattern, ver_patter_len)) {
+        msu->check_type = w_tolower_str(strtok(msu->product + w10_patter_len + ver_patter_len, " "));
+        return;
+    }
+
+    if (!strncmp(msu->product + w11_patter_len, version_pattern, ver_patter_len)) {   
+        msu->check_type = w_tolower_str(strtok(msu->product + w11_patter_len + ver_patter_len, " "));
+        minfo("wm_vuln_check_msu_type :%s (version_pattern)", msu->check_type);
+        return;
+    }
+
+    for (; patchs; patchs = patchs->next) {
+        cJSON *product_json = cJSON_GetObjectItem(patchs, "product");
+        char *product_name;
+        
+        if (!product_json || !(product_name = product_json->valuestring)) {
+            continue;
+        }
+
+        if (strncmp(product_name, win10_pattern, w10_patter_len) ||
+            strncmp(product_name + w10_patter_len, version_pattern, ver_patter_len)) {
+            continue;
+        }
+
+        if (strncmp(product_name, win11_pattern, w11_patter_len) ||
+            strncmp(product_name + w11_patter_len, version_pattern, ver_patter_len)) {
+            minfo("wm_vuln_check_msu_type win11_pattern continue");
+            continue;
+        }
+       
         w_strdup("1", msu->check_type);
         break;
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -516,6 +516,14 @@ STATIC int wm_vuldet_compare_vendors(char * vendor);
  */
 STATIC void wm_vuldel_truncate_revision(char * revision);
 
+/**
+ * @brief Generates the cpe product name for Windows versions.
+ * @param pr Version of the Windows distribution.
+ * @param ver Display version of Windows agent (1909, 21H2, 22H2, etc).
+ * @return cpe product name.
+ */
+STATIC char *wm_vuldet_build_product_name(const char *pr, const char *ver);
+
 time_t curr_time;
 int wdb_vuldet_sock = -1;
 int *vu_queue;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2003,7 +2003,7 @@ int wm_vuldet_get_vuln_nvd_cpe(sqlite3 *db,
             // CPE's that matched using '-' or '*'.
             if (agent_cpe->part && (agent_cpe->part[0] == 'o') && cpe_version &&
                 agent_cpe->vendor && strcmp(cpe_version, agent_cpe->version) &&
-                agent->dist_ver == FEED_W10) {
+                (agent->dist_ver == FEED_W10 || agent->dist_ver == FEED_W11) {
                 continue;
             }
 
@@ -3663,15 +3663,15 @@ vu_logic wm_vuldet_check_hotfix(sqlite3 *db, scan_agent *agent, wm_vuldet_flags 
         goto end;
     }
 
-    
+
     char *ver_aux = NULL;
-    
+
     if (agent->os_display_version && *agent->os_display_version != ' ') {
         ver_aux = w_tolower_str(agent->os_display_version);
         os_free(agent->os_display_version);
         agent->os_display_version = ver_aux;
     }
-    
+
 
     // Get the related patches
     request = wm_vuldet_generate_msu_request(s_cpe,

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2016,10 +2016,19 @@ int wm_vuldet_get_vuln_nvd_cpe(sqlite3 *db,
 
                     uri = (char *)sqlite3_column_text(stmt2, 1);
                     vulnerable = sqlite3_column_int(stmt2, 2);
-                    v_start_inc = (char *)sqlite3_column_text(stmt2, 3);
-                    v_start_exc = (char *)sqlite3_column_text(stmt2, 4);
-                    v_end_inc = (char *)sqlite3_column_text(stmt2, 5);
-                    v_end_exc = (char *)sqlite3_column_text(stmt2, 6);
+                    
+                    if (agent_cpe->part && (agent_cpe->part[0] == 'o') &&
+                        (agent->dist_ver == FEED_W10 || agent->dist_ver == FEED_W11)) {
+                        v_start_inc = NULL;
+                        v_start_exc = NULL;
+                        v_end_inc = NULL;
+                        v_end_exc = NULL;                   
+                    } else {
+                        v_start_inc = (char *)sqlite3_column_text(stmt2, 3);
+                        v_start_exc = (char *)sqlite3_column_text(stmt2, 4);
+                        v_end_inc = (char *)sqlite3_column_text(stmt2, 5);
+                        v_end_exc = (char *)sqlite3_column_text(stmt2, 6);
+                    }
 
                     wdb_finalize(stmt3);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -165,7 +165,7 @@ STATIC void wm_vuldet_fit_nvd_matches(const char *cve, nvd_conf_cpe_match **cpe_
 STATIC void wm_vuldet_free_nvd_conf_cpe_match_node(nvd_conf_cpe_match *data);
 STATIC void wm_vuldet_adapt_os_cpe(cpe *ag_cpe);
 STATIC int wm_vuln_valid_os_cpe(vu_feed dist, cpe *ag_cpe, char *c_version);
-STATIC char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver, char *version);
+STATIC char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver, char *win_version);
 
 // Common tags
 const char *vu_cpe_tags[] = {
@@ -1999,14 +1999,6 @@ int wm_vuldet_get_vuln_nvd_cpe(sqlite3 *db,
 
             wdb_finalize(stmt2);
 
-            // For a WIN10 O.S product with a valid product version, discard those
-            // CPE's that matched using '-' or '*'.
-            if (agent_cpe->part && (agent_cpe->part[0] == 'o') && cpe_version &&
-                agent_cpe->vendor && strcmp(cpe_version, agent_cpe->version) &&
-                (agent->dist_ver == FEED_W10 || agent->dist_ver == FEED_W11) {
-                continue;
-            }
-
             if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_MATCHES], -1, &stmt2, NULL) != SQLITE_OK) {
                 goto end;
             }
@@ -3648,6 +3640,7 @@ vu_logic wm_vuldet_check_hotfix(sqlite3 *db, scan_agent *agent, wm_vuldet_flags 
     char patch_find[50 + 1];
     char *request = NULL;
     int result;
+    char *ver_aux;
 
     // Get the vulnerability string code
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_CVE], -1, &stmt, NULL) != SQLITE_OK) {
@@ -3663,24 +3656,15 @@ vu_logic wm_vuldet_check_hotfix(sqlite3 *db, scan_agent *agent, wm_vuldet_flags 
         goto end;
     }
 
-
-    char *ver_aux = NULL;
-
     if (agent->os_display_version && *agent->os_display_version != ' ') {
-        ver_aux = w_tolower_str(agent->os_display_version);
-        os_free(agent->os_display_version);
-        agent->os_display_version = ver_aux;
+        ver_aux = agent->os_display_version;
+    } else {
+        ver_aux = agent->os_release;
     }
-
 
     // Get the related patches
     request = wm_vuldet_generate_msu_request(s_cpe,
-                                            agent->dist_ver, ver_aux?ver_aux:agent->os_release);
-
-
-    if(ver_aux) {
-        os_free(ver_aux);
-    }
+                                            agent->dist_ver, ver_aux);
 
 
     snprintf(product_name, OS_SIZE_128, "^%s.*", s_cpe->msu_name);
@@ -4260,7 +4244,7 @@ int wm_vuln_valid_os_cpe(vu_feed dist, cpe *ag_cpe, char *c_version) {
     return 0;
 }
 
-char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver, char *os_version) {
+char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver, char *win_version) {
     char *request;
     char extra_check[OS_SIZE_256] = { '\0' };
     const char *sp_check_template = " AND (M1.PRODUCT NOT LIKE '%%Service Pack%%' OR "\
@@ -4280,13 +4264,9 @@ char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver, char *os_vers
         if (!strncmp(s_cpe->update, "sp", 2)) {
             snprintf(extra_check, OS_SIZE_256, sp_check_template, s_cpe->update[2]);
         }
-    } else if (s_cpe->version && dist_ver == FEED_W10 && !wm_vuldet_is_cpe_wc(s_cpe->version)) {
-        snprintf(extra_check, OS_SIZE_256, w10_check_template, s_cpe->version, s_cpe->version);
-    } else if (s_cpe->version && dist_ver == FEED_W11 && !wm_vuldet_is_cpe_wc(s_cpe->version)) {
-        snprintf(extra_check, OS_SIZE_256, w10_check_template, os_version, os_version);
-        minfo("**** extra_check :%s", extra_check);
+    } else if (s_cpe->version && (dist_ver == FEED_W10 || dist_ver == FEED_W11) && !wm_vuldet_is_cpe_wc(s_cpe->version)) {
+        snprintf(extra_check, OS_SIZE_256, w10_check_template, win_version, win_version);
     }
-
 
     snprintf(request, OS_SIZE_512,
                         vu_queries[wm_vulndet_without_r2(dist_ver)

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -165,7 +165,7 @@ STATIC void wm_vuldet_fit_nvd_matches(const char *cve, nvd_conf_cpe_match **cpe_
 STATIC void wm_vuldet_free_nvd_conf_cpe_match_node(nvd_conf_cpe_match *data);
 STATIC void wm_vuldet_adapt_os_cpe(cpe *ag_cpe);
 STATIC int wm_vuln_valid_os_cpe(vu_feed dist, cpe *ag_cpe, char *c_version);
-STATIC char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver);
+STATIC char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver, char *version);
 
 // Common tags
 const char *vu_cpe_tags[] = {
@@ -3663,9 +3663,25 @@ vu_logic wm_vuldet_check_hotfix(sqlite3 *db, scan_agent *agent, wm_vuldet_flags 
         goto end;
     }
 
+    
+    char *ver_aux = NULL;
+    
+    if (agent->os_display_version && *agent->os_display_version != ' ') {
+        ver_aux = w_tolower_str(agent->os_display_version);
+        os_free(agent->os_display_version);
+        agent->os_display_version = ver_aux;
+    }
+    
+
     // Get the related patches
     request = wm_vuldet_generate_msu_request(s_cpe,
-                                            agent->dist_ver);
+                                            agent->dist_ver, ver_aux?ver_aux:agent->os_release);
+
+
+    if(ver_aux) {
+        os_free(ver_aux);
+    }
+
 
     snprintf(product_name, OS_SIZE_128, "^%s.*", s_cpe->msu_name);
 
@@ -4244,7 +4260,7 @@ int wm_vuln_valid_os_cpe(vu_feed dist, cpe *ag_cpe, char *c_version) {
     return 0;
 }
 
-char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver) {
+char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver, char *os_version) {
     char *request;
     char extra_check[OS_SIZE_256] = { '\0' };
     const char *sp_check_template = " AND (M1.PRODUCT NOT LIKE '%%Service Pack%%' OR "\
@@ -4266,7 +4282,11 @@ char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver) {
         }
     } else if (s_cpe->version && dist_ver == FEED_W10 && !wm_vuldet_is_cpe_wc(s_cpe->version)) {
         snprintf(extra_check, OS_SIZE_256, w10_check_template, s_cpe->version, s_cpe->version);
+    } else if (s_cpe->version && dist_ver == FEED_W11 && !wm_vuldet_is_cpe_wc(s_cpe->version)) {
+        snprintf(extra_check, OS_SIZE_256, w10_check_template, os_version, os_version);
+        minfo("**** extra_check :%s", extra_check);
     }
+
 
     snprintf(request, OS_SIZE_512,
                         vu_queries[wm_vulndet_without_r2(dist_ver)

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2025,6 +2025,7 @@ int wm_vuldet_get_vuln_nvd_cpe(sqlite3 *db,
                     uri = (char *)sqlite3_column_text(stmt2, 1);
                     vulnerable = sqlite3_column_int(stmt2, 2);
                     
+                    // For W10 and W11, we bypass the versioning check on OS vulnerabilities, with the NVD to be scanned by the MSU.
                     if (agent_cpe->part && (agent_cpe->part[0] == 'o') &&
                         (agent->dist_ver == FEED_W10 || agent->dist_ver == FEED_W11)) {
                         v_start_inc = NULL;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -165,6 +165,14 @@ STATIC void wm_vuldet_fit_nvd_matches(const char *cve, nvd_conf_cpe_match **cpe_
 STATIC void wm_vuldet_free_nvd_conf_cpe_match_node(nvd_conf_cpe_match *data);
 STATIC void wm_vuldet_adapt_os_cpe(cpe *ag_cpe);
 STATIC int wm_vuln_valid_os_cpe(vu_feed dist, cpe *ag_cpe, char *c_version);
+
+/**
+ * @brief Generates the vulnerability request to the MSU DB, in order to check the corresponding hotfixes.
+ * @param s_cpe CPE generated for the Windows agent.
+ * @param dist_ver Version of the Windows distribution used in the agent.
+ * @param win_version Display version of Windows agent (1909, 21H2, 22H2, etc).
+ * @return Request to check the MSU DB.
+ */
 STATIC char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver, char *win_version);
 
 // Common tags


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/15160|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The issue originates from the change in the **CPE** format that has been applied in **NVD**, as previously the **Windows 11** CPE was:  

- [cpe:2.3-o:microsoft:windows_11:21h2:::::::*](https://nvd.nist.gov/products/cpe/detail/46138D1E-853D-4899-9D8F-E1B0E8D484D0?namingFormat=2.3&orderBy=CPEURI&keyword=cpe%3A2.3%3Ao%3Amicrosoft%3Awindows_11%3A-%3A*%3A*%3A*%3A*%3A*%3A*%3A*&status=FINAL%2CDEPRECATED)

**This has been deprecated and the format is:**

- [cpe:2.3-o:microsoft:windows_11_21h2:-::::::x64](https://nvd.nist.gov/products/cpe/detail/E4604687-B03E-478C-B119-226D2BF51448?namingFormat=2.3&orderBy=CPEURI&keyword=cpe%3A2.3%3Ao%3Amicrosoft%3Awindows_11_22h2%3A-%3A*%3A*%3A*%3A*%3A*%3A*%3A*&status=FINAL%2CDEPRECATED)

This resulted in a mismatch with the corresponding vulnerability and therefore it was not reported.
Examples:

> Old CPE: https://nvd.nist.gov/vuln/detail/CVE-2022-44698#vulnConfigurationsArea
> New CPE: https://nvd.nist.gov/vuln/detail/CVE-2023-28250#vulnConfigurationsArea

The "_product_name_" build chain for **Windows 10** and **Windows 11** has been updated adding the `wm_vuldet_build_product_name` function, with it the CVE structure is generated for each agent, 
the rest was to update the code to detect well the vulnerabilities of the systems:

```
W11 21H2 & W11 22H2
W10 22H2 & W10 1809 
```
Among the most important changes we have **removed** the if in which it entered when the generated CPE had a valid version and then it would scan all the vulnerabilities that did not have version (`-`) in the CPE or the version was generic (`*`) in order not to cause false positives, in the function `wm_vuldet_get_vuln_vulnvd_cpe`:

```
            // For a WIN10 O.S product with a valid product version, discard those
            // CPE's that matched using '-' or '*'.
            if (agent_cpe->part && (agent_cpe->part[0] == 'o') && cpe_version &&
                agent_cpe->vendor && strcmp(cpe_version, agent_cpe->version) &&
                (agent->dist_ver == FEED_W10 || agent->dist_ver == FEED_W11) {
                continue;
            }
```

The following CPEs were discarded so as not to generate false positives:

- o:microsoft:windows_10:*
- o:microsoft:windows_10:-

Accepting only:

- o:microsoft:windows_10:<version>

Now it is not necessary, because the `CPE` product already includes the version, so we can accept all 3 CPEs:

- microsoft:windows_10_<version>:os_version
- microsoft:windows_10_<version>:*
- microsoft:windows_10_<version>:-

An example of this issue [here](https://wazuh-team.slack.com/archives/C04FFKZ0ABS/p1684255745980979?thread_ts=1683559264.197009&cid=C04FFKZ0ABS)
 

## Logs/Alerts example
`Windows 11 22h2 patched`
```
[...]
2023/05/17 19:00:45 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:2804 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5438): A full scan will be run on agent '004'
2023/05/17 19:00:45 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:5682 at wm_vuldet_collect_agent_software(): DEBUG: (5437): Collecting agent '004' software.
2023/05/17 19:00:45 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:6974 at wm_vuldet_insert_agent_data(): DEBUG: (5446): The CPE 'o:microsoft:windows_11_22h2:10.0.22621.1702::::::x64:' from the agent '004' was indexed.
2023/05/17 19:00:45 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector_nvd.c:3272 at wm_vuldet_add_dic_cpe(): DEBUG: (5446): The CPE 'a:wazuh:wazuh:4.4.1::::::x86:' from the agent '004' was indexed.
2023/05/17 19:00:45 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:2827 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5450): Analyzing agent '004' vulnerabilities.
2023/05/17 19:00:45 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector_nvd.c:1859 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5451): Analyzing NVD vulnerabilities for agent '004'
2023/05/17 19:00:45 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector_nvd.c:1871 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5470): It took '0' seconds to 'find NVD' vulnerabilities in agent '004'
2023/05/17 19:00:45 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector_nvd.c:1873 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5466): Sending vulnerabilities report for agent '004'
2023/05/17 19:00:45 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector_nvd.c:1883 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5470): It took '0' seconds to 'report' vulnerabilities in agent '004'
2023/05/17 19:00:45 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:2846 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5471): Finished vulnerability assessment for agent '004'
2023/05/17 19:00:45 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:2847 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5470): It took '0' seconds to 'scan' vulnerabilities in agent '004'
```


`Windows 11 21h2 patched`
```
[...]
2023/05/17 19:00:46 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:2799 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5491): A baseline scan will be run on agent '006'
2023/05/17 19:00:46 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:5682 at wm_vuldet_collect_agent_software(): DEBUG: (5437): Collecting agent '006' software.
2023/05/17 19:00:46 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:6974 at wm_vuldet_insert_agent_data(): DEBUG: (5446): The CPE 'o:microsoft:windows_11_21h2:10.0.22000.318::::::x64:' from the agent '006' was indexed.
2023/05/17 19:00:46 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector_nvd.c:3272 at wm_vuldet_add_dic_cpe(): DEBUG: (5446): The CPE 'a:wazuh:wazuh:4.4.1::::::x86:' from the agent '006' was indexed.
2023/05/17 19:00:46 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:2827 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5450): Analyzing agent '006' vulnerabilities.
2023/05/17 19:00:46 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector_nvd.c:1859 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5451): Analyzing NVD vulnerabilities for agent '006'
2023/05/17 19:00:46 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector_nvd.c:1871 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5470): It took '0' seconds to 'find NVD' vulnerabilities in agent '006'
2023/05/17 19:00:46 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector_nvd.c:1873 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5466): Sending vulnerabilities report for agent '006'
2023/05/17 19:00:46 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector_nvd.c:1883 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5470): It took '0' seconds to 'report' vulnerabilities in agent '006'
2023/05/17 19:00:46 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:2846 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5471): Finished vulnerability assessment for agent '006'
2023/05/17 19:00:46 wazuh-modulesd:vulnerability-detector[225176] wm_vuln_detector.c:2847 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5470): It took '0' seconds to 'scan' vulnerabilities in agent '006'

```

<!--
Paste here related logs and alerts
-->

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer