### PR TITLE
Fix/17695 scan time option

### DIFF
--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -237,7 +237,7 @@ void start_daemon()
         syscheck.time = 604800;
     }else if(syscheck.scan_time){
         syscheck.time=86400;
-    }
+    } 
 
     // Deleting content of FIM diff directory
     char diff_file_dir[PATH_MAX];

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -232,9 +232,11 @@ void start_daemon()
 #endif
 
     // If the scan time/day is set, reset the syscheck.time/rootcheck.time
-    if (syscheck.scan_time || syscheck.scan_day) {
+    if ((syscheck.scan_time && syscheck.scan_day) || (!syscheck.scan_time && syscheck.scan_day)) {
         // At least once a week
         syscheck.time = 604800;
+    }else if(syscheck.scan_time){
+        syscheck.time=86400;
     }
 
     // Deleting content of FIM diff directory


### PR DESCRIPTION
|Scan time option is not working as expected #17695|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Fixed the scan_time option

  When both syscheck.scan_time and syscheck.scan_day are set or only syscheck.scan_day is set, set the syscheck.time to "604800" (1 week).
When only syscheck.scan_time is set, set the syscheck.time to "86400" (1 day).
Here is a more detailed explanation of the code:

The syscheck.scan_time option specifies the time interval between scans.
The syscheck.scan_day option specifies the day of the week on which the scan should be run.
If both syscheck.scan_time and syscheck.scan_day are set, then the scan will be run on the specified day of the week at the specified time interval.
If only syscheck.scan_day is set, then the scan will be run on the specified day of the week at the default time interval, which is 1 week.
If only syscheck.scan_time is set, then the scan will be run at the specified time interval every day.
The code that you provided fixes the syscheck.scan_time option by setting the syscheck.time to the appropriate value depending on whether syscheck.scan_day is set. This ensures that the scan is run at the correct interval.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
 <syscheck>
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>10</frequency>

    <scan_on_start>no</scan_on_start>
    <scan_time>8:30</scan_time>

    <!-- Generate alert when new file detected -->
    <alert_new_files>no</alert_new_files>
    <directories>/tmp/testing</directories>
  </syscheck>
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
{"timestamp":"2023/07/20 14:22:14","tag":"wazuh-syscheckd","level":"info","description":"(6010): File integrity monitoring scan frequency: 86400 seconds"}

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors