### PR TITLE
Fixed segmentation fault due to duplicate VD configuration

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -367,8 +367,7 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
 
     if (upd_list[os_index]) {
         mdebug1("Duplicate OVAL configuration for '%s%s%s'", upd->dist, upd->version ? " " : "", upd->version ? upd->version : "");
-        wm_vuldet_free_update_node(upd_list[os_index]);
-        free(upd_list[os_index]);
+        wm_vuldet_release_update_node(upd_list, os_index);
     }
 
     upd_list[os_index] = upd;
@@ -954,15 +953,18 @@ int wm_vuldet_add_allow_os(update_node *update, char *os_tags) {
         }
         mdebug1("'%s' successfully added to the monitored OS list.", os_tags);
         update->allowed_os_name[size + 1] = NULL;
+        update->allowed_os_ver[size + 1] = NULL;
         os_tags = found;
     }
     os_realloc(update->allowed_os_name, (size + 2)*sizeof(char *), update->allowed_os_name);
+    os_realloc(update->allowed_os_ver, (size + 2)*sizeof(char *), update->allowed_os_ver);
     if (format_os_version(os_tags, &update->allowed_os_name[size], &update->allowed_os_ver[size])) {
         merror("Invalid OS entered in %s: %s", WM_VULNDETECTOR_CONTEXT.name, os_tags);
         return OS_INVALID;
     }
     mdebug1("'%s' successfully added to the monitored OS list.", os_tags);
     update->allowed_os_name[size + 1] = NULL;
+    update->allowed_os_ver[size + 1] = NULL;
 
     return 0;
 }

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -110,7 +110,7 @@ int format_os_version(char *OS, char **os_name, char **os_ver) {
     } else if (elements == 1) {
         snprintf(*os_name, size, "%s", distr);
     } else {
-        free(*os_name);
+        os_free(*os_name);
         return OS_INVALID;
     }
 
@@ -120,7 +120,7 @@ int format_os_version(char *OS, char **os_name, char **os_ver) {
         *ver_end = '\0';
     }
     if (size = strlen(ver), size >= 20) {
-        free(*os_name);
+        os_free(*os_name);
         return OS_INVALID;
     }
     os_strdup(ver, *os_ver);


### PR DESCRIPTION
|Related issue|
|---|
|#17649|

## Description

Fixed a segmentation fault that was caused due to bad memory management when using the scan option for unsupported systems (`os allow`), which tried to free memory that had junk in it.

This occurred only when duplicating an `<os>` block that used the `allow` parameter, as it was not allocating the necessary memory for it.

## Configuration options

```xml
    <provider name="redhat">
        <enabled>yes</enabled>
        <os allow="Oracle Linux-7">7</os>
        <os path="/local_path/com.redhat.rhsa-RHEL5.xml.bz2">5</os>
        <os path="/local_path/rhel-6-including-unpatched.oval.xml.bz2">6</os>
        <os path="/local_path/rhel-7-including-unpatched.oval.xml.bz2">7</os>
        <os path="/local_path/rhel-8-including-unpatched.oval.xml.bz2">8</os>
        <os path="/local_path/rhel-9-including-unpatched.oval.xml.bz2">9</os>
        <path>/local_path/rh-feed/redhat-feed[[:digit:]]\+\.json$</path>
        <update_interval>1h</update_interval>
    </provider>
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
