### PR TITLE
Limited allowed inputs for file_path parameter in upgrade_custom endpoint

### DIFF
--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -470,24 +470,25 @@ async def test_put_upgrade_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, 
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('agents_list', [
-    (['all']),
-    (['001', '002']),
+@pytest.mark.parametrize('agents_list, file_path',  [
+    (['all'], '/var/ossec/valid_file.wpk'),
+    (['001', '002'], '/var/ossec/var/upgrade/valid_file.wpk'),
+    (['001'], '/var/ossec/wrong_file.txt')
 ])
 @patch('api.configuration.api_conf')
 @patch('api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock())
 @patch('api.controllers.agent_controller.remove_nones_to_dict')
 @patch('api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_put_upgrade_custom_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, agents_list):
+async def test_put_upgrade_custom_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, agents_list, file_path):
     """Verify 'put_upgrade_custom_agents' endpoint is working as expected."""
     mock_request = MagicMock()
-    result = await put_upgrade_custom_agents(request=mock_request, agents_list=agents_list)
+    result = await put_upgrade_custom_agents(request=mock_request, agents_list=agents_list, file_path=file_path)
 
     if 'all' in agents_list:
         agents_list = '*'
     f_kwargs = {'agent_list': agents_list,
-                'file_path': None,
+                'file_path': file_path,
                 'installer': None,
                 'filters': {
                     'manager': None,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6903,7 +6903,7 @@ components:
       required: True
       schema:
         type: string
-        format: wazuh_path
+        format: wpk_path
     installer:
       in: query
       name: installer

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -79,6 +79,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
     ('local_rules1.xml,local_rules2.xml', _xml_filename),
     ('scripts/active_response', _active_response_command),
     ('!scripts/active_response', _active_response_command),
+    ('correct.wpk', _wpk_path),
     # relative paths
     ('etc/lists/new_lists3', _get_dirnames_path),
     # version
@@ -88,7 +89,6 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
     ('wazuh v4.4.0', _wazuh_version),
     # miscellaneous
     ('aHR0cHM6Ly9zdGFja2FidXNlLmNvbS90YWcvamF2YS8=', _base64),
-    ('correct.wpk', _wpk_path)
 ])
 def test_validation_check_exp_ok(exp, regex_name):
     """Verify that check_exp() returns True with correct params"""
@@ -148,6 +148,8 @@ def test_validation_check_exp_ok(exp, regex_name):
     ('/var/ossec/etc/rules/local_rules.xml()', _paths),
     ('!scripts/active_response()', _active_response_command),
     ('scripts\\active_response$', _active_response_command),
+    ('incorrect.txt', _wpk_path),
+    ('.wpk', _wpk_path),
     # relative paths
     ('etc/internal_options', _get_dirnames_path),
     ('../../path', _get_dirnames_path),
@@ -161,8 +163,6 @@ def test_validation_check_exp_ok(exp, regex_name):
     ('wazuh v4.4', _wazuh_version),
     # miscellaneous
     ('aDhjasdh3=', _base64),
-    ('incorrect.txt', _wpk_path),
-    ('.wpk', _wpk_path)
 ])
 def test_validation_check_exp_ko(exp, regex_name):
     """Verify that check_exp() returns False with incorrect params"""
@@ -308,5 +308,3 @@ def test_check_component_configuration_pair(component, configuration, expected_r
         assert response.code == expected_response.code
     else:
         assert response is expected_response
-
-

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -14,7 +14,7 @@ from api.validator import (check_exp, check_xml, _alphanumeric_param, _array_num
                            _get_dirnames_path, allowed_fields, is_safe_path, _wazuh_version,
                            _symbols_alphanumeric_param, _base64, _group_names, _group_names_or_all, _iso8601_date,
                            _iso8601_date_time, _numbers_or_all, _cdb_filename_path, _xml_filename_path, _xml_filename,
-                           check_component_configuration_pair, _active_response_command)
+                           check_component_configuration_pair, _active_response_command, _wpk_path)
 from wazuh import WazuhError
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -87,7 +87,8 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
     ('wazuh 4.4.0', _wazuh_version),
     ('wazuh v4.4.0', _wazuh_version),
     # miscellaneous
-    ('aHR0cHM6Ly9zdGFja2FidXNlLmNvbS90YWcvamF2YS8=', _base64)
+    ('aHR0cHM6Ly9zdGFja2FidXNlLmNvbS90YWcvamF2YS8=', _base64),
+    ('correct.wpk', _wpk_path)
 ])
 def test_validation_check_exp_ok(exp, regex_name):
     """Verify that check_exp() returns True with correct params"""
@@ -159,7 +160,9 @@ def test_validation_check_exp_ok(exp, regex_name):
     ('wazuh 4.4', _wazuh_version),
     ('wazuh v4.4', _wazuh_version),
     # miscellaneous
-    ('aDhjasdh3=', _base64)
+    ('aDhjasdh3=', _base64),
+    ('incorrect.txt', _wpk_path),
+    ('.wpk', _wpk_path)
 ])
 def test_validation_check_exp_ko(exp, regex_name):
     """Verify that check_exp() returns False with incorrect params"""
@@ -305,3 +308,5 @@ def test_check_component_configuration_pair(component, configuration, expected_r
         assert response.code == expected_response.code
     else:
         assert response is expected_response
+
+

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -48,6 +48,7 @@ _search_param = re.compile(r'^[^;|&^*>]+$')
 _sort_param = re.compile(r'^[\w_\-,\s+.]+$')
 _timeframe_type = re.compile(r'^(\d+[dhms]?)$')
 _type_format = re.compile(r'^xml$|^json$')
+_wpk_path = re.compile(r'^[\w\-.\\/:\s]*[^\/]\.wpk$')
 _yes_no_boolean = re.compile(r'^yes$|^no$')
 _active_response_command = re.compile(f"^!?{_paths.pattern.lstrip('^')}")
 
@@ -381,11 +382,11 @@ def format_path(value):
     return check_exp(value, _paths)
 
 
-@draft4_format_checker.checks("wazuh_path")
-def format_wazuh_path(value):
+@draft4_format_checker.checks("wpk_path")
+def format_wpk_path(value):
     if not is_safe_path(value, relative=False):
         return False
-    return check_exp(value, _paths)
+    return check_exp(value, _wpk_path)
 
 
 @draft4_format_checker.checks("active_response_command")


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17603 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

As explained in #17603, Changing the parameter to filename is a breaking change that will not be addressed at the moment.
To address the issue a minor development of validating the extension of the file has been developed and tested. 

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

More Test Result and logs related to issue can be seen [here](https://github.com/wazuh/wazuh/issues/17603#issuecomment-1603249558).  

<details> <summary> Test validator  </summary>

```
(unit-test) eduardoleon@pop-os:~/git/wazuh$ pytest api/api/test/test_validator.py
==================================== test session starts ====================================
platform linux -- Python 3.9.9, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/eduardoleon/git/wazuh/api
plugins: asyncio-0.18.1, aiohttp-1.0.4, trio-0.7.0, cov-3.0.0, anyio-3.6.2, metadata-2.0.2, html-3.0.0
asyncio: mode=auto
collected 176 items

api/api/test/test_validator.py ...................................................... [ 30%]
..................................................................................... [ 78%]
.....................................                                                 [100%]

============================== 176 passed, 3 warnings in 0.19s ==============================
```

</details>

<details> <summary> Api Test </summary>

```
(unit-test) eduardoleon@pop-os:~/git/wazuh$ pytest --disable-warnings  api/api/
==================================== test session starts ====================================
platform linux -- Python 3.9.9, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/eduardoleon/git/wazuh/api
plugins: asyncio-0.18.1, aiohttp-1.0.4, trio-0.7.0, cov-3.0.0, anyio-3.6.2, metadata-2.0.2, html-3.0.0
asyncio: mode=auto
collected 540 items

api/api/controllers/test/test_active_response_controller.py .                         [  0%]
api/api/controllers/test/test_agent_controller.py ................................... [  6%]
.........                                                                             [  8%]
api/api/controllers/test/test_cdb_list_controller.py ......                           [  9%]
api/api/controllers/test/test_ciscat_controller.py .                                  [  9%]
api/api/controllers/test/test_cluster_controller.py ........................          [ 14%]
api/api/controllers/test/test_decoder_controller.py .......                           [ 15%]
api/api/controllers/test/test_default_controller.py .                                 [ 15%]
api/api/controllers/test/test_experimental_controller.py ...............              [ 18%]
api/api/controllers/test/test_manager_controller.py ..................                [ 21%]
api/api/controllers/test/test_mitre_controller.py .......                             [ 22%]
api/api/controllers/test/test_overview_controller.py .                                [ 23%]
api/api/controllers/test/test_rootcheck_controller.py ....                            [ 23%]
api/api/controllers/test/test_rule_controller.py ........                             [ 25%]
api/api/controllers/test/test_sca_controller.py ..                                    [ 25%]
api/api/controllers/test/test_security_controller.py ................................ [ 31%]
...................                                                                   [ 35%]
api/api/controllers/test/test_syscheck_controller.py ....                             [ 35%]
api/api/controllers/test/test_syscollector_controller.py .........                    [ 37%]
api/api/controllers/test/test_task_controller.py .                                    [ 37%]
api/api/controllers/test/test_vulnerability_controller.py ....                        [ 38%]
api/api/models/test/test_model.py ...........................                         [ 43%]
api/api/test/test_alogging.py ..................                                      [ 46%]
api/api/test/test_authentication.py ...........                                       [ 48%]
api/api/test/test_configuration.py ..........................................         [ 56%]
api/api/test/test_encoder.py ...                                                      [ 57%]
api/api/test/test_middlewares.py ............                                         [ 59%]
api/api/test/test_uri_parser.py ...                                                   [ 60%]
api/api/test/test_util.py ........................................                    [ 67%]
api/api/test/test_validator.py ...................................................... [ 77%]
..................................................................................... [ 93%]
.....................................                                                 [100%]

============================= 540 passed, 19 warnings in 2.32s ==============================
```

</details>

<details> <summary> Framework  UT </summary>

```
(unit-test) eduardoleon@pop-os:~/git/wazuh$ pytest --disable-warnings framework/
==================================== test session starts ====================================
platform linux -- Python 3.9.9, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/eduardoleon/git/wazuh/framework
plugins: asyncio-0.18.1, aiohttp-1.0.4, trio-0.7.0, cov-3.0.0, anyio-3.6.2, metadata-2.0.2, html-3.0.0
asyncio: mode=auto
collected 2049 items

framework/scripts/tests/test_agent_groups.py ..............                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                         [  1%]
framework/scripts/tests/test_cluster_control.py ......                                [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................ [  4%]
                                                                                      [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py .................................. [  7%]
.                                                                                     [  7%]
framework/wazuh/core/cluster/tests/test_common.py ................................... [  8%]
........................................                                              [ 10%]
framework/wazuh/core/cluster/tests/test_control.py ......                             [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                 [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................      [ 12%]
framework/wazuh/core/cluster/tests/test_master.py ................................... [ 14%]
..........                                                                            [ 15%]
framework/wazuh/core/cluster/tests/test_server.py ...................                 [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                          [ 16%]
framework/wazuh/core/cluster/tests/test_worker.py ................................... [ 18%]
.                                                                                     [ 18%]
framework/wazuh/core/tests/test_active_response.py ..............                     [ 19%]
framework/wazuh/core/tests/test_agent.py ............................................ [ 21%]
..................................................................................... [ 25%]
.................                                                                     [ 26%]
framework/wazuh/core/tests/test_cdb_list.py ......................................    [ 28%]
framework/wazuh/core/tests/test_common.py .......                                     [ 28%]
framework/wazuh/core/tests/test_configuration.py .................................... [ 30%]
..................................                                                    [ 31%]
framework/wazuh/core/tests/test_database.py .............                             [ 32%]
framework/wazuh/core/tests/test_decoder.py ................                           [ 33%]
framework/wazuh/core/tests/test_exception.py ...                                      [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                                         [ 33%]
framework/wazuh/core/tests/test_manager.py ...............                            [ 34%]
framework/wazuh/core/tests/test_mitre.py .............                                [ 34%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                               [ 35%]
framework/wazuh/core/tests/test_results.py ........................................   [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                            [ 37%]
framework/wazuh/core/tests/test_rule.py ......................                        [ 38%]
framework/wazuh/core/tests/test_sca.py ........................                       [ 40%]
framework/wazuh/core/tests/test_security.py ............                              [ 40%]
framework/wazuh/core/tests/test_stats.py .................                            [ 41%]
framework/wazuh/core/tests/test_syscheck.py .......                                   [ 41%]
framework/wazuh/core/tests/test_syscollector.py ...                                   [ 41%]
framework/wazuh/core/tests/test_task.py ........                                      [ 42%]
framework/wazuh/core/tests/test_utils.py ............................................ [ 44%]
..................................................................................... [ 48%]
..................................................................................... [ 52%]
............................                                                          [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                   [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                  [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                [ 57%]
framework/wazuh/core/tests/test_wlogging.py .........                                 [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                    [ 58%]
framework/wazuh/rbac/tests/test_decorators.py ....................................... [ 60%]
......................................................................                [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py ............................ [ 64%]
............................                                                          [ 66%]
framework/wazuh/rbac/tests/test_orm.py .............................................. [ 68%]
........                                                                              [ 68%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                           [ 69%]
framework/wazuh/tests/test_active_response.py ............                            [ 70%]
framework/wazuh/tests/test_agent.py ................................................. [ 72%]
....................................................................                  [ 75%]
framework/wazuh/tests/test_cdb_list.py .............................................. [ 77%]
.......                                                                               [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                [ 79%]
framework/wazuh/tests/test_cluster.py ..........                                      [ 80%]
framework/wazuh/tests/test_decoder.py ...................................             [ 82%]
framework/wazuh/tests/test_group.py .......                                           [ 82%]
framework/wazuh/tests/test_logtest.py ......                                          [ 82%]
framework/wazuh/tests/test_manager.py ....................................            [ 84%]
framework/wazuh/tests/test_mitre.py .......                                           [ 84%]
framework/wazuh/tests/test_rootcheck.py ............................................. [ 87%]
.....                                                                                 [ 87%]
framework/wazuh/tests/test_rule.py .................................................. [ 89%]
......                                                                                [ 90%]
framework/wazuh/tests/test_sca.py ...........                                         [ 90%]
framework/wazuh/tests/test_security.py .............................................. [ 92%]
...........................                                                           [ 94%]
framework/wazuh/tests/test_stats.py ...............                                   [ 94%]
framework/wazuh/tests/test_syscheck.py .........................                      [ 96%]
framework/wazuh/tests/test_syscollector.py ............                               [ 96%]
framework/wazuh/tests/test_task.py ............................                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................................  [100%]

======================= 2049 passed, 50 warnings in 238.30s (0:03:58) =======================
```

</details>