### PR TITLE
Add reference for new macOS Sonoma to syscollector

### DIFF
--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -438,6 +438,7 @@ bool MacOsParser::parseUname(const std::string& in, nlohmann::json& output)
         {"20", "Big Sur"},
         {"21", "Monterey"},
         {"22", "Ventura"},
+        {"23", "Sonoma"},
     };
     constexpr auto PATTERN_MATCH{"[0-9]+"};
     std::string match;

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -376,6 +376,7 @@ const char *OSX_ReleaseName(int version) {
     /* 20 */ "Big Sur",
     /* 21 */ "Monterey",
     /* 22 */ "Ventura",
+    /* 23 */ "Sonoma",
     };
 
     version -= 10;

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -1751,6 +1751,7 @@ void test_OSX_ReleaseName(void **state) {
     assert_string_equal(OSX_ReleaseName(21), "Monterey");
     assert_string_equal(OSX_ReleaseName(22), "Ventura");
     assert_string_equal(OSX_ReleaseName(23), "Sonoma");
+    assert_string_equal(OSX_ReleaseName(24), "Unknown");
 }
 
 #endif

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -1750,7 +1750,7 @@ void test_OSX_ReleaseName(void **state) {
     assert_string_equal(OSX_ReleaseName(20), "Big Sur");
     assert_string_equal(OSX_ReleaseName(21), "Monterey");
     assert_string_equal(OSX_ReleaseName(22), "Ventura");
-    assert_string_equal(OSX_ReleaseName(23), "Unknown");
+    assert_string_equal(OSX_ReleaseName(23), "Sonoma");
 }
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
| #17150  |

This PR aims to add a new macOS version `Sonoma`  so syscollector provides the correct name of the new macOS when it's available.

## Description of the new feature

We proceeded to add the codename and id for the new operating system in `version_op.c` 

```c
const char *R_NAMES[] = {
    /* 10 */ "Snow Leopard",
    /* 11 */ "Lion",
    /* 12 */ "Mountain Lion",
    /* 13 */ "Mavericks",
    /* 14 */ "Yosemite",
    /* 15 */ "El Capitan",
    /* 16 */ "Sierra",
    /* 17 */ "High Sierra",
    /* 18 */ "Mojave",
    /* 19 */ "Catalina",
    /* 20 */ "Big Sur",
    /* 21 */ "Monterey",
    /* 22 */ "Ventura",
    /* 23 */ "Sonoma", //New macOS
    };
```

And `sysOSParser.cpp`

```cpp
static const std::map<std::string, std::string> MAC_CODENAME_MAP
    {
        {"10", "Snow Leopard"},
        {"11", "Lion"},
        {"12", "Mountain Lion"},
        {"13", "Mavericks"},
        {"14", "Yosemite"},
        {"15", "El Capitan"},
        {"16", "Sierra"},
        {"17", "High Sierra"},
        {"18", "Mojave"},
        {"19", "Catalina"},
        {"20", "Big Sur"},
        {"21", "Monterey"},
        {"22", "Ventura"},
        {"23", "Sonoma"},  //New macOS
    };
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors