### PR TITLE
save a reference to created tasks, to avoid tasks disappearing

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -925,7 +925,7 @@ class Handler(asyncio.Protocol):
         dapi_client, error_msg = data.split(b' ', 1)
         if dapi_client.decode() in self.server.local_server.clients:
             try:
-                asyncio.create_task(
+                task = asyncio.create_task(
                     self.server.local_server.clients[dapi_client.decode()].send_request(b'dapi_err', error_msg))
             except exception.WazuhClusterError:
                 raise exception.WazuhClusterError(3025)

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -264,7 +264,7 @@ class LocalServerHandlerMaster(LocalServerHandler):
             node_name, request = data.split(b' ', 1)
             node_name = node_name.decode()
             if node_name in self.server.node.clients:
-                asyncio.create_task(self.log_exceptions(
+                task = asyncio.create_task(self.log_exceptions(
                     self.server.node.clients[node_name].send_request(b'dapi', self.name.encode() + b' ' + request)))
                 return b'ok', b'Request forwarded to worker node'
             else:
@@ -387,19 +387,19 @@ class LocalServerHandlerWorker(LocalServerHandler):
         if command == b'dapi':
             if self.server.node.client is None:
                 raise WazuhClusterError(3023)
-            asyncio.create_task(self.log_exceptions(
+            task = asyncio.create_task(self.log_exceptions(
                 self.server.node.client.send_request(b'dapi', self.name.encode() + b' ' + data)))
             return b'ok', b'Added request to API requests queue'
         elif command == b'sendsync':
             if self.server.node.client is None:
                 raise WazuhClusterError(3023)
-            asyncio.create_task(self.log_exceptions(
+            task = asyncio.create_task(self.log_exceptions(
                 self.server.node.client.send_request(b'sendsync', self.name.encode() + b' ' + data)))
             return None, None
         elif command == b'sendasync':
             if self.server.node.client is None:
                 raise WazuhClusterError(3023)
-            asyncio.create_task(self.log_exceptions(
+            task = asyncio.create_task(self.log_exceptions(
                 self.server.node.client.send_request(b'sendsync', self.name.encode() + b' ' + data)))
             return b'ok', b'Added request to sendsync requests queue'
         else:

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -451,7 +451,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             self.in_str.pop(string_id, None)
             return b'ok', b'Forwarded response'
         elif req_id in self.server.local_server.clients:
-            asyncio.create_task(self.forward_dapi_response(data))
+            task = asyncio.create_task(self.forward_dapi_response(data))
             return b'ok', b'Response forwarded to worker'
         else:
             raise exception.WazuhClusterError(3032, extra_message=req_id)

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -212,14 +212,14 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             logger = self.task_loggers['Agent-info sync']
             return c_common.error_receiving_agent_information(logger, data.decode(), info_type='agent-info')
         elif command == b'dapi_res':
-            asyncio.create_task(self.forward_dapi_response(data))
+            task = asyncio.create_task(self.forward_dapi_response(data))
             return b'ok', b'Response forwarded to worker'
         elif command == b'sendsyn_res':
-            asyncio.create_task(self.forward_sendsync_response(data))
+            task = asyncio.create_task(self.forward_sendsync_response(data))
             return b'ok', b'Response forwarded to worker'
         elif command == b'sendsyn_err':
             sendsync_client, error_msg = data.split(b' ', 1)
-            asyncio.create_task(self.log_exceptions(
+            task = asyncio.create_task(self.log_exceptions(
                 self.server.local_server.clients[sendsync_client.decode()].send_request(b'err', error_msg)))
             return b'ok', b'SendSync error forwarded to worker'
         elif command == b'dapi':


### PR DESCRIPTION
> Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done.
>
> [python docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task)

|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Please review the link: https://textual.textualize.io/blog/2023/02/11/the-heisenbug-lurking-in-your-async-code/

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors