### PR TITLE
Fix hourly_events variable race condition

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1151,10 +1151,14 @@ static void DumpLogstats()
     } while ((rulenode_pt = rulenode_pt->next) != NULL);
 
     /* Print total for the hour */
+
+    w_mutex_lock(&hourly_alert_mutex);                                       \
     fprintf(flog, "%d--%d--%d--%d--%d\n\n",
             thishour,
             hourly_alerts, hourly_events, hourly_syscheck, hourly_firewall);
-    w_guard_mutex_variable(hourly_alert_mutex, (hourly_alerts = 0));
+    hourly_alerts = 0;
+    w_mutex_unlock(&hourly_alert_mutex)
+    
     hourly_events = 0;
     hourly_syscheck = 0;
     hourly_firewall = 0;


### PR DESCRIPTION
|Related issue|
|---|
|[#16130](https://github.com/wazuh/wazuh/pull/16130)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR avoids a race condition that might occurr when reading hourly_events in analysisd module.
No protection was present for a situation where several threads might access the variable,
when it was used as a parameter to a printf.

Although the referred issue contains several race conditions detected, some have been
corrected before this PR, none was reproduced during testings and this is the only
one that, by inspection, was detected as probable to ocurr.

Several other race conditions were on heap allocated variables, and the original source code
was not identify (it was incorrectly marked a 3.7.1). Because of this, there is no correlation between
the logs in the issue and the source codes that were inspected.

