### PR TITLE
Prevent invalid free of stack memory at osquery integration module

### DIFF
--- a/src/unit_tests/wazuh_modules/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/CMakeLists.txt
@@ -30,4 +30,4 @@ endif()
 
 add_subdirectory(github)
 add_subdirectory(office365)
-
+add_subdirectory(osquery)

--- a/src/unit_tests/wazuh_modules/osquery/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/osquery/CMakeLists.txt
@@ -1,0 +1,81 @@
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+# Tests list and flags
+list(APPEND tests_names "test_wm_osquery_already_running")
+list(APPEND tests_flags "-Wl,--wrap,access -Wl,--wrap,wurl_http_request \
+                         -Wl,--wrap,wurl_free_response -Wl,--wrap,wm_sendmsg -Wl,--wrap,strftime \
+                         -Wl,--wrap,wm_state_io -Wl,--wrap,time -Wl,--wrap,StartMQ \
+                         -Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck \ -Wl,--wrap=is_fim_shutdown \
+                         -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown \
+                         -Wl,--wrap,fim_sync_push_msg -Wl,--wrap,fim_run_integrity -Wl,--wrap,fim_db_remove_path \
+                         -Wl,--wrap,fim_db_get_path -Wl,--wrap,fim_db_transaction_start -Wl,--wrap,fim_db_transaction_deleted_rows \
+                         -Wl,--wrap,fim_db_transaction_sync_row -Wl,--wrap,fim_db_file_update -Wl,--wrap,fim_db_file_pattern_search \
+                         -Wl,--wrap,fim_db_init,--wrap,getpid")
+
+# Generate wazuh modules library
+file(GLOB osquery ../../../wazuh_modules/*.o)
+list(REMOVE_ITEM osquery ../../../wazuh_modules/main.o)
+
+add_library(OSQUERY_O STATIC ${osquery})
+
+set_source_files_properties(
+  ${osquery}
+  PROPERTIES
+  EXTERNAL_OBJECT true
+  GENERATED true
+  )
+
+set_target_properties(
+  OSQUERY_O
+  PROPERTIES
+  LINKER_LANGUAGE C
+  )
+
+target_link_libraries(OSQUERY_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
+
+
+# Compiling tests
+list(LENGTH tests_names count)
+math(EXPR count "${count} - 1")
+foreach(counter RANGE ${count})
+    list(GET tests_names ${counter} test_name)
+    list(GET tests_flags ${counter} test_flags)
+    list(GET use_shared_libs ${counter} use_libs)
+
+    if(use_libs EQUAL "1")
+      add_executable(${test_name} ${test_name}.c ${shared_libs})
+    else ()
+      add_executable(${test_name} ${test_name}.c)
+    endif()
+
+    if(${TARGET} STREQUAL "server")
+        target_link_libraries(
+            ${test_name}
+            ${WAZUHLIB}
+            ${WAZUHEXT}
+            OSQUERY_O
+            -lcmocka
+            -ldl
+            -fprofile-arcs
+            -ftest-coverage
+        )
+    else()
+        target_link_libraries(
+            ${test_name}
+            ${TEST_DEPS}
+        )
+    endif()
+
+    if(NOT test_flags STREQUAL " ")
+        target_link_libraries(
+            ${test_name}
+            ${test_flags}
+        )
+    endif()
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()

--- a/src/unit_tests/wazuh_modules/osquery/test_wm_osquery_already_running.c
+++ b/src/unit_tests/wazuh_modules/osquery/test_wm_osquery_already_running.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+char * wm_osquery_already_running(char * text);
+
+void test_wm_osquery_already_running_null(void **state)
+{
+    char *input = NULL;
+    char *output = wm_osquery_already_running(input);
+
+    assert_null(output);
+}
+
+void test_wm_osquery_already_running_pattern_1(void **state)
+{
+    char input[] = "osqueryd (1000) is already running";
+    char *output = wm_osquery_already_running(input);
+
+    assert_non_null(output);
+    assert_string_equal(output, "1000");
+
+    free(output);
+}
+
+void test_wm_osquery_already_running_pattern_2(void **state)
+{
+    char input[] = "Pidfile::Error::Busy";
+    char *output = wm_osquery_already_running(input);
+
+    assert_non_null(output);
+    assert_string_equal(output, "unknown");
+
+    free(output);
+}
+
+void test_wm_osquery_already_running_no_match(void **state)
+{
+    char input[] = "No match";
+    char *output = wm_osquery_already_running(input);
+    assert_null(output);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        // wm_osquery_already_running
+        cmocka_unit_test(test_wm_osquery_already_running_null),
+        cmocka_unit_test(test_wm_osquery_already_running_pattern_1),
+        cmocka_unit_test(test_wm_osquery_already_running_pattern_2),
+        cmocka_unit_test(test_wm_osquery_already_running_no_match),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -425,6 +425,8 @@ char * wm_osquery_already_running(char * text) {
             // Find "Pidfile::Error::Busy"
         } else if (strstr(text, PATTERNS[2]) != NULL) {
             os_strdup("unknown", text);
+        } else {
+            text = NULL;
         }
     }
     return text;

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -37,6 +37,13 @@
 #define mdebug1(msg, ...) _mtdebug1(WM_OSQUERYMONITOR_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define mdebug2(msg, ...) _mtdebug2(WM_OSQUERYMONITOR_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 
+#ifdef WAZUH_UNIT_TESTING
+// Remove static qualifier when unit testing
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 #ifdef WIN32
 static DWORD WINAPI wm_osquery_monitor_main(void *arg);
 #else
@@ -45,7 +52,7 @@ static void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery_monitor);
 static void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor);
 static int wm_osquery_check_logfile(const char * path, FILE * fp);
 static int wm_osquery_packs(wm_osquery_monitor_t *osquery);
-static char * wm_osquery_already_running(char * text);
+STATIC char * wm_osquery_already_running(char * text);
 cJSON *wm_osquery_dump(const wm_osquery_monitor_t *osquery_monitor);
 
 static volatile int active = 1;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17440|

This PR aims to fix a bug that mishandles logging data from osquery.

There is a 4 KB buffer allocated in the thread's stack that receives each log from the osquery output. The log parser may call `wm_osquery_already_running()` to match a message like:

> osqueryd (1000) is already running

This function should return a heap-allocated string containing either the process PID, `"unknown"`, or a null pointer (if the message did not match the pattern). However, a recent change let the function return the source string itself. As the caller assumes that the returned string is independent and heap-allocated, it tries to free it after, causing an invalid free hazard.

## Proposed fix

Let `wm_osquery_already_running()` return `NULL` if the input string matches no pattern.