### PR TITLE
Invalid os_version Arch Linux and openSUSE Tumbleweed

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -424,7 +424,7 @@ os_info *get_unix_version()
                         info->os_name = strdup(name);
                     }
                 } else if (strcmp (tag,"VERSION") == 0) {
-                    if (!version) {    
+                    if (!version) {
                         if (version_id) {
                             os_free(info->os_version);
                         }
@@ -456,6 +456,7 @@ os_info *get_unix_version()
         fclose(os_release);
 
         // If the OS is CentOS, try to get the version from the 'centos-release' file.
+        // If the OS is Arch Linux, openSUSE Tumbleweed set os_version as empty string.
         if (info->os_platform) {
             if (strcmp(info->os_platform, "centos") == 0) {
                 regex_t regexCompiled;
@@ -479,8 +480,10 @@ os_info *get_unix_version()
                     fclose(version_release);
                 }
             }
-            else if (strcmp(info->os_platform, "opensuse-tumbleweed") == 0) {
-                os_strdup("rolling", info->os_build);
+            else if (strcmp(info->os_platform, "opensuse-tumbleweed") == 0 ||
+                        strcmp(info->os_platform, "arch") == 0) {
+                os_free(info->os_version);
+                os_strdup("", info->os_version);
             }
         }
     }
@@ -576,9 +579,7 @@ os_info *get_unix_version()
                     break;
                 }
             }
-            if (info->os_version == NULL) {
-                os_strdup("rolling", info->os_build);
-            }
+
             regfree(&regexCompiled);
             fclose(version_release);
         // Ubuntu
@@ -891,12 +892,9 @@ os_info *get_unix_version()
                 info->os_version = tmp_os_version;
             }
         }
-    } else if (info->os_build && strcmp(info->os_build, "rolling") == 0) {
-        // Rolling releases doesn't have a version.
-        info->os_version = strdup("");
     } else {
         // Empty version
-        info->os_version = strdup("0.0");
+        os_strdup("0.0", info->os_version);
     }
 
     return info;

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -479,9 +479,8 @@ os_info *get_unix_version()
                     regfree(&regexCompiled);
                     fclose(version_release);
                 }
-            }
-            else if (strcmp(info->os_platform, "opensuse-tumbleweed") == 0 ||
-                        strcmp(info->os_platform, "arch") == 0) {
+            } else if (strcmp(info->os_platform, "opensuse-tumbleweed") == 0 ||
+                          strcmp(info->os_platform, "arch") == 0) {
                 os_free(info->os_version);
                 os_strdup("", info->os_version);
             }
@@ -578,6 +577,9 @@ os_info *get_unix_version()
                     snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                     break;
                 }
+            }
+            if (info->os_version == NULL) {
+            os_strdup("", info->os_version);
             }
 
             regfree(&regexCompiled);
@@ -852,46 +854,48 @@ os_info *get_unix_version()
     }
 
     if (info->os_version) { // Parsing version
-        // os_major.os_minor (os_codename)
-        os_strdup(info->os_version, version);
-        if (codename = strstr(version, " ("), codename){
-            *codename = '\0';
-            codename += 2;
-            *(codename + strlen(codename) - 1) = '\0';
-            info->os_codename = strdup(codename);
-        }
-        free(version);
-        // Get os_major
-        if (w_regexec("^([0-9]+)\\.*", info->os_version, 2, match)) {
-            match_size = match[1].rm_eo - match[1].rm_so;
-            os_malloc(match_size + 1, info->os_major);
-            snprintf(info->os_major, match_size + 1, "%.*s", match_size, info->os_version + match[1].rm_so);
-        }
-        // Get os_minor
-        if (w_regexec("^[0-9]+\\.([0-9]+)\\.*", info->os_version, 2, match)) {
-            match_size = match[1].rm_eo - match[1].rm_so;
-            os_malloc(match_size + 1, info->os_minor);
-            snprintf(info->os_minor, match_size + 1, "%.*s", match_size, info->os_version + match[1].rm_so);
-        }
-        // Get os_patch
-        if (w_regexec("^[0-9]+\\.[0-9]+\\.([0-9]+)*", info->os_version, 2, match)) {
-            match_size = match[1].rm_eo - match[1].rm_so;
-            os_malloc(match_size + 1, info->os_patch);
-            snprintf(info->os_patch, match_size + 1, "%.*s", match_size, info->os_version + match[1].rm_so);
-        }
-        // Get OSX codename
-        if (info->os_platform && strcmp(info->os_platform,"darwin") == 0) {
-            if (info->os_codename) {
-                char * tmp_os_version;
-                size_t len = 4;
-                len += strlen(info->os_version);
-                len += strlen(info->os_codename);
-                os_malloc(len, tmp_os_version);
-                snprintf(tmp_os_version, len, "%s (%s)", info->os_version, info->os_codename);
-                free(info->os_version);
-                info->os_version = tmp_os_version;
+	    if (strcmp(info->os_version, "") != 0) {
+            // os_major.os_minor (os_codename)
+            os_strdup(info->os_version, version);
+            if (codename = strstr(version, " ("), codename){
+                *codename = '\0';
+                codename += 2;
+                *(codename + strlen(codename) - 1) = '\0';
+                info->os_codename = strdup(codename);
             }
-        }
+            free(version);
+            // Get os_major
+            if (w_regexec("^([0-9]+)\\.*", info->os_version, 2, match)) {
+                match_size = match[1].rm_eo - match[1].rm_so;
+                os_malloc(match_size + 1, info->os_major);
+                snprintf(info->os_major, match_size + 1, "%.*s", match_size, info->os_version + match[1].rm_so);
+            }
+            // Get os_minor
+            if (w_regexec("^[0-9]+\\.([0-9]+)\\.*", info->os_version, 2, match)) {
+                match_size = match[1].rm_eo - match[1].rm_so;
+                os_malloc(match_size + 1, info->os_minor);
+                snprintf(info->os_minor, match_size + 1, "%.*s", match_size, info->os_version + match[1].rm_so);
+            }
+            // Get os_patch
+            if (w_regexec("^[0-9]+\\.[0-9]+\\.([0-9]+)*", info->os_version, 2, match)) {
+                match_size = match[1].rm_eo - match[1].rm_so;
+                os_malloc(match_size + 1, info->os_patch);
+                snprintf(info->os_patch, match_size + 1, "%.*s", match_size, info->os_version + match[1].rm_so);
+            }
+            // Get OSX codename
+            if (info->os_platform && strcmp(info->os_platform,"darwin") == 0) {
+                if (info->os_codename) {
+                    char * tmp_os_version;
+                    size_t len = 4;
+                    len += strlen(info->os_version);
+                    len += strlen(info->os_codename);
+                    os_malloc(len, tmp_os_version);
+                    snprintf(tmp_os_version, len, "%s (%s)", info->os_version, info->os_codename);
+                    free(info->os_version);
+                    info->os_version = tmp_os_version;
+                }
+            }
+    	}
     } else {
         // Empty version
         os_strdup("0.0", info->os_version);

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -579,7 +579,7 @@ os_info *get_unix_version()
                 }
             }
             if (info->os_version == NULL) {
-            os_strdup("", info->os_version);
+                os_strdup("", info->os_version);
             }
 
             regfree(&regexCompiled);
@@ -854,7 +854,7 @@ os_info *get_unix_version()
     }
 
     if (info->os_version) { // Parsing version
-	    if (strcmp(info->os_version, "") != 0) {
+        if (strcmp(info->os_version, "") != 0) {
             // os_major.os_minor (os_codename)
             os_strdup(info->os_version, version);
             if (codename = strstr(version, " ("), codename){
@@ -895,7 +895,7 @@ os_info *get_unix_version()
                     info->os_version = tmp_os_version;
                 }
             }
-    	}
+        }
     } else {
         // Empty version
         os_strdup("0.0", info->os_version);

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -160,7 +160,6 @@ void test_get_unix_version_archlinux(void **state)
     assert_string_equal(ret->os_version, "");
     assert_string_equal(ret->os_platform, "arch");
     assert_string_equal(ret->sysname, "Linux");
-    assert_string_equal(ret->os_build, "rolling");
 }
 
 void test_get_unix_version_opensuse_tumbleweed(void **state)
@@ -193,7 +192,6 @@ void test_get_unix_version_opensuse_tumbleweed(void **state)
     assert_string_equal(ret->os_version, "");
     assert_string_equal(ret->os_platform, "opensuse-tumbleweed");
     assert_string_equal(ret->sysname, "Linux");
-    assert_string_equal(ret->os_build, "rolling");
 }
 
 void test_get_unix_version_alpine(void **state)

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -130,6 +130,39 @@ void test_get_unix_version_centos(void **state)
     assert_string_equal(ret->sysname, "Linux");
 }
 
+void test_get_unix_version_archlinux(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "NAME=\"Arch Linux\"");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "VERSION_ID=\"TEMPLATE_VERSION_ID\"");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "ID=arch");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, NULL);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Arch Linux");
+    assert_string_equal(ret->os_version, "");
+    assert_string_equal(ret->os_platform, "arch");
+    assert_string_equal(ret->sysname, "Linux");
+    assert_string_equal(ret->os_build, "rolling");
+}
+
 void test_get_unix_version_opensuse_tumbleweed(void **state)
 {
     (void) state;
@@ -143,7 +176,7 @@ void test_get_unix_version_opensuse_tumbleweed(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "NAME=\"openSUSE Tumbleweed\"");
     expect_value(__wrap_fgets, __stream, 1);
-    will_return(__wrap_fgets, "# VERSION=\"20211202\"");
+    will_return(__wrap_fgets, "VERSION_ID=\"20230619\"");
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "ID=opensuse-tumbleweed");
     expect_value(__wrap_fgets, __stream, 1);
@@ -1881,6 +1914,7 @@ int main(void) {
 #ifdef __linux__
             cmocka_unit_test_teardown(test_get_unix_version_Ubuntu1904, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_centos, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_archlinux, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_opensuse_tumbleweed, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_alpine, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_centos, delete_os_info),

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -2028,7 +2028,7 @@ int main(void) {
 #ifdef __linux__
             cmocka_unit_test_teardown(test_get_unix_version_Ubuntu1904, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_centos, delete_os_info),
-  	        cmocka_unit_test_teardown(test_get_unix_version_archlinux_distro_based, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_archlinux_distro_based, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_archlinux_no_version_id, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_archlinux, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_opensuse_tumbleweed_no_version_id, delete_os_info),

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -130,6 +130,92 @@ void test_get_unix_version_centos(void **state)
     assert_string_equal(ret->sysname, "Linux");
 }
 
+void test_get_unix_version_archlinux_distro_based(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "NAME=\"Manjaro Linux\"");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "ID=manjaro");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, NULL);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    // Attempt to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Attempt to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Attempt to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, NULL);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Arch Linux");
+    assert_string_equal(ret->os_version, "");
+    assert_string_equal(ret->os_platform, "arch");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_archlinux_no_version_id(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "NAME=\"Arch Linux\"");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "ID=arch");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, NULL);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Arch Linux");
+    assert_string_equal(ret->os_version, "");
+    assert_string_equal(ret->os_platform, "arch");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
 void test_get_unix_version_archlinux(void **state)
 {
     (void) state;
@@ -159,6 +245,36 @@ void test_get_unix_version_archlinux(void **state)
     assert_string_equal(ret->os_name, "Arch Linux");
     assert_string_equal(ret->os_version, "");
     assert_string_equal(ret->os_platform, "arch");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_opensuse_tumbleweed_no_version_id(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "NAME=\"openSUSE Tumbleweed\"");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "ID=opensuse-tumbleweed");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, NULL);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "openSUSE Tumbleweed");
+    assert_string_equal(ret->os_version, "");
+    assert_string_equal(ret->os_platform, "opensuse-tumbleweed");
     assert_string_equal(ret->sysname, "Linux");
 }
 
@@ -1912,7 +2028,10 @@ int main(void) {
 #ifdef __linux__
             cmocka_unit_test_teardown(test_get_unix_version_Ubuntu1904, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_centos, delete_os_info),
+  	        cmocka_unit_test_teardown(test_get_unix_version_archlinux_distro_based, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_archlinux_no_version_id, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_archlinux, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_opensuse_tumbleweed_no_version_id, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_opensuse_tumbleweed, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_alpine, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_centos, delete_os_info),


### PR DESCRIPTION
|Related issue|
|---|
|#17402|

## Description

This PR fixes the wrong description in `os_version` attribute in `agent` table from the `global.db`. When the file /etc/os-release has a tag `VERSION_ID`, the empty string was not being set in the `os_version` variable.

## Dod

### Before 

Was not reproducible on Arch. 
![2023-06-21_17-21](https://github.com/wazuh/wazuh/assets/13010397/e4588354-6420-4c72-b6a6-d9e4e2c734e6)

The reason why it was only reproduced with openSUSE is that the os-release file for Arch Linux there was not a `VERSION_ID` tag. But as mentioned in the issue, the behavior also may occur in Arch Linux. 

<details><summary> Expand </summary>

![2023-06-21_16-28](https://github.com/wazuh/wazuh/assets/13010397/85701a47-f664-40b8-a34f-6b7fe7f075e9)
![2023-06-21_16-28_1](https://github.com/wazuh/wazuh/assets/13010397/57fb814f-ded3-4f50-8e5f-f5c67421fd83)

</details>

### After 

<details><summary> Expand </summary>

![2023-06-22_17-12](https://github.com/wazuh/wazuh/assets/13010397/cdfeb8c7-a40d-47c5-9eb7-5f29497d75f5)

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] Added unit tests (for new features)
