### PR TITLE
Avoid exceeding the maximum number of fields when loading a rule

### DIFF
--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -759,6 +759,13 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_field) == 0) {
 
+                        if (Config.decoder_order_size <= ifield) {
+                            smerror(log_msg, "Rule %d has exceeded the maximum number of allowed fields",
+                                   config_ruleinfo->sigid);
+
+                            goto cleanup;
+                        }
+
                         if (!w_check_attr_field_name(rule_tmp_params.rule_arr_opt[k],
                                                      &config_ruleinfo->fields[ifield],
                                                      config_ruleinfo->sigid, log_msg)) {
@@ -2159,7 +2166,7 @@ RuleInfo *zerorulemember(int id, int level, int maxsize, int frequency,
     ruleinfo_pt->program_name = NULL;
     ruleinfo_pt->action = NULL;
     ruleinfo_pt->location = NULL;
-    os_calloc(Config.decoder_order_size, sizeof(FieldInfo*), ruleinfo_pt->fields);
+    os_calloc(Config.decoder_order_size + 1, sizeof(FieldInfo*), ruleinfo_pt->fields);
 
     ruleinfo_pt->same_fields = NULL;
     ruleinfo_pt->not_same_fields = NULL;


### PR DESCRIPTION
|Related issue| Documentation| Testing issue|
|---|---|---|
| #15638|  |  |


# Description
The purpose of this code is to prevent analysisd from loading a rule that exceeds the number of fields allowed by configuration, to avoid exceeding the value of the analysisd.decoder_order_size parameter. Avoiding in this way that analysisd breaks when trying to use this rule. 

# Configuration
## Default configuration

internal_options.conf default value:

```
# Maximum number of fields in a decoder (order tag) [32..1024]
analysisd.decoder_order_size=256
```

## Custom configuration

<details><summary>large rule</summary>

```
    <rule id="1000001" level="13">
        <info type="link">https://github.com/SigmaHQ/sigma/tree/master/rules/network/zeek/zeek_smb_converted_win_lm_namedpipe.yml</info>
        <description>First Time Seen Remote Named Pipe - Zeek</description>
        <options>no_full_log</options>
        <group>zeek,smb_files</group>
        <field name="full_log" type="pcre2">(?i)\\\\\\.+\\IPC\$</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)samr</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)lsarpc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)winreg</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netlogon</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)srvsvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)protected_storage</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)wkssvc</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)browser</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)netdfs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)svcctl</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)spoolss</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)ntsvcs</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)LSM_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)HydraLsPipe</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)TermSrv_API_service</field>
        <field name="full_log" negate="yes" type="pcre2">(?i)MsFteWds</field>
    </rule>
```

</details>

# Tests
### Case 1 
- Parameter `analysisd.decoder_order_size=256`
- Custom rule with 255 `fields name`

``` bash
$cat /var/ossec/etc/internal_options.conf | grep decoder_order_size
analysisd.decoder_order_size=256

$ cat /var/ossec/etc/rules/sigma_linux_auditd.xml | grep "field name" | wc -l
255

$ /var/ossec/bin/wazuh-control start
Starting Wazuh v4.4.0...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2023/06/07 18:41:42 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
Started wazuh-modulesd...
Completed.
```

### Case 2 
- Parameter `analysisd.decoder_order_size=255`
- Custom rule with 255 `fields name`

``` bash
$cat /var/ossec/etc/internal_options.conf | grep decoder_order_size
analysisd.decoder_order_size=255

$ cat /var/ossec/etc/rules/sigma_linux_auditd.xml | grep "field name" | wc -l
255

$ /var/ossec/bin/wazuh-control start
Starting Wazuh v4.4.0...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2023/06/07 18:41:42 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
Started wazuh-modulesd...
Completed.
```

### Case 3 
- Parameter `analysisd.decoder_order_size=254`
- Custom rule with 255 `fields name`

``` bash
$cat /var/ossec/etc/internal_options.conf | grep decoder_order_size
analysisd.decoder_order_size=254

$ cat /var/ossec/etc/rules/sigma_linux_auditd.xml | grep "field name" | wc -l
255

$ /var/ossec/bin/wazuh-control start
2023/06/07 18:58:11 wazuh-analysisd: ERROR: Rule 900728 has exceeded the maximum number of allowed fields
2023/06/07 18:58:11 wazuh-analysisd: CRITICAL: (1220): Error loading the rules: 'etc/rules/sigma_linux_auditd.xml'.
wazuh-analysisd: Configuration error. Exiting
```

### Case 4 
- Parameter `analysisd.decoder_order_size=253`
- Custom rule with 255 `fields name`

``` bash
$cat /var/ossec/etc/internal_options.conf | grep decoder_order_size
analysisd.decoder_order_size=253

$ cat /var/ossec/etc/rules/sigma_linux_auditd.xml | grep "field name" | wc -l
255

$ /var/ossec/bin/wazuh-control start
2023/06/07 18:59:08 wazuh-analysisd: ERROR: Rule 900728 has exceeded the maximum number of allowed fields
2023/06/07 18:59:08 wazuh-analysisd: CRITICAL: (1220): Error loading the rules: 'etc/rules/sigma_linux_auditd.xml'.
wazuh-analysisd: Configuration error. Exiting
```

### Case 5 
- Parameter `analysisd.decoder_order_size=253`
- Custom rule with 250 `fields name`

``` bash
$cat /var/ossec/etc/internal_options.conf | grep decoder_order_size
analysisd.decoder_order_size=253

$ cat /var/ossec/etc/rules/sigma_linux_auditd.xml | grep "field name" | wc -l
250

$ /var/ossec/bin/wazuh-control start
Starting Wazuh v4.4.0...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2023/06/07 18:41:42 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
Started wazuh-modulesd...
Completed.

```


<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
