### PR TITLE
Delete cluster files when the connection is lost

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -982,7 +982,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         for pending_task in self.sync_tasks.values():
             pending_task.task.cancel()
 
-        # Clean cluster files from previous executions 
+        # Clean cluster files from previous executions.
         cluster.clean_up(node_name=self.name)
 
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -982,6 +982,9 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         for pending_task in self.sync_tasks.values():
             pending_task.task.cancel()
 
+        # Clean cluster files from previous executions 
+        cluster.clean_up(node_name=self.name)
+
 
 class Master(server.AbstractServer):
     """

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1398,15 +1398,20 @@ def test_master_handler_connection_lost(clean_up_mock, connection_lost_mock, log
         """Auxiliary class."""
 
         def __init__(self):
-            pass
+            self.cancel_called = False
 
         def cancel(self):
             """Auxiliary method."""
-            pass
+            self.cancel_called = True
 
+    tast_mock = TaskMock()
     master_handler.sync_tasks = {"key": PendingTaskMock()}
     master_handler.connection_lost(Exception())
 
+    for pending_task_mock in master_handler.sync_tasks.values():
+        assert pending_task_mock.task.cancel_called
+
+    connection_lost_mock.assert_called_once()
     clean_up_mock.assert_called_once_with(node_name=master_handler.name)
 
 

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1381,7 +1381,8 @@ def test_master_handler_get_logger():
 
 @patch.object(logging.getLogger("wazuh"), "info")
 @patch("wazuh.core.cluster.master.server.AbstractServerHandler.connection_lost")
-def test_master_handler_connection_lost(connection_lost_mock, logger_mock):
+@patch("wazuh.core.cluster.master.cluster.clean_up") 
+def test_master_handler_connection_lost(clean_up_mock, connection_lost_mock, logger_mock):
     """Check if all the pending tasks are closed when the connection between workers and master is lost."""
 
     master_handler = get_master_handler()
@@ -1405,6 +1406,8 @@ def test_master_handler_connection_lost(connection_lost_mock, logger_mock):
 
     master_handler.sync_tasks = {"key": PendingTaskMock()}
     master_handler.connection_lost(Exception())
+
+    clean_up_mock.assert_called_once_with(node_name=master_handler.name)
 
 
 # Test Master class

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1404,7 +1404,6 @@ def test_master_handler_connection_lost(clean_up_mock, connection_lost_mock, log
             """Auxiliary method."""
             self.cancel_called = True
 
-    tast_mock = TaskMock()
     master_handler.sync_tasks = {"key": PendingTaskMock()}
     master_handler.connection_lost(Exception())
 

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -434,7 +434,7 @@ def test_worker_handler_process_request_ok(logger_mock):
 def test_worker_handler_connection_lost(clean_up_mock, connection_lost_mock, logger_mock):
     """Check if all the pending tasks are closed when the connection between workers and master is lost."""
 
-    worker_handler = get_worker_handler()  # Llamada a la función get_worker_handler()
+    worker_handler = get_worker_handler()  
     worker_handler.logger = logging.getLogger("wazuh")
 
     class PendingTaskMock:
@@ -456,10 +456,10 @@ def test_worker_handler_connection_lost(clean_up_mock, connection_lost_mock, log
     worker_handler.sync_tasks = {"key": PendingTaskMock()}
     worker_handler.connection_lost(Exception())
 
+    connection_lost_mock.assert_called_once()
     clean_up_mock.assert_called_once_with(node_name=worker_handler.name)
 
     
-
 @patch.object(logging.getLogger("wazuh"), "debug")
 @patch("asyncio.create_task", side_effect=exception.WazuhClusterError(1001))
 def test_worker_handler_process_request_ko(create_task_mock, logger_mock):

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -428,6 +428,38 @@ def test_worker_handler_process_request_ok(logger_mock):
         process_request_mock.assert_called_once_with(b"random", b"data")
 
 
+@patch.object(logging.getLogger("wazuh"), "info")
+@patch("wazuh.core.cluster.worker.client.AbstractClient.connection_lost")
+@patch("wazuh.core.cluster.worker.cluster.clean_up") 
+def test_worker_handler_connection_lost(clean_up_mock, connection_lost_mock, logger_mock):
+    """Check if all the pending tasks are closed when the connection between workers and master is lost."""
+
+    worker_handler = get_worker_handler()  # Llamada a la función get_worker_handler()
+    worker_handler.logger = logging.getLogger("wazuh")
+
+    class PendingTaskMock:
+        """Auxiliary class."""
+
+        def __init__(self):
+            self.task = TaskMock()
+
+    class TaskMock:
+        """Auxiliary class."""
+
+        def __init__(self):
+            pass
+
+        def cancel(self):
+            """Auxiliary method."""
+            pass
+
+    worker_handler.sync_tasks = {"key": PendingTaskMock()}
+    worker_handler.connection_lost(Exception())
+
+    clean_up_mock.assert_called_once_with(node_name=worker_handler.name)
+
+    
+
 @patch.object(logging.getLogger("wazuh"), "debug")
 @patch("asyncio.create_task", side_effect=exception.WazuhClusterError(1001))
 def test_worker_handler_process_request_ko(create_task_mock, logger_mock):

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -176,6 +176,22 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             if not os.path.exists(worker_tmp_files):
                 utils.mkdir_with_mode(worker_tmp_files)
 
+    def connection_lost(self, exc):
+        """Define process of closing connection with the server.
+
+        Cancel all tasks and set 'on_con_lost' as True if not already.
+
+        Parameters
+        ----------
+        exc : Exception, None
+            'None' means a regular EOF is received, or the connection was aborted or closed
+            by this side of the connection.
+        """
+        super().connection_lost(exc)
+
+        # Clean cluster files from previous executions 
+        cluster.clean_up(node_name=self.name)
+
     def process_request(self, command: bytes, data: bytes) -> Union[bytes, Tuple[bytes, bytes]]:
         """Define all commands that a worker can receive from the master.
 

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -189,7 +189,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         """
         super().connection_lost(exc)
 
-        # Clean cluster files from previous executions 
+        # Clean cluster files from previous executions.
         cluster.clean_up(node_name=self.name)
 
     def process_request(self, command: bytes, data: bytes) -> Union[bytes, Tuple[bytes, bytes]]:


### PR DESCRIPTION
|Related issue|
|---|
|#15075|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description


The solution has been implemented in the **connection_lost()** method of both **framework/wazuh/core/cluster/master.py** and **framework/wazuh/core/cluster/worker.py.** The **cluster.clean_up()** method has been added so that if the connection is lost between the master and worker or the wazuh-clusterd process is started, those temporary files will be deleted.


## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example


### Logs **/var/ossec/bin/wazuh-clusterd**

2023/07/12 11:33:22 DEBUG: [Worker worker] [Main] Disconnected worker.
2023/07/12 11:33:22 INFO: [Worker worker] [Main] Cancelling pending tasks.
2023/07/12 11:33:22 DEBUG: [Worker worker] [Main] Removing '/var/ossec/queue/cluster/worker'.
2023/07/12 11:33:22 DEBUG: [Worker worker] [Main] Removed '/var/ossec/queue/cluster/worker'.


## Tests


### Test framework/wazuh/core/cluster/tests/test_master.py -v
```
platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-0.13.1 -- /home/wazuh/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.19.0-46-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '0.3.0', 'metadata': '2.0.4', 'html': '2.1.1', 'trio': '0.7.0', 'asyncio': '0.15.1'}}
rootdir: /home/wazuh/Git/wazuh/framework
plugins: aiohttp-0.3.0, metadata-2.0.4, html-2.1.1, trio-0.7.0, asyncio-0.15.1
collected 47 items                                                                                                                                                                                        

framework/wazuh/core/cluster/tests/test_master.py::test_rit_init PASSED                                                                                                                             [  2%]
framework/wazuh/core/cluster/tests/test_master.py::test_rit_set_up_coro PASSED                                                                                                                      [  4%]
framework/wazuh/core/cluster/tests/test_master.py::test_rit_done_callback PASSED                                                                                                                    [  6%]
framework/wazuh/core/cluster/tests/test_master.py::test_revt_init PASSED                                                                                                                            [  8%]
framework/wazuh/core/cluster/tests/test_master.py::test_revt_set_up_coro PASSED                                                                                                                     [ 10%]
framework/wazuh/core/cluster/tests/test_master.py::test_revt_done_callback PASSED                                                                                                                   [ 12%]
framework/wazuh/core/cluster/tests/test_master.py::test_rait_init PASSED                                                                                                                            [ 14%]
framework/wazuh/core/cluster/tests/test_master.py::test_seagt_init PASSED                                                                                                                           [ 17%]
framework/wazuh/core/cluster/tests/test_master.py::test_rait_set_up_coro PASSED                                                                                                                     [ 19%]
framework/wazuh/core/cluster/tests/test_master.py::test_rait_done_callback PASSED                                                                                                                   [ 21%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_init PASSED                                                                                                                  [ 23%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_to_dict PASSED                                                                                                               [ 25%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_process_request PASSED                                                                                                       [ 27%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_execute_ok PASSED                                                                                                            [ 29%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_execute_ko PASSED                                                                                                            [ 31%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_hello_ok PASSED                                                                                                              [ 34%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_hello_ko PASSED                                                                                                              [ 36%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_get_manager PASSED                                                                                                           [ 38%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_process_dapi_res_ok PASSED                                                                                                   [ 40%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_process_dapi_res_ko PASSED                                                                                                   [ 42%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_get_nodes PASSED                                                                                                             [ 44%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_get_health PASSED                                                                                                            [ 46%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_get_permission PASSED                                                                                                        [ 48%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_setup_sync_integrity PASSED                                                                                                  [ 51%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_setup_send_info PASSED                                                                                                       [ 53%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_process_sync_error_from_worker PASSED                                                                                        [ 55%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_end_receiving_integrity_checksums PASSED                                                                                     [ 57%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_wazuh_db_info PASSED                                                                                                    [ 59%]
framework/wazuh/core/cluster/tests/test_master.py::test_manager_handler_send_entire_agent_groups_information PASSED                                                                                 [ 61%]
framework/wazuh/core/cluster/tests/test_master.py::test_manager_handler_send_agent_groups_information PASSED                                                                                        [ 63%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_worker_files_ok PASSED                                                                                                  [ 65%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_worker_files_ko PASSED                                                                                                  [ 68%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_extra_valid PASSED                                                                                                      [ 70%]
framework/wazuh/core/cluster/tests/test_master.py::test_set_date_end_master PASSED                                                                                                                  [ 72%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_integrity_check[compare_result0] PASSED                                                                                      [ 74%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_integrity_check[compare_result1] PASSED                                                                                      [ 76%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_integrity_check_ko PASSED                                                                                                    [ 78%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_integrity_sync PASSED                                                                                                        [ 80%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_process_files_from_worker_ok PASSED                                                                                          [ 82%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_get_logger PASSED                                                                                                            [ 85%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_connection_lost PASSED                                                                                                       [ 87%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_init PASSED                                                                                                                          [ 89%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_to_dict PASSED                                                                                                                       [ 91%]
framework/wazuh/core/cluster/tests/test_master.py::test_agent_groups_update PASSED                                                                                                                  [ 93%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_file_status_update_ok PASSED                                                                                                         [ 95%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_get_health PASSED                                                                                                                    [ 97%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_get_node PASSED                                                                                                                      [100%]
```

### Test framework/wazuh/core/cluster/tests/test_worker.py -v 
```
platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-0.13.1 -- /home/wazuh/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.19.0-46-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '0.3.0', 'metadata': '2.0.4', 'html': '2.1.1', 'trio': '0.7.0', 'asyncio': '0.15.1'}}
rootdir: /home/wazuh/Git/wazuh/framework
plugins: aiohttp-0.3.0, metadata-2.0.4, html-2.1.1, trio-0.7.0, asyncio-0.15.1
collected 35 items                                                                                                                                                                                        

framework/wazuh/core/cluster/tests/test_worker.py::test_rgit_init PASSED                                                                                                                            [  2%]
framework/wazuh/core/cluster/tests/test_worker.py::test_rgit_set_up_coro PASSED                                                                                                                     [  5%]
framework/wazuh/core/cluster/tests/test_worker.py::test_rgcit_set_up_coro PASSED                                                                                                                    [  8%]
framework/wazuh/core/cluster/tests/test_worker.py::test_rgit_done_callback PASSED                                                                                                                   [ 11%]
framework/wazuh/core/cluster/tests/test_worker.py::test_rgcit_done_callback PASSED                                                                                                                  [ 14%]
framework/wazuh/core/cluster/tests/test_worker.py::test_rit_set_up_coro PASSED                                                                                                                      [ 17%]
framework/wazuh/core/cluster/tests/test_worker.py::test_rit_done_callback PASSED                                                                                                                    [ 20%]
framework/wazuh/core/cluster/tests/test_worker.py::test_sync_wazuh_db_init PASSED                                                                                                                   [ 22%]
framework/wazuh/core/cluster/tests/test_worker.py::test_sync_wazuh_db_sync_ok PASSED                                                                                                                [ 25%]
framework/wazuh/core/cluster/tests/test_worker.py::test_sync_wazuh_db_sync_ko PASSED                                                                                                                [ 28%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_init PASSED                                                                                                                  [ 31%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_connection_result PASSED                                                                                                     [ 34%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_process_request_ok PASSED                                                                                                    [ 37%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_connection_lost PASSED                                                                                                       [ 40%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_process_request_ko PASSED                                                                                                    [ 42%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_get_manager PASSED                                                                                                           [ 45%]
framework/wazuh/core/cluster/tests/test_worker.py::test_master_handler_setup_sync_integrity PASSED                                                                                                  [ 48%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_setup_receive_files_from_master PASSED                                                                                       [ 51%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_end_receiving_integrity PASSED                                                                                               [ 54%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_error_receiving_integrity PASSED                                                                                             [ 57%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_integrity_ok_from_master PASSED                                                                                         [ 60%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_compare_agent_groups_checksums PASSED                                                                                                [ 62%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_check_agent_groups_checksums PASSED                                                                                                  [ 65%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_recv_agent_groups_information PASSED                                                                                         [ 68%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_integrity PASSED                                                                                                        [ 71%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_agent_info PASSED                                                                                                       [ 74%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_agent_info_ko PASSED                                                                                                    [ 77%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_extra_valid PASSED                                                                                                      [ 80%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_process_files_from_master_ok PASSED                                                                                          [ 82%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_process_files_from_master_ko PASSED                                                                                          [ 85%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_update_master_files_in_worker_ok PASSED                                                                                      [ 88%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_get_logger PASSED                                                                                                            [ 91%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_init PASSED                                                                                                                          [ 94%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_add_tasks PASSED                                                                                                                     [ 97%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_get_node PASSED                                                                                                                      [100%]
```


