### PR TITLE
Preventing Implicit Import of dbsync and rsync Libraries in Windows - Implementation

### DIFF
--- a/.github/workflows/windows-dll-hijack.yml
+++ b/.github/workflows/windows-dll-hijack.yml
@@ -1,6 +1,7 @@
 name: Testing DLL search order to prevent hijack
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "src/**"

--- a/src/Makefile
+++ b/src/Makefile
@@ -464,7 +464,6 @@ OSSEC_LINK    =${QUIET_LINK}${MING_BASE}ar -crus
 OSSEC_RANLIB  =${QUIET_RANLIB}${MING_BASE}ranlib
 OSSEC_WINDRES =${QUIET_CCBIN}${MING_BASE}windres
 
-
 ifneq (,$(filter ${USE_INOTIFY},YES auto yes y Y 1))
 	DEFINES+=-DINOTIFY_ENABLED
 	ifeq (${uname_S},FreeBSD)
@@ -501,6 +500,7 @@ ifeq (${TARGET}, winagent)
 	OSSEC_LDFLAGS+=-L${SYSCOLLECTOR}build/bin
 	OSSEC_LDFLAGS+=-L${SYSINFO}build/bin
 	OSSEC_LDFLAGS+=-L${SYSCHECK}build/lib
+	OSSEC_LDFLAGS+=-L${SYSCHECK}build/bin
 else
 	OSSEC_LDFLAGS+=-L${SYSCOLLECTOR}build/lib
 	OSSEC_LDFLAGS+=-L${SYSINFO}build/lib
@@ -812,7 +812,7 @@ endif
 winagent: external win32/libwinpthread-1.dll ${WAZUH_LIB_OUTPUT_PATH}${LIBGCC_S_NAME} ${WAZUH_LIB_OUTPUT_PATH}${LIBSTDCPP_NAME}
 	${MAKE} ${WAZUHEXT_LIB} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lws2_32 -lcrypt32"
 	${MAKE} ${WINDOWS_LIBS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1"
-	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust -lfimdb"
+	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust"
 	${MAKE} ${WINDOWS_ACTIVE_RESPONSES} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust"
 	cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
 	cd win32/ && ./unix2dos.pl help.txt > help_win.txt
@@ -840,18 +840,6 @@ win32/sysinfo: $(WAZUHEXT_LIB)
 #### Syscollector ##
 win32/syscollector: win32/shared_modules win32/sysinfo
 	cd ${SYSCOLLECTOR} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSCOLLECTOR_TEST} ${SYSCOLLECTOR_RELEASE_TYPE} .. && ${MAKE}
-
-#### FIM ##
-
-syscheck_o := $(wildcard syscheckd/build/CMakeFiles/wazuh-syscheckd.dir/src/*.obj)
-syscheck_o += $(wildcard syscheckd/build/CMakeFiles/wazuh-syscheckd.dir/src/registry/*.obj)
-syscheck_o += $(wildcard syscheckd/build/CMakeFiles/wazuh-syscheckd.dir/src/whodata/*.obj)
-syscheck_o += $(wildcard syscheckd/build/src/db/CMakeFiles/fimdb.dir/src/*obj)
-
-syscheck_eventchannel_o := $(wildcard syscheckd/build/CMakeFiles/wazuh-syscheckd-event.dir/src/*.obj)
-syscheck_eventchannel_o += $(wildcard syscheckd/build/CMakeFiles/wazuh-syscheckd-event.dir/src/registry/*.obj)
-syscheck_eventchannel_o += $(wildcard syscheckd/build/CMakeFiles/wazuh-syscheckd-event.dir/src/whodata/*.obj)
-syscheck_eventchannel_o += $(wildcard syscheckd/build/src/db/CMakeFiles/fimdb.dir/src/*obj)
 
 win32/syscheck: win32/shared_modules $(WAZUHEXT_LIB)
 	cd ${SYSCHECK} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSCHECK_TEST} ${SYSCHECK_RELEASE_TYPE} .. && ${MAKE}
@@ -2437,11 +2425,11 @@ win32_ui_o := $(win32_ui_c:.c=.o)
 win32/ui/%.o: win32/ui/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -UOSSECHIDS -DARGV0=\"wazuh-win32ui\" -c $^ -o $@
 
-win32/wazuh-agent.exe: win32/wazuh_agent_resource.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o $(filter-out syscheckd/main.o, ${syscheck_o}) ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) $(filter-out os_execd/main.o, ${os_execd_o}) active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o ${FIMDB_LIB}
-	${OSSEC_CXXBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} ${RSYNC_LIB} -lwazuh-syscheckd -o $@
+win32/wazuh-agent.exe: win32/wazuh_agent_resource.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) $(filter-out os_execd/main.o, ${os_execd_o}) active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
+	${OSSEC_CCBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} ${RSYNC_LIB} -lwazuh-syscheckd -l:libfimdb.lib libwazuh.a -o $@
 
-win32/wazuh-agent-eventchannel.exe: win32/wazuh_agent_eventchannel_resource.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o $(filter-out syscheckd/main-event.o, ${syscheck_eventchannel_o}) ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) $(filter-out os_execd/main.o, ${os_execd_o}) active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o ${FIMDB_LIB}
-	${OSSEC_CXXBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} ${RSYNC_LIB} -lwazuh-syscheckd-event -o $@
+win32/wazuh-agent-eventchannel.exe: win32/wazuh_agent_eventchannel_resource.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) $(filter-out os_execd/main.o, ${os_execd_o}) active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
+	${OSSEC_CCBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} ${RSYNC_LIB} -lwazuh-syscheckd-event -l:libfimdb.lib libwazuh.a -lwevtapi -o $@
 
 win32/manage_agents.exe: win32/manage_agents_resource.o win32/win_service_rk.o ${addagent_o}
 	${OSSEC_CCBIN} -DARGV0=\"manage-agents\" -DMA ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
@@ -2457,6 +2445,7 @@ win32/setup-iis.exe: win32/setup-iis.o
 
 win32/ui_resource.o: win32/ui/win32ui.rc
 	${OSSEC_WINDRES} -i $< -o $@
+
 win32/auth_resource.o: win32/agent-auth.rc
 	${OSSEC_WINDRES} -i $< -o $@
 
@@ -2474,7 +2463,6 @@ win32/route-null.exe: win32/route_null_resource.o active-response/active_respons
 
 win32/netsh.exe: win32/netsh_resource.o active-response/active_responses.o active-response/netsh.o shared/cryptography.o shared/dll_load_notify.o shared/debug_op_proc.o shared/time_op.o shared/file_op_proc.o ${WAZUH_LIB} ${WAZUHEXT_LIB}
 	${OSSEC_CCBIN} -DARGV0=\"netsh\" ${AR_LDFLAGS} $^ -lwintrust -lpsapi -lcrypt32 -lshlwapi -o $@
-
 
 
 ####################

--- a/src/syscheckd/src/db/CMakeLists.txt
+++ b/src/syscheckd/src/db/CMakeLists.txt
@@ -31,7 +31,7 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_definitions(-DOS_TYPE=OSType::WINDOWS)
-  add_library(fimdb STATIC ${DB_SRC}
+  add_library(fimdb SHARED ${DB_SRC}
                            ${CMAKE_SOURCE_DIR}/src/db/src/registry.cpp
                            ${CMAKE_SOURCE_DIR}/src/db/src/fimDBSpecializationWindows.cpp
                            )
@@ -46,7 +46,7 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_target_properties(
-    fimdb PROPERTIES LINK_FLAGS "-Wl,--add-stdcall-alias -static-libstdc++")
+    fimdb PROPERTIES LINK_FLAGS "-Wl,--add-stdcall-alias -Wl,--output-def,libfimdb.def")
 elseif(UNIX AND NOT APPLE)
   if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
     string(REPLACE ";" ":" CXX_IMPLICIT_LINK_DIRECTORIES_STR
@@ -73,6 +73,18 @@ else()
     -Wl,-blibpath:${INSTALL_PREFIX}/lib:${CXX_IMPLICIT_LINK_DIRECTORIES_STR}:${PLATFORM_REQUIRED_RUNTIME_PATH_STR}
   )
 endif(NOT CMAKE_SYSTEM_NAME STREQUAL "AIX")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  find_program(DLLTOOL i686-w64-mingw32-dlltool)
+if(NOT DLLTOOL)
+  message(FATAL_ERROR "DLL tool for delayed load libraries not found.")
+endif(NOT DLLTOOL)
+
+add_custom_command(TARGET fimdb POST_BUILD
+  COMMAND "${DLLTOOL}" -D "libfimdb.dll" --def "libfimdb.def" --output-delaylib "libfimdb.lib"
+  COMMAND cp "libfimdb.lib" "${CMAKE_BINARY_DIR}/bin/libfimdb.lib"
+  COMMENT "Creating delayed load library for fimdb.")
+endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
 if(UNIT_TEST)
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -54,6 +54,8 @@ extern "C" {
  * @param value_limit Maximum number of registry values to be monitored.
  * @param sync_registry_enable Flag to enable the registry synchronization.
  * @param sync_queue_size Number to define the size of the queue to be synchronized.
+ * @param dbsync_log_function Logging function for dbsync module.
+ * @param rsync_log_function Logging function for rsync module.
  *
  * @return FIMDB_OK on success, FIMDB_ERROR on error.
  */
@@ -67,7 +69,9 @@ EXPORTED FIMDBErrorCode fim_db_init(int storage,
                                     int value_limit,
                                     bool sync_registry_enabled,
                                     int sync_thread_pool,
-                                    unsigned int sync_queue_size);
+                                    unsigned int sync_queue_size,
+                                    log_fnc_t dbsync_log_function,
+                                    log_fnc_t rsync_log_function);
 
 /**
  * @brief Get entry data using path.

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -17,7 +17,9 @@
 #ifdef WIN_EXPORT
 #define EXPORTED __declspec(dllexport)
 #else
-#define EXPORTED __declspec(dllimport)
+// We avoid the definition __declspec(dllimport) as a workaround for the MinGW bug
+// for delayed loaded DLLs in 32bits (https://www.sourceware.org/bugzilla/show_bug.cgi?id=14339)
+#define EXPORTED
 #endif
 #elif __GNUC__ >= 4
 #define EXPORTED __attribute__((visibility("default")))

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -12,6 +12,19 @@
 #ifndef FIMDB_H
 #define FIMDB_H
 
+// Define EXPORTED for any platform
+#ifdef _WIN32
+#ifdef WIN_EXPORT
+#define EXPORTED __declspec(dllexport)
+#else
+#define EXPORTED __declspec(dllimport)
+#endif
+#elif __GNUC__ >= 4
+#define EXPORTED __attribute__((visibility("default")))
+#else
+#define EXPORTED
+#endif
+
 #include "fimCommonDefs.h"
 #include "commonDefs.h"
 #include "syscheck.h"
@@ -44,17 +57,17 @@ extern "C" {
  *
  * @return FIMDB_OK on success, FIMDB_ERROR on error.
  */
-FIMDBErrorCode fim_db_init(int storage,
-                           int sync_interval,
-                           uint32_t sync_max_interval,
-                           uint32_t sync_response_timeout,
-                           fim_sync_callback_t sync_callback,
-                           logging_callback_t log_callback,
-                           int file_limit,
-                           int value_limit,
-                           bool sync_registry_enabled,
-                           int sync_thread_pool,
-                           unsigned int sync_queue_size);
+EXPORTED FIMDBErrorCode fim_db_init(int storage,
+                                    int sync_interval,
+                                    uint32_t sync_max_interval,
+                                    uint32_t sync_response_timeout,
+                                    fim_sync_callback_t sync_callback,
+                                    logging_callback_t log_callback,
+                                    int file_limit,
+                                    int value_limit,
+                                    bool sync_registry_enabled,
+                                    int sync_thread_pool,
+                                    unsigned int sync_queue_size);
 
 /**
  * @brief Get entry data using path.
@@ -66,8 +79,8 @@ FIMDBErrorCode fim_db_init(int storage,
  * @retval FIMDB_FULL if the table limit was reached.
  * @retval FIMDB_ERR on failure.
  */
-FIMDBErrorCode fim_db_get_path(const char* file_path,
-                               callback_context_t data);
+EXPORTED FIMDBErrorCode fim_db_get_path(const char* file_path,
+                                        callback_context_t data);
 
 /**
  * @brief Find entries based on pattern search.
@@ -79,8 +92,8 @@ FIMDBErrorCode fim_db_get_path(const char* file_path,
  * @retval FIMDB_FULL if the table limit was reached.
  * @retval FIMDB_ERR on failure.
  */
-FIMDBErrorCode fim_db_file_pattern_search(const char* pattern,
-                                          callback_context_t data);
+EXPORTED FIMDBErrorCode fim_db_file_pattern_search(const char* pattern,
+                                                   callback_context_t data);
 
 /**
  * @brief Delete entry from the DB using file path.
@@ -91,21 +104,21 @@ FIMDBErrorCode fim_db_file_pattern_search(const char* pattern,
  * @retval FIMDB_FULL if the table limit was reached.
  * @retval FIMDB_ERR on failure.
  */
-FIMDBErrorCode fim_db_remove_path(const char* path);
+EXPORTED FIMDBErrorCode fim_db_remove_path(const char* path);
 
 /**
  * @brief Get count of all inodes in file_entry table.
  *
  * @return Number of inodes in file_entry table.
  */
-int fim_db_get_count_file_inode();
+EXPORTED int fim_db_get_count_file_inode();
 
 /**
  * @brief Get count of all entries in file_entry table.
  *
  * @return Number of entries in file_entry table.
  */
-int fim_db_get_count_file_entry();
+EXPORTED int fim_db_get_count_file_entry();
 
 /**
  * @brief Makes any necessary queries to get the entry updated in the DB.
@@ -115,8 +128,8 @@ int fim_db_get_count_file_entry();
  *
  * @return FIMDB_OK on success.
  */
-FIMDBErrorCode fim_db_file_update(fim_entry* data,
-                                  callback_context_t callback);
+EXPORTED FIMDBErrorCode fim_db_file_update(fim_entry* data,
+                                           callback_context_t callback);
 
 /**
  * @brief Find entries using the inode.
@@ -127,9 +140,9 @@ FIMDBErrorCode fim_db_file_update(fim_entry* data,
  *
  * @return FIMDB_OK on success.
  */
-FIMDBErrorCode fim_db_file_inode_search(unsigned long long int inode,
-                                        unsigned long int dev,
-                                        callback_context_t data);
+EXPORTED FIMDBErrorCode fim_db_file_inode_search(unsigned long long int inode,
+                                                 unsigned long int dev,
+                                                 callback_context_t data);
 
 /**
  * @brief Push a message to the syscheck queue
@@ -138,14 +151,14 @@ FIMDBErrorCode fim_db_file_inode_search(unsigned long long int inode,
  *
  * @return FIMDB_OK on success.
  */
-FIMDBErrorCode fim_sync_push_msg(const char* msg);
+EXPORTED FIMDBErrorCode fim_sync_push_msg(const char* msg);
 
 /**
  * @brief Thread that performs the syscheck data synchronization
  *
  * @return FIMDB_OK on success.
  */
-FIMDBErrorCode fim_run_integrity();
+EXPORTED FIMDBErrorCode fim_run_integrity();
 
 /*
  * @brief Function that starts a new DBSync transaction.
@@ -156,9 +169,9 @@ FIMDBErrorCode fim_run_integrity();
  *
  * @return TXN_HANDLE Transaction handler.
  */
-TXN_HANDLE fim_db_transaction_start(const char* table,
-                                    result_callback_t row_callback,
-                                    void *user_data);
+EXPORTED TXN_HANDLE fim_db_transaction_start(const char* table,
+                                             result_callback_t row_callback,
+                                             void *user_data);
 
 /**
  * @brief Function to perform a sync row operation (ADD OR REPLACE).
@@ -170,8 +183,8 @@ TXN_HANDLE fim_db_transaction_start(const char* table,
  * @retval FIMDB_FULL if the table limit was reached.
  * @retval FIMDB_ERR on failure.
  */
-FIMDBErrorCode fim_db_transaction_sync_row(TXN_HANDLE txn_handler,
-                                           const fim_entry* entry);
+EXPORTED FIMDBErrorCode fim_db_transaction_sync_row(TXN_HANDLE txn_handler,
+                                                    const fim_entry* entry);
 
 /**
  * @brief Function to perform the deleted rows operation.
@@ -183,16 +196,16 @@ FIMDBErrorCode fim_db_transaction_sync_row(TXN_HANDLE txn_handler,
  * @retval FIMDB_FULL if the table limit was reached.
  * @retval FIMDB_ERR on failure.
  */
-FIMDBErrorCode fim_db_transaction_deleted_rows(TXN_HANDLE txn_handler,
-                                               result_callback_t callback,
-                                               void* txn_ctx);
+EXPORTED FIMDBErrorCode fim_db_transaction_deleted_rows(TXN_HANDLE txn_handler,
+                                                        result_callback_t callback,
+                                                        void* txn_ctx);
 
 /**
  * @brief Turns off the services provided.
  *
  * It will be responsible to close sync and release resources
  */
-void fim_db_teardown();
+EXPORTED void fim_db_teardown();
 
 #ifdef WIN32
 
@@ -203,14 +216,14 @@ void fim_db_teardown();
  *
  * @return Number of entries in registry data table.
  */
-int fim_db_get_count_registry_data();
+EXPORTED int fim_db_get_count_registry_data();
 
 /**
  * @brief Get count of all entries in registry key table.
  *
  * @return Number of entries in registry data table.
  */
-int fim_db_get_count_registry_key();
+EXPORTED int fim_db_get_count_registry_key();
 
 #endif /* WIN32 */
 

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -45,6 +45,9 @@ void DB::init(const int storage,
 
     auto rsyncHandler { std::make_shared<RemoteSync>(syncThreadPool, syncQueueSize) };
 
+    dbsync_initialize(NULL);
+    rsync_initialize(NULL);
+
     FIMDB::instance().init(syncInterval,
                            syncMaxInterval,
                            syncResponseTimeout,

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -244,11 +244,13 @@ FIMDBErrorCode fim_db_init(int storage,
             }
         };
 
-        if (dbsync_log_function) {
+        if (dbsync_log_function)
+        {
             dbsync_initialize(dbsync_log_function);
         }
 
-        if (rsync_log_function) {
+        if (rsync_log_function)
+        {
             rsync_initialize(rsync_log_function);
         }
 

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -45,9 +45,6 @@ void DB::init(const int storage,
 
     auto rsyncHandler { std::make_shared<RemoteSync>(syncThreadPool, syncQueueSize) };
 
-    dbsync_initialize(NULL);
-    rsync_initialize(NULL);
-
     FIMDB::instance().init(syncInterval,
                            syncMaxInterval,
                            syncResponseTimeout,
@@ -130,7 +127,9 @@ FIMDBErrorCode fim_db_init(int storage,
                            int value_limit,
                            bool sync_registry_enabled,
                            int sync_thread_pool,
-                           unsigned int sync_queue_size)
+                           unsigned int sync_queue_size,
+                           log_fnc_t dbsync_log_function,
+                           log_fnc_t rsync_log_function)
 {
     auto retVal { FIMDBErrorCode::FIMDB_ERR };
 
@@ -244,6 +243,15 @@ FIMDBErrorCode fim_db_init(int storage,
                 }
             }
         };
+
+        if (dbsync_log_function) {
+            dbsync_initialize(dbsync_log_function);
+        }
+
+        if (rsync_log_function) {
+            rsync_initialize(rsync_log_function);
+        }
+
         DB::instance().init(storage,
                             sync_interval,
                             sync_max_interval,

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -237,7 +237,9 @@ TEST(DBTest, TestInvalidFimLimit)
                     -1,
                     true,
                     0,
-                    0)
+                    0,
+                    nullptr,
+                    nullptr)
     };
     ASSERT_EQ(result, FIMDB_ERR);
 
@@ -262,7 +264,9 @@ TEST(DBTest, TestValidFimLimit)
                     100000,
                     true,
                     0,
-                    0)
+                    0,
+                    nullptr,
+                    nullptr)
     };
     ASSERT_EQ(result, FIMDB_OK);
 

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
@@ -90,7 +90,9 @@ class DBTestFixture : public testing::Test {
                         100000,
                         true,
                         1,
-                        0);
+                        0,
+                        nullptr,
+                        nullptr);
 
             evt_data = {};
             evt_data.report_event = true;

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -88,7 +88,9 @@ void fim_initialize() {
                                          0,
                                          false,
                                          syscheck.sync_thread_pool,
-                                         syscheck.sync_queue_size);
+                                         syscheck.sync_queue_size,
+                                         NULL,
+                                         NULL);
 #else
     FIMDBErrorCode ret_val = fim_db_init(syscheck.database_store,
                                          syscheck.sync_interval,
@@ -100,7 +102,9 @@ void fim_initialize() {
                                          syscheck.db_entry_registry_limit,
                                          syscheck.enable_registry_synchronization,
                                          syscheck.sync_thread_pool,
-                                         syscheck.sync_queue_size);
+                                         syscheck.sync_queue_size,
+                                         loggingErrorFunction,
+                                         loggingErrorFunction);
 #endif
 
     if (ret_val != FIMDB_OK) {

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -22,6 +22,10 @@ set_target_properties(
 
 target_link_libraries(CLIENT-AGENT ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
+if(${TARGET} STREQUAL "winagent")
+    link_directories(${SRC_FOLDER}/syscheckd/build/bin)
+endif(${TARGET} STREQUAL "winagent")
+
 #include wrappers
 include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
@@ -100,6 +104,10 @@ foreach(counter RANGE ${count})
         CLIENT-AGENT
         ${TEST_DEPS}
     )
+
+    if(${TARGET} STREQUAL "winagent")
+        target_link_libraries(${client-agent_test_name} fimdb)
+    endif(${TARGET} STREQUAL "winagent")
 
     if(NOT client-agent_test_flags STREQUAL " ")
         target_link_libraries(

--- a/src/unit_tests/config/CMakeLists.txt
+++ b/src/unit_tests/config/CMakeLists.txt
@@ -19,6 +19,10 @@ set_target_properties(
 
 target_link_libraries(CONFIG_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
+if(${TARGET} STREQUAL "winagent")
+    link_directories(${SRC_FOLDER}/syscheckd/build/bin)
+endif(${TARGET} STREQUAL "winagent")
+
 # Include wrappers
 include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
@@ -44,6 +48,9 @@ foreach(counter RANGE ${count})
         CONFIG_O
         ${TEST_DEPS}
     )
+    if(${TARGET} STREQUAL "winagent")
+        target_link_libraries(${test_name} fimdb)
+    endif(${TARGET} STREQUAL "winagent")
 
     if(NOT test_flags STREQUAL " ")
         target_link_libraries(

--- a/src/unit_tests/os_execd/CMakeLists.txt
+++ b/src/unit_tests/os_execd/CMakeLists.txt
@@ -20,6 +20,10 @@ set_target_properties(
 
 target_link_libraries(EXECD_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
+if(${TARGET} STREQUAL "winagent")
+    link_directories(${SRC_FOLDER}/syscheckd/build/bin)
+endif(${TARGET} STREQUAL "winagent")
+
 #include wrappers
 include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
@@ -64,6 +68,10 @@ foreach(counter RANGE ${count})
         EXECD_O
         ${TEST_DEPS}
     )
+
+    if(${TARGET} STREQUAL "winagent")
+          target_link_libraries(${execd_test_name} fimdb)
+    endif(${TARGET} STREQUAL "winagent")
 
     if(NOT execd_test_flags STREQUAL " ")
         target_link_libraries(

--- a/src/unit_tests/os_regex/CMakeLists.txt
+++ b/src/unit_tests/os_regex/CMakeLists.txt
@@ -26,6 +26,10 @@ set_target_properties(
 
 target_link_libraries(OS_REGEX_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
+if(${TARGET} STREQUAL "winagent")
+    link_directories(${SRC_FOLDER}/syscheckd/build/bin)
+endif(${TARGET} STREQUAL "winagent")
+
 # Generate os_regex tests
 list(APPEND os_regex_names "test_os_regex")
 if(${TARGET} STREQUAL "winagent")
@@ -75,6 +79,9 @@ foreach(counter RANGE ${count})
         OS_REGEX_O
         ${TEST_DEPS}
     )
+    if(${TARGET} STREQUAL "winagent")
+          target_link_libraries(${test_name} fimdb)
+    endif(${TARGET} STREQUAL "winagent")
 
     if(NOT test_macro STREQUAL " ")
     target_compile_definitions(

--- a/src/unit_tests/os_xml/CMakeLists.txt
+++ b/src/unit_tests/os_xml/CMakeLists.txt
@@ -17,6 +17,10 @@ set_target_properties(
     LINKER_LANGUAGE C
 )
 
+if(${TARGET} STREQUAL "winagent")
+    link_directories(${SRC_FOLDER}/syscheckd/build/bin)
+endif(${TARGET} STREQUAL "winagent")
+
 target_link_libraries(OS_XML_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
 add_executable(test_os_xml test_os_xml.c)
@@ -27,6 +31,7 @@ if(${TARGET} STREQUAL "winagent")
 target_link_libraries(test_os_xml "-Wl,--wrap,getpid -Wl,--wrap,getSyscheckConfig -Wl,--wrap,getRootcheckConfig \
                                    -Wl,--wrap,getSyscheckInternalOptions -Wl,--wrap=Start_win32_Syscheck \
                                    -Wl,--wrap,syscom_dispatch -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
-                                   -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown")
+                                   -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown"
+                                   fimdb)
 endif()
 add_test(NAME test_os_xml COMMAND test_os_xml)

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -1,6 +1,10 @@
 #include wrappers
 include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
+if(${TARGET} STREQUAL "winagent")
+    link_directories(${SRC_FOLDER}/syscheckd/build/bin)
+endif(${TARGET} STREQUAL "winagent")
+
 # Tests list and flags
 list(APPEND shared_tests_names "test_list_op")
 set(LIST_OP_BASE_FLAGS "-Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,pthread_mutex_lock \
@@ -321,6 +325,9 @@ foreach(counter RANGE ${count})
             ${test_name}
             ${TEST_DEPS}
         )
+        if(${TARGET} STREQUAL "winagent")
+          target_link_libraries(${test_name} fimdb)
+        endif(${TARGET} STREQUAL "winagent")
     endif()
 
     if(NOT test_flags STREQUAL " ")

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -61,6 +61,10 @@ set_target_properties(
 
 target_link_libraries(SYSCHECK_O ROOTCHECK_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
+if(${TARGET} STREQUAL "winagent")
+    link_directories(${SRC_FOLDER}/syscheckd/build/bin)
+endif(${TARGET} STREQUAL "winagent")
+
 # Add fim_tools library to compilation
 include_directories(${SRC_FOLDER}/syscheckd/include)
 include_directories(${SRC_FOLDER}/syscheckd/src)
@@ -296,6 +300,10 @@ foreach(counter RANGE ${count})
       ${TEST_DEPS}
     )
 
+    if(${TARGET} STREQUAL "winagent")
+      target_link_libraries(test_${test_name} fimdb)
+    endif(${TARGET} STREQUAL "winagent")
+
     if(NOT test_flags STREQUAL " ")
         target_link_libraries(
             test_${test_name}
@@ -320,6 +328,7 @@ if(${TARGET} STREQUAL "winagent")
         ${test_name}
         SYSCHECK_EVENT_O
         ${TEST_EVENT_DEPS}
+        fimdb
       )
 
       target_compile_definitions(${test_name} PUBLIC WIN_WHODATA)
@@ -370,7 +379,8 @@ if(${TARGET} STREQUAL "winagent")
                                           -Wl,--wrap,get_file_user -Wl,--wrap,fim_registry_scan \
                                           -Wl,--wrap,get_UTC_modification_time -Wl,--wrap,fim_sync_push_msg \
                                           -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
-                                          -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown")
+                                          -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown"
+                                          fimdb)
 else()
     target_link_libraries(test_create_db "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=lstat -Wl,--wrap=count_watches \
                                           -Wl,--wrap,get_user -Wl,--wrap,realpath -Wl,--wrap,add_whodata_directory \

--- a/src/unit_tests/syscheckd/registry/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/registry/CMakeLists.txt
@@ -3,10 +3,15 @@ include_directories(${SRC_FOLDER}/syscheckd/include)
 
 link_directories(${SRC_FOLDER}/unit_tests/wrappers/syscheckd/registry)
 
+if(${TARGET} STREQUAL "winagent")
+    link_directories(${SRC_FOLDER}/syscheckd/build/bin)
+endif(${TARGET} STREQUAL "winagent")
+
 # registry.c tests
 add_executable(test_registry test_registry.c)
 
 target_compile_options(test_registry PRIVATE "-Wall")
+target_compile_options(test_registry PRIVATE "-g")
 
 target_link_libraries(test_registry SYSCHECK_O ${TEST_DEPS} fim_shared)
 target_link_libraries(test_registry "${DEBUG_OP_WRAPPERS} \
@@ -22,6 +27,10 @@ target_link_libraries(test_registry "${DEBUG_OP_WRAPPERS} \
                                      -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
                                      -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown")
 
+if(${TARGET} STREQUAL "winagent")
+    target_link_libraries(test_registry fimdb)
+endif(${TARGET} STREQUAL "winagent")
+
 add_test(NAME test_registry COMMAND test_registry)
 
 # events.c tests
@@ -36,5 +45,9 @@ target_link_libraries(test_events "${DEBUG_OP_WRAPPERS} \
                                    -Wl,--wrap=fim_db_get_count_registry_data -Wl,--wrap=fim_db_get_count_registry_key -Wl,--wrap=syscom_dispatch \
                                    -Wl,--wrap=fim_db_file_update -Wl,--wrap,fim_db_get_path -Wl,--wrap=fim_db_file_pattern_search -Wl,--wrap=fim_db_remove_path \
                                    -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown")
+
+if(${TARGET} STREQUAL "winagent")
+    target_link_libraries(test_events fimdb)
+endif(${TARGET} STREQUAL "winagent")
 
 add_test(NAME test_events COMMAND test_events)

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -111,6 +111,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
     target_link_libraries(test_audit_parse "${AUDIT_PARSE_FLAGS}")
     add_test(NAME test_audit_parse COMMAND test_audit_parse)
 else()
+    link_directories(${SRC_FOLDER}/syscheckd/build/bin)
     add_executable(test_win_whodata test_win_whodata.c)
     target_compile_options(test_win_whodata PRIVATE "-Wall")
     set(WIN_WHODATA_FLAGS "-Wl,--wrap,wstr_replace -Wl,--wrap,SendMSG \
@@ -132,7 +133,7 @@ else()
                            -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
                            -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown ${HASH_OP_WRAPPERS} \
                            ${DEBUG_OP_WRAPPERS}")
-    target_link_libraries(test_win_whodata SYSCHECK_EVENT_O ${TEST_EVENT_DEPS})
+    target_link_libraries(test_win_whodata SYSCHECK_EVENT_O ${TEST_EVENT_DEPS} fimdb)
 
     target_link_libraries(test_win_whodata "${WIN_WHODATA_FLAGS}")
     add_test(NAME test_win_whodata COMMAND test_win_whodata)

--- a/src/unit_tests/wazuh_modules/github/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/github/CMakeLists.txt
@@ -17,7 +17,7 @@ set(WM_GITHUB_BASE_FLAGS "-Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,_merr
                           -Wl,--wrap,OSRegex_FreePattern -Wl,--wrap,wurl_http_request -Wl,--wrap,strftime -Wl,--wrap,gmtime_r \
                           -Wl,--wrap,isDebug")
 if(${TARGET} STREQUAL "winagent")
-    list(APPEND tests_flags "${WM_GITHUB_BASE_FLAGS} -Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck -Wl,--wrap=is_fim_shutdown \ 
+    list(APPEND tests_flags "${WM_GITHUB_BASE_FLAGS} -Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck -Wl,--wrap=is_fim_shutdown \
                              -Wl,--wrap=fim_db_teardown -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=_imp__rsync_initialize")
 else()
     list(APPEND tests_flags "${WM_GITHUB_BASE_FLAGS}")
@@ -49,6 +49,9 @@ set_target_properties(
 
 target_link_libraries(GITHUB_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
+if(${TARGET} STREQUAL "winagent")
+    link_directories(${SRC_FOLDER}/syscheckd/build/bin)
+endif(${TARGET} STREQUAL "winagent")
 
 # Compiling tests
 list(LENGTH tests_names count)
@@ -80,6 +83,9 @@ foreach(counter RANGE ${count})
             ${test_name}
             ${TEST_DEPS}
         )
+        if(${TARGET} STREQUAL "winagent")
+            target_link_libraries(${test_name} fimdb)
+        endif(${TARGET} STREQUAL "winagent")
     endif()
 
 

--- a/src/unit_tests/wazuh_modules/office365/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/office365/CMakeLists.txt
@@ -46,6 +46,9 @@ set_target_properties(
 
 target_link_libraries(OFFICE365_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
+if(${TARGET} STREQUAL "winagent")
+    link_directories(${SRC_FOLDER}/syscheckd/build/bin)
+endif(${TARGET} STREQUAL "winagent")
 
 # Compiling tests
 list(LENGTH tests_names count)
@@ -77,6 +80,9 @@ foreach(counter RANGE ${count})
             ${test_name}
             ${TEST_DEPS}
         )
+        if(${TARGET} STREQUAL "winagent")
+          target_link_libraries(${test_name} fimdb)
+        endif(${TARGET} STREQUAL "winagent")
     endif()
 
     if(NOT test_flags STREQUAL " ")

--- a/src/unit_tests/win32/CMakeLists.txt
+++ b/src/unit_tests/win32/CMakeLists.txt
@@ -22,6 +22,7 @@ set_target_properties(
 )
 
 target_link_libraries(WIN32 ${WAZUHLIB} ${WAZUHEXT} -lpthread)
+link_directories(${SRC_FOLDER}/syscheckd/build/bin)
 
 #include wrappers
 include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
@@ -51,6 +52,7 @@ foreach(counter RANGE ${count})
         ${WAZUHEXT}
         WIN32
         ${TEST_DEPS}
+        fimdb
     )
 
     if(NOT win32_test_flags STREQUAL " ")

--- a/src/win32/wazuh-installer.nsi
+++ b/src/win32/wazuh-installer.nsi
@@ -219,6 +219,7 @@ Section "Wazuh Agent (required)" MainSec
     File /oname=rsync.dll ..\shared_modules\rsync\build\bin\rsync.dll
     File /oname=sysinfo.dll ..\data_provider\build\bin\sysinfo.dll
     File /oname=syscollector.dll ..\wazuh_modules\syscollector\build\bin\syscollector.dll
+    File /oname=libfimdb.dll ..\syscheckd/build/bin/libfimdb.dll
     File /oname=queue\syscollector\norm_config.json ..\wazuh_modules\syscollector\norm_config.json
     File VERSION
     File REVISION

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -208,6 +208,9 @@
                     <Component Id="SYSCOLLECTOR_DLL" DiskId="1" Guid="7CE63D8B-C959-43CC-A7B6-4226414EBADB">
                         <File Id="SYSCOLLECTOR_DLL" Name="syscollector.dll" Source="..\wazuh_modules\syscollector\build\bin\syscollector.dll" />
                     </Component>
+                    <Component Id="FIMDB_DLL" DiskId="1" Guid="15806BCA-876E-41D7-A82E-623EEEC63C3A">
+                        <File Id="FIMDB_DLL" Name="libfimdb.dll" Source="..\syscheckd/build/bin/libfimdb.dll" />
+                    </Component>
 
                     <!-- Mark this file as permanent, so it is not deleted on uninstall. -->
                     <Component Id="LOCAL_INTERNAL_OPTIONS.CONF" DiskId="1" Guid="10245598-2EE7-4EDB-A114-5398F01A21F9" NeverOverwrite="yes" Permanent="yes">

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -209,7 +209,7 @@
                         <File Id="SYSCOLLECTOR_DLL" Name="syscollector.dll" Source="..\wazuh_modules\syscollector\build\bin\syscollector.dll" />
                     </Component>
                     <Component Id="FIMDB_DLL" DiskId="1" Guid="15806BCA-876E-41D7-A82E-623EEEC63C3A">
-                        <File Id="FIMDB_DLL" Name="libfimdb.dll" Source="..\syscheckd/build/bin/libfimdb.dll" />
+                        <File Id="FIMDB_DLL" Name="libfimdb.dll" Source="..\syscheckd\build\bin\libfimdb.dll" />
                     </Component>
 
                     <!-- Mark this file as permanent, so it is not deleted on uninstall. -->
@@ -606,6 +606,7 @@
             <ComponentRef Id="AGENT_AUTH.EXE" />
             <ComponentRef Id="SYSCOLLECTOR_NORM_CONFIG" />
             <ComponentRef Id="SYSCOLLECTOR_DLL" />
+            <ComponentRef Id="FIMDB_DLL" />
             <ComponentRef Id="LIBWAZUHEXT_DLL" />
             <ComponentRef Id="LIBWAZUHSHARED_DLL" />
             <ComponentRef Id="RSYNC_DLL" />

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -101,10 +101,6 @@ int local_start()
         merror_exit("WSAStartup() failed");
     }
 
-    /* Initialize error logging for shared modulesd */
-    dbsync_initialize(loggingErrorFunction);
-    rsync_initialize(loggingErrorFunction);
-
     /* Read agent config */
     mdebug1("Reading agent configuration.");
     if (ClientConf(cfg) < 0) {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17882|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This issue removes all the implicit libraries loaded in the `wazuh-agent.exe` binary after the new FIM implementation.
These are the main steps involved:
- Make the `fimdb` a shared library in Windows and create a `.lib` delayed version of it.
- Remove the syscheck code compiled by the Makefile and inserted directly as objects in the final binaries.
- Avoid the implicit load of `libgcc_s_dw2-1.dll` by compiling the Windows agent with gcc instead of g++.

Check the issue for more details of the process. 

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

Only system libraries are shown in the imports sections

![2023-07-18_20-19](https://github.com/wazuh/wazuh/assets/65046601/c3f9a919-c89f-47e9-a1e3-6631951b834f)


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation

The agent was connected to manager and:

- [x] No ERROR/WARNING messages are generated after these changes in the agent's log.
- [x] The FIM module generates alerts as expected.
- [x] The FIM synchronization with the manager is working.
