### PR TITLE
Change 'Ossec' text to 'Wazuh' on the current rules

### DIFF
--- a/ruleset/rules/0010-rules_config.xml
+++ b/ruleset/rules/0010-rules_config.xml
@@ -52,6 +52,6 @@
 <group name="ossec,">
   <rule id="7" level="0" noalert="1">
     <category>ossec</category>
-    <description>Generic template for all ossec rules.</description>
+    <description>Generic template for all wazuh rules.</description>
   </rule>
 </group>

--- a/ruleset/rules/0015-ossec_rules.xml
+++ b/ruleset/rules/0015-ossec_rules.xml
@@ -11,35 +11,35 @@
   <rule id="500" level="0">
     <category>ossec</category>
     <decoded_as>ossec</decoded_as>
-    <description>Grouping of ossec rules.</description>
+    <description>Grouping of wazuh rules.</description>
   </rule>
 
   <rule id="501" level="3">
     <if_sid>500</if_sid>
     <if_fts />
     <match>Agent started</match>
-    <description>New ossec agent connected.</description>
+    <description>New wazuh agent connected.</description>
     <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="502" level="3">
     <if_sid>500</if_sid>
     <match>Manager started</match>
-    <description>Ossec server started.</description>
+    <description>Wazuh server started.</description>
     <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="503" level="3">
     <if_sid>500</if_sid>
     <match>Agent started</match>
-    <description>Ossec agent started.</description>
+    <description>Wazuh agent started.</description>
     <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,</group>
   </rule>
 
   <rule id="504" level="3">
     <if_sid>500</if_sid>
     <match>Agent disconnected</match>
-    <description>Ossec agent disconnected.</description>
+    <description>Wazuh agent disconnected.</description>
     <mitre>
       <id>T1562.001</id>
     </mitre>
@@ -49,7 +49,7 @@
   <rule id="505" level="3">
     <if_sid>500</if_sid>
     <match>Agent removed</match>
-    <description>Ossec agent removed.</description>
+    <description>Wazuh agent removed.</description>
     <mitre>
       <id>T1562.001</id>
     </mitre>
@@ -59,7 +59,7 @@
   <rule id="506" level="3">
     <if_sid>500</if_sid>
     <match>Agent stopped</match>
-    <description>Ossec agent stopped.</description>
+    <description>Wazuh agent stopped.</description>
     <mitre>
       <id>T1562.001</id>
     </mitre>
@@ -77,7 +77,7 @@
     <if_sid>509</if_sid>
     <description>Host-based anomaly detection event (rootcheck).</description>
     <group>rootcheck,pci_dss_10.6.1,gdpr_IV_35.7.d,</group>
-   <!-- <if_fts />  -->
+    <!-- <if_fts />  -->
   </rule>
 
   <rule id="511" level="0">
@@ -174,7 +174,7 @@
   <rule id="530" level="0">
     <if_sid>500</if_sid>
     <match>^ossec: output: </match>
-    <description>OSSEC process monitoring rules.</description>
+    <description>Wazuh process monitoring rules.</description>
     <group>process_monitor,</group>
   </rule>
 
@@ -186,7 +186,7 @@
     <group>low_diskspace,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
- <rule id="532" level="0">
+  <rule id="532" level="0">
     <if_sid>531</if_sid>
     <match>cdrom|/media|usb|/mount|floppy|dvd</match>
     <description>Ignoring external medias.</description>
@@ -219,8 +219,8 @@
 
   <rule id="536" level="0">
     <if_sid>531</if_sid>
-      <regex>'df -P':\s+/dev/loop\d+\s+\d+\s+\d+\s+0\s+100%\s+/snap/\w+/\d+</regex>
-      <description>Ignore snap disks because they are always at 100% of capacity</description>
+    <regex>'df -P':\s+/dev/loop\d+\s+\d+\s+\d+\s+0\s+100%\s+/snap/\w+/\d+</regex>
+    <description>Ignore snap disks because they are always at 100% of capacity</description>
   </rule>
 
 

--- a/ruleset/rules/0545-osquery_rules.xml
+++ b/ruleset/rules/0545-osquery_rules.xml
@@ -121,7 +121,7 @@
     <options>no_full_log</options>
   </rule>
 
-    <rule id="24033" level="4">
+  <rule id="24033" level="4">
     <if_sid>24030</if_sid>
     <field name="osquery.name">crontab</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Command launched $(osquery.columns.command) at $(osquery.columns.hour):$(osquery.columns.minute) $(osquery.columns.day_of_month) $(osquery.columns.month) </description>
@@ -185,7 +185,7 @@
     <options>no_full_log</options>
   </rule>
 
-    <rule id="24041" level="4">
+  <rule id="24041" level="4">
     <if_sid>24030</if_sid>
     <field name="osquery.name">alf_services</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Application Layer Firewall for OSX service $(osquery.columns.service) state $(osquery.columns.state)</description>
@@ -1176,7 +1176,7 @@
   <rule id="24500" level="4">
     <if_sid>24010</if_sid>
     <field name="osquery.pack">^ossec-rootkit$</field>
-    <description>osquery: $(osquery.pack) $(osquery.subquery): Ossec rootkit file $(osquery.columns.path) detected</description>
+    <description>osquery: $(osquery.pack) $(osquery.subquery): Wazuh rootkit file $(osquery.columns.path) detected</description>
     <group>ossec_rootkit,</group>
     <options>no_full_log</options>
   </rule>
@@ -1472,4 +1472,3 @@
   </rule>
 
 </group>
-


### PR DESCRIPTION
|Related issue|
|---|
|#17168|

Sample of action taken. 

Current rule: 
```
  <rule id="500" level="0">
    <category>ossec</category>
    <decoded_as>ossec</decoded_as>
    <description>Grouping of ossec rules.</description>
  </rule>
```
Changed rule: 
```
  <rule id="500" level="0">
    <category>ossec</category>
    <decoded_as>ossec</decoded_as>
    <description>Grouping of wazuh rules.</description>
  </rule>
```


Rules affected by this change

| id  | Action | Field       | Description           |
| --- | ------ | ----------- | --------------------- |
| 7   | Change | description | Change ossec to wazuh |
| 500 | Change | description | Change ossec to wazuh |
| 501 | Change | description | Change ossec to wazuh |
| 502 | Change | description | Change ossec to wazuh |
| 503 | Change | description | Change ossec to wazuh |
| 504 | Change | description | Change ossec to wazuh |
| 505 | Change | description | Change ossec to wazuh |
| 506 | Change | description | Change ossec to wazuh |
| 530 | Change | description | Change ossec to wazuh |
|  24500   | Change | description | Change ossec to wazuh |

