### PR TITLE
Fixed restore agent database

### DIFF
--- a/src/shared/os_utils.c
+++ b/src/shared/os_utils.c
@@ -118,15 +118,14 @@ OSList *w_os_get_process_list()
 
 #endif
 /* Check if a file exists */
-int w_is_file(const char * const file)
-{
-    FILE *fp;
-    fp = fopen(file, "r");
-    if (fp) {
+int w_is_file(const char * const file) {
+    FILE *fp = fopen(file, "r");
+    int is_exist = 0;
+    if (fp != NULL) {
+        is_exist = 1;
         fclose(fp);
-        return (1);
     }
-    return (0);
+    return is_exist;
 }
 
 /* Delete the process list */

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_scan_info_get -Wl,--wrap,wdb_fim_upd
                         -Wl,--wrap,wdb_get_config -Wl,--wrap,wdb_get_internal_config -Wl,--wrap,wdb_finalize_all_statements \
                         -Wl,--wrap,wdb_global_create_backup -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_vacuum -Wl,--wrap,wdb_get_db_state \
                         -Wl,--wrap,wdb_update_last_vacuum_data -Wl,--wrap,wdb_get_db_free_pages_percentage \
+                        -Wl,--wrap,w_is_file -Wl,--wrap,wdb_close\
                         ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -82,6 +82,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_vacuum -Wl,--wrap,wdb_get_db_state -Wl,--wrap,wdb_finalize_all_statements \
                              -Wl,--wrap,wdb_update_last_vacuum_data -Wl,--wrap,wdb_get_db_free_pages_percentage -Wl,--wrap,wdb_global_get_distinct_agent_groups \
                              -Wl,--wrap,w_inc_global_agent_get_distinct_groups -Wl,--wrap,w_inc_global_agent_get_distinct_groups_time \
+                             -Wl,--wrap,w_is_file -Wl,--wrap,wdb_close \
                              ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global")

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -109,6 +109,9 @@ void test_wdb_parse_global_substr_fail(void **state)
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'error'");
@@ -129,6 +132,9 @@ void test_wdb_parse_global_sql_error(void **state)
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_sql);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -189,6 +195,9 @@ void test_wdb_parse_global_sql_fail(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_sql_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -228,6 +237,9 @@ void test_wdb_parse_global_insert_agent_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'insert-agent'");
@@ -252,6 +264,9 @@ void test_wdb_parse_global_insert_agent_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -274,6 +289,9 @@ void test_wdb_parse_global_insert_agent_compliant_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -307,6 +325,9 @@ void test_wdb_parse_global_insert_agent_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -364,6 +385,9 @@ void test_wdb_parse_global_update_agent_name_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-agent-name'");
@@ -388,6 +412,9 @@ void test_wdb_parse_global_update_agent_name_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -410,6 +437,9 @@ void test_wdb_parse_global_update_agent_name_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -437,6 +467,9 @@ void test_wdb_parse_global_update_agent_name_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -486,6 +519,9 @@ void test_wdb_parse_global_update_agent_data_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-agent-data'");
@@ -509,6 +545,9 @@ void test_wdb_parse_global_update_agent_data_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -566,6 +605,9 @@ void test_wdb_parse_global_update_agent_data_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -598,6 +640,9 @@ void test_wdb_parse_global_update_agent_data_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -678,6 +723,9 @@ void test_wdb_parse_global_get_agent_labels_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_labels_get_labels);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-labels'");
@@ -702,6 +750,9 @@ void test_wdb_parse_global_get_agent_labels_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_labels_get_labels_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -760,6 +811,9 @@ void test_wdb_parse_global_update_agent_keepalive_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-keepalive'");
@@ -784,6 +838,9 @@ void test_wdb_parse_global_update_agent_keepalive_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -806,6 +863,9 @@ void test_wdb_parse_global_update_agent_keepalive_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -835,6 +895,9 @@ void test_wdb_parse_global_update_agent_keepalive_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -886,6 +949,9 @@ void test_wdb_parse_global_update_connection_status_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-connection-status'");
@@ -910,6 +976,9 @@ void test_wdb_parse_global_update_connection_status_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -932,6 +1001,9 @@ void test_wdb_parse_global_update_connection_status_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -962,6 +1034,9 @@ void test_wdb_parse_global_update_connection_status_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1014,6 +1089,9 @@ void test_wdb_parse_global_update_status_code_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-status-code'");
@@ -1038,6 +1116,9 @@ void test_wdb_parse_global_update_status_code_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -1060,6 +1141,9 @@ void test_wdb_parse_global_update_status_code_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1090,6 +1174,9 @@ void test_wdb_parse_global_update_status_code_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1142,6 +1229,9 @@ void test_wdb_parse_global_delete_agent_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_delete_agent);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'delete-agent'");
@@ -1166,6 +1256,9 @@ void test_wdb_parse_global_delete_agent_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_delete_agent_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1214,6 +1307,9 @@ void test_wdb_parse_global_select_agent_name_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_name);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'select-agent-name'");
@@ -1238,6 +1334,9 @@ void test_wdb_parse_global_select_agent_name_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_name_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1290,6 +1389,9 @@ void test_wdb_parse_global_select_agent_group_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_group);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'select-agent-group'");
@@ -1314,6 +1416,9 @@ void test_wdb_parse_global_select_agent_group_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_group_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1366,6 +1471,9 @@ void test_wdb_parse_global_find_agent_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_find_agent);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'find-agent'");
@@ -1390,6 +1498,9 @@ void test_wdb_parse_global_find_agent_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_find_agent_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -1412,6 +1523,9 @@ void test_wdb_parse_global_find_agent_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_find_agent_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1439,6 +1553,9 @@ void test_wdb_parse_global_find_agent_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_find_agent_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1492,6 +1609,9 @@ void test_wdb_parse_global_find_group_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_group_find_group);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'find-group'");
@@ -1516,6 +1636,9 @@ void test_wdb_parse_global_find_group_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_find_group_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1568,6 +1691,9 @@ void test_wdb_parse_global_insert_agent_group_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_group_insert_agent_group);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'insert-agent-group'");
@@ -1592,6 +1718,9 @@ void test_wdb_parse_global_insert_agent_group_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_insert_agent_group_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1640,6 +1769,9 @@ void test_wdb_parse_global_select_group_belong_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_belongs_select_group_belong);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'select-group-belong'");
@@ -1664,6 +1796,9 @@ void test_wdb_parse_global_select_group_belong_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_select_group_belong_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1715,6 +1850,9 @@ void test_wdb_parse_global_get_group_agents_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-group-agents'");
@@ -1737,6 +1875,9 @@ void test_wdb_parse_global_get_group_agents_group_missing(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1761,6 +1902,9 @@ void test_wdb_parse_global_get_group_agents_last_id_missing(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments, 'last_id' not found.");
@@ -1783,6 +1927,9 @@ void test_wdb_parse_global_get_group_agents_last_id_value_missing(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1811,6 +1958,9 @@ void test_wdb_parse_global_get_group_agents_failed(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1863,6 +2013,9 @@ void test_wdb_parse_global_delete_group_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_group_delete_group);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'delete-group'");
@@ -1887,6 +2040,9 @@ void test_wdb_parse_global_delete_group_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_delete_group_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1937,6 +2093,9 @@ void test_wdb_parse_global_select_groups_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_select_groups_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2080,6 +2239,9 @@ void test_wdb_parse_global_sync_agent_info_set_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'sync-agent-info-set'");
@@ -2103,6 +2265,9 @@ void test_wdb_parse_global_sync_agent_info_set_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2133,6 +2298,9 @@ void test_wdb_parse_global_sync_agent_info_set_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -2160,6 +2328,9 @@ void test_wdb_parse_global_sync_agent_info_set_id_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2192,6 +2363,9 @@ void test_wdb_parse_global_sync_agent_info_set_del_label_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2228,6 +2402,9 @@ void test_wdb_parse_global_sync_agent_info_set_set_label_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2286,6 +2463,9 @@ void test_wdb_parse_global_set_agent_groups_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'set-agent-groups'");
@@ -2310,6 +2490,9 @@ void test_wdb_parse_global_set_agent_groups_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -2333,6 +2516,9 @@ void test_wdb_parse_global_set_agent_groups_missing_field(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, missing required fields");
@@ -2355,6 +2541,9 @@ void test_wdb_parse_global_set_agent_groups_invalid_mode(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2381,6 +2570,9 @@ void test_wdb_parse_global_set_agent_groups_fail(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2431,6 +2623,9 @@ void test_wdb_parse_global_sync_agent_groups_get_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'sync-agent-groups-get'");
@@ -2454,6 +2649,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2515,6 +2713,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_data_type(void 
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
@@ -2537,6 +2738,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_negative(void *
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2561,6 +2765,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_condition_data_type(voi
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
@@ -2583,6 +2790,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_set_synced_data_type(vo
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2607,6 +2817,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_get_hash_data_type(void
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
@@ -2630,6 +2843,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delt
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
@@ -2652,6 +2868,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delt
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2681,6 +2900,9 @@ void test_wdb_parse_global_sync_agent_groups_get_null_response(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2775,6 +2997,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_response(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid response from wdb_global_sync_agent_groups_get");
@@ -2797,6 +3022,9 @@ void test_wdb_parse_global_get_groups_integrity_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2822,6 +3050,9 @@ void test_wdb_parse_global_get_groups_integrity_hash_length_expected_fail(void *
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Hash hex-digest does not have the expected length. Expected (40) got (10)");
@@ -2846,6 +3077,9 @@ void test_wdb_parse_global_get_groups_integrity_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2945,6 +3179,9 @@ void test_wdb_parse_global_disconnect_agents_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'disconnect-agents'");
@@ -2967,6 +3204,9 @@ void test_wdb_parse_global_disconnect_agents_last_id_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2991,6 +3231,9 @@ void test_wdb_parse_global_disconnect_agents_keepalive_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments keepalive not found");
@@ -3013,6 +3256,9 @@ void test_wdb_parse_global_disconnect_agents_sync_status_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3068,6 +3314,9 @@ void test_wdb_parse_global_get_all_agents_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_get_all_agents);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-all-agents'");
@@ -3090,6 +3339,10 @@ void test_wdb_parse_global_get_all_agents_argument_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_all_agents_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments 'last_id' not found");
@@ -3112,6 +3365,9 @@ void test_wdb_parse_global_get_all_agents_argument2_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_all_agents_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3165,6 +3421,9 @@ void test_wdb_parse_global_get_agent_info_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_get_agent_info);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-agent-info'");
@@ -3189,6 +3448,9 @@ void test_wdb_parse_global_get_agent_info_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agent_info_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3241,6 +3503,9 @@ void test_wdb_parse_reset_agents_connection_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_reset_agents_connection);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'reset-agents-connection'");
@@ -3266,6 +3531,9 @@ void test_wdb_parse_reset_agents_connection_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_reset_agents_connection_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3314,6 +3582,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_syntax_error(void **s
     expect_function_call(__wrap_w_inc_global);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-agents-by-connection-status'");
@@ -3336,6 +3607,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_status_error(void **s
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3360,6 +3634,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_last_id_error(void **
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments 'last_id' not found");
@@ -3382,6 +3659,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_limit_error(void **st
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3474,6 +3754,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_query_fail(void **sta
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting agents by connection status from global.db.");
@@ -3500,6 +3783,9 @@ void test_wdb_parse_global_get_backup_failed(void **state) {
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_backup_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -3558,6 +3844,9 @@ void test_wdb_parse_global_restore_backup_invalid_syntax(void **state) {
     expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_backup_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -3708,6 +3997,9 @@ void test_wdb_parse_global_vacuum_commit_error(void **state) {
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_vacuum_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot end transaction");
@@ -3741,6 +4033,9 @@ void test_wdb_parse_global_vacuum_vacuum_error(void **state) {
 
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_vacuum_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -3777,6 +4072,9 @@ void test_wdb_parse_global_vacuum_success_get_db_state_error(void **state) {
 
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_vacuum_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -3816,6 +4114,9 @@ void test_wdb_parse_global_vacuum_success_update_vacuum_data_error(void **state)
 
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_vacuum_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -3888,6 +4189,9 @@ void test_wdb_parse_global_get_fragmentation_db_state_error(void **state) {
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_get_fragmentation_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot get database fragmentation");
@@ -3919,6 +4223,9 @@ void test_wdb_parse_global_get_fragmentation_free_pages_error(void **state) {
 
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_get_fragmentation_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -4033,6 +4340,9 @@ void test_wdb_parse_global_get_distinct_agent_groups_result_null(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting agent groups from global.db.");
@@ -4060,10 +4370,45 @@ void test_wdb_parse_global_get_distinct_agent_groups_result_null_with_last_hash(
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups_time);
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting agent groups from global.db.");
     assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_delete_db_file (void **state) {
+
+    int result = OS_INVALID;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char *query = NULL;
+
+    os_strdup("global non-query", query);
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: non-query");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid DB query syntax.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: non-query");
+
+    expect_function_call(__wrap_w_inc_queries_total);
+    expect_function_call(__wrap_w_inc_global);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    //DB file deleted manually
+    will_return(__wrap_w_is_file, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "DB(queue/db/global.db) not found.");
+    expect_function_call(__wrap_pthread_mutex_lock);
+    will_return(__wrap_wdb_close, OS_SUCCESS);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    result = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'non-query'");
+    assert_int_equal(result, OS_INVALID);
+
+    os_free(query);
 }
 
 int main()
@@ -4251,6 +4596,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_distinct_agent_groups_result_null, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_distinct_agent_groups_success_with_last_hash, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_distinct_agent_groups_result_null_with_last_hash, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_delete_db_file, test_setup, test_teardown)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -765,7 +765,8 @@ void test_osinfo_syntax_error(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Invalid DB query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "DB(000) query error near: osinfo");
-
+    expect_string(__wrap_w_is_file, file, "queue/db/000.db");
+    will_return(__wrap_w_is_file, 1);
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'osinfo'");
@@ -783,7 +784,8 @@ void test_osinfo_invalid_action(void **state) {
     expect_value(__wrap_wdb_open_agent2, agent_id, atoi(data->wdb->id));
     will_return(__wrap_wdb_open_agent2, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: osinfo invalid");
-
+    expect_string(__wrap_w_is_file, file, "queue/db/000.db");
+    will_return(__wrap_w_is_file, 1);
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid osinfo action: invalid");
@@ -1257,7 +1259,8 @@ void test_vuln_cves_syntax_error(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Invalid vuln_cves query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "DB(000) vuln_cves query error near: vuln_cves");
-
+    expect_string(__wrap_w_is_file, file, "queue/db/000.db");
+    will_return(__wrap_w_is_file, 1);
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid vuln_cves query syntax, near 'vuln_cves'");
@@ -1275,7 +1278,8 @@ void test_vuln_cves_invalid_action(void **state) {
     expect_value(__wrap_wdb_open_agent2, agent_id, atoi(data->wdb->id));
     will_return(__wrap_wdb_open_agent2, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: vuln_cves invalid");
-
+    expect_string(__wrap_w_is_file, file, "queue/db/000.db");
+    will_return(__wrap_w_is_file, 1);
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid vuln_cves action: invalid");
@@ -2623,7 +2627,8 @@ void test_wdb_parse_agent_vacuum_commit_error(void **state) {
     expect_function_call(__wrap_wdb_finalize_all_statements);
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot end transaction.");
-
+    expect_string(__wrap_w_is_file, file, "queue/db/000.db");
+    will_return(__wrap_w_is_file, 1);
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot end transaction");
@@ -2649,7 +2654,8 @@ void test_wdb_parse_agent_vacuum_vacuum_error(void **state) {
     will_return(__wrap_wdb_vacuum, OS_INVALID);
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot vacuum database.");
-
+    expect_string(__wrap_w_is_file, file, "queue/db/000.db");
+    will_return(__wrap_w_is_file, 1);
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot vacuum database");
@@ -2677,7 +2683,8 @@ void test_wdb_parse_agent_vacuum_success_get_db_state_error(void **state) {
     will_return(__wrap_wdb_get_db_state, OS_INVALID);
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Couldn't get fragmentation after vacuum for the database.");
-
+    expect_string(__wrap_w_is_file, file, "queue/db/000.db");
+    will_return(__wrap_w_is_file, 1);
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Vacuum performed, but couldn't get fragmentation information after vacuum");
@@ -2710,7 +2717,8 @@ void test_wdb_parse_agent_vacuum_success_update_vacuum_error(void **state) {
     will_return(__wrap_wdb_update_last_vacuum_data, OS_INVALID);
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Couldn't update last vacuum info for the database.");
-
+    expect_string(__wrap_w_is_file, file, "queue/db/000.db");
+    will_return(__wrap_w_is_file, 1);
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Vacuum performed, but last vacuum information couldn't be updated in the metadata table");
@@ -2771,7 +2779,8 @@ void test_wdb_parse_agent_get_fragmentation_db_state_error(void **state) {
     will_return(__wrap_wdb_get_db_free_pages_percentage, 10);
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot get database fragmentation.");
-
+    expect_string(__wrap_w_is_file, file, "queue/db/000.db");
+    will_return(__wrap_w_is_file, 1);
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot get database fragmentation");
@@ -2795,7 +2804,8 @@ void test_wdb_parse_agent_get_fragmentation_free_pages_error(void **state) {
     will_return(__wrap_wdb_get_db_free_pages_percentage, OS_INVALID);
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot get database fragmentation.");
-
+    expect_string(__wrap_w_is_file, file, "queue/db/000.db");
+    will_return(__wrap_w_is_file, 1);
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot get database fragmentation");
@@ -2827,6 +2837,35 @@ void test_wdb_parse_global_get_fragmentation_success(void **state) {
 
     assert_string_equal(data->output, "ok {\"fragmentation\":50,\"free_pages_percentage\":10}");
     assert_int_equal(result, OS_SUCCESS);
+
+    os_free(query);
+}
+
+void test_wdb_parse_delete_db_file (void **state) {
+    int result = OS_INVALID;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char *query = NULL;
+
+    os_strdup("agent 000 non-query", query);
+
+    expect_value(__wrap_wdb_open_agent2, agent_id, atoi(data->wdb->id));
+    will_return(__wrap_wdb_open_agent2, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: non-query");
+
+
+    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Invalid DB query syntax.");
+    expect_string(__wrap__mdebug2, formatted_msg, "DB(000) query error near: non-query");
+
+    expect_string(__wrap_w_is_file, file, "queue/db/000.db");
+    //DB file deleted manually
+    will_return(__wrap_w_is_file, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "DB(queue/db/000.db) not found.");
+    will_return(__wrap_wdb_close, OS_SUCCESS);
+    result = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'non-query'");
+    assert_int_equal(result, OS_INVALID);
 
     os_free(query);
 }
@@ -2990,6 +3029,8 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_agent_get_fragmentation_db_state_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_agent_get_fragmentation_free_pages_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_fragmentation_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_delete_db_file, test_setup, test_teardown),
+
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -2532,6 +2532,9 @@ void test_wdb_parse_global_backup_invalid_syntax(void **state) {
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for backup.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: backup");
 
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'backup'");
@@ -2580,6 +2583,9 @@ void test_wdb_parse_global_backup_create_failed(void **state) {
     will_return(__wrap_wdb_global_create_backup, "ERROR MESSAGE");
     will_return(__wrap_wdb_global_create_backup, OS_INVALID);
     expect_string(__wrap__merror, formatted_msg, "Creating Global DB snapshot on demand failed: ERROR MESSAGE");
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
 
     result = wdb_parse(query, data->output, 0);
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -1357,6 +1357,15 @@ int wdb_parse(char * input, char * output, int peer) {
             result = OS_INVALID;
         }
         wdb_leave(wdb);
+        if (result == OS_INVALID) {
+            snprintf(path, sizeof(path), "%s/%s.db", WDB2_DIR, WDB_GLOB_NAME);
+            if (!w_is_file(path)) {
+                mdebug2("DB(%s) not found.", path);
+                w_mutex_lock(&pool_mutex);
+                wdb_close(wdb, FALSE);
+                w_mutex_unlock(&pool_mutex);
+            }
+        }
         return result;
     } else if (strcmp(actor, "task") == 0) {
         cJSON *parameters_json = NULL;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -739,12 +739,12 @@ int wdb_parse(char * input, char * output, int peer) {
             snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
             result = OS_INVALID;
         }
+        wdb_leave(wdb);
         if (result == OS_INVALID && wdb) {
             w_mutex_lock(&pool_mutex);
             wdb_close(wdb, FALSE);
             w_mutex_unlock(&pool_mutex);
         }
-        wdb_leave(wdb);
         return result;
     } else if (strcmp(actor, "wazuhdb") == 0) {
         query = next;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -197,8 +197,6 @@ static struct kv_list const TABLE_MAP[] = {
     { .current = { "processes", "sys_processes",  false, TABLE_PROCESSES, PROCESSES_FIELD_COUNT }, .next = NULL},
 };
 
-static bool file_exists(const char *filename);
-
 int wdb_parse(char * input, char * output, int peer) {
     char * actor;
     char * id;
@@ -744,7 +742,7 @@ int wdb_parse(char * input, char * output, int peer) {
         wdb_leave(wdb);
         if (result == OS_INVALID) {
             snprintf(path, sizeof(path), "%s/%s.db", WDB2_DIR, wdb->id);
-            if (!file_exists(path)) {
+            if (!w_is_file(path)) {
                 mdebug2("DB(%s) not found.", path);
                 w_mutex_lock(&pool_mutex);
                 wdb_close(wdb, FALSE);
@@ -6761,14 +6759,3 @@ int wdb_parse_agents_remove_vuln_cves(wdb_t* wdb, char* input, char* output) {
     cJSON_Delete(data);
     return ret;
 }
-
-static bool file_exists(const char *filename) {
-    FILE *fp = fopen(filename, "r");
-    bool is_exist = false;
-    if (fp != NULL) {
-        is_exist = true;
-        fclose(fp);
-    }
-    return is_exist;
-}
-

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -739,6 +739,11 @@ int wdb_parse(char * input, char * output, int peer) {
             snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
             result = OS_INVALID;
         }
+        if (result == OS_INVALID && wdb) {
+            w_mutex_lock(&pool_mutex);
+            wdb_close(wdb, FALSE);
+            w_mutex_unlock(&pool_mutex);
+        }
         wdb_leave(wdb);
         return result;
     } else if (strcmp(actor, "wazuhdb") == 0) {


### PR DESCRIPTION
|Wazuh version|Component|Install type|Install method|Platform|Related issue|
|---|---|---|---|---|---|
| 4.5.0 | WazuhDB | Manager | Packages/Sources | OS version |#15279|

## Description

This PR includes a fix for issue #15279, which presented an error when deleting the agent database in the manager. In the `wdb_parser.c` file, a condition has been added that verifies the status of `result` and the existence of the database. Then the function `wdb_close()` is called.

## Configuration options
```xml
  <!-- System inventory -->

  <wodle name="syscollector">
    <disabled>no</disabled>
    <interval>10s</interval>
    <scan_on_start>yes</scan_on_start>
    <hardware>yes</hardware>
    <os>yes</os>
    <network>yes</network>
    <packages>yes</packages>
    <ports all="no">yes</ports>
    <processes>yes</processes>

    <!-- Database synchronization settings -->
    <synchronization>
      <max_eps>10</max_eps>
    </synchronization>
  </wodle>
```



## Logs/Alerts example

```
2023/06/09 19:22:58 wazuh-modulesd:syscollector[56431] wm_syscollector.c:98 at wm_sys_log(): DEBUG: Sync sent: {"component":"syscollector_processes","data":{"begin":"56288","checksum":"d93afc6b277f223c3b635f685e138c9919daf4a2","end":"56288","id":1667328464},"type":"integrity_check_right"}
2023/06/09 19:22:58 wazuh-db: ERROR: at wdb_process_insert(): sqlite3_step(): attempt to write a readonly database
2023/06/09 19:22:58 wazuh-analysisd: ERROR: dbsync: Bad response from database: Cannot save Syscollector
```

## Tests

<img width="911" alt="image" src="https://github.com/wazuh/wazuh/assets/114432526/e5c0ff7b-7356-4be7-9290-1c409e907ef1">

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
