### PR TITLE
Add support for joins and group by in WazuhDBQuery

### DIFF
--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -215,6 +215,10 @@ class WazuhException(Exception):
         1415: {'message': 'Rules file not found',
                'remediation': 'Please, use GET /rules/files to list all available rules'
                },
+        1416: {'message': 'Not a valid join type field',
+               'remediation': 'Please, use only one of: LEFT, CROSS or OUTER'
+               },
+        1417: 'Invalid join conditions',
 
         # Decoders: 1500 - 1599
         1500: {'message': 'Error reading decoders from ossec.conf',

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1360,6 +1360,8 @@ class WazuhDBBackend(AbstractDatabaseBackend):
 class WazuhDBQuery(object):
     """This class describes a database query for wazuh."""
 
+    JOIN_TYPES = ['LEFT', 'CROSS', 'OUTER']
+
     def __init__(self, offset: int, limit: int, table: str, sort: dict, search: dict, select: list, query: str,
                  fields: dict, default_sort_field: str, count: bool, get_data: bool, backend: str,
                  default_sort_order: str = 'ASC', filters: dict = {}, min_select_fields: set = set(),
@@ -1464,7 +1466,6 @@ class WazuhDBQuery(object):
         self.backend = backend
         self.rbac_negate = rbac_negate
         self.joins = joins
-        self.join_types = ['LEFT', 'CROSS', 'OUTER']
         self.group_by = group_by
 
     def __enter__(self):
@@ -1578,7 +1579,7 @@ class WazuhDBQuery(object):
 
         for table, join in self.joins.items():
             join_type = join['type'].upper()
-            if join_type not in self.join_types:
+            if join_type not in WazuhDBQuery.JOIN_TYPES:
                 raise WazuhError(1416, 'invalid join type: ' + join_type)
 
             conditions = join['conditions']

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -40,6 +40,8 @@ if sys.version_info[0] == 3:
 # Temporary cache
 t_cache = TTLCache(maxsize=4500, ttl=60)
 
+SQLITE_JOIN_TYPES = ['LEFT', 'CROSS', 'OUTER']
+
 
 def clean_pid_files(daemon: str):
     """Check the existence of '.pid' files for a specified daemon.
@@ -1363,7 +1365,8 @@ class WazuhDBQuery(object):
     def __init__(self, offset: int, limit: int, table: str, sort: dict, search: dict, select: list, query: str,
                  fields: dict, default_sort_field: str, count: bool, get_data: bool, backend: str,
                  default_sort_order: str = 'ASC', filters: dict = {}, min_select_fields: set = set(),
-                 date_fields: set = set(), extra_fields=set(), distinct: bool = False, rbac_negate: bool = True):
+                 date_fields: set = set(), extra_fields=set(), distinct: bool = False, rbac_negate: bool = True,
+                 joins: typing.Dict[str, str] = None, group_by: list = None):
         """Wazuh DB Query constructor.
 
         Parameters
@@ -1406,6 +1409,10 @@ class WazuhDBQuery(object):
             Whether to use IN or NOT IN on RBAC resources.
         backend : str
             Database engine to use. Possible options are 'wdb' and 'sqlite3'.
+        joins: dict
+            Table joins to perform. Format: {"table1": {"type": "left", "conditions": ["condition1", "condition2"]}}.
+        group_by: list
+            Groups the items. Format: ["field1","field2"].
         """
         self.offset = offset
         self.limit = limit
@@ -1458,6 +1465,8 @@ class WazuhDBQuery(object):
         self.inverse_fields = {v: k for k, v in self.fields.items()}
         self.backend = backend
         self.rbac_negate = rbac_negate
+        self.joins = joins
+        self.group_by = group_by
 
     def __enter__(self):
         return self
@@ -1491,6 +1500,14 @@ class WazuhDBQuery(object):
             self.request['limit'] = self.limit
         elif self.limit == 0:  # 0 is not a valid limit
             raise WazuhError(1406)
+
+    def _add_group_by_to_query(self):
+        if self.group_by:
+            for field in self.group_by:
+                if field not in self.fields.keys():
+                    raise WazuhError(1408, "Available fields: {}. Field: {}".format(', '.join(self.fields), field))
+
+            self.query += ' GROUP BY ' + ','.join(self.group_by)
 
     def _sort_query(self, field):
         return '{} {}'.format(self.fields[field], self.sort['order'])
@@ -1538,6 +1555,38 @@ class WazuhDBQuery(object):
 
     def _add_select_to_query(self):
         self.select = self._parse_select_filter(self.select)
+
+    def _validate_join_conditions(self, conditions: typing.List[str]):
+        if not conditions:
+            raise WazuhError(1417)
+
+        for condition in conditions:
+            if not self.query_regex.match(condition):
+                raise WazuhError(1407, condition)
+        
+        # Value could be any value or another table field, so we are not making any validation
+        for _, field, operator, _, _, _ in self.query_regex.findall(condition):
+            if field not in self.fields.keys():
+                raise WazuhError(1408, "Available fields: {}. Field: {}".format(', '.join(self.fields), field))
+            if operator not in self.query_operators:
+                raise WazuhError(1409,
+                                 "Valid operators: {}. Used operator: {}".format(', '.join(self.query_operators),
+                                                                                 operator))
+
+    def _add_joins_to_query(self):
+        if not self.joins:
+            return
+
+        for table, join in self.joins.items():
+            join_type = join['type'].upper()
+            if join_type not in SQLITE_JOIN_TYPES:
+                raise WazuhError(1416, 'invalid join type: ' + join_type)
+
+            conditions = join['conditions']
+            self._validate_join_conditions(conditions)
+            join_conditions = ' AND '.join(conditions)
+
+            self.query += f" {join_type} JOIN {table} ON {join_conditions}"
 
     def _parse_query(self):
         """A query has the following pattern: field operator value separator field operator value...
@@ -1693,12 +1742,14 @@ class WazuhDBQuery(object):
             Dictionary with the formatted data.
         """
         self._add_select_to_query()
+        self._add_joins_to_query()
         self._add_filters_to_query()
         self._add_search_to_query()
         if self.count:
             self._get_total_items()
             if not self.data:
                 return {'totalItems': self.total_items}
+        self._add_group_by_to_query()
         self._add_sort_to_query()
         self._add_limit_to_query()
         if self.data:
@@ -1720,10 +1771,12 @@ class WazuhDBQuery(object):
             Error communicating with socket. Query too long.
         """
         self._add_select_to_query()
+        self._add_joins_to_query()
         original_select = self.select
         rbac_ids = set(self.legacy_filters.pop('rbac_ids', set()))
         self._add_filters_to_query()
         self._add_search_to_query()
+        self._add_group_by_to_query()
         self._add_sort_to_query()
 
         resource = None

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -40,8 +40,6 @@ if sys.version_info[0] == 3:
 # Temporary cache
 t_cache = TTLCache(maxsize=4500, ttl=60)
 
-SQLITE_JOIN_TYPES = ['LEFT', 'CROSS', 'OUTER']
-
 
 def clean_pid_files(daemon: str):
     """Check the existence of '.pid' files for a specified daemon.
@@ -1366,7 +1364,7 @@ class WazuhDBQuery(object):
                  fields: dict, default_sort_field: str, count: bool, get_data: bool, backend: str,
                  default_sort_order: str = 'ASC', filters: dict = {}, min_select_fields: set = set(),
                  date_fields: set = set(), extra_fields=set(), distinct: bool = False, rbac_negate: bool = True,
-                 joins: typing.Dict[str, str] = None, group_by: list = None):
+                 joins: typing.Dict[str, dict] = None, group_by: list = None):
         """Wazuh DB Query constructor.
 
         Parameters
@@ -1466,6 +1464,7 @@ class WazuhDBQuery(object):
         self.backend = backend
         self.rbac_negate = rbac_negate
         self.joins = joins
+        self.join_types = ['LEFT', 'CROSS', 'OUTER']
         self.group_by = group_by
 
     def __enter__(self):
@@ -1579,7 +1578,7 @@ class WazuhDBQuery(object):
 
         for table, join in self.joins.items():
             join_type = join['type'].upper()
-            if join_type not in SQLITE_JOIN_TYPES:
+            if join_type not in self.join_types:
                 raise WazuhError(1416, 'invalid join type: ' + join_type)
 
             conditions = join['conditions']


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/17864 |

## Description

This PR adds supports for table joins and grouping by specific fields to the `WazuhDBQuery` class.

The new `joins` field is a dictionary in which the key contains the name of the table to be joined and the value is a dictionary with two fields: `type` (string) and `conditions` (list). 

`type` could be either "LEFT", "CROSS" or "OUTER". And `conditions` should contain a valid query, where the first value must be a field present in `WazuhDBQuery.fields` (the second value could be anything, a string, int or another field so it's not validated).

In order to join, select and group by fields that belong to a joined table and not the main one, they must be added to the  `WazuhDBQuery.fields` dictionary manually and the fields should start with the name of the table and be separated by a dot (`agent.id`).

### Example

If we would like to join the `agent` table with the `belongs` one, the [`WazuhDBQueryAgents.fields`](https://github.com/wazuh/wazuh/blob/ffa66c34698cb12b52161b022f69e3f5f02a1229/framework/wazuh/core/agent.py#L83) parameter should contain the fields present in the `agent` table as well as the ones from `belongs` that will be used in the query

```
fields = {'id': 'id', 'name': 'name', 'ip': 'coalesce(ip,register_ip)', 'status': 'connection_status',
              'os.name': 'os_name', 'os.version': 'os_version', 'os.platform': 'os_platform',
              'version': 'version', 'manager': 'manager_host', 'dateAdd': 'date_add',
              'group': '`group`', 'mergedSum': 'merged_sum', 'configSum': 'config_sum',
              'os.codename': 'os_codename', 'os.major': 'os_major', 'os.minor': 'os_minor',
              'os.uname': 'os_uname', 'os.arch': 'os_arch', 'os.build': 'os_build',
              'node_name': 'node_name', 'lastKeepAlive': 'last_keepalive', 'internal_key': 'internal_key',
              'registerIP': 'register_ip', 'disconnection_time': 'disconnection_time',
              'group_config_status': 'group_config_status',
+             '`group`': 'belongs.name_group'}
```