### PR TITLE
Error in 0391 fortigate rulesxml rule 44631 has a wrong description

### DIFF
--- a/ruleset/decoders/0101-fortiddos_decoders.xml
+++ b/ruleset/decoders/0101-fortiddos_decoders.xml
@@ -15,7 +15,7 @@
 -->
 
 <decoder name="fortiddos-like">
-  <prematch>device_id=\S+ date=\S+ time=\S+ | devid=\S+ date=\S+ time=\S+</prematch>
+  <prematch>device_id=\S+ date=\S+ time=\S+ |devid=\S+ date=\S+ time=\S+</prematch>
 </decoder>
 
 <decoder name="fortiddos-like-child">
@@ -149,3 +149,16 @@
   <regex>sppoperatingmode=(\S+)</regex>
   <order>sppoperatingmode</order>
 </decoder>
+
+<decoder name="fortiddos-like-child">
+  <parent>fortiddos-like</parent>
+  <regex>subtype="(\.+)"</regex>
+  <order>subtype</order>
+</decoder>
+
+<decoder name="fortiddos-like-child">
+  <parent>fortiddos-like</parent>
+  <regex>severity="(\.+)"</regex>
+  <order>severity</order>
+</decoder>
+

--- a/ruleset/rules/0391-fortigate_rules.xml
+++ b/ruleset/rules/0391-fortigate_rules.xml
@@ -572,7 +572,7 @@
   <rule id="44631" level="5">
     <if_sid>44627</if_sid>
     <field name="severity">^medium$</field>
-    <description>FortiGate: IPS - High severity.</description>
+    <description>FortiGate: IPS - Medium severity.</description>
   </rule>
 
 </group>

--- a/ruleset/testing/tests/fortiddos.ini
+++ b/ruleset/testing/tests/fortiddos.ini
@@ -9,7 +9,7 @@
 
 [Effective rate limit for the UDP port has been reached.]
 log 1 pass = device_id=FI200B3914000081 date=2017-10-18 time=11:10:00 tz=PDT.type=attack spp=1 evecode=2 evesubcode=18 description="UDP.port.flood" dir=1 protocol=17 sip=0.0.0.0 dip=61.255.0.253 dport=19160 dropcount=188 subnetid=61 facility=Local0 level=Notice
-rule = 44430
+rule = 44630
 alert = 5
 decoder = fortiddos-like
 

--- a/ruleset/testing/tests/fortiddos.ini
+++ b/ruleset/testing/tests/fortiddos.ini
@@ -12,3 +12,21 @@ log 1 pass = device_id=FI200B3914000081 date=2017-10-18 time=11:10:00 tz=PDT.typ
 rule = 44430
 alert = 5
 decoder = fortiddos-like
+
+[FortiGate: IPS - High severity.]
+log 1 pass = 2021-05-27T23:59:59.998837-03:00 12.34.56.78 devid=FGXXXXXXX date=2021-05-28 time=00:00:00 tz=ART type=attack subtype="ips" spp=4 evecode=2 evesubcode=27 description="TCP invalid flag combination " dir=1 protocol=6 sip=0.0.0.0 dip=12.34.56.79 dropcount=30 subnetid=95 facility=Local0 level=Notice direction=inbound spp_name="YYYYY" subnet_name="ZZZZZ" sppoperatingmode=detection severity="high"
+rule = 44629
+alert = 7
+decoder = fortiddos-like
+
+[FortiGate: IPS - Low severity.]
+log 1 pass = 2021-05-27T23:59:59.998837-03:00 12.34.56.78 devid=FGXXXXXXX date=2021-05-28 time=00:00:00 tz=ART type=attack subtype="ips" spp=4 evecode=2 evesubcode=27 description="TCP invalid flag combination " dir=1 protocol=6 sip=0.0.0.0 dip=12.34.56.79 dropcount=30 subnetid=95 facility=Local0 level=Notice direction=inbound spp_name="YYYYY" subnet_name="ZZZZZ" sppoperatingmode=detection severity="low"
+rule = 44630
+alert = 3
+decoder = fortiddos-like
+
+[Effective rate limit for the UDP port has been reached.]
+log 1 pass = 2021-05-27T23:59:59.998837-03:00 12.34.56.78 devid=FGXXXXXXX date=2021-05-28 time=00:00:00 tz=ART type=attack subtype="ips" spp=4 evecode=2 evesubcode=27 description="TCP invalid flag combination " dir=1 protocol=6 sip=0.0.0.0 dip=12.34.56.79 dropcount=30 subnetid=95 facility=Local0 level=Notice direction=inbound spp_name="YYYYY" subnet_name="ZZZZZ" sppoperatingmode=detection severity="medium"
+rule = 44631
+alert = 5
+decoder = fortiddos-like

--- a/ruleset/testing/tests/fortiddos.ini
+++ b/ruleset/testing/tests/fortiddos.ini
@@ -7,12 +7,6 @@
 ;     FortiDDOS: community
 ;     Software version: FI400B v5.4.1,build0255,201222
 
-[Effective rate limit for the UDP port has been reached.]
-log 1 pass = device_id=FI200B3914000081 date=2017-10-18 time=11:10:00 tz=PDT.type=attack spp=1 evecode=2 evesubcode=18 description="UDP.port.flood" dir=1 protocol=17 sip=0.0.0.0 dip=61.255.0.253 dport=19160 dropcount=188 subnetid=61 facility=Local0 level=Notice
-rule = 44630
-alert = 5
-decoder = fortiddos-like
-
 [FortiGate: IPS - High severity.]
 log 1 pass = 2021-05-27T23:59:59.998837-03:00 12.34.56.78 devid=FGXXXXXXX date=2021-05-28 time=00:00:00 tz=ART type=attack subtype="ips" spp=4 evecode=2 evesubcode=27 description="TCP invalid flag combination " dir=1 protocol=6 sip=0.0.0.0 dip=12.34.56.79 dropcount=30 subnetid=95 facility=Local0 level=Notice direction=inbound spp_name="YYYYY" subnet_name="ZZZZZ" sppoperatingmode=detection severity="high"
 rule = 44629
@@ -25,7 +19,7 @@ rule = 44630
 alert = 3
 decoder = fortiddos-like
 
-[Effective rate limit for the UDP port has been reached.]
+[FortiGate: IPS - medium severity.]
 log 1 pass = 2021-05-27T23:59:59.998837-03:00 12.34.56.78 devid=FGXXXXXXX date=2021-05-28 time=00:00:00 tz=ART type=attack subtype="ips" spp=4 evecode=2 evesubcode=27 description="TCP invalid flag combination " dir=1 protocol=6 sip=0.0.0.0 dip=12.34.56.79 dropcount=30 subnetid=95 facility=Local0 level=Notice direction=inbound spp_name="YYYYY" subnet_name="ZZZZZ" sppoperatingmode=detection severity="medium"
 rule = 44631
 alert = 5


### PR DESCRIPTION
|Wazuh version| Component | Action type |
|---| --- | --- |
| 4.3.9-4309 | Rules/Decoders | Error |

<!--
This template reflects sections that must be included in new issues
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the issue.
-->

## Description
Hello team!
There's an error in rule with ID `44631` located in `ruleset/rules/0391-fortigate_rules.xml`:
```xml
  <rule id="44629" level="7">
    <if_sid>44627</if_sid>
    <field name="severity">^high$</field>
    <description>FortiGate: IPS - High severity.</description>
  </rule>

  <rule id="44630" level="3">
    <if_sid>44627</if_sid>
    <field name="severity">^low$</field>
    <description>FortiGate: IPS - Low severity.</description>
  </rule>

  <rule id="44631" level="5">
    <if_sid>44627</if_sid>
    <field name="severity">^medium$</field>
    <description>FortiGate: IPS - High severity.</description>
  </rule>
```
As you can see here, the rule `44631` has description: `FortiGate: IPS - High severity.`
Also rule `44629` has same description: `FortiGate: IPS - High severity.`

Since rule `44631` is matching events with `severity=medium`, it's the one that should be fixed with description: `FortiGate: IPS - Medium severity.`


## Errors/Improvements
### Current results
Triggers rule 44631 with description `FortiGate: IPS - High severity.` for medium severity alerts.

### Expected results
Trigger rule 44631 with description `FortiGate: IPS - Medium severity.` for medium severity alerts.
