### PR TITLE
Renamed macOS Login Item

### DIFF
--- a/src/init/darwin-init.sh
+++ b/src/init/darwin-init.sh
@@ -9,7 +9,7 @@
 INSTALLATION_PATH=${1}
 SERVICE=/Library/LaunchDaemons/com.wazuh.agent.plist
 STARTUP=/Library/StartupItems/WAZUH/StartupParameters.plist
-LAUNCHER_SCRIPT=/Library/StartupItems/WAZUH/launcher.sh
+LAUNCHER_SCRIPT=/Library/StartupItems/WAZUH/Wazuh-launcher
 STARTUP_SCRIPT=/Library/StartupItems/WAZUH/WAZUH
 
 launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist 2> /dev/null


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2199|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This pull request changes the name given to the Login Item by script `darwin-init.sh` to fix the problem explained in https://github.com/wazuh/wazuh-packages/issues/2199, removing the confusion that comes from the Login Item being called `launcher.sh`.

## Tests

All tests are explained in the parallel PR to https://wazuh/wazuh-packages, https://github.com/wazuh/wazuh-packages/pull/2207.

The failing check has been run again, and it is waiting in the queue for https://ci.wazuh.info/job/Packages_builder_macos/
