### PR TITLE
Removed unwanted filebeat fields and added mappings for agent field

### DIFF
--- a/src/engine/extension/filebeat/7.x/filebeat.yml
+++ b/src/engine/extension/filebeat/7.x/filebeat.yml
@@ -54,4 +54,13 @@ filebeat.inputs:
     json.overwrite_keys: true
     json.keys_under_root: true
     json.expand_keys: true
+    publisher_pipeline.disable_host: true
 
+processors:
+  - drop_fields:
+      when:
+        equals:
+          log.file.path: "/var/ossec/logs/alerts/alerts-ECS.json"
+      fields: ["log.offset", "log.file.path"]
+  - drop_fields:
+      fields: ["agent.ephemeral_id", "agent.hostname", "agent.version", "input.type"]

--- a/src/engine/extension/filebeat/7.x/filebeat.yml
+++ b/src/engine/extension/filebeat/7.x/filebeat.yml
@@ -64,3 +64,9 @@ processors:
       fields: ["log.offset", "log.file.path"]
   - drop_fields:
       fields: ["agent.ephemeral_id", "agent.hostname", "agent.version", "input.type"]
+  - drop_fields:
+      when:
+        not:
+          equals:
+            agent.type: wazuh-agent
+      fields: ["agent.type"]

--- a/src/engine/ruleset/wazuh-core/decoders/core-wazuh-message.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-wazuh-message.yml
@@ -41,5 +41,6 @@ normalize:
   - check:
       - agent.id: +exists
     map:
+      - agent.type: wazuh-agent
       - host.id: $agent.id
       - host: +kvdb_get/agents_host_data/$agent.id


### PR DESCRIPTION
|Related issue|
|---|
|#17615|

The following fields added by default by Filebeat has ben removed:
- host.hostname
- host.name
- agent.ephemeral_id
- input.type
- log.file.path
- log.offset

The log and host fields are only deleted if added by the Filebeat log ingestion type.

Added mappings for agent fields, as we want these fields and are not overwritten by Filebeat if already present in the event.

