### PR TITLE
Correct samba package check on ubuntu 22.04

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -1501,7 +1501,7 @@ checks:
     condition: all
     rules:
       - "c:dpkg-query -s samba -> r:package 'samba' is not installed"
-      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' samba -> r:no packages found matching sambad|deinstall|not-installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' samba -> r:no packages found matching samba|deinstall|not-installed"
 
   # 2.2.12 Ensure HTTP Proxy Server is not installed (Automated)
   - id: 28562


### PR DESCRIPTION

|Related issue|
|---|
|contribution|


## Description
Fix typo (searching for 'sambad' in command output) in Rsync package check on Ubuntu 22.04 (CIS 2.2.11 / Wazuh 28561).


## Configuration options
NA

## Tests

I have skipped the tests, hoping that the yaml change will not trigger any of them.
