### PR TITLE
FPs 92655 due to substring false positive

### DIFF
--- a/ruleset/rules/0840-win_event_channel.xml
+++ b/ruleset/rules/0840-win_event_channel.xml
@@ -2,11 +2,11 @@
   Copyright (C) 2015, Wazuh Inc.
 -->
 
-<!--
+<!-- 
   General Windows Event channel detection rules: 92650 - 92700
 -->
 
-<group name="win_evt_channel,windows,">
+<group name="win_evt_channel,">
 
   <rule id="92650" level="12">
     <if_sid>61138</if_sid>
@@ -33,10 +33,9 @@
   <rule id="92652" level="6">
     <if_sid>92651</if_sid>
     <field name="win.eventdata.authenticationPackageName" type="pcre2">NTLM</field>
-    <description>Successful Remote Logon Detected - User:$(win.eventdata.subjectDomainName)\$(win.eventdata.targetUserName) - NTLM authentication, possible pass-the-hash attack.</description>
+    <description>Successful Remote Logon Detected - NTLM authentication, possible pass-the-hash attack.</description>
     <mitre>
       <id>T1550.002</id>
-      <id>T1078.002</id>
     </mitre>
     <group>authentication_success,gdpr_IV_32.2,gpg13_7.1,gpg13_7.2,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -64,7 +63,7 @@
 
   <rule id="92655" level="15">
     <if_sid>60011</if_sid>
-    <field name="win.system.eventID" type="pcre2">808</field>
+    <field name="win.system.eventID">^808$</field>
     <description>Printer driver failed to load, possible remote code execution using PrinterNightmare exploit: CVE-2021-34527.</description>
     <mitre>
       <id>T1210</id>
@@ -74,27 +73,12 @@
 
   <rule id="92656" level="15">
     <if_sid>60106</if_sid>
-    <field name="win.eventdata.logonType" type="pcre2">^10$</field>
     <field name="win.eventdata.ipAddress" type="pcre2">::1|127\.0\.0\.1</field>
     <description>User: $(win.eventdata.subjectDomainName)\$(win.eventdata.targetUserName) logged using Remote Desktop Connection (RDP) from loopback address, possible exploit over reverse tunneling using stolen credentials.</description>
     <mitre>
       <id>T1021.001</id>
       <id>T1078.002</id>
     </mitre>
-  </rule>
-
-  <rule id="92657" level="6">
-    <if_sid>92652</if_sid>
-    <field name="win.eventdata.workstationName" type="pcre2">.+</field>
-    <description>Successful Remote Logon Detected - User:$(win.eventdata.subjectDomainName)\$(win.eventdata.targetUserName) - NTLM authentication, possible pass-the-hash attack - Possible RDP connection. Verify that $(win.eventdata.workstationName) is allowed to perform RDP connections</description>
-    <mitre>
-      <id>T1550.002</id>
-      <id>T1078.002</id>
-      <id>T1021.001</id>
-    </mitre>
-    <group>
-      authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
-    </group>
   </rule>
 
 </group>


### PR DESCRIPTION
|Related issue|
|---|
|#13174|

Matching Windows eventID just for 808 will catch other eventIDs like event 33808 that have nothing to do this rule.  Always match specific event ID numbers surrounded by ^ and $ symbols so you are not just searching for a substring.  
Also this rule has no need for PCRE2.  Plain OS_Match or OS_Regex can handle what we're doing here.   I assume from a CPU performance standpoint we only want to use PCRE2 when it is actually giving us benefit beyond what we can already do easily with the older/faster OS_Match or OS_Regex options.


<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors