### PR TITLE
Rework SCA policy for Ubuntu Linux 20.04 (CIS v2.0.0)

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for Ubuntu Linux 20.04 LTS
-# Copyright (C) 2015, Wazuh Inc.
+# Copyright (C) 2023, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -8,12 +8,12 @@
 # Foundation
 #
 # Based on:
-# Center for Internet Security Ubuntu Linux 20.04 LTS Benchmark v1.1.0 - 03-31-2021
+# Center for Internet Security Ubuntu Linux 20.04 LTS Benchmark v2.0.0 - 05-30-2023
 
 policy:
   id: "cis_ubuntu20-04"
   file: "cis_ubuntu20-04.yml"
-  name: "CIS Ubuntu Linux 20.04 LTS Benchmark v1.1.0"
+  name: "CIS Ubuntu Linux 20.04 LTS Benchmark v2.0.0"
   description: "This document provides prescriptive guidance for establishing a secure configuration posture for Ubuntu Linux 20.04 LTS."
   references:
     - https://www.cisecurity.org/cis-benchmarks/
@@ -27,781 +27,909 @@ requirements:
     - "f:/proc/sys/kernel/ostype -> Linux"
 
 checks:
-  ############################################################
-  # 1 Initial Setup
-  ############################################################
+  # 1.1.1.1 Ensure mounting of cramfs filesystems is disabled. (Automated) - Not Implemented
+  # 1.1.1.2 Ensure mounting of freevxfs filesystems is disabled. (Automated) - Not Implemented
+  # 1.1.1.4 Ensure mounting of hfs filesystems is disabled. (Automated) - Not Implemented
+  # 1.1.1.5 Ensure mounting of hfsplus filesystems is disabled. (Automated) - Not Implemented
+  # 1.1.1.6 Ensure mounting of squashfs filesystems is disabled. (Automated) - Not Implemented
+  # 1.1.1.7 Ensure mounting of udf filesystems is disabled. (Automated) - Not Implemented
 
-  # 1.1 Filesystem configuration
-  # 1.1.1 Disable unused filesystems
-
-  # 1.1.1.1 Ensure mounting of cramfs filesystems is disabled (Automated)
-  - id: 19000
-    title: "Ensure mounting of cramfs filesystems is disabled."
-    description: "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image."
-    rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vim /etc/modprobe.d/cramfs.conf and add the following line: install cramfs /bin/true Run the following command to unload the cramfs module: # rmmod cramfs"
-    compliance:
-      - cis: ["1.1.1.1"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - "c:modprobe -n -v cramfs -> r:^install /bin/true|^install /bin/false"
-      - "not c:lsmod -> r:cramfs"
-
-  # 1.1.1.2 Ensure mounting of freevxfs filesystems is disabled (Automated)
-  - id: 19001
-    title: "Ensure mounting of freevxfs filesystems is disabled."
-    description: "The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the primary filesystem type for HP-UX operating systems."
-    rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/freevxfs.conf and add the following line: install freevxfs /bin/true. Run the following command to unload the freevxfs module: # rmmod freevxfs."
-    compliance:
-      - cis: ["1.1.1.2"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - "c:/sbin/modprobe -n -v freevxfs -> r:^install /bin/true|^install /bin/false"
-      - "not c:lsmod -> r:freevxfs"
-
-  # 1.1.1.3 Ensure mounting of jffs2 filesystems is disabled (Automated)
-  - id: 19002
-    title: "Ensure mounting of jffs2 filesystems is disabled."
-    description: "The jffs2 (journaling flash filesystem 2) filesystem type is a log-structured filesystem used in flash memory devices."
-    rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/jffs2.conf and add the following line: install jffs2 /bin/true. Run the following command to unload the jffs2 module: # rmmod jffs2."
-    compliance:
-      - cis: ["1.1.1.3"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - "c:/sbin/modprobe -n -v jffs2 -> r:^install /bin/true|^install /bin/false"
-      - "not c:lsmod -> r:jffs2"
-
-  #1.1.1.4 Ensure mounting of hfs filesystems is disabled (Automated)
-  - id: 19003
-    title: "Ensure mounting of hfs filesystems is disabled."
-    description: "The hfs filesystem type is a hierarchical filesystem that allows you to mount Mac OS filesystems."
-    rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/hfs.conf and add the following line: install hfs /bin/true. Run the following command to unload the hfs module: # rmmod hfs."
-    compliance:
-      - cis: ["1.1.1.4"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - "c:/sbin/modprobe -n -v hfs -> r:^install /bin/true|^install /bin/false"
-      - "not c:lsmod -> r:hfs"
-
-  # 1.1.1.5 Ensure mounting of hfsplus filesystems is disabled (Automated)
-  - id: 19004
-    title: "Ensure mounting of hfsplus filesystems is disabled."
-    description: "The hfsplus filesystem type is a hierarchical filesystem designed to replace hfs that allows you to mount Mac OS filesystems."
-    rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/hfsplus.conf and add the following line: install hfsplus /bin/true. Run the following command to unload the hfsplus module: # rmmod hfsplus."
-    compliance:
-      - cis: ["1.1.1.5"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - "c:/sbin/modprobe -n -v hfsplus -> r:^install /bin/true|^install /bin/false"
-      - "not c:lsmod -> r:hfsplus"
-
-  # 1.1.1.6 Ensure mounting of squashfs filesystems is disabled (Manual)
-  - id: 19005
-    title: "Ensure mounting of squashfs filesystems is disabled."
-    description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image."
-    rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
-    impact: 'Disabling squashfs will prevent the use of snap. Snap is a package manager for Linux for installing Snap packages. "Snap" application packages of software are self-contained and work across a range of Linux distributions. This is unlike traditional Linux package management approaches, like APT or RPM, which require specifically adapted packages per Linux distribution on an application update and delay therefore application deployment from developers to their software''s end-user. Snaps themselves have no dependency on any external store ("App store"), can be obtained from any source and can be therefore used for upstream software deployment. When snaps are deployed on versions of Linux, the Ubuntu app store is used as default back-end, but other stores can be enabled as well.'
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/squashfs.conf and add the following line: install squashfs /bin/true. Run the following command to unload the squashfs module: # rmmod squashfs"
-    compliance:
-      - cis: ["1.1.1.6"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - "c:/sbin/modprobe -n -v squashfs -> r:^install /bin/true|^install /bin/false"
-      - "not c:lsmod -> r:squashfs"
-
-  # 1.1.1.7 Ensure mounting of udf filesystems is disabled (Automated)
-  - id: 19006
-    title: "Ensure mounting of udf filesystems is disabled."
-    description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
-    rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/udf.conf and add the following line: install udf /bin/true Run the following command to unload the udf module: # rmmod udf"
-    compliance:
-      - cis: ["1.1.1.7"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - "c:/sbin/modprobe -n -v udf -> r:^install /bin/true|^install /bin/false"
-      - "not c:lsmod -> r:udf"
-
-  #  1.1.2 Ensure /tmp is configured (Automated)
-  - id: 19007
-    title: "Ensure /tmp is configured."
+  # 1.1.2.1 Ensure /tmp is a separate partition. (Automated)
+  - id: 31007
+    title: "Ensure /tmp is a separate partition."
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
-    rationale: "Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp."
-    impact: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. Running out of /tmp space is a problem regardless of what kind of filesystem lies under it, but in a default installation a disk-based /tmp will essentially have the whole disk available, as it only creates a single / partition. On the other hand, a RAM-based /tmp as with tmpfs will almost certainly be much smaller, which can lead to applications filling up the filesystem much more easily. /tmp utilizing tmpfs can be resized using the size={size} parameter on the Options line on the tmp.mount file."
-    remediation: "Configure /etc/fstab as appropriate. Example: tmpfs /tmp tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0. OR Run the following commands to enable systemd /tmp mounting: Run the following command to create the tmp.mount file in the correct location: # cp -v /usr/share/systemd/tmp.mount /etc/systemd/system/. Edit /etc/systemd/system/tmp.mount to configure the /tmp mount: [Mount] What=tmpfs Where=/tmp Type=tmpfs Options=mode=1777,strictatime,nosuid,nodev,noexec. Run the following command to reload the systemd daemon with the unpdated tmp.mount unit file: # systemctl daemon-reload. Run the following command to enable and start tmp.mount # systemctl --now enable tmp.mount."
-    compliance:
-      - cis: ["1.1.2"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+    rationale: "Making /tmp its own file system allows an administrator to set additional mount options such as the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hard link to a system setuid program and wait for it to be updated. Once the program was updated, the hard link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp."
+    impact: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. Running out of /tmp space is a problem regardless of what kind of filesystem lies under it, but in a configuration where /tmp is not a separate file system it will essentially have the whole disk available, as the default installation only creates a single / partition. On the other hand, a RAM-based /tmp (as with tmpfs) will almost certainly be much smaller, which can lead to applications filling up the filesystem much more easily. Another alternative is to create a dedicated partition for /tmp from a separate volume or disk. One of the downsides of a disk-based dedicated partition is that it will be slower than tmpfs which is RAM-based. /tmp utilizing tmpfs can be resized using the size={size} parameter in the relevant entry in /etc/fstab."
+    remediation: "For specific configuration requirements of the /tmp mount for your environment, modify /etc/fstab or tmp.mount unit file: Using /etc/fstab: Configure /etc/fstab as appropriate: Example: tmpfs /tmp tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0 -OR- Using a tmp.mount unit file: Run the following command to create the tmp.mount file is the correct location: # cp -v /usr/share/systemd/tmp.mount /etc/systemd/system/ Edit /etc/systemd/system/tmp.mount to configure the /tmp mount: Example: # SPDX-License-Identifier: LGPL-2.1+ # # This file is part of systemd. # # systemd is free software; you can redistribute it and/or modify it # under the terms of the GNU Lesser General Public License as published by # the Free Software Foundation; either version 2.1 of the License, or # (at your option) any later version. [Unit] Description=Temporary Directory (/tmp) Documentation=https://systemd.io/TEMPORARY_DIRECTORIES Documentation=man:file-hierarchy(7) Documentation=https://www.freedesktop.org/wiki/Software/systemd/APIFileSystem s ConditionPathIsSymbolicLink=!/tmp DefaultDependencies=no Conflicts=umount.target Before=local-fs.target umount.target After=swap.target [Mount] What=tmpfs Where=/tmp Type=tmpfs Options=mode=1777,strictatime,nosuid,nodev,noexec [Install] WantedBy=local-fs.target Run the following command to reload the systemd daemon with the updated tmp.mount unit file: # systemctl daemon-reload Run the following command to enable and start tmp.mount # systemctl --now enable tmp.mount Note: A reboot may be required to transition to /tmp mounted to tmpfs."
     references:
-      - http://tldp.org/HOWTO/LVM-HOWTO/
-      - https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
+      - "https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/"
+      - "https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html"
+    compliance:
+      - cis: ["1.1.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:findmnt -n /tmp -> r:\s*/tmp\s'
+      - 'c:findmnt -kn /tmp -> r:\s*/tmp\s'
 
-  # 1.1.3 Ensure nodev option set on /tmp partition (Automated)
-  - id: 19008
+  # 1.1.2.2 Ensure nodev option set on /tmp partition. (Automated)
+  - id: 31008
     title: "Ensure nodev option set on /tmp partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
-    rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
-    remediation: "Edit the /etc/fstab file OR the /etc/systemd/system/local-fs.target.wants/tmp.mount file: If /etc/fstab is used to mount /tmp: Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp: # mount -o remount,nodev /tmp. OR If systemd is used to mount /tmp: Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nodev to the /tmp mount options: [Mount] Options=mode=1777,strictatime,noexec,nodev,nosuid. Run the following command to restart the systemd daemon: # systemctl daemon-reload. Run the following command to restart tmp.mount # systemctl restart tmp.mount."
+    rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /tmp with the configured options: # mount -o remount /tmp."
     compliance:
-      - cis: ["1.1.3"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis: ["1.1.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:findmnt -n /tmp -> r:\s*/tmp\s && r:nodev'
+      - 'c:findmnt -kn /tmp -> r:\s*/tmp\s && r:nodev'
 
-  # 1.1.4 Ensure nosuid option set on /tmp partition (Automated)
-  - id: 19009
-    title: "Ensure nosuid option set on /tmp partition."
-    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
-    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
-    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp : # mount -o remount,nosuid /tmp OR Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nosuid to the /tmp mount options: [Mount] Options=mode=1777,strictatime,noexec,nodev,nosuid Run the following command to remount /tmp : # mount -o remount,nosuid /tmp"
-    compliance:
-      - cis: ["1.1.4"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - 'c:findmnt -n /tmp -> r:\s*/tmp\s && r:nosuid'
-
-  # 1.1.5 Ensure noexec option set on /tmp partition (Automated)
-  - id: 19010
+  # 1.1.2.3 Ensure noexec option set on /tmp partition. (Automated)
+  - id: 31009
     title: "Ensure noexec option set on /tmp partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
-    remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp: # mount -o remount,noexec /tmp. OR Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add noexec to the /tmp mount options: [Mount] Options=mode=1777,strictatime,noexec,nodev,nosuid Run the following command to remount /tmp: # mount -o remount,noexec /tmp."
+    remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /tmp with the configured options: # mount -o remount /tmp."
     compliance:
-      - cis: ["1.1.5"]
-      - cis_csc_v7: ["2.6"]
-      - cmmc_v2.0: ["CM.2.063", "CM.3.069", "CM.4.073"]
-      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
-      - mitre_techniques: ["T1191", "T1092", "T1175", "T1173", "T1519", "T1052", "T1210", "T1133", "T1118", "T1171", "T1170", "T1046", "T1137", "T1086", "T1164", "T1121", "T1076", "T1091", "T1180", "T1064", "T1184", "T1221", "T1127", "T1028"]
-      - nist_sp_800-53: ["CM-11"]
+      - cis: ["1.1.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:findmnt -n /tmp -> r:\s*/tmp\s && r:noexec'
+      - 'c:findmnt -kn /tmp -> r:\s*/tmp\s && r:noexec'
 
-  # 1.1.6 Ensure /dev/shm is configured (Automated)
-  - id: 19011
-    title: "Ensure /dev/shm is configured."
-    description: "/dev/shm is a traditional shared memory concept. One program will create a memory portion, which other processes (if permitted) can access. Mounting tmpfs at /dev/shm is handled automatically by systemd."
-    rationale: "Any user can upload and execute files inside the /dev/shm similar to the /tmp partition. Configuring /dev/shm allows an administrator to set the noexec option on the mount, making /dev/shm useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
-    remediation: "Edit /etc/fstab and add or edit the following line: tmpfs /dev/shm tmpfs defaults,noexec,nodev,nosuid,seclabel 0 0. Run the following command to remount /dev/shm: # mount -o remount,noexec,nodev,nosuid /dev/shm."
+  # 1.1.2.4 Ensure nosuid option set on /tmp partition. (Automated)
+  - id: 31010
+    title: "Ensure nosuid option set on /tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
+    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /tmp with the configured options: # mount -o remount /tmp."
     compliance:
-      - cis: ["1.1.6"]
-      - cis_csc_v7: ["5.1", "13"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis: ["1.1.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:findmnt -n /dev/shm -> r:\s*/dev/shm\s'
+      - 'c:findmnt -kn /tmp -> r:\s*/tmp\s && r:nosuid'
 
-  # 1.1.7 Ensure nodev option set on /dev/shm partition (Automated)
-  - id: 19012
+  # 1.1.3.1 Ensure separate partition exists for /var. (Automated)
+  - id: 31011
+    title: "Ensure separate partition exists for /var."
+    description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
+    rationale: "The reasoning for mounting /var on a separate partition is as follow. Protection from resource exhaustion The default installation only creates a single / partition. Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var and cause unintended behavior across the system as the disk is full. See man auditd.conf for details. Fine grained control over the mount Configuring /var as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behaviour. See man mount for exact details regarding filesystem-independent and filesystem-specific options. Protection from exploitation An example of exploiting /var may be an attacker establishing a hard-link to a system setuid program and wait for it to be updated. Once the program was updated, the hard-link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.3.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var -> r:\s*/var\s'
+
+  # 1.1.3.2 Ensure nodev option set on /var partition. (Automated)
+  - id: 31012
+    title: "Ensure nodev option set on /var partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> defaults,rw,nosuid,nodev,relatime 0 0 Run the following command to remount /var with the configured options: # mount -o remount /var."
+    compliance:
+      - cis: ["1.1.3.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var -> r:\s*/var\s && r:nodev'
+
+  # 1.1.3.3 Ensure nosuid option set on /var partition. (Automated)
+  - id: 31013
+    title: "Ensure nosuid option set on /var partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> defaults,rw,nosuid,nodev,relatime 0 0 Run the following command to remount /var with the configured options: # mount -o remount /var."
+    compliance:
+      - cis: ["1.1.3.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var -> r:\s*/var\s && r:nosuid'
+
+  # 1.1.4.1 Ensure separate partition exists for /var/tmp. (Automated)
+  - id: 31014
+    title: "Ensure separate partition exists for /var/tmp."
+    description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications. Temporary files residing in /var/tmp are to be preserved between reboots."
+    rationale: "The reasoning for mounting /var/tmp on a separate partition is as follows. Protection from resource exhaustion The default installation only creates a single / partition. Since the /var/tmp directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var/tmp and cause the potential disruption to daemons as the disk is full. Fine grained control over the mount Configuring /var/tmp as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. Protection from exploitation An example of exploiting /var/tmp may be an attacker establishing a hard-link to a system setuid program and wait for it to be updated. Once the program was updated, the hard-link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/tmp. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.4.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var/tmp -> r:\s*/var/tmp\s'
+
+  # 1.1.4.2 Ensure nodev option set on /var/tmp partition. (Automated)
+  - id: 31015
+    title: "Ensure nodev option set on /var/tmp partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /var/tmp with the configured options: # mount -o remount /var/tmp."
+    compliance:
+      - cis: ["1.1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: findmnt -kn /var/tmp -> r:\s*/var/tmp\s && r:nodev'
+
+  # 1.1.4.3 Ensure noexec option set on /var/tmp partition. (Automated)
+  - id: 31016
+    title: "Ensure noexec option set on /var/tmp partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /var/tmp with the configured options: # mount -o remount /var/tmp."
+    compliance:
+      - cis: ["1.1.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var/tmp -> r:\s*/var/tmp\s && r:noexec'
+
+  # 1.1.4.4 Ensure nosuid option set on /var/tmp partition. (Automated)
+  - id: 31017
+    title: "Ensure nosuid option set on /var/tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /var/tmp with the configured options: # mount -o remount /var/tmp."
+    compliance:
+      - cis: ["1.1.4.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var/tmp -> r:\s*/var/tmp\s && r:nosuid'
+
+  # 1.1.5.1 Ensure separate partition exists for /var/log. (Automated)
+  - id: 31018
+    title: "Ensure separate partition exists for /var/log."
+    description: "The /var/log directory is used by system services to store log data."
+    rationale: "The reasoning for mounting /var/log on a separate partition is as follows. Protection from resource exhaustion The default installation only creates a single / partition. Since the /var/log directory contains log files which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. Fine grained control over the mount Configuring /var/log as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. Protection of log data As /var/log contains log files, care should be taken to ensure the security and integrity of the data and mount point."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.5.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var/log -> r:\s*/var/log\s'
+
+  # 1.1.5.2 Ensure nodev option set on /var/log partition. (Automated)
+  - id: 31019
+    title: "Ensure nodev option set on /var/log partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/log filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /var/log with the configured options: # mount -o remount /var/log."
+    compliance:
+      - cis: ["1.1.5.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var/log -> r:\s*/var/log\s && r:nodev'
+
+  # 1.1.5.3 Ensure noexec option set on /var/log partition. (Automated)
+  - id: 31020
+    title: "Ensure noexec option set on /var/log partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot run executable binaries from /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /var/log with the configured options: # mount -o remount /var/log."
+    compliance:
+      - cis: ["1.1.5.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var/log -> r:\s*/var/log\s && r:noexec'
+
+  # 1.1.5.4 Ensure nosuid option set on /var/log partition. (Automated)
+  - id: 31021
+    title: "Ensure nosuid option set on /var/log partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot create setuid files in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /var/log with the configured options: # mount -o remount /var/log."
+    compliance:
+      - cis: ["1.1.5.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var/log -> r:\s*/var/log\s && r:nosuid'
+
+  # 1.1.6.1 Ensure separate partition exists for /var/log/audit. (Automated)
+  - id: 31022
+    title: "Ensure separate partition exists for /var/log/audit."
+    description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
+    rationale: "The reasoning for mounting /var/log/audit on a separate partition is as follows. Protection from resource exhaustion The default installation only creates a single / partition. Since the /var/log/audit directory contains the audit.log file which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var/log/audit and cause auditd to trigger it's space_left_action as the disk is full. See man auditd.conf for details. Fine grained control over the mount Configuring /var/log/audit as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. Protection of audit data As /var/log/audit contains audit logs, care should be taken to ensure the security and integrity of the data and mount point."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log/audit. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.6.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var/log/audit -> r:\s*/var/log/audit\s'
+
+  # 1.1.6.2 Ensure nodev option set on /var/log/audit partition. (Automated)
+  - id: 31023
+    title: "Ensure nodev option set on /var/log/audit partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/log/audit filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/log/audit."
+    remediation: "IF the /var/log/audit partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/log/audit partition. Example: <device> /var/log/audit <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /var/log/audit with the configured options: # mount -o remount /var/log/audit."
+    compliance:
+      - cis: ["1.1.6.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var/log/audit -> r:\s*/var/log/audit\s && r:nodev'
+
+  # 1.1.6.3 Ensure noexec option set on /var/log/audit partition. (Automated)
+  - id: 31024
+    title: "Ensure noexec option set on /var/log/audit partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/log/audit filesystem is only intended for audit logs, set this option to ensure that users cannot run executable binaries from /var/log/audit."
+    remediation: "IF the /var/log/audit partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var partition. Example: <device> /var/log/audit <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /var/log/audit with the configured options: # mount -o remount /var/log/audit."
+    compliance:
+      - cis: ["1.1.6.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var/log/audit -> r:\s*/var/log/audit\s && r:noexec'
+
+  # 1.1.6.4 Ensure nosuid option set on /var/log/audit partition. (Automated)
+  - id: 31025
+    title: "Ensure nosuid option set on /var/log/audit partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/log/audit filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var/log/audit."
+    remediation: "IF the /var/log/audit partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/log/audit partition. Example: <device> /var/log/audit <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /var/log/audit with the configured options: # mount -o remount /var/log/audit."
+    compliance:
+      - cis: ["1.1.6.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /var/log/audit -> r:\s*/var/log/audit\s && r:nosuid'
+
+  # 1.1.7.1 Ensure separate partition exists for /home. (Automated)
+  - id: 31026
+    title: "Ensure separate partition exists for /home."
+    description: "The /home directory is used to support disk storage needs of local users."
+    rationale: "The reasoning for mounting /home on a separate partition is as follows. Protection from resource exhaustion The default installation only creates a single / partition. Since the /home directory contains user generated data, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /home and impact all local users. Fine grained control over the mount Configuring /home as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. In the case of /home options such as usrquota/grpquota may be considered to limit the impact that users can have on each other with regards to disk resource exhaustion. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. Protection of user data As /home contains user data, care should be taken to ensure the security and integrity of the data and mount point."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /home. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.7.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /home -> r:\s*/home\s'
+
+  # 1.1.7.2 Ensure nodev option set on /home partition. (Automated)
+  - id: 31027
+    title: "Ensure nodev option set on /home partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /home filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /home."
+    remediation: "IF the /home partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /home partition. Example: <device> /home <fstype> defaults,rw,nosuid,nodev,relatime 0 0 Run the following command to remount /home with the configured options: # mount -o remount /home."
+    compliance:
+      - cis: ["1.1.7.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /home -> r:\s*/home\s && r:nodev'
+
+  # 1.1.7.3 Ensure nosuid option set on /home partition. (Automated)
+  - id: 31028
+    title: "Ensure nosuid option set on /home partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /home filesystem is only intended for user file storage, set this option to ensure that users cannot create setuid files in /home."
+    remediation: "IF the /home partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /home partition. Example: <device> /home <fstype> defaults,rw,nosuid,nodev,relatime 0 0 Run the following command to remount /home with the configured options: # mount -o remount /home."
+    compliance:
+      - cis: ["1.1.7.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:findmnt -kn /home -> r:\s*/home\s && r:nosuid'
+
+  # 1.1.8.1 Ensure nodev option set on /dev/shm partition. (Automated)
+  - id: 31029
     title: "Ensure nodev option set on /dev/shm partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
-    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information. Run the following command to remount /dev/shm: # mount -o remount,nosuid,nodev,noexec /dev/shm."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information. Example: tmpfs /dev/shm tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /dev/shm with the configured options: # mount -o remount /dev/shm NOTE It is recommended to use tmpfs as the device/filesystem type as /dev/shm is used as shared memory space by applications."
     compliance:
-      - cis: ["1.1.7"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis: ["1.1.8.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:findmnt -n /dev/shm -> r:\s*/dev/shm\s && r:nodev'
+      - 'c:findmnt -kn /dev/shm -> r:\s*/dev/shm\s && r:nodev'
 
-  # 1.1.8 Ensure nosuid option set on /dev/shm partition (Automated)
-  - id: 19013
-    title: "Ensure nosuid option set on /dev/shm partition."
-    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
-    rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
-    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information. Run the following command to remount /dev/shm: # mount -o remount,nosuid,nodev,noexec /dev/shm."
-    compliance:
-      - cis: ["1.1.8"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - 'c:findmnt -n /dev/shm -> r:\s*/dev/shm\s && r:nosuid'
-
-  # 1.1.9 Ensure noexec option set on /dev/shm partition (Automated)
-  - id: 19014
+  # 1.1.8.2 Ensure noexec option set on /dev/shm partition. (Automated)
+  - id: 31030
     title: "Ensure noexec option set on /dev/shm partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
-    remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information. Run the following command to remount /dev/shm: # mount -o remount,nosuid,nodev,noexec /dev/shm."
+    remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /dev/shm partition. Example: tmpfs /dev/shm tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /dev/shm with the configured options: # mount -o remount /dev/shm Note: It is recommended to use tmpfs as the device/filesystem type as /dev/shm is used as shared memory space by applications."
     compliance:
-      - cis: ["1.1.9"]
-      - cis_csc_v7: ["2.6"]
-      - cmmc_v2.0: ["CM.2.063", "CM.3.069", "CM.4.073"]
-      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
-      - mitre_techniques: ["T1191", "T1092", "T1175", "T1173", "T1519", "T1052", "T1210", "T1133", "T1118", "T1171", "T1170", "T1046", "T1137", "T1086", "T1164", "T1121", "T1076", "T1091", "T1180", "T1064", "T1184", "T1221", "T1127", "T1028"]
-      - nist_sp_800-53: ["CM-11"]
+      - cis: ["1.1.8.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:findmnt -n /dev/shm  -> r:\s*/dev/shm\s && r:noexec'
+      - 'c:findmnt -kn /dev/shm  -> r:\s*/dev/shm\s && r:noexec'
 
-  # 1.1.10 Ensure separate partition exists for /var (Automated)
-  - id: 19015
-    title: "Ensure separate partition exists for /var."
-    description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
-    rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
-    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
-    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
-    compliance:
-      - cis: ["1.1.10"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    references:
-      - http://tldp.org/HOWTO/LVM-HOWTO/
-    condition: all
-    rules:
-      - 'c:findmnt -n /var -> r:\s*/var\s'
-
-  # 1.1.11 Ensure separate partition exists for /var/tmp (Automated)
-  - id: 19016
-    title: "Ensure separate partition exists for /var/tmp."
-    description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications."
-    rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
-    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
-    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/tmp. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
-    compliance:
-      - cis: ["1.1.11"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - 'c:findmnt -n /var/tmp -> r:\s*/var/tmp\s'
-
-  # 1.1.12 Ensure /var/tmp partition includes the nodev option (Automated)
-  - id: 19017
-    title: "Ensure /var/tmp partition includes the nodev option."
-    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
-    rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp."
-    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
-    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /var/tmp: # mount -o remount,nosuid,nodev,noexec /var/tmp."
-    compliance:
-      - cis: ["1.1.12"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - 'c: findmnt -n /var/tmp -> r:\s*/var/tmp\s && r:nodev'
-
-  # 1.1.13 Ensure /var/tmp partition includes the nosuid option (Automated)
-  - id: 19018
-    title: "Ensure /var/tmp partition includes the nosuid option."
+  # 1.1.8.3 Ensure nosuid option set on /dev/shm partition. (Automated)
+  - id: 31031
+    title: "Ensure nosuid option set on /dev/shm partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
-    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
-    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /var/tmp: # mount -o remount,nosuid,nodev,noexec /var/tmp."
+    rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
+    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information. Example: tmpfs /dev/shm tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0 Run the following command to remount /dev/shm with the configured options: # mount -o remount /dev/shm Note: It is recommended to use tmpfs as the device/filesystem type as /dev/shm is used as shared memory space by applications."
     compliance:
-      - cis: ["1.1.13"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis: ["1.1.8.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:findmnt -n /var/tmp -> r:\s*/var/tmp\s && r:nosuid'
+      - 'c:findmnt -kn /dev/shm  -> r:\s*/dev/shm\s && r:nosuid'
 
-  # 1.1.14 Ensure /var/tmp partition includes the noexec option (Automated)
-  - id: 19019
-    title: "Ensure /var/tmp partition includes the noexec option."
-    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
-    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
-    remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /var/tmp: # mount -o remount,nosuid,nodev,noexec /var/tmp."
-    compliance:
-      - cis: ["1.1.14"]
-      - cis_csc_v7: ["2.6"]
-      - cmmc_v2.0: ["CM.2.063", "CM.3.069", "CM.4.073"]
-      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
-      - mitre_techniques: ["T1191", "T1092", "T1175", "T1173", "T1519", "T1052", "T1210", "T1133", "T1118", "T1171", "T1170", "T1046", "T1137", "T1086", "T1164", "T1121", "T1076", "T1091", "T1180", "T1064", "T1184", "T1221", "T1127", "T1028"]
-      - nist_sp_800-53: ["CM-11"]
-    condition: all
-    rules:
-      - 'c:findmnt -n /var/tmp -> r:\s*/var/tmp\s && r:noexec'
-
-  # 1.1.15 Ensure separate partition exists for /var/log (Automated)
-  - id: 19020
-    title: "Ensure separate partition exists for /var/log."
-    description: "The /var/log directory is used by system services to store log data."
-    rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
-    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
-    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
-    compliance:
-      - cis: ["1.1.15"]
-      - cis_csc_v7: ["6.4"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-4"]
-      - pci_dss_v3.2.1: ["10.7"]
-    references:
-      - http://tldp.org/HOWTO/LVM-HOWTO/
-    condition: all
-    rules:
-      - 'c:findmnt -n /var/log -> r:\s*/var/log\s'
-
-  # 1.1.16 Ensure separate partition exists for /var/log/audit (Automated)
-  - id: 19021
-    title: "Ensure separate partition exists for /var/log/audit."
-    description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
-    rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog) consume space in the same partition as auditd, it may not perform as desired."
-    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
-    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log/audit. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
-    compliance:
-      - cis: ["1.1.16"]
-      - cis_csc_v7: ["6.4"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-4"]
-      - pci_dss_v3.2.1: ["10.7"]
-    references:
-      - http://tldp.org/HOWTO/LVM-HOWTO/
-    condition: all
-    rules:
-      - 'c:findmnt -n /var/log/audit -> r:\s*/var/log/audit\s'
-
-  # 1.1.17 Ensure separate partition exists for /home (Automated)
-  - id: 19022
-    title: "Ensure separate partition exists for /home."
-    description: "The /home directory is used to support disk storage needs of local users."
-    rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
-    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /home. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
-    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
-    compliance:
-      - cis: ["1.1.17"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    references:
-      - http://tldp.org/HOWTO/LVM-HOWTO/
-    condition: all
-    rules:
-      - 'c:findmnt -n /home -> r:\s*/home\s'
-
-  # 1.1.18 Ensure /home partition includes the nodev option (Automated)
-  - id: 19023
-    title: "Ensure /home partition includes the nodev option."
-    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
-    rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
-    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /home partition. See the fstab(5) manual page for more information. # mount -o remount,nodev /home"
-    compliance:
-      - cis: ["1.1.18"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - 'c:findmnt -n /home -> r:\s*/home\s && r:nodev'
-
-  # 1.1.19 Ensure nodev option set on removable media partitions (Manual) - NOT IMPLEMENTED
-  # 1.1.20 Ensure nosuid option set on removable media partitions (Manual) - NOT IMPLEMENTED
-  # 1.1.21 Ensure noexec option set on removable media partitions (Manual) - NOT IMPLEMENTED
-  # 1.1.22 Ensure sticky bit is set on all world-writable directories (Automated) - NOT IMPLEMENTED
-
-  # 1.1.23 Disable Automounting (Automated)
-  - id: 19024
+  # 1.1.9 Disable Automounting. (Automated)
+  - id: 31032
     title: "Disable Automounting."
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
-    rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
-    impact: "The use of portable hard drives is very common for workstation users. If your organization allows the use of portable storage or media on workstations and physical access controls to workstations is considered adequate there is little value add in turning off automounting."
-    remediation: "Run one of the following commands: Run the following command to disable autofs: # systemctl --now disable autofs OR  Run the following command to remove autofs: # apt purge autofs"
+    rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in the filesystem even if they lacked permissions to mount it themselves."
+    impact: "The use of portable hard drives is very common for workstation users. If your organization allows the use of portable storage or media on workstations and physical access controls to workstations are considered adequate there is little value add in turning off automounting."
+    remediation: "If there are no other packages that depends on autofs, remove the package with: # apt purge autofs -OR- if there are dependencies on the autofs package: Run the following commands to mask autofs: # systemctl stop autofs # systemctl mask autofs."
     compliance:
-      - cis: ["1.1.23"]
-      - cis_csc_v7: ["8.4", "8.5"]
-      - cmmc_v2.0: ["SI.1.213"]
+      - cis: ["1.1.9"]
+      - cis_csc_v8: ["10.3"]
+      - cis_csc_v7: ["8.5"]
+      - cmmc_v2.0: ["MP.L2-3.8.7"]
+      - hipaa: ["164.310(d)(1)"]
       - iso_27001-2013: ["A.12.2.1"]
-      - mitre_techniques: ["T1215", "T1027", "T1045", "T1193", "T1194", "T1221", "T1200", "T1091"]
-      - nist_sp_800-53: ["SI-3"]
+      - mitre_techniques: ["T1068", "T1203", "T1211", "T1212"]
     condition: any
     rules:
       - "c: dpkg -s autofs -> r:package 'autofs' is not installed"
       - "c: systemctl is-enabled autofs -> r:No such file or directory|disabled"
 
-  # 1.1.24 Disable USB Storage (Automated)
-  - id: 19025
-    title: "Disable USB Storage."
-    description: "USB storage provides a means to transfer and store files insuring persistence and availability of the files independent of network connection status. Its popularity and utility has led to USB-based malware being a simple and common means for network infiltration and a first step to establishing a persistent threat within a networked environment. Note: An alternative solution to disabling the usb-storage module may be found in USBGuard. Use of USBGuard and construction of USB device policies should be done in alignment with site policy."
-    rationale: "Restricting USB access on the system will decrease the physical attack surface for a device and diminish the possible vectors to introduce malware."
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/usb_storage.conf and add the following line: install usb-storage /bin/true. Run the following command to unload the usb-storage module: rmmod usb-storage"
-    compliance:
-      - cis: ["1.1.24"]
-      - cis_csc_v7: ["8.4", "8.5"]
-      - cmmc_v2.0: ["SI.1.213"]
-      - iso_27001-2013: ["A.12.2.1"]
-      - mitre_techniques: ["T1215", "T1027", "T1045", "T1193", "T1194", "T1221", "T1200", "T1091"]
-      - nist_sp_800-53: ["SI-3"]
-    condition: all
-    rules:
-      - "c:/sbin/modprobe -n -v usb-storage -> r:install /bin/true|install /bin/false"
-      - "not c:lsmod -> r:usb-storage"
+  # 1.1.10 Disable USB Storage. (Automated) - Not Implemented
 
-  # 1.2 Configure Software Updates
-  # 1.2.1 Ensure package manager repositories are configured (Manual) - NOT IMPLEMENTED
-  # 1.2.2 Ensure GPG keys are configured (Manual) - NOT IMPLEMENTED
-
-  # 1.3 Filesystem Integrity Checking
-
-  # 1.3.1 Ensure AIDE is installed (Automated)
-  - id: 19026
+  # 1.2.1 Ensure AIDE is installed. (Automated)
+  - id: 31034
     title: "Ensure AIDE is installed."
     description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
     rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
-    remediation: "Install AIDE using the appropriate package manager or manual installation: # apt install aide aide-common Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options. Run the following commands to initialize AIDE: # aideinit # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db"
+    remediation: "Install AIDE using the appropriate package manager or manual installation: # apt install aide aide-common Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options. Run the following commands to initialize AIDE: # aideinit # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db."
     compliance:
-      - cis: ["1.3.1"]
+      - cis: ["1.2.1"]
+      - cis_csc_v8: ["3.14"]
       - cis_csc_v7: ["14.9"]
-      - cmmc_v2.0: ["AU.3.050"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
       - iso_27001-2013: ["A.12.4.3"]
-      - nist_sp_800-53: ["AU-3"]
+      - mitre_techniques: ["T1036", "T1036.002", "T1036.003", "T1036.004", "T1036.005", "T1565", "T1565.001"]
+      - nist_sp_800-53: ["AC-6(9)"]
       - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
     condition: all
     rules:
       - "c:dpkg -s aide -> r:install ok installed"
       - "c:dpkg -s aide-common -> r:install ok installed"
 
-  # 1.3.2 Ensure filesystem integrity is regularly checked (Automated)
-  - id: 19027
+  # 1.2.2 Ensure filesystem integrity is regularly checked. (Automated)
+  - id: 31035
     title: "Ensure filesystem integrity is regularly checked."
     description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
-    remediation: "If cron will be used to schedule and run aide check: Run the following command: # crontab -u root -e Add the following line to the crontab: 0 5 * * * /usr/bin/aide.wrapper --config /etc/aide/aide.conf --check OR If aidecheck.service and aidecheck.timer will be used to schedule and run aide check: Create or edit the file /etc/systemd/system/aidecheck.service and add the following lines: [Unit] Description=Aide Check [Service] Type=simple ExecStart=/usr/bin/aide.wrapper --config /etc/aide/aide.conf --check [Install] WantedBy=multi-user.target Create or edit the file /etc/systemd/system/aidecheck.timer and add the following lines: [Unit] Description=Aide check every day at 5AM [Timer] OnCalendar=*-*-* 05:00:00 Unit=aidecheck.service [Install] WantedBy=multi-user.target Run the following commands: # chown root:root /etc/systemd/system/aidecheck.* # chmod 0644 /etc/systemd/system/aidecheck.* # systemctl daemon-reload # systemctl enable aidecheck.service # systemctl --now enable aidecheck.timer"
-    compliance:
-      - cis: ["1.3.2"]
-      - cis_csc_v7: ["14.9"]
-      - cmmc_v2.0: ["AU.3.050"]
-      - iso_27001-2013: ["A.12.4.3"]
-      - nist_sp_800-53: ["AU-3"]
-      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+    remediation: "If cron will be used to schedule and run aide check: Run the following command: # crontab -u root -e Add the following line to the crontab: 0 5 * * * /usr/bin/aide.wrapper --config /etc/aide/aide.conf --check OR If aidecheck.service and aidecheck.timer will be used to schedule and run aide check: Create or edit the file /etc/systemd/system/aidecheck.service and add the following lines: [Unit] Description=Aide Check [Service] Type=simple ExecStart=/usr/bin/aide.wrapper --config /etc/aide/aide.conf --check [Install] WantedBy=multi-user.target Create or edit the file /etc/systemd/system/aidecheck.timer and add the following lines: [Unit] Description=Aide check every day at 5AM [Timer] OnCalendar=*-*-* 05:00:00 Unit=aidecheck.service [Install] WantedBy=multi-user.target Run the following commands: # chown root:root /etc/systemd/system/aidecheck.* # chmod 0644 /etc/systemd/system/aidecheck.* # systemctl daemon-reload # systemctl enable aidecheck.service # systemctl --now enable aidecheck.timer."
     references:
-      - https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.service
-      - https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.timer
-    condition: any
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.service"
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.timer"
+    compliance:
+      - cis: ["1.2.2"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1036", "T1036.002", "T1036.003", "T1036.004", "T1036.005", "T1565", "T1565.001"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
     rules:
-      - 'd:/var/spool/cron -> r:\. -> !r:^\s*# && r:aide && r:--check|\$AIDEARGS'
-      - 'd:/etc -> r:cron.* -> !r:^\s*# && r:aide && r:--check|\$AIDEARGS'
-      - 'f:/etc/crontab -> !r:^\s*# && r:aide && r:--check|\$AIDEARGS'
       - "c:systemctl is-enabled aidecheck.service -> r:enabled"
       - "c:systemctl is-enabled aidecheck.timer -> r:enabled"
       - "c:systemctl status aidecheck.timer -> r:Active: active"
 
-  # 1.4 Secure Boot Settings
+  # 1.3.1 Ensure updates, patches, and additional security software are installed. (Manual) - Not Implemented
+  # 1.3.2 Ensure package manager repositories are configured. (Manual) - Not Implemented
+  # 1.3.3 Ensure GPG keys are configured. (Manual) Not Implemented
 
-  # 1.4.1 Ensure permissions on bootloader config are not overridden (Automated)
-  - id: 19028
-    title: "Ensure permissions on bootloader config are not overridden."
-    description: "The permissions on /boot/grub/grub.cfg are changed to 444 when gub.cfg is updated by the update-grub command."
-    rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
-    remediation: "Run the following command to update chmod 444 to chmod 400 in /usr/sbin/grub- mkconfig: # sed -ri 's/chmod\\s+[0-7][0-7][0-7]\\s+\\$\\{grub_cfg\\}\\.new/chmod 400 ${grub_cfg}.new/' /usr/sbin/grub-mkconfig Run the following command to remove check on password not being set to before running chmod command: # sed -ri 's/ && ! grep \"\\^password\" \\$\\{grub_cfg\\}.new >\\/dev\\/null//' /usr/sbin/grub-mkconfig."
-    compliance:
-      - cis: ["1.4.1"]
-      - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
-      - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
-      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
-    condition: all
-    rules:
-      - 'f:/usr/sbin/grub-mkconfig -> r:if [ "x${grub_cfg}" != "x" ]; then'
-      - "f:/usr/sbin/grub-mkconfig -> r:chmod 400 ${grub_cfg}.new && r:true"
-
-  # 1.4.2 Ensure bootloader password is set (Automated)
-  - id: 19029
+  # 1.4.1 Ensure bootloader password is set. (Automated)
+  - id: 31039
     title: "Ensure bootloader password is set."
     description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
     rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off AppArmor at boot time)."
-    impact: 'If password protection is enabled, only the designated superuser can edit a Grub 2 menu item by pressing "e" or access the GRUB 2 command line by pressing "c" If GRUB 2 is set up to boot automatically to a password-protected menu entry the user has no option to back out of the password prompt to select another menu entry. Holding the SHIFT key will not display the menu in this case. The user must enter the correct username and password. If unable, the configuration files will have to be edited via the LiveCD or other means to fix the problem You can add --unrestricted to the menu entries to allow the system to boot without entering a password. Password will still be required to edit menu items. More Information: https://help.ubuntu.com/community/Grub2/Passwords'
-    remediation: 'Create an encrypted password with grub-mkpasswd-pbkdf2: # grub-mkpasswd-pbkdf2 Enter password: <password> Reenter password: <password> PBKDF2 hash of your password is <encrypted-password> Add the following into a custom /etc/grub.d configuration file: cat <<EOF set superusers="<username>" password_pbkdf2 <username> <encrypted-password> EOF. The superuser/user information and password should not be contained in the /etc/grub.d/00_header file as this file could be overwritten in a package update. If there is a requirement to be able to boot/reboot without entering the password, edit /etc/grub.d/10_linux and add --unrestricted to the line CLASS= Example: CLASS="--class gnu-linux --class gnu --class os --unrestricted". Run the following command to update the grub2 configuration: # update-grub.'
+    impact: 'If password protection is enabled, only the designated superuser can edit a GRUB 2 menu item by pressing "e" or access the GRUB 2 command line by pressing "c" If GRUB 2 is set up to boot automatically to a password-protected menu entry the user has no option to back out of the password prompt to select another menu entry. Holding the SHIFT key will not display the menu in this case. The user must enter the correct username and password. If unable to do so, the configuration files will have to be edited via a LiveCD or other means to fix the problem You can add --unrestricted to the menu entries to allow the system to boot without entering a password. A password will still be required to edit menu items. More Information: https://help.ubuntu.com/community/Grub2/Passwords.'
+    remediation: 'Create an encrypted password with grub-mkpasswd-pbkdf2: # grub-mkpasswd-pbkdf2 Enter password: <password> Reenter password: <password> PBKDF2 hash of your password is <encrypted-password> Add the following into a custom /etc/grub.d configuration file: cat <<EOF set superusers="<username>" password_pbkdf2 <username> <encrypted-password> EOF The superuser/user information and password should not be contained in the /etc/grub.d/00_header file as this file could be overwritten in a package update. If there is a requirement to be able to boot/reboot without entering the password, edit /etc/grub.d/10_linux and add --unrestricted to the line CLASS= Example: CLASS="--class gnu-linux --class gnu --class os --unrestricted" Run the following command to update the grub2 configuration: # update-grub.'
     compliance:
-      - cis: ["1.4.2"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis: ["1.4.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1046"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1542"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
     condition: all
     rules:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*set superusers'
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*password'
 
-  # 1.4.3 Ensure permissions on bootloader config are configured (Automated)
-  - id: 19030
+  # 1.4.2 Ensure permissions on bootloader config are configured. (Automated)
+  - id: 31040
     title: "Ensure permissions on bootloader config are configured."
     description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options."
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
-    remediation: "Run the following commands to set permissions on your grub configuration: # chown root:root /boot/grub/grub.cfg # chmod u-wx,go-rwx /boot/grub/grub.cfg."
+    remediation: "Run the following commands to set permissions on your grub configuration: # chown root:root /boot/grub/grub.cfg # chmod u-x,go-rwx /boot/grub/grub.cfg."
     compliance:
-      - cis: ["1.4.3"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
+      - cis: ["1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005", "TA0007"]
+      - mitre_techniques: ["T1542"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
     rules:
+      - 'c:stat /boot/grub/grub.cfg -> r:Access:\s*\(0600/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
       - 'c:stat /boot/grub/grub.cfg -> r:Access:\s*\(0400/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  # 1.4.4 Ensure authentication required for single user mode (Automated)
-  - id: 19031
+  # 1.4.3 Ensure authentication required for single user mode. (Automated)
+  - id: 31041
     title: "Ensure authentication required for single user mode."
     description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
     rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
-    remediation: "Run the following command and follow the prompts to set a password for the root user: # passwd root"
+    remediation: "Run the following command and follow the prompts to set a password for the root user: # passwd root."
     compliance:
-      - cis: ["1.4.4"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis: ["1.4.3"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
     condition: none
     rules:
       - 'f:/etc/shadow -> r:^root:\p:'
 
-  # 1.5 Additional Process Hardening
-
-  # 1.5.1 Ensure XD/NX support is enabled (Manual)
-  - id: 19032
-    title: "Ensure XD/NX support is enabled."
-    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature. Note: Ensure your system supports the XD or NX bit and has PAE support before implementing this recommendation as this may prevent it from booting if these are not supported by your hardware."
-    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
-    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
-    compliance:
-      - cis: ["1.5.1"]
-      - cis_csc_v7: ["8.3"]
-      - mitre_techniques: ["T1189", "T1190", "T1203", "T1212", "T1211", "T1068", "T1210", "T1117", "T1085", "T1080", "T1131", "T1003", "T1101"]
-      - nist_sp_800-53: ["SC-39", "SI-16"]
-    condition: all
-    rules:
-      - 'c:sh -c "journalctl | grep \"protection: active\"" -> r:NX \(Execute Disable\) protection: active'
-
-  # 1.5.2 Ensure address space layout randomization (ASLR) is enabled (Automated)
-  - id: 19033
-    title: "Ensure address space layout randomization (ASLR) is enabled."
-    description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
-    rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
-    remediation: 'Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file ending in .conf: kernel.randomize_va_space = 2 Run the following script to comment out entries that override the default setting of kernel.randomize_va_space: #!/usr/bin/bash for file in /etc/sysctl.conf /etc/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /run/sysctl.d/*.conf; do if [ -f "$file" ]; then grep -Esq "^\s*kernel\.randomize_va_space\s*=\s*([0-1]|[3-9]|[1-9][0-9]+)" "$file" && sed -ri ''s/^\s*kernel\.randomize_va_space\s*=\s*([0-1]|[3-9]|[1-9][0-9]+)/# &/gi'' "$file" fi done Run the following command to set the active kernel parameter: # sysctl -w kernel.randomize_va_space=2'
-    compliance:
-      - cis: ["1.5.2"]
-      - cis_csc_v7: ["8.3"]
-      - mitre_techniques: ["T1189", "T1190", "T1203", "T1212", "T1211", "T1068", "T1210", "T1117", "T1085", "T1080", "T1131", "T1003", "T1101"]
-      - nist_sp_800-53: ["SC-39", "SI-16"]
-    references:
-      - http://manpages.ubuntu.com/manpages/focal/man5/sysctl.d.5.html
-    condition: all
-    rules:
-      - 'not d:/usr/lib/sysctl.d -> r:\.*.conf -> r:kernel.randomize_va_space\s*= && !r:\s=\s*2\s+|\s=\s*2$'
-      - 'not d:/etc/sysctl.d -> r:\.*.conf -> r:kernel.randomize_va_space\s*= && !r:\s=\s*2\s+|\s=\s*2$'
-      - 'not f:/etc/sysctl.conf -> r:kernel.randomize_va_space\s*= && !r:\s=\s*2\s+|\s=\s*2$'
-      - 'c:sysctl kernel.randomize_va_space -> r:^kernel.randomize_va_space\s*\t*=\s*\t*2$'
-
-  # 1.5.3 Ensure prelink is not installed (Automated)
-  - id: 19034
+  # 1.5.1 Ensure prelink is not installed. (Automated)
+  - id: 31042
     title: "Ensure prelink is not installed."
     description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
     rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
     remediation: "Run the following command to restore binaries to normal: # prelink -ua Uninstall prelink using the appropriate package manager or manual installation: # apt purge prelink."
     compliance:
-      - cis: ["1.5.3"]
+      - cis: ["1.5.1"]
+      - cis_csc_v8: ["3.14"]
       - cis_csc_v7: ["14.9"]
-      - cmmc_v2.0: ["AU.3.050"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
       - iso_27001-2013: ["A.12.4.3"]
-      - nist_sp_800-53: ["AU-3"]
+      - mitre_mitigations: ["M1050"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1055", "T1055.009", "T1065", "T1065.001"]
+      - nist_sp_800-53: ["AC-6(9)"]
       - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
     condition: all
     rules:
       - "c:dpkg -s prelink -> r:package 'prelink' is not installed"
 
-  # 1.5.4 Ensure core dumps are restricted (Automated)
-  - id: 19035
-    title: "Ensure core dumps are restricted."
-    description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
-    rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
-    remediation: "Add the following line to /etc/security/limits.conf or a /etc/security/limits.d/* file: * hard core 0 Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: fs.suid_dumpable = 0 Run the following command to set the active kernel parameter: # sysctl -w fs.suid_dumpable=0 IF systemd-coredump is installed: edit /etc/systemd/coredump.conf and add/modify the following lines: Storage=none ProcessSizeMax=0 Run the command: systemctl daemon-reload."
+  # 1.5.2 Ensure address space layout randomization (ASLR) is enabled. (Automated) - Not Implemented
+  # 1.5.3 Ensure ptrace_scope is restricted. (Automated) - Not Implemented
+
+  # 1.5.4 Ensure Automatic Error Reporting is not enabled. (Automated)
+  - id: 31045
+    title: "Ensure Automatic Error Reporting is not enabled."
+    description: "The Apport Error Reporting Service automatically generates crash reports for debugging."
+    rationale: "Apport collects potentially sensitive data, such as core dumps, stack traces, and log files. They can contain passwords, credit card numbers, serial numbers, and other private material."
+    remediation: "Edit /etc/default/apport and add or edit the enabled parameter to equal 0: enabled=0 Run the following commands to stop and disable the apport service # systemctl stop apport.service # systemctl --now disable apport.service -- OR -- Run the following command to remove the apport package: # apt purge apport."
     compliance:
       - cis: ["1.5.4"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "c:sysctl fs.suid_dumpable -> r:=^fs.suid_dumpable = 0"
-      - "c:systemctl is-enabled coredump.service -> r:enabled|masked|disabled"
-      - 'c:grep -Rh "fs.suid_dumpable" /etc/sysctl.conf /etc/sysctl.d/ -> !r:^\s*\t*# && r:fs.suid_dumpable = 0'
-      - 'c:grep -Rh "hard core 0" /etc/security/limits.conf /etc/security/limits.d/ -> !r:^\s*\t*# && r:\p hard core 0'
+      - "c:dpkg-query -s apport -> !r:enabled"
+      - "c:systemctl is-active apport.service -> !r:active"
 
-  # 1.6 Mandatory Access Control
+  # 1.5.5 Ensure core dumps are restricted. (Automated) - Not Implemented
 
-  # 1.6.1 Configure AppArmor
-
-  # 1.6.1.1 Ensure AppArmor is installed (Automated)
-  - id: 19036
+  # 1.6.1.1 Ensure AppArmor is installed. (Automated)
+  - id: 31047
     title: "Ensure AppArmor is installed."
     description: "AppArmor provides Mandatory Access Controls."
     rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
-    remediation: "Install Apparmor. # apt install apparmor"
+    remediation: "Install AppArmor. # apt install apparmor apparmor-utils."
     compliance:
       - cis: ["1.6.1.1"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1068", "T1565", "T1565.001", "T1565.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
-    condition: any
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
     rules:
       - "c:dpkg -s apparmor -> r:install ok installed"
 
-  # 1.6.1.2 Ensure AppArmor is enabled in the bootloader configuration (Automated)
-  - id: 19037
+  # 1.6.1.2 Ensure AppArmor is enabled in the bootloader configuration. (Automated)
+  - id: 31048
     title: "Ensure AppArmor is enabled in the bootloader configuration."
     description: "Configure AppArmor to be enabled at boot time and verify that it has not been overwritten by the bootloader boot parameters. Note: This recommendation is designed around the grub bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings."
     rationale: "AppArmor must be enabled at boot time in your bootloader configuration to ensure that the controls it provides are not overridden."
-    remediation: 'Edit /etc/default/grub and add the apparmor=1 and security=apparmor parameters to the GRUB_CMDLINE_LINUX= line GRUB_CMDLINE_LINUX="apparmor=1 security=apparmor" Run the following command to update the grub2 configuration: # update-grub'
+    remediation: 'Edit /etc/default/grub and add the apparmor=1 and security=apparmor parameters to the GRUB_CMDLINE_LINUX= line GRUB_CMDLINE_LINUX="apparmor=1 security=apparmor" Run the following command to update the grub2 configuration: # update-grub.'
     compliance:
       - cis: ["1.6.1.2"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1068", "T1565", "T1565.001", "T1565.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && r:apparmor=1'
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && r:security=apparmor'
 
-  # 1.6.1.3 Ensure all AppArmor Profiles are in enforce or complain mode (Automated)
-  - id: 19038
+  # 1.6.1.3 Ensure all AppArmor Profiles are in enforce or complain mode. (Automated)
+  - id: 31049
     title: "Ensure all AppArmor Profiles are in enforce or complain mode."
     description: "AppArmor profiles define what resources applications are able to access."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that any policies that exist on the system are activated."
     remediation: "Run the following command to set all profiles to enforce mode: # aa-enforce /etc/apparmor.d/* OR Run the following command to set all profiles to complain mode: # aa-complain /etc/apparmor.d/* Note: Any unconfined processes may need to have a profile created or activated for them and then be restarted."
     compliance:
       - cis: ["1.6.1.3"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_tactics: ["TA0005"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
       - 'c:apparmor_status -> n:^(\d+)\s+profiles\s+are\s+loaded compare > 0'
       - "c:apparmor_status -> r:0 processes are unconfined"
 
-  # 1.6.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
-  - id: 19039
+  # 1.6.1.4 Ensure all AppArmor Profiles are enforcing. (Automated)
+  - id: 31050
     title: "Ensure all AppArmor Profiles are enforcing."
     description: "AppArmor profiles define what resources applications are able to access."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that any policies that exist on the system are activated."
     remediation: "Run the following command to set all profiles to enforce mode: # aa-enforce /etc/apparmor.d/* Note: Any unconfined processes may need to have a profile created or activated for them and then be restarted."
     compliance:
       - cis: ["1.6.1.4"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1068", "T1565", "T1565.001", "T1565.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
       - 'c:apparmor_status -> n:^(\d+)\s+profiles\s+are\s+loaded compare > 0'
@@ -809,2756 +937,2380 @@ checks:
       - 'c:apparmor_status -> r:^0\s*profiles\s+are\s+in\s+complain\s+mode'
       - 'c:apparmor_status -> r:^0\s*processes\s+are\s+unconfined'
 
-  # 1.7 Command Line Warning Banners
-
-  # 1.7.1 Ensure message of the day is configured properly (Automated)
-  - id: 19040
+  # 1.7.1 Ensure message of the day is configured properly. (Automated)
+  - id: 31051
     title: "Ensure message of the day is configured properly."
-    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version."
     rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
-    remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , \\v or references to the OS platform OR If the motd is not used, this file can be removed. Run the following command to remove the motd file: # rm /etc/motd"
+    remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , \\v or references to the OS platform. Add or update the message text to follow local site policy. Example Text: # echo \"Authorized use only. All activity may be monitored and reported.\" > /etc/issue.net -- OR -- If the motd is not used, this file can be removed. Run the following command to remove the motd file: # rm /etc/motd."
     compliance:
       - cis: ["1.7.1"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1082", "T1592", "T1592.004"]
     condition: any
     rules:
       - 'not f:/etc/motd -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
       - "not f:/etc/motd"
 
-  # 1.7.2 Ensure local login warning banner is configured properly (Automated)
-  - id: 19041
+  # 1.7.2 Ensure local login warning banner is configured properly. (Automated)
+  - id: 31052
     title: "Ensure local login warning banner is configured properly."
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version - or the operating system's name."
     rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
-    remediation: "Edit the /etc/issue file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , \\v or references to the OS platform # echo 'Authorized uses only. All activity may be monitored and reported.' > /etc/issue"
+    remediation: "Edit the /etc/issue file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , \\v or references to the OS platform. Add or update the message text to follow local site policy. Example Text: # echo \"Authorized use only. All activity may be monitored and reported.\" > /etc/issue.net."
     compliance:
       - cis: ["1.7.2"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1082", "T1592", "T1592.004"]
     condition: none
     rules:
       - 'f:/etc/issue -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
 
-  # 1.7.3 Ensure remote login warning banner is configured properly (Automated)
-  - id: 19042
+  # 1.7.3 Ensure remote login warning banner is configured properly. (Automated)
+  - id: 31053
     title: "Ensure remote login warning banner is configured properly."
-    description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
+    description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version."
     rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
-    remediation: "Edit the /etc/issue.net file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , or \\v or references to the OS platform: # echo \"Authorized uses only. All activity may be monitored and reported.\" > /etc/issue.net"
+    remediation: "Edit the /etc/issue.net file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , \\v or references to the OS platform. Add or update the message text to follow local site policy. Example Text: # echo \"Authorized use only. All activity may be monitored and reported.\" > /etc/issue.net."
     compliance:
       - cis: ["1.7.3"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1018", "T1082", "T1592", "T1592.004"]
     condition: none
     rules:
       - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
 
-  # 1.7.4 Ensure permissions on /etc/motd are configured (Automated)
-  - id: 19043
+  # 1.7.4 Ensure permissions on /etc/motd are configured. (Automated)
+  - id: 31054
     title: "Ensure permissions on /etc/motd are configured."
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
     rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
-    remediation: "Run the following commands to set permissions on /etc/motd : # chown root:root $(readlink -e /etc/motd) # chmod u-x,go-wx $(readlink -e /etc/motd) OR run the following command to remove the /etc/motd file: # rm /etc/motd."
+    remediation: "Run the following commands to set permissions on /etc/motd : # chown root:root $(readlink -e /etc/motd) # chmod u-x,go-wx $(readlink -e /etc/motd) -- OR -- Run the following command to remove the /etc/motd file: # rm /etc/motd."
     compliance:
       - cis: ["1.7.4"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: any
     rules:
       - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
       - "not f:/etc/motd"
 
-  # 1.7.5 Ensure permissions on /etc/issue are configured (Automated)
-  - id: 19044
+  # 1.7.5 Ensure permissions on /etc/issue are configured. (Automated)
+  - id: 31055
     title: "Ensure permissions on /etc/issue are configured."
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
     rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
-    remediation: "Run the following commands to set permissions on /etc/issue: # chown root:root /etc/issue # chmod u-x,go-wx /etc/issue"
+    remediation: "Run the following commands to set permissions on /etc/issue: # chown root:root $(readlink -e /etc/issue) # chmod u-x,go-wx $(readlink -e /etc/issue)."
     compliance:
       - cis: ["1.7.5"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
       - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  # 1.7.6 Ensure permissions on /etc/issue.net are configured (Automated)
-  - id: 19045
+  # 1.7.6 Ensure permissions on /etc/issue.net are configured. (Automated)
+  - id: 31056
     title: "Ensure permissions on /etc/issue.net are configured."
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
     rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
-    remediation: "Run the following commands to set permissions on /etc/issue.net: # chown root:root $(readlink -e /etc/issue.net) # chmod u-x,go-wx $(readlink -e /etc/issue.net)"
+    remediation: "Run the following commands to set permissions on /etc/issue.net : # chown root:root $(readlink -e /etc/issue.net) # chmod u-x,go-wx $(readlink -e /etc/issue.net)."
     compliance:
       - cis: ["1.7.6"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
       - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  # 1.8.1 Ensure GNOME Display Manager is removed (Manual)
-  - id: 19046
+  # 1.8.1 Ensure GNOME Display Manager is removed. (Automated)
+  - id: 31057
     title: "Ensure GNOME Display Manager is removed."
     description: "The GNOME Display Manager (GDM) is a program that manages graphical display servers and handles graphical user logins."
     rationale: "If a Graphical User Interface (GUI) is not required, it should be removed to reduce the attack surface of the system."
     impact: "Removing the GNOME Display manager will remove the Graphical User Interface (GUI) from the system."
-    remediation: "Run the following command to uninstall gdm3: # apt purge gdm3"
+    remediation: "Run the following command to uninstall gdm3: # apt purge gdm3."
     compliance:
       - cis: ["1.8.1"]
-      - cis_csc_v7: ["2.6"]
-      - cmmc_v2.0: ["CM.2.063", "CM.3.069", "CM.4.073"]
-      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
-      - mitre_techniques: ["T1191", "T1092", "T1175", "T1173", "T1519", "T1052", "T1210", "T1133", "T1118", "T1171", "T1170", "T1046", "T1137", "T1086", "T1164", "T1121", "T1076", "T1091", "T1180", "T1064", "T1184", "T1221", "T1127", "T1028"]
-      - nist_sp_800-53: ["CM-11"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
       - "c:dpkg -s gdm3 -> r: package 'gdm3' is not installed"
 
-  # 1.8.2 Ensure GDM login banner is configured (Automated)
-  - id: 19047
-    title: "Ensure GDM login banner is configured."
-    description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
-    rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place."
-    remediation: "Edit or create the file /etc/gdm3/greeter.dconf-defaults and add the following: [org/gnome/login-screen] banner-message-enable=true banner-message-text='<banner message>' disable-user-list=true Example banner message: 'Authorized uses only. All activity may be monitored and reported.' Run the following command to re-load GDM on the next login or reboot: # dpkg-reconfigure gdm3"
-    compliance:
-      - cis: ["1.8.2"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - "f:/etc/gdm3/greeter.dconf-defaults -> r:^[org/gnome/login-screen]"
-      - "f:/etc/gdm3/greeter.dconf-defaults -> r:^banner-message-enable=true"
-      - 'f:/etc/gdm3/greeter.dconf-defaults -> r:^banner-message-text=\.+'
+  # 1.8.2 Ensure GDM login banner is configured. (Automated) - Not Implemented
+  # 1.8.3 Ensure GDM disable-user-list option is enabled. (Automated) - Not Implemented
+  # 1.8.4 Ensure GDM screen locks when the user is idle. (Automated) - Not Implemented
+  # 1.8.5 Ensure GDM screen locks cannot be overridden. (Automated) - Not Implemented
+  # 1.8.6 Ensure GDM automatic mounting of removable media is disabled. (Automated) - Not Implemented
+  # 1.8.7 Ensure GDM disabling automatic mounting of removable media is not overridden. (Automated) - Not Implemented
+  # 1.8.8 Ensure GDM autorun-never is enabled. (Automated) - Not Implemented
+  # 1.8.9 Ensure GDM autorun-never is not overridden. (Automated) - Not Implemented
 
-  # 1.8.3 Ensure disable-user-list is enabled (Automated)
-  - id: 19048
-    title: "Ensure disable-user-list is enabled."
-    description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems. The disable-user-list option controls is a list of users is displayed on the login screen."
-    rationale: "Displaying the user list eliminates half of the Userid/Password equation that an unauthorized person would need to log on."
-    remediation: "Edit or create the file /etc/gdm3/greeter.dconf-defaults and edit or add the following: [org/gnome/login-screen] banner-message-enable=true banner-message-text='<banner message>' disable-user-list=true Run the following command to re-load GDM on the next login or reboot: # dpkg-reconfigure gdm3"
-    compliance:
-      - cis: ["1.8.3"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - 'f:/etc/gdm3/greeter.dconf-defaults -> r:^\s*disable-user-list\s*=\s*true'
-
-  # 1.8.4 Ensure XDCMP is not enabled (Automated)
-  - id: 19049
+  # 1.8.10 Ensure XDCMP is not enabled. (Automated)
+  - id: 31066
     title: "Ensure XDCMP is not enabled."
     description: "X Display Manager Control Protocol (XDMCP) is designed to provide authenticated access to display management services for remote displays."
-    rationale: "XDMCP is inherently insecure. - XDMCP is not a ciphered protocol. This may allow an attacker to capture keystrokes entered by a user. - XDMCP is vulnerable to man-in-the-middle attacks. This may allow an attacker to steal the credentials of legitimate users by impersonating the XDMCP server."
-    remediation: "Edit the file /etc/gdm3/custom.conf and remove the line: Enable=true"
+    rationale: "XDMCP is inherently insecure. - XDMCP is not a ciphered protocol. This may allow an attacker to capture keystrokes entered by a user - XDMCP is vulnerable to man-in-the-middle attacks. This may allow an attacker to steal the credentials of legitimate users by impersonating the XDMCP server."
+    remediation: "Edit the file /etc/gdm3/custom.conf and remove the line: Enable=true."
     compliance:
-      - cis: ["1.8.4"]
+      - cis: ["1.8.10"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
+      - mitre_mitigations: ["M1050"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1040", "T1056", "T1056.001", "T1557"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
       - 'not f:/etc/gdm3/custom.conf -> r:^\s*Enable\s*=\s*true'
 
-  # 1.9 Ensure updates, patches, and additional security software are installed (Manual)
-  - id: 19050
-    title: "Ensure updates, patches, and additional security software are installed."
-    description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
-    rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
-    remediation: "Run the following command to update all packages following local site policy guidance on applying updates and patches: # apt upgrade OR # apt dist-upgrade"
-    compliance:
-      - cis: ["1.9"]
-      - cis_csc_v7: ["3.4", "3.5"]
-      - cmmc_v2.0: ["MA.2.111"]
-      - mitre_techniques: ["T1103", "T1017", "T1138", "T1073", "T1189", "T1190", "T1212", "T1211", "T1068", "T1210", "T1495", "T1137", "T1075", "T1195", "T1019", "T1072", "T1100", "T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078", "T1103", "T1017", "T1138"]
-    condition: all
-    rules:
-      - "c:apt -s upgrade -> r:0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded"
-
-  # 2 Services
-  # 2.1 Special Purpose Services
-  # 2.1.1 Time Synchronization
-
-  # 2.1.1.1 Ensure time synchronization is in use (Automated)
-  - id: 19051
-    title: "Ensure time synchronization is in use."
-    description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them. Notes: - If access to a physical host's clock is available and configured according to site policy, this section can be skipped. - Only one time synchronization method should be in use on the system. - If access to a physical host's clock is available and configured according to site policy, systemd-timesyncd should be stopped and masked."
-    rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
-    remediation: 'On systems where host based time synchronization is not available, configure systemd- timesyncd. If "full featured" and/or encrypted time synchronization is required, install chrony or NTP. To install chrony: # apt install chrony To install ntp: # apt install ntp On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.'
+  # 2.1.1.1 Ensure a single time synchronization daemon is in use. (Automated)
+  - id: 31067
+    title: "Ensure a single time synchronization daemon is in use."
+    description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them. Note: - On virtual systems where host based time synchronization is available consult your virtualization software documentation and verify that host based synchronization is in use and follows local site policy. In this scenario, this section should be skipped - Only one time synchronization method should be in use on the system. Configuring multiple time synchronization methods could lead to unexpected or unreliable results."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
+    remediation: "On physical systems, and virtual systems where host based time synchronization is not available. Select one of the three time synchronization daemons; chrony (1), systemd-timesyncd (2), or ntp (3), and following the remediation procedure for the selected daemon. Note: enabling more than one synchronization daemon could lead to unexpected or unreliable results: 1. chrony Run the following command to install chrony: # apt install chrony Run the following commands to stop and mask the systemd-timesyncd daemon: # systemctl stop systemd-timesyncd.service # systemctl --now mask systemd-timesyncd.service Run the following command to remove the ntp package: # apt purge ntp NOTE: - Subsection: Configure chrony should be followed - Subsections: Configure systemd-timesyncd and Configure ntp should be skipped 2. systemd-timesyncd Run the following command to remove the chrony package: # apt purge chrony Run the following command to remove the ntp package: # apt purge ntp NOTE: - Subsection: Configure systemd-timesyncd should be followed - Subsections: Configure chrony and Configure ntp should be skipped 3. ntp Run the following command to install ntp: # apt install ntp Run the following commands to stop and mask the systemd-timesyncd daemon: # systemctl stop systemd-timesyncd.service # systemctl --now mask systemd-timesyncd.service Run the following command to remove the chrony package: # apt purge chrony NOTE: - Subsection: Configure ntp should be followed - Subsections: Configure chrony and Configure systemd-timesyncd should be skipped."
     compliance:
       - cis: ["2.1.1.1"]
+      - cis_csc_v8: ["8.4"]
       - cis_csc_v7: ["6.1"]
-      - cmmc_v2.0: ["AU.2.043"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
       - iso_27001-2013: ["A.12.4.4"]
-      - nist_sp_800-53: ["AU-8"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
       - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
     condition: any
     rules:
       - "c:dpkg -s ntp -> r:install ok installed"
       - "c:dpkg -s chrony -> r:install ok installed"
-      - "c:systemctl is-enabled systemd-timesyncd -> r:enabled"
+      - "c:systemctl is-enabled systemd-timesyncd -> r:^enabled"
 
-  # 2.1.1.2 Ensure systemd-timesyncd is configured (Automated)
-  - id: 19052
-    title: "Ensure systemd-timesyncd is configured."
-    description: 'systemd-timesyncd is a daemon that has been added for synchronizing the system clock across the network. It implements an SNTP client. In contrast to NTP implementations such as chrony or the NTP reference server this only implements a client side, and does not bother with the full NTP complexity, focusing only on querying time from one remote server and synchronizing the local clock to it. The daemon runs with minimal privileges, and has been hooked up with networkd to only operate when network connectivity is available. The daemon saves the current clock to disk every time a new NTP sync has been acquired, and uses this to possibly correct the system clock early at bootup, in order to accommodate for systems that lack an RTC such as the Raspberry Pi and embedded devices, and make sure that time monotonically progresses on these systems, even if it is not always correct. To make use of this daemon a new system user and group "systemd-timesync" needs to be created on installation of systemd. Note: - If chrony or ntp are used, systemd-timesyncd should be stopped and masked, and this section skipped. - This recommendation only applies if timesyncd is in use on the system. - Only one time synchronization method should be in use on the system.'
-    rationale: "Proper configuration is vital to ensuring time synchronization is working properly."
-    remediation: "- Remove additional time synchronization methods: Run the following commands to remove ntp and chrony: # apt purge ntp # apt purge chrony - Configure systemd-timesyncd: Run the following command to enable systemd-timesyncd: # systemctl enable systemd-timesyncd.service. Edit the file /etc/systemd/timesyncd.conf and add/modify the following lines: NTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org #Servers listed should be In Accordence With Local Policy FallbackNTP=2.debian.pool.ntp.org 3.debian.pool.ntp.org #Servers listed should be In Accordence With Local Policy. RootDistanceMax=1 #should be In Accordence With Local Policy. Run the following commands to start systemd-timesyncd.service: # systemctl start systemd-timesyncd.service # timedatectl set-ntp true"
+  # 2.1.2.1 Ensure chrony is configured with authorized timeserver. (Manual)
+  - id: 31068
+    title: "Ensure chrony is configured with authorized timeserver."
+    description: "-> server - The server directive specifies an NTP server which can be used as a time source. The client-server relationship is strictly hierarchical: a client might synchronize its system time to that of the server, but the server's system time will never be influenced by that of a client. - This directive can be used multiple times to specify multiple servers. o The directive is immediately followed by either the name of the server, or its IP address. -> pool - The syntax of this directive is similar to that for the server directive, except that it is used to specify a pool of NTP servers rather than a single NTP server. The pool name is expected to resolve to multiple addresses which might change over time. - This directive can be used multiple times to specify multiple pools. - All options valid in the server directive can be used in this directive too."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /etc/chrony/chrony.conf or a file ending in .sources in /etc/chrony/sources.d/ and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool directive: pool time.nist.gov iburst maxsources 4 #The maxsources option is unique to the pool directive server directive: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run one of the following commands to load the updated time sources into chronyd running config: # systemctl restart chronyd - OR if sources are in a .sources file - # chronyc reload sources OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # apt purge chrony."
     compliance:
-      - cis: ["2.1.1.2"]
+      - cis: ["2.1.2.1"]
+      - cis_csc_v8: ["8.4"]
       - cis_csc_v7: ["6.1"]
-      - cmmc_v2.0: ["AU.2.043"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
       - iso_27001-2013: ["A.12.4.4"]
-      - nist_sp_800-53: ["AU-8"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
       - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
     condition: all
     rules:
-      - "c:systemctl is-enabled systemd-timesyncd.service -> r:enabled"
-      - "c:dpkg -s ntp -> r:package 'ntp' is not installed"
-      - "c:dpkg -s chrony -> r:package 'chrony' is not installed"
-
-  # 2.1.1.3 Ensure chrony is configured (Automated)
-  - id: 19053
-    title: "Ensure chrony is configured."
-    description: "chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on chrony can be found at: http://chrony.tuxfamily.org/. chrony can be configured to be a client and/or a server. Notes: - If ntp or systemd-timesyncd are used, chrony should be removed and this section skipped. - This recommendation only applies if chrony is in use on the system. - Only one time synchronization method should be in use on the system."
-    rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
-    remediation: "Remove and/or disable additional time synchronization methods: Run the following command to remove ntp: # apt purge ntp Run the following command to stop and mask systemd-timesyncd: # systemctl --now mask systemd-timesyncd Configure chrony: Add or edit server or pool lines to /etc/chrony/chrony.conf as appropriate: server <remote-server> Add or edit the user line to /etc/chrony/chrony.conf: user _chrony"
-    compliance:
-      - cis: ["2.1.1.3"]
-      - cis_csc_v7: ["6.1"]
-      - cmmc_v2.0: ["AU.2.043"]
-      - iso_27001-2013: ["A.12.4.4"]
-      - nist_sp_800-53: ["AU-8"]
-      - pci_dss_v3.2.1: ["10.4"]
-    condition: all
-    rules:
-      - "c:dpkg -s chrony -> r:^Status: install ok installed"
-      - "c:systemctl is-enabled systemd-timesyncd.service -> r:masked"
-      - "c:dpkg -s ntp -> r:package 'ntp' is not installed"
-      - 'f:/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
       - "c:ps -ef -> r:^_chrony && r:/chronyd"
+      - 'f:/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
 
-  # 2.1.1.4 Ensure ntp is configured (Automated)
-  - id: 19054
-    title: "Ensure ntp is configured."
-    description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at http://www.ntp.org. ntp can be configured to be a client and/or a server. Notes: - If chrony or systemd-timesyncd are used, ntp should be removed and this section skipped. - This recommendation only applies if ntp is in use on the system. - Only one time synchronization method should be in use on the system."
-    rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
-    remediation: "- Remove and/or disable additional time synchronization methods: Run the following command to remove chrony: # apt purge chrony Run the following command to stop and mask systemd-timesyncd: # systemctl --now mask systemd-timesyncd - Configure ntp: Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery. Add or edit server or pool lines to /etc/ntp.conf as appropriate: server <remote-server> Configure ntp to run as the ntp user by adding or editing the /etc/init.d/ntp file: RUNASUSER=ntp."
+  # 2.1.2.2 Ensure chrony is running as user _chrony. (Automated)
+  - id: 31069
+    title: "Ensure chrony is running as user _chrony."
+    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
+    rationale: "The chronyd service should run with only the required privileges."
+    remediation: "Add or edit the user line to /etc/chrony/chrony.conf or a file ending in .conf in /etc/chrony/conf.d/: user _chrony OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # apt purge chrony."
     compliance:
-      - cis: ["2.1.1.4"]
+      - cis: ["2.1.2.2"]
+      - cis_csc_v8: ["8.4"]
       - cis_csc_v7: ["6.1"]
-      - cmmc_v2.0: ["AU.2.043"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
       - iso_27001-2013: ["A.12.4.4"]
-      - nist_sp_800-53: ["AU-8"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
       - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
     condition: all
     rules:
-      - "c:dpkg -s ntp -> r:^Status: install ok installed"
-      - "c:systemctl is-enabled systemd-timesyncd.service -> r:masked"
-      - "c:dpkg -s chrony -> r:package 'chrony' is not installed"
-      - 'f:/etc/ntp.conf -> r:^restrict\s+-4\s+default|^restrict\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
-      - 'f:/etc/ntp.conf -> r:^restrict\s+-6\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
-      - 'f:/etc/ntp.conf -> r:^server\.+|^pool\.+'
-      - 'f:/etc/init.d/ntp -> r:^RUNASUSER\s*\t*=\s*\t*ntp'
+      - "f:/etc/chrony/chrony.conf -> r:^user _chrony"
 
-  # 2.1.2 Ensure X Window System is not installed (Automated)
-  - id: 19055
-    title: "Ensure the X Window system is not installed."
+  # 2.1.2.3 Ensure chrony is enabled and running. (Automated)
+  - id: 31070
+    title: "Ensure chrony is enabled and running."
+    description: "chrony is a daemon for synchronizing the system clock across the network."
+    rationale: "chrony needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF chrony is in use on the system, run the following commands: Run the following command to unmask chrony.service: # systemctl unmask chrony.service Run the following command to enable and start chrony.service: # systemctl --now enable chrony.service OR If another time synchronization service is in use on the system, run the following command to remove chrony: # apt purge chrony."
+    compliance:
+      - cis: ["2.1.2.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled chrony.service -> r:^enabled"
+      - "c:systemctl is-active chrony.service -> r:^active"
+
+  # 2.1.3.1 Ensure systemd-timesyncd configured with authorized timeserver. (Automated)
+  - id: 31071
+    title: "Ensure systemd-timesyncd configured with authorized timeserver."
+    description: "NTP= - A space-separated list of NTP server host names or IP addresses. During runtime this list is combined with any per-interface NTP servers acquired from systemd-networkd.service(8). systemd-timesyncd will contact all configured system or per-interface servers in turn, until one responds. When the empty string is assigned, the list of NTP servers is reset, and all prior assignments will have no effect. This setting defaults to an empty list. FallbackNTP= - A space-separated list of NTP server host names or IP addresses to be used as the fallback NTP servers. Any per-interface NTP servers obtained from systemd-networkd.service(8) take precedence over this setting, as do any servers set via NTP= above. This setting is hence only relevant if no other NTP server information is known. When the empty string is assigned, the list of NTP servers is reset, and all prior assignments will have no effect. If this option is not given, a compiled-in list of NTP servers is used."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /etc/systemd/timesyncd.conf and add the NTP= and/or FallbackNTP= lines to the [Time] section: Example: [Time] NTP=time.nist.gov # Uses the generic name for NIST's time servers -AND/OR- FallbackNTP=time-a-g.nist.gov time-b-g.nist.gov time-c-g.nist.gov # Space separated list of NIST time servers Note: Servers added to these line(s) should follow local site policy. NIST servers are for example. Example script: The following example script will add the example NIST time servers to /etc/systemd/timesyncd.conf #!/usr/bin/env bash { l_ntp_ts=\"time.nist.gov\" l_ntp_fb=\"time-a-g.nist.gov time-b-g.nist.gov time-c-g.nist.gov\" l_conf_file=\"/etc/systemd/timesyncd.conf\" if ! grep -Ph '^\\h*NTP=\\H+' \"$l_conf_file\"; then ! grep -Pqs '^\\h*\\[Time\\]' \"$l_conf_file\" && echo \"[Time]\" >> \"$l_conf_file\" echo \"NTP=$l_ntp_ts\" >> \"$l_conf_file\" fi if ! grep -Ph '^\\h*FallbackNTP=\\H+' \"$l_conf_file\"; then ! grep -Pqs '^\\h*\\[Time\\]' \"$l_conf_file\" && echo \"[Time]\" >> \"$l_conf_file\" echo \"FallbackNTP=$l_ntp_fb\" >> \"$l_conf_file\" fi } Run the following command to reload the systemd-timesyncd configuration: # systemctl try-reload-or-restart systemd-timesyncd -OR- If another time synchronization service is in use on the system, run the following command to stop and mask systemd-timesyncd: # systemctl --now mask systemd-timesyncd."
+    references:
+      - "https://www.freedesktop.org/software/systemd/man/timesyncd.conf.html"
+      - "https://tf.nist.gov/tf-cgi/servers.cgi"
+    compliance:
+      - cis: ["2.1.3.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "d:/etc/systemd"
+      - 'd:/etc/systemd -> r:\.+.conf$'
+      - 'd:/etc/systemd -> r:\.+.conf$ -> r:^\s*NTP=|^\s*FallbackNTP='
+
+  # 2.1.3.2 Ensure systemd-timesyncd is enabled and running. (Manual)
+  - id: 31072
+    title: "Ensure systemd-timesyncd is enabled and running."
+    description: "systemd-timesyncd is a daemon that has been added for synchronizing the system clock across the network."
+    rationale: "systemd-timesyncd needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF systemd-timesyncd is in use on the system, run the following commands: Run the following command to unmask systemd-timesyncd.service: # systemctl unmask systemd-timesyncd.service Run the following command to enable and start systemd-timesyncd.service: # systemctl --now enable systemd-timesyncd.service OR If another time synchronization service is in use on the system, run the following command to stop and mask systemd-timesyncd: # systemctl --now mask systemd-timesyncd.service."
+    compliance:
+      - cis: ["2.1.3.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled systemd-timesyncd.service -> r:^enabled"
+      - "c:systemctl is-active systemd-timesyncd.service -> r:^active"
+
+  # 2.1.4.1 Ensure ntp access control is configured. (Automated)
+  - id: 31073
+    title: "Ensure ntp access control is configured."
+    description: 'ntp Access Control Commands: restrict address [mask mask] [ippeerlimit int] [flag ...] The address argument expressed in dotted-quad form is the address of a host or network. Alternatively, the address argument can be a valid host DNS name. The mask argument expressed in dotted-quad form defaults to 255.255.255.255, meaning that the address is treated as the address of an individual host. A default entry (address 0.0.0.0, mask 0.0.0.0) is always included and is always the first entry in the list. Note: the text string default, with no mask option, may be used to indicate the default entry. The ippeerlimit directive limits the number of peer requests for each IP to int, where a value of -1 means "unlimited", the current default. A value of 0 means "none". There would usually be at most 1 peering request per IP, but if the remote peering requests are behind a proxy there could well be more than 1 per IP. In the current implementation, flag always restricts access, i.e., an entry with no flags indicates that free access to the server is to be given. The flags are not orthogonal, in that more restrictive flags will often make less restrictive ones redundant. The flags can generally be classed into two categories, those which restrict time service and those which restrict informational queries and attempts to do run-time reconfiguration of the server. One or more of the following flags may be specified: - kod - If this flag is set when an access violation occurs, a kiss-o''-death (KoD) packet is sent. KoD packets are rate limited to no more than one per second. If another KoD packet occurs within one second after the last one, the packet is dropped. - limited - Deny service if the packet spacing violates the lower limits specified in the discard command. A history of clients is kept using the monitoring capability of ntpd. Thus, monitoring is always active as long as there is a restriction entry with the limited flag. - lowpriotrap - Declare traps set by matching hosts to be low priority. The number of traps a server can maintain is limited (the current limit is 3). Traps are usually assigned on a first come, first served basis, with later trap requestors being denied service. This flag modifies the assignment algorithm by allowing low priority traps to be overridden by later requests for normal priority traps. - noepeer - Deny ephemeral peer requests, even if they come from an authenticated source. Note that the ability to use a symmetric key for authentication may be restricted to one or more IPs or subnets via the third field of the ntp.keys file. This restriction is not enabled by default, to maintain backward compatibility. Expect noepeer to become the default in ntp-4.4. - nomodify - Deny ntpq and ntpdc queries which attempt to modify the state of the server (i.e., run time reconfiguration). Queries which return information are permitted. - noquery - Deny ntpq and ntpdc queries. Time service is not affected. - nopeer - Deny unauthenticated packets which would result in mobilizing a new association. This includes broadcast and symmetric active packets when a configured association does not exist. It also includes pool associations, so if you want to use servers from a pool directive and also want to use nopeer by default, you''ll want a restrict source ... line as well that does not include the nopeer directive. - noserve - Deny all packets except ntpq and ntpdc queries. - notrap - Decline to provide mode 6 control message trap service to matching hosts. The trap service is a subsystem of the ntpq control message protocol which is intended for use by remote event logging programs. - notrust - Deny service unless the packet is cryptographically authenticated. - ntpport - This is actually a match algorithm modifier, rather than a restriction flag. Its presence causes the restriction entry to be matched only if the source port in the packet is the standard NTP UDP port (123). Both ntpport and non-ntpport may be specified. The ntpport is considered more specific and is sorted later in the list.'
+    rationale: "If ntp is in use on the system, proper configuration is vital to ensuring time synchronization is accurate."
+    remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp."
+    references:
+      - "http://www.ntp.org/"
+    compliance:
+      - cis: ["2.1.4.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1498", "T1498.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - 'f:/etc/ntp.conf -> r:^restrict\s*\t*-4\s*\t*default|^restrict\s*\t*default && r:\s*kod && r:\s*nomodify && r:\s*notrap && r:\s*nopeer && r:\s*noquery'
+      - 'f:/etc/ntp.conf -> r:^restrict\s*\t*-6\s*\t*default && r:\s*kod && r:\s*nomodify && r:\s*notrap && r:\s*nopeer && r:\s*noquery'
+
+  # 2.1.4.2 Ensure ntp is configured with authorized timeserver. (Manual)
+  - id: 31074
+    title: "Ensure ntp is configured with authorized timeserver."
+    description: 'The various modes are determined by the command keyword and the type of the required IP address. Addresses are classed by type as (s) a remote server or peer (IPv4 class A, B and C), (b) the broadcast address of a local interface, (m) a multicast address (IPv4 class D), or (r) a reference clock address (127.127.x.x). Note: That only those options applicable to each command are listed below. Use of options not listed may not be caught as an error, but may result in some weird and even destructive behavior. If the Basic Socket Interface Extensions for IPv6 (RFC-2553) is detected, support for the IPv6 address family is generated in addition to the default support of the IPv4 address family. In a few cases, including the reslist billboard generated by ntpq or ntpdc, IPv6 addresses are automatically generated. IPv6 addresses can be identified by the presence of colons ":" in the address field. IPv6 addresses can be used almost everywhere where IPv4 addresses can be used, with the exception of reference clock addresses, which are always IPv4. Note: In contexts where a host name is expected, a -4 qualifier preceding the host name forces DNS resolution to the IPv4 namespace, while a -6 qualifier forces DNS resolution to the IPv6 namespace. See IPv6 references for the equivalent classes for that address family. - pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. - server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses.'
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool mode: pool time.nist.gov iburst server mode: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run the following command to load the updated time sources into ntp running config: # systemctl restart ntp OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp."
+    references:
+      - "http://www.ntp.org/"
+      - "https://tf.nist.gov/tf-cgi/servers.cgi"
+    compliance:
+      - cis: ["2.1.4.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1498", "T1498.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "f:/etc/ntp.conf -> r:^pool"
+      - "f:/etc/ntp.conf -> r:^server"
+
+  # 2.1.4.3 Ensure ntp is running as user ntp. (Automated)
+  - id: 31075
+    title: "Ensure ntp is running as user ntp."
+    description: "The ntp package is installed with a dedicated user account ntp. This account is granted the access required by the ntpd daemon Note: - If chrony or systemd-timesyncd are used, ntp should be removed and this section skipped - This recommendation only applies if ntp is in use on the system - Only one time synchronization method should be in use on the system."
+    rationale: "The ntpd daemon should run with only the required privlidge."
+    remediation: "Add or edit the following line in /usr/lib/ntp/ntp-systemd-wrapper: RUNASUSER=ntp Run the following command to restart ntp.servocee: # systemctl restart ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp."
+    references:
+      - "http://www.ntp.org/"
+    compliance:
+      - cis: ["2.1.4.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "f:/usr/lib/ntp/ntp-systemd-wrapper -> r:^RUNASUSER=ntp"
+
+  # 2.1.4.4 Ensure ntp is enabled and running. (Automated)
+  - id: 31076
+    title: "Ensure ntp is enabled and running."
+    description: "ntp is a daemon for synchronizing the system clock across the network."
+    rationale: "ntp needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF ntp is in use on the system, run the following commands: Run the following command to unmask ntp.service: # systemctl unmask ntp.service Run the following command to enable and start ntp.service: # systemctl --now enable ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp: # apt purge ntp."
+    compliance:
+      - cis: ["2.1.4.4"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled ntp.service -> r:^enabled"
+      - "c:systemctl is-active ntp.service -> r:^active"
+
+  # 2.2.1 Ensure X Window System is not installed. (Automated)
+  - id: 31077
+    title: "Ensure X Window System is not installed."
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
     impact: 'Many Linux systems run applications which require a Java runtime. Some Linux Java packages have a dependency on specific X Windows xorg-x11-fonts. One workaround to avoid this dependency is to use the "headless" Java packages for your specific Java runtime, if provided by your distribution.'
-    remediation: "Remove the X Windows System packages: apt purge xserver-xorg*"
+    remediation: "Remove the X Windows System packages: apt purge xserver-xorg*."
     compliance:
-      - cis: ["2.1.2"]
+      - cis: ["2.2.1"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["2.6"]
-      - cmmc_v2.0: ["CM.2.063", "CM.3.069", "CM.4.073"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
-      - mitre_techniques: ["T1191", "T1092", "T1175", "T1173", "T1519", "T1052", "T1210", "T1133", "T1118", "T1171", "T1170", "T1046", "T1137", "T1086", "T1164", "T1121", "T1076", "T1091", "T1180", "T1064", "T1184", "T1221", "T1127", "T1028"]
-      - nist_sp_800-53: ["CM-11"]
-    condition: none
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - 'c:dpkg -l xserver-xorg* -> r:^\wi\s*xserver-xorg'
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' xserver-xorg -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' xserver-xorg -> r:install ok installed"
 
-  # 2.1.3 Ensure Avahi Server is not installed (Automated)
-  - id: 19056
+  # 2.2.2 Ensure Avahi Server is not installed. (Automated)
+  - id: 31078
     title: "Ensure Avahi Server is not installed."
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
-    remediation: "Run the following commands to remove avahi-daemon: # systemctl stop avahi-daaemon.service # systemctl stop avahi-daemon.socket # apt purge avahi-daemon"
+    remediation: "Run the following commands to remove avahi-daemon: # systemctl stop avahi-daaemon.service # systemctl stop avahi-daemon.socket # apt purge avahi-daemon."
     compliance:
-      - cis: ["2.1.3"]
+      - cis: ["2.2.2"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s avahi-daemon -> r:package 'avahi-daemon' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' avahi-daemon -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' avahi-daemon -> r:install ok installed"
 
-  # 2.1.4 Ensure CUPS is not installed (Automated)
-  - id: 19057
+  # 2.2.3 Ensure CUPS is not installed. (Automated)
+  - id: 31079
     title: "Ensure CUPS is not installed."
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface."
     impact: "Removing CUPS will prevent printing from the system, a common task for workstation systems."
-    remediation: "Run one of the following commands to remove cups: # apt purge cups"
+    remediation: "Run one of the following commands to remove cups : # apt purge cups."
     references:
-      - https://www.cups.org
+      - "http://www.cups.org."
     compliance:
-      - cis: ["2.1.4"]
+      - cis: ["2.2.3"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s cups -> r:package 'cups' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' cups -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' cups -> r:install ok installed"
 
-  # 2.1.5 Ensure DHCP Server is not installed (Automated)
-  - id: 19058
+  # 2.2.4 Ensure DHCP Server is not installed. (Automated)
+  - id: 31080
     title: "Ensure DHCP Server is not installed."
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this package be removed to reduce the potential attack surface."
-    remediation: "Run the following command to remove isc-dhcp-server: # apt purge isc-dhcp-server"
+    remediation: "Run the following command to remove isc-dhcp-server: # apt purge isc-dhcp-server."
     references:
-      - https://www.isc.org/dhcp/
+      - "http://www.isc.org/software/dhcp."
     compliance:
-      - cis: ["2.1.5"]
+      - cis: ["2.2.4"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s isc-dhcp-server -> r:package 'isc-dhcp-server' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' isc-dhcp-server -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' isc-dhcp-server -> r:install ok installed"
 
-  # 2.1.6 Ensure LDAP server is not installed (Automated)
-  - id: 19059
+  # 2.2.5 Ensure LDAP server is not installed. (Automated)
+  - id: 31081
     title: "Ensure LDAP server is not installed."
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
-    remediation: "Run one of the following commands to remove slapd: # apt purge slapd"
-    compliance:
-      - cis: ["2.1.6"]
-      - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
-      - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
+    remediation: "Run one of the following commands to remove slapd: # apt purge slapd."
     references:
-      - https://www.openldap.org
-    condition: all
+      - "http://www.openldap.org."
+    compliance:
+      - cis: ["2.2.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s slapd -> r:package 'slapd' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' slapd -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' slapd -> r:install ok installed"
 
-  # 2.1.7 Ensure NFS is not installed (Automated)
-  - id: 19060
+  # 2.2.6 Ensure NFS is not installed. (Automated)
+  - id: 31082
     title: "Ensure NFS is not installed."
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
-    rationale: "If the system does not export NFS shares or act as an NFS client, it is recommended that these services be removed to reduce the remote attack surface."
-    remediation: "Run the following command to remove nfs: # apt purge nfs-kernel-server"
+    rationale: "If the system does not export NFS shares, it is recommended that the nfs-kernel-server package be removed to reduce the remote attack surface."
+    remediation: "Run the following command to remove nfs: # apt purge nfs-kernel-server."
     compliance:
-      - cis: ["2.1.7"]
+      - cis: ["2.2.6"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s nfs-kernel-server -> r:package 'nfs-kernel-server' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nfs-kernel-server -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nfs-kernel-server -> r:install ok installed"
 
-  # 2.1.8 Ensure DNS Server is not installed (Automated)
-  - id: 19061
+  # 2.2.7 Ensure DNS Server is not installed. (Automated)
+  - id: 31083
     title: "Ensure DNS Server is not installed."
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
-    remediation: "Run the following commands to disable DNS server: # apt purge bind9"
+    remediation: "Run the following commands to disable DNS server: # apt purge bind9."
     compliance:
-      - cis: ["2.1.8"]
+      - cis: ["2.2.7"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s bind9 -> r:package 'bind9' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' bind9 -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' bind9 -> r:install ok installed"
 
-  # 2.1.9 Ensure FTP Server is not installed (Automated)
-  - id: 19062
+  # 2.2.8 Ensure FTP Server is not installed. (Automated)
+  - id: 31084
     title: "Ensure FTP Server is not installed."
     description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended SFTP be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
-    remediation: "Run the following command to remove vsftpd: # apt purge vsftpd"
+    remediation: "Run the following command to remove vsftpd: # apt purge vsftpd."
     compliance:
-      - cis: ["2.1.9"]
+      - cis: ["2.2.8"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s vsftpd -> r:package 'vsftpd' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' vsftpd -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' vsftpd -> r:install ok installed"
 
-  # 2.1.10 Ensure HTTP server is not installed (Automated)
-  - id: 19063
-    title: "Ensure HTTP Server is not installed."
+  # 2.2.9 Ensure HTTP server is not installed. (Automated)
+  - id: 31085
+    title: "Ensure HTTP server is not installed."
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
-    remediation: "Run the following command to remove apache: # apt purge apache2"
+    remediation: "Run the following command to remove apache2: # apt purge apache2."
     compliance:
-      - cis: ["2.1.10"]
+      - cis: ["2.2.9"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s apache2 -> r:package 'apache2' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' apache2 -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' apache2 -> r:install ok installed"
 
-  # 2.1.11 Ensure IMAP and POP3 server are not installed (Automated)
-  - id: 19064
+  # 2.2.10 Ensure IMAP and POP3 server are not installed. (Automated)
+  - id: 31086
     title: "Ensure IMAP and POP3 server are not installed."
     description: "dovecot-imapd and dovecot-pop3d are an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
-    remediation: "Run one of the following commands to remove dovecot-imapd and dovecot-pop3d: # apt purge dovecot-imapd dovecot-pop3d"
+    remediation: "Run one of the following commands to remove dovecot-imapd and dovecot-pop3d: # apt purge dovecot-imapd dovecot-pop3d."
     compliance:
-      - cis: ["2.1.11"]
+      - cis: ["2.2.10"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "c:dpkg -s dovecot-imapd -> r:package 'dovecot-imapd' is not installed"
-      - "c:dpkg -s dovecot-pop3d -> r:package 'dovecot-pop3d' is not installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' dovecot-imapd -> r:install ok installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' dovecot-pop3d -> r:install ok installed"
 
-  # 2.1.12 Ensure Samba is not installed (Automated)
-  - id: 19065
+  # 2.2.11 Ensure Samba is not installed. (Automated)
+  - id: 31087
     title: "Ensure Samba is not installed."
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Server Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this service should be deleted to reduce the potential attack surface."
-    remediation: "Run the following command to remove samba: # apt purge samba"
+    remediation: "Run the following command to remove samba: # apt purge samba."
     compliance:
-      - cis: ["2.1.12"]
+      - cis: ["2.2.11"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1005", "T1039", "T1083", "T1135", "T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s samba -> r:package 'samba' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' samba -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' samba -> r:install ok installed"
 
-  # 2.1.13 Ensure HTTP Proxy Server is not installed (Automated)
-  - id: 19066
+  # 2.2.12 Ensure HTTP Proxy Server is not installed. (Automated)
+  - id: 31088
     title: "Ensure HTTP Proxy Server is not installed."
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
-    remediation: "Run the following command to remove squid: # apt purge squid"
+    remediation: "Run the following command to remove squid: # apt purge squid."
     compliance:
-      - cis: ["2.1.13"]
+      - cis: ["2.2.12"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s squid -> r:package 'squid' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' squid -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' squid -> r:install ok installed"
 
-  # 2.1.14 Ensure SNMP Server is not installed (Automated)
-  - id: 19067
+  # 2.2.13 Ensure SNMP Server is not installed. (Automated)
+  - id: 31089
     title: "Ensure SNMP Server is not installed."
     description: 'Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system.'
-    rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the net-snmp package should be removed to reduce the attack surface of the system. Note: If SNMP is required: - The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. - If SNMP v2 is absolutely necessary, modify the community strings' values."
-    remediation: "Run the following command to remove snmpd: # apt purge snmpd"
+    rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the snmpd package should be removed to reduce the attack surface of the system. Note: If SNMP is required: - The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values. -."
+    remediation: "Run the following command to remove snmpd: # apt purge snmpd."
     compliance:
-      - cis: ["2.1.14"]
+      - cis: ["2.2.13"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s snmpd -> r:package 'snmpd' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' snmp -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' snmp -> r:install ok installed"
 
-  # 2.1.15 Ensure mail transfer agent is configured for local-only mode (Automated)
-  - id: 19068
-    title: "Ensure mail transfer agent is configured for local-only mode."
-    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
-    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: This recommendation is designed around the exim4 mail server, depending on your environment you may have an alternative MTA installed such as sendmail. If this is the case consult the documentation for your installed MTA to configure the recommended state."
-    remediation: "Edit /etc/exim4/update-exim4.conf.conf and and or modify following lines to look like the lines below: dc_eximconfig_configtype='local' dc_local_interfaces='127.0.0.1 ; ::1' dc_readhost='' dc_relay_domains='' dc_minimaldns='false' dc_relay_nets='' dc_smarthost='' dc_use_split_config='false' dc_hide_mailname='' dc_mailname_in_oh='true' dc_localdelivery='mail_spool' Restart exim4: # systemctl restart exim4"
-    compliance:
-      - cis: ["2.1.15"]
-      - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
-      - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
-    rules:
-      - 'not c:ss -lntu -> r:\.*:25\s && r:127.0.0.1:25\s+|::1]:25\s+'
-
-  # 2.1.16 Ensure rsync service is not installed (Automated)
-  - id: 19069
-    title: "Ensure rsync service is not installed."
-    description: "The rsync service can be used to synchronize files between systems over network links."
-    rationale: "The rsync service presents a security risk as it uses unencrypted protocols for communication. The rsync package should be removed to reduce the attack area of the system."
-    remediation: "Run the following command to remove rsync: # apt purge rsync"
-    compliance:
-      - cis: ["2.1.16"]
-      - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
-      - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
-    rules:
-      - "c:dpkg -s rsync -> r:package 'rsync' is not installed"
-
-  # 2.1.17 Ensure NIS Server is not installed (Automated)
-  - id: 19070
+  # 2.2.14 Ensure NIS Server is not installed. (Automated)
+  - id: 31090
     title: "Ensure NIS Server is not installed."
     description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed and other, more secure services be used."
-    remediation: "Run the following command to remove nis: # apt purge nis"
+    remediation: "Run the following command to remove nis: # apt purge nis."
     compliance:
-      - cis: ["2.1.17"]
+      - cis: ["2.2.14"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nis -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nis -> r:install ok installed"
+
+  # 2.2.15 Ensure dnsmasq is not installed. (Automated)
+  - id: 31091
+    title: "Ensure dnsmasq is not installed."
+    description: "dnsmasq is a lightweight tool that provides DNS caching, DNS forwarding and DHCP (Dynamic Host Configuration Protocol) services."
+    rationale: "Unless a system is specifically designated to act as a DNS caching, DNS forwarding and/or DHCP server, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove dnsmasq: # apt purge dnsmasq."
+    compliance:
+      - cis: ["2.2.15"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' dnsmaq -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' dnsmaq -> r:install ok installed"
+
+  # 2.2.16 Ensure mail transfer agent is configured for local-only mode. (Automated)
+  - id: 31092
+    title: "Ensure mail transfer agent is configured for local-only mode."
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: - This recommendation is designed around the postfix mail server. - Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only Run the following command to restart postfix: # systemctl restart postfix."
+    compliance:
+      - cis: ["2.2.16"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1018", "T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "c:dpkg -s nis -> r:package 'nis' is not installed"
+      - 'c:ss -lntu -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.*LISTEN|::1:25\.*LISTEN'
 
-  # 2.2 Service Clients
+  # 2.2.17 Ensure rsync service is either not installed or is masked. (Automated)
+  - id: 31093
+    title: "Ensure rsync service is either not installed or is masked."
+    description: "The rsync service can be used to synchronize files between systems over network links."
+    rationale: "The rsync service presents a security risk as the rsync protocol is unencrypted. The rsync package should be removed or if required for dependencies, the rsync service should be stopped and masked to reduce the attack area of the system."
+    remediation: "Run the following command to remove rsync: # apt purge rsync -- OR -- Run the following commands to stop and mask rsync: # systemctl stop rsync # systemctl mask rsync."
+    compliance:
+      - cis: ["2.2.17"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1105", "T1203", "T1210", "T1543", "T1543.002", "T1570"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' rsync -> r:unknown ok not-installed"
+      - "c:systemctl is-active rsync -> r:^inactive"
+      - "c:systemctl is-enabled rsync -> r:^masked"
 
-  # 2.2.1 Ensure NIS Client is not installed (Automated)
-  - id: 19071
+  # 2.3.1 Ensure NIS Client is not installed. (Automated)
+  - id: 31094
     title: "Ensure NIS Client is not installed."
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client was used to bind a machine to an NIS server and receive the distributed configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
     impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
-    remediation: "Uninstall nis: # apt purge nis"
+    remediation: "Uninstall nis: # apt purge nis."
     compliance:
-      - cis: ["2.2.1"]
+      - cis: ["2.3.1"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["2.6"]
-      - cmmc_v2.0: ["CM.2.063", "CM.3.069", "CM.4.073"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
-      - mitre_techniques: ["T1191", "T1092", "T1175", "T1173", "T1519", "T1052", "T1210", "T1133", "T1118", "T1171", "T1170", "T1046", "T1137", "T1086", "T1164", "T1121", "T1076", "T1091", "T1180", "T1064", "T1184", "T1221", "T1127", "T1028"]
-      - nist_sp_800-53: ["CM-11"]
-    condition: all
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s nis -> r:package 'nis' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nis -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nis -> r:install ok installed"
 
-  # 2.2.2 Ensure rsh client is not installed (Automated)
-  - id: 19072
+  # 2.3.2 Ensure rsh client is not installed. (Automated)
+  - id: 31095
     title: "Ensure rsh client is not installed."
-    description: The rsh-client package contains the client commands for the rsh services."
-    rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh, rcp and rlogin."
+    description: "The rsh-client package contains the client commands for the rsh services."
+    rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh-client package removes the clients for rsh, rcp and rlogin."
     impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
-    remediation: "Uninstall rsh: # apt purge rsh-client"
+    remediation: "Uninstall rsh: # apt purge rsh-client."
     compliance:
-      - cis: ["2.2.2"]
-      - cis_csc_v7: ["4.5"]
-      - cmmc_v2.0: ["IA.3.083"]
-      - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1176", "T1501", "T1098", "T1017", "T1110", "T1136", "T1530", "T1114", "T1133", "T1040", "T1076", "T1021", "T1539", "T1072", "T1078", "T1134", "T1067", "T1088", "T1175", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1100", "T1077", "T1047", "T1084", "T1028"]
-      - pci_dss_v3.2.1: ["2.3", "8.3", "8.3.1", "8.3.2"]
-    condition: all
+      - cis: ["2.3.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1040", "T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s rsh-client -> r:package 'rsh-client' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' rsh-client -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' rsh-client -> r:install ok installed"
 
-  # 2.2.3 Ensure talk client is not installed (Automated)
-  - id: 19073
+  # 2.3.3 Ensure talk client is not installed. (Automated)
+  - id: 31096
     title: "Ensure talk client is not installed."
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
     impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
-    remediation: "Uninstall talk: # apt purge talk"
+    remediation: "Uninstall talk: # apt purge talk."
     compliance:
-      - cis: ["2.2.3"]
-      - cis_csc_v7: ["2.6"]
-      - cmmc_v2.0: ["CM.2.063", "CM.3.069", "CM.4.073"]
-      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
-      - mitre_techniques: ["T1191", "T1092", "T1175", "T1173", "T1519", "T1052", "T1210", "T1133", "T1118", "T1171", "T1170", "T1046", "T1137", "T1086", "T1164", "T1121", "T1076", "T1091", "T1180", "T1064", "T1184", "T1221", "T1127", "T1028"]
-      - nist_sp_800-53: ["CM-11"]
-    condition: all
+      - cis: ["2.3.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0006", "TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s talk -> r:package 'talk' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' talk -> r:unknown ok not-installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' talk -> r:no packages found matching talk"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' talk -> r:install ok installed"
 
-  # 2.2.4 Ensure telnet client is not installed (Automated)
-  - id: 19074
+  # 2.3.4 Ensure telnet client is not installed. (Automated)
+  - id: 31097
     title: "Ensure telnet client is not installed."
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
     impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
-    remediation: "Uninstall telnet: # apt purge telnet"
+    remediation: "Uninstall telnet: # apt purge telnet."
     compliance:
-      - cis: ["2.2.4"]
-      - cis_csc_v7: ["4.5"]
-      - cmmc_v2.0: ["IA.3.083"]
-      - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1176", "T1501", "T1098", "T1017", "T1110", "T1136", "T1530", "T1114", "T1133", "T1040", "T1076", "T1021", "T1539", "T1072", "T1078", "T1134", "T1067", "T1088", "T1175", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1100", "T1077", "T1047", "T1084", "T1028"]
-      - pci_dss_v3.2.1: ["2.3", "8.3", "8.3.1", "8.3.2"]
-    condition: all
+      - cis: ["2.3.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0006", "TA0008"]
+      - mitre_techniques: ["T1040", "T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s telnet -> r:package 'telnet' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' telnet -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' telnet -> r:install ok installed"
 
-  # 2.2.5 Ensure LDAP client is not installed (Automated)
-  - id: 19075
+  # 2.3.5 Ensure LDAP client is not installed. (Automated)
+  - id: 31098
     title: "Ensure LDAP client is not installed."
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
     impact: "Removing the LDAP client will prevent or inhibit using LDAP for authentication in your environment."
-    remediation: "Uninstall ldap-utils: # apt purge ldap-utils"
+    remediation: "Uninstall ldap-utils: # apt purge ldap-utils."
     compliance:
-      - cis: ["2.2.5"]
-      - cis_csc_v7: ["2.6"]
-      - cmmc_v2.0: ["CM.2.063", "CM.3.069", "CM.4.073"]
-      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
-      - mitre_techniques: ["T1191", "T1092", "T1175", "T1173", "T1519", "T1052", "T1210", "T1133", "T1118", "T1171", "T1170", "T1046", "T1137", "T1086", "T1164", "T1121", "T1076", "T1091", "T1180", "T1064", "T1184", "T1221", "T1127", "T1028"]
-      - nist_sp_800-53: ["CM-11"]
-    condition: all
-    rules:
-      - "c:dpkg -s ldap-utils -> r:package 'ldap-utils' is not installed"
-
-  # 2.2.6 Ensure RPC is not installed (Automated)
-  - id: 19076
-    title: "Ensure RPC is not installed."
-    description: "Remote Procedure Call (RPC) is a method for creating low level client server applications across different system architectures. It requires an RPC compliant client listening on a network port. The supporting package is rpcbind."
-    rationale: "If RPC is not required, it is recommended that this services be removed to reduce the remote attack surface."
-    remediation: "Run the following command to remove rpcbind: # apt purge rpcbind"
-    compliance:
-      - cis: ["2.2.6"]
+      - cis: ["2.3.5"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s rpcbind -> r:package 'rpcbind' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' ldap-utils -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' ldap-utils -> r:install ok installed"
 
-  # 2.3 Ensure nonessential services are removed or masked (Manual) - Not implemented
+  # 2.3.6 Ensure RPC is not installed. (Automated)
+  - id: 31099
+    title: "Ensure RPC is not installed."
+    description: 'Remote Procedure Call (RPC) is a method for creating low level client server applications across different system architectures. It requires an RPC compliant client listening on a network port. The supporting package is rpcbind.".'
+    rationale: "If RPC is not required, it is recommended that this services be removed to reduce the remote attack surface."
+    remediation: "Run the following command to remove rpcbind: # apt purge rpcbind."
+    compliance:
+      - cis: ["2.3.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' rpcbind -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' rpcbind -> r:install ok installed"
 
-  # 3 Network Configuration
-  # 3.1 Disable unused network protocols and devices
+  # 2.4 Ensure nonessential services are removed or masked. (Manual) - Not Implemented
 
-  # 3.1.1 Disable IPv6 (Manual)
-  - id: 19077
-    title: "Disable IPv6."
-    description: "Although IPv6 has many advantages over IPv4, not all organizations have IPv6 or dual stack configurations implemented."
-    rationale: "If IPv6 or dual stack is not to be used, it is recommended that IPv6 be disabled to reduce the attack surface of the system."
-    impact: "If IPv6 is disabled through sysctl config, SSH X11forwarding may no longer function as expected. We recommend that SSH X11fowarding be disabled, but if required, the following will allow for SSH X11forwarding with IPv6 disabled through sysctl config: Add the following line the /etc/ssh/sshd_config file: AddressFamily inet Run the following command to re-start the openSSH server: # systemctl restart sshd"
-    remediation: 'Use one of the two following methods to disable IPv6 on the system: To disable IPv6 through the GRUB2 config: Edit /etc/default/grub and add ipv6.disable=1 to the GRUB_CMDLINE_LINUX parameters: GRUB_CMDLINE_LINUX="ipv6.disable=1" Run the following command to update the grub2 configuration: # update-grub OR To disable IPv6 through sysctl settings: Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv6.conf.all.disable_ipv6 = 1 net.ipv6.conf.default.disable_ipv6 = 1 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv6.conf.all.disable_ipv6=1 # sysctl -w net.ipv6.conf.default.disable_ipv6=1 # sysctl -w net.ipv6.route.flush=1'
+  # 3.1.1 Ensure IPv6 status is identified. (Manual)
+  - id: 31101
+    title: "Ensure IPv6 status is identified."
+    description: "Internet Protocol Version 6 (IPv6) is the most recent version of Internet Protocol (IP). It's designed to supply IP addressing and additional security to support the predicted growth of connected devices. IPv6 is based on 128-bit addressing and can support 340 undecillion addresses, which is 340 followed by 36 zeroes. Features of IPv6 - Hierarchical addressing and routing infrastructure - Stateful and Stateless configuration - Support for quality of service (QoS) - An ideal protocol for neighboring node interaction."
+    rationale: "IETF RFC 4038 recommends that applications are built with an assumption of dual stack. It is recommended that IPv6 be enabled and configured in accordance with Benchmark recommendations. If dual stack and IPv6 are not used in your environment, IPv6 may be disabled to reduce the attack surface of the system, and recommendations pertaining to IPv6 can be skipped. Note: It is recommended that IPv6 be enabled and configured unless this is against local site policy."
+    impact: "IETF RFC 4038 recommends that applications are built with an assumption of dual stack. When enabled, IPv6 will require additional configuration to reduce risk to the system."
+    remediation: "Enable or disable IPv6 in accordance with system requirements and local site policy."
     compliance:
       - cis: ["3.1.1"]
-      - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
-      - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
-    condition: any
-    rules:
-      - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && r:ipv6.disable\s*=\s*1'
-      - 'c:sysctl net.ipv6.conf.all.disable_ipv6 -> r:net.ipv6.conf.all.disable_ipv6\s*=\s*1'
-      - 'c:sysctl net.ipv6.conf.default.disable_ipv6 -> r:net.ipv6.conf.default.disable_ipv6\s*=\s*1'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv6.conf.all.disable_ipv6\s*=\s*1'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv6.conf.default.disable_ipv6\s*=\s*1'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv6.conf.all.disable_ipv6\s*=\s*1'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv6.conf.default.disable_ipv6\s*=\s*1'
-
-  # 3.1.2 Ensure wireless interfaces are disabled (Automated) - Not implemented
-
-  # 3.2 Network Parameters (Host Only)
-
-  # 3.2.1 Ensure packet redirect sending is disabled (Automated)
-  - id: 19078
-    title: "Ensure packet redirect sending is disabled."
-    description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
-    rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
-    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.send_redirects = 0 net.ipv4.conf.default.send_redirects = 0 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.send_redirects=0 # sysctl -w net.ipv4.conf.default.send_redirects=0 # sysctl -w net.ipv4.route.flush=1"
-    compliance:
-      - cis: ["3.2.1"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: any
-    rules:
-      - 'c:sysctl net.ipv4.conf.all.send_redirects -> r:net.ipv4.conf.all.send_redirects\s*=\s*0'
-      - 'c:sysctl net.ipv4.conf.default.send_redirects -> r:net.ipv4.conf.default.send_redirects\s*=\s*0'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.all.send_redirects\s*=\s*0'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.default.send_redirects\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.all.send_redirects\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.default.send_redirects\s*=\s*0'
-
-  # 3.2.2 Ensure IP forwarding is disabled (Automated)
-  - id: 19079
-    title: "Ensure IP forwarding is disabled."
-    description: "The net.ipv4.ip_forward and net.ipv6.conf.all.forwarding flags are used to tell the system whether it can forward packets or not."
-    rationale: "Setting the flags to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
-    remediation: 'Run the following command to restore the default parameter and set the active kernel parameter: # grep -Els "^\s*net\.ipv4\.ip_forward\s*=\s*1" /etc/sysctl.conf /etc/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /run/sysctl.d/*.conf | while read filename; do sed -ri "s/^\s*(net\.ipv4\.ip_forward\s*)(=)(\s*\S+\b).*$/# *REMOVED* \1/" $filename; done; sysctl -w net.ipv4.ip_forward=0; sysctl -w net.ipv4.route.flush=1 IF IPv6 is enabled: Run the following command to restore the default parameter and set the active kernel parameter: # grep -Els "^\s*net\.ipv6\.conf\.all\.forwarding\s*=\s*1" /etc/sysctl.conf /etc/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /run/sysctl.d/*.conf | while read filename; do sed -ri "s/^\s*(net\.ipv6\.conf\.all\.forwarding\s*)(=)(\s*\S+\b).*$/# *REMOVED* \1/" $filename; done; sysctl -w net.ipv6.conf.all.forwarding=0; sysctl -w net.ipv6.route.flush=1'
-    compliance:
-      - cis: ["3.2.2"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: any
-    rules:
-      - 'c:sysctl net.ipv4.ip_forward -> r:net.ipv4.ip_forward\s*=\s*0$'
-      - 'c:sysctl net.ipv6.conf.all.forwarding -> r:net.ipv6.conf.all.forwarding\s*=\s*0$'
-      - 'not f:/etc/sysctl.conf -> r:^\s*net.ipv4.ip_forward\s*=\s*1'
-      - 'not f:/etc/sysctl.conf -> r:^\s*net.ipv6.conf.all.forwarding\s*=\s*1'
-      - 'not d:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.ip_forward\s*=\s*1'
-      - 'not d:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv6.conf.all.forwarding\s*=\s*1'
-
-  # 3.3 Network Parameters
-
-  # 3.3.1 Ensure source routed packets are not accepted (Automated)
-  - id: 19080
-    title: "Ensure source routed packets are not accepted."
-    description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
-    rationale: "Setting net.ipv4.conf.all.accept_source_route, net.ipv4.conf.default.accept_source_route, net.ipv6.conf.all.accept_source_route and net.ipv6.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
-    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_source_route = 0 net.ipv4.conf.default.accept_source_route = 0 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.accept_source_route=0 # sysctl -w net.ipv4.conf.default.accept_source_route=0 # sysctl -w net.ipv4.route.flush=1 IF IPv6 is enabled: Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv6.conf.all.accept_source_route = 0 net.ipv6.conf.default.accept_source_route = 0 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv6.conf.all.accept_source_route=0 # sysctl -w net.ipv6.conf.default.accept_source_route=0 # sysctl -w net.ipv6.route.flush=1 "
-    compliance:
-      - cis: ["3.3.1"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: any
-    rules:
-      - 'c:sysctl net.ipv4.conf.all.accept_source_route -> r:net.ipv4.conf.all.accept_source_route\s*=\s*0$'
-      - 'c:sysctl net.ipv4.conf.default.accept_source_route -> r:net.ipv4.conf.default.accept_source_route\s*=\s*0$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.all.accept_source_route\s*=\s*0'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.default.accept_source_route\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.all.accept_source_route\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.default.accept_source_route\s*=\s*0'
-      - 'c:sysctl net.ipv6.conf.all.accept_source_route -> r:net.ipv6.conf.all.accept_source_route\s*=\s*0$'
-      - 'c:sysctl net.ipv6.conf.default.accept_source_route -> r:net.ipv6.conf.default.accept_source_route\s*=\s*0$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv6.conf.all.accept_source_route\s*=\s*0'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv6.conf.default.accept_source_route\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv6.conf.all.accept_source_route\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv6.conf.default.accept_source_route\s*=\s*0'
-
-  # 3.3.2 Ensure ICMP redirects are not accepted (Automated)
-  - id: 19081
-    title: "Ensure ICMP redirects are not accepted."
-    description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables. By setting net.ipv4.conf.all.accept_redirects and net.ipv6.conf.all.accept_redirects to 0, the system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables."
-    rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
-    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_redirects = 0 net.ipv4.conf.default.accept_redirects = 0 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.accept_redirects=0 # sysctl -w net.ipv4.conf.default.accept_redirects=0 # sysctl -w net.ipv4.route.flush=1 IF IPv6 is enabled: Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv6.conf.all.accept_redirects = 0 net.ipv6.conf.default.accept_redirects = 0 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv6.conf.all.accept_redirects=0 # sysctl -w net.ipv6.conf.default.accept_redirects=0 # sysctl -w net.ipv6.route.flush=1"
-    compliance:
-      - cis: ["3.3.2"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: any
-    rules:
-      - 'c:sysctl net.ipv4.conf.all.accept_redirects -> r:net.ipv4.conf.all.accept_redirects\s*=\s*0$'
-      - 'c:sysctl net.ipv4.conf.default.accept_redirects -> r:net.ipv4.conf.default.accept_redirects\s*=\s*0$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.all.accept_redirects\s*=\s*0'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.default.accept_redirects\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.all.accept_redirects\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.default.accept_redirects\s*=\s*0'
-      - 'c:sysctl net.ipv6.conf.all.accept_redirects -> r:net.ipv6.conf.all.accept_redirects\s*=\s*0$'
-      - 'c:sysctl net.ipv6.conf.default.accept_redirects -> r:net.ipv6.conf.default.accept_redirects\s*=\s*0$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv6.conf.all.accept_redirects \s*=\s*0'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv6.conf.default.accept_redirects\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\snet.ipv6.conf.all.accept_redirects\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\snet.ipv6.conf.default.accept_redirects\s*=\s*0'
-
-  # 3.3.3 Ensure secure ICMP redirects are not accepted (Automated)
-  - id: 19082
-    title: "Ensure secure ICMP redirects are not accepted."
-    description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
-    rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
-    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.secure_redirects = 0 net.ipv4.conf.default.secure_redirects = 0 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.secure_redirects=0 # sysctl -w net.ipv4.conf.default.secure_redirects=0 # sysctl -w net.ipv4.route.flush=1"
-    compliance:
-      - cis: ["3.3.3"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: any
-    rules:
-      - 'c:sysctl net.ipv4.conf.all.secure_redirects -> r:net.ipv4.conf.all.secure_redirects\s*=\s*0$'
-      - 'c:sysctl net.ipv4.conf.default.secure_redirects -> r:net.ipv4.conf.default.secure_redirects\s*=\s*0$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.all.secure_redirects\s*=\s*0'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.default.secure_redirects\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.all.secure_redirects\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.default.secure_redirects\s*=\s*0'
-
-  # 3.3.4 Ensure suspicious packets are logged (Automated)
-  - id: 19083
-    title: "Ensure suspicious packets are logged."
-    description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
-    rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
-    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.log_martians = 1 net.ipv4.conf.default.log_martians = 1 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.log_martians=1 # sysctl -w net.ipv4.conf.default.log_martians=1 # sysctl -w net.ipv4.route.flush=1"
-    compliance:
-      - cis: ["3.3.4"]
-      - cis_csc_v7: ["6.2", "6.3"]
-      - cmmc_v2.0: ["AU.2.042", "AU.5.055", "CM.2.065"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-12", "AU-3"]
-      - pci_dss_v3.2.1: ["10.1", "10.2", "10.3"]
-    condition: any
-    rules:
-      - 'c:sysctl net.ipv4.conf.all.log_martians -> r:net.ipv4.conf.all.log_martians\s*=\s*1$'
-      - 'c:sysctl net.ipv4.conf.default.log_martians -> r:net.ipv4.conf.default.log_martians\s*=\s*1$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.all.log_martians\s*=\s*1'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.default.log_martians\s*=\s*1'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.all.log_martians\s*=\s*1'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.default.log_martians\s*=\s*1'
-
-  # 3.3.5 Ensure broadcast ICMP requests are ignored (Automated)
-  - id: 19084
-    title: "Ensure broadcast ICMP requests are ignored."
-    description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
-    rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
-    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_echo_ignore_broadcasts = 1 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1 # sysctl -w net.ipv4.route.flush=1"
-    compliance:
-      - cis: ["3.3.5"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: any
-    rules:
-      - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1'
-
-  # 3.3.6 Ensure bogus ICMP responses are ignored (Automated)
-  - id: 19085
-    title: "Ensure bogus ICMP responses are ignored."
-    description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
-    rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
-    remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_ignore_bogus_error_responses = 1 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1 # sysctl -w net.ipv4.route.flush=1"
-    compliance:
-      - cis: ["3.3.6"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: any
-    rules:
-      - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1'
-
-  # 3.3.7 Ensure Reverse Path Filtering is enabled (Automated)
-  - id: 19086
-    title: "Ensure Reverse Path Filtering is enabled."
-    description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
-    rationale: "Setting these flags is a good way to deter attackers from sending your system bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
-    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.rp_filter = 1 net.ipv4.conf.default.rp_filter = 1 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.rp_filter=1 # sysctl -w net.ipv4.conf.default.rp_filter=1 # sysctl -w net.ipv4.route.flush=1"
-    compliance:
-      - cis: ["3.3.7"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: any
-    rules:
-      - 'c:sysctl net.ipv4.conf.all.rp_filter -> r:net.ipv4.conf.all.rp_filter\s*=\s*1$'
-      - 'c:sysctl net.ipv4.conf.default.rp_filter -> r:net.ipv4.conf.default.rp_filter\s*=\s*1$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.all.rp_filter\s*=\s*1'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.conf.default.rp_filter\s*=\s*1'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.all.rp_filter\s*=\s*1'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.conf.default.rp_filter\s*=\s*1'
-
-  # 3.3.8 Ensure TCP SYN Cookies is enabled (Scored)
-  - id: 19087
-    title: "Ensure TCP SYN Cookies is enabled."
-    description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue."
-    rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
-    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.tcp_syncookies = 1 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.tcp_syncookies=1 # sysctl -w net.ipv4.route.flush=1"
-    compliance:
-      - cis: ["3.3.8"]
-      - cis_csc_v7: ["5.1"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: any
-    rules:
-      - 'c:sysctl net.ipv4.tcp_syncookies -> r:net.ipv4.tcp_syncookies\s*=\s*1$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv4.tcp_syncookies\s*=\s*1'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv4.tcp_syncookies\s*=\s*1'
-
-  # 3.3.9 Ensure IPv6 router advertisements are not accepted (Scored)
-  - id: 19088
-    title: "Ensure IPv6 router advertisements are not accepted."
-    description: "This setting disables the system's ability to accept IPv6 router advertisements."
-    rationale: "It is recommended that systems do not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
-    remediation: "IF IPv6 is enabled: Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv6.conf.all.accept_ra = 0 net.ipv6.conf.default.accept_ra = 0 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv6.conf.all.accept_ra=0 # sysctl -w net.ipv6.conf.default.accept_ra=0 # sysctl -w net.ipv6.route.flush=1"
-    compliance:
-      - cis: ["3.3.9"]
-      - cis_csc_v7: ["5.1"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: any
-    rules:
-      - 'c:sysctl net.ipv6.conf.all.accept_ra -> r:net.ipv6.conf.all.accept_ra\s*=\s0$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv6.conf.all.accept_ra\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv6.conf.all.accept_ra\s*=\s*0'
-      - 'c:sysctl net.ipv6.conf.default.accept_ra -> r:net.ipv6.conf.default.accept_ra\s*=\s*0$'
-      - 'f:/etc/sysctl.conf -> r:^\s*net.ipv6.conf.default.accept_ra\s*=\s*0'
-      - 'd:/etc/sysctl.d -> r:\.*.conf -> r:^\s*net.ipv6.conf.default.accept_ra\s*=\s*0'
-
-  # 3.4 Uncommon Network Protocols
-
-  # 3.4.1 Ensure DCCP is disabled (Automated)
-  - id: 19089
-    title: "Ensure DCCP is disabled."
-    description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
-    rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/dccp.conf Add the following line: install dccp /bin/true"
-    compliance:
-      - cis: ["3.4.1"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: none
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1557", "T1595", "T1595.001", "T1595.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
     rules:
-      - "not c:modprobe -n -v dccp -> r:install /bin/true|install /bin/false"
-      - "c:lsmod -> r:dccp"
+      - "f:/sys/module/ipv6/parameters/disable -> r:^0$"
 
-  # 3.4.2 Ensure SCTP is disabled (Scored)
-  - id: 19090
-    title: "Ensure SCTP is disabled."
-    description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
-    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/sctp.conf and add the following line: install sctp /bin/true"
+  # 3.1.2 Ensure wireless interfaces are disabled. (Automated) - Not Implemented
+
+  # 3.1.3 Ensure bluetooth is disabled. (Automated)
+  - id: 31103
+    title: "Ensure bluetooth is disabled."
+    description: "Bluetooth is a short-range wireless technology standard that is used for exchanging data between devices over short distances. It employs UHF radio waves in the ISM bands, from 2.402 GHz to 2.48 GHz. It is mainly used as an alternative to wire connections."
+    rationale: "An attacker may be able to find a way to access or corrupt your data. One example of this type of activity is bluesnarfing, which refers to attackers using a Bluetooth connection to steal information off of your Bluetooth device. Also, viruses or other malicious code can take advantage of Bluetooth technology to infect other devices. If you are infected, your data may be corrupted, compromised, stolen, or lost."
+    impact: "Many personal electronic devices (PEDs) use Bluetooth technology. For example, you may be able to operate your computer with a wireless keyboard. Disabling Bluetooth will prevent these devices from connecting to the system."
+    remediation: "Run the following commands to stop and mask the Bluetooth service # systemctl stop bluetooth.service # systemctl mask bluetooth.service Note: A reboot may be required."
+    references:
+      - "https://www.cisa.gov/tips/st05-015"
     compliance:
-      - cis: ["3.4.2"]
+      - cis: ["3.1.3"]
+      - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: none
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
     rules:
-      - "not c:modprobe -n -v sctp -> r:install /bin/true|install /bin/false"
-      - "c:lsmod -> r:sctp"
+      - "not c:systemctl is-enabled bluetooth.service -> r:^enabled"
+      - "not c:systemctl is-active bluetooth.service -> r:^active"
 
-  # 3.4.3 Ensure RDS is disabled (Scored)
-  - id: 19091
-    title: "Ensure RDS is disabled."
-    description: "The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to provide low-latency, high-bandwidth communications between cluster nodes. It was developed by the Oracle Corporation."
-    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/rds.conf and add the following line: install rds /bin/true"
-    compliance:
-      - cis: ["3.4.3"]
-      - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
-      - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: none
-    rules:
-      - "not c:modprobe -n -v rds -> r:install /bin/true|install /bin/false"
-      - "c:lsmod -> r:rds"
+  # 3.1.4 Ensure DCCP is disabled. (Automated) - Not Implemented
+  # 3.1.5 Ensure SCTP is disabled. (Automated) - Not Implemented
+  # 3.1.6 Ensure RDS is disabled. (Automated) Not Implemented
+  # 3.1.7 Ensure TIPC is disabled. (Automated) - Not Implemented
 
-  # 3.4.4 Ensure TIPC is disabled (Scored)
-  - id: 19092
-    title: "Ensure TIPC is disabled."
-    description: "The Transparent Inter-Process Communication (TIPC) protocol is designed to provide communication between cluster nodes."
-    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
-    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/tipc.conf and add the following line: install tipc /bin/true"
-    compliance:
-      - cis: ["3.4.4"]
-      - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
-      - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: none
-    rules:
-      - "not c:modprobe -n -v tipc -> r:install /bin/true|install /bin/false"
-      - "c:lsmod -> r:tipc"
+  # 3.2.1 Ensure packet redirect sending is disabled. (Automated) - Not Implemented
+  # 3.2.2 Ensure IP forwarding is disabled. (Automated) - Not Implemented
 
-  # 3.5 Firewall configuration
-  ## 3.5.1 Configure UncomplicatedFirewall
+  # 3.3.1 Ensure source routed packets are not accepted. (Automated) - Not Implemented
+  # 3.3.2 Ensure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.3 Ensure secure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.4 Ensure suspicious packets are logged. (Automated) - Not Implemented
+  # 3.3.5 Ensure broadcast ICMP requests are ignored. (Automated) - Not Implemented
+  # 3.3.6 Ensure bogus ICMP responses are ignored. (Automated) - Not Implemented
+  # 3.3.7 Ensure Reverse Path Filtering is enabled. (Automated) - Not Implemented
+  # 3.3.8 Ensure TCP SYN Cookies is enabled. (Automated) - Not Implemented
+  # 3.3.9 Ensure IPv6 router advertisements are not accepted. (Automated) - Not Implemented
 
-  # 3.5.1.1 Ensure ufw is installed (Automated)
-  - id: 19093
+  # 3.4.1.1 Ensure ufw is installed. (Automated)
+  - id: 31119
     title: "Ensure ufw is installed."
     description: "The Uncomplicated Firewall (ufw) is a frontend for iptables and is particularly well-suited for host-based firewalls. ufw provides a framework for managing netfilter, as well as a command-line interface for manipulating the firewall."
     rationale: "A firewall utility is required to configure the Linux kernel's netfilter framework via the iptables or nftables back-end. The Linux kernel's netfilter framework host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured. UFW is dependent on the iptables package."
-    remediation: "Run the following command to install Uncomplicated Firewall (UFW): apt install ufw"
+    remediation: "Run the following command to install Uncomplicated Firewall (UFW): apt install ufw."
     compliance:
-      - cis: ["3.5.1.1"]
+      - cis: ["3.4.1.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "c:dpkg -s ufw -> r:Status: install ok installed"
-      - "c:dpkg -s nftables -> r:package 'nftables' is not installed"
-      - "c:dpkg -s iptables -> r:package 'iptables' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' ufw -> r:install ok installed"
 
-  # 3.5.1.2 Ensure iptables-persistent is not installed with ufw (Automated)
-  - id: 19094
+  # 3.4.1.2 Ensure iptables-persistent is not installed with ufw. (Automated)
+  - id: 31120
     title: "Ensure iptables-persistent is not installed with ufw."
     description: "The iptables-persistent is a boot-time loader for netfilter rules, iptables plugin."
     rationale: "Running both ufw and the services included in the iptables-persistent package may lead to conflict."
-    remediation: "Run the following command to remove the iptables-persistent package: # apt purge iptables-persistent"
+    remediation: "Run the following command to remove the iptables-persistent package: # apt purge iptables-persistent."
     compliance:
-      - cis: ["3.5.1.2"]
+      - cis: ["3.4.1.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "c:dpkg -s ufw -> r:Status: install ok installed"
-      - "not c:dpkg -s iptables-persistent -> r:Status: install ok installed"
+      - "c:dpkg-query -s iptables-persistent -> r:package 'iptables-persistent' is not installed"
 
-  # 3.5.1.3 Ensure ufw service is enabled (Automated)
-  - id: 19095
+  # 3.4.1.3 Ensure ufw service is enabled. (Automated)
+  - id: 31121
     title: "Ensure ufw service is enabled."
-    description: "UncomplicatedFirewall (ufw) is a frontend for iptables. ufw provides a framework for managing netfilter, as well as a command-line and available graphical user interface for manipulating the firewall. Notes: - When running ufw enable or starting ufw via its initscript, ufw will flush its chains. This is required so ufw can maintain a consistent state, but it may drop existing connections (eg ssh). ufw does support adding rules before enabling the firewall. - Run the following command before running ufw enable. # ufw allow proto tcp from any to any port 22. - The rules will still be flushed, but the ssh port will be open after enabling the firewall. Please note that once ufw is 'enabled', ufw will not flush the chains when adding or removing rules (but will when modifying a rule or changing the default policy). - By default, ufw will prompt when enabling the firewall while running under ssh. This can be disabled by using ufw --force enable."
+    description: "UncomplicatedFirewall (ufw) is a frontend for iptables. ufw provides a framework for managing netfilter, as well as a command-line and available graphical user interface for manipulating the firewall. Note: - When running ufw enable or starting ufw via its initscript, ufw will flush its chains. This is required so ufw can maintain a consistent state, but it may drop existing connections (eg ssh). ufw does support adding rules before enabling the firewall. - Run the following command before running ufw enable. # ufw allow proto tcp from any to any port 22 - The rules will still be flushed, but the ssh port will be open after enabling the firewall. Please note that once ufw is 'enabled', ufw will not flush the chains when adding or removing rules (but will when modifying a rule or changing the default policy) - By default, ufw will prompt when enabling the firewall while running under ssh. This can be disabled by using ufw --force enable."
     rationale: "The ufw service must be enabled and running in order for ufw to protect the system."
     impact: "Changing firewall settings while connected over network can result in being locked out of the system."
-    remediation: "Run the following command to enable ufw: # ufw enable"
-    compliance:
-      - cis: ["3.5.1.3"]
-      - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
-      - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+    remediation: "Run the following command to unmask the ufw daemon: # systemctl unmask ufw.service Run the following command to enable and start the ufw daemon: # systemctl --now enable ufw.service active Run the following command to enable ufw: # ufw enable."
     references:
       - "http://manpages.ubuntu.com/manpages/precise/en/man8/ufw.8.html"
+    compliance:
+      - cis: ["3.4.1.3"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "c:dpkg -s ufw -> r:Status: install ok installed"
-      - "c:systemctl is-enabled ufw -> r:enabled"
-      - "c:ufw status -> r:Status: active"
+      - "c:systemctl is-enabled ufw.service -> r:enabled"
+      - "c:systemctl is-active ufw -> r:^active"
+      - "c:ufw status -> r:active"
 
-  # 3.5.1.4 Ensure ufw loopback traffic is configured (Automated)
-  - id: 19096
+  # 3.4.1.4 Ensure ufw loopback traffic is configured. (Automated)
+  - id: 31122
     title: "Ensure ufw loopback traffic is configured."
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8 for IPv4 and ::1/128 for IPv6)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8 for IPv4 and ::1/128 for IPv6) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
-    remediation: "Run the following commands to implement the loopback rules: # ufw allow in on lo # ufw allow out on lo # ufw deny in from 127.0.0.0/8 # ufw deny in from ::1"
+    remediation: "Run the following commands to implement the loopback rules: # ufw allow in on lo # ufw allow out on lo # ufw deny in from 127.0.0.0/8 # ufw deny in from ::1."
     compliance:
-      - cis: ["3.5.1.4"]
+      - cis: ["3.4.1.4"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "c:dpkg -s ufw -> r:Status: install ok installed"
-      - 'c:ufw status verbose -> r:Anywhere on lo\s*ALLOW IN\s*Anywhere'
-      - 'c:ufw status verbose -> r:Anywhere\s*DENY IN\s*127.0.0.0/8'
-      - 'c:ufw status verbose -> r:Anywhere \(v6\) on lo\s*ALLOW IN\s*Anywhere \(v6\)'
-      - 'c:ufw status verbose -> r:Anywhere \(v6\)\s*DENY IN\s*::1'
-      - 'c:ufw status verbose -> r:Anywhere\s*\t*ALLOW OUT\s*Anywhere on lo'
-      - 'c:ufw status verbose -> r:Anywhere \(v6\)\s*ALLOW OUT\s*Anywhere \(v6\) on lo'
+      - 'c:ufw status verbose -> r:Anywhere on lo\s*\t*ALLOW IN\s*\t*Anywhere'
+      - 'c:ufw status verbose -> r:Anywhere\s*\t*DENY IN\s*\t*127.0.0.0/8'
+      - 'c:ufw status verbose -> r:Anywhere \(v6\) on lo\s*\t*ALLOW IN\s*\t*Anywhere \(v6\)'
+      - 'c:ufw status verbose -> r:Anywhere \(v6\)\s*\t*DENY IN\s*\t*::1'
+      - 'c:ufw status verbose -> r:Anywhere\s*\t*ALLOW OUT\s*\t*Anywhere on lo'
+      - 'c:ufw status verbose -> r:Anywhere \(v6\)\s*\t*ALLOW OUT\s*\t*Anywhere \(v6\) on lo'
 
-  # 3.5.1.5 Ensure ufw outbound connections are configured (Manual) - Not implemented
-  # 3.5.1.6 Ensure ufw firewall rules exist for all open ports (Manual) - Not inmplemented
+  # 3.4.1.5 Ensure ufw outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.1.6 Ensure ufw firewall rules exist for all open ports. (Automated) - Not Implemented
 
-  # 3.5.1.7 Ensure ufw default deny firewall policy (Automated)
-  - id: 19097
+  # 3.4.1.7 Ensure ufw default deny firewall policy. (Automated)
+  - id: 31125
     title: "Ensure ufw default deny firewall policy."
     description: "A default deny policy on connections ensures that any unconfigured network usage will be rejected. Note: Any port or protocol without a explicit allow before the default deny will be blocked."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
-    impact: "Any port and protocol not explicitly allowed will be blocked. The following rules should be considered before applying the default deny. ufw allow git ufw allow in http ufw allow in https ufw allow out 53 ufw logging on"
-    remediation: "Run the following commands to implement a default deny policy: # ufw default deny incoming # ufw default deny outgoing # ufw default deny routed"
+    impact: "Any port and protocol not explicitly allowed will be blocked. The following rules should be considered before applying the default deny. ufw allow git ufw allow in http ufw allow out http <- required for apt to connect to repository ufw allow in https ufw allow out https ufw allow out 53 ufw logging on."
+    remediation: "Run the following commands to implement a default deny policy: # ufw default deny incoming # ufw default deny outgoing # ufw default deny routed."
     compliance:
-      - cis: ["3.5.1.7"]
+      - cis: ["3.4.1.7"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "c:dpkg -s ufw -> r:Status: install ok installed"
-      - 'c:ufw status verbose -> r:^Default: && r:deny\s+\(incoming\)|reject\s+\(incoming\)'
-      - 'c:ufw status verbose -> r:^Default: && r:deny\s+\(outgoing\)|reject\s+\(outgoing\)'
-      - 'c:ufw status verbose -> r:^Default: && r:deny\s+\(routed\)|reject\s+\(routed\)'
+      - 'c:ufw status verbose -> r:^Default && r:deny\W+(incoming)|reject\W+(incoming)'
+      - 'c:ufw status verbose -> r:^Default && r:deny\W+(outgoing)|reject\W+(outgoing)'
+      - 'c:ufw status verbose -> r:^Default && r:deny\W+(routed)|reject\W+(routed)'
 
-  # 3.5.2 Configure nftables
-
-  # 3.5.2.1 Ensure nftables is installed (Automated)
-  - id: 19098
+  # 3.4.2.1 Ensure nftables is installed. (Automated)
+  - id: 31126
     title: "Ensure nftables is installed."
-    description: "nftables provides a new in-kernel packet classification framework that is based on a network-specific Virtual Machine (VM) and a new nft userspace command line tool. nftables reuses the existing Netfilter subsystems such as the existing hook infrastructure, the connection tracking system, NAT, userspace queuing and logging subsystem. Notes: - nftables is available in Linux kernel 3.13 and newer. - Only one firewall utility should be installed and configured. - Changing firewall settings while connected over the network can result in being locked out of the system."
+    description: "nftables provides a new in-kernel packet classification framework that is based on a network-specific Virtual Machine (VM) and a new nft userspace command line tool. nftables reuses the existing Netfilter subsystems such as the existing hook infrastructure, the connection tracking system, NAT, userspace queuing and logging subsystem. Notes: - nftables is available in Linux kernel 3.13 and newer - Only one firewall utility should be installed and configured - Changing firewall settings while connected over the network can result in being locked out of the system."
     rationale: "nftables is a subsystem of the Linux kernel that can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host."
-    remediation: "Run the following command to install nftables: # apt install nftables"
+    remediation: "Run the following command to install nftables: # apt install nftables."
     compliance:
-      - cis: ["3.5.2.1"]
+      - cis: ["3.4.2.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "c:dpkg -s nftables -> r:Status: install ok installed"
-      - "c:dpkg -s iptables -> r:package 'iptables' is not installed"
-      - "c:dpkg -s ufw -> r:package 'ufw' is not installed"
+      - "c:dpkg-query -s nftables -> r:install ok installed"
 
-  # 3.5.2.2 Ensure ufw is uninstalled or disabled with nftables (Automated)
-  - id: 19099
+  # 3.4.2.2 Ensure ufw is uninstalled or disabled with nftables. (Automated)
+  - id: 31127
     title: "Ensure ufw is uninstalled or disabled with nftables."
     description: "Uncomplicated Firewall (UFW) is a program for managing a netfilter firewall designed to be easy to use."
     rationale: "Running both the nftables service and ufw may lead to conflict and unexpected results."
-    remediation: "Run one of the following commands to either remove ufw or disable ufw Run the following command to remove ufw: # apt purge ufw Run the following command to disable ufw: # ufw disable"
+    remediation: "Run one of the following to either remove ufw or disable ufw and mask ufw.service: Run the following command to remove ufw: # apt purge ufw -OR- Run the following commands to disable ufw and mask ufw.service: # ufw disable # systemctl stop ufw.service # systemctl mask ufw.service Note: ufw disable needs to be run before systemctl mask ufw.service in order to correctly disable UFW."
     compliance:
-      - cis: ["3.5.2.2"]
+      - cis: ["3.4.2.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
-    condition: all
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
     rules:
-      - "c:dpkg -s nftables -> r:Status: install ok installed"
-      - "c:dpkg -s ufw -> r:package 'ufw' is not installed"
-      - 'c:ufw status -> r:Status:\s*inactive'
+      - "not c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' ufw -> r:install ok installed"
+      - "c:ufw status -> r:inactive"
+      - "c:systemctl is-enabled ufw.service -> r:^masked"
 
-  # 3.5.2.3 Ensure iptables are flushed with nftables (Manual)
-  - id: 19100
-    title: "Ensure iptables are flushed with nftables."
-    description: "nftables is a replacement for iptables, ip6tables, ebtables and arptables."
-    rationale: "It is possible to mix iptables and nftables. However, this increases complexity and also the chance to introduce errors. For simplicity flush out all iptables rules, and ensure it is not loaded."
-    remediation: "Run the following commands to flush iptables: For iptables: # iptables -F For ip6tables: # ip6tables -F"
-    compliance:
-      - cis: ["3.5.2.3"]
-      - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
-      - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
-    condition: all
-    rules:
-      - "c:dpkg -s nftables -> r:Status: install ok installed"
-      - "not c:iptables -L -> r:^ACCEPT|^DROP|^REJECT"
-      - "not c:ip6tables -L -> r:^ACCEPT|^DROP|^REJECT"
+  # 3.4.2.3 Ensure iptables are flushed with nftables. (Manual) - Not Implemented
 
-  # 3.5.2.4 Ensure a nftables table exists (Automated)
-  - id: 19101
+  # 3.4.2.4 Ensure a nftables table exists. (Automated)
+  - id: 31129
     title: "Ensure a nftables table exists."
     description: "Tables hold chains. Each table only has one address family and only applies to packets of this family. Tables can have one of five families."
     rationale: "nftables doesn't have any default tables. Without a table being build, nftables will not filter network traffic."
     impact: "Adding rules to a running nftables can cause loss of connectivity to the system."
-    remediation: "Run the following command to create a table in nftables # nft create table inet <table name> Example: # nft create table inet filter"
+    remediation: "Run the following command to create a table in nftables # nft create table inet <table name> Example: # nft create table inet filter."
     compliance:
-      - cis: ["3.5.2.4"]
+      - cis: ["3.4.2.4"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "c:dpkg -s nftables -> r:Status: install ok installed"
       - 'c:nft list tables -> r:\w+'
 
-  # 3.5.2.5 Ensure nftables base chains exist (Automated)
-  - id: 19102
+  # 3.4.2.5 Ensure nftables base chains exist. (Automated)
+  - id: 31130
     title: "Ensure nftables base chains exist."
     description: "Chains are containers for rules. They exist in two kinds, base chains and regular chains. A base chain is an entry point for packets from the networking stack, a regular chain may be used as jump target and is used for better rule organization."
     rationale: "If a base chain doesn't exist with a hook for input, forward, and delete, packets that would flow through those chains will not be touched by nftables."
     impact: "If configuring nftables over ssh, creating a base chain with a policy of drop will cause loss of connectivity. Ensure that a rule allowing ssh has been added to the base chain prior to setting the base chain's policy to drop."
-    remediation: "Run the following command to create the base chains: # nft create chain inet <table name> <base chain name> { type filter hook <(input|forward|output)> priority 0 \\; } Example: # nft create chain inet filter input { type filter hook input priority 0 \\; } # nft create chain inet filter forward { type filter hook forward priority 0 \\; } # nft create chain inet filter output { type filter hook output priority 0 \\; }"
+    remediation: "Run the following command to create the base chains: # nft create chain inet <table name> <base chain name> { type filter hook <(input|forward|output)> priority 0 \\; } Example: # nft create chain inet filter input { type filter hook input priority 0 \\; } # nft create chain inet filter forward { type filter hook forward priority 0 \\; } # nft create chain inet filter output { type filter hook output priority 0 \\; }."
     compliance:
-      - cis: ["3.5.2.5"]
+      - cis: ["3.4.2.5"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "c:dpkg -s nftables -> r:Status: install ok installed"
       - "c:nft list ruleset -> r:hook input"
       - "c:nft list ruleset -> r:hook forward"
       - "c:nft list ruleset -> r:hook output"
 
-  # 3.5.2.6 Ensure nftables loopback traffic is configured (Automated)
-  - id: 19103
+  # 3.4.2.6 Ensure nftables loopback traffic is configured. (Automated)
+  - id: 31131
     title: "Ensure nftables loopback traffic is configured."
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
-    remediation: "Run the following commands to implement the loopback rules: # nft add rule inet filter input iif lo accept # nft create rule inet filter input ip saddr 127.0.0.0/8 counter drop IF IPv6 is enabled on the system: Run the following command to implement the IPv6 loopback rule: # nft add rule inet filter input ip6 saddr ::1 counter drop"
+    remediation: "Run the following commands to implement the loopback rules: # nft add rule inet filter input iif lo accept # nft create rule inet filter input ip saddr 127.0.0.0/8 counter drop -IF- IPv6 is enabled on the system: Run the following command to implement the IPv6 loopback rule: # nft add rule inet filter input ip6 saddr ::1 counter drop."
     compliance:
-      - cis: ["3.5.2.6"]
+      - cis: ["3.4.2.6"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
-    condition: all
-    rules:
-      - "c:dpkg -s nftables -> r:Status: install ok installed"
-      - 'c:nft list ruleset -> r:hook input && r:iif "lo" accept'
-      - "c:nft list ruleset -> r:hook input && r:ip saddr 127.0.0.0/8"
-      - "c:nft list ruleset -> r:hook input && r:ip6 saddr ::1 counter packets"
-
-  # 3.5.2.7 Ensure nftables outbound and established connections are configured (Manual) - Not implemented
-
-  # 3.5.2.8 Ensure nftables default deny firewall policy (Automated)
-  - id: 19104
-    title: "Ensure nftables default deny firewall policy."
-    description: "Base chain policy is the default verdict that will be applied to packets reaching the end of the chain."
-    rationale: "There are two policies: accept (Default) and drop. If the policy is set to accept, the firewall will accept any packet that is not configured to be denied and the packet will continue transversing the network stack. It is easier to white list acceptable usage than to black list unacceptable usage. Note: Changing firewall settings while connected over network can result in being locked out of the system."
-    impact: "If configuring nftables over ssh, creating a base chain with a policy of drop will cause loss of connectivity. Ensure that a rule allowing ssh has been added to the base chain prior to setting the base chain's policy to drop."
-    remediation: "Run the following command for the base chains with the input, forward, and output hooks to implement a default DROP policy: # nft chain <table family> <table name> <chain name> { policy drop \\; } Example: # nft chain inet filter input { policy drop \\; } # nft chain inet filter forward { policy drop \\; } # nft chain inet filter output { policy drop \\; }"
-    compliance:
-      - cis: ["3.5.2.8"]
-      - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
-      - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
-    condition: all
-    rules:
-      - "c:dpkg -s nftables -> r:Status: install ok installed"
-      - "c:nft list ruleset -> r:hook input && r:policy drop"
-      - "c:nft list ruleset -> r:hook forward && r:policy drop"
-      - "c:nft list ruleset -> r:hook output && r:policy drop"
-
-  # 3.5.2.9 Ensure nftables service is enabled (Automated)
-  - id: 19105
-    title: "Ensure nftables service is enabled."
-    description: "The nftables service allows for the loading of nftables rulesets during boot, or starting on the nftables service."
-    rationale: "The nftables service restores the nftables rules from the rules files referenced in the /etc/nftables.conf file during boot or the starting of the nftables service."
-    remediation: "Run the following command to enable the nftables service: # systemctl enable nftables"
-    compliance:
-      - cis: ["3.5.2.9"]
-      - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
-      - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
-    condition: all
-    rules:
-      - "c:dpkg -s nftables -> r:Status: install ok installed"
-      - "c:systemctl is-enabled nftables -> enabled"
-
-  # 3.5.2.10 Ensure nftables rules are permanent (Automated) - Not implemented
-
-  # 3.5.3 Configure iptables
-  # 3.5.3.1 Configure software
-
-  # 3.5.3.1.1 Ensure iptables packages are installed (Automated)
-  - id: 19106
-    title: "Ensure iptables packages are installed."
-    description: "iptables is a utility program that allows a system administrator to configure the tables provided by the Linux kernel firewall, implemented as different Netfilter modules, and the chains and rules it stores. Different kernel modules and programs are used for different protocols; iptables applies to IPv4, ip6tables to IPv6, arptables to ARP, and ebtables to Ethernet frames."
-    rationale: "A method of configuring and maintaining firewall rules is necessary to configure a Host Based Firewall."
-    remediation: "Run the following command to install iptables and iptables-persistent # apt install iptables iptables-persistent"
-    compliance:
-      - cis: ["3.5.3.1.1"]
-      - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
-      - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
-    condition: all
-    rules:
-      - "c:dpkg -s iptables -> r:Status: install ok installed"
-      - "c:dpkg -s iptables-persistent -> r:Status: install ok installed"
-      - "c:dpkg -s nftables -> r:package 'nftables' is not installed"
-      - "c:dpkg -s ufw -> r:package 'ufw' is not installed"
-
-  # 3.5.3.1.2 Ensure nftables is not installed with iptables (Automated)
-  - id: 19107
-    title: "Ensure nftables is not installed with iptables."
-    description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables."
-    rationale: "Running both iptables and nftables may lead to conflict."
-    remediation: "Run the following command to remove nftables: # apt purge nftables"
-    compliance:
-      - cis: ["3.5.3.1.2"]
-      - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
-      - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
-    condition: all
-    rules:
-      - "c:dpkg -s iptables -> r:Status: install ok installed"
-      - "c:dpkg -s nftables -> r:package 'nftables' is not installed"
-
-  # 3.5.3.1.3 Ensure ufw is uninstalled or disabled with iptables (Automated)
-  - id: 19108
-    title: "Ensure ufw is uninstalled or disabled with iptables."
-    description: "Uncomplicated Firewall (UFW) is a program for managing a netfilter firewall designed to be easy to use. - Uses a command-line interface consisting of a small number of simple commands. - Uses iptables for configuration."
-    rationale: "Running iptables.persistent with ufw enabled may lead to conflict and unexpected results."
-    remediation: "Run one of the following commands to either remove ufw or stop and mask ufw Run the following command to remove ufw: # apt purge ufw OR Run the following commands to disable ufw: # ufw disable"
-    compliance:
-      - cis: ["3.5.3.1.3"]
-      - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
-      - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
-    condition: any
-    rules:
-      - "c:ufw status -> r:Status:\\s*inactive"
-      - "c:dpkg -s ufw -> r:package 'ufw' is not installed"
-      - "c:systemctl is-enabled ufw -> r:masked"
-
-  # 3.5.3.2 Configure IPv4 iptables
-
-  # 3.5.3.2.1 Ensure iptables loopback traffic is configured (Automated)
-  - id: 19109
-    title: "Ensure iptables loopback traffic is configured."
-    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8). Notes: - Changing firewall settings while connected over network can result in being locked out of the system. - Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well."
-    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
-    remediation: "Run the following commands to implement the loopback rules: # iptables -A INPUT -i lo -j ACCEPT # iptables -A OUTPUT -o lo -j ACCEPT # iptables -A INPUT -s 127.0.0.0/8 -j DROP"
-    compliance:
-      - cis: ["3.5.3.2.1"]
-      - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
-      - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
       - 'c:iptables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*0.0.0.0/0\.*0.0.0.0/0'
       - 'c:iptables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*127.0.0.0/8\.*0.0.0.0/0'
       - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
 
-  # 3.5.3.2.2 Ensure iptables outbound and established connections are configured (Manual) - Not implemented
+  # 3.4.2.7 Ensure nftables outbound and established connections are configured. (Manual) - Not Implemented
 
-  # 3.5.3.2.3 Ensure iptables default deny firewall policy (Automated)
-  - id: 19110
-    title: "Ensure iptables default deny firewall policy."
-    description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected. Notes: - Changing firewall settings while connected over network can result in being locked out of the system. - Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well."
-    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
-    remediation: "Run the following commands to implement a default DROP policy: # iptables -P INPUT DROP # iptables -P OUTPUT DROP # iptables -P FORWARD DROP"
+  # 3.4.2.8 Ensure nftables default deny firewall policy. (Automated)
+  - id: 31133
+    title: "Ensure nftables default deny firewall policy."
+    description: "Base chain policy is the default verdict that will be applied to packets reaching the end of the chain."
+    rationale: "There are two policies: accept (Default) and drop. If the policy is set to accept, the firewall will accept any packet that is not configured to be denied and the packet will continue transversing the network stack. It is easier to white list acceptable usage than to black list unacceptable usage. Note: Changing firewall settings while connected over network can result in being locked out of the system."
+    impact: "If configuring nftables over ssh, creating a base chain with a policy of drop will cause loss of connectivity. Ensure that a rule allowing ssh has been added to the base chain prior to setting the base chain's policy to drop."
+    remediation: "Run the following command for the base chains with the input, forward, and output hooks to implement a default DROP policy: # nft chain <table family> <table name> <chain name> { policy drop \\; } Example: # nft chain inet filter input { policy drop \\; } # nft chain inet filter forward { policy drop \\; } # nft chain inet filter output { policy drop \\; }."
     compliance:
-      - cis: ["3.5.3.2.3"]
+      - cis: ["3.4.2.8"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:nft list ruleset -> r:hook input && r:policy drop"
+      - "c:nft list ruleset -> r:hook forward && r:policy drop"
+      - "c:nft list ruleset -> r:hook output && r:policy drop"
+
+  # 3.4.2.9 Ensure nftables service is enabled. (Automated)
+  - id: 31134
+    title: "Ensure nftables service is enabled."
+    description: "The nftables service allows for the loading of nftables rulesets during boot, or starting on the nftables service."
+    rationale: "The nftables service restores the nftables rules from the rules files referenced in the /etc/nftables.conf file during boot or the starting of the nftables service."
+    remediation: "Run the following command to enable the nftables service: # systemctl enable nftables."
+    compliance:
+      - cis: ["3.4.2.9"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled nftables -> r:enabled"
+
+  # 3.4.2.10 Ensure nftables rules are permanent. (Automated)
+  - id: 31135
+    title: "Ensure nftables rules are permanent."
+    description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames. The nftables service reads the /etc/nftables.conf file for a nftables file or files to include in the nftables ruleset. A nftables ruleset containing the input, forward, and output base chains allow network traffic to be filtered."
+    rationale: "Changes made to nftables ruleset only affect the live system, you will also need to configure the nftables ruleset to apply on boot."
+    remediation: 'Edit the /etc/nftables.conf file and un-comment or add a line with include <Absolute path to nftables rules file> for each nftables file you want included in the nftables ruleset on boot Example: # vi /etc/nftables.conf Add the line: include "/etc/nftables.rules".'
+    compliance:
+      - cis: ["3.4.2.10"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "f:/etc/nftables.conf -> r:include *"
+
+  # 3.4.3.1.1 Ensure iptables packages are installed. (Automated)
+  - id: 31136
+    title: "Ensure iptables packages are installed."
+    description: "iptables is a utility program that allows a system administrator to configure the tables provided by the Linux kernel firewall, implemented as different Netfilter modules, and the chains and rules it stores. Different kernel modules and programs are used for different protocols; iptables applies to IPv4, ip6tables to IPv6, arptables to ARP, and ebtables to Ethernet frames."
+    rationale: "A method of configuring and maintaining firewall rules is necessary to configure a Host Based Firewall."
+    remediation: "Run the following command to install iptables and iptables-persistent # apt install iptables iptables-persistent."
+    compliance:
+      - cis: ["3.4.3.1.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:apt list iptables iptables-persistent -> r:installed,automatic"
+
+  # 3.4.3.1.2 Ensure nftables is not installed with iptables. (Automated)
+  - id: 31137
+    title: "Ensure nftables is not installed with iptables."
+    description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables."
+    rationale: "Running both iptables and nftables may lead to conflict."
+    remediation: "Run the following command to remove nftables: # apt purge nftables."
+    compliance:
+      - cis: ["3.4.3.1.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables -> r:unknown ok not-installed"
+
+  # 3.4.3.1.3 Ensure ufw is uninstalled or disabled with iptables. (Automated)
+  - id: 31138
+    title: "Ensure ufw is uninstalled or disabled with iptables."
+    description: "Uncomplicated Firewall (UFW) is a program for managing a netfilter firewall designed to be easy to use. - Uses a command-line interface consisting of a small number of simple commands - Uses iptables for configuration."
+    rationale: "Running iptables.persistent with ufw enabled may lead to conflict and unexpected results."
+    remediation: "Run one of the following commands to either remove ufw or stop and mask ufw Run the following command to remove ufw: # apt purge ufw -OR- Run the following commands to disable ufw: # ufw disable # systemctl stop ufw # systemctl mask ufw Note: ufw disable needs to be run before systemctl mask ufw in order to correctly disable UFW."
+    compliance:
+      - cis: ["3.4.3.1.3"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' ufw -> r:unknown ok not-installed"
+      - "c:ufw status -> r:inactive"
+      - "c:systemctl is-enabled ufw -> r:masked"
+      - "c:ufw status -> r:inactive"
+
+  # 3.4.3.2.1 Ensure iptables default deny firewall policy. (Automated)
+  - id: 31139
+    title: "Ensure iptables default deny firewall policy."
+    description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected. Notes: - Changing firewall settings while connected over network can result in being locked out of the system - Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well."
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
+    remediation: "Run the following commands to implement a default DROP policy: # iptables -P INPUT DROP # iptables -P OUTPUT DROP # iptables -P FORWARD DROP."
+    compliance:
+      - cis: ["3.4.3.2.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
       - 'c:iptables -L -> r:Chain INPUT \(policy DROP\)|Chain INPUT \(policy REJECT\)'
       - 'c:iptables -L -> r:Chain FORWARD \(policy DROP\)|Chain FORWARD \(policy REJECT\)'
       - 'c:iptables -L -> r:Chain OUTPUT \(policy DROP\)|Chain OUTPUT \(policy REJECT\)'
 
-  # 3.5.3.2.4 Ensure iptables firewall rules exist for all open ports (Automated) - Not implemented
-
-  # 3.5.3.3 Configure IPv6 ip6tables
-
-  # 3.5.3.3.1 Ensure ip6tables loopback traffic is configured (Automated)
-  - id: 19111
-    title: "Ensure ip6tables loopback traffic is configured."
-    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (::1). Note: - Changing firewall settings while connected over network can result in being locked out of the system. - Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well."
-    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
-    remediation: "Run the following commands to implement the loopback rules: # ip6tables -A INPUT -i lo -j ACCEPT # ip6tables -A OUTPUT -o lo -j ACCEPT # ip6tables -A INPUT -s ::1 -j DROP"
+  # 3.4.3.2.2 Ensure iptables loopback traffic is configured. (Automated)
+  - id: 31140
+    title: "Ensure iptables loopback traffic is configured."
+    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8). Notes: - Changing firewall settings while connected over network can result in being locked out of the system - Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well."
+    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
+    remediation: "Run the following commands to implement the loopback rules: # iptables -A INPUT -i lo -j ACCEPT # iptables -A OUTPUT -o lo -j ACCEPT # iptables -A INPUT -s 127.0.0.0/8 -j DROP."
     compliance:
-      - cis: ["3.5.3.3.1"]
+      - cis: ["3.4.3.2.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - 'c:ip6tables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*::/0\.*::/0'
-      - 'c:ip6tables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*::1\.*::/0'
-      - 'c:ip6tables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*::/0\.*::/0'
+      - 'c:iptables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*0.0.0.0/0\.*0.0.0.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*127.0.0.0/8\.*0.0.0.0/0'
+      - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
 
-  # 3.5.3.3.2 Ensure ip6tables outbound and established connections are configured (Manual) - Not implemented
+  # 3.4.3.2.3 Ensure iptables outbound and established connections are configured. (Manual) - Not Implemented
 
-  # 3.5.3.3.3 Ensure ip6tables default deny firewall policy (Automated)
-  - id: 19112
+  # 3.4.3.2.4 Ensure iptables firewall rules exist for all open ports. (Automated) - Not Implemented
+
+  # 3.4.3.3.1 Ensure ip6tables default deny firewall policy. (Automated)
+  - id: 31143
     title: "Ensure ip6tables default deny firewall policy."
-    description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected. Note: - Changing firewall settings while connected over network can result in being locked out of the system. - Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well."
+    description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected. Note: - Changing firewall settings while connected over network can result in being locked out of the system - Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
-    remediation: "Run the following commands to implement a default DROP policy: # ip6tables -P INPUT DROP # ip6tables -P OUTPUT DROP # ip6tables -P FORWARD DROP"
+    remediation: "IF IPv6 is enabled on your system: Run the following commands to implement a default DROP policy: # ip6tables -P INPUT DROP # ip6tables -P OUTPUT DROP # ip6tables -P FORWARD DROP."
     compliance:
-      - cis: ["3.5.3.3.3"]
+      - cis: ["3.4.3.3.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
       - cis_csc_v7: ["9.4"]
-      - cmmc_v2.0: ["CM.3.068"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1"]
-      - pci_dss_v3.2.1: ["1.4"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
       - "c:ip6tables -L -> r:^Chain INPUT && r:policy DROP"
       - "c:ip6tables -L -> r:^Chain FORWARD && r:policy DROP"
       - "c:ip6tables -L -> r:^Chain OUTPUT && r:policy DROP"
 
-  # 3.5.3.3.4 Ensure ip6tables firewall rules exist for all open ports (Automated) - Not implemented
-
-  # 4 Logging and Auditing
-  # 4.1.1 Ensure auditing is enabled
-
-  # 4.1.1.1 Ensure auditd is installed (Automated)
-  - id: 19113
-    title: "Ensure auditd is installed."
-    description: "auditd is the userspace component to the Linux Auditing System. It's responsible for writing audit records to the disk."
-    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
-    remediation: "Run the following command to Install auditd: # apt install auditd audispd-plugins"
+  # 3.4.3.3.2 Ensure ip6tables loopback traffic is configured. (Automated)
+  - id: 31144
+    title: "Ensure ip6tables loopback traffic is configured."
+    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (::1). Note: - Changing firewall settings while connected over network can result in being locked out of the system - Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well."
+    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
+    remediation: "Run the following commands to implement the loopback rules: # ip6tables -A INPUT -i lo -j ACCEPT # ip6tables -A OUTPUT -o lo -j ACCEPT # ip6tables -A INPUT -s ::1 -j DROP."
     compliance:
-      - cis: ["4.1.1.1"]
-      - cis_csc_v7: ["6.2", "6.3"]
-      - cmmc_v2.0: ["AU.2.042", "AU.5.055", "CM.2.065"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-12", "AU-3"]
-      - pci_dss_v3.2.1: ["10.1", "10.2", "10.3"]
+      - cis: ["3.4.3.3.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "c:dpkg -s auditd -> r:Status: install ok installed"
-      - "c:dpkg -s audispd-plugins -> r:Status: install ok installed"
+      - 'c:ip6tables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*::/0\.*::/0'
+      - 'c:ip6tables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*::1\.*::/0'
+      - 'c:ip6tables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*::/0\.*::/0'
 
-  # 4.1.1.2 Ensure auditd service is enabled (Automated)
-  - id: 19114
-    title: "Ensure auditd service is enabled."
-    description: "Enable and start the auditd daemon to record system events."
-    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
-    remediation: "Run the following command to enable auditd : # systemctl --now enable auditd"
-    compliance:
-      - cis: ["4.1.1.2"]
-      - cis_csc_v7: ["6.2", "6.3"]
-      - cmmc_v2.0: ["AU.2.042", "AU.5.055", "CM.2.065"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-12", "AU-3"]
-      - pci_dss_v3.2.1: ["10.1", "10.2", "10.3"]
-    condition: all
-    rules:
-      - "c:systemctl is-enabled auditd -> r:enabled"
+  # 3.4.3.3.3 Ensure ip6tables outbound and established connections are configured. (Manual) - Not Implemented
+  # 3.4.3.3.4 Ensure ip6tables firewall rules exist for all open ports. (Automated) - Not Implemented
 
-  # 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled (Automated)
-  - id: 19115
-    title: "Ensure auditing for processes that start prior to auditd is enabled."
-    description: "Configure grub so that processes that are capable of being audited can be audited even if they start up prior to auditd startup. Note: This recommendation is designed around the grub bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings. Replace /boot/grub/grub.cfg with the appropriate grub configuration file for your environment."
-    rationale: "Audit events need to be captured on processes that start up prior to auditd , so that potential malicious activity cannot go undetected."
-    remediation: 'Edit /etc/default/grub and add audit=1 to GRUB_CMDLINE_LINUX: GRUB_CMDLINE_LINUX="audit=1" Run the following command to update the grub2 configuration: # update-grub'
-    compliance:
-      - cis: ["4.1.1.3"]
-      - cis_csc_v7: ["6.2", "6.3"]
-      - cmmc_v2.0: ["AU.2.042", "AU.5.055", "CM.2.065"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-12", "AU-3"]
-      - pci_dss_v3.2.1: ["10.1", "10.2", "10.3"]
-    condition: none
-    rules:
-      - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:audit=1'
-
-  # 4.1.1.4 Ensure audit_backlog_limit is sufficient (Automated) - Not implemented
-
-  # 4.1.2 Configure Data Retention
-
-  # 4.1.2.1 Ensure audit log storage size is configured (Automated)
-  - id: 19116
-    title: "Ensure audit log storage size is configured."
-    description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started. Notes: - The max_log_file parameter is measured in megabytes. - Other methods of log rotation may be appropriate based on site policy. One example is time-based rotation strategies which don't have native support in auditd configurations. - Manual audit of custom configurations should be evaluated for effectiveness and completeness."
-    rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
-    remediation: "Set the following parameter in /etc/audit/auditd.conf in accordance with site policy: max_log_file = <MB>"
-    compliance:
-      - cis: ["4.1.2.1"]
-      - cis_csc_v7: ["6.4"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-4"]
-      - pci_dss_v3.2.1: ["10.7"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - "f:/etc/audit/auditd.conf"
-      - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file\s*=\s*\d+'
-
-  # 4.1.2.2 Ensure audit logs are not automatically deleted (Automated)
-  - id: 19117
-    title: "Ensure audit logs are not automatically deleted."
-    description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
-    rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
-    remediation: "Set the following parameter in /etc/audit/auditd.conf: max_log_file_action = keep_logs"
-    compliance:
-      - cis: ["4.1.2.2"]
-      - cis_csc_v7: ["6.4"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-4"]
-      - pci_dss_v3.2.1: ["10.7"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - "f:/etc/audit/auditd.conf"
-      - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file_action\s*=\s*keep_logs'
-
-  # 4.1.2.3 Ensure system is disabled when audit logs are full (Automated)
-  - id: 19118
-    title: "Ensure system is disabled when audit logs are full."
-    description: "The auditd daemon can be configured to halt the system when the audit logs are full."
-    rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
-    remediation: "Set the following parameters in /etc/audit/auditd.conf: space_left_action = email action_mail_acct = root admin_space_left_action = halt"
-    compliance:
-      - cis: ["4.1.2.3"]
-      - cis_csc_v7: ["6.4"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-4"]
-      - pci_dss_v3.2.1: ["10.7"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - "f:/etc/audit/auditd.conf"
-      - 'f:/etc/audit/auditd.conf -> r:^\s*action_mail_acct\s*=\s*root'
-      - 'f:/etc/audit/auditd.conf -> r:^\s*space_left_action\s*=\s*email'
-      - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt'
-
-  # 4.1.3 Ensure events that modify date and time information are collected (Automated)
-  - id: 19119
-    title: "Ensure events that modify date and time information are collected."
-    description: 'Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier "time-change" Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot.'
-    rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
-    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-time-change.rules Add the following lines: -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change -a always,exit -F arch=b32 -S clock_settime -k time-change -w /etc/localtime -p wa -k time-change For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-time-change.rules Add the following lines: -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change -a always,exit -F arch=b64 -S clock_settime -k time-change -a always,exit -F arch=b32 -S clock_settime -k time-change -w /etc/localtime -p wa -k time-change"
-    compliance:
-      - cis: ["4.1.3"]
-      - cis_csc_v7: ["5.5"]
-      - iso_27001-2013: ["A.12.1.2"]
-      - mitre_techniques: ["T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
-      - nist_sp_800-53: ["CM-6"]
-      - pci_dss_v3.2.1: ["11.5"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S adjtimex && r:-S settimeofday && r:-S stime && r:-k time-change'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S adjtimex && r:-S settimeofday && r:-k time-change'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S clock_settime && r:-k time-change'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S clock_settime && r:-k time-change'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/localtime && r:-p wa && r:-k time-change'
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:adjtimex && r:settimeofday && r:stime && r:-F key=time-change"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S && r:adjtimex && r:settimeofday &&  r:-F key=time-change"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S clock_settime && r:-F key=time-change"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S clock_settime && r:-F key=time-change"
-      - "c:auditctl -l -> r:^-w && r:/etc/localtime && r:-p wa && r:-k time-change"
-
-  # 4.1.4 Ensure events that modify user/group information are collected (Automated)
-  - id: 19120
-    title: "Ensure events that modify user/group information are collected."
-    description: 'Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier "identity" in the audit log file. Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot.'
-    rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
-    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules: Example: vi /etc/audit/rules.d/50-identity.rules Add the following lines: -w /etc/group -p wa -k identity -w /etc/passwd -p wa -k identity -w /etc/gshadow -p wa -k identity -w /etc/shadow -p wa -k identity -w /etc/security/opasswd -p wa -k identity"
-    compliance:
-      - cis: ["4.1.4"]
-      - cis_csc_v7: ["4.8"]
-      - iso_27001-2013: ["A.12.4.3"]
-      - mitre_techniques: ["T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209"]
-      - nist_sp_800-53: ["AU-3"]
-      - pci_dss_v3.2.1: ["10.2.5"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/group && r:-p wa && r:-k identity'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/passwd && r:-p wa && r:-k identity'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/gshadow && r:-p wa && r:-k identity'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/shadow && r:-p wa && r:-k identity'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/security/opasswd && r:-p wa && r:-k identity'
-      - "c:auditctl -l -> r:^-w && r:/etc/group && r:-p wa && r:-k identity"
-      - "c:auditctl -l -> r:^-w && r:/etc/passwd && r:-p wa && r:-k identity"
-      - "c:auditctl -l -> r:^-w && r:/etc/gshadow && r:-p wa && r:-k identity"
-      - "c:auditctl -l -> r:^-w && r:/etc/shadow && r:-p wa && r:-k identity"
-      - "c:auditctl -l -> r:^-w && r:/etc/security/opasswd && r:-p wa && r:-k identity"
-
-  # 4.1.5 Ensure events that modify the system's network environment are collected (Automated)
-  - id: 19121
-    title: "Ensure events that modify the system's network environment are collected."
-    description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre-login), /etc/hosts (file containing host names and associated IP addresses) and /etc/network (directory containing network interface scripts and configurations) files. Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot."
-    rationale: 'Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/network is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier "system-locale."'
-    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-system-locale.rules Add the following lines: -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale -w /etc/issue -p wa -k system-locale -w /etc/issue.net -p wa -k system-locale -w /etc/hosts -p wa -k system-locale -w /etc/network -p wa -k system-locale For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-system-locale.rules Add the following lines: -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale -w /etc/issue -p wa -k system-locale -w /etc/issue.net -p wa -k system-locale -w /etc/hosts -p wa -k system-locale -w /etc/network -p wa -k system-locale"
-    compliance:
-      - cis: ["4.1.5"]
-      - cis_csc_v7: ["5.5"]
-      - iso_27001-2013: ["A.12.1.2"]
-      - mitre_techniques: ["T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
-      - nist_sp_800-53: ["CM-6"]
-      - pci_dss_v3.2.1: ["11.5"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:exit,always|always,exit && r:-F arch=b32 && r:-S sethostname && r:-S setdomainname && r:-k system-locale'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:exit,always|always,exit && r:-F arch=b64 && r:-S sethostname && r:-S setdomainname && r:-k system-locale'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/issue && r:-p wa && r:-k system-locale'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/issue.net && r:-p wa && r:-k system-locale'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/network && r:-p wa && r:-k system-locale'
-      - "c:auditctl -l -> r:^-a && r:exit,always|always,exit && r:-F arch=b32 && r: -S && r:sethostname && r:setdomainname && r:-F key=system-locale"
-      - "c:auditctl -l -> r:^-a && r:exit,always|always,exit && r:-F arch=b64 && r: -S && r:sethostname && r:setdomainname && r:-F key=system-locale"
-      - "c:auditctl -l -> r:^-w && r:/etc/issue && r:-p wa && r:-k system-locale"
-      - "c:auditctl -l -> r:^-w && r:/etc/issue.net && r:-p wa && r:-k system-locale"
-      - "c:auditctl -l -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale"
-      - "c:auditctl -l -> r:^-w && r:/etc/network && r:-p wa && r:-k system-locale"
-
-  # 4.1.6 Ensure events that modify the system's Mandatory Access Controls are collected (Automated)
-  - id: 19122
-    title: "Ensure events that modify the system's Mandatory Access Controls are collected."
-    description: "Monitor AppArmor mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to /etc/apparmor and /etc/apparmor.d directories. Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot. "
-    rationale: "Changes to files in these directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
-    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-MAC-policy.rules Add the following lines: -w /etc/apparmor/ -p wa -k MAC-policy -w /etc/apparmor.d/ -p wa -k MAC-policy"
-    compliance:
-      - cis: ["4.1.6"]
-      - cis_csc_v7: ["5.5"]
-      - iso_27001-2013: ["A.12.1.2"]
-      - mitre_techniques: ["T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
-      - nist_sp_800-53: ["CM-6"]
-      - pci_dss_v3.2.1: ["11.5"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/apparmor/ && r:-p wa && r:-k MAC-policy'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/apparmor.d/ && r:-p wa && r:-k MAC-policy'
-      - "c:auditctl -l -> r:^-w && r:/etc/apparmor/ && r:-p wa && r:-k MAC-policy"
-      - "c:auditctl -l -> r:^-w && r:/etc/apparmor.d/ && r:-p wa && r:-k MAC-policy"
-
-  # 4.1.7 Ensure login and logout events are collected (Automated)
-  - id: 19123
-    title: "Ensure login and logout events are collected."
-    description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/faillog tracks failed events from login. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The file /var/log/tallylog maintains records of failures via the pam_tally2 module. Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot."
-    rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
-    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules: Example: vi /etc/audit/rules.d/50-logins.rules Add the following lines: -w /var/log/faillog -p wa -k logins -w /var/log/lastlog -p wa -k logins -w /var/log/tallylog -p wa -k logins"
-    compliance:
-      - cis: ["4.1.7"]
-      - cis_csc_v7: ["4.9", "16.11", "16.13"]
-      - cmmc_v2.0: ["AC.2.010", "AC.3.019", "IA.3.086", "SI.5.223", "AC.4.032"]
-      - iso_27001-2013: ["A.8.1.3", "A.9.4.2"]
-      - mitre_techniques: ["T1110", "T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1527", "T1176", "T1213", "T1038", "T1482", "T1114", "T1484", "T1161", "T1031", "T1528", "T1197", "T1538", "T1044", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1050", "T1163", "T1021", "T1023", "T1537", "T1004"]
-      - nist_sp_800-53: ["AU-3"]
-      - pci_dss_v3.2.1: ["8.1.8", "10.2.4", "10.2.5"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/faillog && r:-p wa && r:-k logins'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/lastlog && r:-p wa && r:-k logins'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/tallylog && r:-p wa && r:-k logins'
-      - "c:auditctl -l -> r:^-w && r:/var/log/faillog && r:-p wa && r:-k logins"
-      - "c:auditctl -l -> r:^-w && r:/var/log/lastlog && r:-p wa && r:-k logins"
-      - "c:auditctl -l -> r:^-w && r:/var/log/tallylog && r:-p wa && r:-k logins"
-
-  # 4.1.8 Ensure session initiation information is collected (Automated)
-  - id: 19124
-    title: "Ensure session initiation information is collected."
-    description: 'Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp tracks all currently logged in users. All audit records will be tagged with the identifier "session." The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp . All audit records will be tagged with the identifier "logins.". Note: - The last command can be used to read /var/log/wtmp (last with no parameters) and /var/run/utmp (last -f /var/run/utmp). - Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot.'
-    rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
-    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules: Example: vi /etc/audit/rules.d/50-session.rules Add the following lines: -w /var/run/utmp -p wa -k session -w /var/log/wtmp -p wa -k logins -w /var/log/btmp -p wa -k logins"
-    compliance:
-      - cis: ["4.1.8"]
-      - cis_csc_v7: ["4.9", "16.11", "16.13"]
-      - cmmc_v2.0: ["AC.2.010", "AC.3.019", "IA.3.086", "SI.5.223", "AC.4.032"]
-      - iso_27001-2013: ["A.8.1.3", "A.9.4.2"]
-      - mitre_techniques: ["T1110", "T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1527", "T1176", "T1213", "T1038", "T1482", "T1114", "T1484", "T1161", "T1031", "T1528", "T1197", "T1538", "T1044", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1050", "T1163", "T1021", "T1023", "T1537", "T1004"]
-      - nist_sp_800-53: ["AU-3"]
-      - pci_dss_v3.2.1: ["8.1.8", "10.2.4", "10.2.5"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/run/utmp && r:-p wa && r:-k session'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/wtmp && r:-p wa && r:-k logins'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/btmp && r:-p wa && r:-k logins'
-      - "c:auditctl -l -> r:^-w && r:/var/run/utmp && r:-p wa && r:-k session"
-      - "c:auditctl -l -> r:^-w && r:/var/log/wtmp && r:-p wa && r:-k logins"
-      - "c:auditctl -l -> r:^-w && r:/var/log/btmp && r:-p wa && r:-k logins"
-
-  # 4.1.9 Ensure discretionary access control permission modification events are collected (Automated)
-  - id: 19125
-    title: "Ensure discretionary access control permission modification events are collected."
-    description: 'Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The chmod , fchmod and fchmodat system calls affect the permissions associated with a file. The chown , fchown , fchownat and lchown system calls affect owner and group attributes on a file. The setxattr , lsetxattr , fsetxattr (set extended file attributes) and removexattr , lremovexattr , fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier "perm_mod.". Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot.'
-    rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
-    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules: Example: vi /etc/audit/rules.d/50-perm_mod.rules Add the following lines: -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-perm_mod.rules Add the following lines: -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod -a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod -a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod"
-    compliance:
-      - cis: ["4.1.9"]
-      - cis_csc_v7: ["5.5"]
-      - iso_27001-2013: ["A.12.1.2"]
-      - mitre_techniques: ["T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
-      - nist_sp_800-53: ["CM-6"]
-      - pci_dss_v3.2.1: ["11.5"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S chmod && r:-S fchmod && r:-S fchmodat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S chmod && r:-S fchmod && r:-S fchmodat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S chown && r:-S fchown && r:-S fchownat && r:-S lchown && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S chown && r:-S fchown && r:-S fchownat && r:-S lchown && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:chmod && r:fchmod && r:fchmodat && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=perm_mod"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S && r:chmod && r:fchmod && r:fchmodat && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=perm_mod"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:chown && r:fchown && r:fchownat && r:lchown && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=perm_mod"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S && r:chown && r:fchown && r:fchownat && r:lchown && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=perm_mod"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:setxattr && r:lsetxattr && r:fsetxattr && r:removexattr && r:lremovexattr && r:fremovexattr && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=perm_mod"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S && r:setxattr && r:lsetxattr && r:fsetxattr && r:removexattr && r:lremovexattr && r:fremovexattr && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=perm_mod"
-
-  # 4.1.10 Ensure unsuccessful unauthorized file access attempts are collected (Automated)
-  - id: 19126
-    title: "Ensure unsuccessful unauthorized file access attempts are collected."
-    description: 'Monitor for unsuccessful attempts to access files. The parameters below are associated with system calls that control creation (creat), opening (open, openat) and truncation (truncate, ftruncate) of files. An audit log record will only be written if the user is a non-privileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the system call returned EACCES (permission denied to the file) or EPERM (some other permanent error associated with the specific system call). All audit records will be tagged with the identifier "access.". Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot.'
-    rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
-    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-access.rules Add the following lines: -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-access.rules Add the following lines: -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access"
-    compliance:
-      - cis: ["4.1.10"]
-      - cis_csc_v7: ["14.9"]
-      - cmmc_v2.0: ["AU.3.050"]
-      - iso_27001-2013: ["A.12.4.3"]
-      - nist_sp_800-53: ["AU-3"]
-      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EACCES && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EACCES && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EPERM && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EPERM && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:creat && r:open && r:openat && r:truncate && r:ftruncate && r:-F exit=-EACCES && r:-F auid>=1000 && r:-F auid!=-1 && r:-k access"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S && r:creat && r:open && r:openat && r:truncate && r:ftruncate && r:-F exit=-EACCES && r:-F auid>=1000 && r:-F auid!=-1 && r:-k access"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:creat && r:open && r:openat && r:truncate && r:ftruncate && r:-F exit=-EPERM && r:-F auid>=1000 && r:-F auid!=-1 && r:-k access"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S && r:creat && r:open && r:openat && r:truncate && r:ftruncate && r:-F exit=-EPERM && r:-F auid>=1000 && r:-F auid!=-1 && r:-k access"
-
-  # 4.1.11 Ensure use of privileged commands is collected (Automated) - Not implemented
-
-  # 4.1.12 Ensure successful file system mounts are collected (Automated)
-  - id: 19127
-    title: "Ensure successful file system mounts are collected."
-    description: "Monitor the use of the mount system call. The mount (and umount) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user. Note: - This tracks successful and unsuccessful mount commands. File system mounts do not have to come from external media and this action still does not verify write (e.g. CD ROMS). - Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot."
-    rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open, creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
-    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-mounts.rules Add the following lines: -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-mounts.rules Add the following lines: -a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts"
-    compliance:
-      - cis: ["4.1.12"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k mounts'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S mount && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k mounts'
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=mounts"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S mount && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=mounts"
-
-  # 4.1.13 Ensure file deletion events by users are collected (Automated)
-  - id: 19128
-    title: "Ensure file deletion events by users are collected."
-    description: 'Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for the unlink (remove a file), unlinkat (remove a file attribute), rename (rename a file) and renameat (rename a file attribute) system calls and tags them with the identifier "delete". Note: - At a minimum, configure the audit system to collect file deletion events for all users and root. - Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot.'
-    rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
-    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-delete.rules Add the following lines: -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-delete.rules Add the following lines: -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete"
-    compliance:
-      - cis: ["4.1.13"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k delete'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k delete'
-      - "c:auditctl -l -> r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:unlink && r:unlinkat && r:rename && r:renameat && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=delete"
-      - "c:auditctl -l -> r:always,exit|exit,always && r:-F arch=b64 && r:-S && r:unlink && r:unlinkat && r:rename && r:renameat && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=delete"
-
-  # 4.1.14 Ensure changes to system administration scope (sudoers) is collected (Automated)
-  - id: 19129
-    title: "Ensure changes to system administration scope (sudoers) is collected."
-    description: 'Monitor scope changes for system administrations. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier "scope.". Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot.'
-    rationale: "Changes in the /etc/sudoers file can indicate that an unauthorized change has been made to scope of system administrator activity."
-    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-scope.rules Add the following lines: -w /etc/sudoers -p wa -k scope -w /etc/sudoers.d/ -p wa -k scope"
-    compliance:
-      - cis: ["4.1.14"]
-      - cis_csc_v7: ["4.8"]
-      - iso_27001-2013: ["A.12.4.3"]
-      - mitre_techniques: ["T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209"]
-      - nist_sp_800-53: ["AU-3"]
-      - pci_dss_v3.2.1: ["10.2.5"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/sudoers && r:-p wa && r:-k scope'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/sudoers.d/ && r:-p wa && r:-k scope'
-      - "c: auditctl -l -> r:^-w && r:/etc/sudoers && r:-p wa && r:-k scope"
-      - "c: auditctl -l -> r:^-w && r:/etc/sudoers.d/ && r:-p wa && r:-k scope"
-
-  # 4.1.15 Ensure system administrator command executions (sudo) are collected (Automated)
-  - id: 19130
-    title: "Ensure system administrator command executions (sudo) are collected."
-    description: "sudo provides users with temporary elevated privileges to perform operations. Monitor the administrator with temporary elevated privileges and the operation(s) they performed. Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot."
-    rationale: "Creating an audit log of administrators with temporary elevated privileges and the operation(s) they performed is essential to reporting. Administrators will want to correlate the events written to the audit trail with the records written to sudo logfile to verify if unauthorized commands have been executed."
-    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules: Example: `vi /etc/audit/rules.d/50-actions.rules Add the following line: -a exit,always -F arch=b32 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k actions For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules: Example: vi /etc/audit/rules.d/50-actions.rules Add the following lines: -a always,exit -F arch=b64 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k actions -a always,exit -F arch=b32 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k actions"
-    compliance:
-      - cis: ["4.1.15"]
-      - cis_csc_v7: ["4.9"]
-      - iso_27001-2013: ["A.9.4.2"]
-      - mitre_techniques: ["T1110", "T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209"]
-      - nist_sp_800-53: ["AU-3"]
-      - pci_dss_v3.2.1: ["10.2.4"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w|^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-C euid!=uid && r:-F euid=0 && r:-S execve && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k actions'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w|^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-C euid!=uid && r:-F euid=0 && r:-S execve && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k actions'
-      - 'c:auditctl -l -> r:^-w|^-a \.+ && r:always,exit|exit,always && r:-F arch=b64 && r:-S execve && r:-C euid!=uid|-C uid!=euid && r:-F euid=0 && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=actions'
-      - 'c:auditctl -l -> r:^-w|^-a \.+ && r:always,exit|exit,always && r:-F arch=b32 && r:-S execve && r:-C euid!=uid|-C uid!=euid && r:-F euid=0 && r:-F auid>=1000 && r:-F auid!=-1 && r:-F key=actions'
-
-  # 4.1.16 Ensure kernel module loading and unloading is collected (Automated)
-  - id: 19131
-    title: "Ensure kernel module loading and unloading is collected."
-    description: 'Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of "modules". Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot.'
-    rationale: "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
-    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-modules.rules Add the following lines: -w /sbin/insmod -p x -k modules -w /sbin/rmmod -p x -k modules -w /sbin/modprobe -p x -k modules -a always,exit -F arch=b32 -S init_module -S delete_module -k modules For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/50-modules.rules Add the following lines: -w /sbin/insmod -p x -k modules -w /sbin/rmmod -p x -k modules -w /sbin/modprobe -p x -k modules -a always,exit -F arch=b64 -S init_module -S delete_module -k modules"
-    compliance:
-      - cis: ["4.1.16"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - "d:/etc/audit"
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/sbin/insmod && r:-p x && r:-k modules'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/sbin/rmmod && r:-p x && r:-k modules'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/sbin/modprobe && r:-p x && r:-k modules'
-      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32|-F arch=b64 && r:-S init_module && r:-S delete_module && r:-k modules'
-      - "c:auditctl -l -> r:^-w && r:/sbin/insmod && r:-p x && r:-k modules"
-      - "c:auditctl -l -> r:^-w && r:/sbin/rmmod && r:-p x && r:-k modules"
-      - "c:auditctl -l -> r:^-w && r:/sbin/modprobe && r:-p x && r:-k modules"
-      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:delete_module && r:-F key=modules"
-
-  # 4.1.17 Ensure the audit configuration is immutable (Automated) - Not implemented
-
-  # 4.2 Configure Logging
-  # 4.2.1 Configure rsyslog
-
-  # 4.2.1.1 Ensure rsyslog is installed (Automated)
-  - id: 19132
-    title: "Ensure rsyslog is installed."
-    description: "The rsyslog software is a recommended replacement to the original syslogd daemon which provide improvements over syslogd, such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server."
-    rationale: "The security enhancements of rsyslog such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
-    remediation: "Install rsyslog: # apt install rsyslog"
-    compliance:
-      - cis: ["4.2.1.1"]
-      - cis_csc_v7: ["6.2", "6.3"]
-      - cmmc_v2.0: ["AU.2.042", "AU.5.055", "CM.2.065"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-12", "AU-3"]
-      - pci_dss_v3.2.1: ["10.1", "10.2", "10.3"]
-    condition: all
-    rules:
-      - "c:dpkg -s rsyslog -> r:install ok installed"
-
-  # 4.2.1.2 Ensure rsyslog Service is enabled (Automated)
-  - id: 19133
-    title: "Ensure rsyslog Service is enabled."
-    description: "Once the rsyslog package is installed it needs to be activated."
-    rationale: "If the rsyslog service is not activated the system may default to the syslogd service or lack logging instead."
-    remediation: "Run the following commands to enable rsyslog: # systemctl --now enable rsyslog"
-    compliance:
-      - cis: ["4.2.1.2"]
-      - cis_csc_v7: ["6.2", "6.3"]
-      - cmmc_v2.0: ["AU.2.042", "AU.5.055", "CM.2.065"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-12", "AU-3"]
-      - pci_dss_v3.2.1: ["10.1", "10.2", "10.3"]
-    condition: all
-    rules:
-      - "c:systemctl is-enabled rsyslog -> r:enabled"
-
-  # 4.2.1.3 Ensure logging is configured (Manual) - Not implemented
-
-  # 4.2.1.4 Ensure rsyslog default file permissions configured (Automated)
-  - id: 19134
-    title: "Ensure rsyslog default file permissions configured."
-    description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
-    rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
-    remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set every instance of $FileCreateMode to 0640 or more restrictive: $FileCreateMode 0640"
-    compliance:
-      - cis: ["4.2.1.4"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: any
-    rules:
-      - 'f:/etc/rsyslog.conf -> r:^\s*\$FileCreateMode 06\d0|^\s*\$FileCreateMode 04\d0|^\s*\$FileCreateMode 02\d0|^\s*\$FileCreateMode 00\d0 && r:^\s*\$FileCreateMode 0\d40|^\s*\$FileCreateMode 0\d00'
-      - 'd:/etc/rsyslog.d/ -> r:\. -> r:^\s*\$FileCreateMode 06\d0|^\s*\$FileCreateMode 04\d0|^\s*\$FileCreateMode 02\d0|^\s*\$FileCreateMode 00\d0 && r:^\s*\$FileCreateMode 0\d40|^\s*\$FileCreateMode 0\d00'
-
-  # 4.2.1.5 Ensure rsyslog is configured to send logs to a remote log host (Automated)
-  - id: 19135
-    title: "Ensure rsyslog is configured to send logs to a remote log host."
-    description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
-    rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system Note: Ensure that the selection of logfiles being sent follows local site policy."
-    remediation: 'Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and add one of the following lines: Newer syntax: <files to sent to the remote log server> action(type="omfwd" target="<FQDN or ip of loghost>" port="<port number>" protocol="tcp" action.resumeRetryCount="<number of re-tries>" queue.type="LinkedList" queue.size=<number of messages to queue>") Example: *.* action(type="omfwd" target="192.168.2.100" port="514" protocol="tcp" action.resumeRetryCount="100" queue.type="LinkedList" queue.size="1000") Older syntax: *.* @@<FQDN or ip of loghost> Example: *.* @@192.168.2.100 Run the following command to reload the rsyslog configuration: # systemctl restart rsyslog'
-    compliance:
-      - cis: ["4.2.1.5"]
-      - cis_csc_v7: ["6.6", "6.8"]
-      - cmmc_v2.0: ["AU.3.051", "AU.3.052", "AU.4.053", "SI.2.214"]
-      - pci_dss_v3.2.1: ["10.5.3", "10.6.1"]
-    condition: any
-    rules:
-      - 'f:/etc/rsyslog.conf -> r:^\s*\w && r:action && r:target="\d|target="\w'
-      - 'd:/etc/rsyslog.d/ -> r:\. -> r:^\s*\w && r:action && r:target="\d|target="\w'
-      - 'f:/etc/rsyslog.conf -> r:^\s*\* && r:@\d|@\w'
-      - 'd:/etc/rsyslog.d/ -> r:\. -> r:^\s*\* && r:@\d|@\w'
-
-  # 4.2.1.6 Ensure remote rsyslog messages are only accepted on designated log hosts. (Manual) - Not implemented
-
-  # 4.2.2 Configure journald
-
-  # 4.2.2.1 Ensure journald is configured to send logs to rsyslog (Automated)
-  - id: 19136
-    title: "Ensure journald is configured to send logs to rsyslog."
-    description: 'Data from journald may be stored in volatile memory or persisted locally on the server. Utilities exist to accept remote export of journald logs, however, use of the rsyslog service provides a consistent means of log collection and export. Notes: - This recommendation assumes that recommendation 4.2.1.5, "Ensure rsyslog is configured to send logs to a remote log host" has been implemented. - As noted in the journald man pages, journald logs may be exported to rsyslog either through the process mentioned here, or through a facility like systemd- journald.service. There are trade-offs involved in each implementation, where ForwardToSyslog will immediately capture all events (and forward to an external log server, if properly configured), but may not capture all boot-up activities. Mechanisms such as systemd-journald.service, on the other hand, will record bootup events, but may delay sending the information to rsyslog, leading to the potential for log manipulation prior to export. Be aware of the limitations of all tools employed to secure a system. - The main configuration file /etc/systemd/journald.conf is read before any of the custom *.conf files. If there are custom configs present, they override the main configuration parameters.'
-    rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
-    remediation: "Edit the /etc/systemd/journald.conf file and add the following line: ForwardToSyslog=yes"
-    compliance:
-      - cis: ["4.2.2.1"]
-      - cis_csc_v7: ["6.5"]
-      - cmmc_v2.0: ["AU.3.048"]
-      - pci_dss_v3.2.1: ["10.5.3", "10.5.4"]
-    references:
-      - "https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf"
-    condition: all
-    rules:
-      - 'f:/etc/systemd/journald.conf -> r:^\s*\t*ForwardToSyslog\s*=\s*yes'
-
-  # 4.2.2.2 Ensure journald is configured to compress large log files (Automated)
-  - id: 19137
-    title: "Ensure journald is configured to compress large log files."
-    description: "The journald system includes the capability of compressing overly large files to avoid filling up the system with logs or making the logs unmanageably large. Note: The main configuration file /etc/systemd/journald.conf is read before any of the custom *.conf files. If there are custom configs present, they override the main configuration parameters."
-    rationale: "Uncompressed large files may unexpectedly fill a filesystem leading to resource unavailability. Compressing logs prior to write can prevent sudden, unexpected filesystem impacts."
-    remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Compress=yes"
-    compliance:
-      - cis: ["4.2.2.2"]
-      - cis_csc_v7: ["6.4"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-4"]
-      - pci_dss_v3.2.1: ["10.7"]
-    references:
-      - "https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf"
-    condition: all
-    rules:
-      - 'f:/etc/systemd/journald.conf -> r:^\s*Compress\s*=\s*yes'
-
-  # 4.2.2.3 Ensure journald is configured to write logfiles to persistent disk (Automated)
-  - id: 19138
-    title: "Ensure journald is configured to write logfiles to persistent disk."
-    description: "Data from journald may be stored in volatile memory or persisted locally on the server. Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the server they are protected from loss. Note: The main configuration file /etc/systemd/journald.conf is read before any of the custom *.conf files. If there are custom configs present, they override the main configuration parameters."
-    rationale: "Writing log data to disk will provide the ability to forensically reconstruct events which may have impacted the operations or security of a system even after a system crash or reboot."
-    remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Storage=persistent"
-    compliance:
-      - cis: ["4.2.2.3"]
-      - cis_csc_v7: ["6.2", "6.3"]
-      - cmmc_v2.0: ["AU.2.042", "AU.5.055", "CM.2.065"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-12", "AU-3"]
-      - pci_dss_v3.2.1: ["10.1", "10.2", "10.3"]
-    references:
-      - "https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf"
-    condition: all
-    rules:
-      - 'f:/etc/systemd/journald.conf -> r:^\s*Storage\s*=\s*persistent'
-
-  # 4.2.3 Ensure permissions on all logfiles are configured (Automated) - Not implemented
-  # 4.3 Ensure logrotate is configured (Manual) - Not implemented
-  # 4.4 Ensure logrotate assigns appropriate permissions (Automated) - Not implemented
-
-  # 5 Access, Authentication and Authorization
-  # 5.1 Configure time-based job schedulers
-
-  # 5.1.1 Ensure cron daemon is enabled and running (Automated)
-  - id: 19139
-    title: "Ensure cron daemon is enabled and running."
+  # 4.1.1 Ensure cron daemon is enabled and active. (Automated)
+  - id: 31147
+    title: "Ensure cron daemon is enabled and active."
     description: "The cron daemon is used to execute batch jobs on the system. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
-    remediation: "Run the following command to enable and start cron: # systemctl --now enable cron"
+    remediation: "Run the following command to enable and start cron: # systemctl unmask cron # systemctl --now enable cron."
     compliance:
-      - cis: ["5.1.1"]
-      - cis_csc_v7: ["6"]
+      - cis: ["4.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
     condition: all
     rules:
-      - "c:systemctl is-enabled cron -> enabled"
-      - 'c:systemctl status cron -> r:Active: active \(running\)'
+      - "c:systemctl is-enabled cron -> r:^enabled"
+      - "c:systemctl status cron -> r:^active"
 
-  # 5.1.2 Ensure permissions on /etc/crontab are configured (Automated)
-  - id: 19140
+  # 4.1.2 Ensure permissions on /etc/crontab are configured. (Automated)
+  - id: 31148
     title: "Ensure permissions on /etc/crontab are configured."
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
-    remediation: "Run the following commands to set ownership and permissions on /etc/crontab: # chown root:root /etc/crontab # chmod og-rwx /etc/crontab"
+    remediation: "Run the following commands to set ownership and permissions on /etc/crontab : # chown root:root /etc/crontab # chmod og-rwx /etc/crontab."
     compliance:
-      - cis: ["5.1.2"]
+      - cis: ["4.1.2"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat /etc/crontab -> r:^Access: \(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/crontab -> r:600\s*\t*-rw-------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Automated)
-  - id: 19141
+  # 4.1.3 Ensure permissions on /etc/cron.hourly are configured. (Automated)
+  - id: 31149
     title: "Ensure permissions on /etc/cron.hourly are configured."
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
-    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.hourly directory: # chown root:root /etc/cron.hourly/ # chmod og-rwx /etc/cron.hourly/"
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.hourly directory: # chown root:root /etc/cron.hourly/ # chmod og-rwx /etc/cron.hourly/."
     compliance:
-      - cis: ["5.1.3"]
+      - cis: ["4.1.3"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.hourly -> r:^Access: \(0700/drwx------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.hourly/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Automated)
-  - id: 19142
+  # 4.1.4 Ensure permissions on /etc/cron.daily are configured. (Automated)
+  - id: 31150
     title: "Ensure permissions on /etc/cron.daily are configured."
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
-    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.daily directory: # chown root:root /etc/cron.daily/ # chmod og-rwx /etc/cron.daily/"
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.daily directory: # chown root:root /etc/cron.daily/ # chmod og-rwx /etc/cron.daily/."
     compliance:
-      - cis: ["5.1.4"]
+      - cis: ["4.1.4"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.daily -> r:^Access: \(0700/drwx------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.daily/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Automated)
-  - id: 19143
+  # 4.1.5 Ensure permissions on /etc/cron.weekly are configured. (Automated)
+  - id: 31151
     title: "Ensure permissions on /etc/cron.weekly are configured."
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
-    remediation: "Run the following commands to set ownership and permissions on /etc/cron.weekly : chown root:root /etc/cron.weekly and chmod og-rwx /etc/cron.weekly"
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.weekly directory: # chown root:root /etc/cron.weekly/ # chmod og-rwx /etc/cron.weekly/."
     compliance:
-      - cis: ["5.1.5"]
+      - cis: ["4.1.5"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.weekly -> r:^Access: \(0700/drwx------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.weekly/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Automated)
-  - id: 19144
+  # 4.1.6 Ensure permissions on /etc/cron.monthly are configured. (Automated)
+  - id: 31152
     title: "Ensure permissions on /etc/cron.monthly are configured."
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
-    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.monthly directory: # chown root:root /etc/cron.monthly/ # chmod og-rwx /etc/cron.monthly/"
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.monthly directory: # chown root:root /etc/cron.monthly/ # chmod og-rwx /etc/cron.monthly/."
     compliance:
-      - cis: ["5.1.6"]
+      - cis: ["4.1.6"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.monthly -> r:^Access: \(0700/drwx------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.monthly/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.7 Ensure permissions on /etc/cron.d are configured (Automated)
-  - id: 19145
+  # 4.1.7 Ensure permissions on /etc/cron.d are configured. (Automated)
+  - id: 31153
     title: "Ensure permissions on /etc/cron.d are configured."
     description: "The /etc/cron.d directory contains system cron jobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab, but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
-    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.d directory: # chown root:root /etc/cron.d/ # chmod og-rwx /etc/cron.d/"
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.d directory: # chown root:root /etc/cron.d/ # chmod og-rwx /etc/cron.d/."
     compliance:
-      - cis: ["5.1.7"]
+      - cis: ["4.1.7"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.d -> r:^Access: \(0700/drwx------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.d/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.8 Ensure cron is restricted to authorized users (Automated)
-  - id: 19146
+  # 4.1.8 Ensure cron is restricted to authorized users. (Automated)
+  - id: 31154
     title: "Ensure cron is restricted to authorized users."
-    description: "Configure /etc/cron.allow to allow specific users to use this service. If /etc/cron.allow does not exist, then /etc/cron.deny is checked. Any user not specifically defined in this file is allowed to use cron. By removing the file, only users in /etc/cron.allow are allowed to use cron. Notes: - Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy. - Even though a given user is not listed in cron.allow, cron jobs can still be run as that user. - The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
+    description: "Configure /etc/cron.allow to allow specific users to use this service. If /etc/cron.allow does not exist, then /etc/cron.deny is checked. Any user not specifically defined in this file is allowed to use cron. By removing the file, only users in /etc/cron.allow are allowed to use cron. Note: - Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy - Even though a given user is not listed in cron.allow, cron jobs can still be run as that user - The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
-    remediation: "Run the following commands to remove /etc/cron.deny: # rm /etc/cron.deny Run the following command to create /etc/cron.allow # touch /etc/cron.allow Run the following commands to set permissions and ownership for /etc/cron.allow: # chmod g-wx,o-rwx /etc/cron.allow # chown root:root /etc/cron.allow"
+    remediation: "Run the following script to: - Remove /etc/cron.deny if it exists - Create /etc/cron.allow if it doesn't exist - Change ownership of /etc/cron.allow to the root user - Change group ownership of /etc/cron.allow to the group crontab #!/usr/bin/env bash { if dpkg-query -W cron > /dev/null 2>&1; then l_file=\"/etc/cron.allow\" l_mask='0137' l_maxperm=\"$( printf '%o' $(( 0777 & ~$l_mask)) )\" if [ -e /etc/cron.deny ]; then echo -e \" - Removing \\\"/etc/cron.deny\\\"\" rm -f /etc/cron.deny fi if [ ! -e /etc/cron.allow ]; then echo -e \" - creating \\\"$l_file\\\"\" touch \"$l_file\" fi while read l_mode l_fown l_fgroup; do if [ $(( $l_mode & $l_mask )) -gt 0 ]; then echo -e \" - Removing excessive permissions from \\\"$l_file\\\"\" chmod u-x,g-wx,o-rwx \"$l_file\" fi if [ \"$l_fown\" != \"root\" ]; then echo -e \" - Changing owner on \\\"$l_file\\\" from: \\\"$l_fown\\\" to: \\\"root\\\"\" chown root \"$l_file\" fi if [ \"$l_fgroup\" != \"crontab\" ]; then echo -e \" - Changing group owner on \\\"$l_file\\\" from: \\\"$l_fgroup\\\" to: \\\"crontab\\\"\" chgrp crontab \"$l_file\" fi done < <(stat -Lc '%#a %U %G' \"$l_file\") else echo -e \"- cron is not installed on the system, no remediation required\\n\" fi }."
     compliance:
-      - cis: ["5.1.8"]
+      - cis: ["4.1.8"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
       - "f:/etc/cron.allow"
       - "not f:/etc/cron.deny"
-      - 'c:stat /etc/cron.allow -> r:^Access: \(0640/-rw-r-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.allow -> r:640\s*\t*-rw-r-----\s*\t*0\s*\t*root\s*\t*0\s*\t*crontab'
 
-  # 5.1.9 Ensure at is restricted to authorized users (Automated)
-  - id: 19147
+  # 4.1.9 Ensure at is restricted to authorized users. (Automated)
+  - id: 31155
     title: "Ensure at is restricted to authorized users."
-    description: "Configure /etc/at.allow to allow specific users to use this service. If /etc/at.allow does not exist, then /etc/at.deny is checked. Any user not specifically defined in this file is allowed to use at. By removing the file, only users in /etc/at.allow are allowed to use at. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, at should be removed, and the alternate method should be secured in accordance with local site policy"
+    description: "Configure /etc/at.allow to allow specific users to use this service. If /etc/at.allow does not exist, then /etc/at.deny is checked. Any user not specifically defined in this file is allowed to use at. By removing the file, only users in /etc/at.allow are allowed to use at. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, at should be removed, and the alternate method should be secured in accordance with local site policy."
     rationale: "On many systems, only the system administrator is authorized to schedule at jobs. Using the at.allow file to control who can run at jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
-    remediation: "Run the following commands to remove /etc/at.deny: # rm /etc/at.deny Run the following command to create /etc/at.allow # touch /etc/at.allow Run the following commands to set permissions and ownership for /etc/at.allow:# chmod g-wx,o-rwx /etc/at.allow # chown root:root /etc/at.allow"
+    remediation: "Run the following script to: - Remove /etc/at.deny if it exists - Create /etc/at.allow if it doesn't exist - Change ownership of /etc/at.allow to the root user - Change group ownership of /etc/at.allow to the group root #!/usr/bin/env bash { if dpkg-query -W at > /dev/null 2>&1; then l_file=\"/etc/at.allow\" l_mask='0137' l_maxperm=\"$( printf '%o' $(( 0777 & ~$l_mask)) )\" if [ -e /etc/at.deny ]; then echo -e \" - Removing \\\"/etc/at.deny\\\"\" rm -f /etc/at.deny fi if [ ! -e /etc/at.allow ]; then echo -e \" - creating \\\"$l_file\\\"\" touch \"$l_file\" fi while read l_mode l_fown l_fgroup; do if [ $(( $l_mode & $l_mask )) -gt 0 ]; then echo -e \" - Removing excessive permissions from \\\"$l_file\\\"\" chmod u-x,g-wx,o-rwx \"$l_file\" fi if [ \"$l_fown\" != \"root\" ]; then echo -e \" - Changing owner on \\\"$l_file\\\" from: \\\"$l_fown\\\" to: \\\"root\\\"\" chown root \"$l_file\" fi if [ \"$l_fgroup\" != \"root\" ]; then echo -e \" - Changing group owner on \\\"$l_file\\\" from: \\\"$l_fgroup\\\" to: \\\"root\\\"\" chgrp root \"$l_file\" fi done < <(stat -Lc '%#a %U %G' \"$l_file\") else echo -e \"- cron is not installed on the system, no remediation required\\n\" fi }."
     compliance:
-      - cis: ["5.1.9"]
+      - cis: ["4.1.9"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
       - "f:/etc/at.allow"
       - "not f:/etc/at.deny"
-      - 'c:stat /etc/at.allow -> r:^Access: \(0640/-rw-r-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/at.allow -> r:640\s*\t*-rw-r-----\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.2 Configure sudo
-
-  # 5.2.1 Ensure sudo is installed (Automated)
-  - id: 19148
-    title: "Ensure sudo is installed."
-    description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy. Note: Use the sudo-ldap package if you need LDAP support for sudoers."
-    rationale: "sudo supports a plugin architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plugins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
-    remediation: "Install sudo using the following command. # apt install sudo OR # apt install sudo-ldap"
+  # 4.2.1 Ensure permissions on /etc/ssh/sshd_config are configured. (Automated)
+  - id: 31156
+    title: "Ensure permissions on /etc/ssh/sshd_config are configured."
+    description: "The file /etc/ssh/sshd_config, and files ending in .conf in the /etc/ssh/sshd_config.d directory, contain configuration specifications for sshd."
+    rationale: "configuration specifications for sshd need to be protected from unauthorized changes by non-privileged users."
+    remediation: "Run the following script to set ownership and permissions on /etc/ssh/sshd_config and files ending in .conf in the /etc/ssh/sshd_config.d directory: #!/usr/bin/env bash { chmod u-x,og-rwx /etc/ssh/sshd_config chown root:root /etc/ssh/sshd_config while IFS= read -r -d $'\\0' l_file; do if [ -e \"$l_file\" ]; then chmod u-x,og-rwx \"$l_file\" chown root:root \"$l_file\" fi done < <(find /etc/ssh/sshd_config.d -type f -print0) }."
     compliance:
-      - cis: ["5.2.1"]
-      - cis_csc_v7: ["4.3"]
-      - cmmc_v2.0: ["AC.2.008", "IA.1.076", "IA.1.077", "SC.3.181"]
-      - iso_27001-2013: ["A.9.2.3"]
-      - mitre_techniques: ["T1176", "T1501", "T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
+      - cis: ["4.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1098", "T1098.004", "T1543", "T1543.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/ssh/sshd_config -> r:600\s*\t*-rw-------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
+      - 'c:sh -c "stat -L /etc/ssh/sshd_config.d/*.conf" -> r:Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+  # 4.2.2 Ensure permissions on SSH private host key files are configured. (Automated) - Not Implemented
+
+  # 4.2.3 Ensure permissions on SSH public host key files are configured. (Automated)
+  - id: 31158
+    title: "Ensure permissions on SSH public host key files are configured."
+    description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Run the following script to set mode, ownership, and group on the public SSH host key files: #!/usr/bin/env bash { l_pmask=\"0133\" l_maxperm=\"$( printf '%o' $(( 0777 & ~$l_pmask )) )\" awk '{print}' <<< \"$(find -L /etc/ssh -xdev -type f -exec stat -Lc \"%n %#a %U %G\" {} +)\" | (while read -r l_file l_mode l_owner l_group; do if file \"$l_file\" | grep -Pq ':\\h+OpenSSH\\h+(\\H+\\h+)?public\\h+key\\b'; then echo -e \" - Checking private key file: \\\"$l_file\\\"\" if [ $(( $l_mode & $l_pmask )) -gt 0 ]; then echo -e \" - File: \\\"$l_file\\\" is mode \\\"$l_mode\\\" changing to mode: \\\"$l_maxperm\\\"\" chmod u-x,go-wx \"$l_file\" fi if [ \"$l_owner\" != \"root\" ]; then echo -e \" - File: \\\"$l_file\\\" is owned by: \\\"$l_owner\\\" changing owner to \\\"root\\\"\" chown root \"$l_file\" fi if [ \"$l_group\" != \"root\" ]; then echo -e \" - File: \\\"$l_file\\\" is owned by group \\\"$l_group\\\" changing to group \\\"root\\\"\" chgrp \"root\" \"$l_file\" fi fi done ) }."
+    compliance:
+      - cis: ["4.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0003", "TA0006"]
+      - mitre_techniques: ["T1557"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sh -c "find /etc/ssh -xdev -type f -name ''ssh_host_*_key.pub'' -exec stat {} \;" -> r:Access:\s*\( && !r:-rw-r--r--'
+
+  # 4.2.4 Ensure SSH access is limited. (Automated)
+  - id: 31159
+    title: "Ensure SSH access is limited."
+    description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: - AllowUsers: o The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. - AllowGroups: o The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. - DenyUsers: o The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. - DenyGroups: o The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
+    rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set one or more of the parameter above any Include entries as follows: AllowUsers <userlist> OR AllowGroups <grouplist> OR DenyUsers <userlist> OR DenyGroups <grouplist> Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location. If the Include location is not the default, /etc/ssh/sshd_config.d/*.conf, the audit will need to be modified to account for the Include location used."
+    compliance:
+      - cis: ["4.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021", "T1021.004"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*AllowUsers\s+\w+|^\s*AllowGroups\s+\w+|^\s*DenyUsers\s+\w+|^\s*DenyGroups\s+\w+'
+      - 'f:/etc/ssh/sshd_config -> r:^\s*AllowUsers\s+\w+|^\s*AllowGroups\s+\w+|^\s*DenyUsers\s+\w+|^\s*DenyGroups\s+\w+'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^\s*AllowUsers\s+\w+|^\s*AllowGroups\s+\w+|^\s*DenyUsers\s+\w+|^\s*DenyGroups\s+\w+'
+
+  # 4.2.5 Ensure SSH LogLevel is appropriate. (Automated)
+  - id: 31160
+    title: "Ensure SSH LogLevel is appropriate."
+    description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
+    rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: LogLevel VERBOSE OR LogLevel INFO Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
     references:
-      - http://www.sudo.ws/
+      - "https://www.ssh.com/ssh/sshd_config/"
+    compliance:
+      - cis: ["4.2.5"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
+      - 'not f:/etc/ssh/sshd_config -> !r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
+      - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> !r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
+
+  # 4.2.6 Ensure SSH PAM is enabled. (Automated)
+  - id: 31161
+    title: "Ensure SSH PAM is enabled."
+    description: "The UsePAM directive enables the Pluggable Authentication Module (PAM) interface. If set to yes this will enable PAM authentication using ChallengeResponseAuthentication and PasswordAuthentication directives in addition to PAM account and session module processing for all authentication types."
+    rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: UsePAM yes Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.6"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1035"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1021", "T1021.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*usepam\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*usepam\s+no'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^\s*usepam\s+no'
+
+  # 4.2.7 Ensure SSH root login is disabled. (Automated)
+  - id: 31162
+    title: "Ensure SSH root login is disabled."
+    description: "The PermitRootLogin parameter specifies if the root user can log in using SSH. The default is prohibit-password."
+    rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root. This limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitRootLogin no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.7"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*PermitRootLogin\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitRootLogin\s+yes'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^\s*PermitRootLogin\s+yes'
+
+  # 4.2.8 Ensure SSH HostbasedAuthentication is disabled. (Automated)
+  - id: 31163
+    title: "Ensure SSH HostbasedAuthentication is disabled."
+    description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication."
+    rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: HostbasedAuthentication no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.8"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*HostbasedAuthentication\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*HostbasedAuthentication\s+yes'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^\s*HostbasedAuthentication\s+yes'
+
+  # 4.2.9 Ensure SSH PermitEmptyPasswords is disabled. (Automated)
+  - id: 31164
+    title: "Ensure SSH PermitEmptyPasswords is disabled."
+    description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
+    rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitEmptyPasswords no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.9"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*PermitEmptyPasswords\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitEmptyPasswords\s+yes'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^\s*PermitEmptyPasswords\s+yes'
+
+  # 4.2.10 Ensure SSH PermitUserEnvironment is disabled. (Automated)
+  - id: 31165
+    title: "Ensure SSH PermitUserEnvironment is disabled."
+    description: "The PermitUserEnvironment option allows users to present environment options to the SSH daemon."
+    rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has SSH executing trojan'd programs)."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitUserEnvironment no Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.10"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*PermitUserEnvironment\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitUserEnvironment\s+yes'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^\s*PermitUserEnvironment\s+yes'
+
+  # 4.2.11 Ensure SSH IgnoreRhosts is enabled. (Automated)
+  - id: 31166
+    title: "Ensure SSH IgnoreRhosts is enabled."
+    description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
+    rationale: "Setting this parameter forces users to enter a password when authenticating with SSH."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: IgnoreRhosts yes Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.11"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*IgnoreRhosts\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*IgnoreRhosts\s+no'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^\s*IgnoreRhosts\s+no'
+
+  # 4.2.12 Ensure SSH X11 forwarding is disabled. (Automated)
+  - id: 31167
+    title: "Ensure SSH X11 forwarding is disabled."
+    description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
+    rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: X11Forwarding no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*X11Forwarding\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s+yes'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^\s*X11Forwarding\s+yes'
+
+  # 4.2.13 Ensure only strong Ciphers are used. (Automated)
+  - id: 31168
+    title: "Ensure only strong Ciphers are used."
+    description: 'This variable limits the ciphers that SSH can use during communication. Note: - Some organizations may have stricter requirements for approved ciphers. - Ensure that ciphers used are in compliance with site policy. - The only "strong" ciphers currently FIPS 140-2 compliant are: o aes256-ctr o aes192-ctr o aes128-ctr.'
+    rationale: 'Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised. - The Triple DES ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain clear text data via a birthday attack against a long-duration encrypted session, aka a "Sweet32" attack. - Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plain text data from an arbitrary block of cipher text in an SSH session via unknown vectors.'
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma separated list of the site approved ciphers above any Include entries: Example: Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128- gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "https://nvd.nist.gov/vuln/detail/CVE-2016-2183"
+      - "https://www.openssh.com/txt/cbc.adv"
+      - "https://nvd.nist.gov/vuln/detail/CVE-2008-5161"
+    compliance:
+      - cis: ["4.2.13"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|rijndael-cbc@lysator.liu.se"
+
+  # 4.2.14 Ensure only strong MAC algorithms are used. (Automated)
+  - id: 31169
+    title: "Ensure only strong MAC algorithms are used."
+    description: 'This variable limits the types of MAC algorithms that SSH can use during communication. Notes: - Some organizations may have stricter requirements for approved MACs. - Ensure that MACs used are in compliance with site policy. - The only "strong" MACs currently FIPS 140-2 approved are: o hmac-sha2-256 o hmac-sha2-512.'
+    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information."
+    remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs above any Include entries: Example: MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2- 512,hmac-sha2-256,umac-128-etm@openssh.com,umac-128@openssh.com Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "http://www.mitls.org/pages/attacks/SLOTH"
+    compliance:
+      - cis: ["4.2.14"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4", "16.5"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:MACs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com"
+
+  # 4.2.15 Ensure only strong Key Exchange algorithms are used. (Automated)
+  - id: 31170
+    title: "Ensure only strong Key Exchange algorithms are used."
+    description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received Notes: - Kex algorithms have a higher preference the earlier they appear in the list - Some organizations may have stricter requirements for approved Key exchange algorithms - Ensure that Key exchange algorithms used are in compliance with site policy - The only Key Exchange Algorithms currently FIPS 140-2 approved are: o ecdh-sha2-nistp256 o ecdh-sha2-nistp384 o ecdh-sha2-nistp521 o diffie-hellman-group-exchange-sha256 o diffie-hellman-group16-sha512 o diffie-hellman-group18-sha512 o diffie-hellman-group14-sha256."
+    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks."
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma separated list of the site approved key exchange algorithms above any Include entries: Example: KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman- group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18- sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie- hellman-group-exchange-sha256 Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.15"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1"
+
+  # 4.2.16 Ensure SSH AllowTcpForwarding is disabled. (Automated)
+  - id: 31171
+    title: "Ensure SSH AllowTcpForwarding is disabled."
+    description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines."
+    rationale: "Leaving port forwarding enabled can expose the organization to security risks and backdoors. SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network."
+    impact: "SSH tunnels are widely used in many corporate environments. In some environments the applications themselves may have very limited native support for security. By utilizing tunneling, compliance with SOX, HIPAA, PCI-DSS, and other standards can be achieved without having to modify the applications."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: AllowTcpForwarding no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "https://www.ssh.com/ssh/tunneling/example"
+    compliance:
+      - cis: ["4.2.16"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1048", "T1048.002", "T1572"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*AllowTcpForwarding\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*AllowTcpForwarding\s+yes'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^\s*AllowTcpForwarding\s+yes'
+
+  # 4.2.17 Ensure SSH warning banner is configured. (Automated)
+  - id: 31172
+    title: "Ensure SSH warning banner is configured."
+    description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
+    rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: Banner /etc/issue.net Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.17"]
+      - mitre_mitigations: ["M1035"]
+      - mitre_tactics: ["TA0001", "TA0007"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*banner\s*\t*/etc/issue.net'
+
+  # 4.2.18 Ensure SSH MaxAuthTries is set to 4 or less. (Automated)
+  - id: 31173
+    title: "Ensure SSH MaxAuthTries is set to 4 or less."
+    description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
+    rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxAuthTries 4 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.18"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - mitre_mitigations: ["M1036"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1110", "T1110.001", "T1110.003"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
+      - 'not f:/etc/ssh/sshd_config -> n:^MaxAuthTries\s*\t*(\d+) compare > 4'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^MaxAuthTries\s*\t*([5-9]|[1-9][0-9]+)'
+
+  # 4.2.19 Ensure SSH MaxStartups is configured. (Automated)
+  - id: 31174
+    title: "Ensure SSH MaxStartups is configured."
+    description: "The MaxStartups parameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon."
+    rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxStartups 10:30:60 Note: First occurrence of an option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.19"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1499", "T1499.002"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*maxstartups\s+10:30:60'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*maxstartups\s+(((1[1-9]|[1-9][0-9][0-9]+):([0-9]+):([0-9]+))|(([0-9]+):(3[1-9]|[4-9][0-9]|[1-9][0-9][0-9]+):([0-9]+))|(([0-9]+):([0-9]+):(6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+)))'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^\s*maxstartups\s+(((1[1-9]|[1-9][0-9][0-9]+):([0-9]+):([0-9]+))|(([0-9]+):(3[1-9]|[4-9][0-9]|[1-9][0-9][0-9]+):([0-9]+))|(([0-9]+):([0-9]+):(6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+)))'
+
+  # 4.2.20 Ensure SSH LoginGraceTime is set to one minute or less. (Automated)
+  - id: 31175
+    title: "Ensure SSH LoginGraceTime is set to one minute or less."
+    description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
+    rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: LoginGraceTime 60 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.20"]
+      - mitre_mitigations: ["M1036"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1110", "T1110.001", "T1110.003", "T1110.004"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:logingracetime\s*\t*(\d+) compare <= 60 && n:LoginGraceTime\s*\t*(\d+) compare != 0'
+      - 'not f:/etc/ssh/sshd_config -> r:\s*LoginGraceTime\s+(0|6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+|[^1]m)'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:\s*LoginGraceTime\s+(0|6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+|[^1]m)'
+
+  # 4.2.21 Ensure SSH MaxSessions is set to 10 or less. (Automated)
+  - id: 31176
+    title: "Ensure SSH MaxSessions is set to 10 or less."
+    description: "The MaxSessions parameter specifies the maximum number of open sessions permitted from a given connection."
+    rationale: "To protect a system from denial of service due to a large number of concurrent sessions, use the rate limiting function of MaxSessions to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxSessions 10 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.21"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1499", "T1499.002"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^\s*maxsessions\s+(\d+) compare <= 10'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxSessions\s+(1[1-9]|[2-9][0-9]|[1-9][0-9][0-9]+)'
+      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf$ -> r:^\s*MaxSessions\s+(1[1-9]|[2-9][0-9]|[1-9][0-9][0-9]+)'
+
+  # 4.2.22 Ensure SSH Idle Timeout Interval is configured. (Automated)
+  - id: 31177
+    title: "Ensure SSH Idle Timeout Interval is configured."
+    description: "Note: To clarify, the two settings described below are only meant for idle connections from a protocol perspective and are not meant to check if the user is active or not. An idle user does not mean an idle connection. SSH does not and never had, intentionally, the capability to drop idle users. In SSH versions before 8.2p1 there was a bug that caused these values to behave in such a manner that they were abused to disconnect idle users. This bug has been resolved in 8.2p1 and thus it can no longer be abused disconnect idle users. The two options ClientAliveInterval and ClientAliveCountMax control the timeout of SSH sessions. Taken directly from man 5 sshd_config: - ClientAliveInterval Sets a timeout interval in seconds after which if no data has been received from the client, sshd(8) will send a message through the encrypted channel to request a response from the client. The default is 0, indicating that these messages will not be sent to the client. - ClientAliveCountMax Sets the number of client alive messages which may be sent without sshd(8) receiving any messages back from the client. If this threshold is reached while client alive messages are being sent, sshd will disconnect the client, terminating the session. It is important to note that the use of client alive messages is very different from TCPKeepAlive. The client alive messages are sent through the encrypted channel and therefore will not be spoofable. The TCP keepalive option enabled by TCPKeepAlive is spoofable. The client alive mechanism is valuable when the client or server depend on knowing when a connection has become unresponsive. The default value is 3. If ClientAliveInterval is set to 15, and ClientAliveCountMax is left at the default, unresponsive SSH clients will be disconnected after approximately 45 seconds. Setting a zero ClientAliveCountMax disables connection termination."
+    rationale: "In order to prevent resource exhaustion, appropriate values should be set for both ClientAliveInterval and ClientAliveCountMax. Specifically, looking at the source code, ClientAliveCountMax must be greater than zero in order to utilize the ability of SSH to drop idle connections. If connections are allowed to stay open indefinately, this can potentially be used as a DDOS attack or simple resource exhaustion could occur over unreliable networks. The example set here is a 45 second timeout. Consult your site policy for network timeouts and apply as appropriate."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameters above any Include entries according to site policy. Example: ClientAliveInterval 15 ClientAliveCountMax 3 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "https://man.openbsd.org/sshd_config"
+    compliance:
+      - cis: ["4.2.22"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:ClientAliveInterval\s*\t*(\d+) compare > 0'
+      - 'c:sshd -T -> n:clientalivecountmax\s*\t*(\d+) compare > 0'
+
+  # 4.3.1 Ensure sudo is installed. (Automated)
+  - id: 31178
+    title: "Ensure sudo is installed."
+    description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
+    rationale: "sudo supports a plug-in architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plug-ins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers and any entries in /etc/sudoers.d. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
+    remediation: "First determine is LDAP functionality is required. If so, then install sudo-ldap, else install sudo. Example: # apt install sudo."
+    compliance:
+      - cis: ["4.3.1"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
     condition: any
     rules:
       - "c:dpkg -s sudo -> r:install ok installed"
       - "c:dpkg -s sudo-ldap -> r:install ok installed"
 
-  # 5.2.2 Ensure sudo commands use pty (Automated)
-  - id: 19149
+  # 4.3.2 Ensure sudo commands use pty. (Automated)
+  - id: 31179
     title: "Ensure sudo commands use pty."
-    description: "sudo can be configured to run only from a pseudo-pty. Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks or parse errors. If the sudoers file is currently being edited you will receive a message to try again later."
-    rationale: "Attackers can run a malicious program using sudo, which would again fork a background process that remains even when the main program has finished executing."
-    remediation: "Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo -f and add the following line: Defaults use_pty"
+    description: "sudo can be configured to run only from a pseudo terminal (pseudo-pty)."
+    rationale: "Attackers can run a malicious program using sudo which would fork a background process that remains even when the main program has finished executing."
+    impact: "WARNING: Editing the sudo configuration incorrectly can cause sudo to stop functioning. Always use visudo to modify sudo configuration files."
+    remediation: "Edit the file /etc/sudoers with visudo or a file in /etc/sudoers.d/ with visudo -f <PATH TO FILE> and add the following line: Defaults use_pty Note: - sudo will read each file in /etc/sudoers.d, skipping file names that end in ~ or contain a . character to avoid causing problems with package manager or editor temporary/backup files. - Files are parsed in sorted lexical order. That is, /etc/sudoers.d/01_first will be parsed before /etc/sudoers.d/10_second. - Be aware that because the sorting is lexical, not numeric, /etc/sudoers.d/1_whoops would be loaded after /etc/sudoers.d/10_second. - Using a consistent number of leading zeroes in the file names can be used to avoid such problems."
     compliance:
-      - cis: ["5.2.2"]
-      - cis_csc_v7: ["4.3"]
-      - cmmc_v2.0: ["AC.2.008", "IA.1.076", "IA.1.077", "SC.3.181"]
-      - iso_27001-2013: ["A.9.2.3"]
-      - mitre_techniques: ["T1176", "T1501", "T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
+      - cis: ["4.3.2"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1026", "M1038"]
+      - mitre_tactics: ["TA0001", "TA0003"]
+      - mitre_techniques: ["T1078", "T1078.003", "T1548", "T1548.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
     condition: any
     rules:
-      - 'f:/etc/sudoers -> r:^\s*Defaults\s*use_pty'
-      - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*Defaults\s*use_pty'
+      - 'f:/etc/sudoers -> r:^\s*\t*Defaults\s*\t*use_pty'
+      - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*use_pty'
 
-  # 5.2.3 Ensure sudo log file exists (Automated)
-  - id: 19150
+  # 4.3.3 Ensure sudo log file exists. (Automated)
+  - id: 31180
     title: "Ensure sudo log file exists."
-    description: "sudo can use a custom log file. Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks or parse errors. If the sudoers file is currently being edited you will receive a message to try again later."
+    description: "sudo can use a custom log file."
     rationale: "A sudo log file simplifies auditing of sudo commands."
-    remediation: 'Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo -f and add the following line: and add the following line: Defaults logfile="<PATH TO CUSTOM LOG FILE>" Example: Defaults logfile="/var/log/sudo.log"'
+    impact: "WARNING: Editing the sudo configuration incorrectly can cause sudo to stop functioning. Always use visudo to modify sudo configuration files."
+    remediation: 'Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH TO FILE> and add the following line: Example: Defaults logfile="/var/log/sudo.log" Note: - sudo will read each file in /etc/sudoers.d, skipping file names that end in ~ or contain a . character to avoid causing problems with package manager or editor temporary/backup files. - Files are parsed in sorted lexical order. That is, /etc/sudoers.d/01_first will be parsed before /etc/sudoers.d/10_second. - Be aware that because the sorting is lexical, not numeric, /etc/sudoers.d/1_whoops would be loaded after /etc/sudoers.d/10_second. - Using a consistent number of leading zeroes in the file names can be used to avoid such problems.'
     compliance:
-      - cis: ["5.2.3"]
+      - cis: ["4.3.3"]
+      - cis_csc_v8: ["8.5"]
       - cis_csc_v7: ["6.3"]
-      - cmmc_v2.0: ["CM.2.065"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
       - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-12"]
-      - pci_dss_v3.2.1: ["10.1", "10.3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
     condition: any
     rules:
-      - 'f:/etc/sudoers -> r:^\s*Defaults\s*logfile="\.+"'
-      - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*Defaults\s*\logfile="\.+"'
+      - 'f:/etc/sudoers -> r:^\s*\t*Defaults\s*\t*logfile='
+      - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile='
 
-  # 5.3 Configure SSH Server
-
-  # 5.3.1 Ensure permissions on /etc/ssh/sshd_config are configured (Automated)
-  - id: 19151
-    title: "Ensure permissions on /etc/ssh/sshd_config are configured."
-    description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
-    rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
-    remediation: "Run the following commands to set ownership and permissions on /etc/ssh/sshd_config: # chown root:root /etc/ssh/sshd_config # chmod og-rwx /etc/ssh/sshd_config"
+  # 4.3.4 Ensure users must provide password for privilege escalation. (Automated)
+  - id: 31181
+    title: "Ensure users must provide password for privilege escalation."
+    description: "The operating system must be configured so that users must provide a password for privilege escalation."
+    rationale: "Without (re-)authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user (re-)authenticate."
+    impact: "This will prevent automated processes from being able to elevate privileges."
+    remediation: "Based on the outcome of the audit procedure, use visudo -f <PATH TO FILE> to edit the relevant sudoers file. Remove any line with occurrences of NOPASSWD tags in the file."
     compliance:
-      - cis: ["5.3.1"]
-      - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
-      - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
-      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
-    condition: all
-    rules:
-      - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-
-  # 5.3.2 Ensure permissions on SSH private host key files are configured (Automated)
-  - id: 19152
-    title: "Ensure permissions on SSH private host key files are configured."
-    description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, The possession of the private key is proof of identity. Only a private key that corresponds to a public key will be able to authenticate successfully. The private keys need to be stored and handled carefully, and no copies of the private key should be distributed."
-    rationale: "If an unauthorized user obtains the private SSH host key file, the host could be impersonated."
-    remediation: "Run the following commands to set permissions, ownership, and group on the private SSH host key files: # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chown root:root {} \\; # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chmod u-x,go-rwx {} \\;"
-    compliance:
-      - cis: ["5.3.2"]
-      - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
-      - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
-      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
-    condition: all
-    rules:
-      - 'c:stat /etc/ssh/ssh_host_rsa_key -> r:^Access: \(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access: \(0400/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /etc/ssh/ssh_host_ecdsa_key -> r:^Access: \(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access: \(0400/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /etc/ssh/ssh_host_ed25519_key -> r:^Access: \(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access: \(0400/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)$'
-      - 'c:stat /etc/ssh/ssh_host_dsa_key -> r:^Access: \(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access: \(0400/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)$'
-
-  # 5.3.3 Ensure permissions on SSH public host key files are configured (Automated)
-  - id: 19153
-    title: "Ensure permissions on SSH public host key files are configured."
-    description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
-    rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
-    remediation: "Run the following commands to set permissions and ownership on the SSH host public key files: # find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chmod u-x,go-wx {} \\; # find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chown root:root {} \\;"
-    compliance:
-      - cis: ["5.3.3"]
-      - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
-      - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
-      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
-    condition: all
-    rules:
-      - 'c:stat /etc/ssh/ssh_host_rsa_key.pub -> r:^Access: \(0644/-rw-r--r--)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /etc/ssh/ssh_host_ecdsa_key.pub -> r:^Access: \(0644/-rw-r--r--)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /etc/ssh/ssh_host_ed25519_key.pub -> r:^Access: \(0644/-rw-r--r--)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /etc/ssh/ssh_host_dsa_key.pub -> r:^Access: \(0644/-rw-r--r--)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-
-  # 5.3.4 Ensure SSH access is limited (Automated)
-  - id: 19154
-    title: "Ensure SSH access is limited."
-    description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: - AllowUsers: > The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. - AllowGroups: > The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. - DenyUsers: > The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. - DenyGroups: > The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
-    rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set one or more of the parameter as follows: AllowUsers <userlist> OR AllowGroups <grouplist> OR DenyUsers <userlist> OR DenyGroups <grouplist>"
-    compliance:
-      - cis: ["5.3.4"]
+      - cis: ["4.3.4"]
+      - cis_csc_v8: ["5.4"]
       - cis_csc_v7: ["4.3"]
-      - cmmc_v2.0: ["AC.2.008", "IA.1.076", "IA.1.077", "SC.3.181"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
       - iso_27001-2013: ["A.9.2.3"]
-      - mitre_techniques: ["T1176", "T1501", "T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1548"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
-    condition: any
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
     rules:
-      - 'c:sshd -T -> r:\s*allowusers\s+\w+|allowgroups\s+\w+|denyusers\s+\w+|denygroups\s+\w+'
+      - "f:/etc/sudoers -> !r:^# && r:*NOPASSWD"
+      - 'd:/etc/sudoers.d -> r:\.* -> !r:^# && r:*NOPASSWD'
 
-  # 5.3.5 Ensure SSH LogLevel is appropriate (Automated)
-  - id: 19155
-    title: "Ensure SSH LogLevel is appropriate."
-    description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
-    rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: LogLevel VERBOSE OR LogLevel INFO"
-    references:
-      - https://www.ssh.com/ssh/sshd_config/
+  # 4.3.5 Ensure re-authentication for privilege escalation is not disabled globally. (Automated)
+  - id: 31182
+    title: "Ensure re-authentication for privilege escalation is not disabled globally."
+    description: "The operating system must be configured so that users must re-authenticate for privilege escalation."
+    rationale: "Without re-authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate."
+    remediation: "Configure the operating system to require users to reauthenticate for privilege escalation. Based on the outcome of the audit procedure, use visudo -f <PATH TO FILE> to edit the relevant sudoers file. Remove any occurrences of !authenticate tags in the file(s)."
     compliance:
-      - cis: ["5.3.5"]
-      - cis_csc_v7: ["6.2", "6.3"]
-      - cmmc_v2.0: ["AU.2.042", "AU.5.055", "CM.2.065"]
-      - iso_27001-2013: ["A.12.4.1"]
-      - nist_sp_800-53: ["AU-12", "AU-3"]
-      - pci_dss_v3.2.1: ["10.1", "10.2", "10.3"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> r:loglevel\s+INFO|loglevel\s+VERBOSE'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*loglevel && !r:INFO|VERBOSE'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> r:^\s*loglevel && !r:INFO|VERBOSE'
-
-  # 5.3.6 Ensure SSH X11 forwarding is disabled (Automated)
-  - id: 19156
-    title: "Ensure SSH X11 forwarding is disabled."
-    description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through an existing SSH shell session to enable remote graphic connections."
-    rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
-    impact: "X11 programs on the server will not be able to be forwarded to a ssh-client display."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: X11Forwarding no"
-    compliance:
-      - cis: ["5.3.6"]
-      - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
-      - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> r:x11forwarding\s+no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s+yes'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> r:^\s*X11Forwarding\s+yes'
-
-  # 5.3.7 Ensure SSH MaxAuthTries is set to 4 or less (Automated)
-  - id: 19157
-    title: "Ensure SSH MaxAuthTries is set to 4 or less."
-    description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
-    rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: MaxAuthTries 4"
-    compliance:
-      - cis: ["5.3.7"]
-      - cis_csc_v7: ["16.13"]
-      - cmmc_v2.0: ["SI.5.223", "AC.4.032"]
-      - mitre_techniques: ["T1134", "T1197", "T1538", "T1530", "T1213", "T1089", "T1157", "T1044", "T1484", "T1054", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1034", "T1163", "T1076", "T1021", "T1053", "T1489", "T1051", "T1023", "T1165", "T1528", "T1501", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> n:^\s*maxauthtries\s*(\d+) compare <= 4'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*MaxAuthTries\s*(\d+) compare > 4'
-      - 'not d:/etc/ssh/sshd_config.d -> n:^\s*MaxAuthTries\s*(\d+) compare > 4'
-
-  # 5.3.8 Ensure SSH IgnoreRhosts is enabled (Automated)
-  - id: 19158
-    title: "Ensure SSH IgnoreRhosts is enabled."
-    description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
-    rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: IgnoreRhosts yes"
-    compliance:
-      - cis: ["5.3.8"]
-      - cis_csc_v7: ["9.2"]
-      - cmmc_v2.0: ["CM.3.068", "SC.5.230"]
-      - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> r:ignorerhosts\s+yes'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*IgnoreRhosts\s+yes'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> r:^\s*IgnoreRhosts\s+yes'
-
-  # 5.3.9 Ensure SSH HostbasedAuthentication is disabled (Automated)
-  - id: 19159
-    title: "Ensure SSH HostbasedAuthentication is disabled."
-    description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication."
-    rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: HostbasedAuthentication no"
-    compliance:
-      - cis: ["5.3.9"]
-      - cis_csc_v7: ["16.3"]
-      - mitre_techniques: ["T1110", "T1098", "T1017", "T1136", "T1530", "T1114", "T1133", "T1040", "T1076", "T1021", "T1539", "T1072", "T1078", "T1134", "T1197", "T1538", "T1213", "T1089", "T1157", "T1044", "T1484", "T1054", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1034", "T1163", "T1053", "T1489", "T1051", "T1023", "T1165", "T1528", "T1501", "T1537", "T1047", "T1084", "T1004"]
-      - pci_dss_v3.2.1: ["8.3"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> r:hostbasedauthentication\s+no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*HostbasedAuthentication\s+yes'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> r:^\s*HostbasedAuthentication\s+yes'
-
-  # 5.3.10 Ensure SSH root login is disabled (Automated)
-  - id: 19160
-    title: "Ensure SSH root login is disabled."
-    description: "The PermitRootLogin parameter specifies if the root user can log in using ssh."
-    rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo. This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: PermitRootLogin no"
-    compliance:
-      - cis: ["5.3.10"]
+      - cis: ["4.3.5"]
+      - cis_csc_v8: ["5.4"]
       - cis_csc_v7: ["4.3"]
-      - cmmc_v2.0: ["AC.2.008", "IA.1.076", "IA.1.077", "SC.3.181"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
       - iso_27001-2013: ["A.9.2.3"]
-      - mitre_techniques: ["T1176", "T1501", "T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> r:permitrootlogin\s+no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitRootLogin\s+yes'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> r:^\s*PermitRootLogin\s+yes'
-
-  # 5.3.11 Ensure SSH PermitEmptyPasswords is disabled (Automated)
-  - id: 19161
-    title: "Ensure SSH PermitEmptyPasswords is disabled."
-    description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
-    rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: PermitEmptyPasswords no"
-    compliance:
-      - cis: ["5.3.11"]
-      - cis_csc_v7: ["16.3"]
-      - mitre_techniques: ["T1110", "T1098", "T1017", "T1136", "T1530", "T1114", "T1133", "T1040", "T1076", "T1021", "T1539", "T1072", "T1078", "T1134", "T1197", "T1538", "T1213", "T1089", "T1157", "T1044", "T1484", "T1054", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1034", "T1163", "T1053", "T1489", "T1051", "T1023", "T1165", "T1528", "T1501", "T1537", "T1047", "T1084", "T1004"]
-      - pci_dss_v3.2.1: ["8.3"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> r:permitemptypasswords\s+no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitEmptyPasswords\s+yes'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> r:^\s*PermitEmptyPasswords\s+yes'
-
-  # 5.3.12 Ensure SSH PermitUserEnvironment is disabled (Automated)
-  - id: 19162
-    title: "Ensure SSH PermitUserEnvironment is disabled."
-    description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
-    rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing a Trojan’s programs)."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: PermitUserEnvironment no"
-    compliance:
-      - cis: ["5.3.12"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> r:permituserenvironment\s+no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitUserEnvironment\s+yes'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> r:^\s*PermitUserEnvironment\s+yes'
-
-  # 5.3.13 Ensure only strong Ciphers are used (Automated)
-  - id: 19163
-    title: "Ensure only strong Ciphers are used."
-    description: "This variable limits the ciphers that SSH can use during communication. Note: Some organizations may have stricter requirements for approved ciphers. Ensure that ciphers used are in compliance with site policy."
-    rationale: 'Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised. - The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a "Sweet32" attack. - The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involving LSB values, aka the "Bar Mitzvah" issue. - The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session. - Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors.'
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf and add or modify the Ciphers line to contain a comma separated list of the site approved ciphers Example: Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
-    compliance:
-      - cis: ["5.3.13"]
-      - cis_csc_v7: ["14.4"]
-      - cmmc_v2.0: ["SC.3.177", "SC.3.185"]
-      - iso_27001-2013: ["A.13.1.1", "A.10.1.1"]
-      - mitre_techniques: ["T1527", "T1119", "T1530", "T1114", "T1070", "T1208", "T1040", "T1145", "T1492", "T1493"]
-      - pci_dss_v3.2.1: ["4.1"]
-    references:
-      - "https://nvd.nist.gov/vuln/detail/CVE-2016-2183"
-      - "https://nvd.nist.gov/vuln/detail/CVE-2015-2808"
-      - "https://nvd.nist.gov/vuln/detail/CVE-2008-5161"
-      - "https://nvd.nist.gov/vuln/detail/CVE-2013-4548"
-      - "https://www.kb.cert.org/vuls/id/565052"
-      - "https://www.openssh.com/txt/cbc.adv"
+      - soc_2: ["CC6.1", "CC6.3"]
     condition: none
     rules:
-      - "c:sshd -T -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|arcfour|arcfour128|arcfour256|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se"
-      - "f:/etc/ssh/sshd_config -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|arcfour|arcfour128|arcfour256|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se"
-      - 'd:/etc/ssh/sshd_config.d -> r:\.*.conf -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|arcfour|arcfour128|arcfour256|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se'
+      - 'f:/etc/sudoers -> !r:^# && r:*\!authenticate'
+      - 'd:/etc/sudoers.d -> r:\.* -> !r:^# && r:*\!authenticate'
 
-  # 5.3.14 Ensure only strong MAC algorithms are used (Automated)
-  - id: 19164
-    title: "Ensure only strong MAC algorithms are used."
-    description: "This variable Specifies the available MAC (message authentication code) algorithms. The MAC algorithm is used in protocol version 2 for data integrity protection. Multiple algorithms must be comma-separated. Note: Some organizations may have stricter requirements for approved MACs. Ensure that MACs used are in compliance with site policy."
-    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf and add or modify the MACs line to contain a comma separated list of the site approved MACs Example: MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2- 512,hmac-sha2-256"
-    compliance:
-      - cis: ["5.3.14"]
-      - cis_csc_v7: ["14.4", "16.5"]
-      - cmmc_v2.0: ["IA.2.081", "SC.3.177", "SC.3.185"]
-      - iso_27001-2013: ["A.13.1.1", "A.10.1.1"]
-      - mitre_techniques: ["T1527", "T1119", "T1530", "T1114", "T1070", "T1208", "T1040", "T1145", "T1492", "T1493"]
-      - nist_sp_800-53: ["IA-5"]
-      - pci_dss_v3.2.1: ["4.1", "8.2.1"]
+  # 4.3.6 Ensure sudo authentication timeout is configured correctly. (Automated)
+  - id: 31183
+    title: "Ensure sudo authentication timeout is configured correctly."
+    description: "sudo caches used credentials for a default of 15 minutes. This is for ease of use when there are multiple administrative tasks to perform. The timeout can be modified to suit local security policies. This default is distribution specific. See audit section for further information."
+    rationale: "Setting a timeout value reduces the window of opportunity for unauthorized privileged access to another user."
+    remediation: "If the currently configured timeout is larger than 15 minutes, edit the file listed in the audit section with visudo -f <PATH TO FILE> and modify the entry timestamp_timeout= to 15 minutes or less as per your site policy. The value is in minutes. This particular entry may appear on it's own, or on the same line as env_reset. See the following two examples: Defaults env_reset, timestamp_timeout=15 Defaults timestamp_timeout=15 Defaults env_reset."
     references:
-      - "http://www.mitls.org/pages/attacks/SLOTH"
-    condition: none
-    rules:
-      - 'c:sshd -T -> r:^\s*macs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'
-      - 'f:/etc/ssh/sshd_config -> r:^\s*macs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'
-      - 'd:/etc/ssh/sshd_config.d -> r:\.*.conf -> r:^\s*macs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'
-
-  # 5.3.15 Ensure only strong Key Exchange algorithms are used (Automated)
-  - id: 19165
-    title: "Ensure only strong Key Exchange algorithms are used."
-    description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received Note: Some organizations may have stricter requirements for approved Key Exchange algorithms. Ensure that Key Exchange algorithms used are in compliance with site policy."
-    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf and add or modify the KexAlgorithms line to contain a comma separated list of the site approved key exchange algorithms. Example: KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
+      - "https://www.sudo.ws/man/1.9.0/sudoers.man.html"
     compliance:
-      - cis: ["5.3.15"]
-      - cis_csc_v7: ["14.4"]
-      - cmmc_v2.0: ["SC.3.177", "SC.3.185"]
-      - iso_27001-2013: ["A.13.1.1", "A.10.1.1"]
-      - mitre_techniques: ["T1527", "T1119", "T1530", "T1114", "T1070", "T1208", "T1040", "T1145", "T1492", "T1493"]
-      - pci_dss_v3.2.1: ["4.1"]
-    condition: none
-    rules:
-      - 'c:sshd -T -> r:^\s*kexalgorithms\s+ && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'
-      - 'f:/etc/ssh/sshd_config -> r:^\s*kexalgorithms\s+ && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'
-      - 'd:/etc/ssh/sshd_config.d -> r:\.*.conf -> r:^\s*kexalgorithms\s+ && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'
-
-  # 5.3.16 Ensure SSH Idle Timeout Interval is configured (Automated)
-  - id: 19166
-    title: "Ensure SSH Idle Timeout Interval is configured."
-    description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. - ClientAliveInterval sets a timeout interval in seconds after which if no data has been received from the client, sshd will send a message through the encrypted channel to request a response from the client. The default is 0, indicating that these messages will not be sent to the client. - ClientAliveCountMax sets the number of client alive messages which may be sent without sshd receiving any messages back from the client. If this threshold is reached while client alive messages are being sent, sshd will disconnect the client, terminating the session. The default value is 3. > The client alive messages are sent through the encrypted channel. > Setting ClientAliveCountMax to 0 disables connection termination. Example: If the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
-    rationale: "Having no timeout value associated with a connection could allow an ssh session to remain active after the connection with the client has been interrupted. Setting a timeout value reduces this risk. - The recommended ClientAliveInterval setting is 300 seconds (5 minutes). - The recommended ClientAliveCountMax setting is 3. - The ssh session would send three keep alive messages at 5 minute intervals. If no response is received after the third keep alive message, the ssh session would be terminated after 15 minutes."
-    remediation: "Edit the /etc/ssh/sshd_config file to set the parameters according to site policy. This should include ClientAliveInterval between 1 and 300 and ClientAliveCountMax between 1 and 3: ClientAliveInterval 300 ClientAliveCountMax 3"
-    compliance:
-      - cis: ["5.3.16"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    references:
-      - "https://man.openbsd.org/sshd_config"
+      - cis: ["4.3.6"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
     condition: all
     rules:
-      - 'c:sshd -T -> n:^\s*clientaliveinterval\s*(\d+) compare <= 300 && n:clientaliveinterval\s*(\d+) compare != 0'
-      - 'c:sshd -T -> n:^\s*clientalivecountmax\s*(\d+) compare <= 3 && n:^\s*clientalivecountmax\s*(\d+) compare != 0'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*clientaliveinterval\s*(\d+) compare > 300'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*clientaliveinterval\s*(\d+) compare == 0'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*clientaliveinterval\s*(\d+) compare > 300'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*clientaliveinterval\s*(\d+) compare == 0'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*clientalivecountmax\s*(\d+) compare > 3'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*clientalivecountmax\s*(\d+) compare == 0'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*clientalivecountmax\s*(\d+) compare > 3'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*clientalivecountmax\s*(\d+) compare == 0'
+      - 'c:sudo -V -> r:Authentication timestamp timeout:\s*\t*15.0 minutes'
+      - 'f:/etc/sudoers -> n:timestamp_timeout=(\d+) compare <=15'
+      - 'd:/etc/sudoers.d -> r:\.* -> n:timestamp_timeout=(\d+) compare <=15'
 
-  # 5.3.17 Ensure SSH LoginGraceTime is set to one minute or less (Automated)
-  - id: 19167
-    title: "Ensure SSH LoginGraceTime is set to one minute or less."
-    description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
-    rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: LoginGraceTime 60"
+  # 4.3.7 Ensure access to the su command is restricted. (Automated)
+  - id: 31184
+    title: "Ensure access to the su command is restricted."
+    description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in a specific groups to execute su. This group should be empty to reinforce the use of sudo for privileged access."
+    rationale: "Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program."
+    remediation: "Create an empty group that will be specified for use of the su command. The group should be named according to site policy. Example: # groupadd sugroup Add the following line to the /etc/pam.d/su file, specifying the empty group: auth required pam_wheel.so use_uid group=sugroup."
     compliance:
-      - cis: ["5.3.17"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis: ["4.3.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:sshd -T -> n:^\s*logingracetime\s*(\d+) compare <= 60 && n:^\s*logingracetime\s*(\d+) compare >= 1'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*LoginGraceTime\s*(\d+) compare > 60'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*LoginGraceTime\s*(\d+) compare == 0'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*LoginGraceTime\s*(\d+) compare > 60'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*LoginGraceTime\s*(\d+) compare == 0'
+      - 'f:/etc/pam.d/su -> !r:^# && r:auth\s*\t*required\s*\t*pam_wheel.so && r:use_uid && r:group=\w+'
 
-  # 5.3.18 Ensure SSH warning banner is configured (Automated)
-  - id: 19168
-    title: "Ensure SSH warning banner is configured."
-    description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
-    rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: Banner /etc/issue.net"
-    compliance:
-      - cis: ["5.3.18"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> r:banner\s*/\w+'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*Banner\s+ && r:none'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*Banner\s+ && r:none'
-
-  # 5.3.19 Ensure SSH PAM is enabled (Automated)
-  - id: 19169
-    title: "Ensure SSH PAM is enabled."
-    description: "UsePAM Enables the Pluggable Authentication Module interface. If set to “yes” this will enable PAM authentication using ChallengeResponseAuthentication and PasswordAuthentication in addition to PAM account and session module processing for all authentication types."
-    rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server."
-    impact: "If UsePAM is enabled, you will not be able to run sshd(5) as a non-root user."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: UsePAM yes"
-    compliance:
-      - cis: ["5.3.19"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> r:^\s*usepam\s+yes'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*UsePAM\s+no'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*UsePAM\s+no'
-
-  # 5.3.20 Ensure SSH AllowTcpForwarding is disabled (Automated)
-  - id: 19170
-    title: "Ensure SSH AllowTcpForwarding is disabled."
-    description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines."
-    rationale: "Leaving port forwarding enabled can expose the organization to security risks and back-doors. SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network."
-    impact: "SSH tunnels are widely used in many corporate environments that employ mainframe systems as their application backends. In those environments the applications themselves may have very limited native support for security. By utilizing tunneling, compliance with SOX, HIPAA, PCI-DSS, and other standards can be achieved without having to modify the applications."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: AllowTcpForwarding no"
-    compliance:
-      - cis: ["5.3.20"]
-      - cis_csc_v7: ["9.2", "13,5"]
-      - cmmc_v2.0: ["AC.3.020", "AC.3.022", "CM.3.068", "SC.5.230"]
-      - iso_27001-2013: ["A.6.2.1", "A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1527", "T1119", "T1530", "T1114", "T1070", "T1208", "T1040", "T1145", "T1492", "T1493"]
-      - nist_sp_800-53: ["SI-4"]
-      - pci_dss_v3.2.1: ["1.2.1", "2.2.2", "2.2.5"]
-    references:
-      - https://www.ssh.com/ssh/tunneling/example
-    condition: all
-    rules:
-      - 'c:sshd -T -> r:^\s*allowtcpforwarding\s+no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*^\s*AllowTcpForwarding\s+yes'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*AllowTcpForwarding\s+yes'
-
-  # 5.3.21 Ensure SSH MaxStartups is configured (Automate)
-  - id: 19171
-    title: "Ensure SSH MaxStartups is configured."
-    description: "The MaxStartups parameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon."
-    rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: MaxStartups 10:30:60"
-    compliance:
-      - cis: ["5.3.21"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> n:^\s*maxstartups\s+(\d+):\d+:\d+ compare <= 10 && n:^\s*maxstartups\s+(\d+):\d+:\d+ compare >= 1'
-      - 'c:sshd -T -> n:^\s*maxstartups\s+\d+:(\d+):\d+ compare <= 30 && n:^\s*maxstartups\s+(\d+):\d+:\d+ compare >= 1'
-      - 'c:sshd -T -> n:^\s*maxstartups\s+\d+:\d+:(\d+) compare <= 60 && n:^\s*maxstartups\s+(\d+):\d+:\d+ compare >= 1'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*MaxStartups\s+(\d+):\d+:\d+ compare > 10'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*MaxStartups\s+(\d+):\d+:\d+ compare == 0'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*MaxStartups\s+(\d+):\d+:\d+ compare > 10'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*MaxStartups\s+(\d+):\d+:\d+ compare == 0'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*MaxStartups\s+\d+:(\d+):\d+ compare > 30'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*MaxStartups\s+\d+:(\d+):\d+ compare == 0'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*MaxStartups\s+\d+:(\d+):\d+ compare > 30'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*MaxStartups\s+\d+:(\d+):\d+ compare == 0'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*MaxStartups\s+\d+:\d+:(\d+) compare > 60'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*MaxStartups\s+\d+:\d+:(\d+) compare == 0'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*MaxStartups\s+\d+:\d+:(\d+) compare > 60'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*MaxStartups\s+\d+:\d+:(\d+) compare == 0'
-
-  # 5.3.22 Ensure SSH MaxSessions is limited (Automated)
-  - id: 19172
-    title: "Ensure SSH MaxSessions is limited."
-    description: "The MaxSessions parameter Specifies the maximum number of open sessions permitted per network connection."
-    rationale: "To protect a system from denial of service due to a large number of concurrent sessions, use the rate limiting function of MaxSessions to protect availability of sshd logins and prevent overwhelming the daemon."
-    remediation: "Edit /etc/ssh/sshd_config or a file in /ssh/sshd_config.d/ ending in .conf to set the parameter as follows: MaxSessions 10"
-    compliance:
-      - cis: ["5.3.22"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> n:^maxsessions\s+(\d+) compare <= 10 && n:^maxsessions\s+(\d+) compare >= 1'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*MaxSessions\s+\d+:\d+:(\d+) compare > 10'
-      - 'not f:/etc/ssh/sshd_config -> n:^\s*MaxSessions\s+\d+:\d+:(\d+) compare == 0'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*MaxSessions\s+\d+:\d+:(\d+) compare > 10'
-      - 'not d:/etc/ssh/sshd_config.d -> r:\.*.conf -> n:^\s*MaxSessions\s+\d+:\d+:(\d+) compare == 0'
-
-  # 5.4 Configure PAM
-
-  # 5.4.1 Ensure password creation requirements are configured (Automated)
-  - id: 19173
+  # 4.4.1 Ensure password creation requirements are configured. (Automated)
+  - id: 31185
     title: "Ensure password creation requirements are configured."
-    description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more. The following are definitions of the pam_pwquality.so options. The following options are set in the /etc/security/pwquality.conf file: - Password Length: > minlen = 14 - password must be 14 characters or more - Password complexity: > minclass = 4 - The minimum number of required classes of characters for the new password (digits, uppercase, lowercase, others) OR > dcredit = -1 - provide at least one digit > ucredit = -1 - provide at least one uppercase character > ocredit = -1 - provide at least one special character > lcredit = -1 - provide at least one lowercase character The following is set in the /etc/pam.d/common-password file: - retry=3 - Allow 3 tries before sending back a failure. The settings shown above are one possible policy. Alter these values to conform to your own organization's password policies. "
+    description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more. The following options are set in the /etc/security/pwquality.conf file: - Password Length: o minlen = 14 - password must be 14 characters or more - Password complexity: o minclass = 4 - The minimum number of required classes of characters for the new password (digits, uppercase, lowercase, others) OR o dcredit = -1 - provide at least one digit o ucredit = -1 - provide at least one uppercase character o ocredit = -1 - provide at least one special character o lcredit = -1 - provide at least one lowercase character."
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
-    remediation: "Run the following command to install the pam_pwquality module: apt install libpam-pwquality Edit the file /etc/security/pwquality.conf and add or modify the following line for password length to conform to site policy minlen = 14 Edit the file /etc/security/pwquality.conf and add or modify the following line for password complexity to conform to site policy minclass = 4 OR dcredit = -1 ucredit = -1 ocredit = -1 lcredit = -1 Edit the /etc/pam.d/common-password file to include the appropriate options for pam_pwquality.so and to conform to site policy: password requisite pam_pwquality.so retry=3"
+    remediation: "The following setting is a recommend example policy. Alter these values to conform to your own organization's password policies. Run the following command to install the pam_pwquality module: # apt install libpam-pwquality Edit the file /etc/security/pwquality.conf and add or modify the following line for password length to conform to site policy: minlen = 14 Edit the file /etc/security/pwquality.conf and add or modify the following line for password complexity to conform to site policy: Option 1 minclass = 4 Option 2 dcredit = -1 ucredit = -1 ocredit = -1 lcredit = -1 Edit the /etc/pam.d/common-password file to include pam_pwquality.so and to conform to site policy: password requisite pam_pwquality.so retry=3."
     compliance:
-      - cis: ["5.4.1"]
+      - cis: ["4.4.1"]
+      - cis_csc_v8: ["5.2"]
       - cis_csc_v7: ["4.4"]
-      - cmmc_v2.0: ["IA.2.078", "IA.2.079"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
-      - nist_sp_800-53: ["IA-5 (1)"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
     condition: all
     rules:
       - 'f:/etc/security/pwquality.conf -> !r:^\s*# && n:minlen\s*=\s*(\d+) compare >= 14'
@@ -3569,411 +3321,1979 @@ checks:
       - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:ocredit = -1'
       - 'f:/etc/pam.d/common-password -> !r:^\s*# && n:password\s*requisite\s*pam_pwquality.so\s*retry=(\d+) compare <=3'
 
-  # 5.4.2 Ensure lockout for failed password attempts is configured (Automated)
-  - id: 19174
+  # 4.4.2 Ensure lockout for failed password attempts is configured. (Automated)
+  - id: 31186
     title: "Ensure lockout for failed password attempts is configured."
-    description: "Lock out users after n unsuccessful consecutive login attempts. The first sets of changes are made to the PAM configuration files. The second set of changes are applied to the program specific PAM configuration file. The second set of changes must be applied to each program that will lock out users. Check the documentation for each secondary program for instructions on how to configure them to work with PAM. - deny=n - n represents the number of failed attempts before the account is locked. - unlock_time=n - n represents the number of seconds before the account is unlocked. - audit - Will log the user name into the system log if the user is not found. - silent - Don't print informative messages. Set the lockout number and unlock time in accordance with local site policy."
+    description: "Lock out users after n unsuccessful consecutive login attempts. The first sets of changes are made to the PAM configuration files. The second set of changes are applied to the program specific PAM configuration file. The second set of changes must be applied to each program that will lock out users. Check the documentation for each secondary program for instructions on how to configure them to work with PAM. - deny=n - n represents the number of failed attempts before the account is locked - unlock_time=n - n represents the number of seconds before the account is unlocked - audit - Will log the user name into the system log if the user is not found. - silent - Don't print informative messages. Set the lockout number and unlock time in accordance with local site policy."
     rationale: "Locking out user IDs after n unsuccessful consecutive login attempts mitigates brute force password attacks against your systems."
-    remediation: "Edit the /etc/pam.d/common-auth file and add the auth line below: auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900 Edit the /etc/pam.d/common-account file and add the account lines bellow: account requisite pam_deny.so account required pam_tally2.so"
+    remediation: "Edit the /etc/pam.d/common-auth file and add the auth line below: auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900 Edit the /etc/pam.d/common-account file and add the account lines bellow: account requisite pam_deny.so account required pam_tally2.so."
     compliance:
-      - cis: ["5.4.2"]
+      - cis: ["4.4.2"]
       - cis_csc_v7: ["16.7"]
-      - cmmc_v2.0: ["AC.4.025", "PS.2.128", "IA.3.085"]
       - iso_27001-2013: ["A.9.2.6"]
-      - mitre_techniques: ["T1134", "T1197", "T1538", "T1530", "T1213", "T1089", "T1157", "T1044", "T1484", "T1054", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1034", "T1163", "T1076", "T1021", "T1053", "T1489", "T1051", "T1023", "T1165", "T1528", "T1501", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-2"]
-      - pci_dss_v3.2.1: ["8.1.3", "8.1.4"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1110", "T1110.001", "T1110.003"]
     condition: all
     rules:
-      - 'f:/etc/pam.d/common-auth -> !r:^# && r:auth\s*required\s*pam_tally2.so && r:onerr=fail && r:audit && r:silent && r:deny\s*=\s*\d+ && r:unlock_time\s*=\s*\d+'
-      - 'f:/etc/pam.d/common-account -> !r:^# && r:account\s*requi\w+\s*pam_deny.so'
-      - 'f:/etc/pam.d/common-account -> !r:^# && r:account\s*requi\w+\s*pam_tally2.so'
+      - 'f:/etc/pam.d/common-auth -> !r:^# && r:auth\s*\t*required\s*\t*pam_tally2.so && r:onerr=fail && r:audit && r:silent && r:deny\s*=\s*\d+ && r:unlock_time\s*=\s*\d+'
+      - 'f:/etc/pam.d/common-auth -> n:deny\s*=\s*(\d+) compare <=5'
+      - 'f:/etc/pam.d/common-account -> !r:^# && r:account\s*\t*requisite\s*\t*pam_deny.so'
+      - 'f:/etc/pam.d/common-account -> !r:^# && r:account\s*\t*required\s*\t*pam_tally2.so'
 
-  # 5.4.3 Ensure password reuse is limited (Automated)
-  - id: 19175
+  # 4.4.3 Ensure password reuse is limited. (Automated)
+  - id: 31187
     title: "Ensure password reuse is limited."
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password."
-    remediation: "Edit the /etc/pam.d/common-password file to include the remember option and conform to site policy as shown: password required pam_pwhistory.so remember=5."
+    remediation: "NOTE: Pay special attention to the configuration. Incorrect configuration can cause system lock outs or unexpected behavior. This is example configuration. You configuration may differ based on previous changes to the files. Edit the /etc/pam.d/common-password file to include: - password required pam_pwhistory.so remember=5 - use_authtok on the pam_unix.so line Example: password required pam_pwhistory.so remember=5 password [success=1 default=ignore] pam_unix.so obscure sha512 use_authtok."
+    references:
+      - "https://manpages.ubuntu.com/manpages/focal/man8/pam_pwhistory.8.html"
+      - "https://bugs.launchpad.net/ubuntu/+source/pam/+bug/1989731"
     compliance:
-      - cis: ["5.4.3"]
-      - cis_csc_v7: ["16"]
+      - cis: ["4.4.3"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
     condition: all
     rules:
-      - 'f:/etc/pam.d/common-password -> !r:^# && r:password\s*\t*required\s*\t*pam_pwhistory.so && n:remember\s*=\s*(\d+) compare >= 5'
+      - 'f:/etc/pam.d/common-password -> !r:^# && r:password\s*\t*required\s*\t*pam_pwhistory.so && n:remember\s*\t*=\s*\t*(\d+) compare => 5'
+      - 'f:/etc/pam.d/common-password -> !r:^# && r:password && r:success && r:default\s*=\s*ignore && r:pam_unix.so && r:use_authtok'
 
-  # 5.4.4 Ensure password hashing algorithm is SHA-512 (Automated)
-  - id: 19176
-    title: "Ensure password hashing algorithm is SHA-512."
-    description: "The commands below change password encryption from md5 to sha512 (a much stronger hashing algorithm). All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
-    rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note that these change only apply to accounts configured on the local system."
-    remediation: "Edit the /etc/pam.d/common-password file to include the sha512 option for pam_unix.so as shown: password [success=1 default=ignore] pam_unix.so sha512"
+  # 4.4.4 Ensure strong password hashing algorithm is configured. (Automated)
+  - id: 31188
+    title: "Ensure strong password hashing algorithm is configured."
+    description: "Hash functions behave as one-way functions by using mathematical operations that are extremely difficult and cumbersome to revert When a user is created, the password is run through a one-way hashing algorithm before being stored. When the user logs in, the password sent is run through the same one-way hashing algorithm and compared to the hash connected with the provided username. If the hashed password and the stored hash match, the login is valid."
+    rationale: "The SHA512 hashing algorithm provides stronger hashing than previous available algorithms like MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords."
+    remediation: "Note: - Pay special attention to the configuration. Incorrect configuration can cause system lock outs. - This is an example configuration. Your configuration may differ based on previous changes to the files. - The encryption method on the password success line for pam_unix.so and the ENCRYPT_METHOD line in /etc/login.defs should match. Edit the /etc/pam.d/common-password file and ensure that sha512 is included and the pam_unix.so success line: Example: password [success=1 default=ignore] pam_unix.so obscure sha512 use_authtok Edit /etc/login.defs and ensure that ENCRYPT_METHOD is set to SHA512. ENCRYPT_METHOD SHA512."
     compliance:
-      - cis: ["5.4.4"]
+      - cis: ["4.4.4"]
+      - cis_csc_v8: ["3.11"]
       - cis_csc_v7: ["16.4"]
-      - cmmc_v2.0: ["IA.2.081"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
       - iso_27001-2013: ["A.10.1.1"]
-      - nist_sp_800-53: ["IA-5", "IA-5 (1)"]
-      - pci_dss_v3.2.1: ["3.2", "8.2.1"]
-    condition: none
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1110", "T1110.002"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
+    condition: all
     rules:
-      - 'f:/etc/pam.d/common-password -> r:^\s*password\.+success=1\s+default=ignore\.+pam_unix.so|^\s*password\.+required\.+pam_unix.so && !r:sha512'
+      - "f:/etc/pam.d/common-password -> !r:^# && r:password && r:pam_unix.so && r:sha512"
 
-  # 5.5 User Accounts and Environment
-  # 5.5.1 Set Shadow Password Suite Parameters
+  # 4.4.5 Ensure all current passwords uses the configured hashing algorithm. (Manual) - Not Implemented
 
-  # 5.5.1.1 Ensure minimum days between password changes is configured (Automated)
-  - id: 19177
+  # 4.5.1.1 Ensure minimum days between password changes is configured. (Automated)
+  - id: 31190
     title: "Ensure minimum days between password changes is configured."
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 1 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
-    remediation: "Set the PASS_MIN_DAYS parameter to 1 in /etc/login.defs : PASS_MIN_DAYS 1 Modify user parameters for all users with a password set to match: # chage --mindays 1 <user>"
+    remediation: "Set the PASS_MIN_DAYS parameter to 1 in /etc/login.defs: PASS_MIN_DAYS 1 Modify user parameters for all users with a password set to match: # chage --mindays 1 <user>."
     compliance:
-      - cis: ["5.5.1.1"]
-      - cis_csc_v6: ["16"]
+      - cis: ["4.5.1.1"]
+      - cis_csc_v8: ["5.2"]
       - cis_csc_v7: ["4.4"]
-      - cmmc_v2.0: ["IA.2.078", "IA.2.079"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
-      - nist_sp_800-53: ["IA-5 (1)"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
     condition: all
     rules:
-      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MAX_DAYS\s*\t*(\d+) compare > 0'
+      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 1'
       - 'not f:/etc/shadow -> !r:^\w+:\p: && n:^\w+:\S*:\d*:(\d+) compare < 1'
 
-  # 5.5.1.2 Ensure password expiration is 365 days or less (Automated)
-  - id: 19178
+  # 4.5.1.2 Ensure password expiration is 365 days or less. (Automated)
+  - id: 31191
     title: "Ensure password expiration is 365 days or less."
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity. It is recommended that the PASS_MAX_DAYS parameter does not exceed 365 days and is greater than the value of PASS_MIN_DAYS."
-    remediation: "Set the PASS_MAX_DAYS parameter to conform to site policy in /etc/login.defs : PASS_MAX_DAYS 365 Modify user parameters for all users with a password set to match: # chage --maxdays 365 <user>"
-    compliance:
-      - cis: ["5.5.1.2"]
-      - cis_csc_v7: ["4.4"]
-      - cmmc_v2.0: ["IA.2.078", "IA.2.079"]
-      - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
-      - nist_sp_800-53: ["IA-5 (1)"]
+    remediation: "Set the PASS_MAX_DAYS parameter to conform to site policy in /etc/login.defs : PASS_MAX_DAYS 365 Modify user parameters for all users with a password set to match: # chage --maxdays 365 <user>."
     references:
-      - https://www.cisecurity.org/white-papers/cis-password-policy-guide/
+      - "https://www.cisecurity.org/white-papers/cis-password-policy-guide/"
+    compliance:
+      - cis: ["4.5.1.2"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
     condition: all
     rules:
       - 'f:/etc/login.defs -> n:^\s*\t*PASS_MAX_DAYS\s*\t*(\d+) compare <= 365'
       - 'f:/etc/login.defs -> n:^\s*\t*PASS_MAX_DAYS\s*\t*(\d+) compare > 0'
       - 'not f:/etc/shadow -> !r:^\w+:\p: && n:^\w+:\S*:\d*:\d*:(\d+) compare > 365'
 
-  # 5.5.1.3 Ensure password expiration warning days is 7 or more (Automated)
-  - id: 19179
+  # 4.5.1.3 Ensure password expiration warning days is 7 or more. (Automated)
+  - id: 31192
     title: "Ensure password expiration warning days is 7 or more."
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
-    remediation: "Set the PASS_WARN_AGE parameter to 7 in /etc/login.defs : PASS_WARN_AGE 7 Modify user parameters for all users with a password set to match: # chage --warndays 7 <user>"
+    remediation: "Set the PASS_WARN_AGE parameter to 7 in /etc/login.defs: PASS_WARN_AGE 7 Modify user parameters for all users with a password set to match: # chage --warndays 7 <user>."
     compliance:
-      - cis: ["5.5.1.3"]
+      - cis: ["4.5.1.3"]
+      - cis_csc_v8: ["5.2"]
       - cis_csc_v7: ["4.4"]
-      - cmmc_v2.0: ["IA.2.078", "IA.2.079"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
-      - nist_sp_800-53: ["IA-5 (1)"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
     condition: all
     rules:
       - 'f:/etc/login.defs -> n:^\s*\t*PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
       - 'not f:/etc/shadow -> !r:^\w+:\p: && n:^\w+:\S*:\d*:\d*:\d*:(\d+) compare < 7'
 
-  # 5.5.1.4 Ensure inactive password lock is 30 days or less (Automated)
-  - id: 19180
+  # 4.5.1.4 Ensure inactive password lock is 30 days or less. (Automated)
+  - id: 31193
     title: "Ensure inactive password lock is 30 days or less."
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
-    remediation: "Run the following command to set the default password inactivity period to 30 days: # useradd -D -f 30 Modify user parameters for all users with a password set to match: # chage --inactive 30 <user> "
+    remediation: "Run the following command to set the default password inactivity period to 30 days: # useradd -D -f 30 Modify user parameters for all users with a password set to match: # chage --inactive 30 <user>."
     compliance:
-      - cis: ["5.5.1.4"]
+      - cis: ["4.5.1.4"]
+      - cis_csc_v8: ["5.2"]
       - cis_csc_v7: ["4.4"]
-      - cmmc_v2.0: ["IA.2.078", "IA.2.079"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
-      - nist_sp_800-53: ["IA-5 (1)"]
-    condition: none
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.002", "T1078.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
     rules:
-      - 'c:useradd -D -> n:^INACTIVE=(\d+) compare >= 30'
-      - 'c:useradd -D -> n:^INACTIVE=(\d+) compare == 0'
-      - "c:useradd -D -> r:^INACTIVE=-1"
-      - 'f:/etc/shadow -> !r:^\w+:\p: && n:^\w+:\S*:\d*:\d*:\d*:\d+:(\d+) compare > 30'
+      - 'c:useradd -D -> n:^INACTIVE=(\d+) compare <= 30'
+      - 'not c:useradd -D -> n:^INACTIVE=(\d+) compare < 0'
+      - 'not f:/etc/shadow -> !r:^\w+:\p: && n:^\w+:\S*:\d*:\d*:\d*:\d+:(\d+) compare > 30'
 
-  # 5.5.1.5 Ensure all users last password change date is in the past (Automated) - Not implemented
-  # 5.5.2 Ensure system accounts are secured (Automated) - Not implemented
+  # 4.5.1.5 Ensure all users last password change date is in the past. (Automated) - Not Implemented
 
-  # 5.5.3 Ensure default group for the root account is GID 0 (Automated)
-  - id: 19181
+  # 4.5.1.6 Ensure the number of changed characters in a new password is configured. (Automated)
+  - id: 31195
+    title: "Ensure the number of changed characters in a new password is configured."
+    description: "The pwquality difok option sets the number of characters in a password that must not be present in the old password."
+    rationale: "Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised."
+    remediation: "Edit or add the following line in /etc/security/pwquality.conf to a value of 2 or more: difok = 2."
+    compliance:
+      - cis: ["4.5.1.6"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/security/pwquality.conf -> !r:^# && n:difok\s*\t*=\s*\t*(\d+) compare => 2'
+
+  # 4.5.1.7 Ensure preventing the use of dictionary words for passwords is configured. (Automated)
+  - id: 31196
+    title: "Ensure preventing the use of dictionary words for passwords is configured."
+    description: "The pwquality dictcheck option sets whether to check for the words from the cracklib dictionary."
+    rationale: "If the operating system allows the user to select passwords based on dictionary words, this increases the chances of password compromise by increasing the opportunity for successful guesses, and brute-force attacks."
+    remediation: "Edit or add the following line in /etc/security/pwquality.conf to a value of 1: dictcheck = 1."
+    compliance:
+      - cis: ["4.5.1.7"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/security/pwquality.conf -> !r:^# && n:dictcheck\s*\t*=\s*\t*(\d+) compare = 1'
+
+  # 4.5.2 Ensure system accounts are secured. (Automated) - Not Implemented
+
+  # 4.5.3 Ensure default group for the root account is GID 0. (Automated)
+  - id: 31198
     title: "Ensure default group for the root account is GID 0."
     description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
     rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
-    remediation: "Run the following command to set the root user default group to GID 0 : # usermod -g 0 root"
+    remediation: "Run the following command to set the root user default group to GID 0 : # usermod -g 0 root."
     compliance:
-      - cis: ["5.5.3"]
+      - cis: ["4.5.3"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'f:/etc/passwd -> r:^root:\S*:\S*:0:'
+      - 'f:/etc/passwd -> !r:^# && r:root:\w+:\w+:0:'
 
-  # 5.5.4 Ensure default user umask is 027 or more restrictive (Automated) - Not implemented
-  # 5.5.5 Ensure default user shell timeout is 900 seconds or less (Automated) - Not implemented
-  # 5.6 Ensure root login is restricted to system console (Manual) - Not implemented
+  # 4.5.4 Ensure default user umask is 027 or more restrictive. (Automated) - Not Implemented
 
-  # 5.7 Ensure access to the su command is restricted (Automated)
-  - id: 19182
-    title: "Ensure access to the su command is restricted."
-    description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By adding, or uncommenting, the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in a specific group to execute su. This group should be empty to reinforce the use of sudo for privileged access."
-    rationale: "Restricting the use of su, and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo, whereas su can only record that a user executed the su program."
-    remediation: "Create an empty group that will be specified for use of the su command. The group should be named according to site policy. Example: # groupadd sugroup Add the following line to the /etc/pam.d/su file, specifying the empty group: Example: auth required pam_wheel.so use_uid group=sugroup"
+  # 4.5.5 Ensure default user shell timeout is configured. (Automated) - Not Implemented
+
+  # 4.5.6 Ensure nologin is not listed in /etc/shells. (Automated)
+  - id: 31201
+    title: "Ensure nologin is not listed in /etc/shells."
+    description: "/etc/shells is a text file which contains the full pathnames of valid login shells. This file is consulted by chsh and available to be queried by other programs. Be aware that there are programs which consult this file to find out if a user is a normal user; for example, FTP daemons traditionally disallow access to users with shells not included in this file."
+    rationale: "A user can use chsh to change their configured shell. If a user has a shell configured that isn't in in /etc/shells, then the system assumes that they're somehow restricted. In the case of chsh it means that the user cannot change that value. Other programs might query that list and apply similar restrictions. By putting nologin in /etc/shells, any user that has nologin as its shell is considered a full, unrestricted user. This is not the expected behavior for nologin."
+    remediation: "Edit /etc/shells and remove any lines that include nologin."
     compliance:
-      - cis: ["5.7"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.1.002", "CM.2.061", "SC.3.180"]
-      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
-      - nist_sp_800-53: ["AU-2", "CM-1", "CM-2", "CM-6", "CM-7", "IA-5", "IA-6", "SC-20", "SC-21"]
-      - pci_dss_v3.2.1: ["2.2"]
+      - cis: ["4.5.6"]
     condition: all
     rules:
-      - 'f:/etc/pam.d/su -> !r:^# && r:auth\s*required\s*pam_wheel.so && r:use_uid && r:group='
+      - "not f:/etc/shells -> !r:^# && r:nologins"
 
-  # 6 System Maintenance
-  # 6.1 System File Permissions
-  # 6.1.1 Audit system file permissions (Manual) - Not implemented
+  # 4.5.7 Ensure maximum number of same consecutive characters in a password is configured. (Automated)
+  - id: 31202
+    title: "Ensure maximum number of same consecutive characters in a password is configured."
+    description: "The pwquality maxrepeat option sets the maximum number of allowed same consecutive characters in a new password."
+    rationale: "Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised."
+    remediation: "Edit or add the following line in /etc/security/pwquality.conf to a value of 3 or less and not 0: maxrepeat = 3."
+    compliance:
+      - cis: ["4.5.7"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/security/pwquality.conf -> !r:^# && n:maxrepeat\s*\t*=\s*\t*(\d+) compare <=3'
+      - 'not f:/etc/security/pwquality.conf -> !r:^# && n:maxrepeat\s*\t*=\s*\t*(\d+) compare =0'
 
-  # 6.1.2 Ensure permissions on /etc/passwd are configured (Automated)
-  - id: 19183
+  # 5.1.1.1.1 Ensure systemd-journal-remote is installed. (Automated)
+  - id: 31203
+    title: "Ensure systemd-journal-remote is installed."
+    description: "Journald (via systemd-journal-remote) supports the ability to send log events it gathers to a remote log host or to receive messages from remote hosts, thus enabling centralised log management."
+    rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
+    remediation: "Run the following command to install systemd-journal-remote: # apt install systemd-journal-remote."
+    compliance:
+      - cis: ["5.1.1.1.1"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1029"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' systemd-journal-remote -> r:install ok installed"
+
+  # 5.1.1.1.2 Ensure systemd-journal-remote is configured. (Manual)
+  - id: 31204
+    title: "Ensure systemd-journal-remote is configured."
+    description: "Journald (via systemd-journal-remote) supports the ability to send log events it gathers to a remote log host or to receive messages from remote hosts, thus enabling centralised log management."
+    rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
+    remediation: "Edit the /etc/systemd/journal-upload.conf file and ensure the following lines are set per your environment: URL=192.168.50.42 ServerKeyFile=/etc/ssl/private/journal-upload.pem ServerCertificateFile=/etc/ssl/certs/journal-upload.pem TrustedCertificateFile=/etc/ssl/ca/trusted.pem Restart the service: # systemctl restart systemd-journal-upload."
+    compliance:
+      - cis: ["5.1.1.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1029"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "f:/etc/systemd/journal-upload.conf -> r:URL="
+      - "f:/etc/systemd/journal-upload.conf -> r:ServerKeyFile="
+      - "f:/etc/systemd/journal-upload.conf -> r:ServerCertificateFile="
+      - "f:/etc/systemd/journal-upload.conf -> r:TrustedCertificateFile="
+
+  # 5.1.1.1.3 Ensure systemd-journal-remote is enabled. (Manual)
+  - id: 31205
+    title: "Ensure systemd-journal-remote is enabled."
+    description: "Journald (via systemd-journal-remote) supports the ability to send log events it gathers to a remote log host or to receive messages from remote hosts, thus enabling centralized log management."
+    rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
+    remediation: "Run the following command to enable systemd-journal-remote: # systemctl --now enable systemd-journal-upload.service."
+    compliance:
+      - cis: ["5.1.1.1.3"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1029"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled systemd-journal-upload.service -> r:^enabled"
+
+  # 5.1.1.1.4 Ensure journald is not configured to receive logs from a remote client. (Automated)
+  - id: 31206
+    title: "Ensure journald is not configured to receive logs from a remote client."
+    description: "Journald supports the ability to receive messages from remote hosts, thus acting as a log server. Clients should not receive data from other hosts. Note: - The same package, systemd-journal-remote, is used for both sending logs to remote hosts and receiving incoming logs. - With regards to receiving logs, there are two services; systemd-journal- remote.socket and systemd-journal-remote.service."
+    rationale: "If a client is configured to also receive data, thus turning it into a server, the client system is acting outside it's operational boundary."
+    remediation: "Run the following command to disable systemd-journal-remote.socket: # systemctl --now disable systemd-journal-remote.socket."
+    compliance:
+      - cis: ["5.1.1.1.4"]
+      - cis_csc_v8: ["4.8", "8.2"]
+      - cis_csc_v7: ["6.2", "6.3", "9.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1", "A.13.1.3"]
+      - mitre_mitigations: ["M1029"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "10.2", "10.3", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "2.2.4", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled systemd-journal-remote.socket -> r:^disabled"
+
+  # 5.1.1.2 Ensure journald service is enabled. (Automated)
+  - id: 31207
+    title: "Ensure journald service is enabled."
+    description: "Ensure that the systemd-journald service is enabled to allow capturing of logging events."
+    rationale: "If the systemd-journald service is not enabled to start on boot, the system will not capture logging events."
+    remediation: "By default the systemd-journald service does not have an [Install] section and thus cannot be enabled / disabled. It is meant to be referenced as Requires or Wants by other unit files. As such, if the status of systemd-journald is not static, investigate why."
+    compliance:
+      - cis: ["5.1.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled systemd-journald.service -> r:^static"
+
+  # 5.1.1.3 Ensure journald is configured to compress large log files. (Automated)
+  - id: 31208
+    title: "Ensure journald is configured to compress large log files."
+    description: "The journald system includes the capability of compressing overly large files to avoid filling up the system with logs or making the logs unmanageably large."
+    rationale: "Uncompressed large files may unexpectedly fill a filesystem leading to resource unavailability. Compressing logs prior to write can prevent sudden, unexpected filesystem impacts."
+    remediation: "Edit the /etc/systemd/journald.conf file or a file ending in .conf in /etc/systemd/journald.conf.d/ and add the following line: Compress=yes Restart the service: # systemctl restart systemd-journald."
+    compliance:
+      - cis: ["5.1.1.3"]
+      - cis_csc_v8: ["8.2", "8.3"]
+      - cis_csc_v7: ["6.2", "6.3", "6.4"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1053"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1562", "T1562.002"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3", "10.7"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["A1.1"]
+    condition: any
+    rules:
+      - "f:/etc/systemd/journald.conf -> r:^Compress=yes"
+      - 'd:/etc/systemd/journald.conf.d -> r:\.* -> r:^Compress=yes'
+
+  # 5.1.1.4 Ensure journald is configured to write logfiles to persistent disk. (Automated)
+  - id: 31209
+    title: "Ensure journald is configured to write logfiles to persistent disk."
+    description: "Data from journald may be stored in volatile memory or persisted locally on the server. Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the server they are protected from loss due to a reboot."
+    rationale: "Writing log data to disk will provide the ability to forensically reconstruct events which may have impacted the operations or security of a system even after a system crash or reboot."
+    remediation: "Edit the /etc/systemd/journald.conf file or a file ending in .conf in /etc/systemd/journald.conf.d/ and add the following line: Storage=persistent Restart the service: # systemctl restart systemd-journald."
+    compliance:
+      - cis: ["5.1.1.4"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: any
+    rules:
+      - "f:/etc/systemd/journald.conf -> r:^Storage=persistent"
+      - 'd:/etc/systemd/journald.conf.d -> r:\.* -> r:^Storage=persistent'
+
+  # 5.1.1.5 Ensure journald is not configured to send logs to rsyslog. (Manual)
+  - id: 31210
+    title: "Ensure journald is not configured to send logs to rsyslog."
+    description: "Data from journald should be kept in the confines of the service and not forwarded on to other services."
+    rationale: "IF journald is the method for capturing logs, all logs of the system should be handled by journald and not forwarded to other logging mechanisms."
+    remediation: "Edit the /etc/systemd/journald.conf file and files in /etc/systemd/journald.conf.d/ and ensure that ForwardToSyslog=yes is removed. Restart the service: # systemctl restart systemd-journald."
+    compliance:
+      - cis: ["5.1.1.5"]
+      - cis_csc_v8: ["8.2", "8.9"]
+      - cis_csc_v7: ["6.2", "6.3", "6.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1029"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-6(3)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3", "10.5.3", "10.5.4"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "10.3.3", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["PL1.4"]
+    condition: any
+    rules:
+      - 'not f:/etc/systemd/journald.conf -> !r:^# && r:ForwardToSyslog\s*=\s*yes'
+      - 'not d:/etc/systemd/journald.conf.d -> r:\.* -> !r:^# && r:ForwardToSyslog\s*=\s*yes'
+
+  # 5.1.1.6 Ensure journald log rotation is configured per site policy. (Manual)
+  - id: 31211
+    title: "Ensure journald log rotation is configured per site policy."
+    description: "Journald includes the capability of rotating log files regularly to avoid filling up the system with logs or making the logs unmanageably large. The file /etc/systemd/journald.conf is the configuration file used to specify how logs generated by Journald should be rotated."
+    rationale: "By keeping the log files smaller and more manageable, a system administrator can easily archive these files to another system and spend less time looking through inordinately large log files."
+    remediation: "Review /etc/systemd/journald.conf and verify logs are rotated according to site policy. The settings should be carefully understood as there are specific edge cases and prioritisation of parameters. The specific parameters for log rotation are: SystemMaxUse= SystemKeepFree= RuntimeMaxUse= RuntimeKeepFree= MaxFileSec=."
+    compliance:
+      - cis: ["5.1.1.6"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1070", "T1070.002"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "f:/etc/systemd/journald.conf -> r:SystemMaxUse="
+      - "f:/etc/systemd/journald.conf -> r:SystemKeepFree="
+      - "f:/etc/systemd/journald.conf -> r:RuntimeMaxUse="
+      - "f:/etc/systemd/journald.conf -> r:RuntimeKeepFree="
+      - "f:/etc/systemd/journald.conf -> r:MaxFileSec="
+
+  # 5.1.1.7 Ensure journald default file permissions configured. (Manual) - Not Implemented
+
+  # 5.1.2.1 Ensure rsyslog is installed. (Automated)
+  - id: 31213
+    title: "Ensure rsyslog is installed."
+    description: "The rsyslog software is recommended in environments where journald does not meet operation requirements."
+    rationale: "The security enhancements of rsyslog such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
+    remediation: "Run the following command to install rsyslog: # apt install rsyslog."
+    compliance:
+      - cis: ["5.1.2.1"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1005", "T1070", "T1070.002"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' rsyslog -> r:install ok installed"
+
+  # 5.1.2.2 Ensure rsyslog service is enabled. (Automated)
+  - id: 31214
+    title: "Ensure rsyslog service is enabled."
+    description: "Once the rsyslog package is installed, ensure that the service is enabled."
+    rationale: "If the rsyslog service is not enabled to start on boot, the system will not capture logging events."
+    remediation: "Run the following command to enable rsyslog: # systemctl --now enable rsyslog."
+    compliance:
+      - cis: ["5.1.2.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled rsyslog -> r:^enabled"
+
+  # 5.1.2.3 Ensure journald is configured to send logs to rsyslog. (Manual)
+  - id: 31215
+    title: "Ensure journald is configured to send logs to rsyslog."
+    description: "Data from journald may be stored in volatile memory or persisted locally on the server. Utilities exist to accept remote export of journald logs, however, use of the RSyslog service provides a consistent means of log collection and export."
+    rationale: "IF RSyslog is the preferred method for capturing logs, all logs of the system should be sent to it for further processing."
+    remediation: "Edit the /etc/systemd/journald.conf file and add the following line: ForwardToSyslog=yes Restart the service: # systemctl restart rsyslog."
+    compliance:
+      - cis: ["5.1.2.3"]
+      - cis_csc_v8: ["8.2", "8.9"]
+      - cis_csc_v7: ["6.2", "6.3", "6.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1029"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-6(3)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3", "10.5.3", "10.5.4"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "10.3.3", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["PL1.4"]
+    condition: all
+    rules:
+      - 'f:/etc/systemd/journald.conf -> r:^\s*\t*ForwardToSyslog\s*=\s*yes'
+
+  # 5.1.2.4 Ensure rsyslog default file permissions are configured. (Automated)
+  - id: 31216
+    title: "Ensure rsyslog default file permissions are configured."
+    description: "RSyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
+    rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
+    impact: "The systems global umask could override, but only making the file permissions stricter, what is configured in RSyslog with the FileCreateMode directive. RSyslog also has it's own $umask directive that can alter the intended file creation mode. In addition, consideration should be given to how FileCreateMode is used. Thus it is critical to ensure that the intended file creation mode is not overridden with less restrictive settings in /etc/rsyslog.conf, /etc/rsyslog.d/*conf files and that FileCreateMode is set before any file is created."
+    remediation: "Edit either /etc/rsyslog.conf or a dedicated .conf file in /etc/rsyslog.d/ and set $FileCreateMode to 0640 or more restrictive: $FileCreateMode 0640 Restart the service: # systemctl restart rsyslog."
+    compliance:
+      - cis: ["5.1.2.4"]
+      - cis_csc_v8: ["3.3", "8.2"]
+      - cis_csc_v7: ["5.1", "6.2", "6.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "AU.L2-3.3.1", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)", "164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1", "A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6", "AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3", "7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
+      - 'd:/etc/rsyslog.d/ -> r:\.*.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
+
+  # 5.1.2.5 Ensure logging is configured. (Manual) - Not Implemented
+  # 5.1.2.6 Ensure rsyslog is configured to send logs to a remote log host. (Manual) - Not Implemented
+
+  # 5.1.2.7 Ensure rsyslog is not configured to receive logs from a remote client. (Automated)
+  - id: 31219
+    title: "Ensure rsyslog is not configured to receive logs from a remote client."
+    description: "RSyslog supports the ability to receive messages from remote hosts, thus acting as a log server. Clients should not receive data from other hosts."
+    rationale: "If a client is configured to also receive data, thus turning it into a server, the client system is acting outside it's operational boundary."
+    remediation: 'Should there be any active log server configuration found in the auditing section, modify those file and remove the specific lines highlighted by the audit. Ensure none of the following entries are present in any of /etc/rsyslog.conf or /etc/rsyslog.d/*.conf. Old format $ModLoad imtcp $InputTCPServerRun New format module(load="imtcp") input(type="imtcp" port="514") Restart the service: # systemctl restart rsyslog.'
+    compliance:
+      - cis: ["5.1.2.7"]
+      - cis_csc_v8: ["4.8", "8.2"]
+      - cis_csc_v7: ["6.2", "6.3", "9.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1", "A.13.1.3"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "10.2", "10.3", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "2.2.4", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - 'not d:/etc/rsyslog.d -> r:\.*.conf$ -> !r:^# && r:module\(load="imtcp"\)|input\(type="imtcp" port="514"\)'
+      - 'not f:/etc/rsyslog.conf -> !r:^# && r:module\(load="imtcp"\)|input\(type="imtcp" port="514"\)'
+
+  # 5.1.3 Ensure all logfiles have appropriate access configured. (Automated) - Not Implemented
+
+  # 5.2.1.1 Ensure auditd is installed. (Automated)
+  - id: 31221
+    title: "Ensure auditd is installed."
+    description: "auditd is the userspace component to the Linux Auditing System. It's responsible for writing audit records to the disk."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "Run the following command to Install auditd # apt install auditd."
+    compliance:
+      - cis: ["5.2.1.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' auditd -> r: install ok installed"
+
+  # 5.2.1.2 Ensure auditd service is enabled and active. (Automated)
+  - id: 31222
+    title: "Ensure auditd service is enabled and active."
+    description: "Turn on the auditd daemon to record system events."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "Run the following command to enable and start auditd: # systemctl --now enable auditd."
+    compliance:
+      - cis: ["5.2.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled auditd -> r:^enabled"
+      - "c:systemctl is-active auditd -> r:^active"
+
+  # 5.2.1.3 Ensure auditing for processes that start prior to auditd is enabled. (Automated)
+  - id: 31223
+    title: "Ensure auditing for processes that start prior to auditd is enabled."
+    description: "Configure grub2 so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
+    rationale: "Audit events need to be captured on processes that start up prior to auditd , so that potential malicious activity cannot go undetected."
+    remediation: 'Edit /etc/default/grub and add audit=1 to GRUB_CMDLINE_LINUX: Example: GRUB_CMDLINE_LINUX="audit=1" Run the following command to update the grub2 configuration: # update-grub.'
+    compliance:
+      - cis: ["5.2.1.3"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - 'not f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:audit=1'
+
+  # 5.2.1.4 Ensure audit_backlog_limit is sufficient. (Automated)
+  - id: 31224
+    title: "Ensure audit_backlog_limit is sufficient."
+    description: "In the kernel-level audit subsystem, a socket buffer queue is used to hold audit events. Whenever a new audit event is received, it is logged and prepared to be added to this queue. The kernel boot parameter audit_backlog_limit=N, with N representing the amount of messages, will ensure that a queue cannot grow beyond a certain size. If an audit event is logged which would grow the queue beyond this limit, then a failure occurs and is handled according to the system configuration."
+    rationale: "If an audit event is logged which would grow the queue beyond the audit_backlog_limit, then a failure occurs, auditd records will be lost, and potential malicious activity could go undetected."
+    remediation: 'Edit /etc/default/grub and add audit_backlog_limit=N to GRUB_CMDLINE_LINUX. The recommended size for N is 8192 or larger. Example: GRUB_CMDLINE_LINUX="audit_backlog_limit=8192" Run the following command to update the grub2 configuration: # update-grub.'
+    compliance:
+      - cis: ["5.2.1.4"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028", "M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - 'not f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:audit_backlog_limit'
+
+  # 5.2.2.1 Ensure audit log storage size is configured. (Automated)
+  - id: 31225
+    title: "Ensure audit log storage size is configured."
+    description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
+    rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
+    remediation: "Set the following parameter in /etc/audit/auditd.conf in accordance with site policy: max_log_file = <MB>."
+    compliance:
+      - cis: ["5.2.2.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - "d:/etc/audit"
+      - "f:/etc/audit/auditd.conf"
+      - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file\s*\t*=\s*\t*\d+'
+
+  # 5.2.2.2 Ensure audit logs are not automatically deleted. (Automated)
+  - id: 31226
+    title: "Ensure audit logs are not automatically deleted."
+    description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
+    rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
+    remediation: "Set the following parameter in /etc/audit/auditd.conf: max_log_file_action = keep_logs."
+    compliance:
+      - cis: ["5.2.2.2"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - "d:/etc/audit"
+      - "f:/etc/audit/auditd.conf"
+      - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file_action\s*\t*=\s*\t*keep_logs'
+
+  # 5.2.2.3 Ensure system is disabled when audit logs are full. (Automated)
+  - id: 31227
+    title: "Ensure system is disabled when audit logs are full."
+    description: "The auditd daemon can be configured to halt the system when the audit logs are full. The admin_space_left_action parameter tells the system what action to take when the system has detected that it is low on disk space. Valid values are ignore, syslog, suspend, single, and halt. - ignore, the audit daemon does nothing - Syslog, the audit daemon will issue a warning to syslog - Suspend, the audit daemon will stop writing records to the disk - single, the audit daemon will put the computer system in single user mode - halt, the audit daemon will shutdown the system."
+    rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
+    impact: "If the admin_space_left_action parameter is set to halt the audit daemon will shutdown the system when the disk partition containing the audit logs becomes full."
+    remediation: "Set the following parameters in /etc/audit/auditd.conf: space_left_action = email action_mail_acct = root set admin_space_left_action to either halt or single in /etc/audit/auditd.conf. Example: admin_space_left_action = halt."
+    compliance:
+      - cis: ["5.2.2.3"]
+      - cis_csc_v8: ["8.2", "8.3"]
+      - cis_csc_v7: ["6.4"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3", "10.7"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'f:/etc/audit/auditd.conf -> r:^\s*space_left_action\s*=\s*email'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*action_mail_acct\s*=\s*root'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt|^\s*admin_space_left_action\s*=\s*single'
+
+  # 5.2.3.1 Ensure changes to system administration scope (sudoers) is collected. (Automated)
+  - id: 31228
+    title: "Ensure changes to system administration scope (sudoers) is collected."
+    description: 'Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers, or files in /etc/sudoers.d, will be written to when the file(s) or related attributes have changed. The audit records will be tagged with the identifier "scope".'
+    rationale: "Changes in the /etc/sudoers and /etc/sudoers.d files can indicate that an unauthorized change has been made to the scope of system administrator activity."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor scope changes for system administrators. Example: # printf \" -w /etc/sudoers -p wa -k scope -w /etc/sudoers.d -p wa -k scope \" >> /etc/audit/rules.d/50-scope.rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi."
+    compliance:
+      - cis: ["5.2.3.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/sudoers && r:-p wa && r:-k scope|key=\\s*\t*scope'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/sudoers.d && r:-p wa && r:-k scope|key=\\s*\t*scope'
+      - 'c:auditctl -l -> r:^-w && r:/etc/sudoers && r:-p wa && r:-k scope|key=\\s*\t*scope'
+      - 'c:auditctl -l -> r:^-w && r:/etc/sudoers.d && r:-p wa && r:-k scope|key=\\s*\t*scope'
+
+  # 5.2.3.2 Ensure actions as another user are always logged. (Automated)
+  - id: 31229
+    title: "Ensure actions as another user are always logged."
+    description: "sudo provides users with temporary elevated privileges to perform operations, either as the superuser or another user."
+    rationale: "Creating an audit log of users with temporary elevated privileges and the operation(s) they performed is essential to reporting. Administrators will want to correlate the events written to the audit trail with the records written to sudo's logfile to verify if unauthorized commands have been executed."
+    remediation: "Create audit rules Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor elevated privileges. 64 Bit systems Example: # printf \" -a always,exit -F arch=b64 -C euid!=uid -F auid!=unset -S execve -k user_emulation -a always,exit -F arch=b32 -C euid!=uid -F auid!=unset -S execve -k user_emulation \" >> /etc/audit/rules.d/50-user_emulation.rules Load audit rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi 32 Bit systems Follow the same procedures as for 64 bit systems and ignore any entries with b64."
+    compliance:
+      - cis: ["5.2.3.2"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.9.4.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:exit,always|always,exit && r:-F arch=b64 && r:-C euid!=uid|-C uid!=euid  && r:-F auid!=unset|-F auid!=-1|-F auid!=4294967295 && r:-S execve && r:-k user_emulation|key=user_emulation'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:exit,always|always,exit && r:-F arch=b32 && r:-C euid!=uid|-C uid!=euid  && r:-F auid!=unset|-F auid!=-1|-F auid!=4294967295 && r:-S execve && r:-k user_emulation|key=user_emulation'
+      - "c:auditctl -l -> r:^-a && r:exit,always|always,exit && r:-F arch=b64 && r:-C euid!=uid|-C uid!=euid && r:-F auid!=unset|-F auid!=-1|-F auid!=4294967295 && r:-S execve && r:-k user_emulation|key=user_emulation"
+      - "c:auditctl -l -> r:^-a && r:exit,always|always,exit && r:-F arch=b32 && r:-C euid!=uid|-C uid!=euid && r:-F auid!=unset|-F auid!=-1|-F auid!=4294967295 && r:-S execve && r:-k user_emulation|key=user_emulation"
+
+  # 5.2.3.3 Ensure events that modify the sudo log file are collected. (Automated) - Not Implemented
+
+  # 5.2.3.4 Ensure events that modify date and time information are collected. (Automated)
+  - id: 31231
+    title: "Ensure events that modify date and time information are collected."
+    description: 'Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the; - adjtimex - tune kernel clock - settimeofday - set time using timeval and timezone structures - stime - using seconds since 1/1/1970 - clock_settime - allows for the setting of several internal clocks and timers system calls have been executed. Further, ensure to write an audit record to the configured audit log file upon exit, tagging the records with a unique identifier such as "time-change".'
+    rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
+    remediation: 'Create audit rules Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor events that modify date and time information. 64 Bit systems Example: # printf " -a always,exit -F arch=b64 -S adjtimex,settimeofday,clock_settime -k time-change -a always,exit -F arch=b32 -S adjtimex,settimeofday,clock_settime -k time-change -w /etc/localtime -p wa -k time-change \" >> /etc/audit/rules.d/50-time-change.rules Load audit rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi 32 Bit systems Follow the same procedures as for 64 bit systems and ignore any entries with b64. In addition, add stime to the system call audit. Example: -a always,exit -F arch=b32 -S adjtimex,settimeofday,clock_settime,stime -k time-change.'
+    compliance:
+      - cis: ["5.2.3.4"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S && r:adjtimex && r:settimeofday && r:clock_settime && r:-k time-change|key=time-change'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:adjtimex && r:settimeofday && r:clock_settime && r:-k time-change|key=time-change'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/localtime && r:-p wa && r:-k time-change|key=time-change'
+      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S && r:adjtimex && r:settimeofday && r:clock_settime && r:-k time-change|key=time-change"
+      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:adjtimex && r:settimeofday && r:clock_settime && r:-k time-change|key=time-change"
+      - "c:auditctl -l -> r:^-w && r:/etc/localtime && r:-p wa && r:-k time-change|key=time-change"
+
+  # 5.2.3.5 Ensure events that modify the system's network environment are collected. (Automated)
+  - id: 31232
+    title: "Ensure events that modify the system's network environment are collected."
+    description: "Record changes to network environment files or system calls. The below parameters monitors the following system calls, and write an audit event on system call exit: - sethostname - set the systems host name - setdomainname - set the systems domain name The files being monitored are: - /etc/issue and /etc/issue.net - messages displayed pre-login - /etc/hosts - file containing host names and associated IP addresses - /etc/networks - symbolic names for networks - /etc/network/ - directory containing network interface scripts and configurations files."
+    rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/network is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records should have a relevant tag associated with them."
+    remediation: "Create audit rules Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor events that modify the system's network environment. 64 Bit systems Example: # printf \" -a always,exit -F arch=b64 -S sethostname,setdomainname -k system-locale -a always,exit -F arch=b32 -S sethostname,setdomainname -k system-locale -w /etc/issue -p wa -k system-locale -w /etc/issue.net -p wa -k system-locale -w /etc/hosts -p wa -k system-locale -w /etc/networks -p wa -k system-locale -w /etc/network/ -p wa -k system-locale \" >> /etc/audit/rules.d/50-system_locale.rules Load audit rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi 32 Bit systems Follow the same procedures as for 64 bit systems and ignore any entries with b64."
+    compliance:
+      - cis: ["5.2.3.5"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:exit,always|always,exit && r:-F arch=b32 && r:-S && r:sethostname && r:setdomainname && r:-k system-locale|key=system-locale'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:exit,always|always,exit && r:-F arch=b64 && r:-S && r:sethostname && r:setdomainname && r:-k system-locale|key=system-locale'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/issue && r:-p wa && r:-k system-locale|key=system-locale'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/issue.net && r:-p wa && r:-k system-locale|key=system-locale'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale|key=system-locale'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/network && r:-p wa && r:-k system-locale|key=system-locale'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/networks/ && r:-p wa && r:-k system-locale|key=system-locale'
+      - "c:auditctl -l -> r:^-a && r:exit,always|always,exit && r:-F arch=b64 && r:-S && r:sethostname && r:setdomainname && r:-k system-locale|-F key=system-locale"
+      - "c:auditctl -l -> r:^-a && r:exit,always|always,exit && r:-F arch=b32 && r:-S && r:sethostname && r:setdomainname && r:-k system-locale|-F key=system-locale"
+      - "c:auditctl -l -> r:^-w && r:/etc/issue && r:-p wa && r:-k system-locale|key=system-locale"
+      - "c:auditctl -l -> r:^-w && r:/etc/issue.net && r:-p wa && r:-k system-locale|key=system-locale"
+      - "c:auditctl -l -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale|key=system-locale"
+      - "c:auditctl -l -> r:^-w && r:/etc/network && r:-p wa && r:-k system-locale|key=system-locale"
+      - "c:auditctl -l -> r:^-w && r:/etc/networks && r:-p wa && r:-k system-locale|key=system-locale"
+
+  # 5.2.3.6 Ensure use of privileged commands are collected. (Automated) - Not Implemented
+  # 5.2.3.7 Ensure unsuccessful file access attempts are collected. (Automated) - Not Implemented
+
+  # 5.2.3.8 Ensure events that modify user/group information are collected. (Automated)
+  - id: 31235
+    title: "Ensure events that modify user/group information are collected."
+    description: 'Record events affecting the modification of user or group information, including that of passwords and old passwords if in use. - /etc/group - system groups - /etc/passwd - system users - /etc/gshadow - encrypted password for each group - /etc/shadow - system user passwords - /etc/security/opasswd - storage of old passwords if the relevant PAM module is in use The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier "identity" in the audit log file.'
+    rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor events that modify user/group information. Example: # printf \" -w /etc/group -p wa -k identity -w /etc/passwd -p wa -k identity -w /etc/gshadow -p wa -k identity -w /etc/shadow -p wa -k identity -w /etc/security/opasswd -p wa -k identity \" >> /etc/audit/rules.d/50-identity.rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi."
+    compliance:
+      - cis: ["5.2.3.8"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/group && r:-p wa && r:-k identity|key=identity'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/passwd && r:-p wa && r:-k identity|key=identity'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/gshadow && r:-p wa && r:-k identity|key=identity'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/shadow && r:-p wa && r:-k identity|key=identity'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/security/opasswd && r:-p wa && r:-k identity|key=identity'
+      - "c:auditctl -l -> r:^-w && r:/etc/group && r:-p wa && r:-k identity|key=identity"
+      - "c:auditctl -l -> r:^-w && r:/etc/passwd && r:-p wa && r:-k identity|key=identity"
+      - "c:auditctl -l -> r:^-w && r:/etc/gshadow && r:-p wa && r:-k identity|key=identity"
+      - "c:auditctl -l -> r:^-w && r:/etc/shadow && r:-p wa && r:-k identity|key=identity"
+      - "c:auditctl -l -> r:^-w && r:/etc/security/opasswd && r:-p wa && r:-k identity|key=identity"
+
+  # 5.2.3.9 Ensure discretionary access control permission modification events are collected. (Automated) - Not Implemented
+
+  # 5.2.3.10 Ensure successful file system mounts are collected. (Automated)
+  - id: 31237
+    title: "Ensure successful file system mounts are collected."
+    description: "Monitor the use of the mount system call. The mount (and umount) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
+    rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open, creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
+    remediation: "Create audit rules Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor successful file system mounts. 64 Bit systems Example: # { UID_MIN=$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs) [ -n \"${UID_MIN}\" ] && printf \" -a always,exit -F arch=b32 -S mount -F auid>=$UID_MIN -F auid!=unset -k mounts -a always,exit -F arch=b64 -S mount -F auid>=$UID_MIN -F auid!=unset -k mounts \" >> /etc/audit/rules.d/50-mounts.rules || printf \"ERROR: Variable 'UID_MIN' is unset.\\n\" } Load audit rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi 32 Bit systems Follow the same procedures as for 64 bit systems and ignore any entries with b64."
+    compliance:
+      - cis: ["5.2.3.10"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1034"]
+      - mitre_tactics: ["TA0010"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["CM-6"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k mounts|key=mounts'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S mount && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k mounts|key=mounts'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S mount && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k mounts|key=mounts'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k mounts|key=mounts'
+
+  # 5.2.3.11 Ensure session initiation information is collected. (Automated)
+  - id: 31238
+    title: "Ensure session initiation information is collected."
+    description: 'Monitor session initiation events. The parameters in this section track changes to the files associated with session events. - /var/run/utmp - tracks all currently logged in users. - /var/log/wtmp - file tracks logins, logouts, shutdown, and reboot events. - /var/log/btmp - keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp. All audit records will be tagged with the identifier "session.".'
+    rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor session initiation information. Example: # printf \" -w /var/run/utmp -p wa -k session -w /var/log/wtmp -p wa -k session -w /var/log/btmp -p wa -k session \" >> /etc/audit/rules.d/50-session.rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi."
+    compliance:
+      - cis: ["5.2.3.11"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9", "16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.9.4.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3", "AU-3(1)"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/run/utmp && r:-p wa && r:-k session|key=session'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/wtmp && r:-p wa && r:-k session|key=session'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/btmp && r:-p wa && r:-k session|key=session'
+      - "c:auditctl -l -> r:^-w && r:/var/run/utmp && r:-p wa && r:-k session|key=session"
+      - "c:auditctl -l -> r:^-w && r:/var/log/wtmp && r:-p wa && r:-k session|key=session"
+      - "c:auditctl -l -> r:^-w && r:/var/log/btmp && r:-p wa && r:-k session|key=session"
+
+  # 5.2.3.12 Ensure login and logout events are collected. (Automated)
+  - id: 31239
+    title: "Ensure login and logout events are collected."
+    description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. - /var/log/lastlog - maintain records of the last time a user successfully logged in. - /var/run/faillock - directory maintains records of login failures via the pam_faillock module."
+    rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor login and logout events. Example: # printf \" -w /var/log/lastlog -p wa -k logins -w /var/run/faillock -p wa -k logins \" >> /etc/audit/rules.d/50-login.rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi."
+    compliance:
+      - cis: ["5.2.3.12"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9", "16.11", "16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.9.4.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3", "AU-3(1)"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/lastlog && r:-p wa && r:-k logins|key=logins'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/run/faillock && r:-p wa && r:-k logins|key=logins'
+      - "c:auditctl -l -> r:^-w && r:/var/log/lastlog && r:-p wa && r:-k logins|key=logins"
+      - "c:auditctl -l -> r:^-w && r:/var/run/faillock && r:-p wa && r:-k logins|key=logins"
+
+  # 5.2.3.13 Ensure file deletion events by users are collected. (Automated)
+  - id: 31240
+    title: "Ensure file deletion events by users are collected."
+    description: 'Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for: - unlink - remove a file - unlinkat - remove a file attribute - rename - rename a file - renameat rename a file attribute system calls and tags them with the identifier "delete".'
+    rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
+    remediation: "Create audit rules Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor file deletion events by users. 64 Bit systems Example: # { UID_MIN=$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs) [ -n \"${UID_MIN}\" ] && printf \" -a always,exit -F arch=b64 -S rename,unlink,unlinkat,renameat -F auid>=${UID_MIN} -F auid!=unset -F key=delete -a always,exit -F arch=b32 -S rename,unlink,unlinkat,renameat -F auid>=${UID_MIN} -F auid!=unset -F key=delete \" >> /etc/audit/rules.d/50-delete.rules || printf \"ERROR: Variable 'UID_MIN' is unset.\\n\" } Load audit rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi 32 Bit systems Follow the same procedures as for 64 bit systems and ignore any entries with b64."
+    compliance:
+      - cis: ["5.2.3.13"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S && r:unlink && r:unlinkat && r:rename && r:renameat && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k delete|key=delete'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:unlink && r:unlinkat && r:rename && r:renameat && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k delete|key=delete'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S && r:unlink && r:unlinkat && r:rename && r:renameat && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k delete|key=delete'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:unlink && r:unlinkat && r:rename && r:renameat && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k delete|key=delete'
+
+  # 5.2.3.14 Ensure events that modify the system's Mandatory Access Controls are collected. (Automated)
+  - id: 31241
+    title: "Ensure events that modify the system's Mandatory Access Controls are collected."
+    description: "Monitor AppArmor, an implementation of mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/apparmor/ and /etc/apparmor.d/ directories. Note: If a different Mandatory Access Control method is used, changes to the corresponding directories should be audited."
+    rationale: "Changes to files in the /etc/apparmor/ and /etc/apparmor.d/ directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor events that modify the system's Mandatory Access Controls. Example: # printf \" -w /etc/apparmor/ -p wa -k MAC-policy -w /etc/apparmor.d/ -p wa -k MAC-policy \" >> /etc/audit/rules.d/50-MAC-policy.rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi."
+    compliance:
+      - cis: ["5.2.3.14"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/apparmor && r:-p wa && r:-k MAC-policy|key=MAC-policy'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/apparmor.d && r:-p wa && r:-k MAC-policy|key=MAC-policy'
+      - "c:auditctl -l -> r:^-w && r:/etc/apparmor && r:-p wa && r:-k MAC-policy|key=MAC-policy"
+      - "c:auditctl -l -> r:^-w && r:/etc/apparmor.d && r:-p wa && r:-k MAC-policy|key=MAC-policy"
+
+  # 5.2.3.15 Ensure successful and unsuccessful attempts to use the chcon command are recorded. (Automated)
+  - id: 31242
+    title: "Ensure successful and unsuccessful attempts to use the chcon command are recorded."
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the chcon command."
+    rationale: "The chcon command is used to change file security context. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter)."
+    remediation: "Create audit rules Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor successful and unsuccessful attempts to use the chcon command. 64 Bit systems Example: # { UID_MIN=$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs) [ -n \"${UID_MIN}\" ] && printf \" -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=${UID_MIN} -F auid!=unset -k perm_chng \" >> /etc/audit/rules.d/50-perm_chng.rules || printf \"ERROR: Variable 'UID_MIN' is unset.\\n\" } Load audit rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi 32 Bit systems Follow the same procedures as for 64 bit systems and ignore any entries with b64."
+    compliance:
+      - cis: ["5.2.3.15"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/chcon && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k perm_chng|key=perm_chng'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/chcon && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k perm_chng|key=perm_chng'
+
+  # 5.2.3.16 Ensure successful and unsuccessful attempts to use the setfacl command are recorded. (Automated)
+  - id: 31243
+    title: "Ensure successful and unsuccessful attempts to use the setfacl command are recorded."
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the setfacl command."
+    rationale: "This utility sets Access Control Lists (ACLs) of files and directories. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter)."
+    remediation: "Create audit rules Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor successful and unsuccessful attempts to use the setfacl command. 64 Bit systems Example: # { UID_MIN=$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs) [ -n \"${UID_MIN}\" ] && printf \" -a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid>=${UID_MIN} -F auid!=unset -k perm_chng \" >> /etc/audit/rules.d/50-perm_chng.rules || printf \"ERROR: Variable 'UID_MIN' is unset.\\n\" } Load audit rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi 32 Bit systems Follow the same procedures as for 64 bit systems and ignore any entries with b64."
+    compliance:
+      - cis: ["5.2.3.16"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/setfacl && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k perm_chng|-F key=perm_chng'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/setfacl && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k perm_chng|-F key=perm_chng'
+
+  # 5.2.3.17 Ensure successful and unsuccessful attempts to use the chacl command are recorded. (Automated)
+  - id: 31244
+    title: "Ensure successful and unsuccessful attempts to use the chacl command are recorded."
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the chacl command. chacl is an IRIX-compatibility command, and is maintained for those users who are familiar with its use from either XFS or IRIX."
+    rationale: "chacl changes the ACL(s) for a file or directory. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter)."
+    remediation: "Create audit rules Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor successful and unsuccessful attempts to use the chacl command. 64 Bit systems Example: # { UID_MIN=$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs) [ -n \"${UID_MIN}\" ] && printf \" -a always,exit -F path=/usr/bin/chacl -F perm=x -F auid>=${UID_MIN} -F auid!=unset -k perm_chng \" >> /etc/audit/rules.d/50-perm_chng.rules || printf \"ERROR: Variable 'UID_MIN' is unset.\\n\" } Load audit rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi 32 Bit systems Follow the same procedures as for 64 bit systems and ignore any entries with b64."
+    compliance:
+      - cis: ["5.2.3.17"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/chacl && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k perm_chng|-F key=perm_chng'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/chacl && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k perm_chng|-F key=perm_chng'
+
+  # 5.2.3.18 Ensure successful and unsuccessful attempts to use the usermod command are recorded. (Automated)
+  - id: 31245
+    title: "Ensure successful and unsuccessful attempts to use the usermod command are recorded."
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the usermod command."
+    rationale: "The usermod command modifies the system account files to reflect the changes that are specified on the command line. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter)."
+    remediation: "Create audit rules Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor successful and unsuccessful attempts to use the usermod command. 64 Bit systems Example: # { UID_MIN=$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs) [ -n \"${UID_MIN}\" ] && printf \" -a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid>=${UID_MIN} -F auid!=unset -k usermod \" >> /etc/audit/rules.d/50-usermod.rules || printf \"ERROR: Variable 'UID_MIN' is unset.\\n\" } Load audit rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi 32 Bit systems Follow the same procedures as for 64 bit systems and ignore any entries with b64."
+    compliance:
+      - cis: ["5.2.3.18"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/sbin/usermod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k usermod|-F key=usermod'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/sbin/usermod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k usermod|-F key=usermod'
+
+  # 5.2.3.19 Ensure kernel module loading unloading and modification is collected. (Automated)
+  - id: 31246
+    title: "Ensure kernel module loading unloading and modification is collected."
+    description: "Monitor the loading and unloading of kernel modules. All the loading / listing / dependency checking of modules is done by kmod via symbolic links. The following system calls control loading and unloading of modules: - init_module - load a module - finit_module - load a module (used when the overhead of using cryptographically signed modules to determine the authenticity of a module can be avoided) - delete_module - delete a module - create_module - create a loadable module entry - query_module - query the kernel for various bits pertaining to modules Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of modules."
+    rationale: "Monitoring the use of all the various ways to manipulate kernel modules could provide system administrators with evidence that an unauthorized change was made to a kernel module, possibly compromising the security of the system."
+    remediation: "Create audit rules Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor kernel module modification. 64 Bit systems Example: # { UID_MIN=$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs) [ -n \"${UID_MIN}\" ] && printf \" -a always,exit -F arch=b64 -S init_module,finit_module,delete_module,create_module,query_module -F auid>=${UID_MIN} -F auid!=unset -k kernel_modules -a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=${UID_MIN} -F auid!=unset -k kernel_modules \" >> /etc/audit/rules.d/50-kernel_modules.rules || printf \"ERROR: Variable 'UID_MIN' is unset.\\n\" } Load audit rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi."
+    compliance:
+      - cis: ["5.2.3.19"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
+      - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
+      - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"
+      - "c:ls -l /usr/sbin/modinfo -> r:/bin/kmod"
+      - "c:ls -l /usr/sbin/modprobe -> r:/bin/kmod"
+      - "c:ls -l /usr/sbin/depmod -> r:/bin/kmod"
+
+  # 5.2.3.20 Ensure the audit configuration is immutable. (Automated)
+  - id: 31247
+    title: "Ensure the audit configuration is immutable."
+    description: 'Set system audit so that audit rules cannot be modified with auditctl. Setting the flag "-e 2" forces audit to be put in immutable mode. Audit changes can only be made on system reboot. Note: This setting will require the system to be rebooted to update the active auditd configuration settings.'
+    rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
+    remediation: "Edit or create the file /etc/audit/rules.d/99-finalize.rules and add the line -e 2 at the end of the file: Example: # printf -- \"-e 2 \" >> /etc/audit/rules.d/99-finalize.rules Load audit rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep \"enabled\") =~ \"2\" ]]; then printf \"Reboot required to load rules\\n\"; fi."
+    compliance:
+      - cis: ["5.2.3.20"]
+      - cis_csc_v8: ["3.3", "8.5"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "AU.L2-3.3.1", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6", "AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3", "7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "7.1", "9.4.5"]
+      - soc_2: ["CC5.2", "CC6.1", "CC7.2"]
+    condition: all
+    rules:
+      - 'c:sh -c "grep -iEh ''^\s*\t*-e 2\s*$'' /etc/audit/rules.d/*.rules | tail -1" -> r:^\s*\t*-e 2\s*$'
+
+  # 5.2.3.21 Ensure the running and on disk configuration is the same. (Manual)
+  - id: 31248
+    title: "Ensure the running and on disk configuration is the same."
+    description: "The Audit system have both on disk and running configuration. It is possible for these configuration settings to differ. Note: Due to the limitations of augenrules and auditctl, it is not absolutely guaranteed that loading the rule sets via augenrules --load will result in all rules being loaded or even that the user will be informed if there was a problem loading the rules."
+    rationale: "Configuration differences between what is currently running and what is on disk could cause unexpected problems or may give a false impression of compliance requirements."
+    remediation: 'If the rules are not aligned across all three () areas, run the following command to merge and load all rules: # augenrules --load Check if reboot is required. if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then echo "Reboot required to load rules"; fi.'
+    compliance:
+      - cis: ["5.2.3.21"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - 'c:augenrules --check -> r:^\s*/usr/sbin/augenrules && r:No change$'
+
+  # 5.2.4.1 Ensure audit log files are mode 0640 or less permissive. (Automated) - Not Implemented
+  # 5.2.4.2 Ensure only authorized users own audit log files. (Automated) - Not Implemented
+
+  # 5.2.4.3 Ensure only authorized groups are assigned ownership of audit log files. (Automated)
+  - id: 31251
+    title: "Ensure only authorized groups are assigned ownership of audit log files."
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: "Run the following command to configure the audit log files to be group owned by adm: # find $(dirname $(awk -F\"=\" '/^\\s*log_file/ {print $2}' /etc/audit/auditd.conf | xargs)) -type f \\( ! -group adm -a ! -group root \\) -exec chgrp adm {} + Run the following command to set the log_group parameter in the audit configuration file to log_group = adm: # sed -ri 's/^\\s*#?\\s*log_group\\s*=\\s*\\S+(\\s*#.*)?.*$/log_group = adm\\1/' /etc/audit/auditd.conf Run the following command to restart the audit daemon to reload the configuration file: # systemctl restart auditd."
+    compliance:
+      - cis: ["5.2.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/audit/auditd.conf -> r:^\s*\t*log_group\s*\t*=\s*\t*adm|^\s*\t*log_group\s*\t*=\s*\t*root'
+
+  # 5.2.4.4 Ensure the audit log directory is 0750 or more restrictive. (Automated) - Not Implemented
+
+  # 5.2.4.5 Ensure audit configuration files are 640 or more restrictive. (Automated)
+  - id: 31253
+    title: "Ensure audit configuration files are 640 or more restrictive."
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to remove more permissive mode than 0640 from the audit configuration files: # find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) -exec chmod u-x,g-wx,o-rwx {} +."
+    compliance:
+      - cis: ["5.2.4.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'not c:sh -c "stat -Lc \"%n %a\" /etc/audit/*.rules" -> r:^/etc/audit && !r:640|600|400'
+      - 'not c:sh -c "stat -Lc \"%n %a\" /etc/audit/*.conf" -> r:^/etc/audit && !r:640|600|400'
+
+  # 5.2.4.6 Ensure audit configuration files are owned by root. (Automated)
+  - id: 31254
+    title: "Ensure audit configuration files are owned by root."
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to change ownership to root user: # find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) ! -user root -exec chown root {} +."
+    compliance:
+      - cis: ["5.2.4.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'not c:sh -c "stat -Lc \"%n %U\" /etc/audit/*.rules" -> r:^/etc/audit && !r:root'
+      - 'not c:sh -c "stat -Lc \"%n %U\" /etc/audit/*.conf" -> r:^/etc/audit && !r:root'
+
+  # 5.2.4.7 Ensure audit configuration files belong to group root. (Automated)
+  - id: 31255
+    title: "Ensure audit configuration files belong to group root."
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to change group to root: # find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) ! -group root -exec chgrp root {} +."
+    compliance:
+      - cis: ["5.2.4.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'not c:sh -c "stat -Lc \"%n %G\" /etc/audit/*.rules" -> r:^/etc/audit && !r:root'
+      - 'not c:sh -c "stat -Lc \"%n %G\" /etc/audit/*.conf" -> r:^/etc/audit && !r:root'
+
+  # 5.2.4.8 Ensure audit tools are 755 or more restrictive. (Automated)
+  - id: 31256
+    title: "Ensure audit tools are 755 or more restrictive."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to remove more permissive mode from the audit tools: # chmod go-w /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/augenrules."
+    compliance:
+      - cis: ["5.2.4.8"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'not c:stat -c "%n %a %U %G" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/augenrules -> r:^/sbin && !r:000|010|040|050|001|011|041|051|004|014|044|054|005|015|045|055|700|710|740|750|701|711|741|751|704|714|744|754|705|715|745|755'
+
+  # 5.2.4.9 Ensure audit tools are owned by root. (Automated)
+  - id: 31257
+    title: "Ensure audit tools are owned by root."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to change the owner of the audit tools to the root user: # chown root /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/augenrules."
+    compliance:
+      - cis: ["5.2.4.9"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'not c:stat -c "%n %u %U %g %G" /sbin/auditctl -> r:^/sbin && !r:0 root 0 root'
+      - 'not c:stat -c "%n %u %U %g %G" /sbin/aureport -> r:^/sbin && !r:0 root 0 root'
+      - 'not c:stat -c "%n %u %U %g %G" /sbin/ausearch -> r:^/sbin && !r:0 root 0 root'
+      - 'not c:stat -c "%n %u %U %g %G" /sbin/autrace -> r:^/sbin && !r:0 root 0 root'
+      - 'not c:stat -c "%n %u %U %g %G" /sbin/auditd -> r:^/sbin && !r:0 root 0 root'
+      - 'not c:stat -c "%n %u %U %g %G" /sbin/augenrules -> r:^/sbin && !r:0 root 0 root'
+
+  # 5.2.4.10 Ensure audit tools belong to group root. (Automated)
+  - id: 31258
+    title: "Ensure audit tools belong to group root."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to remove more permissive mode from the audit tools: # chmod go-w /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/augenrules Run the following command to change owner and group of the audit tools to root user and group: # chown root:root /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/augenrules."
+    compliance:
+      - cis: ["5.2.4.10"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'not c:stat -c "%n %a %U %G" /sbin/auditctl -> r:^/sbin && !r:000|010|040|050|001|011|041|051|004|014|044|054|005|015|045|055|700|710|740|750|701|711|741|751|704|714|744|754|705|715|745|755'
+      - 'not c:stat -c "%n %a %U %G" /sbin/aureport -> r:^/sbin && !r:000|010|040|050|001|011|041|051|004|014|044|054|005|015|045|055|700|710|740|750|701|711|741|751|704|714|744|754|705|715|745|755'
+      - 'not c:stat -c "%n %a %U %G" /sbin/ausearch -> r:^/sbin && !r:000|010|040|050|001|011|041|051|004|014|044|054|005|015|045|055|700|710|740|750|701|711|741|751|704|714|744|754|705|715|745|755'
+      - 'not c:stat -c "%n %a %U %G" /sbin/autrace -> r:^/sbin && !r:000|010|040|050|001|011|041|051|004|014|044|054|005|015|045|055|700|710|740|750|701|711|741|751|704|714|744|754|705|715|745|755'
+      - 'not c:stat -c "%n %a %U %G" /sbin/auditd -> r:^/sbin && !r:000|010|040|050|001|011|041|051|004|014|044|054|005|015|045|055|700|710|740|750|701|711|741|751|704|714|744|754|705|715|745|755'
+      - 'not c:stat -c "%n %a %U %G" /sbin/augenrules -> r:^/sbin && !r:000|010|040|050|001|011|041|051|004|014|044|054|005|015|045|055|700|710|740|750|701|711|741|751|704|714|744|754|705|715|745|755'
+
+  # 5.2.4.11 Ensure cryptographic mechanisms are used to protect the integrity of audit tools. (Automated)
+  - id: 31259
+    title: "Ensure cryptographic mechanisms are used to protect the integrity of audit tools."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting the integrity of the tools used for auditing purposes is a critical step toward ensuring the integrity of audit information. Audit information includes all information (e.g., audit records, audit settings, and audit reports) needed to successfully audit information system activity. Attackers may replace the audit tools or inject code into the existing tools with the purpose of providing the capability to hide or erase system activity from the audit logs. Audit tools should be cryptographically signed in order to provide the capability to identify when the audit tools have been modified, manipulated, or replaced. An example is a checksum hash of the file or files."
+    remediation: "Add or update the following selection lines for to a file ending in .conf in the /etc/aide/aide.conf.d/ or to /etc/aide/aide.conf to protect the integrity of the audit tools: # Audit Tools /sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512 /sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512 /sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512 /sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512 /sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512 /sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512."
+    compliance:
+      - cis: ["5.2.4.11"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+    condition: all
+    rules:
+      - "f:/etc/aide/aide.conf -> r:/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/etc/aide/aide.conf -> r:/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/etc/aide/aide.conf -> r:/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/etc/aide/aide.conf -> r:/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/etc/aide/aide.conf -> r:/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/etc/aide/aide.conf -> r:/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512"
+
+  # 6.1.1 Ensure permissions on /etc/passwd are configured. (Automated)
+  - id: 31260
     title: "Ensure permissions on /etc/passwd are configured."
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
-    remediation: "Run the following command to set permissions on /etc/passwd: # chown root:root /etc/passwd # chmod u-x,go-wx /etc/passwd"
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/passwd: # chmod u-x,go-wx /etc/passwd # chown root:root /etc/passwd."
     compliance:
-      - cis: ["6.1.2"]
-      - cis_csc_v7: ["16.4"]
-      - cmmc_v2.0: ["IA.2.081"]
-      - iso_27001-2013: ["A.10.1.1"]
-      - nist_sp_800-53: ["IA-5", "IA-5 (1)"]
-      - pci_dss_v3.2.1: ["3.2", "8.2.1"]
-    condition: all
+      - cis: ["6.1.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
     rules:
-      - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  # 6.1.3 Ensure permissions on /etc/passwd- are configured (Automated)
-  - id: 19184
+  # 6.1.2 Ensure permissions on /etc/passwd- are configured. (Automated)
+  - id: 31261
     title: "Ensure permissions on /etc/passwd- are configured."
     description: "The /etc/passwd- file contains backup user account information."
     rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
-    remediation: "Run the following command to set permissions on /etc/passwd-:  # chown root:root /etc/passwd- # chmod u-x,go-wx /etc/passwd-"
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/passwd-: # chmod u-x,go-wx /etc/passwd- # chown root:root /etc/passwd-."
     compliance:
-      - cis: ["6.1.3"]
-      - cis_csc_v7: ["16.4"]
-      - cmmc_v2.0: ["IA.2.081"]
-      - iso_27001-2013: ["A.10.1.1"]
-      - nist_sp_800-53: ["IA-5", "IA-5 (1)"]
-      - pci_dss_v3.2.1: ["3.2", "8.2.1"]
-    condition: all
+      - cis: ["6.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
     rules:
-      - 'c:stat /etc/passwd- -> r:^Access:\s*\(0644/-rw-r--r--\)|^Access:\s*\(0640/-rw-r-----\)|^Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  # 6.1.4 Ensure permissions on /etc/group are configured (Automated)
-  - id: 19185
+  # 6.1.3 Ensure permissions on /etc/group are configured. (Automated)
+  - id: 31262
     title: "Ensure permissions on /etc/group are configured."
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
-    remediation: "Run the following command to set permissions on /etc/group: # chown root:root /etc/group # chmod u-x,go-wx /etc/group"
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/group: # chmod u-x,go-wx /etc/group # chown root:root /etc/group."
     compliance:
-      - cis: ["6.1.4"]
-      - cis_csc_v7: ["16.4"]
-      - cmmc_v2.0: ["IA.2.081"]
-      - iso_27001-2013: ["A.10.1.1"]
-      - nist_sp_800-53: ["IA-5", "IA-5 (1)"]
-      - pci_dss_v3.2.1: ["3.2", "8.2.1"]
-    condition: all
+      - cis: ["6.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
     rules:
-      - 'c:stat /etc/group -> r:^Access:\s*\(0644/-rw-r--r--\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  # 6.1.5 Ensure permissions on /etc/group- are configured (Automated)
-  - id: 19186
+  # 6.1.4 Ensure permissions on /etc/group- are configured. (Automated)
+  - id: 31263
     title: "Ensure permissions on /etc/group- are configured."
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
     rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
-    remediation: "Run the following command to set permissions on /etc/group-: # chown root:root /etc/group- # chmod u-x,go-wx /etc/group-"
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/group-: # chmod u-x,go-wx /etc/group- # chown root:root /etc/group-."
     compliance:
-      - cis: ["6.1.5"]
-      - cis_csc_v7: ["16.4"]
-      - cmmc_v2.0: ["IA.2.081"]
-      - iso_27001-2013: ["A.10.1.1"]
-      - nist_sp_800-53: ["IA-5", "IA-5 (1)"]
-      - pci_dss_v3.2.1: ["3.2", "8.2.1"]
-    condition: all
+      - cis: ["6.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
     rules:
-      - 'c:stat /etc/group- -> r:^Access:\s*\(0644/-rw-r--r--\)|^Access:\s*\(0640/-rw-r-----\)|^Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  # 6.1.6 Ensure permissions on /etc/shadow are configured (Automated)
-  - id: 19187
+  # 6.1.5 Ensure permissions on /etc/shadow are configured. (Automated)
+  - id: 31264
     title: "Ensure permissions on /etc/shadow are configured."
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
-    remediation: "Run one of the following commands to set ownership of /etc/shadow to root and group to either root or shadow: # chown root:root /etc/shadow # chown root:shadow /etc/shadow Run the following command to remove excess permissions form /etc/shadow: # chmod u-x,g-wx,o-rwx /etc/shadow"
+    remediation: "Run one of the following commands to set ownership of /etc/shadow to root and group to either root or shadow: # chown root:shadow /etc/shadow -OR- # chown root:root /etc/shadow Run the following command to remove excess permissions form /etc/shadow: # chmod u-x,g-wx,o-rwx /etc/shadow."
     compliance:
-      - cis: ["6.1.6"]
-      - cis_csc_v7: ["16.4"]
-      - cmmc_v2.0: ["IA.2.081"]
-      - iso_27001-2013: ["A.10.1.1"]
-      - nist_sp_800-53: ["IA-5", "IA-5 (1)"]
-      - pci_dss_v3.2.1: ["3.2", "8.2.1"]
-    condition: any
+      - cis: ["6.1.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
     rules:
-      - 'c:stat /etc/shadow -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /etc/shadow -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
-  #  6.1.7 Ensure permissions on /etc/shadow- are configured (Automated)
-  - id: 19188
+  # 6.1.6 Ensure permissions on /etc/shadow- are configured. (Automated)
+  - id: 31265
     title: "Ensure permissions on /etc/shadow- are configured."
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
-    remediation: "Run one of the following commands to set ownership of /etc/shadow- to root and group to either root or shadow: # chown root:root /etc/shadow- # chown root:shadow /etc/shadow- Run the following command to remove excess permissions form /etc/shadow-: # chmod u-x,g-wx,o-rwx /etc/shadow-"
+    remediation: "Run one of the following commands to set ownership of /etc/shadow- to root and group to either root or shadow: # chown root:shadow /etc/shadow- -OR- # chown root:root /etc/shadow- Run the following command to remove excess permissions form /etc/shadow-: # chmod u-x,g-wx,o-rwx /etc/shadow-."
     compliance:
-      - cis: ["6.1.7"]
-      - cis_csc_v7: ["16.4"]
-      - cmmc_v2.0: ["IA.2.081"]
-      - iso_27001-2013: ["A.10.1.1"]
-      - nist_sp_800-53: ["IA-5", "IA-5 (1)"]
-      - pci_dss_v3.2.1: ["3.2", "8.2.1"]
-    condition: any
+      - cis: ["6.1.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
     rules:
-      - 'c:stat /etc/shadow- -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /etc/shadow- -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
-  # 6.1.8 Ensure permissions on /etc/gshadow are configured (Automated)
-  - id: 19189
+  # 6.1.7 Ensure permissions on /etc/gshadow are configured. (Automated)
+  - id: 31266
     title: "Ensure permissions on /etc/gshadow are configured."
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group."
-    remediation: "Run one of the following commands to set ownership of /etc/gshadow to root and group to either root or shadow:  # chown root:root /etc/gshadow # chown root:shadow /etc/gshadow Run the following command to remove excess permissions form /etc/gshadow: # chmod u-x,g-wx,o-rwx /etc/gshadow"
+    remediation: "Run one of the following commands to set ownership of /etc/gshadow to root and group to either root or shadow: # chown root:shadow /etc/gshadow -OR- # chown root:root /etc/gshadow Run the following command to remove excess permissions form /etc/gshadow: # chmod u-x,g-wx,o-rwx /etc/gshadow."
     compliance:
-      - cis: ["6.1.8"]
-      - cis_csc_v7: ["16.4"]
-      - cmmc_v2.0: ["IA.2.081"]
-      - iso_27001-2013: ["A.10.1.1"]
-      - nist_sp_800-53: ["IA-5", "IA-5 (1)"]
-      - pci_dss_v3.2.1: ["3.2", "8.2.1"]
-    condition: any
+      - cis: ["6.1.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
     rules:
-      - 'c:stat /etc/gshadow -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /etc/gshadow -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
-  # 6.1.9 Ensure permissions on /etc/gshadow- are configured (Automated)
-  - id: 19190
+  # 6.1.8 Ensure permissions on /etc/gshadow- are configured. (Automated)
+  - id: 31267
     title: "Ensure permissions on /etc/gshadow- are configured."
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
-    remediation: "Run one of the following commands to set ownership of /etc/gshadow- to root and group to either root or shadow: # chown root:root /etc/gshadow- # chown root:shadow /etc/gshadow- Run the following command to remove excess permissions form /etc/gshadow-: # chmod u-x,g-wx,o-rwx /etc/gshadow-"
+    remediation: "Run one of the following commands to set ownership of /etc/gshadow- to root and group to either root or shadow: # chown root:shadow /etc/gshadow- -OR- # chown root:root /etc/gshadow- Run the following command to remove excess permissions form /etc/gshadow-: # chmod u-x,g-wx,o-rwx /etc/gshadow-."
     compliance:
       - cis: ["6.1.8"]
-      - cis_csc_v7: ["16.4"]
-      - cmmc_v2.0: ["IA.2.081"]
-      - iso_27001-2013: ["A.10.1.1"]
-      - nist_sp_800-53: ["IA-5", "IA-5 (1)"]
-      - pci_dss_v3.2.1: ["3.2", "8.2.1"]
-    condition: any
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
     rules:
-      - 'c:stat /etc/gshadow- -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /etc/gshadow- -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
-  # 6.1.10 Ensure no world writable files exist (Automated) - Not implemented
-  # 6.1.11 Ensure no unowned files or directories exist (Automated) - Not implemented
-  # 6.1.12 Ensure no ungrouped files or directories exist (Automated) - Not implemented
-  # 6.1.13 Audit SUID executables (Manual) - Not implemented
-  # 6.1.14 Audit SGID executables (Manual) - Not implemented
+  # 6.1.9 Ensure permissions on /etc/shells are configured. (Automated)
+  - id: 31268
+    title: "Ensure permissions on /etc/shells are configured."
+    description: "/etc/shells is a text file which contains the full pathnames of valid login shells. This file is consulted by chsh and available to be queried by other programs."
+    rationale: "It is critical to ensure that the /etc/shells file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/shells: # chmod u-x,go-wx /etc/shells # chown root:root /etc/shells."
+    compliance:
+      - cis: ["6.1.9"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
+    rules:
 
-  # 6.2 User and Group Settings
+  # 6.1.10 Ensure permissions on /etc/opasswd are configured. (Automated)
+  - id: 31269
+    title: "Ensure permissions on /etc/opasswd are configured."
+    description: "/etc/security/opasswd and it's backup /etc/security/opasswd.old hold user's previous passwords if pam_unix or pam_pwhistory is in use on the system."
+    rationale: "It is critical to ensure that /etc/security/opasswd is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: 'Run the following commands to remove excess permissions, set owner, and set group on /etc/security/opasswd and /etc/security/opasswd.old is they exist: # [ -e "/etc/security/opasswd" ] && chmod u-x,go-rwx /etc/security/opasswd # [ -e "/etc/security/opasswd" ] && chown root:root /etc/security/opasswd # [ -e "/etc/security/opasswd.old" ] && chmod u-x,go-rwx /etc/security/opasswd.old # [ -e "/etc/security/opasswd.old" ] && chown root:root /etc/security/opasswd.old.'
+    compliance:
+      - cis: ["6.1.10"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
+    rules:
 
-  # 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords (Automated)
-  - id: 19191
+  # 6.1.11 Ensure world writable files and directories are secured. (Automated)
+  - id: 31270
+    title: "Ensure world writable files and directories are secured."
+    description: "World writable files are the least secure. Data in world-writable files can be modified and compromised by any user on the system. World writable files may also indicate an incorrectly written script or program that could potentially be the cause of a larger compromise to the system's integrity. See the chmod(2) man page for more information. Setting the sticky bit on world writable directories prevents users from deleting or renaming files in that directory that are not owned by them."
+    rationale: "Data in world-writable files can be modified and compromised by any user on the system. World writable files may also indicate an incorrectly written script or program that could potentially be the cause of a larger compromise to the system's integrity. This feature prevents the ability to delete or rename files in world writable directories (such as /tmp) that are owned by another user."
+    remediation: "- World Writable Files: o It is recommended that write access is removed from other with the command ( chmod o-w <filename> ), but always consult relevant vendor documentation to avoid breaking any application dependencies on a given file. - World Writable Directories: o Set the sticky bit on all world writable directories with the command ( chmod a+t <directory_name> ) Run the following script to: - Remove other write permission from any world writable files - Add the sticky bit to all world writable directories #!/usr/bin/env bash { l_smask='01000' a_path=(); a_arr=() # Initialize array a_path=(! -path \"/run/user/*\" -a ! -path \"/proc/*\" -a ! -path \"*/containerd/*\" -a ! -path \"*/kubelet/pods/*\" -a ! -path \"/sys/kernel/security/apparmor/*\" -a ! -path \"/snap/*\" -a ! -path \"/sys/fs/cgroup/memory/*\") while read -r l_bfs; do a_path+=( -a ! -path \"\"$l_bfs\"/*\") done < <(findmnt -Dkerno fstype,target | awk '$1 ~ /^\\s*(nfs|proc|smb)/ {print $2}') # Populate array with files while IFS= read -r -d $'\\0' l_file; do [ -e \"$l_file\" ] && a_arr+=(\"$(stat -Lc '%n^%#a' \"$l_file\")\") done < <(find / \\( \"${a_path[@]}\" \\) \\( -type f -o -type d \\) -perm -0002 -print0 2>/dev/null) while IFS=\"^\" read -r l_fname l_mode; do # Test files in the array if [ -f \"$l_fname\" ]; then # Remove excess permissions from WW files echo -e \" - File: \\\"$l_fname\\\" is mode: \\\"$l_mode\\\"\\n - removing write permission on \\\"$l_fname\\\" from \\\"other\\\"\" chmod o-w \"$l_fname\" fi if [ -d \"$l_fname\" ]; then if [ ! $(( $l_mode & $l_smask )) -gt 0 ]; then # Add sticky bit echo -e \" - Directory: \\\"$l_fname\\\" is mode: \\\"$l_mode\\\" and doesn't have the sticky bit set\\n - Adding the sticky bit\" chmod a+t \"$l_fname\" fi fi done < <(printf '%s\\n' \"${a_arr[@]}\") unset a_path; unset a_arr # Remove array }."
+    compliance:
+      - cis: ["6.1.11"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1028"]
+      - mitre_tactics: ["TA0004", "TA0005"]
+      - mitre_techniques: ["T1222", "T1222.002", "T1548"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
+    rules:
+
+  # 6.1.12 Ensure no unowned or ungrouped files or directories exist. (Automated)
+  - id: 31271
+    title: "Ensure no unowned or ungrouped files or directories exist."
+    description: "Administrators may delete users or groups from the system and neglect to remove all files and/or directories owned by those users or groups."
+    rationale: 'A new user or group who is assigned a deleted user''s user ID or group ID may then end up "owning" a deleted user or group''s files, and thus have more access on the system than was intended.'
+    remediation: "Remove or set ownership and group ownership of these files and/or directories to an active user on the system as appropriate."
+    compliance:
+      - cis: ["6.1.12"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
+    rules:
+
+  # 6.1.13 Ensure SUID and SGID files are reviewed. (Manual)
+  - id: 31272
+    title: "Ensure SUID and SGID files are reviewed."
+    description: "The owner of a file can set the file's permissions to run with the owner's or group's permissions, even if the user running the program is not the owner or a member of the group. The most common reason for a SUID or SGID program is to enable users to perform functions (such as changing their password) that require root privileges."
+    rationale: "There are valid reasons for SUID and SGID programs, but it is important to identify and review such programs to ensure they are legitimate. Review the files returned by the action in the audit section and check to see if system binaries have a different checksum than what from the package. This is an indication that the binary may have been replaced."
+    remediation: "Ensure that no rogue SUID or SGID programs have been introduced into the system. Review the files returned by the action in the Audit section and confirm the integrity of these binaries."
+    compliance:
+      - cis: ["6.1.13"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
+    rules:
+
+  # 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords. (Automated)
+  - id: 31273
     title: "Ensure accounts in /etc/passwd use shadowed passwords."
     description: "Local accounts can uses shadowed passwords. With shadowed passwords, The passwords are saved in shadow password file, /etc/shadow, encrypted by a salted one-way hash. Accounts with a shadowed password have an x in the second field in /etc/passwd."
-    rationale: "The /etc/passwd file also contains information like user ID's and group ID's that are used by many system programs. Therefore, the /etc/passwd file must remain world readable. In spite of encoding the password with a randomly-generated one-way hash function, an attacker could still break the system if they got access to the /etc/passwd file. This can be mitigated by using shadowed passwords, thus moving the passwords in the /etc/passwd file to /etc/shadow. The /etc/shadow file is set so only root will be able to read and write. This helps mitigate the risk of an attacker gaining access to the encoded passwords with which to perform a dictionary attack. Notes: - All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user. - A user account with an empty second field in /etc/passwd allows the account to be logged into by providing only the username."
-    remediation: 'Run the following command to set accounts to use shadowed passwords: # sed -e ''s/^\([a-zA-Z0-9_]*\):[^:]*:/\1:x:/'' -i /etc/passwd Investigate to determine if the account is logged in and what it is being used for, to determine if it needs to be forced off.'
+    rationale: "The /etc/passwd file also contains information like user ID's and group ID's that are used by many system programs. Therefore, the /etc/passwd file must remain world readable. In spite of encoding the password with a randomly-generated one-way hash function, an attacker could still break the system if they got access to the /etc/passwd file. This can be mitigated by using shadowed passwords, thus moving the passwords in the /etc/passwd file to /etc/shadow. The /etc/shadow file is set so only root will be able to read and write. This helps mitigate the risk of an attacker gaining access to the encoded passwords with which to perform a dictionary attack. Note: - All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user. - A user account with an empty second field in /etc/passwd allows the account to be logged into by providing only the username."
+    remediation: "Run the following command to set accounts to use shadowed passwords: # sed -e 's/^\\([a-zA-Z0-9_]*\\):[^:]*:/\\1:x:/' -i /etc/passwd Investigate to determine if the account is logged in and what it is being used for, to determine if it needs to be forced off."
     compliance:
-      - cis: ["6.1.8"]
-      - cis_csc_v7: ["4.4"]
-      - cmmc_v2.0: ["IA.2.078", "IA.2.079"]
-      - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
-      - nist_sp_800-53: ["IA-5 (1)"]
-    condition: none
+      - cis: ["6.2.1"]
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["16.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1003", "T1003.008"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
+    condition:
     rules:
-      - 'f:/etc/passwd -> !r:^\w+:x:'
 
-  # 6.2.2 Ensure password fields are not empty (Automated)
-  - id: 19192
-    title: "Ensure password fields are not empty."
+  # 6.2.2 Ensure /etc/shadow password fields are not empty. (Automated)
+  - id: 31274
+    title: "Ensure /etc/shadow password fields are not empty."
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
     remediation: "If any accounts in the /etc/shadow file do not have a password, run the following command to lock the account until it can be determined why it does not have a password: # passwd -l <username> Also, check to see if the account is logged in and investigate what it is being used for to determine if it needs to be forced off."
     compliance:
       - cis: ["6.2.2"]
+      - cis_csc_v8: ["5.2"]
       - cis_csc_v7: ["4.4"]
-      - cmmc_v2.0: ["IA.2.078", "IA.2.079"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
-      - nist_sp_800-53: ["IA-5 (1)"]
-    condition: none
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition:
     rules:
-      - 'f:/etc/shadow -> r:^\w+::'
 
-  # 6.2.3 Ensure all groups in /etc/passwd exist in /etc/group (Automated) - Not implemented
-  # 6.2.4 Ensure all users' home directories exist (Automated) - Not implemented
-  # 6.2.5 Ensure users own their home directories (Automated) - Not implemented
-  # 6.2.6 Ensure users' home directories permissions are 750 or more restrictive (Automated) - Not implemented
-  # 6.2.7 Ensure users' dot files are not group or world writable (Automated) - Not implemented
-  # 6.2.8 Ensure no users have .netrc files (Automated) - Not implemented
-  # 6.2.9 Ensure no users have .forward files (Automated) - Not implemented
-  # 6.2.10 Ensure no users have .rhosts files (Automated) - Not implemented
+  # 6.2.3 Ensure all groups in /etc/passwd exist in /etc/group. (Automated)
+  - id: 31275
+    title: "Ensure all groups in /etc/passwd exist in /etc/group."
+    description: "Over time, system administration errors and changes can lead to groups being defined in /etc/passwd but not in /etc/group ."
+    rationale: "Groups defined in the /etc/passwd file but not in the /etc/group file pose a threat to system security since group permissions are not properly managed."
+    remediation: "Analyze the output of the Audit step above and perform the appropriate action to correct any discrepancies found."
+    compliance:
+      - cis: ["6.2.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1222", "T1222.002"]
+    condition:
+    rules:
 
-  # 6.2.11 Ensure root is the only UID 0 account (Automated)
-  - id: 19193
+  # 6.2.4 Ensure shadow group is empty. (Automated)
+  - id: 31276
+    title: "Ensure shadow group is empty."
+    description: "The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group."
+    rationale: "Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts."
+    remediation: "Run the following command to remove all users from the shadow group # sed -ri 's/(^shadow:[^:]*:[^:]*:)([^:]+$)/\\1/' /etc/group Change the primary group of any users with shadow as their primary group. # usermod -g <primary group> <user>."
+    compliance:
+      - cis: ["6.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
+    rules:
+
+  # 6.2.5 Ensure no duplicate UIDs exist. (Automated)
+  - id: 31277
+    title: "Ensure no duplicate UIDs exist."
+    description: "Although the useradd program will not let you create a duplicate User ID (UID), it is possible for an administrator to manually edit the /etc/passwd file and change the UID field."
+    rationale: "Users must be assigned unique UIDs for accountability and to ensure appropriate access protections."
+    remediation: "Based on the results of the audit script, establish unique UIDs and review all files owned by the shared UIDs to determine which UID they are supposed to belong to."
+    compliance:
+      - cis: ["6.2.5"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+    condition:
+    rules:
+
+  # 6.2.6 Ensure no duplicate GIDs exist. (Automated)
+  - id: 31278
+    title: "Ensure no duplicate GIDs exist."
+    description: "Although the groupadd program will not let you create a duplicate Group ID (GID), it is possible for an administrator to manually edit the /etc/group file and change the GID field."
+    rationale: "User groups must be assigned unique GIDs for accountability and to ensure appropriate access protections."
+    remediation: "Based on the results of the audit script, establish unique GIDs and review all files owned by the shared GID to determine which group they are supposed to belong to."
+    compliance:
+      - cis: ["6.2.6"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+    condition:
+    rules:
+
+  # 6.2.7 Ensure no duplicate user names exist. (Automated)
+  - id: 31279
+    title: "Ensure no duplicate user names exist."
+    description: "Although the useradd program will not let you create a duplicate user name, it is possible for an administrator to manually edit the /etc/passwd file and change the user name."
+    rationale: 'If a user is assigned a duplicate user name, it will create and have access to files with the first UID for that username in /etc/passwd . For example, if "test4" has a UID of 1000 and a subsequent "test4" entry has a UID of 2000, logging in as "test4" will use UID 1000. Effectively, the UID is shared, which is a security problem.'
+    remediation: "Based on the results of the audit script, establish unique user names for the users. File ownerships will automatically reflect the change as long as the users have unique UIDs."
+    compliance:
+      - cis: ["6.2.7"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+    condition:
+    rules:
+
+  # 6.2.8 Ensure no duplicate group names exist. (Automated)
+  - id: 31280
+    title: "Ensure no duplicate group names exist."
+    description: "Although the groupadd program will not let you create a duplicate group name, it is possible for an administrator to manually edit the /etc/group file and change the group name."
+    rationale: "If a group is assigned a duplicate group name, it will create and have access to files with the first GID for that group in /etc/group . Effectively, the GID is shared, which is a security problem."
+    remediation: "Based on the results of the audit script, establish unique names for the user groups. File group ownerships will automatically reflect the change as long as the groups have unique GIDs."
+    compliance:
+      - cis: ["6.2.8"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+    condition:
+    rules:
+
+  # 6.2.9 Ensure root PATH Integrity. (Automated)
+  - id: 31281
+    title: "Ensure root PATH Integrity."
+    description: "The root user can execute any command on the system and could be fooled into executing programs unintentionally if the PATH is not set correctly."
+    rationale: "Including the current working directory (.) or other writable directory in root's executable path makes it likely that an attacker can gain superuser access by forcing an administrator operating as root to execute a Trojan horse program."
+    remediation: "Correct or justify any items discovered in the Audit step."
+    compliance:
+      - cis: ["6.2.9"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+    condition:
+    rules:
+
+  # 6.2.10 Ensure root is the only UID 0 account. (Automated)
+  - id: 31282
     title: "Ensure root is the only UID 0 account."
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
     remediation: "Remove any users other than root with UID 0 or assign them a new UID if appropriate."
     compliance:
-      - cis: ["6.2.11"]
-      - cis_csc_v7: ["4.6"]
-      - cmmc_v2.0: ["AC.2.008"]
-      - iso_27001-2013: ["A.9.2.3"]
-      - mitre_techniques: ["T1019", "T1098", "T1017", "T1043", "T1175", "T1136", "T1094", "T1482", "T1048", "T1190", "T1210", "T1133", "T1046", "T1145", "T1076", "T1494", "T1489", "T1051", "T1095", "T1072", "T1199", "T1065", "T1028", "T1112", "T1058", "T1198", "T1209"]
-    condition: none
+      - cis: ["6.2.10"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1548"]
+    condition:
     rules:
-      - 'f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:'
 
-  # 6.2.12 Ensure root PATH Integrity (Automated) - Not implemented
-  # 6.2.13 Ensure no duplicate UIDs exist (Automated) - Not implemented
-  # 6.2.14 Ensure no duplicate GIDs exist (Automated) - Not implemented
-  # 6.2.15 Ensure no duplicate user names exist (Automated) - Not implemented
-  # 6.2.16 Ensure no duplicate group names exist (Automated) - Not implemented
-
-  # 6.2.17 Ensure shadow group is empty (Automated)
-  - id: 19194
-    title: "Ensure shadow group is empty."
-    description: "The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group."
-    rationale: "Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts."
-    remediation: 'Run the following command to remove all users from the shadow group # sed -ri ''s/(^shadow:[^:]*:[^:]*:)([^:]+$)/\1/'' /etc/group Change the primary group of any users with shadow as their primary group. # usermod -g <primary group> <user>'
+  # 6.2.11 Ensure local interactive user home directories are configured. (Automated)
+  - id: 31283
+    title: "Ensure local interactive user home directories are configured."
+    description: "The user home directory is space defined for the particular user to set local environment variables and to store personal files. While the system administrator can establish secure permissions for users' home directories, the users can easily override these. Users can be defined in /etc/passwd without a home directory or with a home directory that does not actually exist."
+    rationale: 'Since the user is accountable for files stored in the user home directory, the user must be the owner of the directory. Group or world-writable user home directories may enable malicious users to steal or modify other users'' data or to gain another user''s system privileges. If the user''s home directory does not exist or is unassigned, the user will be placed in "/" and will not be able to write any files or have local environment variables set.'
+    remediation: "If a local interactive users' home directory is undefined and/or doesn't exist, follow local site policy and perform one of the following: - Lock the user account - Remove the user from the system - create a directory for the user. If undefined, edit /etc/passwd and add the absolute path to the directory to the last field of the user. Run the following script to: - Remove excessive permissions from local interactive users home directories - Update the home directory's owner #!/usr/bin/env bash { l_output2=\"\" l_valid_shells=\"^($( awk -F\\/ '$NF != \"nologin\" {print}' /etc/shells | sed -rn '/^\\//{s,/,\\\\\\\\/,g;p}' | paste -s -d '|' - ))$\" unset a_uarr && a_uarr=() # Clear and initialize array while read -r l_epu l_eph; do # Populate array with users and user home location a_uarr+=(\"$l_epu $l_eph\") done <<< \"$(awk -v pat=\"$l_valid_shells\" -F: '$(NF) ~ pat { print $1 \" \" $(NF-1) }' /etc/passwd)\" l_asize=\"${#a_uarr[@]}\" # Here if we want to look at number of users before proceeding [ \"$l_asize \" -gt \"10000\" ] && echo -e \"\\n ** INFO **\\n - \\\"$l_asize\\\" Local interactive users found on the system\\n - This may be a long running process\\n\" while read -r l_user l_home; do if [ -d \"$l_home\" ]; then l_mask='0027' l_max=\"$( printf '%o' $(( 0777 & ~$l_mask)) )\" while read -r l_own l_mode; do if [ \"$l_user\" != \"$l_own\" ]; then l_output2=\"$l_output2\\n - User: \\\"$l_user\\\" Home \\\"$l_home\\\" is owned by: \\\"$l_own\\\"\\n - changing ownership to: \\\"$l_user\\\"\\n\" chown \"$l_user\" \"$l_home\" fi if [ $(( $l_mode & $l_mask )) -gt 0 ]; then l_output2=\"$l_output2\\n - User: \\\"$l_user\\\" Home \\\"$l_home\\\" is mode: \\\"$l_mode\\\" should be mode: \\\"$l_max\\\" or more restrictive\\n - removing excess permissions\\n\" chmod g-w,o-rwx \"$l_home\" fi done <<< \"$(stat -Lc '%U %#a' \"$l_home\")\" else l_output2=\"$l_output2\\n - User: \\\"$l_user\\\" Home \\\"$l_home\\\" Doesn't exist\\n - Please create a home in accordance with local site policy\" fi done <<< \"$(printf '%s\\n' \"${a_uarr[@]}\")\" if [ -z \"$l_output2\" ]; then # If l_output2 is empty, we pass echo -e \" - No modification needed to local interactive users home directories\" else echo -e \"\\n$l_output2\" fi }."
     compliance:
-      - cis: ["6.2.17"]
+      - cis: ["6.2.11"]
+      - cis_csc_v8: ["3.3"]
       - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.2.007", "MP.2.120"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1035", "T1489", "T1198", "T1184", "T1165", "T1492", "T1169", "T1501", "T1080", "T1209", "T1134", "T1197", "T1538", "T1213", "T1044", "T1484", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1163", "T1021", "T1053", "T1023", "T1528", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
-      - nist_sp_800-53: ["AC-3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
-    condition: none
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
     rules:
-      - 'f:/etc/group -> !r:^# && r:shadow:\w*:\w*:\d+'
+
+  # 6.2.12 Ensure local interactive user dot files access is configured. (Automated)
+  - id: 31284
+    title: "Ensure local interactive user dot files access is configured."
+    description: 'While the system administrator can establish secure permissions for users'' "dot" files, the users can easily override these. - .forward file specifies an email address to forward the user''s mail to. - .rhost file provides the "remote authentication" database for the rcp, rlogin, and rsh commands and the rcmd() function. These files bypass the standard password-based user authentication mechanism. They specify remote hosts and users that are considered trusted (i.e. are allowed to access the local system without supplying a password) - .netrc file contains data for logging into a remote host or passing authentication to an API. - .bash_history file keeps track of the user’s last 500 commands.'
+    rationale: "User configuration files with excessive or incorrect access may enable malicious users to steal or modify other users' data or to gain another user's system privileges."
+    remediation: "Making global modifications to users' files without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user dot file permissions and determine the action to be taken in accordance with site policy. The following script will: - remove excessive permissions on dot files within interactive users' home directories - change ownership of dot files within interactive users' home directories to the user - change group ownership of dot files within interactive users' home directories to the user's primary group list .forward and .rhost files to be investigated and manually deleted - #!/usr/bin/env bash { l_valid_shells=\"^($( awk -F\\/ '$NF != \"nologin\" {print}' /etc/shells | sed -rn '/^\\//{s,/,\\\\\\\\/,g;p}' | paste -s -d '|' - ))$\" unset a_uarr && a_uarr=() # Clear and initialize array while read -r l_epu l_eph; do # Populate array with users and user home location [[ -n \"$l_epu\" && -n \"$l_eph\" ]] && a_uarr+=(\"$l_epu $l_eph\") done <<< \"$(awk -v pat=\"$l_valid_shells\" -F: '$(NF) ~ pat { print $1 \" \" $(NF-1) }' /etc/passwd)\" l_asize=\"${#a_uarr[@]}\" # Here if we want to look at number of users before proceeding l_maxsize=\"1000\" # Maximum number of local interactive users before warning (Default 1,000) [ \"$l_asize \" -gt \"$l_maxsize\" ] && echo -e \"\\n ** INFO **\\n - \\\"$l_asize\\\" Local interactive users found on the system\\n - This may be a long running check\\n\" file_access_fix() { l_facout2=\"\" l_max=\"$( printf '%o' $(( 0777 & ~$l_mask)) )\" if [ $(( $l_mode & $l_mask )) -gt 0 ]; then echo -e \" - File: \\\"$l_hdfile\\\" is mode: \\\"$l_mode\\\" and should be mode: \\\"$l_max\\\" or more restrictive\\n - Changing to mode \\\"$l_max\\\"\" chmod \"$l_chp\" \"$l_hdfile\" fi if [[ ! \"$l_owner\" =~ ($l_user) ]]; then echo -e \" - File: \\\"$l_hdfile\\\" owned by: \\\"$l_owner\\\" and should be owned by \\\"${l_user//|/ or }\\\"\\n - Changing ownership to \\\"$l_user\\\"\" chown \"$l_user\" \"$l_hdfile\" fi if [[ ! \"$l_gowner\" =~ ($l_group) ]]; then echo -e \" - File: \\\"$l_hdfile\\\" group owned by: \\\"$l_gowner\\\" and should be group owned by \\\"${l_group//|/ or }\\\"\\n - Changing group ownership to \\\"$l_group\\\"\" chgrp \"$l_group\" \"$l_hdfile\" fi } while read -r l_user l_home; do if [ -d \"$l_home\" ]; then echo -e \"\\n - Checking user: \\\"$l_user\\\" home directory: \\\"$l_home\\\"\" l_group=\"$(id -gn \"$l_user\" | xargs)\" l_group=\"${l_group// /|}\" while IFS= read -r -d $'\\0' l_hdfile; do while read -r l_mode l_owner l_gowner; do case \"$(basename \"$l_hdfile\")\" in .forward | .rhost ) echo -e \" - File: \\\"$l_hdfile\\\" exists\\n - Please investigate and manually delete \\\"$l_hdfile\\\"\" ;; .netrc ) l_mask='0177' l_chp=\"u-x,go-rwx\" file_access_fix ;; .bash_history ) l_mask='0177' l_chp=\"u-x,go-rwx\" file_access_fix ;; * ) l_mask='0133' l_chp=\"u-x,go-wx\" file_access_fix ;; esac done <<< \"$(stat -Lc '%#a %U %G' \"$l_hdfile\")\" done < <(find \"$l_home\" -xdev -type f -name '.*' -print0) fi done <<< \"$(printf '%s\\n' \"${a_uarr[@]}\")\" unset a_uarr # Remove array }."
+    compliance:
+      - cis: ["6.2.12"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1222", "T1222.001", "T1222.002", "T1552", "T1552.003", "T1552.004"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition:
+    rules:


### PR DESCRIPTION
| Component | Action type           | Main Issue 
| --- | --- | ---
| SCA       | Create |  #14358 

## Main tasks

- [x] Use the latest CIS benchmark PDF Draft version - CIS Amazon Linux 2022 Benchmark v1.0.0 Draft
- [x] Verify IDs numbers.
- [x] Verify texts are correct: Title, Description, Rationale and Remediation.
- [x] Verify Compliance: CIS, CIS_CSC.
- [x] Verify condition and rules:
  - [x] To Pass.
  - [x] To Fail.

  
### Issue QA:
- TBD

## PR Tests
### Syntax and semantic

- [x] a) ID of each policy must be contiguous.
- [x] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [x] c) YML must be valid to avoid errors.

### Content

- [x] a) Compare each check with its analog from CIS Benchmark.
- [x] b) Try maintaining each rule as similar as possible with the `Audit` section from the CIS check.
- [x] c) Check that the commands provide the expected output.
- [x] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [x] a) Output from `ossec.log` after the SCA scan and a raw output of the result of the checks.
<details><summary>Tests results</summary>
<p>

#### Analysisd (server or local)
analysisd.debug=2

#### Auth daemon debug (server)
authd.debug=0

#### Exec daemon debug (server, local, or Unix agent)
execd.debug=0

#### Monitor daemon debug (server, local, or Unix agent)
monitord.debug=0

#### Log collector (server, local or Unix agent)
logcollector.debug=0

#### Integrator daemon debug (server, local, or Unix agent)
integrator.debug=0

#### Unix agentd
agent.debug=2

</p>
</details>

### Deployment

- [x] a) If the policy it's new, it must be added to the `sca.files` templates.
- [x] b) If the OS has many supported SCA policies, a policy must be set as the default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))

### Documentation

- [x] a) Ensure documentation SCA list includes the created or updated SCA.
