### PR TITLE
Move scan build fixes from 4.5.1 to 4.5.0

### DIFF
--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -758,6 +758,7 @@ void fim_read_values(HKEY key_handle,
         fim_registry_process_value_event(new, saved, mode, data_buffer);
     }
 
+    new->registry_entry.value = NULL;
     os_free(value_buffer);
     os_free(data_buffer);
 }

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -80,7 +80,10 @@ int wm_exec(char *command, char **output, int *status, int secs, const char * ad
         }
 
         char *new_env = getenv("PATH");
-        mdebug1("New 'PATH' environment variable set: '%s'", new_env);
+        if (new_env) {
+            mdebug1("New 'PATH' environment variable set: '%s'", new_env);
+        }
+
         free(new_path);
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|As part of #17495|

## Description
The purpose of this PR is to transfer the changes from 4.5.1 to 4.5.0 for the execution of scanbuild.

These changes fix real issues that are reported by running scanbuild.
