### PR TITLE
Syscollector is reading a bad value for the process RSS memory

### DIFF
--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -123,7 +123,7 @@ static nlohmann::json getProcessInfo(const SysInfoProcess& process)
     jsProcessInfo["nice"]       = process->nice;
     jsProcessInfo["size"]       = process->size;
     jsProcessInfo["vm_size"]    = process->vm_size;
-    jsProcessInfo["resident"]   = process->resident;
+    jsProcessInfo["resident"]   = process->vm_rss;
     jsProcessInfo["share"]      = process->share;
     jsProcessInfo["start_time"] = Utils::timeTick2unixTime(process->start_time);
     jsProcessInfo["pgrp"]       = process->pgrp;


### PR DESCRIPTION
|Related issue|
|---|
| #5232 |

## Description

Fix the origin of  RSS memory data of processes reported by `syscollector`.

the scope stated in the related issue is all OS, however, this information is currently only available in `Linux` environments.

## Tests

![image](https://github.com/wazuh/wazuh/assets/93778492/b66fd901-d206-4795-98b0-a55787aa60fe)
two runs of `sysinfo_test_tool` focused on similar processes, after & before of change were made,  showing the data difference

- Compilation without warnings in every supported platform
  - [x] Linux