### PR TITLE
Enhance 32-bit and 64-bit Number Operations in Assets

### DIFF
--- a/src/engine/ruleset/integrations/fortinet/decoders/fortinet-firewall.yml
+++ b/src/engine/ruleset/integrations/fortinet/decoders/fortinet-firewall.yml
@@ -97,7 +97,6 @@ normalize:
     - event.kind: event
     - event.timezone: $~tmp.tz
     - event.code: $~tmp.logid
-    # due to type value limitations, multiplying by a large number can cause an overflow on the result
     - event.duration: $~tmp.duration
     - event.duration: +int_calculate/mul/100000000
     - event.reference: $~tmp.ref

--- a/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
@@ -61,19 +61,19 @@ std::function<base::result::Result<base::Event>(base::Event)> getIntCmpFunction(
     const std::string& targetField, Operator op, const helper::base::Parameter& rightParameter, const std::string& name)
 {
     // Depending on rValue type we store the reference or the integer value
-    std::variant<std::string, int> rValue {};
+    std::variant<std::string, int64_t> rValue {};
     auto rValueType {rightParameter.m_type};
     switch (rightParameter.m_type)
     {
         case helper::base::Parameter::Type::VALUE:
             try
             {
-                rValue = std::stoi(rightParameter.m_value);
+                rValue = std::stoll(rightParameter.m_value);
             }
             catch (const std::exception& e)
             {
                 throw std::runtime_error(fmt::format("\"{}\" function: Parameter \"{}\" "
-                                                     "could not be converted to int: {}.",
+                                                     "could not be converted to int64_t: {}.",
                                                      name,
                                                      rightParameter.m_value,
                                                      e.what()));
@@ -87,45 +87,45 @@ std::function<base::result::Result<base::Event>(base::Event)> getIntCmpFunction(
             throw std::runtime_error(fmt::format("\"{}\" function: Parameter \"{}\" has an invalid type ({}).",
                                                  name,
                                                  rightParameter.m_value,
-                                                 static_cast<int>(rightParameter.m_type)));
+                                                 static_cast<int64_t>(rightParameter.m_type)));
     }
 
     // Depending on the operator we return the correct function
-    std::function<bool(int l, int r)> cmpFunction;
+    std::function<bool(int64_t l, int64_t r)> cmpFunction;
     switch (op)
     {
         case Operator::EQ:
-            cmpFunction = [](int l, int r)
+            cmpFunction = [](int64_t l, int64_t r)
             {
                 return l == r;
             };
             break;
         case Operator::NE:
-            cmpFunction = [](int l, int r)
+            cmpFunction = [](int64_t l, int64_t r)
             {
                 return l != r;
             };
             break;
         case Operator::GT:
-            cmpFunction = [](int l, int r)
+            cmpFunction = [](int64_t l, int64_t r)
             {
                 return l > r;
             };
             break;
         case Operator::GE:
-            cmpFunction = [](int l, int r)
+            cmpFunction = [](int64_t l, int64_t r)
             {
                 return l >= r;
             };
             break;
         case Operator::LT:
-            cmpFunction = [](int l, int r)
+            cmpFunction = [](int64_t l, int64_t r)
             {
                 return l < r;
             };
             break;
         case Operator::LE:
-            cmpFunction = [](int l, int r)
+            cmpFunction = [](int64_t l, int64_t r)
             {
                 return l <= r;
             };
@@ -148,16 +148,16 @@ std::function<base::result::Result<base::Event>(base::Event)> getIntCmpFunction(
         // empty ot not. Then if is a reference we get the value from the event, otherwise
         // we get the value from the parameter
 
-        std::optional<int> lValue {event->getInt(targetField)};
+        std::optional<int64_t> lValue {event->getInt64(targetField)};
         if (!lValue.has_value())
         {
             return base::result::makeFailure(event, failureTrace1);
         }
 
-        int resolvedValue {0};
+        int64_t resolvedValue {0};
         if (helper::base::Parameter::Type::REFERENCE == rValueType)
         {
-            std::optional<int> resolvedRValue {event->getInt(std::get<std::string>(rValue))};
+            std::optional<int64_t> resolvedRValue {event->getInt64(std::get<std::string>(rValue))};
             if (!resolvedRValue.has_value())
             {
                 return base::result::makeFailure(event, failureTrace2);
@@ -166,7 +166,7 @@ std::function<base::result::Result<base::Event>(base::Event)> getIntCmpFunction(
         }
         else
         {
-            resolvedValue = std::get<int>(rValue);
+            resolvedValue = std::get<int64_t>(rValue);
         }
 
         if (cmpFunction(lValue.value(), resolvedValue))

--- a/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
@@ -72,11 +72,11 @@ std::function<base::result::Result<base::Event>(base::Event)> getIntCmpFunction(
             }
             catch (const std::exception& e)
             {
-                throw std::runtime_error(fmt::format("\"{}\" function: Parameter \"{}\" "
-                                                     "could not be converted to int64_t: {}.",
-                                                     name,
-                                                     rightParameter.m_value,
-                                                     e.what()));
+                throw std::runtime_error(
+                    fmt::format(R"('{}' function: Parameter '{}' could not be converted to int64_t: '{}'.)",
+                                name,
+                                rightParameter.m_value,
+                                e.what()));
             }
 
             break;
@@ -84,9 +84,8 @@ std::function<base::result::Result<base::Event>(base::Event)> getIntCmpFunction(
         case helper::base::Parameter::Type::REFERENCE: rValue = rightParameter.m_value; break;
 
         default:
-            throw std::runtime_error(fmt::format("\"{}\" function: Parameter \"{}\" has an invalid type ({}).",
+            throw std::runtime_error(fmt::format(R"('{}' function: Unsupported parameter type ({}).)",
                                                  name,
-                                                 rightParameter.m_value,
                                                  static_cast<int64_t>(rightParameter.m_type)));
     }
 
@@ -142,13 +141,13 @@ std::function<base::result::Result<base::Event>(base::Event)> getIntCmpFunction(
     const std::string failureTrace3 {fmt::format("[{}] -> Failure: Comparison is false", name)};
 
     // Function that implements the helper
-    return [=](base::Event event) -> base::result::Result<base::Event>
+    return [=](const base::Event& event) -> base::result::Result<base::Event>
     {
         // We assert that references exists, checking if the optional from Json getter is
         // empty ot not. Then if is a reference we get the value from the event, otherwise
         // we get the value from the parameter
 
-        std::optional<int64_t> lValue {event->getInt64(targetField)};
+        auto lValue = event->getIntAsInt64(targetField);
         if (!lValue.has_value())
         {
             return base::result::makeFailure(event, failureTrace1);
@@ -157,7 +156,7 @@ std::function<base::result::Result<base::Event>(base::Event)> getIntCmpFunction(
         int64_t resolvedValue {0};
         if (helper::base::Parameter::Type::REFERENCE == rValueType)
         {
-            std::optional<int64_t> resolvedRValue {event->getInt64(std::get<std::string>(rValue))};
+            auto resolvedRValue = event->getIntAsInt64(std::get<std::string>(rValue));
             if (!resolvedRValue.has_value())
             {
                 return base::result::makeFailure(event, failureTrace2);

--- a/src/engine/source/builder/builders/opBuilderSCAdecoder.hpp
+++ b/src/engine/source/builder/builders/opBuilderSCAdecoder.hpp
@@ -117,7 +117,7 @@ struct DecodeCxt
      * @param field Field to get the value.
      * @return empty if the field is not found or the value is not an int
      */
-    std::optional<int> getSrcInt(sca::field::Name field) const { return event->getInt(sourcePath.at(field)); };
+    std::optional<int> getSrcInt(sca::field::Name field) const { return event->getInt64(sourcePath.at(field)); };
 
     /**
      * @brief Get number as a double value from a field.

--- a/src/engine/source/builder/helperParser.hpp
+++ b/src/engine/source/builder/helperParser.hpp
@@ -128,7 +128,7 @@ inline std::tuple<std::string, json::Json> toBuilderInput(const ExpressionToken&
         throw std::runtime_error("Expression field is empty");
     }
 
-    bool isValueIntiger = expressionToken.value.isInt() || expressionToken.value.isInt64();
+    bool isValueInteger = expressionToken.value.isInt() || expressionToken.value.isInt64();
 
     if (expressionToken.op == ExpressionOperator::EQUAL)
     {
@@ -136,20 +136,20 @@ inline std::tuple<std::string, json::Json> toBuilderInput(const ExpressionToken&
     }
 
     if (expressionToken.op == ExpressionOperator::NOT_EQUAL && !expressionToken.value.isString()
-        && !isValueIntiger)
+        && !isValueInteger)
     {
         throw std::runtime_error("Not equal operator is not supported for non string or number values");
     }
 
     // Rest of operators only support string or number values
-    if (!expressionToken.value.isString() && !isValueIntiger)
+    if (!expressionToken.value.isString() && !isValueInteger)
     {
         throw std::runtime_error("Expression value is not string or number");
     }
 
     HelperToken helperToken {};
 
-    if (isValueIntiger)
+    if (isValueInteger)
     {
         helperToken.name = "int";
         helperToken.args = {std::to_string(expressionToken.value.getIntAsInt64().value())};

--- a/src/engine/source/builder/helperParser.hpp
+++ b/src/engine/source/builder/helperParser.hpp
@@ -147,6 +147,7 @@ inline std::tuple<std::string, json::Json> toBuilderInput(const ExpressionToken&
 
     HelperToken helperToken {};
 
+    // TODO Check float/double and int64 numbers
     if (expressionToken.value.isNumber())
     {
         helperToken.name = "int";

--- a/src/engine/source/builder/helperParser.hpp
+++ b/src/engine/source/builder/helperParser.hpp
@@ -128,30 +128,31 @@ inline std::tuple<std::string, json::Json> toBuilderInput(const ExpressionToken&
         throw std::runtime_error("Expression field is empty");
     }
 
+    bool isValueIntiger = expressionToken.value.isInt() || expressionToken.value.isInt64();
+
     if (expressionToken.op == ExpressionOperator::EQUAL)
     {
         return std::make_tuple(expressionToken.field.substr(1), expressionToken.value);
     }
 
     if (expressionToken.op == ExpressionOperator::NOT_EQUAL && !expressionToken.value.isString()
-        && !expressionToken.value.isNumber())
+        && !isValueIntiger)
     {
         throw std::runtime_error("Not equal operator is not supported for non string or number values");
     }
 
     // Rest of operators only support string or number values
-    if (!expressionToken.value.isString() && !expressionToken.value.isNumber())
+    if (!expressionToken.value.isString() && !isValueIntiger)
     {
         throw std::runtime_error("Expression value is not string or number");
     }
 
     HelperToken helperToken {};
 
-    // TODO Check float/double and int64 numbers
-    if (expressionToken.value.isNumber())
+    if (isValueIntiger)
     {
         helperToken.name = "int";
-        helperToken.args = {std::to_string(expressionToken.value.getInt().value())};
+        helperToken.args = {std::to_string(expressionToken.value.getIntAsInt64().value())};
     }
     else
     {

--- a/src/engine/source/json/include/json/json.hpp
+++ b/src/engine/source/json/include/json/json.hpp
@@ -308,6 +308,16 @@ public:
      */
     std::optional<int64_t> getInt64(std::string_view path = "") const;
 
+
+    /**
+     * @brief Get the value of the int or int64 field as int64.
+     *
+     * @param path The path to the field.
+     * @return std::optional<int64_t> The value of the field or nothing if the path not found.
+     * @throws std::runtime_error If the path is invalid.
+     */
+    std::optional<int64_t> getIntAsInt64(std::string_view path = "") const;
+
     /**
      * @brief get the value of the float field.
      * Overwrites previous value. If reference field is not found, sets base field to

--- a/src/engine/source/json/src/json.cpp
+++ b/src/engine/source/json/src/json.cpp
@@ -278,6 +278,33 @@ std::optional<int64_t> Json::getInt64(std::string_view path) const
     }
 }
 
+std::optional<int64_t> Json::getIntAsInt64(std::string_view path) const
+{
+    auto pp = rapidjson::Pointer(path.data());
+
+    if (pp.IsValid())
+    {
+        const auto* value = pp.Get(m_document);
+        if (value && value->IsInt64())
+        {
+            return value->GetInt64();
+        }
+        else if (value && value->IsInt())
+        {
+            return static_cast<int64_t>(value->GetInt());
+        }
+        else
+        {
+            return std::nullopt;
+        }
+    }
+    else
+    {
+        throw std::runtime_error(fmt::format("[Json::get(basePointerPath)] Invalid json path: '{}'", path));
+    }
+}
+
+
 std::optional<float_t> Json::getFloat(std::string_view path) const
 {
     auto pp = rapidjson::Pointer(path.data());
@@ -332,9 +359,17 @@ std::optional<double> Json::getNumberAsDouble(std::string_view path) const
             {
                 retval = static_cast<double>(value->GetInt());
             }
+            else if (value->IsInt64())
+            {
+                retval = static_cast<double>(value->GetInt64());
+            }
             else if (value->IsDouble())
             {
                 retval = value->GetDouble();
+            }
+            else if (value->IsFloat())
+            {
+                retval = value->GetFloat();
             }
         }
         return retval;

--- a/src/engine/source/yml/src/yml.cpp
+++ b/src/engine/source/yml/src/yml.cpp
@@ -29,6 +29,10 @@ rapidjson::Value Converter::parseScalar(const YAML::Node& node, rapidjson::Docum
     {
         v.SetInt(i);
     }
+    else if (int64_t i = 0; YAML::convert<int64_t>::decode(node, i))
+    {
+        v.SetInt64(i);
+    }
     else if (double d = 0.0f; YAML::convert<double>::decode(node, d))
     {
         v.SetDouble(d);

--- a/src/engine/test/source/builder/builders/opBuilderHelperDateFromEpochTime_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperDateFromEpochTime_test.cpp
@@ -51,7 +51,7 @@ TEST(opBuilderHelperDateFromEpochTime, wrongParameters)
 TEST(opBuilderHelperDateFromEpochTime, nonCorrectArguments)
 {
     // Big number (bigger than INT_MAX)
-    auto biggerThanMax = 1 + static_cast<uint64_t>(INT64_MAX);
+    auto biggerThanMax = 1 + static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
     auto event =
         std::make_shared<json::Json>(fmt::format(R"({{"field_ref": {}, "field": ""}})", biggerThanMax).c_str());
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -11,10 +11,10 @@
 using namespace base;
 namespace bld = builder::internals::builders;
 
-// INT_MAX = 2147483647
-constexpr auto almostMaxNum = INT_MAX - 1;
-// INT_MIN =-2147483648
-constexpr auto almostMinNum = INT_MIN + 1;
+// INT64_MAX = 
+constexpr auto almostMaxNum = INT64_MAX - 1;
+// INT64_MIN =-
+constexpr auto almostMinNum = INT64_MIN + 1;
 
 TEST(opBuilderHelperIntCalc, Builds)
 {
@@ -77,7 +77,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_sum)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(20, result.payload()->getInt("/field2check").value());
+    ASSERT_EQ(20, result.payload()->getInt64("/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_sub)
@@ -95,7 +95,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_sub)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(0, result.payload()->getInt("/field2check").value());
+    ASSERT_EQ(0, result.payload()->getInt64("/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_mul)
@@ -113,7 +113,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_mul)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(100, result.payload()->getInt("/field2check").value());
+    ASSERT_EQ(100, result.payload()->getInt64("/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_div)
@@ -131,7 +131,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_div)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(1, result.payload()->getInt("/field2check").value());
+    ASSERT_EQ(1, result.payload()->getInt64("/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_ref_field_not_exist)
@@ -167,7 +167,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_ref_sum)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(20, result.payload()->getInt("/field2check").value());
+    ASSERT_EQ(20, result.payload()->getInt64("/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_ref_sub)
@@ -186,7 +186,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_ref_sub)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(0, result.payload()->getInt("/field2check").value());
+    ASSERT_EQ(0, result.payload()->getInt64("/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_ref_mul)
@@ -205,7 +205,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_ref_mul)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(100, result.payload()->getInt("/field2check").value());
+    ASSERT_EQ(100, result.payload()->getInt64("/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_ref_division_by_zero)
@@ -241,7 +241,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_ref_div)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(1, result.payload()->getInt("/field2check").value());
+    ASSERT_EQ(1, result.payload()->getInt64("/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_field_not_exist)
@@ -293,7 +293,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_sum)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(20, result.payload()->getInt("/parentObjt_1/field2check").value());
+    ASSERT_EQ(20, result.payload()->getInt64("/parentObjt_1/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_sub)
@@ -320,7 +320,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_sub)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(0, result.payload()->getInt("/parentObjt_1/field2check").value());
+    ASSERT_EQ(0, result.payload()->getInt64("/parentObjt_1/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_mul)
@@ -347,7 +347,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_mul)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(100, result.payload()->getInt("/parentObjt_1/field2check").value());
+    ASSERT_EQ(100, result.payload()->getInt64("/parentObjt_1/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_div)
@@ -374,7 +374,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_div)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(1, result.payload()->getInt("/parentObjt_1/field2check").value());
+    ASSERT_EQ(1, result.payload()->getInt64("/parentObjt_1/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_ref_field_not_exist)
@@ -418,7 +418,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_ref_sum)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(20, result.payload()->getInt("/parentObjt_1/field2check").value());
+    ASSERT_EQ(20, result.payload()->getInt64("/parentObjt_1/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_ref_sub)
@@ -445,7 +445,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_ref_sub)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(0, result.payload()->getInt("/parentObjt_1/field2check").value());
+    ASSERT_EQ(0, result.payload()->getInt64("/parentObjt_1/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_ref_mul)
@@ -471,7 +471,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_ref_mul)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(100, result.payload()->getInt("/parentObjt_1/field2check").value());
+    ASSERT_EQ(100, result.payload()->getInt64("/parentObjt_1/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_ref_division_by_zero)
@@ -523,7 +523,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_multilevel_ref_div)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ(1, result.payload()->getInt("/parentObjt_1/field2check").value());
+    ASSERT_EQ(1, result.payload()->getInt64("/parentObjt_1/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_sum_multiple_parameters)
@@ -541,7 +541,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_sum_multiple_parameters)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ((1 + 10 + 20 + 30), result.payload()->getInt("/field2check").value());
+    ASSERT_EQ((1 + 10 + 20 + 30), result.payload()->getInt64("/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_sub_multiple_parameters)
@@ -559,7 +559,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_sub_multiple_parameters)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ((1 - 10 - 20 - 30), result.payload()->getInt("/field2check").value());
+    ASSERT_EQ((1 - 10 - 20 - 30), result.payload()->getInt64("/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_mul_multiple_parameters)
@@ -577,7 +577,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_mul_multiple_parameters)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ((1 * 10 * 20 * 30), result.payload()->getInt("/field2check").value());
+    ASSERT_EQ((1 * 10 * 20 * 30), result.payload()->getInt64("/field2check").value());
 }
 
 TEST(opBuilderHelperIntCalc, Exec_int_calc_div_multiple_parameters)
@@ -595,7 +595,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_div_multiple_parameters)
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ((1 / 10 / 20 / 30), result.payload()->getInt("/field2check").value());
+    ASSERT_EQ((1 / 10 / 20 / 30), result.payload()->getInt64("/field2check").value());
 }
 
 // Division by zero by value and reference with multiple arguments
@@ -699,7 +699,7 @@ TEST(opBuilderHelperIntCalc, Exec_int_calc_sum_multiple_parameters_values_and_re
 
     ASSERT_TRUE(result);
 
-    ASSERT_EQ((10 + 10 + 10 + 30), result.payload()->getInt("/field2check").value());
+    ASSERT_EQ((10 + 10 + 10 + 30), result.payload()->getInt64("/field2check").value());
 }
 
 // Failing on several non existing references

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -11,10 +11,8 @@
 using namespace base;
 namespace bld = builder::internals::builders;
 
-// INT64_MAX = 
-constexpr auto almostMaxNum = INT64_MAX - 1;
-// INT64_MIN =-
-constexpr auto almostMinNum = INT64_MIN + 1;
+constexpr auto almostMaxNum = std::numeric_limits<int64_t>::max() - 1;
+constexpr auto almostMinNum = std::numeric_limits<int64_t>::min() + 1;
 
 TEST(opBuilderHelperIntCalc, Builds)
 {

--- a/src/engine/test/source/json/json_test.cpp
+++ b/src/engine/test/source/json/json_test.cpp
@@ -1070,7 +1070,12 @@ TEST_P(IntAsInt64, IntAsInt64)
 
 INSTANTIATE_TEST_SUITE_P(Json,
                          IntAsInt64,
-                         ::testing::Values(0, 1, 2, 3, static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 10));
+                         ::testing::Values(0,
+                                           1,
+                                           2,
+                                           3,
+                                           static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 10,
+                                           static_cast<int64_t>(std::numeric_limits<int32_t>::min()) - 10));
 
 TEST_F(JsonGettersTest, GetFloat)
 {

--- a/src/engine/test/source/json/json_test.cpp
+++ b/src/engine/test/source/json/json_test.cpp
@@ -1042,6 +1042,36 @@ TEST_F(JsonGettersTest, GetInt64)
     ASSERT_THROW(jObjInt64.getInt64("object/key"), std::runtime_error);
 }
 
+// Test parameter for check if path if empty [should pass, input json str, path]
+class IntAsInt64 : public ::testing::TestWithParam<int64_t>
+{
+};
+
+TEST_P(IntAsInt64, IntAsInt64)
+{
+    auto number = GetParam();
+    Json inputJson {fmt::format(R"({{"a":{}}})", number).c_str()};
+
+    ASSERT_TRUE(inputJson.isNumber("/a"));
+    if (number > std::numeric_limits<int>::max() || number < std::numeric_limits<int>::min())
+    {
+        ASSERT_TRUE(inputJson.getInt64("/a").has_value());
+        ASSERT_EQ(inputJson.getInt64("/a").value(), number);
+    }
+    else
+    {
+        ASSERT_TRUE(inputJson.getInt("/a").has_value());
+        ASSERT_EQ(inputJson.getInt("/a").value(), number);
+    }
+
+    ASSERT_TRUE(inputJson.getIntAsInt64("/a").has_value());
+    ASSERT_EQ(inputJson.getIntAsInt64("/a").value(), number);
+}
+
+INSTANTIATE_TEST_SUITE_P(Json,
+                         IntAsInt64,
+                         ::testing::Values(0, 1, 2, 3, static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 10));
+
 TEST_F(JsonGettersTest, GetFloat)
 {
     // Success cases


### PR DESCRIPTION
|Related issue|
|---|
|#17731|

**Description:**

### Overview:
This PR addresses the differentiation between 32-bit and 64-bit numbers in the Wazuh Engine's parsing of JSON and YAML. The goal is to provide a seamless experience for users, ensuring numbers are handled consistently regardless of their size.

### Changes:
1. **Dynamic Number Parsing:** Enhanced the parsing mechanism to dynamically choose the storage type based on the number's size. Numbers stored as 32-bit are now always retrieved and converted to 64-bit when necessary.
2. **Helper Function Updates:** Modified helper functions to support both 32-bit and 64-bit numbers.
3. **Backward Compatibility:** Ensured that the changes are backward compatible, eliminating the need for converting existing assets.
4. **Normalization Updates:** Modified the normalization stage in assets to set all values to true, aligning with the provided YAML example.

### Fixes:
- Resolved the issue where numbers exceeding 32 bits in YAML assets were stored as doubles in the resulting JSON.
- Enhanced helper functions to work seamlessly with both 32-bit and 64-bit numbers.

### Testing:
- Manually tested the changes with various assets to ensure consistent behavior.
- Verified that the helper functions now support both 32-bit and 64-bit numbers.

### Additional Notes:
- This enhancement aligns with the expected behavior, providing users with a consistent experience when working with numbers in assets.

