### PR TITLE
Add tests to the ExecutionContext class

### DIFF
--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -54,6 +54,7 @@ private:
         if (std::filesystem::exists(outputFolderPath))
         {
             // Delete the output folder to avoid conflicts.
+            std::cout << "The previous output folder: " << outputFolderPath << " will be removed." << std::endl;
             std::filesystem::remove_all(outputFolderPath);
         }
 

--- a/src/shared_modules/content_manager/tests/unit/executionContext_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/executionContext_test.cpp
@@ -49,12 +49,7 @@ TEST_F(ExecutionContextTest, TestDefaultFolderWhenThereIsNoConfigurationForTheOu
 
     m_spUpdaterBaseContext->configData.erase("outputFolder");
 
-    // Start silence stdout
-    testing::internal::CaptureStdout();
-
     m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
-
-    testing::internal::GetCapturedStdout();
 
     EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, GENERIC_OUTPUT_FOLDER_PATH);
 
@@ -71,12 +66,7 @@ TEST_F(ExecutionContextTest, TestDefaultFolderWhenTheOutputFolderPathIsEmpty)
 
     m_spUpdaterBaseContext->configData["outputFolder"] = "";
 
-    // Start silence stdout
-    testing::internal::CaptureStdout();
-
     m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
-
-    testing::internal::GetCapturedStdout();
 
     EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, GENERIC_OUTPUT_FOLDER_PATH);
 
@@ -93,12 +83,7 @@ TEST_F(ExecutionContextTest, TestValidCaseWhenTheOutputFolderPathIsNotEmpty)
     // Remove the output folder if exists
     removeOutputFolderIfExists(expectedOutputFolder);
 
-    // Start silence stdout
-    testing::internal::CaptureStdout();
-
     m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
-
-    testing::internal::GetCapturedStdout();
 
     EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, expectedOutputFolder);
 
@@ -115,15 +100,11 @@ TEST_F(ExecutionContextTest, TestValidCaseWhenTheOutputFolderPathIsNotEmptyAndEx
 
     // Remove the output folder if exists
     removeOutputFolderIfExists(expectedOutputFolder);
+
     // Create the output folder.
     std::filesystem::create_directory(expectedOutputFolder);
 
-    // Start silence stdout
-    testing::internal::CaptureStdout(); 
-
     m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
-
-    testing::internal::GetCapturedStdout();
 
     EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, expectedOutputFolder);
 

--- a/src/shared_modules/content_manager/tests/unit/executionContext_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/executionContext_test.cpp
@@ -47,17 +47,14 @@ TEST_F(ExecutionContextTest, TestDefaultFolderWhenThereIsNoConfigurationForTheOu
     // Remove the output folder if exists
     removeOutputFolderIfExists(GENERIC_OUTPUT_FOLDER_PATH);
 
-    const auto expectedCapturedOutput = "Created output folder: \"" + GENERIC_OUTPUT_FOLDER_PATH + "\"\n";
-
     m_spUpdaterBaseContext->configData.erase("outputFolder");
 
+    // Start silence stdout
     testing::internal::CaptureStdout();
 
     m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
 
-    const auto capturedOutput {testing::internal::GetCapturedStdout()};
-
-    EXPECT_EQ(capturedOutput, expectedCapturedOutput);
+    testing::internal::GetCapturedStdout();
 
     EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, GENERIC_OUTPUT_FOLDER_PATH);
 
@@ -72,17 +69,14 @@ TEST_F(ExecutionContextTest, TestDefaultFolderWhenTheOutputFolderPathIsEmpty)
     // Remove the output folder if exists
     removeOutputFolderIfExists(GENERIC_OUTPUT_FOLDER_PATH);
 
-    const auto expectedCapturedOutput = "Created output folder: \"" + GENERIC_OUTPUT_FOLDER_PATH + "\"\n";
-
     m_spUpdaterBaseContext->configData["outputFolder"] = "";
 
+    // Start silence stdout
     testing::internal::CaptureStdout();
 
     m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
 
-    const auto capturedOutput {testing::internal::GetCapturedStdout()};
-
-    EXPECT_EQ(capturedOutput, expectedCapturedOutput);
+    testing::internal::GetCapturedStdout();
 
     EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, GENERIC_OUTPUT_FOLDER_PATH);
 
@@ -95,18 +89,16 @@ TEST_F(ExecutionContextTest, TestDefaultFolderWhenTheOutputFolderPathIsEmpty)
 TEST_F(ExecutionContextTest, TestValidCaseWhenTheOutputFolderPathIsNotEmpty)
 {
     const auto expectedOutputFolder {m_spUpdaterBaseContext->configData.at("outputFolder").get<const std::string>()};
-    const auto expectedCapturedOutput = "Created output folder: \"" + expectedOutputFolder + "\"\n";
 
     // Remove the output folder if exists
     removeOutputFolderIfExists(expectedOutputFolder);
 
+    // Start silence stdout
     testing::internal::CaptureStdout();
 
     m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
 
-    const auto capturedOutput {testing::internal::GetCapturedStdout()};
-
-    EXPECT_EQ(capturedOutput, expectedCapturedOutput);
+    testing::internal::GetCapturedStdout();
 
     EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, expectedOutputFolder);
 
@@ -120,22 +112,18 @@ TEST_F(ExecutionContextTest, TestValidCaseWhenTheOutputFolderPathIsNotEmptyAndEx
 {
     m_spUpdaterBaseContext->configData["outputFolder"] = "/tmp/output-folder";
     const auto expectedOutputFolder {m_spUpdaterBaseContext->configData.at("outputFolder").get<const std::string>()};
-    const auto expectedCapturedOutput = "The previous output folder: \"" + expectedOutputFolder +
-                                        "\" will be removed.\nCreated output folder: \"" + expectedOutputFolder +
-                                        "\"\n";
 
     // Remove the output folder if exists
     removeOutputFolderIfExists(expectedOutputFolder);
     // Create the output folder.
     std::filesystem::create_directory(expectedOutputFolder);
 
-    testing::internal::CaptureStdout();
+    // Start silence stdout
+    testing::internal::CaptureStdout(); 
 
     m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
 
-    const auto capturedOutput {testing::internal::GetCapturedStdout()};
-
-    EXPECT_EQ(capturedOutput, expectedCapturedOutput);
+    testing::internal::GetCapturedStdout();
 
     EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, expectedOutputFolder);
 

--- a/src/shared_modules/content_manager/tests/unit/executionContext_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/executionContext_test.cpp
@@ -12,6 +12,23 @@
 #include "executionContext_test.hpp"
 #include "executionContext.hpp"
 #include "updaterContext.hpp"
+#include <filesystem>
+#include <memory>
+#include <string>
+
+/**
+ * @brief Removes the directory if it exists.
+ *
+ * @param outputFolder Folder to be removed.
+ */
+void removeOutputFolderIfExists(const std::string& outputFolder)
+{
+    if (std::filesystem::exists(outputFolder))
+    {
+        // Delete the output folder.
+        std::filesystem::remove_all(outputFolder);
+    }
+}
 
 /*
  * @brief Tests the instantiation of the ExecutionContext class
@@ -20,4 +37,107 @@ TEST_F(ExecutionContextTest, instantiation)
 {
     // Check that the ExecutionContext class can be instantiated
     EXPECT_NO_THROW(std::make_shared<ExecutionContext>());
+}
+
+/*
+ * @brief Test default folder when there is no configuration for the output folder.
+ */
+TEST_F(ExecutionContextTest, TestDefaultFolderWhenThereIsNoConfigurationForTheOutputFolder)
+{
+    // Remove the output folder if exists
+    removeOutputFolderIfExists(GENERIC_OUTPUT_FOLDER_PATH);
+
+    const auto expectedCapturedOutput = "Created output folder: \"" + GENERIC_OUTPUT_FOLDER_PATH + "\"\n";
+
+    m_spUpdaterBaseContext->configData.erase("outputFolder");
+
+    testing::internal::CaptureStdout();
+
+    m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
+
+    const auto capturedOutput {testing::internal::GetCapturedStdout()};
+
+    EXPECT_EQ(capturedOutput, expectedCapturedOutput);
+
+    EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, GENERIC_OUTPUT_FOLDER_PATH);
+
+    EXPECT_TRUE(std::filesystem::exists(m_spUpdaterBaseContext->outputFolder));
+}
+
+/*
+ * @brief Test default folder when the output folder path is empty.
+ */
+TEST_F(ExecutionContextTest, TestDefaultFolderWhenTheOutputFolderPathIsEmpty)
+{
+    // Remove the output folder if exists
+    removeOutputFolderIfExists(GENERIC_OUTPUT_FOLDER_PATH);
+
+    const auto expectedCapturedOutput = "Created output folder: \"" + GENERIC_OUTPUT_FOLDER_PATH + "\"\n";
+
+    m_spUpdaterBaseContext->configData["outputFolder"] = "";
+
+    testing::internal::CaptureStdout();
+
+    m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
+
+    const auto capturedOutput {testing::internal::GetCapturedStdout()};
+
+    EXPECT_EQ(capturedOutput, expectedCapturedOutput);
+
+    EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, GENERIC_OUTPUT_FOLDER_PATH);
+
+    EXPECT_TRUE(std::filesystem::exists(m_spUpdaterBaseContext->outputFolder));
+}
+
+/*
+ * @brief Test valid case when the output folder path is not empty.
+ */
+TEST_F(ExecutionContextTest, TestValidCaseWhenTheOutputFolderPathIsNotEmpty)
+{
+    const auto expectedOutputFolder {m_spUpdaterBaseContext->configData.at("outputFolder").get<const std::string>()};
+    const auto expectedCapturedOutput = "Created output folder: \"" + expectedOutputFolder + "\"\n";
+
+    // Remove the output folder if exists
+    removeOutputFolderIfExists(expectedOutputFolder);
+
+    testing::internal::CaptureStdout();
+
+    m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
+
+    const auto capturedOutput {testing::internal::GetCapturedStdout()};
+
+    EXPECT_EQ(capturedOutput, expectedCapturedOutput);
+
+    EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, expectedOutputFolder);
+
+    EXPECT_TRUE(std::filesystem::exists(m_spUpdaterBaseContext->outputFolder));
+}
+
+/*
+ * @brief Test valid case when the output folder path is not empty and already exists.
+ */
+TEST_F(ExecutionContextTest, TestValidCaseWhenTheOutputFolderPathIsNotEmptyAndExists)
+{
+    m_spUpdaterBaseContext->configData["outputFolder"] = "/tmp/output-folder";
+    const auto expectedOutputFolder {m_spUpdaterBaseContext->configData.at("outputFolder").get<const std::string>()};
+    const auto expectedCapturedOutput = "The previous output folder: \"" + expectedOutputFolder +
+                                        "\" will be removed.\nCreated output folder: \"" + expectedOutputFolder +
+                                        "\"\n";
+
+    // Remove the output folder if exists
+    removeOutputFolderIfExists(expectedOutputFolder);
+    // Create the output folder.
+    std::filesystem::create_directory(expectedOutputFolder);
+
+    testing::internal::CaptureStdout();
+
+    m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);
+
+    const auto capturedOutput {testing::internal::GetCapturedStdout()};
+
+    EXPECT_EQ(capturedOutput, expectedCapturedOutput);
+
+    EXPECT_EQ(m_spUpdaterBaseContext->outputFolder, expectedOutputFolder);
+
+    EXPECT_TRUE(std::filesystem::exists(m_spUpdaterBaseContext->outputFolder));
 }

--- a/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
@@ -12,7 +12,10 @@
 #ifndef _EXECUTION_CONTEXT_TEST_HPP
 #define _EXECUTION_CONTEXT_TEST_HPP
 
+#include "executionContext.hpp"
+#include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <memory>
 
 /**
  * @brief Runs unit tests for ExecutionContext
@@ -22,6 +25,30 @@ class ExecutionContextTest : public ::testing::Test
 protected:
     ExecutionContextTest() = default;
     ~ExecutionContextTest() override = default;
+
+    std::shared_ptr<UpdaterContext> m_spUpdaterContext; ///< UpdaterContext used on the merge pipeline.
+
+    std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on the merge pipeline.
+
+    std::shared_ptr<ExecutionContext> m_spExecutionContext; ///< ExecutionContext.
+
+    /**
+     * @brief Sets initial conditions for each test case.
+     *
+     */
+    // cppcheck-suppress unusedFunction
+    void SetUp() override
+    {
+        m_spExecutionContext = std::make_shared<ExecutionContext>();
+        // Create a updater context
+        m_spUpdaterContext = std::make_shared<UpdaterContext>();
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spUpdaterBaseContext->configData = R"(
+            {
+                "outputFolder": "/tmp/content_manager"
+            }
+        )"_json;
+    }
 };
 
 #endif //_EXECUTION_CONTEXT_TEST_HPP


### PR DESCRIPTION
|Related issue|
|---|
| Closes #17702 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR aims to add unit tests to the ExecutionContext class. Component tests are not added because this class does not have dependencies on other classes. Additionally, the [removeOutputFolderIfExists](https://github.com/wazuh/wazuh/blob/2649c354f9e5857066599c37cff567f6e50ed4b2/src/shared_modules/content_manager/tests/unit/executionContext_test.cpp#L24) function was added so the tests will not depend on previous executions since these do not remove the folders and create conflicts with other tests.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->