### PR TITLE
Fix manager and cluster GET active configuration endpoint for labels and reports 

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5324,7 +5324,7 @@ components:
         </tr>
         <tr>
         <td>monitor</td>
-        <td>internal</td>
+        <td>reports</td>
         <td><code>&lt;reports&gt;</code></td>
         </tr>
         <tr>

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -198,7 +198,7 @@ WAZUH_COMPONENT_CONFIGURATION_MAPPING = MappingProxyType(
         'integrator': {"integration"},
         'logcollector': {"localfile", "socket", "internal"},
         'mail': {"global", "alerts", "internal"},
-        'monitor': {"global", "internal"},
+        'monitor': {"global", "internal", "reports"},
         'request': {"global", "remote", "internal"},
         'syscheck': {"syscheck", "rootcheck", "internal"},
         'wazuh-db': {"wdb", "internal"},

--- a/api/test/integration/env/configurations/cluster/manager/configuration_files/entrypoint.sh
+++ b/api/test/integration/env/configurations/cluster/manager/configuration_files/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+sed -i -e "/<\/ossec_config>/i   <reports>\n  <title>Auth_Report</title>\n  <group>authentication_failed,</group>\n  <srcip>192.168.1.10</srcip>\n  <email_to>recipient@example.wazuh.com</email_to>\n  <showlogs>yes</showlogs>\n  </reports>" /var/ossec/etc/ossec.conf
 mkdir -p /var/ossec/stats/totals/2019/Aug/
 cp -rf /tmp_volume/configuration_files/ossec-totals-27.log /var/ossec/stats/totals/2019/Aug/ossec-totals-27.log
 chown -R wazuh:wazuh /var/ossec/stats/totals/2019/Aug/ossec-totals-27.log

--- a/api/test/integration/env/configurations/manager/manager/configuration_files/manager.sh
+++ b/api/test/integration/env/configurations/manager/manager/configuration_files/manager.sh
@@ -2,6 +2,7 @@
 
 if [ "$HOSTNAME" == "wazuh-master" ]; then
   sed -i -e "/<cluster>/,/<\/cluster>/ s|<disabled>[a-z]\+</disabled>|<disabled>yes</disabled>|g" /var/ossec/etc/ossec.conf
+  sed -i -e "/<\/ossec_config>/i   <reports>\n  <title>Auth_Report</title>\n  <group>authentication_failed,</group>\n  <srcip>192.168.1.10</srcip>\n  <email_to>recipient@example.wazuh.com</email_to>\n  <showlogs>yes</showlogs>\n  </reports>" /var/ossec/etc/ossec.conf
   rm -rf /var/ossec/stats/totals/*
   mkdir -p /var/ossec/stats/totals/2019/Aug/
   cp -rf /tmp_volume/configuration_files/ossec-totals-27.log /var/ossec/stats/totals/2019/Aug/ossec-totals-27.log

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1285,6 +1285,24 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
+  - name: Show the config of monitor/reports in the manager
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/monitor/reports"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - reports: !anything
+          failed_items: [ ]
+          total_affected_items: 1
+          total_failed_items: 0
+
   - name: Show the config of request/remote on worker2
     request:
       verify: False

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1152,6 +1152,24 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
+  - name: Show the config of monitor/reports in the manager
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/monitor/reports"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - reports: !anything
+          failed_items: [ ]
+          total_affected_items: 1
+          total_failed_items: 0
+
   - name: Show the config of request/remote in the manager
     request:
       verify: False

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -803,7 +803,7 @@ def get_active_configuration(agent_id: str, component: str, configuration: str) 
         The active configuration the agent is currently using.
     """
     sockets_json_protocol = {'remote', 'analysis', 'wdb'}
-    component_socket_mapping = {'agent': 'agent', 'agentless': 'agentless', 'analysis': 'analysis', 'auth': 'auth',
+    component_socket_mapping = {'agent': 'analysis', 'agentless': 'agentless', 'analysis': 'analysis', 'auth': 'auth',
                                 'com': 'com', 'csyslog': 'csyslog', 'integrator': 'integrator',
                                 'logcollector': 'logcollector', 'mail': 'mail', 'monitor': 'monitor',
                                 'request': 'remote', 'syscheck': 'syscheck', 'wazuh-db': 'wdb', 'wmodules': 'wmodules'}

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -339,7 +339,7 @@ def test_upload_group_file(mock_safe_move, mock_open, mock_wazuh_uid, mock_wazuh
     ('000', 'auth', 'auth', 'sockets', 'ok {"auth": {"use_password": "yes"}}'),
     ('000', 'auth', 'auth', 'sockets', 'ok {"auth": {"use_password": "no"}}'),
     ('000', 'auth', 'auth', 'sockets', 'ok {"auth": {}}'),
-    ('000', 'agent', 'agent', 'sockets', 'ok {"agent": {"enabled": "yes"}}'),
+    ('000', 'agent', 'analysis', 'sockets', {"error": 0, "data": {"enabled": "yes"}}),
     ('000', 'agentless', 'agentless', 'sockets', 'ok {"agentless": {"enabled": "yes"}}'),
     ('000', 'analysis', 'analysis', 'sockets', {"error": 0, "data": {"enabled": "yes"}}),
     ('000', 'com', 'com', 'sockets', 'ok {"com": {"enabled": "yes"}}'),


### PR DESCRIPTION
|Related issue|
|---|
| #17610 |


## Description

Added `reports` as a configuration parameter value both for `GET /manager/configuration/monitor/{configuration}` and `GET /cluster/{worker-1-id}/configuration/monitor/{configuration}`. Also, modified the requested socket (`/var/ossec/queue/sockets/analysis`) for  `GET /manager/configuration/agent/labels` and `GET /cluster/{worker-1-id}/configuration/agent/labels`.

## Tests

### Unit Tests
<details><summary>Framework</summary>

    pytest framework/
    ====================================================================== test session starts ======================================================================
    platform linux -- Python 3.9.17, pytest-7.0.1, pluggy-0.13.1
    rootdir: /home/fdalmau/git/wazuh/framework
    plugins: cov-3.0.0, aiohttp-1.0.4, trio-0.7.0, anyio-3.6.2, metadata-2.0.2, html-3.0.0, asyncio-0.18.1
    asyncio: mode=auto
    collected 2049 items                                                                                                                                            
    
    framework/scripts/tests/test_agent_groups.py ..............                                                                                               [  0%]
    framework/scripts/tests/test_agent_upgrade.py ...............                                                                                             [  1%]
    framework/scripts/tests/test_cluster_control.py ......                                                                                                    [  1%]
    framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                    [  2%]
    framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                      [  3%]
    framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                     [  4%]
    framework/wazuh/core/cluster/tests/test_client.py ................                                                                                        [  5%]
    framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                    [  7%]
    framework/wazuh/core/cluster/tests/test_common.py ...........................................................................                             [ 10%]
    framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                 [ 11%]
    framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                     [ 11%]
    framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                          [ 12%]
    framework/wazuh/core/cluster/tests/test_master.py .............................................                                                           [ 15%]
    framework/wazuh/core/cluster/tests/test_server.py ...................                                                                                     [ 16%]
    framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                              [ 16%]
    framework/wazuh/core/cluster/tests/test_worker.py ....................................                                                                    [ 18%]
    framework/wazuh/core/tests/test_active_response.py ..............                                                                                         [ 19%]
    framework/wazuh/core/tests/test_agent.py ................................................................................................................ [ 24%]
    ..................................                                                                                                                        [ 26%]
    framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                        [ 28%]
    framework/wazuh/core/tests/test_common.py .......                                                                                                         [ 28%]
    framework/wazuh/core/tests/test_configuration.py ......................................................................                                   [ 31%]
    framework/wazuh/core/tests/test_database.py .............                                                                                                 [ 32%]
    framework/wazuh/core/tests/test_decoder.py ................                                                                                               [ 33%]
    framework/wazuh/core/tests/test_exception.py ...                                                                                                          [ 33%]
    framework/wazuh/core/tests/test_input_validator.py ...                                                                                                    [ 33%]
    framework/wazuh/core/tests/test_logtest.py ..                                                                                                             [ 33%]
    framework/wazuh/core/tests/test_manager.py ...............                                                                                                [ 34%]
    framework/wazuh/core/tests/test_mitre.py .............                                                                                                    [ 34%]
    framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                   [ 35%]
    framework/wazuh/core/tests/test_results.py ........................................                                                                       [ 37%]
    framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                [ 37%]
    framework/wazuh/core/tests/test_rule.py ......................                                                                                            [ 38%]
    framework/wazuh/core/tests/test_sca.py ........................                                                                                           [ 40%]
    framework/wazuh/core/tests/test_security.py ............                                                                                                  [ 40%]
    framework/wazuh/core/tests/test_stats.py .................                                                                                                [ 41%]
    framework/wazuh/core/tests/test_syscheck.py .......                                                                                                       [ 41%]
    framework/wazuh/core/tests/test_syscollector.py ...                                                                                                       [ 41%]
    framework/wazuh/core/tests/test_task.py ........                                                                                                          [ 42%]
    framework/wazuh/core/tests/test_utils.py ................................................................................................................ [ 47%]
    ..................................................................................................................................                        [ 54%]
    framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                       [ 54%]
    framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                       [ 55%]
    framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                      [ 56%]
    framework/wazuh/core/tests/test_wdb.py ...............................                                                                                    [ 57%]
    framework/wazuh/core/tests/test_wlogging.py .........                                                                                                     [ 58%]
    framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                        [ 58%]
    framework/wazuh/rbac/tests/test_decorators.py ........................................................................................................... [ 63%]
    ..                                                                                                                                                        [ 63%]
    framework/wazuh/rbac/tests/test_default_configuration.py ........................................................                                         [ 66%]
    framework/wazuh/rbac/tests/test_orm.py ......................................................                                                             [ 68%]
    framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                               [ 69%]
    framework/wazuh/tests/test_active_response.py ............                                                                                                [ 70%]
    framework/wazuh/tests/test_agent.py ..................................................................................................................... [ 75%]
                                                                                                                                                              [ 75%]
    framework/wazuh/tests/test_cdb_list.py .....................................................                                                              [ 78%]
    framework/wazuh/tests/test_ciscat.py .................................                                                                                    [ 79%]
    framework/wazuh/tests/test_cluster.py ..........                                                                                                          [ 80%]
    framework/wazuh/tests/test_decoder.py ...................................                                                                                 [ 82%]
    framework/wazuh/tests/test_group.py .......                                                                                                               [ 82%]
    framework/wazuh/tests/test_logtest.py ......                                                                                                              [ 82%]
    framework/wazuh/tests/test_manager.py ....................................                                                                                [ 84%]
    framework/wazuh/tests/test_mitre.py .......                                                                                                               [ 84%]
    framework/wazuh/tests/test_rootcheck.py ..................................................                                                                [ 87%]
    framework/wazuh/tests/test_rule.py ........................................................                                                               [ 90%]
    framework/wazuh/tests/test_sca.py ...........                                                                                                             [ 90%]
    framework/wazuh/tests/test_security.py .........................................................................                                          [ 94%]
    framework/wazuh/tests/test_stats.py ...............                                                                                                       [ 94%]
    framework/wazuh/tests/test_syscheck.py .........................                                                                                          [ 96%]
    framework/wazuh/tests/test_syscollector.py ............                                                                                                   [ 96%]
    framework/wazuh/tests/test_task.py ............................                                                                                           [ 98%]
    framework/wazuh/tests/test_vulnerability.py ........................................                                                                      [100%]
    
    ========================================================= 2049 passed, 47 warnings in 249.55s (0:04:09) =========================================================

</details>

<details><summary>API</summary>

    pytest api/api
    ====================================================================== test session starts ======================================================================
    platform linux -- Python 3.9.17, pytest-7.0.1, pluggy-0.13.1
    rootdir: /home/fdalmau/git/wazuh/api
    plugins: cov-3.0.0, aiohttp-1.0.4, trio-0.7.0, anyio-3.6.2, metadata-2.0.2, html-3.0.0, asyncio-0.18.1
    asyncio: mode=auto
    collected 536 items                                                                                                                                             
    
    api/api/controllers/test/test_active_response_controller.py .                                                                                             [  0%]
    api/api/controllers/test/test_agent_controller.py ...........................................                                                             [  8%]
    api/api/controllers/test/test_cdb_list_controller.py ......                                                                                               [  9%]
    api/api/controllers/test/test_ciscat_controller.py .                                                                                                      [  9%]
    api/api/controllers/test/test_cluster_controller.py ........................                                                                              [ 13%]
    api/api/controllers/test/test_decoder_controller.py .......                                                                                               [ 15%]
    api/api/controllers/test/test_default_controller.py .                                                                                                     [ 15%]
    api/api/controllers/test/test_experimental_controller.py ...............                                                                                  [ 18%]
    api/api/controllers/test/test_manager_controller.py ..................                                                                                    [ 21%]
    api/api/controllers/test/test_mitre_controller.py .......                                                                                                 [ 22%]
    api/api/controllers/test/test_overview_controller.py .                                                                                                    [ 23%]
    api/api/controllers/test/test_rootcheck_controller.py ....                                                                                                [ 23%]
    api/api/controllers/test/test_rule_controller.py ........                                                                                                 [ 25%]
    api/api/controllers/test/test_sca_controller.py ..                                                                                                        [ 25%]
    api/api/controllers/test/test_security_controller.py ...................................................                                                  [ 35%]
    api/api/controllers/test/test_syscheck_controller.py ....                                                                                                 [ 36%]
    api/api/controllers/test/test_syscollector_controller.py .........                                                                                        [ 37%]
    api/api/controllers/test/test_task_controller.py .                                                                                                        [ 37%]
    api/api/controllers/test/test_vulnerability_controller.py ....                                                                                            [ 38%]
    api/api/models/test/test_model.py ...........................                                                                                             [ 43%]
    api/api/test/test_alogging.py ..................                                                                                                          [ 47%]
    api/api/test/test_authentication.py ...........                                                                                                           [ 49%]
    api/api/test/test_configuration.py ..........................................                                                                             [ 56%]
    api/api/test/test_encoder.py ...                                                                                                                          [ 57%]
    api/api/test/test_middlewares.py ............                                                                                                             [ 59%]
    api/api/test/test_uri_parser.py ...                                                                                                                       [ 60%]
    api/api/test/test_util.py ........................................                                                                                        [ 67%]
    api/api/test/test_validator.py .......................................................................................................................... [ 90%]
    ...................................................                                                                                                       [100%]
    
    =============================================================== 536 passed, 18 warnings in 2.43s ================================================================

</details>

### Integration Tests
<details><summary>test_manager_endpoints.tavern.yaml</summary>

      pytest -vv test_manager_endpoints.tavern.yaml
      ====================================================================== test session starts ======================================================================
      platform linux -- Python 3.8.10, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/fdalmau/venv/integrationtest-env/bin/python3
      cachedir: .pytest_cache
      metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.0-75-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'tavern': '1.2.2', 'metadata': '2.0.2'}}
      rootdir: /home/fdalmau/git/wazuh/api/test/integration, inifile: pytest.ini
      plugins: html-3.1.1, tavern-1.2.2, metadata-2.0.2
      collected 32 items                                                                                                                                              
      
      test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                            [  3%]
      test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                              [  6%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                                                   [  9%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                                                     [ 12%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                                                  [ 15%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                                                  [ 18%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                                                  [ 21%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                                                   [ 25%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                                                [ 28%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                                                  [ 31%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                                                   [ 34%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                                                [ 37%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                                                  [ 40%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                                                      [ 43%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                                                 [ 46%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                                                             [ 50%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED                                                   [ 53%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                     [ 56%]
      test_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                                                     [ 59%]
      test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                             [ 62%]
      test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                      [ 65%]
      test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                      [ 68%]
      test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                   [ 71%]
      test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                     [ 75%]
      test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                              [ 78%]
      test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                      [ 81%]
      test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                        [ 84%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                                                     [ 87%]
      test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED                                                                                   [ 90%]
      test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                         [ 93%]
      test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                                                     [ 96%]
      test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                           [100%]
      
      ======================================================================= warnings summary ========================================================================
      /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
        /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
          return YamlFile(path, parent)
      
      /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 18 tests with warnings
        /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
          item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)
      
      /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:182: 15 tests with warnings
        /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:182: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
          item_new = YamlItem(spec_new["test_name"], self, spec_new, self.fspath)
      
      -- Docs: https://docs.pytest.org/en/latest/warnings.html
      ========================================================== 32 passed, 34 warnings in 315.54s (0:05:15) ==========================================================

</details>

<details><summary>test_cluster_endpoints.tavern.yaml</summary>

    pytest -vv test_cluster_endpoints.tavern.yaml
    ====================================================================== test session starts ======================================================================
    platform linux -- Python 3.8.10, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/fdalmau/venv/integrationtest-env/bin/python3
    cachedir: .pytest_cache
    metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.0-75-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'tavern': '1.2.2', 'metadata': '2.0.2'}}
    rootdir: /home/fdalmau/git/wazuh/api/test/integration, inifile: pytest.ini
    plugins: html-3.1.1, tavern-1.2.2, metadata-2.0.2
    collected 49 items                                                                                                                                              
    
    test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                      [  2%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                       [  4%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/ruleset/synchronization PASSED                                                                           [  6%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                        [  8%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                             [ 10%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                                [ 12%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                                    [ 14%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                                    [ 16%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                                  [ 18%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                                [ 20%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                                [ 22%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                             [ 24%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                            [ 26%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                           [ 28%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                          [ 30%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                        [ 32%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                               [ 34%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                                       [ 36%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                           [ 38%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                           [ 40%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                                       [ 42%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                           [ 44%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                           [ 46%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                                   [ 48%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                                   [ 51%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[master-node] PASSED                                                              [ 53%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker1] PASSED                                                                  [ 55%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker2] PASSED                                                                  [ 57%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                                      [ 59%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                                          [ 61%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                                          [ 63%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                                  [ 65%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                                                            [ 67%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                                                [ 69%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                                                [ 71%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                               [ 73%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                                   [ 75%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                                   [ 77%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                              [ 79%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                                  [ 81%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                                  [ 83%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                               [ 85%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                                   [ 87%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                                   [ 89%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                                     [ 91%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                                         [ 93%]
    test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                                         [ 95%]
    test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                           [ 97%]
    test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                           [100%]
    
    ======================================================================= warnings summary ========================================================================
    /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
      /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
        return YamlFile(path, parent)
    
    /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 25 tests with warnings
      /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
        item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)
    
    /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:182: 36 tests with warnings
      /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:182: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
        item_new = YamlItem(spec_new["test_name"], self, spec_new, self.fspath)
    
    -- Docs: https://docs.pytest.org/en/latest/warnings.html
    ========================================================== 49 passed, 62 warnings in 481.83s (0:08:01) ==========================================================


</details>
