### PR TITLE
 Clear SQLAlchemy mappers for RBAC tests

### DIFF
--- a/framework/wazuh/rbac/tests/test_decorators.py
+++ b/framework/wazuh/rbac/tests/test_decorators.py
@@ -26,8 +26,9 @@ def db_setup():
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.decorators as decorator
-                    reload(decorator)
+
     init_db('schema_security_test.sql', test_data_path)
+    reload(decorator)
 
     yield decorator
 

--- a/framework/wazuh/rbac/tests/test_preprocessor.py
+++ b/framework/wazuh/rbac/tests/test_preprocessor.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy import create_engine
 
-from wazuh.rbac.tests.utils import init_db
+from framework.wazuh.rbac.tests.utils import init_db
 
 test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(test_path, 'data/')


### PR DESCRIPTION
|Related issue|
|---|
| #11957 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR implements the solution, already explained in the related issue, of clearing the SQLAlchemy mappers for the RBAC tests.   

## Tests

