### PR TITLE
Fix inverse logic in MS Windows Server 2022 Benchmark for SCA

### DIFF
--- a/ruleset/sca/windows/cis_win2022.yml
+++ b/ruleset/sca/windows/cis_win2022.yml
@@ -4960,7 +4960,7 @@ checks:
     rules:
       - 'not r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'
       - 'not r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> PerSessionTempDir'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> PerSessionTempDir -> 0'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services -> PerSessionTempDir -> 1'
 
   - id: 27314
     title: "Ensure 'Prevent downloading of enclosures' is set to 'Enabled'."


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17898|

This PR aims to fix an inverse logic issue at Windows Server 2022 Benchmark's check 27313.

The check's title states:
> Ensure 'Do not use temporary folders per session' is set to 'Disabled'.

According to this documentation: [Do not use temporary folders per session](https://admx.help/?Category=Windows_11_2022&Policy=Microsoft.Policies.TerminalServer::TS_TEMP_PER_SESSION), the value `1` is the one that corresponds to "Disabled".

On the other hand, the rest of the CIS Benchmarks have the correct check:

- [cis_win2019.yml](https://github.com/wazuh/wazuh/blob/73ae6e7d821a00c9d8a1fc9394cd7cad4f3e30ca/ruleset/sca/windows/cis_win2019.yml#L4107)
- [cis_win2012r2.yml](https://github.com/wazuh/wazuh/blob/73ae6e7d821a00c9d8a1fc9394cd7cad4f3e30ca/ruleset/sca/windows/cis_win2012r2.yml#L3594)
- [cis_win2016.yml](https://github.com/wazuh/wazuh/blob/73ae6e7d821a00c9d8a1fc9394cd7cad4f3e30ca/ruleset/sca/windows/cis_win2016.yml#L4023)

Thanks to @oleKHard for reporting this problem.