### PR TITLE
Enhance AWS Security Lake CLI Arguments

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -551,16 +551,28 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     if (strlen(children[j]->content) != 0) {
                         free(cur_subscriber->sqs_name);
                         os_strdup(children[j]->content, cur_subscriber->sqs_name);
+                    } else {
+                         // If the value is empty, raise error
+                         merror("Invalid content for tag '%s': It cant be empty", XML_SUBSCRIBER_QUEUE);
+                         return OS_INVALID;
                     }
                 } else if (!strcmp(children[j]->element, XML_AWS_EXTERNAL_ID)) {
                     if (strlen(children[j]->content) != 0) {
                         free(cur_subscriber->external_id);
                         os_strdup(children[j]->content, cur_subscriber->external_id);
+                    } else {
+                         // If the value is empty, raise error
+                         merror("Invalid content for tag '%s': It cant be empty", XML_AWS_EXTERNAL_ID);
+                         return OS_INVALID;
                     }
                 } else if (!strcmp(children[j]->element, XML_IAM_ROLE_ARN)) {
                     if (strlen(children[j]->content) != 0) {
                         free(cur_subscriber->iam_role_arn);
                         os_strdup(children[j]->content, cur_subscriber->iam_role_arn);
+                    } else {
+                         // If the value is empty, raise error
+                         merror("Invalid content for tag '%s': It cant be empty", XML_IAM_ROLE_ARN);
+                         return OS_INVALID;
                     }
                 } else if (!strcmp(children[j]->element, XML_IAM_ROLE_DURATION)){
                         if (strlen(children[j]->content) != 0){

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -553,7 +553,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         os_strdup(children[j]->content, cur_subscriber->sqs_name);
                     } else {
                          // If the value is empty, raise error
-                         merror("Invalid content for tag '%s': It cant be empty", XML_SUBSCRIBER_QUEUE);
+                         merror("Invalid content for tag '%s': It cannot be empty", XML_SUBSCRIBER_QUEUE);
                          return OS_INVALID;
                     }
                 } else if (!strcmp(children[j]->element, XML_AWS_EXTERNAL_ID)) {
@@ -562,7 +562,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         os_strdup(children[j]->content, cur_subscriber->external_id);
                     } else {
                          // If the value is empty, raise error
-                         merror("Invalid content for tag '%s': It cant be empty", XML_AWS_EXTERNAL_ID);
+                         merror("Invalid content for tag '%s': It cannot be empty", XML_AWS_EXTERNAL_ID);
                          return OS_INVALID;
                     }
                 } else if (!strcmp(children[j]->element, XML_IAM_ROLE_ARN)) {
@@ -571,7 +571,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         os_strdup(children[j]->content, cur_subscriber->iam_role_arn);
                     } else {
                          // If the value is empty, raise error
-                         merror("Invalid content for tag '%s': It cant be empty", XML_IAM_ROLE_ARN);
+                         merror("Invalid content for tag '%s': It cannot be empty", XML_IAM_ROLE_ARN);
                          return OS_INVALID;
                     }
                 } else if (!strcmp(children[j]->element, XML_IAM_ROLE_DURATION)){

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3760,9 +3760,63 @@ def arg_valid_iam_role_duration(arg_string):
         If the number provided is not in the expected range.
     """
     # Session duration must be between 15m and 12h
-    if not (arg_string is None or (900 <= int(arg_string) <= 3600)):
+    # Session duration must be between 15m and 12h
+    if arg_string is None:
+        return None
+
+    # Validate if the argument is a number
+    if not arg_string.isdigit():
+        raise argparse.ArgumentTypeError("Invalid session duration specified. Value must be a valid number.")
+
+    # Convert to integer and check range
+    num_seconds = int(arg_string)
+    if not (900 <= num_seconds <= 3600):
         raise argparse.ArgumentTypeError("Invalid session duration specified. Value must be between 900 and 3600.")
-    return int(arg_string)
+
+    return num_seconds
+
+
+def args_valid_iam_role_arn(iam_role_arn):
+    """Checks if the IAM role ARN specified is a valid parameter.
+
+    Parameters
+    ----------
+    iam_role_arn : str
+        The IAM role ARN to validate.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If the ARN provided is not in the expected format.
+    """
+    pattern = r'^arn:aws:connect:\w+(?:-\w+)+:\d{12}:instance\/[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$'
+
+    if not re.match(pattern, iam_role_arn):
+        raise argparse.ArgumentTypeError("Invalid ARN specified. Value must be a valid ARN.")
+
+    return iam_role_arn
+
+
+def args_valid_sqs_name(sqs_name):
+    """Checks if the SQS name specified is a valid parameter.
+
+    Parameters
+    ----------
+    sqs_name : str
+        The SQS name to validate.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If the SQS name provided is not in the expected format.
+    """
+    pattern = r'^[a-zA-Z0-9-_]{1,80}$'
+
+    if not re.match(pattern, sqs_name):
+        raise argparse.ArgumentTypeError("Invalid SQS Name specified. Value must be up to 80 characters and the valid "
+                                         "values are alphanumeric characters, hyphens (-), and underscores (_)")
+
+    return sqs_name
 
 
 def get_script_arguments():
@@ -3778,7 +3832,7 @@ def get_script_arguments():
     group.add_argument('-sb', '--subscriber', dest='subscriber', help='Specify the type of the subscriber',
                        action='store')
     parser.add_argument('-q', '--queue', dest='queue', help='Specify the name of the SQS',
-                        action='store')
+                        type=args_valid_sqs_name, action='store')
     parser.add_argument('-O', '--aws_organization_id', dest='aws_organization_id',
                         help='AWS organization ID for logs', required=False)
     parser.add_argument('-c', '--aws_account_id', dest='aws_account_id',
@@ -3800,6 +3854,7 @@ def get_script_arguments():
                         default=None)
     parser.add_argument('-i', '--iam_role_arn', dest='iam_role_arn',
                         help='ARN of IAM role to assume for access to S3 bucket',
+                        type=args_valid_iam_role_arn,
                         default=None)
     parser.add_argument('-n', '--aws_account_alias', dest='aws_account_alias',
                         help='AWS Account ID Alias', default='')

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3593,6 +3593,7 @@ class AWSSQSQueue(WazuhIntegration):
 
     def __init__(self, name: str, iam_role_arn: str, access_key: str = None, secret_key: str = None,
                  external_id: str = None, sts_endpoint=None, service_endpoint=None, **kwargs):
+        self._validate_params(external_id=external_id, name=name, iam_role_arn=iam_role_arn)
         self.sqs_name = name
         WazuhIntegration.__init__(self, access_key=access_key, secret_key=secret_key, iam_role_arn = iam_role_arn,
                                   aws_profile=None, external_id=external_id, service_name='sqs', sts_endpoint=sts_endpoint,
@@ -3605,6 +3606,29 @@ class AWSSQSQueue(WazuhIntegration):
                                                         iam_role_arn=self.iam_role_arn,
                                                         service_endpoint=service_endpoint,
                                                         sts_endpoint=sts_endpoint)
+
+    def _validate_params(self, external_id: Optional[str], name: Optional[str], iam_role_arn: Optional[str]):
+        """
+        Class for getting AWS SQS Queue notifications.
+        Parameters
+        ----------
+        external_id : Optional[str]
+            The name of the External ID to use.
+        name: Optional[str]
+            Name of the SQS Queue.
+        iam_role_arn : Optional[str]
+            IAM Role.
+        """
+
+        if iam_role_arn is None:
+            print('ERROR: Used a subscriber but no --iam_role_arn provided.')
+            sys.exit(21)
+        if name is None:
+            print('ERROR: Used a subscriber but no --queue provided.')
+            sys.exit(21)
+        if external_id is None:
+            print('ERROR: Used a subscriber but no --external_id provided.')
+            sys.exit(21)
 
     def _get_sqs_url(self) -> str:
         """Get the URL of the AWS SQS queue

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3789,10 +3789,10 @@ def args_valid_iam_role_arn(iam_role_arn):
     argparse.ArgumentTypeError
         If the ARN provided is not in the expected format.
     """
-    pattern = r'^arn:aws:connect:\w+(?:-\w+)+:\d{12}:instance\/[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$'
+    pattern = r'^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$'
 
     if not re.match(pattern, iam_role_arn):
-        raise argparse.ArgumentTypeError("Invalid ARN specified. Value must be a valid ARN.")
+        raise argparse.ArgumentTypeError("Invalid ARN Role specified. Value must be a valid ARN Role.")
 
     return iam_role_arn
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -36,6 +36,7 @@ import signal
 import socket
 import sqlite3
 import sys
+from typing import Optional
 
 try:
     import boto3


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/17630|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Added validation for the following arguments:
- `sqs_name ` in C parser: Tag is present and does not contain an empty value.
- `iam_role_arn` in C parser: Tag is present and does not contain an empty value. 
- `external_id`: Tag is present and does not contain an empty value.

- `sqs_name` in Python script: Value complies with the minimal AWS requirements for the SQS name.
- `iam_role_arn` in Python script: Value complies with the expected ARN format.
-  `iam_role_duration` in Python script: This is a numeric value.

