### PR TITLE
Fix error requesting plain manager logs in the API

### DIFF
--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -111,7 +111,7 @@ def get_ossec_logs(limit: int = 2000) -> list:
     logs = []
 
     log_format = get_wazuh_active_logging_format()
-    if log_format == LoggingFormat.plain and exists(common.WAZUH_LOG_JSON):
+    if log_format == LoggingFormat.plain and exists(common.WAZUH_LOG):
         wazuh_log_content = tail(common.WAZUH_LOG, limit)
     elif log_format == LoggingFormat.json and exists(common.WAZUH_LOG_JSON):
         wazuh_log_content = tail(common.WAZUH_LOG_JSON, limit)

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -116,26 +116,19 @@ def test_get_ossec_logs(log_format):
     logs = get_logs(json_log=log_format == LoggingFormat.json).splitlines()
 
     with patch("wazuh.core.manager.get_wazuh_active_logging_format", return_value=log_format):
-        with pytest.raises(WazuhInternalError, match=".*1020.*"):
-            get_ossec_logs()
-
-        with patch('wazuh.core.manager.exists', return_value=True):
-            with patch('wazuh.core.manager.tail', return_value=logs):
-                result = get_ossec_logs()
-                assert all(key in log for key in ('timestamp', 'tag', 'level', 'description') for log in result)
-
-
-@patch("wazuh.core.manager.get_wazuh_active_logging_format", return_value=LoggingFormat.plain)
-@patch('wazuh.core.manager.exists', return_value=True)
-def test_get_logs_summary(mock_exists, mock_active_logging_format):
-    """Test get_logs_summary() method returns result with expected information"""
-    logs = get_logs().splitlines()
-    with patch('wazuh.core.manager.tail', return_value=logs):
-        result = get_logs_summary()
-        assert all(key in log for key in ('all', 'info', 'error', 'critical', 'warning', 'debug')
-                   for log in result.values())
-        assert result['wazuh-modulesd:database'] == {'all': 2, 'info': 0, 'error': 0, 'critical': 0, 'warning': 0,
-                                                     'debug': 2}
+        if log_format == LoggingFormat.plain:
+            with patch('wazuh.core.manager.exists', return_value=True):
+                with patch('wazuh.core.manager.tail', return_value=logs):
+                    result = get_ossec_logs()
+                    assert all(key in log for key in ('timestamp', 'tag', 'level', 'description') for log in result)
+        elif log_format == LoggingFormat.json:
+            with patch('wazuh.core.manager.exists', return_value=True):
+                with patch('wazuh.core.manager.tail', return_value=logs):
+                    result = get_ossec_logs()
+                    assert all(key in log for key in ('timestamp', 'tag', 'level', 'description') for log in result)
+        else:
+            with pytest.raises(WazuhInternalError, match=".*1020.*"):
+                get_ossec_logs()
 
 
 @patch('wazuh.core.manager.exists', return_value=True)

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -116,14 +116,13 @@ def test_get_ossec_logs(log_format):
     logs = get_logs(json_log=log_format == LoggingFormat.json).splitlines()
 
     with patch("wazuh.core.manager.get_wazuh_active_logging_format", return_value=log_format):
-        if log_format == LoggingFormat.plain:
-            with pytest.raises(WazuhInternalError, match=".*1020.*"):
-                get_ossec_logs()
-        else:
-            with patch('wazuh.core.manager.exists', return_value=True):
-                with patch('wazuh.core.manager.tail', return_value=logs):
-                    result = get_ossec_logs()
-                    assert all(key in log for key in ('timestamp', 'tag', 'level', 'description') for log in result)
+        with pytest.raises(WazuhInternalError, match=".*1020.*"):
+            get_ossec_logs()
+
+        with patch('wazuh.core.manager.exists', return_value=True):
+            with patch('wazuh.core.manager.tail', return_value=logs):
+                result = get_ossec_logs()
+                assert all(key in log for key in ('timestamp', 'tag', 'level', 'description') for log in result)
 
 
 @patch("wazuh.core.manager.get_wazuh_active_logging_format", return_value=LoggingFormat.plain)


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

When executing **GET /manager/logs**, if the logging format was **.plain** and **ossec.json** did not exist, an error was thrown. This has been modified in the function **get_ossec_logs** and **test_get_ossec_logs** so that if it is **.plain**, it does not check for **.json**.

## Configuration options

**/var/ossec/etc/ossec.conf**
```
<ossec_config>
  <global>
    <jsonout_output>no</jsonout_output>
```



## Logs/Alerts example

```
Starting API in foreground
======== Running on https://0.0.0.0:55000 ========
(Press CTRL+C to quit)
2023/07/18 12:28:18 INFO: wazuh 127.0.0.1 "GET /manager/logs" with parameters {} and body {} done in 0.295s: 200
```

## Tests

**framework/wazuh/core/tests/test_manager.py**
```
(unittest-env) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest framework/wazuh/core/tests/test_manager.py -v
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-0.13.1 -- /home/wazuh/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.19.0-46-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '0.3.0', 'metadata': '2.0.4', 'html': '2.1.1', 'trio': '0.7.0', 'asyncio': '0.15.1'}}
rootdir: /home/wazuh/Git/wazuh/framework
plugins: aiohttp-0.3.0, metadata-2.0.4, html-2.1.1, trio-0.7.0, asyncio-0.15.1
collected 16 items                                                                                                                                                                                                

framework/wazuh/core/tests/test_manager.py::test_get_status[running] PASSED                                                                                                                                 [  6%]
framework/wazuh/core/tests/test_manager.py::test_get_status[stopped] PASSED                                                                                                                                 [ 12%]
framework/wazuh/core/tests/test_manager.py::test_get_status[failed] PASSED                                                                                                                                  [ 18%]
framework/wazuh/core/tests/test_manager.py::test_get_status[restarting] PASSED                                                                                                                              [ 25%]
framework/wazuh/core/tests/test_manager.py::test_get_status[starting] PASSED                                                                                                                                [ 31%]
framework/wazuh/core/tests/test_manager.py::test_get_ossec_log_fields PASSED                                                                                                                                [ 37%]
framework/wazuh/core/tests/test_manager.py::test_get_ossec_log_fields_ko PASSED                                                                                                                             [ 43%]
framework/wazuh/core/tests/test_manager.py::test_get_ossec_logs[LoggingFormat.plain] PASSED                                                                                                                 [ 50%]
framework/wazuh/core/tests/test_manager.py::test_get_ossec_logs[LoggingFormat.json] PASSED                                                                                                                  [ 56%]
framework/wazuh/core/tests/test_manager.py::test_get_logs_summary PASSED                                                                                                                                    [ 62%]
framework/wazuh/core/tests/test_manager.py::test_validate_ossec_conf PASSED                                                                                                                                 [ 68%]
framework/wazuh/core/tests/test_manager.py::test_validation_ko PASSED                                                                                                                                       [ 75%]
framework/wazuh/core/tests/test_manager.py::test_parse_execd_output[0-] PASSED                                                                                                                              [ 81%]
framework/wazuh/core/tests/test_manager.py::test_parse_execd_output[1-2019/02/27 11:30:07 wazuh-clusterd: ERROR: [Cluster] [Main] Error 3004 - Error in cluster configuration: Unspecified key] PASSED      [ 87%]
framework/wazuh/core/tests/test_manager.py::test_parse_execd_output[1-2019/02/27 11:30:24 wazuh-authd: ERROR: (1230): Invalid element in the configuration: 'use_source_i'.\n2019/02/27 11:30:24 wazuh-authd: ERROR: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.] PASSED [ 93%]
framework/wazuh/core/tests/test_manager.py::test_get_api_config PASSED                                                                                                                                      [100%]
```


