### PR TITLE
Review the timestamp logs of the RTR - Implementation

### DIFF
--- a/src/ci/utils.py
+++ b/src/ci/utils.py
@@ -13,7 +13,8 @@ import subprocess
 import multiprocessing
 from pathlib import Path
 from ci import build_tools
-
+import functools
+print = functools.partial(print, flush=True)
 
 # Constant values
 CURRENT_DIR = Path(__file__).parent


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17500|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR flushes the output of the RTR script to allow a real timestamp in the Github Actions logs.

## Tests

We can see in this job that now the logs have a natural and logical timestamp
https://github.com/wazuh/wazuh/actions/runs/5212433706/jobs/9406022849

![2023-06-08_12-00](https://github.com/wazuh/wazuh/assets/65046601/6f88fae9-6995-4af5-9296-b7b66e9ac24a)

There is no time gap in at the beginning, the coverage related logs are printed below the corresponding header, etc.

