### PR TITLE
Add discard_regex functionality to AWSServices classes

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -305,7 +305,9 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                                 free(cur_bucket->discard_regex);
                                 os_strdup(children[j]->content, cur_bucket->discard_regex);
                             } else {
-                                mwarn("Required attribute '%s' is missing in '%s'. No event will be skipped.", XML_DISCARD_FIELD, XML_DISCARD_REGEX);
+                                merror("Required attribute '%s' is missing in '%s'. This is a mandatory parameter.", XML_DISCARD_FIELD, XML_DISCARD_REGEX);
+                                OS_ClearNode(children);
+                                return OS_INVALID;
                             }
                         } else {
                             mwarn("No value was provided for '%s'. No event will be skipped.", XML_DISCARD_REGEX);
@@ -458,7 +460,14 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                             free(cur_service->discard_regex);
                             os_strdup(children[j]->content, cur_service->discard_regex);
                         } else {
-                            mwarn("Required attribute '%s' is missing in '%s'. No event will be skipped.", XML_DISCARD_FIELD, XML_DISCARD_REGEX);
+                             if(strcmp(*nodes[i]->values, CLOUDWATCHLOGS_SERVICE_TYPE) == 0){
+                                free(cur_service->discard_regex);
+                                os_strdup(children[j]->content, cur_service->discard_regex);
+                            } else {
+                                merror("Required attribute '%s' is missing in '%s'. This is a mandatory parameter.", XML_DISCARD_FIELD, XML_DISCARD_REGEX);
+                                OS_ClearNode(children);
+                                return OS_INVALID;
+                            }
                         }
                     } else {
                         mwarn("No value was provided for '%s'. No event will be skipped.", XML_DISCARD_REGEX);

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3289,7 +3289,7 @@ class AWSCloudWatchLogs(AWSService):
                             f'+++ The "{self.discard_regex.pattern}" regex found a match. The event will be skipped.',
                             2)
                         continue
-                debug('The message is "{}"'.format(event_msg), 3)
+                debug('The message is "{}"'.format(event_msg), 2)
                 debug('The message\'s timestamp is {}'.format(event["timestamp"]), 3)
                 self.send_msg(event_msg, dump_json=False)
                 sent_events += 1
@@ -3306,6 +3306,7 @@ class AWSCloudWatchLogs(AWSService):
 
             if sent_events:
                 debug(f"+++ Sent {sent_events} events to Analysisd", 1)
+                sent_events = 0
             else:
                 debug(f'+++ There are no new events in the "{log_group}" group', 1)
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -346,6 +346,30 @@ class WazuhIntegration:
 
         return sts_client
 
+    def event_should_be_skipped(self, event_):
+        def _check_recursive(json_item=None, nested_field: str = '', regex: str = ''):
+            field_list = nested_field.split('.', 1)
+            try:
+                expression_to_evaluate = json_item[field_list[0]]
+            except TypeError:
+                if isinstance(json_item, list):
+                    return any(_check_recursive(i, field_list[0], regex=regex) for i in json_item)
+                return False
+            except KeyError:
+                return False
+            if len(field_list) == 1:
+                def check_regex(exp):
+                    try:
+                        return re.match(regex, exp) is not None
+                    except TypeError:
+                        return isinstance(exp, list) and any(check_regex(ex) for ex in exp)
+
+                return check_regex(expression_to_evaluate)
+            return _check_recursive(expression_to_evaluate, field_list[1], regex=regex)
+
+        return self.discard_field and self.discard_regex \
+            and _check_recursive(event_, nested_field=self.discard_field, regex=self.discard_regex)
+
     def send_msg(self, msg, dump_json=True):
         """
         Sends an AWS event to the Wazuh Queue
@@ -1037,33 +1061,9 @@ class AWSBucket(WazuhIntegration):
                 self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
 
     def iter_events(self, event_list, log_key, aws_account_id):
-        def check_recursive(json_item=None, nested_field: str = '', regex: str = ''):
-            field_list = nested_field.split('.', 1)
-            try:
-                expression_to_evaluate = json_item[field_list[0]]
-            except TypeError:
-                if isinstance(json_item, list):
-                    return any(check_recursive(i, field_list[0], regex=regex) for i in json_item)
-                return False
-            except KeyError:
-                return False
-            if len(field_list) == 1:
-                def check_regex(exp):
-                    try:
-                        return re.match(regex, exp) is not None
-                    except TypeError:
-                        return isinstance(exp, list) and any(check_regex(ex) for ex in exp)
-
-                return check_regex(expression_to_evaluate)
-            return check_recursive(expression_to_evaluate, field_list[1], regex=regex)
-
-        def event_should_be_skipped(event_):
-            return self.discard_field and self.discard_regex \
-                and check_recursive(event_, nested_field=self.discard_field, regex=self.discard_regex)
-
         if event_list is not None:
             for event in event_list:
-                if event_should_be_skipped(event):
+                if self.event_should_be_skipped(event):
                     debug(
                         f'+++ The "{self.discard_regex.pattern}" regex found a match in the "{self.discard_field}" field. '
                         f'The event will be skipped.', 2)
@@ -2921,10 +2921,14 @@ class AWSInspector(AWSService):
         """
         if len(arn_list) != 0:
             response = self.client.describe_findings(findingArns=arn_list)['findings']
-            self.sent_events += len(response)
             debug(f"+++ Processing {len(response)} events", 3)
             for elem in response:
+                if self.event_should_be_skipped(elem):
+                    debug(f'+++ The "{self.discard_regex.pattern}" regex found a match in the "{self.discard_field}" '
+                          f'field. The event will be skipped.', 2)
+                    continue
                 self.send_msg(self.format_message(elem))
+                self.sent_events += 1
 
     def get_alerts(self):
         self.init_db(self.sql_create_table.format(table_name=self.db_table_name))
@@ -3233,6 +3237,7 @@ class AWSCloudWatchLogs(AWSService):
         A dict containing the Token for the next set of logs, the timestamp of the first fetched log and the timestamp
         of the latest one.
         """
+        sent_events = 0
         response = None
         min_start_time = start_time
         max_end_time = end_time if end_time is not None else start_time
@@ -3265,12 +3270,29 @@ class AWSCloudWatchLogs(AWSService):
             token = response['nextForwardToken']
             parameters['nextToken'] = token
 
+            debug('+++ Sending events to Analysisd...', 1)
             # Send events to Analysisd
             for event in response['events']:
-                debug('+++ Sending events to Analysisd...', 1)
-                debug('The message is "{}"'.format(event['message']), 2)
+                event_msg = event['message']
+                try:
+                    json_event = json.loads(event_msg)
+                    if self.event_should_be_skipped(json_event):
+                        debug(
+                            f'+++ The "{self.discard_regex.pattern}" regex found a match in the "{self.discard_field}" '
+                            f'field. The event will be skipped.', 2)
+                        continue
+                except ValueError:
+                    # event_msg is not a JSON object, check if discard_regex.pattern matches the given string
+                    debug(f"+++ Retrieved log event is not a JSON object.", 3)
+                    if re.match(self.discard_regex, event_msg):
+                        debug(
+                            f'+++ The "{self.discard_regex.pattern}" regex found a match. The event will be skipped.',
+                            2)
+                        continue
+                debug('The message is "{}"'.format(event_msg), 3)
                 debug('The message\'s timestamp is {}'.format(event["timestamp"]), 3)
-                self.send_msg(event['message'], dump_json=False)
+                self.send_msg(event_msg, dump_json=False)
+                sent_events += 1
 
                 if min_start_time is None:
                     min_start_time = event['timestamp']
@@ -3281,6 +3303,11 @@ class AWSCloudWatchLogs(AWSService):
                     max_end_time = event['timestamp']
                 elif event['timestamp'] > max_end_time:
                     max_end_time = event['timestamp']
+
+            if sent_events:
+                debug(f"+++ Sent {sent_events} events to Analysisd", 1)
+            else:
+                debug(f'+++ There are no new events in the "{log_group}" group', 1)
 
         return {'token': token, 'start_time': min_start_time, 'end_time': max_end_time}
 


### PR DESCRIPTION
|Related issue|
|---|
|#17388|


## Description

This PR closes #17388. It adds the `discard_regex` functionality to `AWSInspector` and `AWSCloudWatchLogs`, moving the logic from `AWSBucket` to `WazuhIntegration`.
Since `AWSCloudWatchLogs` fetches logs in string format, the parameter now allows not setting the `field` for those cases. For the other types of buckets and services, the module breaks the execution of the wazuh server process if the attribute is not part of the `discard_regex` parameter, thus introducing a breaking change.

## AWS Integration Tests

<details><summary>test_discard_regex</summary>
   
    pytest -vv wazuh-qa/tests/integration/test_aws/test_discard_regex.py
    ====================================================================== test session starts ======================================================================
    platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0 -- /usr/bin/python3
    cachedir: .pytest_cache
    metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.19.0-1025-aws-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.0.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.0'}}
    rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
    plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0
    collected 17 items                                                                                                                                              
    
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[cloudtrail_discard_regex] PASSED                                     [  5%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[vpc_discard_regex] PASSED                                            [ 11%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[config_discard_regex] PASSED                                         [ 17%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[alb_discard_regex] PASSED                                            [ 23%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[clb_discard_regex] PASSED                                            [ 29%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[nlb_discard_regex] PASSED                                            [ 35%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[kms_discard_regex] PASSED                                            [ 41%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[macie_discard_regex] PASSED                                          [ 47%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[trusted_advisor_discard_regex] PASSED                                [ 52%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[guardduty_discard_regex] PASSED                                      [ 58%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[native_guardduty_discard_regex] PASSED                               [ 64%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[waf_discard_regex] PASSED                                            [ 70%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[server_access_discard_regex] PASSED                                  [ 76%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_bucket_discard_regex[cisco_umbrella_discard_regex] PASSED                                 [ 82%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_cloudwatch_discard_regex_json[cloudwatch_discard_regex_json] PASSED                       [ 88%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_cloudwatch_discard_regex_simple_text[cloudwatch_discard_regex_simple_text] PASSED         [ 94%]
    wazuh-qa/tests/integration/test_aws/test_discard_regex.py::test_inspector_discard_regex[inspector_discard_regex] PASSED                                   [100%]
    
    ================================================================ 17 passed in 336.47s (0:05:36) =================================================================
</details>
