### PR TITLE
Remove `launchctl` as deployment variables tool

### DIFF
--- a/.github/actions/test_deploy_macos.sh
+++ b/.github/actions/test_deploy_macos.sh
@@ -13,7 +13,9 @@ MAJOR=$(echo "${VERSION}" | cut -dv -f2 | cut -d. -f1)
 MINOR=$(echo "${VERSION}" | cut -d. -f2)
 SHA="$(git rev-parse --short=7 "$1")"
 
+WAZUH_MACOS_AGENT_DEPLOYMENT_VARS="/tmp/wazuh_vars"
 conf_path="/Library/Ossec/etc/ossec.conf"
+
 
 VARS=( "WAZUH_MANAGER" "WAZUH_MANAGER_PORT" "WAZUH_PROTOCOL" "WAZUH_REGISTRATION_SERVER" "WAZUH_REGISTRATION_PORT" "WAZUH_REGISTRATION_PASSWORD" "WAZUH_KEEP_ALIVE_INTERVAL" "WAZUH_TIME_RECONNECT" "WAZUH_REGISTRATION_CA" "WAZUH_REGISTRATION_CERTIFICATE" "WAZUH_REGISTRATION_KEY" "WAZUH_AGENT_NAME" "WAZUH_AGENT_GROUP" "ENROLLMENT_DELAY" )
 VALUES=( "1.1.1.1" "7777" "udp" "2.2.2.2" "8888" "password" "10" "10" "/Library/Ossec/etc/testsslmanager.cert" "/Library/Ossec/etc/testsslmanager.cert" "/Library/Ossec/etc/testsslmanager.key" "test-agent" "test-group" "10" )
@@ -23,9 +25,11 @@ WAZUH_REGISTRATION_PASSWORD_PATH="/Library/Ossec/etc/authd.pass"
 
 function install_wazuh(){
 
-  echo "Testing the following variables $*"
+  echo "Testing the following variables $1"
 
-  eval "launchctl setenv ${*} && installer -pkg wazuh-agent-${VERSION}-0.commit${SHA}.pkg -target / > /dev/null 2>&1"
+  
+
+  eval "echo -e $1 > ${WAZUH_MACOS_AGENT_DEPLOYMENT_VARS} /&& installer -pkg wazuh-agent-${VERSION}-0.commit${SHA}.pkg -target / > /dev/null 2>&1"
   
 }
 
@@ -78,62 +82,62 @@ function test() {
 echo "Download package https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/warehouse/pullrequests/${MAJOR}.${MINOR}/macos/wazuh-agent-${VERSION}-0.commit${SHA}.pkg"
 wget "https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/warehouse/pullrequests/${MAJOR}.${MINOR}/macos/wazuh-agent-${VERSION}-0.commit${SHA}.pkg" > /dev/null 2>&1
 
-install_wazuh 'WAZUH_MANAGER "1.1.1.1" WAZUH_MANAGER_PORT "7777" WAZUH_PROTOCOL "udp" WAZUH_REGISTRATION_SERVER "2.2.2.2" WAZUH_REGISTRATION_PORT "8888" WAZUH_REGISTRATION_PASSWORD "password" WAZUH_KEEP_ALIVE_INTERVAL "10" WAZUH_TIME_RECONNECT "10" WAZUH_REGISTRATION_CA "/Library/Ossec/etc/testsslmanager.cert" WAZUH_REGISTRATION_CERTIFICATE "/Library/Ossec/etc/testsslmanager.cert" WAZUH_REGISTRATION_KEY "/Library/Ossec/etc/testsslmanager.key" WAZUH_AGENT_NAME "test-agent" WAZUH_AGENT_GROUP "test-group" ENROLLMENT_DELAY "10"' 
+install_wazuh 'WAZUH_MANAGER="1.1.1.1"\nWAZUH_MANAGER_PORT="7777"\nWAZUH_PROTOCOL="udp"\nWAZUH_REGISTRATION_SERVER="2.2.2.2"\nWAZUH_REGISTRATION_PORT="8888"\nWAZUH_REGISTRATION_PASSWORD="password"\nWAZUH_KEEP_ALIVE_INTERVAL="10"\nWAZUH_TIME_RECONNECT="10"\nWAZUH_REGISTRATION_CA="/Library/Ossec/etc/testsslmanager.cert"\nWAZUH_REGISTRATION_CERTIFICATE="/Library/Ossec/etc/testsslmanager.cert"\nWAZUH_REGISTRATION_KEY="/Library/Ossec/etc/testsslmanager.key"\nWAZUH_AGENT_NAME="test-agent"\nWAZUH_AGENT_GROUP="test-group"\nENROLLMENT_DELAY "10"' 
 test "WAZUH_MANAGER WAZUH_MANAGER_PORT WAZUH_PROTOCOL WAZUH_REGISTRATION_SERVER WAZUH_REGISTRATION_PORT WAZUH_REGISTRATION_PASSWORD WAZUH_KEEP_ALIVE_INTERVAL WAZUH_TIME_RECONNECT WAZUH_REGISTRATION_CA WAZUH_REGISTRATION_CERTIFICATE WAZUH_REGISTRATION_KEY WAZUH_AGENT_NAME WAZUH_AGENT_GROUP ENROLLMENT_DELAY" 
 remove_wazuh
 
-install_wazuh 'WAZUH_MANAGER "1.1.1.1"'
+install_wazuh 'WAZUH_MANAGER="1.1.1.1"'
 test "WAZUH_MANAGER"
 remove_wazuh
 
-install_wazuh 'WAZUH_MANAGER_PORT "7777"'
+install_wazuh 'WAZUH_MANAGER_PORT="7777"'
 test "WAZUH_MANAGER_PORT"
 remove_wazuh
 
-install_wazuh 'WAZUH_PROTOCOL "udp"'
+install_wazuh 'WAZUH_PROTOCOL="udp"'
 test "WAZUH_PROTOCOL"
 remove_wazuh
 
-install_wazuh 'WAZUH_REGISTRATION_SERVER "2.2.2.2"'
+install_wazuh 'WAZUH_REGISTRATION_SERVER="2.2.2.2"'
 test "WAZUH_REGISTRATION_SERVER"
 remove_wazuh
 
-install_wazuh 'WAZUH_REGISTRATION_PORT "8888"'
+install_wazuh 'WAZUH_REGISTRATION_POR="8888"'
 test "WAZUH_REGISTRATION_PORT"
 remove_wazuh
 
-install_wazuh 'WAZUH_REGISTRATION_PASSWORD "password"'
+install_wazuh 'WAZUH_REGISTRATION_PASSWORD="password"'
 test "WAZUH_REGISTRATION_PASSWORD"
 remove_wazuh
 
-install_wazuh 'WAZUH_KEEP_ALIVE_INTERVAL "10"'
+install_wazuh 'WAZUH_KEEP_ALIVE_INTERVAL="10"'
 test "WAZUH_KEEP_ALIVE_INTERVAL"
 remove_wazuh
 
-install_wazuh 'WAZUH_TIME_RECONNECT "10"'
+install_wazuh 'WAZUH_TIME_RECONNECT="10"'
 test "WAZUH_TIME_RECONNECT"
 remove_wazuh
 
-install_wazuh 'WAZUH_REGISTRATION_CA "/Library/Ossec/etc/testsslmanager.cert"'
+install_wazuh 'WAZUH_REGISTRATION_CA="/Library/Ossec/etc/testsslmanager.cert"'
 test "WAZUH_REGISTRATION_CA"
 remove_wazuh
 
-install_wazuh 'WAZUH_REGISTRATION_CERTIFICATE "/Library/Ossec/etc/testsslmanager.cert"'
+install_wazuh 'WAZUH_REGISTRATION_CERTIFICATE="/Library/Ossec/etc/testsslmanager.cert"'
 test "WAZUH_REGISTRATION_CERTIFICATE"
 remove_wazuh
 
-install_wazuh 'WAZUH_REGISTRATION_KEY "/Library/Ossec/etc/testsslmanager.key"'
+install_wazuh 'WAZUH_REGISTRATION_KEY="/Library/Ossec/etc/testsslmanager.key"'
 test "WAZUH_REGISTRATION_KEY"
 remove_wazuh
 
-install_wazuh 'WAZUH_AGENT_NAME "test-agent"'
+install_wazuh 'WAZUH_AGENT_NAME="test-agent"'
 test "WAZUH_AGENT_NAME"
 remove_wazuh
 
-install_wazuh 'WAZUH_AGENT_GROUP "test-group"'
+install_wazuh 'WAZUH_AGENT_GROUP="test-group"'
 test "WAZUH_AGENT_GROUP"
 remove_wazuh
 
-install_wazuh 'ENROLLMENT_DELAY "10"'
+install_wazuh 'ENROLLMENT_DELAY="10"'
 test "ENROLLMENT_DELAY"
 remove_wazuh

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -13,6 +13,7 @@ CONF_FILE="${INSTALLDIR}/etc/ossec.conf"
 TMP_ENROLLMENT="${INSTALLDIR}/tmp/enrollment-configuration"
 TMP_SERVER="${INSTALLDIR}/tmp/server-configuration"
 WAZUH_REGISTRATION_PASSWORD_PATH="etc/authd.pass"
+WAZUH_MACOS_AGENT_DEPLOYMENT_VARS="/tmp/wazuh_vars"
 
 
 # Set default sed alias
@@ -181,22 +182,6 @@ set_vars () {
     export WAZUH_AGENT_NAME
     export WAZUH_AGENT_GROUP
     export ENROLLMENT_DELAY
-
-    WAZUH_MANAGER=$(launchctl getenv WAZUH_MANAGER)
-    WAZUH_MANAGER_PORT=$(launchctl getenv WAZUH_MANAGER_PORT)
-    WAZUH_PROTOCOL=$(launchctl getenv WAZUH_PROTOCOL)
-    WAZUH_REGISTRATION_SERVER=$(launchctl getenv WAZUH_REGISTRATION_SERVER)
-    WAZUH_REGISTRATION_PORT=$(launchctl getenv WAZUH_REGISTRATION_PORT)
-    WAZUH_REGISTRATION_PASSWORD=$(launchctl getenv WAZUH_REGISTRATION_PASSWORD)
-    WAZUH_KEEP_ALIVE_INTERVAL=$(launchctl getenv WAZUH_KEEP_ALIVE_INTERVAL)
-    WAZUH_TIME_RECONNECT=$(launchctl getenv WAZUH_TIME_RECONNECT)
-    WAZUH_REGISTRATION_CA=$(launchctl getenv WAZUH_REGISTRATION_CA)
-    WAZUH_REGISTRATION_CERTIFICATE=$(launchctl getenv WAZUH_REGISTRATION_CERTIFICATE)
-    WAZUH_REGISTRATION_KEY=$(launchctl getenv WAZUH_REGISTRATION_KEY)
-    WAZUH_AGENT_NAME=$(launchctl getenv WAZUH_AGENT_NAME)
-    WAZUH_AGENT_GROUP=$(launchctl getenv WAZUH_AGENT_GROUP)
-    ENROLLMENT_DELAY=$(launchctl getenv ENROLLMENT_DELAY)
-
     # The following variables are yet supported but all of them are deprecated
     export WAZUH_MANAGER_IP
     export WAZUH_NOTIFY_TIME
@@ -208,21 +193,14 @@ set_vars () {
     export WAZUH_KEY
     export WAZUH_PEM
 
-    WAZUH_MANAGER_IP=$(launchctl getenv WAZUH_MANAGER_IP)
-    WAZUH_NOTIFY_TIME=$(launchctl getenv WAZUH_NOTIFY_TIME)
-    WAZUH_AUTHD_SERVER=$(launchctl getenv WAZUH_AUTHD_SERVER)
-    WAZUH_AUTHD_PORT=$(launchctl getenv WAZUH_AUTHD_PORT)
-    WAZUH_PASSWORD=$(launchctl getenv WAZUH_PASSWORD)
-    WAZUH_GROUP=$(launchctl getenv WAZUH_GROUP)
-    WAZUH_CERTIFICATE=$(launchctl getenv WAZUH_CERTIFICATE)
-    WAZUH_KEY=$(launchctl getenv WAZUH_KEY)
-    WAZUH_PEM=$(launchctl getenv WAZUH_PEM)
+    if [ -r "${WAZUH_MACOS_AGENT_DEPLOYMENT_VARS}" ]; then
+        . ${WAZUH_MACOS_AGENT_DEPLOYMENT_VARS}
+        rm -rf "${WAZUH_MACOS_AGENT_DEPLOYMENT_VARS}"
+    fi
 
 }
 
 unset_vars() {
-
-    OS=$1
 
     vars=(WAZUH_MANAGER_IP WAZUH_PROTOCOL WAZUH_MANAGER_PORT WAZUH_NOTIFY_TIME \
           WAZUH_TIME_RECONNECT WAZUH_AUTHD_SERVER WAZUH_AUTHD_PORT WAZUH_PASSWORD \
@@ -233,9 +211,6 @@ unset_vars() {
           ENROLLMENT_DELAY)
 
     for var in "${vars[@]}"; do
-        if [ "${OS}" = "Darwin" ]; then
-            launchctl unsetenv "${var}"
-        fi
         unset "${var}"
     done
 
@@ -371,7 +346,7 @@ main () {
     edit_value_tag "notify_time" "${WAZUH_KEEP_ALIVE_INTERVAL}"
     edit_value_tag "time-reconnect" "${WAZUH_TIME_RECONNECT}"
 
-    unset_vars "${uname_s}"
+    unset_vars
 
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#2205|

## Description

This PR aims to replace `launchctl setenv` /  `launchctl getenv` usage as part of macOS Wazuh Agent installation process since macOS Ventura 13.4 forbids access to such commands when executed as root. This breaks mainly the [Deployment Variables](https://documentation.wazuh.com/current/user-manual/deployment-variables/deployment-variables-macos.html) feature.


## Configuration options

Changes basically replace the mentioned mechanism with a temporary file that contains the deployment variables and will be ingested internally during the installation process if exist

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors