### PR TITLE
Engine - Removing status field of check event type when needed

### DIFF
--- a/src/engine/source/builder/builders/opBuilderSCAdecoder.hpp
+++ b/src/engine/source/builder/builders/opBuilderSCAdecoder.hpp
@@ -44,7 +44,6 @@ enum class Name
     CHECK_REMEDIATION,     ///< checkEvent
     CHECK_RESULT,          ///< checkEvent
     CHECK_RULES,           ///< checkEvent
-    CHECK_STATUS,          ///< checkEvent
     CHECK_TITLE,           ///< checkEvent
     CHECK,                 ///< checkEvent
     DESCRIPTION,           ///< scaninfo


### PR DESCRIPTION
Removing status field of check event type when needed, updating test to work alongside changes

|Related issue|
|---|
|#17346|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

After reviewing the issue on sca alongside the engine usage we found the need of:

- [x] Updating sca helper function to work alongside [#15853](https://github.com/wazuh/wazuh/pull/15853)
- [x] SCA non update agent sca_che db solution.
- [x] SOlution of tests due to modifications
 