### PR TITLE
Migrate integration test scripts to docker v2

### DIFF
--- a/api/test/integration/pytest.ini
+++ b/api/test/integration/pytest.ini
@@ -2,6 +2,7 @@
 render_collapsed = True
 tavern-strict=json:off headers:off
 tavern-global-cfg=common.yaml
+asyncio_mode=auto
 markers =
     standalone: mark a test to be passed in a Wazuh standalone environment.
     cluster: mark a test to be passed in a Wazuh cluster environment.

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -441,7 +441,7 @@ def check_agentd_started(response, agents_list):
         while tries < 80:
             try:
                 # Save agentd logs in a list
-                command = f"docker exec env_wazuh-agent{int(agent_id)}_1 grep agentd /var/ossec/logs/ossec.log"
+                command = f"docker exec env-wazuh-agent{int(agent_id)}-1 grep agentd /var/ossec/logs/ossec.log"
                 output = subprocess.check_output(command.split()).decode().strip().split('\n')
             except subprocess.SubprocessError as exc:
                 raise subprocess.SubprocessError(f"Error while trying to get logs from agent {agent_id}") from exc
@@ -475,7 +475,7 @@ def check_agent_active_status(agents_list):
     while tries < 25:
         try:
             # Get active agents
-            output = subprocess.check_output(f"docker exec env_wazuh-master_1 /var/ossec/framework/python/bin/python3 "
+            output = subprocess.check_output(f"docker exec env-wazuh-master-1 /var/ossec/framework/python/bin/python3 "
                                              f"{active_agents_script_path}".split()).decode().strip()
         except subprocess.SubprocessError as exc:
             raise subprocess.SubprocessError("Error while trying to get agents") from exc


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/16812|

## Description
Use docker-compose V2 to run pytest tavern files.

## Test results

### Running test in jenkins
- This [check](https://ci.wazuh.info/view/Tests/job/Test_integration_endpoints/3654/) was run with the following parameters;
- **SOURCE_REFERENCE**: feature/16812-migrate-it-to-docker-v2
- **JENKINS_REFERENCE**: feature/5373-migrate-it-to-docker-v2
- **PYTEST_ARGS**: -v --tb=short
- **TEST_LIST**: test_decoder_endpoints.tavern.yaml,test_agent_GET_endpoints.tavern.yaml

The pipeline finished successfully.

The file Test_integration_endpoints_B3654_test_agent_GET_endpoints.txt file shows these header lines:

```
============================= test session starts ==============================
platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-1.2.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.19.0-1028-aws-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'asyncio': '0.18.1', 'html': '2.1.1', 'trio': '0.7.0', 'metadata': '3.0.0', 'tavern': '1.23.5', 'aiohttp': '1.0.4'}}
rootdir: /tmp/Test_integration_endpoints_B3654_test_files/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, html-2.1.1, trio-0.7.0, metadata-3.0.0, tavern-1.23.5, aiohttp-1.0.4
asyncio: mode=auto
```
Python 3.10.6 and newer pytest packages and plugins are now used to run the Integration tests.

The docker.log file contained in Test_integration_endpoints_B3654_test_agent_GET_endpoints_logs.zip show the containers name following docker-compose v2 style:

```
 Network env_default  Creating
 Network env_default  Created
 Container env-nginx-lb-1  Creating
 Container env-wazuh-worker1-1  Creating
 Container env-wazuh-worker2-1  Creating
 Container env-wazuh-master-1  Creating
 Container env-wazuh-worker1-1  Created
 Container env-wazuh-master-1  Created
 Container env-nginx-lb-1  Created
```

### Running test in development environment
In the development environment, several tavern files are allowed. On each tavern execution the environment is created and destroyed, avoiding conflicts between tests.


```

(venv-3.9) mhamra@DESKTOP-THP4I5R:~/wazuh/wazuh/api/test/integration$ pytest -vv --nobuild test_decoder_endpoints.tavern.yaml test_agent_GET_endpoints.tavern.yaml
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.2.0 -- /home/mhamra/wazuh/wazuh/venv-3.9/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.31', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'aiohttp': '1.0.4', 'asyncio': '0.18.1', 'trio': '0.7.0', 'tavern': '1.23.5', 'metadata': '3.0.0', 'html': '2.1.1'}}
rootdir: /home/mhamra/wazuh/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, asyncio-0.18.1, trio-0.7.0, tavern-1.23.5, metadata-3.0.0, html-2.1.1
asyncio: mode=auto
collected 118 items

test_decoder_endpoints.tavern.yaml::GET /decoders PASSED                                                                                                                                                  [  0%]
test_decoder_endpoints.tavern.yaml::GET /decoders[filename] PASSED                                                                                                                                        [  1%]
test_decoder_endpoints.tavern.yaml::GET /decoders[relative_dirname] PASSED                                                                                                                                [  2%]
test_decoder_endpoints.tavern.yaml::GET /decoders[name] PASSED                                                                                                                                            [  3%]
test_decoder_endpoints.tavern.yaml::GET /decoders[position] PASSED                                                                                                                                        [  4%]
test_decoder_endpoints.tavern.yaml::GET /decoders[status] PASSED                                                                                                                                          [  5%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name} PASSED                                                                                                                                   [  5%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[filename] PASSED                                                                                                                         [  6%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[relative_dirname] PASSED                                                                                                                 [  7%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[name] PASSED                                                                                                                             [  8%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[position] PASSED                                                                                                                         [  9%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[status] PASSED                                                                                                                           [ 10%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files PASSED                                                                                                                                            [ 11%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files[filename] PASSED                                                                                                                                  [ 11%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files[relative_dirname] PASSED                                                                                                                          [ 12%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files[status] PASSED                                                                                                                                    [ 13%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents PASSED                                                                                                                                          [ 14%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[filename] PASSED                                                                                                                                [ 15%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[name] PASSED                                                                                                                                    [ 16%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[relative_dirname] PASSED                                                                                                                        [ 16%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[position] PASSED                                                                                                                                [ 17%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[status] PASSED                                                                                                                                  [ 18%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files/(filename) PASSED                                                                                                                                 [ 19%]
test_decoder_endpoints.tavern.yaml::PUT /rule/decoders/{filename} PASSED                                                                                                                                  [ 20%]
test_decoder_endpoints.tavern.yaml::DELETE /decoders/files/{filename} PASSED                                                                                                                              [ 21%]
test_agent_GET_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                                  [ 22%]
test_agent_GET_endpoints.tavern.yaml::GET /agents with single agent id PASSED                                                                                                                             [ 22%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                                    [ 23%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} (only cluster configuration) PASSED                                                                       [ 24%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                                         [ 25%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                                   [ 26%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                                                                                                         [ 27%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                                                                                     [ 27%]
test_agent_GET_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                                  [ 28%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED                                                                                                                                 [ 29%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED                                                                                                                                [ 30%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED                                                                                                                              [ 31%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED                                                                                                                              [ 32%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED                                                                                                                              [ 33%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED                                                                                                                              [ 33%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED                                                                                                                             [ 34%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED                                                                                                                             [ 35%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED                                                                                                                            [ 36%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED                                                                                                                            [ 37%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED                                                                                                                            [ 38%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED                                                                                                                            [ 38%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                                [ 39%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED                                                                                                       [ 40%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED                                                                                                         [ 41%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED                                                                                                           [ 42%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED                                                                                                              [ 43%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED                                                                                                              [ 44%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED                                                                                                   [ 44%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED                                                                                                         [ 45%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED                                                                                                       [ 46%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED                                                                                                            [ 47%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED                                                                                                       [ 48%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED                                                                                                         [ 49%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED                                                                                                        [ 50%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED                                                                                                     [ 50%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED                                                                                                        [ 51%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED                                                                                                        [ 52%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED                                                                                                         [ 53%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED                                                                                                     [ 54%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED                                                                                                        [ 55%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED                                                                                                      [ 55%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED                                                                                                      [ 56%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED                                                                                                          [ 57%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED                                                                                                         [ 58%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                                         [ 59%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                                 [ 60%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED                                                                                                                [ 61%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED                                                                                                               [ 61%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED                                                                                                             [ 62%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED                                                                                                             [ 63%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED                                                                                                             [ 64%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED                                                                                                             [ 65%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED                                                                                                            [ 66%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED                                                                                                            [ 66%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED                                                                                                           [ 67%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED                                                                                                           [ 68%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED                                                                                                           [ 69%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED                                                                                                           [ 70%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                                                 [ 71%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                                                  [ 72%]
test_agent_GET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                                  [ 72%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                                         [ 73%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED                                                                                                                  [ 74%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED                                                                                                                       [ 75%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED                                                                                                                       [ 76%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED                                                                                                                     [ 77%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED                                                                                                                [ 77%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED                                                                                                               [ 78%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED                                                                                                                   [ 79%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                                         [ 80%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                                   [ 81%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED                                                                                                                 [ 82%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED                                                                                                                      [ 83%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED                                                                                                                      [ 83%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED                                                                                                           [ 84%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED                                                                                                                 [ 85%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED                                                                                                                    [ 86%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED                                                                                                               [ 87%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED                                                                                                                 [ 88%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED                                                                                                                [ 88%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED                                                                                                             [ 89%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED                                                                                                                [ 90%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED                                                                                                                [ 91%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED                                                                                                                 [ 92%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED                                                                                                             [ 93%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED                                                                                                                [ 94%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED                                                                                                              [ 94%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED                                                                                                              [ 95%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED                                                                                                                  [ 96%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED                                                                                                                 [ 97%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                                   [ 98%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                                       [ 99%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                                                   [100%]

=============================================================================================== warnings summary ================================================================================================
../../../venv-3.9/lib/python3.9/site-packages/_pytest/nodes.py:642
../../../venv-3.9/lib/python3.9/site-packages/_pytest/nodes.py:642
  /home/mhamra/wazuh/wazuh/venv-3.9/lib/python3.9/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== 118 passed, 2 warnings in 321.64s (0:05:21) ==================================================================================

```
The file api/test/integration/_test_results/logs/docker.log shows that the containers are created, stopped, and removed twice.

```
(venv-3.9) mhamra@DESKTOP-THP4I5R:~/wazuh/wazuh/api/test/integration/_test_results/logs$ more docker.log
 Container env-wazuh-worker2-1  Creating
 Container env-wazuh-master-1  Creating
 Container env-nginx-lb-1  Creating
 Container env-wazuh-worker1-1  Creating
 Container env-wazuh-worker2-1  Created
 Container env-nginx-lb-1  Created
 Container env-wazuh-agent1-1  Creating
 Container env-wazuh-worker1-1  Created
 Container env-wazuh-master-1  Created
 Container env-wazuh-agent1-1  Created
 Container env-wazuh-agent2-1  Creating
 Container env-wazuh-agent2-1  Created
 Container env-wazuh-agent3-1  Creating
 Container env-wazuh-agent3-1  Created
 Container env-wazuh-agent4-1  Creating
 Container env-wazuh-agent4-1  Created
 Container env-wazuh-agent5-1  Creating
 Container env-wazuh-agent5-1  Created
 Container env-wazuh-agent6-1  Creating
 Container env-wazuh-agent6-1  Created
 Container env-wazuh-agent7-1  Creating
 Container env-wazuh-agent7-1  Created
 Container env-wazuh-agent8-1  Creating
 Container env-wazuh-agent8-1  Created
 Container env-nginx-lb-1  Starting
 Container env-wazuh-worker1-1  Starting
 Container env-wazuh-worker2-1  Starting
 Container env-wazuh-master-1  Starting
 Container env-nginx-lb-1  Started
 Container env-wazuh-agent1-1  Starting
 Container env-wazuh-worker1-1  Started
 Container env-wazuh-master-1  Started
 Container env-wazuh-worker2-1  Started
 Container env-wazuh-agent1-1  Started
 Container env-wazuh-agent2-1  Starting
 Container env-wazuh-agent2-1  Started
 Container env-wazuh-agent3-1  Starting
 Container env-wazuh-agent3-1  Started
 Container env-wazuh-agent4-1  Starting
 Container env-wazuh-agent4-1  Started
 Container env-wazuh-agent5-1  Starting
 Container env-wazuh-agent5-1  Started
 Container env-wazuh-agent6-1  Starting
 Container env-wazuh-agent6-1  Started
 Container env-wazuh-agent7-1  Starting
 Container env-wazuh-agent7-1  Started
 Container env-wazuh-agent8-1  Starting
 Container env-wazuh-agent8-1  Started
time="2023-07-31T15:29:16-03:00" level=warning msg="The \"ENV_MODE\" variable is not set. Defaulting to a blank string."
time="2023-07-31T15:29:16-03:00" level=warning msg="The \"ENV_MODE\" variable is not set. Defaulting to a blank string."
 Container env-wazuh-agent8-1  Stopping
 Container env-wazuh-worker1-1  Stopping
 Container env-nginx-lb-1  Stopping
 Container env-wazuh-worker2-1  Stopping
 Container env-wazuh-agent7-1  Stopping
 Container env-wazuh-agent6-1  Stopping
 Container env-wazuh-agent3-1  Stopping
 Container env-wazuh-agent2-1  Stopping
 Container env-wazuh-agent1-1  Stopping
 Container env-wazuh-master-1  Stopping
 Container env-wazuh-agent5-1  Stopping
 Container env-wazuh-agent4-1  Stopping
 Container env-wazuh-agent7-1  Stopped
 Container env-wazuh-agent7-1  Removing
 Container env-wazuh-agent7-1  Removed
 Container env-wazuh-agent8-1  Stopped
 Container env-wazuh-agent8-1  Removing
 Container env-wazuh-agent8-1  Removed
 Container env-wazuh-agent5-1  Stopped
 Container env-wazuh-agent5-1  Removing
 Container env-wazuh-agent5-1  Removed
 Container env-wazuh-agent2-1  Stopped
 Container env-wazuh-agent2-1  Removing
 Container env-wazuh-agent2-1  Removed
 Container env-wazuh-worker1-1  Stopped
 Container env-wazuh-worker1-1  Removing
 Container env-wazuh-worker1-1  Removed
 Container env-wazuh-worker2-1  Stopped
 Container env-wazuh-worker2-1  Removing
 Container env-wazuh-worker2-1  Removed
 Container env-wazuh-agent4-1  Stopped
 Container env-wazuh-agent4-1  Removing
 Container env-wazuh-agent4-1  Removed
 Container env-wazuh-agent6-1  Stopped
 Container env-wazuh-agent6-1  Removing
 Container env-wazuh-agent6-1  Removed
 Container env-wazuh-agent3-1  Stopped
 Container env-wazuh-agent3-1  Removing
 Container env-wazuh-agent3-1  Removed
 Container env-wazuh-agent1-1  Stopped
 Container env-wazuh-agent1-1  Removing
 Container env-wazuh-agent1-1  Removed
 Container env-nginx-lb-1  Stopped
 Container env-nginx-lb-1  Removing
 Container env-nginx-lb-1  Removed
 Container env-wazuh-master-1  Stopped
 Container env-wazuh-master-1  Removing
 Container env-wazuh-master-1  Removed
 Container env-wazuh-worker1-1  Creating
 Container env-wazuh-worker2-1  Creating
 Container env-wazuh-master-1  Creating
 Container env-nginx-lb-1  Creating
 Container env-wazuh-worker1-1  Created
 Container env-nginx-lb-1  Created
 Container env-wazuh-agent1-1  Creating
 Container env-wazuh-master-1  Created
 Container env-wazuh-worker2-1  Created
 Container env-wazuh-agent1-1  Created
 Container env-wazuh-agent2-1  Creating
 Container env-wazuh-agent2-1  Created
 Container env-wazuh-agent3-1  Creating
 Container env-wazuh-agent3-1  Created
 Container env-wazuh-agent4-1  Creating
 Container env-wazuh-agent4-1  Created
 Container env-wazuh-agent5-1  Creating
 Container env-wazuh-agent5-1  Created
 Container env-wazuh-agent6-1  Creating
 Container env-wazuh-agent6-1  Created
 Container env-wazuh-agent7-1  Creating
 Container env-wazuh-agent7-1  Created
 Container env-wazuh-agent8-1  Creating
 Container env-wazuh-agent8-1  Created
 Container env-nginx-lb-1  Starting
 Container env-wazuh-worker1-1  Starting
 Container env-wazuh-worker2-1  Starting
 Container env-wazuh-master-1  Starting
 Container env-wazuh-worker1-1  Started
 Container env-nginx-lb-1  Started
 Container env-wazuh-agent1-1  Starting
 Container env-wazuh-worker2-1  Started
 Container env-wazuh-master-1  Started
 Container env-wazuh-agent1-1  Started
 Container env-wazuh-agent2-1  Starting
 Container env-wazuh-agent2-1  Started
 Container env-wazuh-agent3-1  Starting
 Container env-wazuh-agent3-1  Started
 Container env-wazuh-agent4-1  Starting
 Container env-wazuh-agent4-1  Started
 Container env-wazuh-agent5-1  Starting
 Container env-wazuh-agent5-1  Started
 Container env-wazuh-agent6-1  Starting
 Container env-wazuh-agent6-1  Started
 Container env-wazuh-agent7-1  Starting
 Container env-wazuh-agent7-1  Started
 Container env-wazuh-agent8-1  Starting
 Container env-wazuh-agent8-1  Started
time="2023-07-31T15:32:27-03:00" level=warning msg="The \"ENV_MODE\" variable is not set. Defaulting to a blank string."
time="2023-07-31T15:32:27-03:00" level=warning msg="The \"ENV_MODE\" variable is not set. Defaulting to a blank string."
 Container env-wazuh-worker1-1  Stopping
 Container env-wazuh-agent8-1  Stopping
 Container env-wazuh-worker2-1  Stopping
 Container env-wazuh-agent6-1  Stopping
 Container env-wazuh-agent1-1  Stopping
 Container env-wazuh-agent3-1  Stopping
 Container env-wazuh-agent7-1  Stopping
 Container env-wazuh-agent4-1  Stopping
 Container env-wazuh-master-1  Stopping
 Container env-nginx-lb-1  Stopping
 Container env-wazuh-agent2-1  Stopping
 Container env-wazuh-agent5-1  Stopping
 Container env-wazuh-agent8-1  Stopped
 Container env-wazuh-agent8-1  Removing
 Container env-wazuh-agent8-1  Removed
 Container env-wazuh-agent1-1  Stopped
 Container env-wazuh-agent1-1  Removing
 Container env-wazuh-agent1-1  Removed
 Container env-wazuh-agent5-1  Stopped
 Container env-wazuh-agent5-1  Removing
 Container env-wazuh-agent5-1  Removed
 Container env-wazuh-agent3-1  Stopped
 Container env-wazuh-agent3-1  Removing
 Container env-wazuh-agent3-1  Removed
 Container env-wazuh-agent7-1  Stopped
 Container env-wazuh-agent7-1  Removing
 Container env-wazuh-agent7-1  Removed
 Container env-wazuh-agent6-1  Stopped
 Container env-wazuh-agent6-1  Removing
 Container env-wazuh-agent6-1  Removed
 Container env-wazuh-agent2-1  Stopped
 Container env-wazuh-agent2-1  Removing
 Container env-wazuh-agent2-1  Removed
 Container env-wazuh-worker1-1  Stopped
 Container env-wazuh-worker1-1  Removing
 Container env-wazuh-worker1-1  Removed
 Container env-wazuh-agent4-1  Stopped
 Container env-wazuh-agent4-1  Removing
 Container env-wazuh-agent4-1  Removed
 Container env-wazuh-master-1  Stopped
 Container env-wazuh-master-1  Removing
 Container env-wazuh-master-1  Removed
 Container env-wazuh-worker2-1  Stopped
 Container env-wazuh-worker2-1  Removing
 Container env-wazuh-worker2-1  Removed
 Container env-nginx-lb-1  Stopped
 Container env-nginx-lb-1  Removing
 Container env-nginx-lb-1  Removed


```