### PR TITLE
Add tests to the PubSubPublisher class

### DIFF
--- a/src/shared_modules/content_manager/src/components/updaterContext.hpp
+++ b/src/shared_modules/content_manager/src/components/updaterContext.hpp
@@ -12,6 +12,7 @@
 #ifndef _UPDATER_CONTEXT_HPP
 #define _UPDATER_CONTEXT_HPP
 
+#include "iRouterProvider.hpp"
 #include "routerProvider.hpp"
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
@@ -33,7 +34,7 @@ struct UpdaterBaseContext
      * @brief Channel where the data will be published.
      *
      */
-    std::shared_ptr<RouterProvider> spChannel;
+    std::shared_ptr<IRouterProvider> spChannel;
 
     /**
      * @brief Path to the output folder where the data will be stored.

--- a/src/shared_modules/content_manager/tests/CMakeLists.txt
+++ b/src/shared_modules/content_manager/tests/CMakeLists.txt
@@ -5,4 +5,5 @@ include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
 
 link_directories(${SRC_FOLDER}/external/googletest/lib/)
 
+add_subdirectory(component)
 add_subdirectory(unit)

--- a/src/shared_modules/content_manager/tests/component/CMakeLists.txt
+++ b/src/shared_modules/content_manager/tests/component/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.12.4)
+
+project(content_manager_component_tests)
+
+file(GLOB PROJECT_SOURCES
+    *.cpp
+    ${CMAKE_SOURCE_DIR}/content_manager/src/*[!main]*.cpp
+)
+
+add_executable(${PROJECT_NAME} ${PROJECT_SOURCES})
+
+target_link_libraries(${PROJECT_NAME}
+    gtest
+    gtest_main
+    gmock
+    urlrequest
+    router
+)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.cpp
@@ -1,7 +1,7 @@
 /*
- * Wazuh content manager - Unit Tests
+ * Wazuh content manager - Component Tests
  * Copyright (C) 2015, Wazuh Inc.
- * Jun 07, 2023.
+ * Jun 20, 2023.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
@@ -10,11 +10,10 @@
  */
 
 #include "pubSubPublisher_test.hpp"
-#include "mocks/MockRouterProvider.hpp"
-#include "pubSubPublisher.hpp"
-#include "updaterContext.hpp"
-#include <gmock/gmock.h>
+#include "routerProvider.hpp"
+#include "gtest/gtest.h"
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 /*
@@ -31,11 +30,7 @@ TEST_F(PubSubPublisherTest, instantiation)
  */
 TEST_F(PubSubPublisherTest, TestPublishEmptyData)
 {
-    auto mockRouterProvider {std::make_shared<MockRouterProvider>()};
-    EXPECT_CALL(*mockRouterProvider, start).Times(1);
-    EXPECT_CALL(*mockRouterProvider, stop).Times(1);
-
-    m_spUpdaterBaseContext->spChannel = mockRouterProvider;
+    m_spUpdaterBaseContext->spChannel = std::make_shared<RouterProvider>("component-tests");
     m_spUpdaterBaseContext->spChannel->start();
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
@@ -58,18 +53,13 @@ TEST_F(PubSubPublisherTest, TestPublishEmptyData)
  */
 TEST_F(PubSubPublisherTest, TestPublishValidData)
 {
-    std::string message {"Hello World!"};
+    std::string data {"Hello World!"};
 
-    auto mockRouterProvider {std::make_shared<MockRouterProvider>()};
-    EXPECT_CALL(*mockRouterProvider, start).Times(1);
-    EXPECT_CALL(*mockRouterProvider, send(::testing::_)).Times(1);
-    EXPECT_CALL(*mockRouterProvider, stop).Times(1);
-
-    m_spUpdaterBaseContext->spChannel = mockRouterProvider;
+    m_spUpdaterBaseContext->spChannel = std::make_shared<RouterProvider>("component-tests");
     m_spUpdaterBaseContext->spChannel->start();
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
-    m_spUpdaterContext->data = std::vector<char>(message.begin(), message.end());
+    m_spUpdaterContext->data = std::vector<char>(data.begin(), data.end());
 
     testing::internal::CaptureStdout();
 
@@ -85,17 +75,13 @@ TEST_F(PubSubPublisherTest, TestPublishValidData)
 }
 
 /*
- * @brief Tests publish valid data without start the MockRouterProvider.
+ * @brief Tests publish valid data without start the RouterProvider.
  */
-TEST_F(PubSubPublisherTest, TestPublishValidDataWithouStartTheMockRouterProvider)
+TEST_F(PubSubPublisherTest, TestPublishValidDataWithouStartTheRouterProvider)
 {
     std::string message {"Hello World!"};
 
-    auto mockRouterProvider {std::make_shared<MockRouterProvider>()};
-    EXPECT_CALL(*mockRouterProvider, send(::testing::_)).Times(1).WillOnce([]() { throw std::runtime_error(""); });
-    EXPECT_CALL(*mockRouterProvider, stop).Times(1).WillOnce([] { throw std::runtime_error(""); });
-
-    m_spUpdaterBaseContext->spChannel = mockRouterProvider;
+    m_spUpdaterBaseContext->spChannel = std::make_shared<RouterProvider>("component-tests");
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
     m_spUpdaterContext->data = std::vector<char>(message.begin(), message.end());
@@ -108,15 +94,11 @@ TEST_F(PubSubPublisherTest, TestPublishValidDataWithouStartTheMockRouterProvider
 }
 
 /*
- * @brief Tests publish empty data without start the MockRouterProvider.
+ * @brief Tests publish empty data without start the RouterProvider.
  */
-TEST_F(PubSubPublisherTest, TestPublishEmptyDataWithouStartTheMockRouterProvider)
+TEST_F(PubSubPublisherTest, TestPublishEmptyDataWithouStartTheRouterProvider)
 {
-    auto mockRouterProvider {std::make_shared<MockRouterProvider>()};
-
-    EXPECT_CALL(*mockRouterProvider, stop).Times(1).WillOnce([] { throw std::runtime_error(""); });
-
-    m_spUpdaterBaseContext->spChannel = mockRouterProvider;
+    m_spUpdaterBaseContext->spChannel = std::make_shared<RouterProvider>("component-tests");
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
 

--- a/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.cpp
@@ -35,13 +35,7 @@ TEST_F(PubSubPublisherTest, TestPublishEmptyData)
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
 
-    testing::internal::CaptureStdout();
-
     EXPECT_NO_THROW(m_spPubSubPublisher->handleRequest(m_spUpdaterContext));
-
-    const auto capturedOutput {testing::internal::GetCapturedStdout()};
-
-    EXPECT_EQ(capturedOutput, "PubSubPublisher - No data data to publish\n");
 
     m_spUpdaterBaseContext->spChannel->stop();
 
@@ -61,13 +55,7 @@ TEST_F(PubSubPublisherTest, TestPublishValidData)
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
     m_spUpdaterContext->data = std::vector<char>(data.begin(), data.end());
 
-    testing::internal::CaptureStdout();
-
     EXPECT_NO_THROW(m_spPubSubPublisher->handleRequest(m_spUpdaterContext));
-
-    const auto capturedOutput {testing::internal::GetCapturedStdout()};
-
-    EXPECT_EQ(capturedOutput, "PubSubPublisher - Data published\n");
 
     m_spUpdaterBaseContext->spChannel->stop();
 
@@ -102,13 +90,7 @@ TEST_F(PubSubPublisherTest, TestPublishEmptyDataWithouStartTheRouterProvider)
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
 
-    testing::internal::CaptureStdout();
-
     EXPECT_NO_THROW(m_spPubSubPublisher->handleRequest(m_spUpdaterContext));
-
-    const auto capturedOutput {testing::internal::GetCapturedStdout()};
-
-    EXPECT_EQ(capturedOutput, "PubSubPublisher - No data data to publish\n");
 
     EXPECT_THROW(m_spUpdaterBaseContext->spChannel->stop(), std::runtime_error);
 

--- a/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.hpp
@@ -1,7 +1,7 @@
 /*
- * Wazuh content manager - Unit Tests
+ * Wazuh content manager - Component Tests
  * Copyright (C) 2015, Wazuh Inc.
- * Jun 07, 2023.
+ * Jun 20, 2023.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
@@ -15,6 +15,7 @@
 #include "pubSubPublisher.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <memory>
 
 /**
  * @brief Runs unit tests for PubSubPublisher

--- a/src/shared_modules/content_manager/tests/unit/mocks/MockRouterProvider.hpp
+++ b/src/shared_modules/content_manager/tests/unit/mocks/MockRouterProvider.hpp
@@ -1,0 +1,40 @@
+/*
+ * Wazuh content manager - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * Jun 26, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _MOCK_ROUTER_PROVIDER_HPP
+#define _MOCK_ROUTER_PROVIDER_HPP
+
+#include "iRouterProvider.hpp"
+#include <gmock/gmock.h>
+
+class MockRouterProvider : public IRouterProvider
+{
+public:
+    MockRouterProvider() = default;
+    virtual ~MockRouterProvider() = default;
+
+    /**
+     * @brief Mock implementation of function IRouterProvider::stop
+     */
+    MOCK_METHOD(void, stop, ());
+
+    /**
+     * @brief Mock implementation of function IRouterProvider::start
+     */
+    MOCK_METHOD(void, start, ());
+
+    /**
+     * @brief Mock implementation of function IRouterProvider::send
+     */
+    MOCK_METHOD(void, send, (const std::vector<char>& data));
+};
+
+#endif //_MOCK_ROUTER_PROVIDER_HPP

--- a/src/shared_modules/content_manager/tests/unit/pubSubPublisher_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/pubSubPublisher_test.cpp
@@ -40,13 +40,7 @@ TEST_F(PubSubPublisherTest, TestPublishEmptyData)
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
 
-    testing::internal::CaptureStdout();
-
     EXPECT_NO_THROW(m_spPubSubPublisher->handleRequest(m_spUpdaterContext));
-
-    const auto capturedOutput {testing::internal::GetCapturedStdout()};
-
-    EXPECT_EQ(capturedOutput, "PubSubPublisher - No data data to publish\n");
 
     m_spUpdaterBaseContext->spChannel->stop();
 
@@ -71,13 +65,7 @@ TEST_F(PubSubPublisherTest, TestPublishValidData)
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
     m_spUpdaterContext->data = std::vector<char>(message.begin(), message.end());
 
-    testing::internal::CaptureStdout();
-
     EXPECT_NO_THROW(m_spPubSubPublisher->handleRequest(m_spUpdaterContext));
-
-    const auto capturedOutput {testing::internal::GetCapturedStdout()};
-
-    EXPECT_EQ(capturedOutput, "PubSubPublisher - Data published\n");
 
     m_spUpdaterBaseContext->spChannel->stop();
 
@@ -120,13 +108,7 @@ TEST_F(PubSubPublisherTest, TestPublishEmptyDataWithouStartTheMockRouterProvider
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
 
-    testing::internal::CaptureStdout();
-
     EXPECT_NO_THROW(m_spPubSubPublisher->handleRequest(m_spUpdaterContext));
-
-    const auto capturedOutput {testing::internal::GetCapturedStdout()};
-
-    EXPECT_EQ(capturedOutput, "PubSubPublisher - No data data to publish\n");
 
     EXPECT_THROW(m_spUpdaterBaseContext->spChannel->stop(), std::runtime_error);
 

--- a/src/shared_modules/router/include/iRouterProvider.hpp
+++ b/src/shared_modules/router/include/iRouterProvider.hpp
@@ -1,0 +1,38 @@
+/*
+ * Wazuh router
+ * Copyright (C) 2015, Wazuh Inc.
+ * Jun 26, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _IROUTER_PROVIDER_HPP
+#define _IROUTER_PROVIDER_HPP
+
+#include <vector>
+
+class IRouterProvider
+{
+public:
+    /**
+     * @brief Stops the local or remote provider.
+     */
+    virtual void stop() = 0;
+
+    /**
+     * @brief Starts the local or remote provider.
+     */
+    virtual void start() = 0;
+
+    /**
+     * @brief Sends the data to the provider.
+     *
+     * @param data Data to be sent
+     */
+    virtual void send(const std::vector<char>& data) = 0;
+};
+
+#endif //_IROUTER_PROVIDER_HPP

--- a/src/shared_modules/router/include/routerProvider.hpp
+++ b/src/shared_modules/router/include/routerProvider.hpp
@@ -18,13 +18,14 @@
 #define EXPORTED
 #endif
 
+#include "iRouterProvider.hpp"
 #include <functional>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
 
-class EXPORTED RouterProvider final
+class EXPORTED RouterProvider final : public IRouterProvider
 {
 private:
     const std::string m_topicName;


### PR DESCRIPTION
|Related issue|
|---|
| Closes: #17601 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR aims to add unit tests and component tests to the PubSubPublisher class. Additionally, the [IRouterProvider](https://github.com/wazuh/wazuh/blob/ddcd1a439f158fddc1179a59bd47b2597f963719/src/shared_modules/router/include/iRouterProvider.hpp#L17) interface was added so that it can be implemented by [RouterProvider](https://github.com/wazuh/wazuh/blob/ddcd1a439f158fddc1179a59bd47b2597f963719/src/shared_modules/router/include/routerProvider.hpp#L28C46-L28C61) or any [Mock object](https://github.com/wazuh/wazuh/blob/ddcd1a439f158fddc1179a59bd47b2597f963719/src/shared_modules/content_manager/tests/unit/mocks/MockRouterProvider.hpp#L18), which can be used for UT's.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->
