### PR TITLE
Enhancing Engine syntax

### DIFF
--- a/src/engine/ruleset/integrations/apache-http/decoders/apache-access.yml
+++ b/src/engine/ruleset/integrations/apache-http/decoders/apache-access.yml
@@ -25,8 +25,8 @@ check:
 # - event.dataset: apache-access
 
 definitions:
-  isSuccess: +is_not_null/http.response.status_code AND +int_less/http.response.status_code/400
-  isFailed: +is_not_null/http.response.status_code AND +int_greater_or_equal/http.response.status_code/400
+  isSuccess: +is_not_null/$http.response.status_code AND +int_less/$http.response.status_code/400
+  isFailed: +is_not_null/$http.response.status_code AND +int_greater_or_equal/$http.response.status_code/400
 
 parse:
   logpar:

--- a/src/engine/ruleset/integrations/apache-http/decoders/apache-access.yml
+++ b/src/engine/ruleset/integrations/apache-http/decoders/apache-access.yml
@@ -1,6 +1,6 @@
 name: decoder/apache-access/0
 
-sources:
+parents:
   - decoder/integrations/0
 
 metadata:

--- a/src/engine/ruleset/integrations/apache-http/decoders/apache-error.yml
+++ b/src/engine/ruleset/integrations/apache-http/decoders/apache-error.yml
@@ -1,6 +1,6 @@
 name: decoder/apache-error/0
 
-sources:
+parents:
   - decoder/integrations/0
 
 metadata:

--- a/src/engine/ruleset/integrations/auditd/decoders/auditd-kv.yml
+++ b/src/engine/ruleset/integrations/auditd/decoders/auditd-kv.yml
@@ -13,7 +13,7 @@ metadata:
       url: https://wazuh.com
       date: 2023/01/30
 
-sources:
+parents:
   - decoder/auditd/0
 
 check:

--- a/src/engine/ruleset/integrations/auditd/decoders/auditd-kv.yml
+++ b/src/engine/ruleset/integrations/auditd/decoders/auditd-kv.yml
@@ -44,7 +44,7 @@ normalize:
   # -> remove quotes from start or end
   # -> key is arch or value is c000003e -> ".. .arch" : "x86_64"
 
-  - check: +is_null/auditd.log.exe OR auditd.log.exe==? OR +string_equal/$auditd.log.exe/$~null_parenthesis
+  - check: +is_null/$auditd.log.exe OR $auditd.log.exe==? OR +string_equal/$auditd.log.exe/$~null_parenthesis
     map:
       - auditd.log.exe: +delete
   - map:
@@ -52,7 +52,7 @@ normalize:
       - auditd.log.exe: +trim/both/"
       - auditd.log.exe: +trim/both/'
 
-  - check: +is_null/auditd.log.cmd OR auditd.log.cmd==? OR +string_equal/$auditd.log.cmd/$~null_parenthesis
+  - check: +is_null/$auditd.log.cmd OR auditd.log.cmd==? OR +string_equal/$auditd.log.cmd/$~null_parenthesis
     map:
       - auditd.log.cmd: +delete
   - map:
@@ -60,7 +60,7 @@ normalize:
       - auditd.log.cmd: +trim/both/"
       - auditd.log.cmd: +trim/both/'
 
-  - check: +is_null/auditd.log.data OR auditd.log.data==? OR +string_equal/$auditd.log.data/$~null_parenthesis
+  - check: +is_null/$auditd.log.data OR auditd.log.data==? OR +string_equal/$auditd.log.data/$~null_parenthesis
     map:
       - auditd.log.data: +delete
   - map:
@@ -68,7 +68,7 @@ normalize:
       - auditd.log.data: +trim/both/"
       - auditd.log.data: +trim/both/'
 
-  - check: +is_null/auditd.log.path OR auditd.log.path==? OR +string_equal/$auditd.log.path/$~null_parenthesis
+  - check: +is_null/$auditd.log.path OR auditd.log.path==? OR +string_equal/$auditd.log.path/$~null_parenthesis
     map:
       - auditd.log.path: +delete
   - map:
@@ -76,7 +76,7 @@ normalize:
       - auditd.log.path: +trim/both/"
       - auditd.log.path: +trim/both/'
 
-  - check: +is_null/auditd.log.comm OR auditd.log.comm==? OR +string_equal/$auditd.log.comm/$~null_parenthesis
+  - check: +is_null/$auditd.log.comm OR auditd.log.comm==? OR +string_equal/$auditd.log.comm/$~null_parenthesis
     map:
       - auditd.log.comm: +delete
   - map:
@@ -84,7 +84,7 @@ normalize:
       - auditd.log.comm: +trim/both/"
       - auditd.log.comm: +trim/both/'
 
-  - check: +is_null/auditd.data.file OR auditd.data.file==? OR +string_equal/$auditd.data.file/$~null_parenthesis
+  - check: +is_null/$auditd.data.file OR auditd.data.file==? OR +string_equal/$auditd.data.file/$~null_parenthesis
     map:
       - auditd.data.file: +delete
   - map:
@@ -92,7 +92,7 @@ normalize:
       - auditd.data.file: +trim/both/"
       - auditd.data.file: +trim/both/'
 
-  - check: +is_null/auditd.log.name OR auditd.log.name==? OR +string_equal/$auditd.log.name/$~null_parenthesis
+  - check: +is_null/$auditd.log.name OR auditd.log.name==? OR +string_equal/$auditd.log.name/$~null_parenthesis
     map:
       - auditd.log.name: +delete
   - map:
@@ -100,7 +100,7 @@ normalize:
       - auditd.log.name: +trim/both/"
       - auditd.log.name: +trim/both/'
 
-  - check: +is_null/auditd.data.watch OR auditd.data.watch==? OR +string_equal/$auditd.data.watch/$~null_parenthesis
+  - check: +is_null/$auditd.data.watch OR auditd.data.watch==? OR +string_equal/$auditd.data.watch/$~null_parenthesis
     map:
       - auditd.data.watch: +delete
   - map:
@@ -108,7 +108,7 @@ normalize:
       - auditd.data.watch: +trim/both/"
       - auditd.data.watch: +trim/both/'
 
-  - check: +is_null/auditd.log.cwd OR auditd.log.cwd==? OR +string_equal/$auditd.log.cwd/$~null_parenthesis
+  - check: +is_null/$auditd.log.cwd OR auditd.log.cwd==? OR +string_equal/$auditd.log.cwd/$~null_parenthesis
     map:
       - auditd.log.cwd: +delete
   - map:
@@ -116,7 +116,7 @@ normalize:
       - auditd.log.cwd: +trim/both/"
       - auditd.log.cwd: +trim/both/'
 
-  - check: +is_null/auditd.log.acct OR auditd.log.acct==? OR +string_equal/$auditd.log.acct/$~null_parenthesis
+  - check: +is_null/$auditd.log.acct OR auditd.log.acct==? OR +string_equal/$auditd.log.acct/$~null_parenthesis
     map:
       - auditd.log.acct: +delete
   - map:
@@ -124,7 +124,7 @@ normalize:
       - auditd.log.acct: +trim/both/"
       - auditd.log.acct: +trim/both/'
 
-  - check: +is_null/auditd.data.dir OR auditd.data.dir==? OR +string_equal/$auditd.data.dir/$~null_parenthesis
+  - check: +is_null/$auditd.data.dir OR auditd.data.dir==? OR +string_equal/$auditd.data.dir/$~null_parenthesis
     map:
       - auditd.data.dir: +delete
   - map:
@@ -132,7 +132,7 @@ normalize:
       - auditd.data.dir: +trim/both/"
       - auditd.data.dir: +trim/both/'
 
-  - check: +is_null/auditd.data.vm OR auditd.data.vm==? OR +string_equal/$auditd.data.vm/$~null_parenthesis
+  - check: +is_null/$auditd.data.vm OR auditd.data.vm==? OR +string_equal/$auditd.data.vm/$~null_parenthesis
     map:
       - auditd.data.vm: +delete
   - map:
@@ -140,7 +140,7 @@ normalize:
       - auditd.data.vm: +trim/both/"
       - auditd.data.vm: +trim/both/'
 
-  - check: +is_null/auditd.data.old-chardev OR auditd.data.old-chardev==? OR +string_equal/$auditd.data.old-chardev/$~null_parenthesis
+  - check: +is_null/$auditd.data.old-chardev OR auditd.data.old-chardev==? OR +string_equal/$auditd.data.old-chardev/$~null_parenthesis
     map:
       - auditd.data.old-chardev: +delete
   - map:
@@ -148,7 +148,7 @@ normalize:
       - auditd.data.old-chardev: +trim/both/"
       - auditd.data.old-chardev: +trim/both/'
 
-  - check: +is_null/auditd.data.new-chardev OR auditd.data.new-chardev==? OR +string_equal/$auditd.data.new-chardev/$~null_parenthesis
+  - check: +is_null/$auditd.data.new-chardev OR auditd.data.new-chardev==? OR +string_equal/$auditd.data.new-chardev/$~null_parenthesis
     map:
       - auditd.data.new-chardev: +delete
   - map:
@@ -156,7 +156,7 @@ normalize:
       - auditd.data.new-chardev: +trim/both/"
       - auditd.data.new-chardev: +trim/both/'
 
-  - check: +is_null/auditd.data.old-disk OR auditd.data.old-disk==? OR +string_equal/$auditd.data.old-disk/$~null_parenthesis
+  - check: +is_null/$auditd.data.old-disk OR auditd.data.old-disk==? OR +string_equal/$auditd.data.old-disk/$~null_parenthesis
     map:
       - auditd.data.old-disk: +delete
   - map:
@@ -164,7 +164,7 @@ normalize:
       - auditd.data.old-disk: +trim/both/"
       - auditd.data.old-disk: +trim/both/'
 
-  - check: +is_null/auditd.data.new-disk OR auditd.data.new-disk==? OR +string_equal/$auditd.data.new-disk/$~null_parenthesis
+  - check: +is_null/$auditd.data.new-disk OR auditd.data.new-disk==? OR +string_equal/$auditd.data.new-disk/$~null_parenthesis
     map:
       - auditd.data.new-disk: +delete
   - map:
@@ -172,7 +172,7 @@ normalize:
       - auditd.data.new-disk: +trim/both/"
       - auditd.data.new-disk: +trim/both/'
 
-  - check: +is_null/auditd.data.old-fs OR auditd.data.old-fs==? OR +string_equal/$auditd.data.old-fs/$~null_parenthesis
+  - check: +is_null/$auditd.data.old-fs OR auditd.data.old-fs==? OR +string_equal/$auditd.data.old-fs/$~null_parenthesis
     map:
       - auditd.data.old-fs: +delete
   - map:
@@ -180,7 +180,7 @@ normalize:
       - auditd.data.old-fs: +trim/both/"
       - auditd.data.old-fs: +trim/both/'
 
-  - check: +is_null/auditd.data.new-fs OR auditd.data.new-fs==? OR +string_equal/$auditd.data.new-fs/$~null_parenthesis
+  - check: +is_null/$auditd.data.new-fs OR auditd.data.new-fs==? OR +string_equal/$auditd.data.new-fs/$~null_parenthesis
     map:
       - auditd.data.new-fs: +delete
   - map:
@@ -188,7 +188,7 @@ normalize:
       - auditd.data.new-fs: +trim/both/"
       - auditd.data.new-fs: +trim/both/'
 
-  - check: +is_null/auditd.data.old-net OR auditd.data.old-net==? OR +string_equal/$auditd.data.old-net/$~null_parenthesis
+  - check: +is_null/$auditd.data.old-net OR auditd.data.old-net==? OR +string_equal/$auditd.data.old-net/$~null_parenthesis
     map:
       - auditd.data.old-net: +delete
   - map:
@@ -196,7 +196,7 @@ normalize:
       - auditd.data.old-net: +trim/both/"
       - auditd.data.old-net: +trim/both/'
 
-  - check: +is_null/auditd.data.new-net OR auditd.data.new-net==? OR +string_equal/$auditd.data.new-net/$~null_parenthesis
+  - check: +is_null/$auditd.data.new-net OR auditd.data.new-net==? OR +string_equal/$auditd.data.new-net/$~null_parenthesis
     map:
       - auditd.data.new-net: +delete
   - map:
@@ -204,7 +204,7 @@ normalize:
       - auditd.data.new-net: +trim/both/"
       - auditd.data.new-net: +trim/both/'
 
-  - check: +is_null/auditd.data.device OR auditd.data.device==? OR +string_equal/$auditd.data.device/$~null_parenthesis
+  - check: +is_null/$auditd.data.device OR auditd.data.device==? OR +string_equal/$auditd.data.device/$~null_parenthesis
     map:
       - auditd.data.device: +delete
   - map:
@@ -212,7 +212,7 @@ normalize:
       - auditd.data.device: +trim/both/"
       - auditd.data.device: +trim/both/'
 
-  - check: +is_null/auditd.data.cgroup OR auditd.data.cgroup==? OR +string_equal/$auditd.data.cgroup/$~null_parenthesis
+  - check: +is_null/$auditd.data.cgroup OR auditd.data.cgroup==? OR +string_equal/$auditd.data.cgroup/$~null_parenthesis
     map:
       - auditd.data.cgroup: +delete
   - map:
@@ -220,7 +220,7 @@ normalize:
       - auditd.data.cgroup: +trim/both/"
       - auditd.data.cgroup: +trim/both/'
 
-  - check: +is_null/auditd.data.apparmor OR auditd.data.apparmor==? OR +string_equal/$auditd.data.apparmor/$~null_parenthesis
+  - check: +is_null/$auditd.data.apparmor OR auditd.data.apparmor==? OR +string_equal/$auditd.data.apparmor/$~null_parenthesis
     map:
       - auditd.data.apparmor: +delete
   - map:
@@ -228,7 +228,7 @@ normalize:
       - auditd.data.apparmor: +trim/both/"
       - auditd.data.apparmor: +trim/both/'
 
-  - check: +is_null/auditd.log.operation OR auditd.log.operation==? OR +string_equal/$auditd.log.operation/$~null_parenthesis
+  - check: +is_null/$auditd.log.operation OR auditd.log.operation==? OR +string_equal/$auditd.log.operation/$~null_parenthesis
     map:
       - auditd.log.operation: +delete
   - map:
@@ -236,7 +236,7 @@ normalize:
       - auditd.log.operation: +trim/both/"
       - auditd.log.operation: +trim/both/'
 
-  - check: +is_null/auditd.log.denied_mask OR auditd.log.denied_mask==? OR +string_equal/$auditd.log.denied_mask/$~null_parenthesis
+  - check: +is_null/$auditd.log.denied_mask OR auditd.log.denied_mask==? OR +string_equal/$auditd.log.denied_mask/$~null_parenthesis
     map:
       - auditd.log.denied_mask: +delete
   - map:
@@ -244,7 +244,7 @@ normalize:
       - auditd.log.denied_mask: +trim/both/"
       - auditd.log.denied_mask: +trim/both/'
 
-  - check: +is_null/auditd.log.info OR auditd.log.info==? OR +string_equal/$auditd.log.info/$~null_parenthesis
+  - check: +is_null/$auditd.log.info OR auditd.log.info==? OR +string_equal/$auditd.log.info/$~null_parenthesis
     map:
       - auditd.log.info: +delete
   - map:
@@ -252,7 +252,7 @@ normalize:
       - auditd.log.info: +trim/both/"
       - auditd.log.info: +trim/both/'
 
-  - check: +is_null/auditd.log.profile OR auditd.log.profile==? OR +string_equal/$auditd.log.profile/$~null_parenthesis
+  - check: +is_null/$auditd.log.profile OR auditd.log.profile==? OR +string_equal/$auditd.log.profile/$~null_parenthesis
     map:
       - auditd.log.profile: +delete
   - map:
@@ -260,7 +260,7 @@ normalize:
       - auditd.log.profile: +trim/both/"
       - auditd.log.profile: +trim/both/'
 
-  - check: +is_null/auditd.log.requested_mask OR auditd.log.requested_mask==? OR +string_equal/$auditd.log.requested_mask/$~null_parenthesis
+  - check: +is_null/$auditd.log.requested_mask OR auditd.log.requested_mask==? OR +string_equal/$auditd.log.requested_mask/$~null_parenthesis
     map:
       - auditd.log.requested_mask: +delete
   - map:
@@ -268,7 +268,7 @@ normalize:
       - auditd.log.requested_mask: +trim/both/"
       - auditd.log.requested_mask: +trim/both/'
 
-  - check: +is_null/auditd.data.old-rng OR auditd.data.old-rng==? OR +string_equal/$auditd.data.old-rng/$~null_parenthesis
+  - check: +is_null/$auditd.data.old-rng OR auditd.data.old-rng==? OR +string_equal/$auditd.data.old-rng/$~null_parenthesis
     map:
       - auditd.data.old-rng: +delete
   - map:
@@ -284,7 +284,7 @@ normalize:
       - auditd.data.new-rng: +trim/both/"
       - auditd.data.new-rng: +trim/both/'
 
-  - check: +is_null/auditd.data.ocomm OR auditd.data.ocomm==? OR +string_equal/$auditd.data.ocomm/$~null_parenthesis
+  - check: +is_null/$auditd.data.ocomm OR auditd.data.ocomm==? OR +string_equal/$auditd.data.ocomm/$~null_parenthesis
     map:
       - auditd.data.ocomm: +delete
   - map:
@@ -292,7 +292,7 @@ normalize:
       - auditd.data.ocomm: +trim/both/"
       - auditd.data.ocomm: +trim/both/'
 
-  - check: +is_null/auditd.data.grp OR auditd.data.grp==? OR +string_equal/$auditd.data.grp/$~null_parenthesis
+  - check: +is_null/$auditd.data.grp OR auditd.data.grp==? OR +string_equal/$auditd.data.grp/$~null_parenthesis
     map:
       - auditd.data.grp: +delete
   - map:
@@ -300,7 +300,7 @@ normalize:
       - auditd.data.grp: +trim/both/"
       - auditd.data.grp: +trim/both/'
 
-  - check: +is_null/auditd.log.new_group OR auditd.log.new_group==? OR +string_equal/$auditd.log.new_group/$~null_parenthesis
+  - check: +is_null/$auditd.log.new_group OR auditd.log.new_group==? OR +string_equal/$auditd.log.new_group/$~null_parenthesis
     map:
       - auditd.log.new_group: +delete
   - map:
@@ -308,7 +308,7 @@ normalize:
       - auditd.log.new_group: +trim/both/"
       - auditd.log.new_group: +trim/both/'
 
-  - check: +is_null/auditd.data.invalid_context OR auditd.data.invalid_context==? OR +string_equal/$auditd.data.invalid_context/$~null_parenthesis
+  - check: +is_null/$auditd.data.invalid_context OR auditd.data.invalid_context==? OR +string_equal/$auditd.data.invalid_context/$~null_parenthesis
     map:
       - auditd.data.invalid_context: +delete
   - map:
@@ -316,7 +316,7 @@ normalize:
       - auditd.data.invalid_context: +trim/both/"
       - auditd.data.invalid_context: +trim/both/'
 
-  - check: +is_null/auditd.log.sw OR auditd.log.sw==? OR +string_equal/$auditd.log.sw/$~null_parenthesis
+  - check: +is_null/$auditd.log.sw OR auditd.log.sw==? OR +string_equal/$auditd.log.sw/$~null_parenthesis
     map:
       - auditd.log.sw: +delete
   - map:
@@ -324,7 +324,7 @@ normalize:
       - auditd.log.sw: +trim/both/"
       - auditd.log.sw: +trim/both/'
 
-  - check: +is_null/auditd.log.root_dir OR auditd.log.root_dir==? OR +string_equal/$auditd.log.root_dir/$~null_parenthesis
+  - check: +is_null/$auditd.log.root_dir OR auditd.log.root_dir==? OR +string_equal/$auditd.log.root_dir/$~null_parenthesis
     map:
       - auditd.log.root_dir: +delete
   - map:
@@ -332,7 +332,7 @@ normalize:
       - auditd.log.root_dir: +trim/both/"
       - auditd.log.root_dir: +trim/both/'
 
-  - check: +is_null/auditd.log.proctitle OR auditd.log.proctitle==? OR +string_equal/$auditd.log.proctitle/$~null_parenthesis
+  - check: +is_null/$auditd.log.proctitle OR auditd.log.proctitle==? OR +string_equal/$auditd.log.proctitle/$~null_parenthesis
     map:
       - auditd.log.proctitle: +delete
   - map:
@@ -362,16 +362,16 @@ normalize:
   # -- -- -- > map each TARGET = VALUE
 
   # auditd KVDBs event field requests
-  - check: +exists/auditd.log.record_type
+  - check: +exists/$auditd.log.record_type
     map:
       - ~temp_event: +kvdb_get/auditd-types/$auditd.log.record_type
-  - check: +not_exists/~temp_event AND +exists/auditd.log.syscall
+  - check: +not_exists/$~temp_event AND +exists/auditd.log.syscall
     map:
       - ~temp_event: +kvdb_get/auditd-syscall/$auditd.log.record_type
-  - check: +not_exists/~temp_event
+  - check: +not_exists/$~temp_event
     map:
       - ~temp_event: +kvdb_get/auditd-syscall/*
-  - check: +exists/~temp_event.event
+  - check: +exists/$~temp_event.event
     map:
       # TODO: Check types -> array is transformed to object
       - ~event: +merge/$~temp_event.event

--- a/src/engine/ruleset/integrations/auditd/decoders/auditd.yml
+++ b/src/engine/ruleset/integrations/auditd/decoders/auditd.yml
@@ -19,7 +19,7 @@ definitions:
   LOG_SEQUENCE: <auditd.log.sequence>
   MSG_FIELD: '<~/literal/msg=audit(>$LOG_EPOCH:$LOG_SEQUENCE<~/literal/):>'
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/aws/decoders/aws-cloudtrail.yml
+++ b/src/engine/ruleset/integrations/aws/decoders/aws-cloudtrail.yml
@@ -18,7 +18,7 @@ metadata:
       url: https://wazuh.com
       date: 2023/06/20
 
-sources:
+parents:
   - decoder/aws-json/0
 
 check:

--- a/src/engine/ruleset/integrations/aws/decoders/aws-cloudtrail.yml
+++ b/src/engine/ruleset/integrations/aws/decoders/aws-cloudtrail.yml
@@ -408,25 +408,25 @@ normalize:
       # source.geo: +geo/$source.ip
       # source.as: +geo/$source.ip # database_file: GeoLite2-ASN.mmdb | properties:[asn, organization_name]
 
-  - check: +string_equal/~json.aws.additionalEventData.MobileVersion/No
+  - check: +string_equal/$~json.aws.additionalEventData.MobileVersion/No
     map:
       - ~tmp.console_login_mobile_version: false
-  - check: +string_not_equal/~json.aws.additionalEventData.MobileVersion/No
+  - check: +string_not_equal/$~json.aws.additionalEventData.MobileVersion/No
     map:
       - ~tmp.console_login_mobile_version: true
 
-  - check: +string_equal/~json.aws.additionalEventData.MFAUsed/No
+  - check: +string_equal/$~json.aws.additionalEventData.MFAUsed/No
     map:
       - ~tmp.console_login_mfa_used: false
-  - check: +string_not_equal/~json.aws.additionalEventData.MFAUsed/No
+  - check: +string_not_equal/$~json.aws.additionalEventData.MFAUsed/No
     map:
       - ~tmp.console_login_mfa_used: true
 
-  - check: +exists/error.code OR +exists/error.message
+  - check: +exists/$error.code OR +exists/$error.message
     map:
       - event.outcome: failure
 
-  - check: +string_equal/~json.aws.eventName/ConsoleLogin AND +exists/~json.aws.responseElements.ConsoleLogin
+  - check: +string_equal/$~json.aws.eventName/ConsoleLogin AND +exists/$~json.aws.responseElements.ConsoleLogin
     map:
       - event.outcome: +downcase/$~json.aws.responseElements.ConsoleLogin
 

--- a/src/engine/ruleset/integrations/aws/decoders/aws-elb.yml
+++ b/src/engine/ruleset/integrations/aws/decoders/aws-elb.yml
@@ -24,7 +24,7 @@ metadata:
 parents:
   - decoder/aws-json/0
 
-check: +string_equal/~json.aws.source/alb OR +string_equal/~json.aws.source/elb OR +string_equal/~json.aws.source/nlb
+check: +string_equal/$~json.aws.source/alb OR +string_equal/$~json.aws.source/elb OR +string_equal/$~json.aws.source/nlb
   #TODO: Once the events arrive tagged, uncomment these lines below and remove the above line
   # - event.module: aws
   # - event.dataset: aws-elb
@@ -84,11 +84,11 @@ normalize:
       - ~aws_elb.redirect_url: $~json.aws.redirect_url
       - ~aws_elb.bucket: $~json.aws.log_info.s3bucket
 
-  - check: +string_equal/~json.aws.type/http
+  - check: +string_equal/$~json.aws.type/http
     map:
       - event.category: +array_append/web
 
-  - check: +string_not_equal/~json.aws.type/http
+  - check: +string_not_equal/$~json.aws.type/http
     map:
       - event.category: +array_append/network
 

--- a/src/engine/ruleset/integrations/aws/decoders/aws-elb.yml
+++ b/src/engine/ruleset/integrations/aws/decoders/aws-elb.yml
@@ -21,7 +21,7 @@ metadata:
       url: https://wazuh.com
       date: 2023/06/20
 
-sources:
+parents:
   - decoder/aws-json/0
 
 check: +string_equal/~json.aws.source/alb OR +string_equal/~json.aws.source/elb OR +string_equal/~json.aws.source/nlb

--- a/src/engine/ruleset/integrations/aws/decoders/aws-json.yml
+++ b/src/engine/ruleset/integrations/aws/decoders/aws-json.yml
@@ -14,7 +14,7 @@ metadata:
     name: Wazuh, Inc.
     date: 2023/05/04
 
-sources:
+parents:
   - decoder/integrations/0
 
 # TODO: wodle output should be fixed

--- a/src/engine/ruleset/integrations/aws/decoders/aws-s3.yml
+++ b/src/engine/ruleset/integrations/aws/decoders/aws-s3.yml
@@ -34,7 +34,7 @@ parse:
 normalize:
   - map:
       - event.outcome: success
-  - check: +string_greater/~json.aws.error_code/- # single character '-' is not an error
+  - check: +string_greater/$~json.aws.error_code/- # single character '-' is not an error
     map:
       - event.outcome: failure
 

--- a/src/engine/ruleset/integrations/aws/decoders/aws-s3.yml
+++ b/src/engine/ruleset/integrations/aws/decoders/aws-s3.yml
@@ -18,7 +18,7 @@ metadata:
       url: https://wazuh.com
       date: 2022/06/20
 
-sources:
+parents:
   - decoder/aws-json/0
 
 check:

--- a/src/engine/ruleset/integrations/docker-listener/decoders/docker-listener.yml
+++ b/src/engine/ruleset/integrations/docker-listener/decoders/docker-listener.yml
@@ -104,7 +104,7 @@ definitions:
     update: change
 
 normalize:
- - check: +exists/~json.docker
+ - check: +exists/$~json.docker
    map:
     - event.module: docker-listener
     - event.dataset: wodle-docker-listener
@@ -127,7 +127,7 @@ normalize:
     - process.command_line: $~tmp.docker_command
     - process.exit_code: $~json.docker.Actor.Attributes.exitCode
     - process.pid: $~json.docker.execID
- - check: +string_equal/~json.docker.Type/container AND +string_not_equal/~json.docker.Actor.Attributes.exitCode/0
+ - check: +string_equal/$~json.docker.Type/container AND +string_not_equal/$~json.docker.Actor.Attributes.exitCode/0
    map:
     - event.outcome: failed
 

--- a/src/engine/ruleset/integrations/docker-listener/decoders/docker-listener.yml
+++ b/src/engine/ruleset/integrations/docker-listener/decoders/docker-listener.yml
@@ -17,7 +17,7 @@ metadata:
     - https://documentation.wazuh.com/current/container-security/docker-monitor/index.html
     - https://docs.docker.com/engine/reference/commandline/events/
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:
@@ -220,4 +220,3 @@ normalize:
     #cleanup
     - ~json: +delete
     - ~tmp: +delete
-

--- a/src/engine/ruleset/integrations/f5/decoders/f5-afm.yml
+++ b/src/engine/ruleset/integrations/f5/decoders/f5-afm.yml
@@ -13,7 +13,7 @@ metadata:
   references:
     - https://support.f5.com/csp/article/K05327372
 
-sources:
+parents:
   - decoder/integrations/0
 
 #TODO: Once the events arrive tagged, uncomment these lines below

--- a/src/engine/ruleset/integrations/f5/decoders/f5-apm.yml
+++ b/src/engine/ruleset/integrations/f5/decoders/f5-apm.yml
@@ -54,7 +54,7 @@ normalize:
 
   # original : March 2017/03/04 11:21:59 unte very-high ueipsa[748]: 011f0005: :cti: failure (Client side: vip=https://www5.example.com/olli/rever.html?rsp=oluptat#metco profile=ipv6-icmp pool=edolorin client_ip=10.104.110.134)
   # content  : :cti: failure (Client side: vip=https://www5.example.com/olli/rever.html?rsp=oluptat#metco profile=ipv6-icmp pool=edolorin client_ip=10.104.110.134)
-  - check: event.code==011f0005
+  - check: $event.code==011f0005
     logpar:
       - ~content: <~/ignore/:><~>:<~/ignore/ ><~tmp.rsa_misc_result> <~/literal/(Client side:><~/ignore/ >vip=<~url/uri> profile=<network.protocol> pool=<~> client_ip=<source.ip>\)
     map:
@@ -63,7 +63,7 @@ normalize:
 
   # original : December 2019/12/14 07:24:31 olupta medium oremagn[2121]: 01490106: :itseddo: uptatev: AD module: authentication with 'oditem' failed in allow: Preauthentication failed, principal name: inimaven. failure olor
   # content  : uptatev: AD module: authentication with 'oditem' failed in allow: Preauthentication failed, principal name: inimaven. failure olor
-  - check: event.code==01490106
+  - check: $event.code==01490106
     logpar:
       - ~content: $DEF_SESSION:<~/ignore/:> <~>:<~/ignore/:> <~>'<~tmp.user>' <~>:<~/ignore/:> <~>, <~>. <~tmp.rsa_misc_result> <~>
     map:
@@ -71,7 +71,7 @@ normalize:
       - user.name: $related.user
       - rsa.misc.result: $~tmp.rsa_misc_result
 
-  - check: event.code==01490107
+  - check: $event.code==01490107
     logpar:
       # original : April 2017/04/02 01:27:07 caboNem medium laudan[7589]: 01490107: :oconse: mag: AD module: authentication with 'tob' failed: Client 'dolores2519.mail.host' not found in Kerberos database, principal name:deF itempo
       # content  :  :oconse: mag: AD module: authentication with 'tob' failed: Client 'dolores2519.mail.host' not found in Kerberos database, principal name:deF itempo
@@ -89,7 +89,7 @@ normalize:
 
   # original : December 2016/12/08 17:06:33 aincidu very-high uaeab[5960]: 01490008: :licabo: enimadmi: Connectivity resource utaliqu assigned
   # content  : :licabo: enimadmi: Connectivity resource utaliqu assigned
-  - check: event.code==01490008
+  - check: $event.code==01490008
     logpar:
       - ~content: :<~/ignore/ ><~tmp.rsa.misc.log_session_id>:<~/ignore/:> <~> resource <~tmp.network.application> assigned
     map:
@@ -97,7 +97,7 @@ normalize:
 
   # original : July 2018/07/03 10:49:23 piciati medium ntin[4646]: 01260009: :rcitat: Connection error:cinge
   # content  :  :rcitat: Connection error:cinge
-  - check: event.code==01260009
+  - check: $event.code==01260009
     logpar:
       - ~content: <~/ignore/ >:<~>:<~/ignore/:> Connection error<~/ignore/:><~tmp.rsa_event_desc>
     map:
@@ -105,7 +105,7 @@ normalize:
 
   # original : February 2018/02/24 19:26:15 oeiusmo very-high cusanti[5019]: 01420002: : AUDIT - pid=4996 user=rem folder=tseddoei module=teursint status=success cmd_data=remagnaa
   # content  : : AUDIT - pid=4996 user=rem folder=tseddoei module=teursint status=success cmd_data=remagnaa
-  - check: event.code==01420002
+  - check: $event.code==01420002
     logpar:
       - ~content: :<~/ignore/ >AUDIT - pid=<~tmp.process.parent.id> user=<user.name> folder=<~tmp.file.directory> module=<~> status=<~tmp.rsa.misc.result> cmd_data=<~tmp.rsa.db.index>
     map:
@@ -116,7 +116,7 @@ normalize:
 
   # original : July 2019/07/10 01:56:14 tatemse low vitae[72]: 01490000: :samvolu: dip
   # content  : :samvolu: dip
-  - check: event.code==01490000
+  - check: $event.code==01490000
     logpar:
       - ~content: :<~>:<~/ignore/ ><~tmp.rsa.internal.event_desc>
     map:
@@ -124,7 +124,7 @@ normalize:
 
   # original : November 2017/11/02 11:05:41 iquip very-high sedquian[4212]: 01490004: :etdolore: magnaa: Executed agent 'sumquiad', return value iusmodt
   # content  : :etdolore: magnaa: Executed agent 'sumquiad', return value iusmodt
-  - check: event.code==01490004
+  - check: $event.code==01490004
     logpar:
       - ~content: :<~>:<~/ignore/ ><~>'<~tmp.network.application>', return value <~tmp.rsa.misc.result_code>
     map:
@@ -136,7 +136,7 @@ normalize:
   # original : January 2018/01/12 22:18:32 rchit medium roquisqu[5924]: 01490005: :iquid: evo: Following rule mcorpori from item mqu to ending pteursi
   # content  : :iquid: evo: Following rule mcorpori from item mqu to ending pteursi
   # Note : rsa.misc.action has semantic value after word "ending", such as 'Deny' or 'Allow'. Check https://support.f5.com/csp/article/K65142400 For sample log.
-  - check: event.code==01490005
+  - check: $event.code==01490005
     logpar:
       - ~content: $DEF_SESSION:<~>ending <~tmp.rsa.misc.action>
     map:
@@ -144,7 +144,7 @@ normalize:
 
   # original : July 2019/07/24 08:58:48 Dui medium nostrude[7057]: 01490007: :ione: ecillum: Session variable 'maccu' set to ame
   # content  : :ione: ecillum: Session variable 'maccu' set to ame
-  - check: event.code==01490007
+  - check: $event.code==01490007
     logpar:
       - ~content: $DEF_SESSION:<~>Session variable '<~tmp.rsa.misc.change_attrib>' set to <~tmp.rsa.misc.change_new>
     map:
@@ -155,7 +155,7 @@ normalize:
   # content  : :radip: upta: AD agent: Retrieving AAA server: tetura
   # original : November 2019/11/15 17:19:22 ationevo very-high datatno[3538]: 01490019: :siar: orisnis: AD agent: Query: query with '(sAMAccountName=texp)' successful
   # content  : :siar: orisnis: AD agent: Query: query with '(sAMAccountName=texp)' successful
-  - check: event.code==01490013 OR event.code==01490019
+  - check: $event.code==01490013 OR event.code==01490019
     logpar:
       - ~content: $DEF_SESSION:<~>(?sAMAccountName=<user.name>)
     map:
@@ -163,7 +163,7 @@ normalize:
 
   # original : April 2018/04/22 23:36:32 exe high illum[2625]: 01490101: :emi: reprehen: Access profile: tvol configuration has been applied. Newly active generation count is: 5959
   # content  :  :emi: reprehen: Access profile: tvol configuration has been applied. Newly active generation count is: 5959
-  - check: event.code==01490101
+  - check: $event.code==01490101
     logpar:
       - ~content: <~/ignore/ >$DEF_SESSION:<~>applied. <~tmp.rsa.counters.dclass_c1_str>:<~/ignore/ ><~tmp.rsa.counters.dclass_c1/long>
     map:
@@ -172,7 +172,7 @@ normalize:
 
   # original : December 2018/12/21 23:20:14 uatDuisa high ano[4054]: 01490102: :uunturm: iatn: Access policy result: unknown
   # content  : :uunturm: iatn: Access policy result: unknown
-  - check: event.code==01490102
+  - check: $event.code==01490102
     logpar:
       - ~content: $DEF_SESSION:<~>Access policy result<~/ignore/:><~/ignore/ ><~tmp.rsa.misc.result>
     map:
@@ -180,13 +180,13 @@ normalize:
 
   # original : September 2016/09/28 05:53:42 remag very-high abor[5983]: 01490103: :tquiin: tse: Retry Username 'tenimad'
   # content  : :tquiin: tse: Retry Username 'tenimad'
-  - check: event.code==01490103
+  - check: $event.code==01490103
     logpar:
       - ~content: $DEF_SESSION:<~>Retry Username '<user.name>'
     map:
       - rsa.misc.result: $~tmp.rsa.misc.result
 
-  - check: event.code==01490113
+  - check: $event.code==01490113
     logpar:
       # original : March 2016/03/26 10:20:16 ude very-high veri[5990]: 01490113: :tempo: inv: session.user.clientip is 10.134.175.248
       # content  : :tempo: inv: session.user.clientip is 10.134.175.248
@@ -210,7 +210,7 @@ normalize:
 
   # original : January 2018/01/27 05:21:06 itessequ low fdeFinib[2580]: 01490128: :sumd: sectetur: Webtop edquian assigned
   # content  : :sumd: sectetur: Webtop edquian assigned
-  - check: event.code==01490128
+  - check: $event.code==01490128
     logpar:
       - ~content: $DEF_SESSION:<~>Webtop <~tmp.network.application> assigned
     map:
@@ -218,7 +218,7 @@ normalize:
 
   # original : May 2018/05/07 06:39:06 iumt medium nulapari[1973]: 01490500: :tsunt: rnat:oremi:ectobeat: New session from client IP 10.187.64.126 (ST=uasiarch/CC=Malor/C=boriosa) at VIP 10.47.99.72 Listener upt (Reputation=oremipsu)
   # content  : :tsunt: rnat:oremi:ectobeat: New session from client IP 10.187.64.126 (ST=uasiarch/CC=Malor/C=boriosa) at VIP 10.47.99.72 Listener upt (Reputation=oremipsu)
-  - check: event.code==01490500
+  - check: $event.code==01490500
     logpar:
       - ~content: :<~>:<~/ignore/ ><~>:<~>:<~tmp.rsa.misc.logsession_id>:<~/ignore/ >New session from client IP <source.ip> \(<~tmp.geodata>\) at <~> <destination.ip> <~>\(Reputation=<~tmp.rsa.misc.category>\)
     map:
@@ -234,7 +234,7 @@ normalize:
 
   # original : February 2016/02/12 13:12:33 billoi medium orev[6153]: 01490504: :tatemU: deF: sist1803.mail.local can not be resolved.
   # content  : :tatemU: deF: sist1803.mail.local can not be resolved.
-  - check: event.code==01490504
+  - check: $event.code==01490504
     logpar:
       - ~content: $DEF_SESSION:<~/ignore/ ><~tmp.rsa.web.fqdn> <~>
     map:
@@ -244,13 +244,13 @@ normalize:
 
   # original : May 2016/05/22 14:30:33 metcon low emeumfug[6823]: 01490505: :emporinc: untutlab: tem
   # content  : :emporinc: untutlab: tem
-  - check: event.code==01490505
+  - check: $event.code==01490505
     logpar:
       - ~content: $DEF_SESSION:<~>
 
   # original : December 2017/12/01 01:10:49 xerc high eturad[1760]: 01490506: :nvol: enimadmi: Received User-Agent header: mobmail android 2.1.3.3150
   # content  : :nvol: enimadmi: Received User-Agent header: mobmail android 2.1.3.3150
-  - check: event.code==01490506
+  - check: $event.code==01490506
     logpar:
       - ~content: $DEF_SESSION:<~/ignore/ >Received User-Agent header:<~/ignore/ ><~tmp.user_agent.original>
     map:
@@ -260,14 +260,14 @@ normalize:
 
   # original : August 2016/08/16 08:45:59 dol high quiratio[3386]: 01490511: :tisetq: tevelite: Initializing Access profile orporiss with max concurrent user sessions limit: 4739
   # content  : :tisetq: tevelite: Initializing Access profile orporiss with max concurrent user sessions limit: 4739
-  - check: event.code==01490511
+  - check: $event.code==01490511
     logpar:
       - ~content: $DEF_SESSION:<~/ignore/ >Initializing Access profile <~> with max concurrent user sessions limit<~/ignore/:> <~tmp.rsa.counters.dclass_c1/long>
     map:
       - rsa.counters.dclass_c1: $~tmp.rsa.counters.dclass_c1
       - rsa.counters.dclass_c1_str: "Max Concurrent User Sessions Limit"
 
-  - check: event.code==01490514 OR event.code==01490517
+  - check: $event.code==01490514 OR event.code==01490517
     logpar:
       # original : July 2016/07/04 11:38:16 sinto very-high CSed[2857]: 01490514: :utlabore: ecillu: Access encountered error: success. File: mnisist, Function: deny, Line: icons
       # content  : :utlabore: ecillu: Access encountered error: success. File: mnisist, Function: deny, Line: icons
@@ -287,7 +287,7 @@ normalize:
   # content  : :itanimi: onoru: data
   # original : March 2019/03/03 10:33:06 omnisis very-high uptatema[7023]: 01490501: :stiaec: Cicero: ven
   # content  : :stiaec: Cicero: ven
-  - check: event.code==01490520 OR event.code==01490538 OR event.code==01490142 OR event.code==01490501
+  - check: $event.code==01490520 OR event.code==01490538 OR event.code==01490142 OR event.code==01490501
     logpar:
       - ~content: $DEF_SESSION:<~/ignore/ ><~tmp.rsa.internal.event_desc>
     map:
@@ -295,13 +295,13 @@ normalize:
 
   # original : August 2019/08/07 16:01:23 reprehe medium enimipsa[2698]: 01490521: :samn: quisnos: Session statistics - bytes in:2132, bytes out: 2552
   # content  : :samn: quisnos: Session statistics - bytes in:2132, bytes out: 2552
-  - check: event.code==01490521
+  - check: $event.code==01490521
     logpar:
       - ~content: $DEF_SESSION:<~/ignore/ >Session statistics - bytes in:<~/ignore/ ><destination.bytes>, bytes out:<~/ignore/ ><source.bytes>
 
   # original : September 2019/09/05 06:06:31 ameaquei very-high uelaud[1306]: 01490544: :ameiu: utei: Received client info - https://internal.example.net/lumquid/oluptat.jpg?equepor=iosamn#erspicia
   # content  : :ameiu: utei: Received client info - https://internal.example.net/lumquid/oluptat.jpg?equepor=iosamn#erspicia
-  - check: event.code==01490544
+  - check: $event.code==01490544
     logpar:
       - ~content: $DEF_SESSION:<~/ignore/ >Received client info - <~tmp.http.request.referrer>
     map:
@@ -309,7 +309,7 @@ normalize:
 
   # original : September 2017/09/06 06:55:24 iconsequ high idunt[571]: 01490549: :siuta: atev: Assigned PPP Dynamic IPv4: 10.6.32.7 Tunnel Type: exerci inesciu Resource: quid Client IP: 10.198.70.58 - orem
   # content  : :siuta: atev: Assigned PPP Dynamic IPv4: 10.6.32.7 Tunnel Type: exerci inesciu Resource: quid Client IP: 10.198.70.58 - orem
-  - check: event.code==01490549
+  - check: $event.code==01490549
     logpar:
       - ~content: $DEF_SESSION:<~/ignore/ >Assigned PPP Dynamic IPv4:<~/ignore/ ><source.nat.ip> Tunnel Type:<~/ignore/ ><~tmp.rsa.misc.group> <~> Resource:<~/ignore/ ><rule.name> Client IP:<~/ignore/ ><source.ip> <~>
     map:
@@ -318,7 +318,7 @@ normalize:
 
   # original : September 2016/09/13 22:51:07 fugiatnu high tobea[2364]: 014d0001: :tateve: ctx: itinvol, SERVER : eavolup
   # content  : :tateve: ctx: itinvol, SERVER : eavolup
-  - check: event.code==014d0001
+  - check: $event.code==014d0001
     logpar:
       - ~content: $DEF_SESSION:<~/ignore/ ><~>, SERVER :<~/ignore/  ><~tmp.rsa.db.index>
     map:
@@ -326,7 +326,7 @@ normalize:
 
   # original : October 2018/10/11 12:07:23 aborio low setquas: 014d0002: :nbyCi: runtmoll: SSOv2 Logon failed, config busBon form norumetM
   # content  : :nbyCi: runtmoll: SSOv2 Logon failed, config busBon form norumetM
-  - check: event.code==014d0002
+  - check: $event.code==014d0002
     logpar:
       - ~content: <~/ignore/ >$DEF_SESSION:<~>
     map:
@@ -334,7 +334,7 @@ normalize:
 
   # original : June 2018/06/19 03:46:49 namaliqu medium aeca[4543]: 014d0044: :autemv: sciveli
   # content  : :autemv: sciveli
-  - check: event.code==014d0044
+  - check: $event.code==014d0044
     logpar:
       - ~content: :<~>:<~/ignore/ ><~tmp.rsa.db.index>
     map:
@@ -342,7 +342,7 @@ normalize:
 
   # original : September 2019/09/19 13:09:05 psumqui high ncu: 01490079: :quaturve: ciad: Access policy 'diconseq' configuration has changed.Access profile 'utod' configuration changes need to be applied for the new configuration
   # content  :  :quaturve: ciad: Access policy 'diconseq' configuration has changed.Access profile 'utod' configuration changes need to be applied for the new configuration
-  - check: event.code==01490079
+  - check: $event.code==01490079
     logpar:
       - ~content: <~/ignore/ >$DEF_SESSION:<~>
 
@@ -350,7 +350,7 @@ normalize:
   # original : July 2016/07/18 18:40:50 lum high CROND[1675]: (sitvolup) CMD (cancel)
   # original : January 2019/01/19 13:25:23 volup very-high crond[4071]: (iconsequ) CMD (block)
   # original : April 2019/04/29 14:43:23 Nequepo high CROND[2977]: (emac) CMD (cancel)
-  - check: event.code==crond OR event.code==CROND
+  - check: $event.code==crond OR event.code==CROND
     map:
       - rsa.misc.action: +array_append/$~tmp.user_command
       - rsa.db.index: $~tmp.rsa.db.index
@@ -358,20 +358,20 @@ normalize:
 
   # original : November 2019/11/01 10:16:48 erc low tasnu: [syslog-ng]
   # original : March 2017/03/18 18:24:33 ptasnula high syslog-ng[2638]: ill
-  - check: event.code==syslog-ng
+  - check: $event.code==syslog-ng
     map:
       - rsa.internal.messageid: syslog-ng
       - rsa.misc.client: $~tmp.rsa_misc_client
 
   # original : May 2018/05/21 13:41:41 sint low auditd[3376]: ctobeat
   # original : November 2019/11/30 00:21:57 pidat very-high sSMTP[6673]: ptateve
-  - check: event.code==auditd OR event.code==sSMTP
+  - check: $event.code==auditd OR $event.code==sSMTP
     map:
       - rsa.db.index: $~tmp.rsa_misc_client
       - rsa.misc.client: $event.code
 
   # original : October 2019/10/18 03:14:14 tem very-high giatnula[71]: Rule: enimadmi <<qui>: APM_EVENT=deny | aecon | sedq ***failure***
-  - check: event.code==Rule
+  - check: $event.code==Rule
     map:
       - rsa.internal.event_desc: $~tmp.rsa.internal.event_desc
       - rsa.misc.action: $event.action

--- a/src/engine/ruleset/integrations/f5/decoders/f5-apm.yml
+++ b/src/engine/ruleset/integrations/f5/decoders/f5-apm.yml
@@ -13,7 +13,7 @@ metadata:
   references:
     - https://techdocs.f5.com/kb/en-us/products/big-ip_apm/manuals/product/apm-network-access-12-1-0/10.html
 
-sources:
+parents:
   - decoder/integrations/0
 
 #TODO: Once the events arrive tagged, uncomment these lines below

--- a/src/engine/ruleset/integrations/fortinet/decoders/fortinet-client-endpoint.yml
+++ b/src/engine/ruleset/integrations/fortinet/decoders/fortinet-client-endpoint.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://docs.fortinet.com/document/forticlient/7.0.2/log-message-reference/327109
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/fortinet/decoders/fortinet-firewall.yml
+++ b/src/engine/ruleset/integrations/fortinet/decoders/fortinet-firewall.yml
@@ -244,7 +244,7 @@ normalize:
     map:
       - event.category: [network]
       - event.type: [connection]
-  - check: +string_equal/~tmp.type/traffic OR +string_equal/~tmp.type/utm
+  - check: +string_equal/$~tmp.type/traffic OR +string_equal/$~tmp.type/utm
     map:
       - event.category: [network]
   - check:
@@ -252,14 +252,14 @@ normalize:
     map:
       - event.type: [connection]
   - check: >-
-        +string_equal/~tmp.type/traffic AND (+string_equal/event.action/block OR +string_equal/event.action/blocked OR
-        +string_equal/event.action/deny OR +string_equal/event.action/close OR
-        +string_equal/event.action/server-rst OR +string_equal/~tmp.utmaction/block)
+        +string_equal/$~tmp.type/traffic AND (+string_equal/$event.action/block OR +string_equal/$event.action/blocked OR
+        +string_equal/$event.action/deny OR +string_equal/$event.action/close OR
+        +string_equal/$event.action/server-rst OR +string_equal/$~tmp.utmaction/block)
     map:
       - event.type: +array_append/denied
   - check: >-
-        +string_equal/~tmp.type/traffic AND +not_exists/~tmp.utmaction AND
-        (+string_equal/event.action/dns OR +string_equal/event.action/accept OR +string_equal/event.action/ip-conn)
+        +string_equal/$~tmp.type/traffic AND +not_exists/$~tmp.utmaction AND
+        (+string_equal/$event.action/dns OR +string_equal/$event.action/accept OR +string_equal/$event.action/ip-conn)
     map:
       - event.type: +array_append/allowed
   - check:
@@ -289,21 +289,21 @@ normalize:
     - source.packets: +exists
     map:
     - network.packets: $source.packets
-  - check: +string_equal/~tmp.type/traffic AND +exists/destination.ip
+  - check: +string_equal/$~tmp.type/traffic AND +exists/$destination.ip
     map:
       - related.ip: +array_append/$destination.ip
 
   # Check-mapping for firewall-utm
   - check: >-
-        +string_equal/~tmp.type/utm AND (+string_equal/event.action/block OR
-        +string_equal/event.action/blocked OR +string_equal/event.action/deny OR
-        +string_equal/event.action/close OR +string_equal/event.action/server-rst OR
-        +string_equal/event.action/dropped)
+        +string_equal/$~tmp.type/utm AND (+string_equal/$event.action/block OR
+        +string_equal/$event.action/blocked OR +string_equal/$event.action/deny OR
+        +string_equal/$event.action/close OR +string_equal/$event.action/server-rst OR
+        +string_equal/$event.action/dropped)
     map:
       - event.type: +array_append/denied
   - check: >-
-        +string_equal/~tmp.type/utm AND (+string_equal/event.action/pass OR
-        +string_equal/event.action/passthrough OR +string_equal/event.action/exempt)
+        +string_equal/$~tmp.type/utm AND (+string_equal/$event.action/pass OR
+        +string_equal/$event.action/passthrough OR +string_equal/$event.action/exempt)
     map:
       - event.type: +array_append/allowed
   - check:
@@ -319,10 +319,10 @@ normalize:
     - destination.ip: +exists
     map:
       - dns.resolved_ip: [$destination.ip]
-  - check: +string_equal/~tmp.type/utm AND +exists/destination.ip AND +not_exists/~tmp.ipaddr
+  - check: +string_equal/$~tmp.type/utm AND +exists/$destination.ip AND +not_exists/$~tmp.ipaddr
     map:
       - related.ip: +array_append/$destination.ip
-  - check: +string_equal/~tmp.type/utm AND +exists/~tmp.ipaddr
+  - check: +string_equal/$~tmp.type/utm AND +exists/$~tmp.ipaddr
     map:
       - related.ip: +merge/$~tmp.ipaddr_array
   - check:
@@ -336,8 +336,8 @@ normalize:
     map:
       - event.category: +array_append/intrusion_detection
   - check: >-
-        +string_equal/~tmp.type/utm AND +not_exists/~tmp.attack AND
-        (+regex_match/~tmp.subtype/ips OR +regex_match/~tmp.subtype/virus)
+        +string_equal/$~tmp.type/utm AND +not_exists/$~tmp.attack AND
+        (+regex_match/$~tmp.subtype/ips OR +regex_match/$~tmp.subtype/virus)
     map:
       - event.kind: alert
   - check:

--- a/src/engine/ruleset/integrations/fortinet/decoders/fortinet-firewall.yml
+++ b/src/engine/ruleset/integrations/fortinet/decoders/fortinet-firewall.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://docs.fortinet.com/document/forticlient/7.0.2/log-message-reference/327109
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/fortinet/decoders/fortinet-fortimail.yml
+++ b/src/engine/ruleset/integrations/fortinet/decoders/fortinet-fortimail.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://docs.fortinet.com
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/fortinet/decoders/fortinet-fortimanager.yml
+++ b/src/engine/ruleset/integrations/fortinet/decoders/fortinet-fortimanager.yml
@@ -156,7 +156,7 @@ normalize:
       - rsa.network.domain: $server.domain
 
   # Checks if a valid fortinet log was found
-  - check: rsa.internal.messageid==generic_fortinetmgr OR rsa.internal.messageid==generic_fortinetmgr_1 OR rsa.internal.messageid==event_fortinetmgr
+  - check: $rsa.internal.messageid==generic_fortinetmgr OR $rsa.internal.messageid==generic_fortinetmgr_1 OR $rsa.internal.messageid==event_fortinetmgr
     map:
       - \@timestamp: +concat/$~kvMap.date/T/$~kvMap.time/.000Z
       - event.action: +downcase/$~kvMap.action
@@ -179,27 +179,27 @@ normalize:
       - tags: +array_append/forwarded
 
   # Finally maps the network protocol numbers to strings
-  - check: +int_equal/network.protocol/0
+  - check: +int_equal/$network.protocol/0
     map:
       - network.protocol: hoport
 
-  - check: +int_equal/network.protocol/1
+  - check: +int_equal/$network.protocol/1
     map:
       - network.protocol: icmp
 
-  - check: +int_equal/network.protocol/3
+  - check: +int_equal/$network.protocol/3
     map:
       - network.protocol: ggp
 
-  - check: +int_equal/network.protocol/6
+  - check: +int_equal/$network.protocol/6
     map:
       - network.protocol: tcp
 
-  - check: +int_equal/network.protocol/17
+  - check: +int_equal/$network.protocol/17
     map:
       - network.protocol: udp
 
-  - check: +int_equal/network.protocol/21
+  - check: +int_equal/$network.protocol/21
     map:
       - network.protocol: prm
   - map:

--- a/src/engine/ruleset/integrations/fortinet/decoders/fortinet-fortimanager.yml
+++ b/src/engine/ruleset/integrations/fortinet/decoders/fortinet-fortimanager.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://docs.fortinet.com/document/fortimanager/7.2.1/log-message-reference/683345/introduction
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/mysql/decoders/mysql-error.yml
+++ b/src/engine/ruleset/integrations/mysql/decoders/mysql-error.yml
@@ -17,7 +17,7 @@ metadata:
     - https://dev.mysql.com/doc/refman/5.7/en/error-log.html
     - https://dev.mysql.com/doc/refman/8.0/en/error-log.html
 
-sources:
+parents:
   - decoder/integrations/0
 
 #TODO: Once the events arrive tagged, uncomment following lines
@@ -54,5 +54,3 @@ normalize:
       - log.level: ERROR
     map:
       - event.type: +array_append/error
-
-

--- a/src/engine/ruleset/integrations/mysql/decoders/mysql-slowlog.yml
+++ b/src/engine/ruleset/integrations/mysql/decoders/mysql-slowlog.yml
@@ -17,7 +17,7 @@ metadata:
     - https://dev.mysql.com/doc/refman/5.7/en/slow-query-log.html
     - https://dev.mysql.com/doc/refman/8.0/en/slow-query-log.html
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/nginx/decoders/nginx-access-base.yml
+++ b/src/engine/ruleset/integrations/nginx/decoders/nginx-access-base.yml
@@ -13,7 +13,7 @@ metadata:
       url: https://wazuh.com
       date: 2023/01/23
 
-sources:
+parents:
   - decoder/integrations/0
 
 #TODO: Once the events arrive tagged, uncomment these lines below

--- a/src/engine/ruleset/integrations/nginx/decoders/nginx-access.yml
+++ b/src/engine/ruleset/integrations/nginx/decoders/nginx-access.yml
@@ -105,7 +105,7 @@ normalize:
   # if first byte 192 && seccondByte 168 -> private
   # if first byte 172 && seccondByte [16;31] -> private
   # if first byte is 127 -> private
-  - check: +ip_cidr_match/~ip1/10.0.0.0/8 OR +ip_cidr_match/~ip1/192.168.0.0/16 OR +ip_cidr_match/~ip1/172.16.0.0/13 OR +ip_cidr_match/~ip1/172.24.0.0/14 OR +ip_cidr_match/~ip1/172.28.0.0/15 OR +ip_cidr_match/~ip1/172.30.0.0/16 OR +ip_cidr_match/~ip1/172.31.0.0/32 OR +ip_cidr_match/~ip1/127.0.0.0/8
+  - check: +ip_cidr_match/$~ip1/10.0.0.0/8 OR +ip_cidr_match/$~ip1/192.168.0.0/16 OR +ip_cidr_match/$~ip1/172.16.0.0/13 OR +ip_cidr_match/$~ip1/172.24.0.0/14 OR +ip_cidr_match/$~ip1/172.28.0.0/15 OR +ip_cidr_match/$~ip1/172.30.0.0/16 OR +ip_cidr_match/$~ip1/172.31.0.0/32 OR +ip_cidr_match/$~ip1/127.0.0.0/8
     map:
       - ~ip1_private: true
   - check:
@@ -118,7 +118,7 @@ normalize:
       - source.address: $~ip1
 
   # IP2
-  - check: +ip_cidr_match/~ip2/10.0.0.0/8 OR +ip_cidr_match/~ip2/192.168.0.0/16 OR +ip_cidr_match/~ip2/172.16.0.0/13 OR +ip_cidr_match/~ip2/172.24.0.0/14 OR +ip_cidr_match/~ip2/172.28.0.0/15 OR +ip_cidr_match/~ip2/172.30.0.0/16 OR +ip_cidr_match/~ip2/172.31.0.0/32 OR +ip_cidr_match/~ip2/127.0.0.0/8
+  - check: +ip_cidr_match/$~ip2/10.0.0.0/8 OR +ip_cidr_match/$~ip2/192.168.0.0/16 OR +ip_cidr_match/$~ip2/172.16.0.0/13 OR +ip_cidr_match/$~ip2/172.24.0.0/14 OR +ip_cidr_match/$~ip2/172.28.0.0/15 OR +ip_cidr_match/$~ip2/172.30.0.0/16 OR +ip_cidr_match/$~ip2/172.31.0.0/32 OR +ip_cidr_match/$~ip2/127.0.0.0/8
     map:
       - ~ip2_private: true
   - check:
@@ -132,7 +132,7 @@ normalize:
       - source.address: $~ip2
 
   # IP3
-  - check: +ip_cidr_match/~ip3/10.0.0.0/8 OR +ip_cidr_match/~ip3/192.168.0.0/16 OR +ip_cidr_match/~ip3/172.16.0.0/13 OR +ip_cidr_match/~ip3/172.24.0.0/14 OR +ip_cidr_match/~ip3/172.28.0.0/15 OR +ip_cidr_match/~ip3/172.30.0.0/16 OR +ip_cidr_match/~ip3/172.31.0.0/32 OR +ip_cidr_match/~ip3/127.0.0.0/8
+  - check: +ip_cidr_match/$~ip3/10.0.0.0/8 OR +ip_cidr_match/$~ip3/192.168.0.0/16 OR +ip_cidr_match/$~ip3/172.16.0.0/13 OR +ip_cidr_match/$~ip3/172.24.0.0/14 OR +ip_cidr_match/$~ip3/172.28.0.0/15 OR +ip_cidr_match/$~ip3/172.30.0.0/16 OR +ip_cidr_match/$~ip3/172.31.0.0/32 OR +ip_cidr_match/$~ip3/127.0.0.0/8
     map:
       - ~ip3_private: true
   - check:

--- a/src/engine/ruleset/integrations/nginx/decoders/nginx-access.yml
+++ b/src/engine/ruleset/integrations/nginx/decoders/nginx-access.yml
@@ -13,7 +13,7 @@ metadata:
       url: https://wazuh.com
       date: 2023/01/23
 
-sources:
+parents:
   - decoder/nginx-access-base/0
 
 check:

--- a/src/engine/ruleset/integrations/nginx/decoders/nginx-error.yml
+++ b/src/engine/ruleset/integrations/nginx/decoders/nginx-error.yml
@@ -12,7 +12,7 @@ metadata:
       url: https://wazuh.com
       date: 2023/01/13
 
-sources:
+parents:
   - decoder/integrations/0
 
 #TODO: Once the events arrive tagged, uncomment these lines below

--- a/src/engine/ruleset/integrations/postgresql/decoders/postgresql-csv-msg-parse.yml
+++ b/src/engine/ruleset/integrations/postgresql/decoders/postgresql-csv-msg-parse.yml
@@ -16,7 +16,7 @@ metadata:
     name: Wazuh Inc. info@wazuh.com
     date: 2023-01-05
 
-sources:
+parents:
   - decoder/postgresql-csv/0
 
 check:

--- a/src/engine/ruleset/integrations/postgresql/decoders/postgresql-csv.yml
+++ b/src/engine/ruleset/integrations/postgresql/decoders/postgresql-csv.yml
@@ -16,7 +16,7 @@ metadata:
     name: Wazuh Inc. info@wazuh.com
     date: 2023-01-05
 
-sources:
+parents:
   - decoder/integrations/0
 
 #TODO: Once the events arrive tagged, uncomment these lines below

--- a/src/engine/ruleset/integrations/redis/decoders/redis.yml
+++ b/src/engine/ruleset/integrations/redis/decoders/redis.yml
@@ -11,7 +11,7 @@ metadata:
   references:
     - https://docs.rs/redis-module/latest/redis_module/logging/index.html
 
-sources:
+parents:
   - decoder/integrations/0
 
 #TODO: Once the events arrive tagged, uncomment these lines below

--- a/src/engine/ruleset/integrations/sonicwall/decoders/sonicwall-firewall-generated.yml
+++ b/src/engine/ruleset/integrations/sonicwall/decoders/sonicwall-firewall-generated.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://www.sonicwall.com/es-mx/support/technical-documentation
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/sonicwall/decoders/sonicwall-firewall.yml
+++ b/src/engine/ruleset/integrations/sonicwall/decoders/sonicwall-firewall.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://www.sonicwall.com/es-mx/support/technical-documentation
 
-sources:
+parents:
   - decoder/sonicwall-syslog/0
 
 # Since the event is first parsed by the syslog, event.original is

--- a/src/engine/ruleset/integrations/sonicwall/decoders/sonicwall-syslog.yml
+++ b/src/engine/ruleset/integrations/sonicwall/decoders/sonicwall-syslog.yml
@@ -15,7 +15,7 @@ metadata:
     - https://datatracker.ietf.org/doc/html/rfc3164
     - https://datatracker.ietf.org/doc/html/rfc5424
 
-sources:
+parents:
   - decoder/integrations/0
 
 parse:

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-antispam.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-antispam.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://support.sophos.com/support/s/?language=en_US#t=DocumentationTab
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-antivirus.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-antivirus.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://support.sophos.com/support/s/?language=en_US#t=DocumentationTab
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-atp.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-atp.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://support.sophos.com/support/s/?language=en_US#t=DocumentationTab
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-cfilter.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-cfilter.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://support.sophos.com/support/s/?language=en_US#t=DocumentationTab
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-event.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-event.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://support.sophos.com/support/s/?language=en_US#t=DocumentationTab
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:
@@ -107,4 +107,3 @@ normalize:
       - related.ip: [$~tmp.destination.ip, $source.ip]
       - wazuh.decoders: +array_append/sophos-event
       - ~tmp: +delete
-

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-firewall.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-firewall.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://support.sophos.com/support/s/?language=en_US#t=DocumentationTab
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-idp.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-idp.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://support.sophos.com/support/s/?language=en_US#t=DocumentationTab
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-sandstorn.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-sandstorn.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://support.sophos.com/support/s/?language=en_US#t=DocumentationTab
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:
@@ -104,4 +104,3 @@ normalize:
       - \@timestamp: +concat/$~tmp.date/T/$~tmp.time
       - wazuh.decoders: +array_append/sophos-sandstorn
       - ~tmp: +delete
-

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-systemhealth.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-systemhealth.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://support.sophos.com/support/s/?language=en_US#t=DocumentationTab
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-utm.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-utm.yml
@@ -40,7 +40,7 @@ parse:
 # TODO: All sophos named fields are not currently in the schema.
 normalize:
 
-  - check: event.code==confd OR event.code==aua
+  - check: $event.code==confd OR $event.code==aua
     logpar:
       - ~tmp.message: <~tmp/kv/=/ /'/'>
     map:
@@ -62,7 +62,7 @@ normalize:
       - source.ip: $~tmp.srcip
       - user.name: $~tmp.user
 
-  - check: event.code==astarosg_TVM OR event.code==httpd OR event.code==ulogd
+  - check: $event.code==astarosg_TVM OR $event.code==httpd OR $event.code==ulogd
     logpar:
       - ~tmp.message: <~tmp/kv/=/ /'/'>
     map:

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-utm.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-utm.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://www.sophos.com/en-us/support/documentation/sophos-utm
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-waf.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-waf.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://support.sophos.com/support/s/?language=en_US#t=DocumentationTab
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/sophos/decoders/sophos-wifi.yml
+++ b/src/engine/ruleset/integrations/sophos/decoders/sophos-wifi.yml
@@ -12,7 +12,7 @@ metadata:
   references:
     - https://support.sophos.com/support/s/?language=en_US#t=DocumentationTab
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/suricata/decoders/suricata-alert.yml
+++ b/src/engine/ruleset/integrations/suricata/decoders/suricata-alert.yml
@@ -1,6 +1,6 @@
 name: decoder/suricata-alert/0
 
-sources:
+parents:
   - decoder/suricata/0
 
 metadata:

--- a/src/engine/ruleset/integrations/suricata/decoders/suricata-alert.yml
+++ b/src/engine/ruleset/integrations/suricata/decoders/suricata-alert.yml
@@ -40,12 +40,12 @@ normalize:
       - threat.technique.id: $~suricata.eve.alert.metadata.mitre_technique_id
       - threat.technique.name: $~suricata.eve.alert.metadata.mitre_technique_name
 
-  - check: source.bytes>=0 OR destination.bytes>=0
+  - check: $source.bytes>=0 OR $destination.bytes>=0
     map:
       - network.bytes: 0
       - network.bytes: +int_calculate/sum/$source.bytes/$destination.bytes
 
-  - check: source.packets>=0 OR destination.packets>=0
+  - check: $source.packets>=0 OR $destination.packets>=0
     map:
       - network.packets: 0
       - network.packets: +int_calculate/sum/$source.packets/$destination.packets

--- a/src/engine/ruleset/integrations/suricata/decoders/suricata.yml
+++ b/src/engine/ruleset/integrations/suricata/decoders/suricata.yml
@@ -1,6 +1,6 @@
 name: decoder/suricata/0
 
-sources:
+parents:
   - decoder/integrations/0
 
 metadata:

--- a/src/engine/ruleset/integrations/suricata/decoders/suricata.yml
+++ b/src/engine/ruleset/integrations/suricata/decoders/suricata.yml
@@ -18,7 +18,7 @@ metadata:
   description: Decoder for Suricata open source network analysis and threat detection software.
 
 definitions:
-  is_good_appProto: +string_not_equal/~suricata.eve.app_proto/failed AND +string_not_equal/~suricata.eve.app_proto/template AND +string_not_equal/~suricata.eve.app_proto/template-rust
+  is_good_appProto: +string_not_equal/$~suricata.eve.app_proto/failed AND +string_not_equal/$~suricata.eve.app_proto/template AND +string_not_equal/$~suricata.eve.app_proto/template-rust
 
 check:
   - ~json.event_type: +exists

--- a/src/engine/ruleset/integrations/syslog/decoders/syslog.yml
+++ b/src/engine/ruleset/integrations/syslog/decoders/syslog.yml
@@ -15,7 +15,7 @@ metadata:
     - https://www.ietf.org/rfc/rfc3164.txt
     - https://www.ietf.org/rfc/rfc5424.txt
 
-sources:
+parents:
   - decoder/integrations/0
 
 parse:

--- a/src/engine/ruleset/integrations/system/decoders/sysmon-linux.yml
+++ b/src/engine/ruleset/integrations/system/decoders/sysmon-linux.yml
@@ -1,6 +1,6 @@
 name: decoder/sysmon-linux/0
 
-sources:
+parents:
   - decoder/syslog/0
 
 metadata:

--- a/src/engine/ruleset/integrations/system/decoders/sysmon-linux.yml
+++ b/src/engine/ruleset/integrations/system/decoders/sysmon-linux.yml
@@ -129,58 +129,58 @@ normalize:
   #########################################################
   #                   Delete invalid fields
   #########################################################
-  - check: +string_equal/~sysmonEvent.Event.EventData.ConfigurationFileHash/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.ConfigurationFileHash/-
     map:
       - ~sysmonEvent.Event.EventData.ConfigurationFileHash: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.FileVersion/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.FileVersion/-
     map:
       - ~sysmonEvent.Event.EventData.FileVersion: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.Description/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.Description/-
     map:
       - ~sysmonEvent.Event.EventData.Description: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.Product/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.Product/-
     map:
       - ~sysmonEvent.Event.EventData.Product: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.Company/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.Company/-
     map:
       - ~sysmonEvent.Event.EventData.Company: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.OriginalFileName/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.OriginalFileName/-
     map:
       - ~sysmonEvent.Event.EventData.OriginalFileName: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.Hashes/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.Hashes/-
     map:
       - ~sysmonEvent.Event.EventData.Hashes: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.User/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.User/-
     map:
       - ~sysmonEvent.Event.EventData.User: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.IsExecutable/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.IsExecutable/-
     map:
       - ~sysmonEvent.Event.EventData.IsExecutable: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.Archived/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.Archived/-
     map:
       - ~sysmonEvent.Event.EventData.Archived: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.RuleName/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.RuleName/-
     map:
       - ~sysmonEvent.Event.EventData.RuleName: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.SourceHostname/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.SourceHostname/-
     map:
       - ~sysmonEvent.Event.EventData.SourceHostname: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.SourcePortName/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.SourcePortName/-
     map:
       - ~sysmonEvent.Event.EventData.SourcePortName: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.DestinationHostname/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.DestinationHostname/-
     map:
       - ~sysmonEvent.Event.EventData.DestinationHostname: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.DestinationPortName/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.DestinationPortName/-
     map:
       - ~sysmonEvent.Event.EventData.DestinationPortName: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.ParentImage/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.ParentImage/-
     map:
       - ~sysmonEvent.Event.EventData.ParentImage: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.ParentCommandLine/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.ParentCommandLine/-
     map:
       - ~sysmonEvent.Event.EventData.ParentCommandLine: +delete
-  - check: +string_equal/~sysmonEvent.Event.EventData.ParentUser/-
+  - check: +string_equal/$~sysmonEvent.Event.EventData.ParentUser/-
     map:
       - ~sysmonEvent.Event.EventData.ParentUser: +delete
 
@@ -336,17 +336,17 @@ normalize:
 
       - dns.question.name: $~sysmonEvent.Event.EventData.QueryName
 
-  - check: ~sysmonEvent.Event.EventData.Initiated=="true" # check true, True, "true", "True"
+  - check: $~sysmonEvent.Event.EventData.Initiated=="true" # check true, True, "true", "True"
     map:
       - network.direction: egress
-  - check: ~sysmonEvent.Event.EventData.Initiated=="false"
+  - check: $~sysmonEvent.Event.EventData.Initiated=="false"
     map:
       - network.direction: ingress
 
-  - check: ~sysmonEvent.Event.EventData.SourceIsIpv6=="true" # check true, True, "true", "True"
+  - check: $~sysmonEvent.Event.EventData.SourceIsIpv6=="true" # check true, True, "true", "True"
     map:
       - network.type: ipv6
-  - check: ~sysmonEvent.Event.EventData.SourceIsIpv6=="false"
+  - check: $~sysmonEvent.Event.EventData.SourceIsIpv6=="false"
     map:
       - network.type: ipv4
 

--- a/src/engine/ruleset/integrations/system/decoders/system-auth.yml
+++ b/src/engine/ruleset/integrations/system/decoders/system-auth.yml
@@ -1,6 +1,6 @@
 name: decoder/system-auth/0
 
-sources:
+parents:
   - decoder/syslog/0
 
 metadata:

--- a/src/engine/ruleset/integrations/system/decoders/system-auth.yml
+++ b/src/engine/ruleset/integrations/system/decoders/system-auth.yml
@@ -20,15 +20,15 @@ metadata:
 
 definitions:
   isAuthProcess: >-
-    process.name=="sshd"
-    OR process.name=="sudo"
-    OR process.name=="groupadd"
-    OR process.name=="useradd"
-    OR process.name=="groupdel"
-    OR process.name=="groupmod"
-    OR process.name=="userdel"
-    OR process.name=="usermod"
-    OR process.name=="CRON"
+    $process.name=="sshd"
+    OR $process.name=="sudo"
+    OR $process.name=="groupadd"
+    OR $process.name=="useradd"
+    OR $process.name=="groupdel"
+    OR $process.name=="groupmod"
+    OR $process.name=="userdel"
+    OR $process.name=="usermod"
+    OR $process.name=="CRON"
 
 #TODO: Once the events arrive tagged, uncommnet following line and comment previous
 #  isAuthProcess: >-
@@ -65,21 +65,21 @@ normalize:
       - message: "<~system.auth.ssh.event>: Read from socket failed: Connection reset by peer [preauth]"
       - message: "Received <~system.auth.ssh.event> from <source.ip>: <~>:  [<~>]"
 
-  - check: ~system.auth.ssh.event=="Accepted" OR ~system.auth.ssh.event=="USER_PROCESS"
+  - check: $~system.auth.ssh.event=="Accepted" OR $~system.auth.ssh.event=="USER_PROCESS"
     map:
       - event.type: +array_append/access/allowed
       - event.category: +array_append/authentication/session
       - event.action: "ssh_login"
       - event.outcome: "success"
 
-  - check: ~system.auth.ssh.event=="DEAD_PROCESS" OR ~system.auth.ssh.event=="disconnect"
+  - check: $~system.auth.ssh.event=="DEAD_PROCESS" OR $~system.auth.ssh.event=="disconnect"
     map:
       - event.type: +array_append/end
       - event.category: +array_append/authentication/session
       - event.action: "ssh_login"
       - event.outcome: "success"
 
-  - check: ~system.auth.ssh.event=="Invalid" OR ~system.auth.ssh.event=="Failed" OR ~system.auth.ssh.event=="failures" OR ~system.auth.ssh.event=="fatal"
+  - check: $~system.auth.ssh.event=="Invalid" OR $~system.auth.ssh.event=="Failed" OR $~system.auth.ssh.event=="failures" OR $~system.auth.ssh.event=="fatal"
     map:
       - event.type: +array_append/access/denied
       - event.category: +array_append/authentication/session
@@ -124,46 +124,46 @@ normalize:
     map:
       - user.name: $~system.auth.pam.foruser.name
 
-  - check: ~system.auth.pam.session.action=="opened" OR ~system.auth.ssh.event=="USER_PROCESS"
+  - check: $~system.auth.pam.session.action=="opened" OR $~system.auth.ssh.event=="USER_PROCESS"
     map:
       - event.type: +array_append/start
 
-  - check: ~system.auth.pam.session.action=="closed"
+  - check: $~system.auth.pam.session.action=="closed"
     map:
       - event.type: +array_append/end
 
-  - check: process.name=="groupadd" OR process.name=="useradd"
+  - check: $process.name=="groupadd" OR $process.name=="useradd"
     logpar:
       - message: "new group: name=<group.name>, GID=<group.id>"
       - message: "new user: name=<user.name>, UID=<user.id>, GID=<group.id>, home=<~system.auth.useradd.home>, shell=<~system.auth.useradd.shell>(?,<~>)"
       - message: "group added to <file.name>: name=<group.name>(?, GID=<group.id>)"
       - message: "<~system.auth.event.outcome> adding user '<user.name>'(?,<~>)"
 
-  - check: ~system.auth.event.outcome=="failed" OR ~system.auth.pam.session.action=="failure"
+  - check: $~system.auth.event.outcome=="failed" OR $~system.auth.pam.session.action=="failure"
     map:
       - event.outcome: "failure"
 
-  - check: process.name=="groupadd" OR process.name=="groupdel" OR process.name=="groupmod" OR process.name=="useradd" OR process.name=="userdel" OR process.name=="usermod"
+  - check: $process.name=="groupadd" OR $process.name=="groupdel" OR $process.name=="groupmod" OR $process.name=="useradd" OR $process.name=="userdel" OR $process.name=="usermod"
     map:
       - event.category: +array_append/iam
 
-  - check: process.name=="useradd" OR process.name=="userdel" OR process.name=="usermod"
+  - check: $process.name=="useradd" OR $process.name=="userdel" OR $process.name=="usermod"
     map:
       - event.type: +array_append/user
 
-  - check: process.name=="groupadd" OR process.name=="groupdel" OR process.name=="groupmod"
+  - check: $process.name=="groupadd" OR $process.name=="groupdel" OR $process.name=="groupmod"
     map:
       - event.type: +array_append/group
 
-  - check: process.name=="groupadd" OR process.name=="useradd"
+  - check: $process.name=="groupadd" OR $process.name=="useradd"
     map:
       - event.type: +array_append/creation
 
-  - check: process.name=="groupdel" OR process.name=="userdel"
+  - check: $process.name=="groupdel" OR $process.name=="userdel"
     map:
       - event.type: +array_append/deletion
 
-  - check: process.name=="groupmod" OR process.name=="usermod"
+  - check: $process.name=="groupmod" OR $process.name=="usermod"
     map:
       - event.type: +array_append/change
 

--- a/src/engine/ruleset/integrations/wazuh-dashboard/decoders/wazuh-dashboard.yml
+++ b/src/engine/ruleset/integrations/wazuh-dashboard/decoders/wazuh-dashboard.yml
@@ -15,7 +15,7 @@ metadata:
     - "https://documentation.wazuh.com/current/user-manual/wazuh-dashboard/index.html"
     - "https://opensearch.org/docs/latest/monitoring-your-cluster/logs/"
 
-sources:
+parents:
   - decoder/syslog/0
 
 check:

--- a/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-deprecation.yml
+++ b/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-deprecation.yml
@@ -15,7 +15,7 @@ metadata:
     - "https://documentation.wazuh.com/current/getting-started/components/wazuh-indexer.html"
     - "https://opensearch.org/docs/latest/monitoring-your-cluster/logs/"
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-server.yml
+++ b/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-server.yml
@@ -15,7 +15,7 @@ metadata:
     - "https://documentation.wazuh.com/current/getting-started/components/wazuh-indexer.html"
     - "https://opensearch.org/docs/latest/monitoring-your-cluster/logs/"
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-server.yml
+++ b/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-server.yml
@@ -26,8 +26,8 @@ check:
   # - event.dataset: wazuh-indexer-server
 
 definitions:
-  isError: log.level==FATAL OR log.level==ERROR
-  isInfo: log.level!=FATAL AND log.level!=ERROR
+  isError: $log.level==FATAL OR $log.level==ERROR
+  isInfo: $log.level!=FATAL AND $log.level!=ERROR
 
 normalize:
   - map:

--- a/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-slowlog.yml
+++ b/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-slowlog.yml
@@ -18,14 +18,14 @@ metadata:
 parents:
   - decoder/integrations/0
 
-check: ~json.type==index_search_slowlog OR ~json.type==index_indexing_slowlog
+check: $~json.type==index_search_slowlog OR $~json.type==index_indexing_slowlog
   # TODO: Once the events arrive tagged, uncomment the following two lines
   # - event.module: wazuh-indexer
   # - event.dataset: wazuh-indexer-slowlog
 
 definitions:
-  isError: log.level==FATAL OR log.level==ERROR
-  isInfo: log.level!=FATAL AND log.level!=ERROR
+  isError: $log.level==FATAL OR $log.level==ERROR
+  isInfo: $log.level!=FATAL AND $log.level!=ERROR
 
 normalize:
   - map:

--- a/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-slowlog.yml
+++ b/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-slowlog.yml
@@ -15,7 +15,7 @@ metadata:
     - "https://documentation.wazuh.com/current/getting-started/components/wazuh-indexer.html"
     - "https://opensearch.org/docs/latest/monitoring-your-cluster/logs/"
 
-sources:
+parents:
   - decoder/integrations/0
 
 check: ~json.type==index_search_slowlog OR ~json.type==index_indexing_slowlog

--- a/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-task-plain.yml
+++ b/src/engine/ruleset/integrations/wazuh-indexer/decoders/wazuh-indexer-task-plain.yml
@@ -16,7 +16,7 @@ metadata:
     - "https://documentation.wazuh.com/current/getting-started/components/wazuh-indexer.html"
     - "https://opensearch.org/docs/latest/monitoring-your-cluster/logs/"
 
-sources:
+parents:
   - decoder/integrations/0
 
 # TODO: Once the events arrive tagged, uncomment following lines

--- a/src/engine/ruleset/integrations/windows/decoders/windows-event-decoder.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-event-decoder.yml
@@ -1,6 +1,6 @@
 name: decoder/windows-event-decoder/0
 
-sources:
+parents:
   - decoder/windows-json/0
 
 metadata:

--- a/src/engine/ruleset/integrations/windows/decoders/windows-json.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-json.yml
@@ -13,7 +13,7 @@ metadata:
     - https://learn.microsoft.com/en-us/windows/win32/events/windows-events
   versions: [Vista, "7", "8", "10", "11", Server 2012, Server 2016, Server 2019, Server 2022]
 
-sources:
+parents:
   - decoder/integrations/0
 
 check:

--- a/src/engine/ruleset/integrations/windows/decoders/windows-powershell-operational.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-powershell-operational.yml
@@ -1,6 +1,6 @@
 name: decoder/windows-powershell-operational/0
 
-sources:
+parents:
   - decoder/windows-event-decoder/0
 
 metadata:

--- a/src/engine/ruleset/integrations/windows/decoders/windows-powershell-operational.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-powershell-operational.yml
@@ -16,7 +16,7 @@ metadata:
     - https://learn.microsoft.com/en-us/powershell/scripting/windows-powershell/wmf/whats-new/script-logging?view=powershell-7.3
   versions: [Vista, "7", "8", "10", "11", Server 2012, Server 2016, Server 2019, Server 2022]
 
-check: ~windows.Event.System.Channel.#text==Microsoft-Windows-PowerShell/Operational
+check: $~windows.Event.System.Channel.#text==Microsoft-Windows-PowerShell/Operational
 
 normalize:
  - map:
@@ -53,11 +53,11 @@ normalize:
    - process.title: $~windows.Event.EventData.HostName
    - process.executable: $file.path
 
- - check: event.code=="4105"
+ - check: $event.code=="4105"
    map:
     - event.type: +array_append/start
 
- - check: event.code=="4106"
+ - check: $event.code=="4106"
    map:
     - event.type: +array_append/end
 

--- a/src/engine/ruleset/integrations/windows/decoders/windows-powershell.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-powershell.yml
@@ -1,6 +1,6 @@
 name: decoder/windows-powershell/0
 
-sources: 
+parents:
   - decoder/windows-event-decoder/0
 
 metadata:

--- a/src/engine/ruleset/integrations/windows/decoders/windows-powershell.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-powershell.yml
@@ -47,11 +47,11 @@ normalize:
    - file.extension: $~temp.file_data.ext
    - file.name: $~temp.file_data.name
 
- - check: event.code=="400"
+ - check: $event.code=="400"
    map:
     - event.type: +array_append/start
 
- - check: event.code=="403"
+ - check: $event.code=="403"
    map:
     - event.type: +array_append/end
 

--- a/src/engine/ruleset/integrations/windows/decoders/windows-security.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-security.yml
@@ -16,7 +16,7 @@ metadata:
     - https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/security-auditing-overview
   versions: [Vista, "7", "8", "10", "11", Server 2012, Server 2016, Server 2019, Server 2022]
 
-check: ~windows.Event.System.Channel.#text==Security AND (event.provider==Microsoft-Windows-Security-Auditing OR event.provider==Microsoft-Windows-Eventlog)
+check: $~windows.Event.System.Channel.#text==Security AND ($event.provider==Microsoft-Windows-Security-Auditing OR $event.provider==Microsoft-Windows-Eventlog)
 
 
 normalize:
@@ -68,7 +68,7 @@ normalize:
 
 
     # Add Session Events
- - check: event.code=="4778" OR event.code=="4779"
+ - check: $event.code=="4778" OR $event.code=="4779"
    map:
         # AccountName to user.name and related.user
         - user.name: $~windows.Event.EventData.AccountName
@@ -83,39 +83,39 @@ normalize:
 
     # Copy Target User
     # TargetUserSid to user.id or user.target.id
- - check: +not_exists/user.id AND +array_contains/~temp.id_target_user_array/$event.code
+ - check: +not_exists/$user.id AND +array_contains/$~temp.id_target_user_array/$event.code
    map:
         - user.id: $~windows.Event.EventData.TargetUserSid
         - user.id: $~windows.Event.EventData.TargetSid
 
- - check: +exists/user.id AND +array_contains/~temp.id_target_user_array/$event.code
+ - check: +exists/$user.id AND +array_contains/$~temp.id_target_user_array/$event.code
    map:
         - user.target.id: $~windows.Event.EventData.TargetUserSid
         - user.target.id: $~windows.Event.EventData.TargetSid
 
  # TargetUserName to related.user and user.name or user.target.name
- - check: +not_exists/user.name AND +array_contains/~temp.id_target_user_array/$event.code
+ - check: +not_exists/$user.name AND +array_contains/$~temp.id_target_user_array/$event.code
    map:
         - user.name: $~windows.Event.EventData.TargetUserName
- - check: +exists/user.name AND +array_contains/~temp.id_target_user_array/$event.code
+ - check: +exists/$user.name AND +array_contains/$~temp.id_target_user_array/$event.code
    map:
         - user.target.name: $~windows.Event.EventData.TargetUserName
 
- - check: +string_not_equal/~windows.Event.EventData.TargetUserName/- AND +array_contains/~temp.id_target_user_array/$event.code
+ - check: +string_not_equal/$~windows.Event.EventData.TargetUserName/- AND +array_contains/$~temp.id_target_user_array/$event.code
    map:
         - related.user: +array_append/$~windows.Event.EventData.TargetUserName
 
     # TargetUserDomain to user.domain or user.target.domain
- - check: +not_exists/user.domain AND +array_contains/~temp.id_target_user_array/$event.code
+ - check: +not_exists/$user.domain AND +array_contains/$~temp.id_target_user_array/$event.code
    map:
         - user.domain: $~windows.Event.EventData.TargetDomainName
- - check: +exists/user.domain AND +array_contains/~temp.id_target_user_array/$event.code
+ - check: +exists/$user.domain AND +array_contains/$~temp.id_target_user_array/$event.code
    map:
         - user.target.domain: $~windows.Event.EventData.TargetDomainName
 
     # Copy MemberName to User and User to Group
  - check:
-        - ~temp.id_memberName_array: +array_contains/event.code
+        - ~temp.id_memberName_array: +array_contains/$event.code
    map:
         - ~temp.split_memberName: +split/$~windows.Event.EventData.MemberName/,
         - ~temp.split_memberName.0: '+replace/CN=/'
@@ -152,24 +152,24 @@ normalize:
      - user.target.domain: $~windows.Event.EventData.TargetDomainName
 
 # Copy Target User to Effective
- - check: event.code=="4648" OR event.code=="4688"
+ - check: $event.code=="4648" OR $event.code=="4688"
    map:
      - user.effective.id: $~windows.Event.EventData.TargetUserSid
 
 
- - check: +string_not_equal/~windows.Event.EventData.TargetUserName/- AND  (event.code=="4648" OR event.code=="4688")
+ - check: +string_not_equal/$~windows.Event.EventData.TargetUserName/- AND  ($event.code=="4648" OR $event.code=="4688")
    map:
      - ~temp.name_part: +split/$~windows.Event.EventData.TargetUserName/@
      - user.effective.name: $~temp.name_part.0
      - related.user: +array_append/event.user.effective.name
 
 
- - check: +string_not_equal/~windows.Event.EventData.TargetDomainName/- AND  (event.code=="4648" OR event.code=="4688")
+ - check: +string_not_equal/$~windows.Event.EventData.TargetDomainName/- AND  ($event.code=="4648" OR $event.code=="4688")
    map:
      - user.effective.domain: $~windows.Event.EventData.TargetDomainName
 
 # Copy Subject User from user_data
- - check: event.code=="1102"
+ - check: $event.code=="1102"
    map:
      - user.id: $~windows.Event.UserData.LogFileCleared.SubjectUserSid.#text
      - user.name: $~windows.Event.UserData.LogFileCleared.SubjectUserName.#text
@@ -186,7 +186,7 @@ normalize:
      - ~temp.file_data: +parse_file/$~windows.Event.EventData.ProcessName
      - process.name: $~temp.file_data.name
 
- - check: +array_contains/~temp.id_rename_common_auth_fields/$event.code AND +string_not_equal/~windows.Event.EventData.IpAddress/-
+ - check: +array_contains/$~temp.id_rename_common_auth_fields/$event.code AND +string_not_equal/$~windows.Event.EventData.IpAddress/-
    map:
      - source.ip: $~windows.Event.EventData.IpAddress
      - source.port: $~windows.Event.EventData.IpPort
@@ -194,7 +194,7 @@ normalize:
      - related.ip: +array_append/$~windows.Event.EventData.ClientAddress
 
 # Process Event 4688
- - check: event.code=="4688"
+ - check: $event.code=="4688"
    map:
      - process.args: '+split/$~windows.Event.EventData.CommandLine/ '
      - process.pid: +hex_to_number/$~windows.Event.EventData.NewProcessId
@@ -207,7 +207,7 @@ normalize:
      - process.parent.name: $~temp.file_data.name
      - process.command_line: $~windows.Event.EventData.CommandLine
 
- - check: event.code=="4624" OR event.code=="4648"
+ - check: $event.code=="4624" OR $event.code=="4648"
    map:
      - related.user: +array_append/$~windows.Event.EventData.SubjectUserName
 

--- a/src/engine/ruleset/integrations/windows/decoders/windows-security.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-security.yml
@@ -1,6 +1,6 @@
 name: decoder/windows-security/0
 
-sources:
+parents:
   - decoder/windows-event-decoder/0
 
 metadata:
@@ -103,7 +103,7 @@ normalize:
 
  - check: +string_not_equal/~windows.Event.EventData.TargetUserName/- AND +array_contains/~temp.id_target_user_array/$event.code
    map:
-        - related.user: +array_append/$~windows.Event.EventData.TargetUserName 
+        - related.user: +array_append/$~windows.Event.EventData.TargetUserName
 
     # TargetUserDomain to user.domain or user.target.domain
  - check: +not_exists/user.domain AND +array_contains/~temp.id_target_user_array/$event.code
@@ -187,7 +187,7 @@ normalize:
      - process.name: $~temp.file_data.name
 
  - check: +array_contains/~temp.id_rename_common_auth_fields/$event.code AND +string_not_equal/~windows.Event.EventData.IpAddress/-
-   map:  
+   map:
      - source.ip: $~windows.Event.EventData.IpAddress
      - source.port: $~windows.Event.EventData.IpPort
      - source.domain: $~windows.Event.EventData.WorkstationName

--- a/src/engine/ruleset/integrations/windows/decoders/windows-sysmon.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-sysmon.yml
@@ -92,15 +92,15 @@ normalize:
     - related.ip: +array_append/$~windows.Event.EventData.NewTargetUserName
 
 
- - check: event.code=="255"
+ - check: $event.code=="255"
    map:
     - error.code: $event.code
 
- - check: event.code=="25"
+ - check: $event.code=="25"
    map:
     - message: $~windows.Event.EventData.Type
 
- - check: +string_not_equal/event.code/7
+ - check: +string_not_equal/$event.code/7
    map:
    - process.pe.original_file_name: $~windows.Event.EventData.OriginalFileName
    - process.pe.company: $~windows.Event.EventData.Company
@@ -108,7 +108,7 @@ normalize:
    - process.pe.file_version: $~windows.Event.EventData.FileVersion
    - process.pe.product: $~windows.Event.EventData.Product
 
- - check: event.code=="7"
+ - check: $event.code=="7"
    map:
     - file.pe.original_file_name: $~windows.Event.EventData.OriginalFileName
     - file.pe.company: $~windows.Event.EventData.Company
@@ -117,41 +117,41 @@ normalize:
     - file.pe.product: $~windows.Event.EventData.Product
 
   # DNS event
- - check: event.code=="22"
+ - check: $event.code=="22"
    map:
     - network.protocol: dns
 
- - check: ~windows.Event.EventData.SignatureStatus==Valid
+ - check: $~windows.Event.EventData.SignatureStatus==Valid
    map:
     - file.code_signature.valid: True
 
- - check: ~windows.Event.EventData.Initiated==True
+ - check: $~windows.Event.EventData.Initiated==True
    map:
     - network.direction: egress
 
- - check: ~windows.Event.EventData.Initiated==false
+ - check: $~windows.Event.EventData.Initiated==false
    map:
     - network.direction: ingress
 
- - check: ~windows.Event.EventData.SourceIsIpv6==true
+ - check: $~windows.Event.EventData.SourceIsIpv6==true
    map:
     - network.type: ipv6
 
- - check: ~windows.Event.EventData.SourceIsIpv6==false
+ - check: $~windows.Event.EventData.SourceIsIpv6==false
    map:
     - network.type: ipv4
 
- - check: event.code=="1" OR event.code=="23"  OR event.code=="24" OR event.code=="25" OR event.code=="26"
+ - check: $event.code=="1" OR $event.code=="23"  OR $event.code=="24" OR $event.code=="25" OR $event.code=="26"
    map:
     - process.hash: $~temp.hashes
 
- - check: event.code=="6" OR event.code=="7"  OR event.code=="15"
+ - check: $event.code=="6" OR $event.code=="7"  OR $event.code=="15"
    map:
     - file.hash: $~temp.hashes
     - file.pe.imphash: file.hash.imphash
 
   ## Registry fields
- - check: event.code=="12" OR event.code=="13"  OR event.code=="14"
+ - check: $event.code=="12" OR $event.code=="13"  OR $event.code=="14"
    map:
     - registry.path: $~windows.Event.EventData.TargetObject
     - ~temp.registry.array: +split/$registry.path/\\
@@ -160,12 +160,12 @@ normalize:
     - registry.key: +join/$~temp.registry.array/\\
     - registry.value: +regex_extract/$registry.path/^.*\\\\(.*)$
 
- - check: (event.code=="12" OR event.code=="13"  OR event.code=="14") AND +starts_with/~windows.Event.EventData.Details/QWORD
+ - check: ($event.code=="12" OR $event.code=="13"  OR $event.code=="14") AND +starts_with/$~windows.Event.EventData.Details/QWORD
    map:
     - registry.data.type: SZ_QWORD
     - registry.data.strings: +regex_extract/$~windows.Event.EventData.Details/^QWORD\s*\((0x[0-9A-F]+-0x[0-9A-F]+)\)
 
- - check: (event.code=="12" OR event.code=="13"  OR event.code=="14") AND +starts_with/~windows.Event.EventData.Details/DWORD
+ - check: ($event.code=="12" OR $event.code=="13"  OR $event.code=="14") AND +starts_with/$~windows.Event.EventData.Details/DWORD
    map:
     - registry.data.type: SZ_DWORD
     - ~temp.value: +regex_extract/$~windows.Event.EventData.Details/DWORD \((0x[0-9A-F]{8})\)
@@ -176,7 +176,7 @@ normalize:
    map:
     - ~temp.is_binary_data: True
 
- - check:  (event.code=="12" OR event.code=="13"  OR event.code=="14") AND +is_true/~temp.is_binary_data
+ - check:  ($event.code=="12" OR $event.code=="13"  OR $event.code=="14") AND +is_true/$~temp.is_binary_data
    map:
     - registry.data.type: REG_BINARY
     - registry.data.strings: $~windows.Event.EventData.Details

--- a/src/engine/ruleset/integrations/windows/decoders/windows-sysmon.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-sysmon.yml
@@ -1,6 +1,6 @@
 name: decoder/windows-sysmon/0
 
-sources:
+parents:
   - decoder/windows-event-decoder/0
 
 metadata:
@@ -159,7 +159,7 @@ normalize:
     - ~temp.registry.array.0: +delete
     - registry.key: +join/$~temp.registry.array/\\
     - registry.value: +regex_extract/$registry.path/^.*\\\\(.*)$
-    
+
  - check: (event.code=="12" OR event.code=="13"  OR event.code=="14") AND +starts_with/~windows.Event.EventData.Details/QWORD
    map:
     - registry.data.type: SZ_QWORD

--- a/src/engine/ruleset/schemas/wazuh-asset.json
+++ b/src/engine/ruleset/schemas/wazuh-asset.json
@@ -66,7 +66,7 @@
         {
             "required": [
                 "allow",
-                "sources"
+                "parents"
             ],
             "not": {
                 "anyOf": [
@@ -160,9 +160,9 @@
                 }
             }
         },
-        "sources": {
+        "parents": {
             "type": "array",
-            "description": "This asset will process events coming only from the specified sources",
+            "description": "This asset will process events coming only from the specified parents",
             "items": {
                 "type": "string"
             }

--- a/src/engine/ruleset/wazuh-core/decoders/ciscat/ciscat.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/ciscat/ciscat.yml
@@ -18,7 +18,7 @@ metadata:
     versions:
       - ""
 
-sources:
+parents:
   - decoder/core-ciscat/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-ciscat.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-ciscat.yml
@@ -15,7 +15,7 @@ metadata:
   references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/ciscat/ciscat.html
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-dbsync.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-dbsync.yml
@@ -15,7 +15,7 @@ metadata:
   references:
     - https://github.com/wazuh/wazuh/issues/13521
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-hostinfo.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-hostinfo.yml
@@ -14,7 +14,7 @@ metadata:
   references:
     - https://documentation.wazuh.com/current/user-manual/reference/core-options.html
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-localfile.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-localfile.yml
@@ -15,7 +15,7 @@ metadata:
   references:
     - https://documentation.wazuh.com/current/development/message-format.html
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-rootcheck.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-rootcheck.yml
@@ -15,7 +15,7 @@ metadata:
     - https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/rootcheck/how-it-works.html
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/rootcheck.html
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-rsyslog.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-rsyslog.yml
@@ -14,7 +14,7 @@ metadata:
   references:
     - https://wazuh.com/blog/how-to-configure-rsyslog-client-to-send-events-to-wazuh/
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-sca.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-sca.yml
@@ -16,7 +16,7 @@ metadata:
     - https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/index.html
     - https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/how-to-configure.html
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-secure.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-secure.yml
@@ -14,7 +14,7 @@ metadata:
   references:
     - https://documentation.wazuh.com/current/development/message-format.html#secure-message-format
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-syscheck.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-syscheck.yml
@@ -14,7 +14,7 @@ metadata:
   references:
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-syscollector.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-syscollector.yml
@@ -14,7 +14,7 @@ metadata:
   references:
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-syscollector.html
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-upgrade.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-upgrade.yml
@@ -15,7 +15,7 @@ metadata:
   references:
     - https://www.json.org
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/core-windows.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/core-windows.yml
@@ -15,7 +15,7 @@ metadata:
   references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/log-data-collection/how-to-collect-wlogs.html
 
-sources:
+parents:
   - decoder/core-wazuh-message/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/dbsync/dbsync.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/dbsync/dbsync.yml
@@ -15,7 +15,7 @@ metadata:
   versions:
     - ""
 
-sources:
+parents:
   - decoder/core-dbsync/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/enrichment/dbsync-host-data.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/enrichment/dbsync-host-data.yml
@@ -15,7 +15,7 @@ metadata:
   versions:
     - ""
 
-sources:
+parents:
   - decoder/dbsync/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/enrichment/kvdb-agent-update.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/enrichment/kvdb-agent-update.yml
@@ -15,7 +15,7 @@ metadata:
   versions:
     - ""
 
-sources:
+parents:
   - decoder/dbsync-host-data/0
   - decoder/syscollector-dbsync-host-data/0
 

--- a/src/engine/ruleset/wazuh-core/decoders/enrichment/syscollector-dbsync-host-data.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/enrichment/syscollector-dbsync-host-data.yml
@@ -15,7 +15,7 @@ metadata:
   versions:
     - ""
 
-sources:
+parents:
   - decoder/syscollector-dbsync/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/fim/fim-event.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/fim/fim-event.yml
@@ -1,7 +1,7 @@
 ---
 name: decoder/fim-event/0
 
-sources:
+parents:
   - decoder/fim/0
 
 metadata:

--- a/src/engine/ruleset/wazuh-core/decoders/fim/fim-scan.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/fim/fim-scan.yml
@@ -1,7 +1,7 @@
 ---
 name: decoder/fim-scan/0
 
-sources:
+parents:
   - decoder/fim/0
 
 metadata:

--- a/src/engine/ruleset/wazuh-core/decoders/fim/fim.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/fim/fim.yml
@@ -21,7 +21,7 @@ metadata:
   versions:
     - ""
 
-sources:
+parents:
   - decoder/core-syscheck/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/integrations.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/integrations.yml
@@ -4,7 +4,7 @@ name: decoder/integrations/0
 metadata:
   title: Base decoder.
 
-sources:
+parents:
   - decoder/core-localfile/0
   - decoder/core-rsyslog/0
   - decoder/core-windows/0

--- a/src/engine/ruleset/wazuh-core/decoders/rootcheck/rootcheck.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/rootcheck/rootcheck.yml
@@ -18,7 +18,7 @@ metadata:
   versions:
     -
 
-sources:
+parents:
   - decoder/core-rootcheck/0
 
 normalize:

--- a/src/engine/ruleset/wazuh-core/decoders/sca/sca.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/sca/sca.yml
@@ -19,7 +19,7 @@ metadata:
   versions:
     - ""
 
-sources:
+parents:
   - decoder/core-sca/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/syscollector/syscollector-base.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/syscollector/syscollector-base.yml
@@ -19,7 +19,7 @@ metadata:
   versions:
     - ""
 
-sources:
+parents:
   - decoder/core-syscollector/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/syscollector/syscollector-dbsync.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/syscollector/syscollector-dbsync.yml
@@ -20,7 +20,7 @@ metadata:
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-syscollector.html
     - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-db.html#syscollector-tables
 
-sources:
+parents:
   - decoder/syscollector-base/0
 
 check:

--- a/src/engine/ruleset/wazuh-core/decoders/upgrade/upgrade.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/upgrade/upgrade.yml
@@ -18,7 +18,7 @@ metadata:
         - https://documentation.wazuh.com/current/user-manual/agents/remote-upgrading/upgrading-agent.html#upgrading-agent
         - https://documentation.wazuh.com/current/user-manual/agents/remote-upgrading/agent-upgrade-module.html
 
-sources:
+parents:
   - decoder/core-upgrade/0
 
 # Examples:
@@ -47,4 +47,3 @@ normalize:
   - map:
       - ~tmp: +delete
       - ~json: +delete
-

--- a/src/engine/source/api/src/graph/handlers.cpp
+++ b/src/engine/source/api/src/graph/handlers.cpp
@@ -79,7 +79,8 @@ api::Handler resourceGet(const Config& config)
                                          std::get<base::Error>(hlpParsers).message);
             return ::api::adapter::genericError<ResponseType>(msg);
         }
-        auto logpar = std::make_shared<hlp::logpar::Logpar>(std::get<json::Json>(hlpParsers));
+        auto schema = std::make_shared<schemf::Schema>();
+        auto logpar = std::make_shared<hlp::logpar::Logpar>(std::get<json::Json>(hlpParsers), schema);
         hlp::registerParsers(logpar);
 
         auto registry = std::make_shared<builder::internals::Registry<builder::internals::Builder>>();
@@ -91,7 +92,7 @@ api::Handler resourceGet(const Config& config)
             deps.logpar = logpar;
             deps.kvdbScopeName = "graph";
             deps.kvdbManager = config.kvdbManager;
-            deps.schema = std::make_shared<schemf::Schema>();
+            deps.schema = schema;
             deps.helperRegistry = std::make_shared<builder::internals::Registry<builder::internals::HelperBuilder>>();
             builder::internals::registerHelperBuilders(deps.helperRegistry, deps);
             builder::internals::registerBuilders(registry, deps);

--- a/src/engine/source/builder/asset.cpp
+++ b/src/engine/source/builder/asset.cpp
@@ -74,26 +74,26 @@ Asset::Asset(const json::Json& jsonDefinition,
     const std::string assetName {jsonDefinition.getString("/name").value_or("")};
 
     // Get parents
-    auto sourcesPos =
+    auto parentsPos =
         std::find_if(objectDefinition.begin(),
                      objectDefinition.end(),
-                     [](auto tuple) { return std::get<0>(tuple) == "sources" || std::get<0>(tuple) == "after"; });
-    if (objectDefinition.end() != sourcesPos)
+                     [](auto tuple) { return std::get<0>(tuple) == "parents" || std::get<0>(tuple) == "after"; });
+    if (objectDefinition.end() != parentsPos)
     {
-        if (!std::get<1>(*sourcesPos).isArray())
+        if (!std::get<1>(*parentsPos).isArray())
         {
             LOG_DEBUG("Engine assets: '{}' method: JSON definition: '{}'.", __func__, jsonDefinition.str());
             throw std::runtime_error(
-                fmt::format("Asset '{}' sources definition is expected to be an array but it is of type '{}'",
+                fmt::format("Asset '{}' parents definition is expected to be an array but it is of type '{}'",
                             assetName,
-                            std::get<1>(*sourcesPos).typeName()));
+                            std::get<1>(*parentsPos).typeName()));
         }
-        auto sources = std::get<1>(*sourcesPos).getArray().value();
-        for (auto& source : sources)
+        auto parents = std::get<1>(*parentsPos).getArray().value();
+        for (auto& parent : parents)
         {
-            m_parents.insert(source.getString().value());
+            m_parents.insert(parent.getString().value());
         }
-        objectDefinition.erase(sourcesPos);
+        objectDefinition.erase(parentsPos);
     }
 
     // Get metadata

--- a/src/engine/source/builder/asset.cpp
+++ b/src/engine/source/builder/asset.cpp
@@ -163,11 +163,16 @@ Asset::Asset(const json::Json& jsonDefinition,
     }
 
     // Delete variables from the event always
+    auto ifVar = [](auto attr)
+    {
+        return !attr.empty() && attr[0] == internals::syntax::VARIABLE_ANCHOR;
+    };
+
     auto deleteVariables =
         base::Term<base::EngineOp>::create("DeleteVariables",
-                                           [](auto e)
+                                           [ifVar](auto e)
                                            {
-                                               e->erase(internals::syntax::VARIABLE_ANCHOR);
+                                               e->eraseIfKey(ifVar);
                                                return base::result::makeSuccess(e, "DeleteVariables");
                                            });
 

--- a/src/engine/source/builder/builders/opBuilderHelperMap.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperMap.cpp
@@ -1124,10 +1124,10 @@ HelperBuilder getOpBuilderHelperEraseCustomFields(std::shared_ptr<schemf::ISchem
         // Return result
         return base::Term<base::EngineOp>::create(
             name,
-            [isCustomField, successTrace](base::Event event) -> base::result::Result<base::Event>
+            [isCustomField, targetField, successTrace](base::Event event) -> base::result::Result<base::Event>
             {
                 // Erase custom fields
-                event->eraseIfKey(isCustomField);
+                event->eraseIfKey(isCustomField, false, targetField);
                 return base::result::makeSuccess(event, successTrace);
             });
     };

--- a/src/engine/source/builder/builders/opBuilderHelperMap.hpp
+++ b/src/engine/source/builder/builders/opBuilderHelperMap.hpp
@@ -253,6 +253,14 @@ base::Expression opBuilderHelperMergeRecursively(const std::string& targetField,
                                                  const std::vector<std::string>& rawParameters,
                                                  std::shared_ptr<defs::IDefinitions> definitions);
 
+/**
+ * @brief Function that returns a builder for the operation to erase custom fields from an event.
+ *
+ * @param schema A shared pointer to the schema to check the fields.
+ * @return A HelperBuilder object that erases custom fields from an event.
+ */
+HelperBuilder getOpBuilderHelperEraseCustomFields(std::shared_ptr<schemf::ISchema> schema);
+
 //*************************************************
 //*           Regex tranform                      *
 //*************************************************

--- a/src/engine/source/builder/builders/stageBuilderCheck.cpp
+++ b/src/engine/source/builder/builders/stageBuilderCheck.cpp
@@ -150,13 +150,13 @@ base::Expression stageBuilderCheckExpression(const std::any& definition,
                             "Check stage: The '{}' operator only allows operate with numbers or string", keyboarder));
                     }
 
-                    const auto prefix = valueJson.isInt64() ? "+int_" : "+string_";
-                    const auto suffix = ((keyboarder == "<=")   ? "less_or_equal/"
-                                         : (keyboarder == ">=") ? "greater_or_equal/"
-                                         : (keyboarder == "<")  ? "less/"
-                                                                : "greater/")
+                    const auto prefix = valueJson.isInt64() ? "int_" : "string_";
+                    const auto suffix = ((keyboarder == "<=")   ? "less_or_equal("
+                                         : (keyboarder == ">=") ? "greater_or_equal("
+                                         : (keyboarder == "<")  ? "less("
+                                                                : "greater(")
                                         + operand;
-                    value = prefix + suffix;
+                    value = prefix + suffix + ")";
                     valueJson.setString(value);
                 }
             }

--- a/src/engine/source/builder/builders/stageBuilderCheck.cpp
+++ b/src/engine/source/builder/builders/stageBuilderCheck.cpp
@@ -82,6 +82,16 @@ base::Expression stageBuilderCheckExpression(const std::any& definition,
         std::string value;
         json::Json valueJson;
 
+        auto getField = [](const std::string& field) -> std::string
+        {
+            if (field[0] != syntax::REFERENCE_ANCHOR)
+            {
+                throw std::runtime_error(fmt::format("Check stage: the fild must be a reference, but got '{}'",
+                                                     field));
+            }
+            return field.substr(1);
+        };
+
         if (syntax::FUNCTION_HELPER_ANCHOR == term[0])
         {
             auto pos1 = term.find("/");
@@ -95,7 +105,7 @@ base::Expression stageBuilderCheckExpression(const std::any& definition,
                 return term.size();
             }();
 
-            field = term.substr(pos1 + 1, pos2 - pos1 - 1);
+            field = getField(term.substr(pos1 + 1, pos2 - pos1 - 1));
             value = term.substr(0, pos1) + term.substr(pos2);
             valueJson.setString(value);
         }
@@ -111,7 +121,7 @@ base::Expression stageBuilderCheckExpression(const std::any& definition,
                 keyboarder = match[1];
                 auto pos = term.find(keyboarder);
 
-                field = term.substr(0, pos);
+                field = getField(term.substr(0, pos));
 
                 auto operand = term.substr(pos + keyboarder.length());
 

--- a/src/engine/source/builder/helperParser.hpp
+++ b/src/engine/source/builder/helperParser.hpp
@@ -1,0 +1,110 @@
+#ifndef _BUILDER_HELPER_PARSER_HPP
+#define _BUILDER_HELPER_PARSER_HPP
+
+#include <string>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+#include <fmt/format.h>
+#include <re2/re2.h>
+
+#include <error.hpp>
+#include <json/json.hpp>
+
+#include "syntax.hpp"
+#include "utils/stringUtils.hpp"
+
+namespace builder::internals
+{
+struct HelperToken
+{
+    std::string name = "";
+    std::vector<std::string> args = {};
+
+    friend std::ostream& operator<<(std::ostream& os, const HelperToken& helperToken)
+    {
+        std::string separator {};
+        separator += syntax::FUNCTION_HELPER_ARG_ANCHOR;
+
+        os << helperToken.name << "(" << base::utils::string::join(helperToken.args, separator, false) << ")";
+
+        return os;
+    }
+};
+
+inline std::tuple<std::string, json::Json> toBuilderInput(const HelperToken& helperToken,
+                                                          const std::string& targetField)
+{
+    json::Json value {};
+    auto valueStr = fmt::format("{}({})", helperToken.name, base::utils::string::join(helperToken.args, ","));
+    value.setString(valueStr);
+
+    return std::make_tuple(targetField, std::move(value));
+}
+
+inline std::tuple<std::string, json::Json> toBuilderInput(const HelperToken& helperToken)
+{
+    if (helperToken.args.empty())
+    {
+        std::stringstream ss {};
+        ss << helperToken;
+        throw std::runtime_error(
+            fmt::format("Helper {} has no arguments, expected to have target field as first argument", ss.str()));
+    }
+
+    return toBuilderInput({helperToken.name, {helperToken.args.begin() + 1, helperToken.args.end()}},
+                          helperToken.args[0]);
+}
+
+inline std::variant<HelperToken, base::Error> parseHelper(const std::string& text)
+{
+    static const auto regexPattern = R"(^([\w_]+)\((.*)\)$)";
+    static const re2::RE2 pattern(regexPattern);
+
+    std::string helperName;
+    std::string strArgs;
+
+    HelperToken result;
+
+    if (re2::RE2::FullMatch(text, pattern, &result.name, &strArgs))
+    {
+        if (!strArgs.empty())
+        {
+            size_t pos = 0;
+            while ((pos = strArgs.find(',', pos)) != std::string::npos)
+            {
+                // if comma is the comma is scaped, skip it
+                if (pos != 0 && strArgs[pos - 1] == '\\')
+                {
+                    ++pos;
+                    continue;
+                }
+
+                // if a space is found after the comma, erase it
+                if ((pos + 1) < strArgs.size() && strArgs[pos + 1] == ' ')
+                {
+                    strArgs.erase(pos + 1, 1);
+                }
+                // if the space is scaped, delete the backslash
+                else if ((pos + 2) < strArgs.size() && strArgs[pos + 1] == syntax::FUNCTION_HELPER_DEFAULT_ESCAPE
+                         && strArgs[pos + 2] == ' ')
+                {
+                    strArgs.erase(pos + 1, 1);
+                }
+
+                ++pos;
+            }
+
+            result.args = base::utils::string::splitEscaped(
+                strArgs, syntax::FUNCTION_HELPER_ARG_ANCHOR, syntax::FUNCTION_HELPER_DEFAULT_ESCAPE);
+        }
+
+        return result;
+    }
+
+    return base::Error {"No match found!"};
+}
+} // namespace builder::internals
+
+#endif // _BUILDER_HELPER_PARSER_HPP

--- a/src/engine/source/builder/helperParser.hpp
+++ b/src/engine/source/builder/helperParser.hpp
@@ -74,7 +74,7 @@ inline std::variant<HelperToken, base::Error> parseHelper(const std::string& tex
             size_t pos = 0;
             while ((pos = strArgs.find(',', pos)) != std::string::npos)
             {
-                // if comma is the comma is scaped, skip it
+                // if the comma is escaped skip it 
                 if (pos != 0 && strArgs[pos - 1] == '\\')
                 {
                     ++pos;

--- a/src/engine/source/builder/register.hpp
+++ b/src/engine/source/builder/register.hpp
@@ -113,6 +113,10 @@ static void registerHelperBuilders(std::shared_ptr<Registry<HelperBuilder>> help
     helperRegistry->registerBuilder(builders::getOpBuilderHelperGetValue(dependencies.schema), "get_value");
     helperRegistry->registerBuilder(builders::getOpBuilderHelperMergeValue(dependencies.schema), "merge_value");
 
+    // Global event helpers
+    helperRegistry->registerBuilder(builders::getOpBuilderHelperEraseCustomFields(dependencies.schema),
+                                    "erase_custom_fields");
+
     // Special helpers
 
     // Active Response

--- a/src/engine/source/builder/register.hpp
+++ b/src/engine/source/builder/register.hpp
@@ -36,7 +36,7 @@ struct dependencies
     std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager;
     std::shared_ptr<Registry<HelperBuilder>> helperRegistry;
     std::shared_ptr<schemf::ISchema> schema;
-    bool forceFieldNaming = false; // TODO remove once test use proper naming for fields
+    bool forceFieldNaming = false;
     std::shared_ptr<sockiface::ISockFactory> sockFactory;
     std::shared_ptr<wazuhdb::IWDBManager> wdbManager;
 };

--- a/src/engine/source/builder/syntax.hpp
+++ b/src/engine/source/builder/syntax.hpp
@@ -15,7 +15,6 @@ constexpr char FUNCTION_HELPER_ARG_ANCHOR {','};
 constexpr char FUNCTION_HELPER_DEFAULT_ESCAPE {'\\'};
 constexpr char JSON_PATH_SEPARATOR {'.'};
 constexpr char CUSTOM_FIELD_ANCHOR {'~'};
-constexpr char CUSTOM_FIELD_SEPARATOR {'.'};
 constexpr char VARIABLE_ANCHOR {'_'};
 
 } // namespace builder::internals::syntax

--- a/src/engine/source/builder/syntax.hpp
+++ b/src/engine/source/builder/syntax.hpp
@@ -11,8 +11,7 @@ namespace builder::internals::syntax
 {
 
 constexpr char REFERENCE_ANCHOR {'$'};
-constexpr char FUNCTION_HELPER_ANCHOR {'+'};
-constexpr char FUNCTION_HELPER_ARG_ANCHOR {'/'};
+constexpr char FUNCTION_HELPER_ARG_ANCHOR {','};
 constexpr char FUNCTION_HELPER_DEFAULT_ESCAPE {'\\'};
 constexpr char JSON_PATH_SEPARATOR {'.'};
 constexpr char CUSTOM_FIELD_ANCHOR {'~'};

--- a/src/engine/source/builder/syntax.hpp
+++ b/src/engine/source/builder/syntax.hpp
@@ -15,6 +15,8 @@ constexpr char FUNCTION_HELPER_ARG_ANCHOR {','};
 constexpr char FUNCTION_HELPER_DEFAULT_ESCAPE {'\\'};
 constexpr char JSON_PATH_SEPARATOR {'.'};
 constexpr char CUSTOM_FIELD_ANCHOR {'~'};
+constexpr char CUSTOM_FIELD_SEPARATOR {'.'};
+constexpr char VARIABLE_ANCHOR {'_'};
 
 } // namespace builder::internals::syntax
 

--- a/src/engine/source/cmds/src/start.cpp
+++ b/src/engine/source/cmds/src/start.cpp
@@ -296,7 +296,7 @@ void runStart(ConfHandler confManager)
             deps.kvdbManager = kvdbManager;
             deps.helperRegistry = std::make_shared<builder::internals::Registry<builder::internals::HelperBuilder>>();
             deps.schema = schema;
-            deps.forceFieldNaming = true;
+            deps.forceFieldNaming = false;
             deps.sockFactory = std::make_shared<sockiface::UnixSocketFactory>();
             deps.wdbManager =
                 std::make_shared<wazuhdb::WDBManager>(std::string(wazuhdb::WDB_SOCK_PATH), deps.sockFactory);

--- a/src/engine/source/cmds/src/test.cpp
+++ b/src/engine/source/cmds/src/test.cpp
@@ -96,7 +96,8 @@ void run(const Options& options)
         g_exitHanlder.execute();
         return;
     }
-    auto logpar = std::make_shared<hlp::logpar::Logpar>(std::get<json::Json>(hlpParsers));
+    auto schema = std::make_shared<schemf::Schema>();
+    auto logpar = std::make_shared<hlp::logpar::Logpar>(std::get<json::Json>(hlpParsers), schema);
     hlp::registerParsers(logpar);
     LOG_INFO("HLP initialized.");
 
@@ -110,7 +111,7 @@ void run(const Options& options)
         deps.kvdbScopeName = "test";
         deps.kvdbManager = kvdbManager;
         deps.helperRegistry = std::make_shared<builder::internals::Registry<builder::internals::HelperBuilder>>();
-        deps.schema = std::make_shared<schemf::Schema>();
+        deps.schema = schema;
         builder::internals::registerHelperBuilders(deps.helperRegistry, deps);
         builder::internals::registerBuilders(registry, deps);
     }

--- a/src/engine/source/cmds/src/test.cpp
+++ b/src/engine/source/cmds/src/test.cpp
@@ -97,6 +97,18 @@ void run(const Options& options)
         return;
     }
     auto schema = std::make_shared<schemf::Schema>();
+    auto result = fileStore->get("schema/engine-schema/0");
+            if (std::holds_alternative<base::Error>(result))
+            {
+                LOG_WARNING("Error loading schema definition: {}", std::get<base::Error>(result).message);
+                LOG_WARNING("Engine running without schema, consistency with indexer mappings is not guaranteed.");
+            }
+            else
+            {
+                auto schemaJson = std::get<json::Json>(result);
+                schema->load(schemaJson);
+            }
+            LOG_INFO("Schema initialized.");
     auto logpar = std::make_shared<hlp::logpar::Logpar>(std::get<json::Json>(hlpParsers), schema);
     hlp::registerParsers(logpar);
     LOG_INFO("HLP initialized.");

--- a/src/engine/source/cmds/src/test.cpp
+++ b/src/engine/source/cmds/src/test.cpp
@@ -5,8 +5,8 @@
 #include <memory>
 #include <thread>
 
-#include <termios.h>
 #include <re2/re2.h>
+#include <termios.h>
 
 #include <cmds/details/stackExecutor.hpp>
 #include <kvdb/kvdbManager.hpp>
@@ -79,7 +79,7 @@ void run(const Options& options)
 
     auto metricsManager = std::make_shared<metricsManager::MetricsManager>();
 
-    kvdbManager::KVDBManagerOptions kvdbOptions { options.kvdbPath, "kvdb" };
+    kvdbManager::KVDBManagerOptions kvdbOptions {options.kvdbPath, "kvdb"};
     auto kvdbManager = std::make_shared<kvdbManager::KVDBManager>(kvdbOptions, metricsManager);
     kvdbManager->initialize();
 
@@ -98,17 +98,17 @@ void run(const Options& options)
     }
     auto schema = std::make_shared<schemf::Schema>();
     auto result = fileStore->get("schema/engine-schema/0");
-            if (std::holds_alternative<base::Error>(result))
-            {
-                LOG_WARNING("Error loading schema definition: {}", std::get<base::Error>(result).message);
-                LOG_WARNING("Engine running without schema, consistency with indexer mappings is not guaranteed.");
-            }
-            else
-            {
-                auto schemaJson = std::get<json::Json>(result);
-                schema->load(schemaJson);
-            }
-            LOG_INFO("Schema initialized.");
+    if (std::holds_alternative<base::Error>(result))
+    {
+        LOG_WARNING("Error loading schema definition: {}", std::get<base::Error>(result).message);
+        LOG_WARNING("Engine running without schema, consistency with indexer mappings is not guaranteed.");
+    }
+    else
+    {
+        auto schemaJson = std::get<json::Json>(result);
+        schema->load(schemaJson);
+    }
+    LOG_INFO("Schema initialized.");
     auto logpar = std::make_shared<hlp::logpar::Logpar>(std::get<json::Json>(hlpParsers), schema);
     hlp::registerParsers(logpar);
     LOG_INFO("HLP initialized.");

--- a/src/engine/source/json/include/json/json.hpp
+++ b/src/engine/source/json/include/json/json.hpp
@@ -742,17 +742,6 @@ public:
     bool erase(std::string_view path = "");
 
     /**
-     * @brief Erase Json object properties at the path.
-     *
-     * @param prefix The prefix of the properties to erase.
-     * @param path The path to the object, default value is root object ("").
-     * @return true if object properties were erased, false if object or properties were not found.
-     *
-     * @throws std::runtime_error If path is invalid.
-     */
-    bool erase(char prefix, std::string_view path = "");
-
-    /**
      * @brief Merge the Json Value at the path with the given Json Value.
      *
      * Objects are merged, arrays are appended.

--- a/src/engine/source/json/include/json/json.hpp
+++ b/src/engine/source/json/include/json/json.hpp
@@ -742,6 +742,17 @@ public:
     bool erase(std::string_view path = "");
 
     /**
+     * @brief Erase Json object properties at the path.
+     *
+     * @param prefix The prefix of the properties to erase.
+     * @param path The path to the object, default value is root object ("").
+     * @return true if object properties were erased, false if object or properties were not found.
+     *
+     * @throws std::runtime_error If path is invalid.
+     */
+    bool erase(char prefix, std::string_view path = "");
+
+    /**
      * @brief Merge the Json Value at the path with the given Json Value.
      *
      * Objects are merged, arrays are appended.
@@ -775,7 +786,8 @@ public:
     void merge(const bool isRecursive, std::string_view other, std::string_view path = "");
 
     /**
-     * @brief Erases all the members of the JSON object that satisfy the given condition in the given Key (No the full path)
+     * @brief Erases all the members of the JSON object that satisfy the given condition in the given Key (No the full
+     * path)
      *
      * @param func A function that takes a string and returns a boolean indicating whether the member should be
      * erased. The string is the key of the member (No the full path)

--- a/src/engine/source/json/include/json/json.hpp
+++ b/src/engine/source/json/include/json/json.hpp
@@ -773,6 +773,19 @@ public:
      * - If Json Values are not the same type.
      */
     void merge(const bool isRecursive, std::string_view other, std::string_view path = "");
+
+    /**
+     * @brief Erases all the members of the JSON object that satisfy the given condition in the given Key (No the full path)
+     *
+     * @param func A function that takes a string and returns a boolean indicating whether the member should be
+     * erased. The string is the key of the member (No the full path)
+     * @param recursive If true, the function will recursively erase members of nested objects.
+     * @param path The path to the JSON object to modify.
+     * @return true if any member was erased, false otherwise.
+     *
+     * @throws std::runtime_error if the given path is invalid.
+     */
+    bool eraseIfKey(const std::function<bool(const std::string&)>&, bool recursive = false, const std::string& = "");
 };
 
 } // namespace json

--- a/src/engine/source/json/src/json.cpp
+++ b/src/engine/source/json/src/json.cpp
@@ -924,41 +924,6 @@ bool Json::erase(std::string_view path)
     }
 }
 
-bool Json::erase(char prefix, std::string_view path)
-{
-
-    const auto pp = rapidjson::Pointer(path.data());
-    auto erased = false;
-
-    if (pp.IsValid())
-    {
-        auto* val = pp.Get(m_document);
-        if (!val || !val->IsObject())
-        {
-            return false;
-        }
-
-        for (auto it = val->MemberBegin(); it != val->MemberEnd();)
-        {
-            if (it->name.GetString()[0] == prefix)
-            {
-                it = val->EraseMember(it);
-                erased = true;
-            }
-            else
-            {
-                ++it;
-            }
-        }
-    }
-    else
-    {
-        throw std::runtime_error(fmt::format(INVALID_POINTER_TYPE_MSG, path));
-    }
-
-    return erased;
-}
-
 void Json::merge(const bool isRecursive, const rapidjson::Value& source, std::string_view path)
 {
     const auto pp = rapidjson::Pointer(path.data());

--- a/src/engine/source/logicExpression/src/logicExpressionParser.cpp
+++ b/src/engine/source/logicExpression/src/logicExpressionParser.cpp
@@ -19,10 +19,12 @@ namespace
 std::queue<Token> tokenize(const std::string& rawExpression)
 {
     std::vector<std::string> rawTokens =
-        base::utils::string::splitMulti(rawExpression,
-                                  base::utils::string::Delimeter(' ', false),
-                                  base::utils::string::Delimeter('(', true),
-                                  base::utils::string::Delimeter(')', true));
+        base::utils::string::splitMulti(rawExpression, base::utils::string::Delimeter(' ', false));
+
+    // TODO: Right now parenthesis conflict with helper builder syntax, so we force
+    // them to be separated by blank spaces. This should be fixed in the future parsing implementation.
+    //   base::utils::string::Delimeter('(', true),
+    //   base::utils::string::Delimeter(')', true));
 
     std::queue<Token> tokens;
     size_t i = 0;
@@ -70,9 +72,7 @@ struct syntaxChecker
             if (expectedOperator())
             {
                 throw std::runtime_error(
-                    fmt::format("Unexpected tocken TERM \"{}\" at position \"{}\"",
-                                token.m_text,
-                                token.m_position));
+                    fmt::format("Unexpected tocken TERM \"{}\" at position \"{}\"", token.m_text, token.m_position));
             }
 
             expectOperator();
@@ -85,8 +85,7 @@ struct syntaxChecker
             if (expectedOperator())
             {
                 throw std::runtime_error(
-                    fmt::format("Unexpected unary operator \"NOT\" at position \"{}\"",
-                                token.m_position));
+                    fmt::format("Unexpected unary operator \"NOT\" at position \"{}\"", token.m_position));
             }
 
             // Still wanting operand
@@ -98,10 +97,8 @@ struct syntaxChecker
         {
             if (expectedOperand())
             {
-                throw std::runtime_error(
-                    fmt::format("Unexpected binary operator \"{}\" at position \"{}\"",
-                                token.m_text,
-                                token.m_position));
+                throw std::runtime_error(fmt::format(
+                    "Unexpected binary operator \"{}\" at position \"{}\"", token.m_text, token.m_position));
             }
 
             expectOperand();
@@ -113,8 +110,8 @@ struct syntaxChecker
         {
             if (expectedOperator())
             {
-                throw std::runtime_error(fmt::format(
-                    "Unexpected parenthesis \"(\" at position \"{}\"", token.m_position));
+                throw std::runtime_error(
+                    fmt::format("Unexpected parenthesis \"(\" at position \"{}\"", token.m_position));
             }
 
             // Still wanting operand
@@ -126,8 +123,8 @@ struct syntaxChecker
         {
             if (expectedOperand())
             {
-                throw std::runtime_error(fmt::format(
-                    "Unexpected parenthesis \")\" at position \"{}\"", token.m_position));
+                throw std::runtime_error(
+                    fmt::format("Unexpected parenthesis \")\" at position \"{}\"", token.m_position));
             }
 
             // Still wanting operator
@@ -160,8 +157,7 @@ std::stack<Token> infixToPostfix(std::queue<Token>& infix)
         }
         else if (TokenType::PARENTHESIS_CLOSE == token.m_type)
         {
-            while (!operatorStack.empty()
-                   && operatorStack.top().m_type != TokenType::PARENTHESIS_OPEN)
+            while (!operatorStack.empty() && operatorStack.top().m_type != TokenType::PARENTHESIS_OPEN)
             {
                 postfix.push(std::move(operatorStack.top()));
                 operatorStack.pop();
@@ -174,8 +170,7 @@ std::stack<Token> infixToPostfix(std::queue<Token>& infix)
         }
         else
         {
-            while (!operatorStack.empty()
-                   && operatorStack.top().m_type != TokenType::PARENTHESIS_OPEN
+            while (!operatorStack.empty() && operatorStack.top().m_type != TokenType::PARENTHESIS_OPEN
                    && operatorStack.top() >= token)
             {
                 postfix.push(std::move(operatorStack.top()));
@@ -215,8 +210,7 @@ std::shared_ptr<Expression> parse(const std::string& rawExpression)
     }
     catch (...)
     {
-        throw std::runtime_error(
-            fmt::format("Failed to parse expression \"{}\"", rawExpression));
+        throw std::runtime_error(fmt::format("Failed to parse expression \"{}\"", rawExpression));
     }
 
     return expression;

--- a/src/engine/source/logpar/CMakeLists.txt
+++ b/src/engine/source/logpar/CMakeLists.txt
@@ -5,4 +5,4 @@ PUBLIC
 PRIVATE
   include/logpar
 )
-target_link_libraries(logpar PUBLIC hlp fmt json)
+target_link_libraries(logpar PUBLIC hlp fmt json schemf::ischema)

--- a/src/engine/source/logpar/include/logpar/logpar.hpp
+++ b/src/engine/source/logpar/include/logpar/logpar.hpp
@@ -2,6 +2,7 @@
 #define _LOGPAR_HPP
 
 #include <list>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -9,6 +10,7 @@
 
 #include <hlp/hlp.hpp>
 #include <json/json.hpp>
+#include <schemf/ischema.hpp>
 
 #include "parsec.hpp"
 
@@ -236,9 +238,9 @@ constexpr auto EXPR_ESCAPE = '\\';
 constexpr auto EXPR_ARG_SEP = '/';
 constexpr auto EXPR_GROUP_BEGIN = '(';
 constexpr auto EXPR_GROUP_END = ')';
-constexpr auto EXPR_CUSTOM_FIELD = '~';
+constexpr auto EXPR_WILDCARD = '~';
 constexpr auto EXPR_FIELD_SEP = '.';
-constexpr auto EXPR_FIELD_EXTENDED_CHARS_FIRST = "@#";
+constexpr auto EXPR_FIELD_EXTENDED_CHARS_FIRST = "@#~";
 constexpr auto EXPR_FIELD_EXTENDED_CHARS = "_@#";
 }; // namespace syntax
 
@@ -279,8 +281,7 @@ struct Literal
 struct FieldName
 {
     std::string value;
-    bool custom;
-    bool operator==(const FieldName& other) const { return value == other.value && custom == other.custom; }
+    bool operator==(const FieldName& other) const { return value == other.value; }
 };
 
 /**
@@ -372,6 +373,8 @@ private:
     using ParserBuilder = hlp::ParserBuilder;
     using Hlp = hlp::parser::Parser;
 
+    std::shared_ptr<schemf::ISchema> m_schema;
+
     size_t m_maxGroupRecursion;
 
     size_t m_debugLvl;
@@ -394,9 +397,16 @@ public:
      * @brief Construct a new Logpar object
      *
      * @param ecsFieldTypes a json object with the schema types of the schema fields
+     * @param schema the schema to validate the fields
+     * @param maxGroupRecursion the maximum number of times a group can be nested
+     * @param debugLvl the debug level
+     *
      * @throws std::runtime_error if errors occur while initializing
      */
-    Logpar(const json::Json& ecsFieldTypes, size_t maxGroupRecursion = 1, size_t debugLvl = 0);
+    Logpar(const json::Json& ecsFieldTypes,
+           const std::shared_ptr<schemf::ISchema>& schema,
+           size_t maxGroupRecursion = 1,
+           size_t debugLvl = 0);
 
     /**
      * @brief Register a parser builder for the given parser type

--- a/src/engine/source/schemf/CMakeLists.txt
+++ b/src/engine/source/schemf/CMakeLists.txt
@@ -1,23 +1,36 @@
+# Defs
+set(SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
+set(INC_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
+set(IFACE_DIR ${CMAKE_CURRENT_LIST_DIR}/interface)
+
 add_library(schemf_ischema INTERFACE)
-target_include_directories(schemf_ischema INTERFACE ${CMAKE_CURRENT_LIST_DIR}/interface)
+target_include_directories(schemf_ischema INTERFACE ${IFACE_DIR})
 target_link_libraries(schemf_ischema INTERFACE json base)
 add_library(schemf::ischema ALIAS schemf_ischema)
 
 add_library(schemf STATIC
-  ${CMAKE_CURRENT_LIST_DIR}/src/schema.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/src/field.cpp
+  ${SRC_DIR}/schema.cpp
+  ${SRC_DIR}/field.cpp
 )
 
 target_include_directories(schemf
 PUBLIC
-  ${CMAKE_CURRENT_LIST_DIR}/include
+  ${INC_DIR}
 PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/src
-  ${CMAKE_CURRENT_LIST_DIR}/include/schemf
+  ${SRC_DIR}
+  ${INC_DIR}/schemf
 )
 target_link_libraries(schemf schemf::ischema)
 
+# Tests
+if(ENGINE_BUILD_TEST)
+
+set(TEST_SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/test/src)
+set(TEST_MOCK_DIR ${CMAKE_CURRENT_LIST_DIR}/test/mocks)
+
 add_library(schemf_mocks INTERFACE)
-target_include_directories(schemf_mocks INTERFACE ${CMAKE_CURRENT_LIST_DIR}/mocks)
-target_link_libraries(schemf_mocks INTERFACE schemf::ischema)
+target_include_directories(schemf_mocks INTERFACE ${TEST_MOCK_DIR})
+target_link_libraries(schemf_mocks INTERFACE gmock schemf::ischema)
 add_library(schemf::mocks ALIAS schemf_mocks)
+
+endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/schemf/test/mocks/schemf/emptySchema.hpp
+++ b/src/engine/source/schemf/test/mocks/schemf/emptySchema.hpp
@@ -1,3 +1,5 @@
+// TODO: Deprecated, remove once all tests are updated
+
 #ifndef _SCHEMF_MOCKS_EMPTY_SCHEMA_HPP
 #define _SCHEMF_MOCKS_EMPTY_SCHEMA_HPP
 

--- a/src/engine/source/schemf/test/mocks/schemf/mockSchema.hpp
+++ b/src/engine/source/schemf/test/mocks/schemf/mockSchema.hpp
@@ -1,0 +1,27 @@
+#ifndef _SCHEMF_MOCK_SCHEMA_HPP
+#define _SCHEMF_MOCK_SCHEMA_HPP
+
+#include <gmock/gmock.h>
+
+#include <schemf/ischema.hpp>
+
+namespace schemf::mocks
+{
+class MockSchema : public ISchema
+{
+public:
+    MOCK_METHOD(json::Json::Type, getType, (const DotPath& name), (const, override));
+    MOCK_METHOD(bool, hasField, (const DotPath& name), (const, override));
+    MOCK_METHOD(std::optional<base::Error>,
+                validate,
+                (const DotPath& target, const json::Json& value),
+                (const, override));
+    MOCK_METHOD(std::optional<base::Error>,
+                validate,
+                (const DotPath& target, const DotPath& reference),
+                (const, override));
+    MOCK_METHOD(RuntimeValidator, getRuntimeValidator, (const DotPath& target), (const, override));
+};
+} // namespace schemf::mocks
+
+#endif // _SCHEMF_MOCK_SCHEMA_HPP

--- a/src/engine/source/schemf/test/mocks/schemf/straightValidator.hpp
+++ b/src/engine/source/schemf/test/mocks/schemf/straightValidator.hpp
@@ -1,3 +1,5 @@
+// TODO: Deprecated, remove once all tests are updated
+
 #ifndef _SCHEMF_MOCKS_SINGLE_FIELD_HPP
 #define _SCHEMF_MOCKS_SINGLE_FIELD_HPP
 

--- a/src/engine/test/source/api/graph/assets/decoder/core-hostinfo/0
+++ b/src/engine/test/source/api/graph/assets/decoder/core-hostinfo/0
@@ -24,7 +24,7 @@
         {
             "map": [
                 {
-                    "wazuh.decoders": "+array_append/core-hostinfo"
+                    "wazuh.decoders": "array_append(core-hostinfo)"
                 }
             ]
         }

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -215,3 +215,8 @@ add_executable(opBuilderHelperUpgradeConfirmation_test
 )
 target_link_libraries(opBuilderHelperUpgradeConfirmation_test sockiface::mocks)
 gtest_discover_tests(opBuilderHelperUpgradeConfirmation_test)
+
+add_executable(helperParser_test
+  ${BUILDER_TEST_SOURCE_DIR}/helperParser_test.cpp
+)
+gtest_discover_tests(helperParser_test)

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -143,6 +143,7 @@ add_executable(opBuilderHelperCheck_test
 gtest_discover_tests(opBuilderHelperCheck_test)
 
 add_executable(opBuilderHelperMap_test
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperEraseCustomField_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperAppend_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperAppendSplitString_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperDateFromEpochTime_test.cpp

--- a/src/engine/test/source/builder/asset_test.cpp
+++ b/src/engine/test/source/builder/asset_test.cpp
@@ -143,7 +143,7 @@ TEST_F(AssetTest, BuildRule)
     auto registry = initTest();
     auto assetJson = R"({
         "name": "rule1",
-        "sources": ["ruleParent"],
+        "parents": ["ruleParent"],
         "check": [
             {"rule": 1}
         ],

--- a/src/engine/test/source/builder/asset_test.cpp
+++ b/src/engine/test/source/builder/asset_test.cpp
@@ -9,7 +9,7 @@
 #include "builder/registry.hpp"
 #include <json/json.hpp>
 #include <testsCommon.hpp>
-#include <schemf/mocks/emptySchema.hpp>
+#include <schemf/emptySchema.hpp>
 
 using namespace builder;
 using namespace builder::internals;

--- a/src/engine/test/source/builder/builders/opBuilderHelperDateFromEpochTime_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperDateFromEpochTime_test.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include <baseTypes.hpp>
-#include <schemf/mocks/emptySchema.hpp>
+#include <schemf/emptySchema.hpp>
 
 #include "opBuilderHelperMap.hpp"
 #include <date/date.h>

--- a/src/engine/test/source/builder/builders/opBuilderHelperEraseCustomField_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperEraseCustomField_test.cpp
@@ -33,7 +33,7 @@ TEST_F(opBuilderHelperEraseCustomField, build) {
 
 TEST_F(opBuilderHelperEraseCustomField, removeCustomField) {
 
-    auto tuple = std::make_tuple(std::string {"/anyField"},
+    auto tuple = std::make_tuple(std::string {""},
                                  std::string {"erase_custom_fields"},
                                  std::vector<std::string> {},
                                   std::make_shared<defs::mocks::FailDef>());

--- a/src/engine/test/source/builder/builders/opBuilderHelperEraseCustomField_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperEraseCustomField_test.cpp
@@ -1,0 +1,90 @@
+#include <any>
+#include <vector>
+
+#include <baseTypes.hpp>
+#include <defs/mocks/failDef.hpp>
+#include <schemf/mockSchema.hpp>
+
+#include <gtest/gtest.h>
+
+#include "opBuilderHelperMap.hpp"
+
+using namespace builder::internals::builders;
+
+class opBuilderHelperEraseCustomField : public ::testing::Test
+{
+protected:
+    std::shared_ptr<schemf::mocks::MockSchema> schema;
+
+    void SetUp() override { schema = std::make_shared<schemf::mocks::MockSchema>(); }
+};
+
+TEST_F(opBuilderHelperEraseCustomField, build) {
+
+    ASSERT_NO_THROW( getOpBuilderHelperEraseCustomFields(schema));
+
+    auto tuple = std::make_tuple(std::string {"/anyField"},
+                                 std::string {"erase_custom_fields"},
+                                 std::vector<std::string> {},
+                                 std::make_shared<defs::mocks::FailDef>());
+
+    ASSERT_NO_THROW(std::apply(getOpBuilderHelperEraseCustomFields(schema), tuple));
+}
+
+TEST_F(opBuilderHelperEraseCustomField, removeCustomField) {
+
+    auto tuple = std::make_tuple(std::string {"/anyField"},
+                                 std::string {"erase_custom_fields"},
+                                 std::vector<std::string> {},
+                                  std::make_shared<defs::mocks::FailDef>());
+
+    auto op = std::apply(getOpBuilderHelperEraseCustomFields(schema), tuple)->getPtr<base::Term<base::EngineOp>>()->getFn();
+
+    auto event1 = std::make_shared<json::Json>(R"({
+                    "key_1": {
+                        "field2check": 10,
+                        "ref_key": 10
+                    },
+                    "custom_1": {
+                        "field2check": 11,
+                        "ref_key": 11
+                    },
+                    "key_2": {
+                        "field2check": 10,
+                        "ref_key": 10
+                    },
+                    "custom_2": {
+                        "field2check": 11,
+                        "ref_key": 11
+                    }
+                    })");
+
+    auto& schemaRef = *schema;
+    const DotPath name_noCustom_1 {"key_1"};
+    const DotPath name_Custom_1 {"custom_1"};
+    const DotPath name_noCustom_2 {"key_2"};
+    const DotPath name_Custom_2 {"custom_2"};
+
+    EXPECT_CALL(schemaRef, hasField(name_noCustom_1)).WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(schemaRef, hasField(name_Custom_1)).WillRepeatedly(testing::Return(false));
+    EXPECT_CALL(schemaRef, hasField(name_noCustom_2)).WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(schemaRef, hasField(name_Custom_2)).WillRepeatedly(testing::Return(false));
+
+    auto result = op(event1);
+
+    json::Json expected {R"({
+                            "key_1": {
+                                "field2check": 10,
+                                "ref_key": 10
+                            },
+                            "key_2": {
+                                "field2check": 10,
+                                "ref_key": 10
+                            }
+                            })"};
+    ASSERT_TRUE(result.success());
+    ASSERT_EQ(*(result.payload()), expected);
+}
+
+// using namespace base;
+// namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperGetValue_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperGetValue_test.cpp
@@ -5,7 +5,7 @@
 #include <baseTypes.hpp>
 #include <defs/defs.hpp>
 #include <defs/mocks/failDef.hpp>
-#include <schemf/mocks/emptySchema.hpp>
+#include <schemf/emptySchema.hpp>
 
 #include "opBuilderHelperMap.hpp"
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperMatchKey_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperMatchKey_test.cpp
@@ -5,7 +5,7 @@
 #include <baseTypes.hpp>
 #include <defs/defs.hpp>
 #include <defs/mocks/failDef.hpp>
-#include <schemf/mocks/emptySchema.hpp>
+#include <schemf/emptySchema.hpp>
 
 #include "opBuilderHelperFilter.hpp"
 

--- a/src/engine/test/source/builder/builders/operationBuilder_test.cpp
+++ b/src/engine/test/source/builder/builders/operationBuilder_test.cpp
@@ -6,8 +6,8 @@
 
 #include <defs/mocks/failDef.hpp>
 #include <json/json.hpp>
-#include <schemf/mocks/emptySchema.hpp>
-#include <schemf/mocks/straightValidator.hpp>
+#include <schemf/emptySchema.hpp>
+#include <schemf/straightValidator.hpp>
 
 using namespace builder::internals;
 using namespace builder::internals::builders;

--- a/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
@@ -9,7 +9,7 @@
 #include <baseHelper.hpp>
 #include <defs/mocks/failDef.hpp>
 #include <json/json.hpp>
-#include <schemf/mocks/emptySchema.hpp>
+#include <schemf/emptySchema.hpp>
 
 using namespace builder::internals;
 using namespace builder::internals::builders;

--- a/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
@@ -110,16 +110,28 @@ TEST_F(StageBuilderCheckTest, ListBuildsCorrectExpression)
 
 TEST_F(StageBuilderCheckTest, ExpressionEqualOperator)
 {
-    auto checkJson = Json {R"("field==value")"};
+    auto checkJson = Json {R"("$field==value")"};
 
     ASSERT_NO_THROW(getStageBuilderCheck(registry)(checkJson, std::make_shared<defs::mocks::FailDef>()));
 }
 
 TEST_F(StageBuilderCheckTest, ExpressionNotEqualOperator)
 {
-    auto checkJson = Json {R"("field!=value")"};
+    auto checkJson = Json {R"("$field!=value")"};
 
     ASSERT_NO_THROW(getStageBuilderCheck(registry)(checkJson, std::make_shared<defs::mocks::FailDef>()));
+}
+
+TEST_F(StageBuilderCheckTest, ExpressionOnlyReference)
+{
+    auto checkJson = Json {R"("field==value")"};
+
+    try {
+        getStageBuilderCheck(registry)(checkJson, std::make_shared<defs::mocks::FailDef>());
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error& e) {
+        EXPECT_STREQ("Check stage: the fild must be a reference, but got 'field'", e.what());
+    }
 }
 
 class StageBuilderCheckHelperOperatorsTest
@@ -152,14 +164,14 @@ INSTANTIATE_TEST_SUITE_P(
     CheckExpressionOperator,
     StageBuilderCheckHelperOperatorsTest,
     ::testing::Values(
-        std::make_tuple(R"("field<\"value\"")", "string_less", opBuilderHelperStringLessThan),
-        std::make_tuple(R"("field<=\"value\"")", "string_less_or_equal", opBuilderHelperStringLessThanEqual),
-        std::make_tuple(R"("field>\"value\"")", "string_greater", opBuilderHelperStringGreaterThan),
-        std::make_tuple(R"("field>=\"value\"")", "string_greater_or_equal", opBuilderHelperStringGreaterThanEqual),
-        std::make_tuple(R"("field<3")", "int_less", opBuilderHelperIntLessThan),
-        std::make_tuple(R"("field<=3")", "int_less_or_equal", opBuilderHelperIntLessThanEqual),
-        std::make_tuple(R"("field>3")", "int_greater", opBuilderHelperIntGreaterThan),
-        std::make_tuple(R"("field>=3")", "int_greater_or_equal", opBuilderHelperIntGreaterThanEqual)));
+        std::make_tuple(R"("$field<\"value\"")", "string_less", opBuilderHelperStringLessThan),
+        std::make_tuple(R"("$field<=\"value\"")", "string_less_or_equal", opBuilderHelperStringLessThanEqual),
+        std::make_tuple(R"("$field>\"value\"")", "string_greater", opBuilderHelperStringGreaterThan),
+        std::make_tuple(R"("$field>=\"value\"")", "string_greater_or_equal", opBuilderHelperStringGreaterThanEqual),
+        std::make_tuple(R"("$field<3")", "int_less", opBuilderHelperIntLessThan),
+        std::make_tuple(R"("$field<=3")", "int_less_or_equal", opBuilderHelperIntLessThanEqual),
+        std::make_tuple(R"("$field>3")", "int_greater", opBuilderHelperIntGreaterThan),
+        std::make_tuple(R"("$field>=3")", "int_greater_or_equal", opBuilderHelperIntGreaterThanEqual)));
 
 class StageBuilderCheckInvalidOperatorsTest : public testing::TestWithParam<std::tuple<Json, std::string>>
 {
@@ -192,37 +204,37 @@ TEST_P(StageBuilderCheckInvalidOperatorsTest, InvalidValuesInField)
 INSTANTIATE_TEST_SUITE_P(
     InvalidValuesInField,
     StageBuilderCheckInvalidOperatorsTest,
-    testing::Values(std::make_tuple(Json {R"("field>{\"key\":\"value\"}")"},
+    testing::Values(std::make_tuple(Json {R"("$field>{\"key\":\"value\"}")"},
                                     "Check stage: The '>' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field>[\"value1\",\"value2\"]")"},
+                    std::make_tuple(Json {R"("$field>[\"value1\",\"value2\"]")"},
                                     "Check stage: The '>' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field>false")"},
+                    std::make_tuple(Json {R"("$field>false")"},
                                     "Check stage: The '>' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field>null")"},
+                    std::make_tuple(Json {R"("$field>null")"},
                                     "Check stage: The '>' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field<{\"key\":\"value\"}")"},
+                    std::make_tuple(Json {R"("$field<{\"key\":\"value\"}")"},
                                     "Check stage: The '<' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field<[\"value1\",\"value2\"]")"},
+                    std::make_tuple(Json {R"("$field<[\"value1\",\"value2\"]")"},
                                     "Check stage: The '<' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field<false")"},
+                    std::make_tuple(Json {R"("$field<false")"},
                                     "Check stage: The '<' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field<null")"},
+                    std::make_tuple(Json {R"("$field<null")"},
                                     "Check stage: The '<' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field<={\"key\":\"value\"}")"},
+                    std::make_tuple(Json {R"("$field<={\"key\":\"value\"}")"},
                                     "Check stage: The '<=' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field<=[\"value1\",\"value2\"]")"},
+                    std::make_tuple(Json {R"("$field<=[\"value1\",\"value2\"]")"},
                                     "Check stage: The '<=' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field<=false")"},
+                    std::make_tuple(Json {R"("$field<=false")"},
                                     "Check stage: The '<=' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field<=null")"},
+                    std::make_tuple(Json {R"("$field<=null")"},
                                     "Check stage: The '<=' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field>={\"key\":\"value\"}")"},
+                    std::make_tuple(Json {R"("$field>={\"key\":\"value\"}")"},
                                     "Check stage: The '>=' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field>=[\"value1\",\"value2\"]")"},
+                    std::make_tuple(Json {R"("$field>=[\"value1\",\"value2\"]")"},
                                     "Check stage: The '>=' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field>=false")"},
+                    std::make_tuple(Json {R"("$field>=false")"},
                                     "Check stage: The '>=' operator only allows operate with numbers or string"),
-                    std::make_tuple(Json {R"("field>=null")"},
+                    std::make_tuple(Json {R"("$field>=null")"},
                                     "Check stage: The '>=' operator only allows operate with numbers or string")));
 
 TEST_F(StageBuilderCheckTest, InvalidOperator)
@@ -241,7 +253,7 @@ TEST_F(StageBuilderCheckTest, InvalidOperator)
 
 TEST_F(StageBuilderCheckTest, ObjectIntoObject)
 {
-    auto checkJson = Json {R"("field=={\"key\":\"value\",\"key2\":{\"key3\":\"value3\"")"};
+    auto checkJson = Json {R"("$field=={\"key\":\"value\",\"key2\":{\"key3\":\"value3\"")"};
 
     try
     {
@@ -286,7 +298,7 @@ base::Expression opBuilderHelperDummy(const std::string& targetField,
 
 TEST_F(StageBuilderCheckTest, CheckExpressionHelperDummyTrue)
 {
-    auto checkJson = Json {R"("+dummy/field")"};
+    auto checkJson = Json {R"("+dummy/$field")"};
 
     auto event = std::make_shared<json::Json>(R"({"field": true})");
 
@@ -298,7 +310,7 @@ TEST_F(StageBuilderCheckTest, CheckExpressionHelperDummyTrue)
 
 TEST_F(StageBuilderCheckTest, CheckExpressionHelperDummyFalse)
 {
-    auto checkJson = Json {R"("+dummy/field")"};
+    auto checkJson = Json {R"("+dummy/$field")"};
 
     auto event = std::make_shared<json::Json>(R"({"field": false})");
 

--- a/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
@@ -298,7 +298,7 @@ base::Expression opBuilderHelperDummy(const std::string& targetField,
 
 TEST_F(StageBuilderCheckTest, CheckExpressionHelperDummyTrue)
 {
-    auto checkJson = Json {R"("+dummy/$field")"};
+    auto checkJson = Json {R"^("dummy($field)")^"};
 
     auto event = std::make_shared<json::Json>(R"({"field": true})");
 
@@ -310,7 +310,7 @@ TEST_F(StageBuilderCheckTest, CheckExpressionHelperDummyTrue)
 
 TEST_F(StageBuilderCheckTest, CheckExpressionHelperDummyFalse)
 {
-    auto checkJson = Json {R"("+dummy/$field")"};
+    auto checkJson = Json {R"^("dummy($field)")^"};
 
     auto event = std::make_shared<json::Json>(R"({"field": false})");
 
@@ -322,7 +322,7 @@ TEST_F(StageBuilderCheckTest, CheckExpressionHelperDummyFalse)
 
 TEST_F(StageBuilderCheckTest, CheckExpressionHelperFail)
 {
-    auto checkJson = Json {R"("+int_equal/~json/2")"};
+    auto checkJson = Json {R"^("int_equal(~json,2)")^"};
 
     helperRegistry->registerBuilder(opBuilderHelperIntLessThanEqual, "int_less_or_equal");
     ASSERT_THROW(getStageBuilderCheck(registry)(checkJson, std::make_shared<defs::mocks::FailDef>()),

--- a/src/engine/test/source/builder/builders/stageBuilderMap_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderMap_test.cpp
@@ -9,7 +9,7 @@
 #include <json/json.hpp>
 
 #include <defs/mocks/failDef.hpp>
-#include <schemf/mocks/emptySchema.hpp>
+#include <schemf/emptySchema.hpp>
 
 using namespace builder::internals;
 using namespace builder::internals::builders;

--- a/src/engine/test/source/builder/builders/stageBuilderNormalize_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderNormalize_test.cpp
@@ -9,7 +9,7 @@
 #include <json/json.hpp>
 
 #include <defs/mocks/failDef.hpp>
-#include <schemf/mocks/emptySchema.hpp>
+#include <schemf/emptySchema.hpp>
 
 using namespace builder::internals;
 using namespace builder::internals::builders;

--- a/src/engine/test/source/builder/helperParser_test.cpp
+++ b/src/engine/test/source/builder/helperParser_test.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include <re2/re2.h>
+
+#include "helperParser.hpp"
+
+using HelperParserT = std::tuple<bool, std::string, builder::internals::HelperToken>;
+class HelperParserTest : public ::testing::TestWithParam<HelperParserT>
+{
+};
+
+TEST_P(HelperParserTest, parse)
+{
+    auto &[shouldPass, input, expected] = GetParam();
+
+    auto result = builder::internals::parseHelper(input);
+
+    if (shouldPass)
+    {
+        ASSERT_TRUE(std::holds_alternative<builder::internals::HelperToken>(result));
+        ASSERT_EQ(std::get<builder::internals::HelperToken>(result).name, expected.name);
+        ASSERT_EQ(std::get<builder::internals::HelperToken>(result).args, expected.args);
+    }
+    else
+    {
+        ASSERT_TRUE(std::holds_alternative<base::Error>(result));
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Builder,
+    HelperParserTest,
+    ::testing::Values(
+        HelperParserT(false, "anything", {}),
+        HelperParserT(true, "name()", {.name = "name"}),
+        HelperParserT(true, "test(arg1)", {.name = "test", .args = {"arg1"}}),
+        HelperParserT(true, "test(arg1,arg2)", {.name = "test", .args = {"arg1", "arg2"}}),
+        HelperParserT(true, "test(arg1, arg2, arg3)", {.name = "test", .args = {"arg1", "arg2", "arg3"}}),
+        HelperParserT(true, "test(arg1, arg2\\,arg3)", {.name = "test", .args = {"arg1", "arg2,arg3"}}),  // Testing escaped comma
+        HelperParserT(true, "test(arg1,\\ arg2)", {.name = "test", .args = {"arg1", " arg2"}}),  // Testing escaped space
+        HelperParserT(false, "test(arg1", {}),  // Missing closing parenthesis
+        HelperParserT(false, "test arg1)", {}),  // Missing opening parenthesis
+        HelperParserT(false, "", {}),  // Empty string
+        HelperParserT(false, "()", {.name = ""}),  // No function name
+        HelperParserT(true, "test(,)", {.name = "test", .args {"", ""}}),
+         HelperParserT(true, "test(,,)", {.name = "test", .args {"", "", ""}}),
+        HelperParserT(true, "test(, ,)", {.name = "test", .args {"", "", ""}}),
+        HelperParserT(true, "test(arg1,)", {.name = "test", .args {"arg1", ""}}),
+        HelperParserT(true, "test(arg1, )", {.name = "test", .args {"arg1", ""}}),
+        HelperParserT(true, "test(arg1,\\ )", {.name = "test", .args {"arg1", " "}}),
+        HelperParserT(true, "test(arg1,  )", {.name = "test", .args {"arg1", " "}})
+
+));

--- a/src/engine/test/source/builder/helperParser_test.cpp
+++ b/src/engine/test/source/builder/helperParser_test.cpp
@@ -43,11 +43,15 @@ INSTANTIATE_TEST_SUITE_P(
         HelperParserT(false, "", {}),  // Empty string
         HelperParserT(false, "()", {.name = ""}),  // No function name
         HelperParserT(true, "test(,)", {.name = "test", .args {"", ""}}),
-         HelperParserT(true, "test(,,)", {.name = "test", .args {"", "", ""}}),
+        HelperParserT(true, "test(,,)", {.name = "test", .args {"", "", ""}}),
         HelperParserT(true, "test(, ,)", {.name = "test", .args {"", "", ""}}),
         HelperParserT(true, "test(arg1,)", {.name = "test", .args {"arg1", ""}}),
         HelperParserT(true, "test(arg1, )", {.name = "test", .args {"arg1", ""}}),
         HelperParserT(true, "test(arg1,\\ )", {.name = "test", .args {"arg1", " "}}),
-        HelperParserT(true, "test(arg1,  )", {.name = "test", .args {"arg1", " "}})
+        HelperParserT(true, "test(arg1,  )", {.name = "test", .args {"arg1", " "}}),
+        HelperParserT(true, "test(arg1, ())", {.name = "test", .args {"arg1", "()"}}),
+        HelperParserT(true, "test(arg1, ( arg2)", {.name = "test", .args = {"arg1", "( arg2"}}),
+        HelperParserT(true, "test(arg1, ) arg2)", {.name = "test", .args = {"arg1", ") arg2"}}),
+        HelperParserT(true, "test(arg1, ) arg2))))", {.name = "test", .args = {"arg1", ") arg2)))"}})
 
 ));

--- a/src/engine/test/source/builder/policy_test.cpp
+++ b/src/engine/test/source/builder/policy_test.cpp
@@ -4,7 +4,7 @@
 #include <filesystem>
 #include <stdexcept>
 
-#include <schemf/mocks/emptySchema.hpp>
+#include <schemf/emptySchema.hpp>
 
 #include "builder/builder.hpp"
 #include "builder/policy.hpp"

--- a/src/engine/test/source/builder/policy_test.hpp
+++ b/src/engine/test/source/builder/policy_test.hpp
@@ -35,7 +35,7 @@ std::map<std::string, const char*> decoders =
         "decoder/decoder1_1/version",
         R"({
             "name": "decoder/decoder1_1/version",
-            "sources": ["decoder/decoder1/version"],
+            "parents": ["decoder/decoder1/version"],
             "check": [
                 {"child": 1}
             ],
@@ -52,7 +52,7 @@ std::map<std::string, const char*> decoders =
         "decoder/decoder1_2/version",
         R"({
             "name": "decoder/decoder1_2/version",
-            "sources": ["decoder/decoder1/version"],
+            "parents": ["decoder/decoder1/version"],
             "check": [
                 {"child": 2}
             ],
@@ -101,7 +101,7 @@ std::map<std::string, const char*> decoders =
         "decoder/decoder23_1/version",
         R"({
             "name": "decoder/decoder23_1/version",
-            "sources": ["decoder/decoder2/version", "decoder/decoder3/version"],
+            "parents": ["decoder/decoder2/version", "decoder/decoder3/version"],
             "check": [
                 {"child": 1}
             ],
@@ -138,7 +138,7 @@ std::map<std::string, const char*> rules =
         "rule/rule1_1/version",
         R"({
             "name": "rule/rule1_1/version",
-            "sources": ["rule/rule1/version"],
+            "parents": ["rule/rule1/version"],
             "check": [
                 {"child": 1}
             ],

--- a/src/engine/test/source/json/json_test.cpp
+++ b/src/engine/test/source/json/json_test.cpp
@@ -1712,8 +1712,8 @@ TEST_F(JsonSettersTest, Append)
     Json jObject {"{\"key\": \"value\"}"};
     Json jEmpty {"null"};
 
-    Json source{"[]"};
-    Json sourceNested{"{\"nested\": []}"};
+    Json source {"[]"};
+    Json sourceNested {"{\"nested\": []}"};
 
     // String
     ASSERT_NO_THROW(source.appendJson(jString));
@@ -2356,12 +2356,12 @@ TEST_F(JsonSettersTest, MergeRecursiveObjRoot)
 
 TEST_F(JsonSettersTest, MergesCopiesMergedSubtree)
 {
-    json::Json source{R"({
+    json::Json source {R"({
         "key": ["value1", "value2", "value3"]
     })"};
-    json::Json destination{R"({
+    json::Json destination {R"({
     })"};
-    json::Json expected{R"({
+    json::Json expected {R"({
         "key": ["value1", "value2", "value3"]
     })"};
 
@@ -2369,7 +2369,6 @@ TEST_F(JsonSettersTest, MergesCopiesMergedSubtree)
     source.appendString("value4", "/key");
     ASSERT_EQ(destination, expected);
 }
-
 
 TEST(JsonTest, eraseIfKeyInvalidPointer)
 {
@@ -2379,7 +2378,6 @@ TEST(JsonTest, eraseIfKeyInvalidPointer)
     })"};
     // Erase with an invalid pointer
     ASSERT_THROW(json.eraseIfKey([](const std::string& key) { return true; }, false, "a"), std::runtime_error);
-
 }
 
 // Test parameters for eraseIfKey [json object, recursive, path, expected json]
@@ -2388,7 +2386,6 @@ using ParamsJEraseIfKey = std::tuple<std::string, bool, std::string, std::string
 class EraseIfKey : public ::testing::TestWithParam<ParamsJEraseIfKey>
 {
 };
-
 
 // Test delete all fields if key starts with "key"
 TEST_P(EraseIfKey, deleteSomeFields)
@@ -2438,12 +2435,19 @@ TEST_P(ErasePrefixTest, Erase)
     Json inputJson {inputJsonStr.c_str()};
     Json expectedJson {expectedJsonStr.c_str()};
 
+    auto ifPrefix = [p = prefix](const std::string& key)
+    {
+        return key[0] == p;
+    };
+
     if (shouldPass)
-    {ASSERT_NO_THROW(inputJson.erase(prefix, path));
-    ASSERT_EQ(inputJson, expectedJson);}
+    {
+        ASSERT_NO_THROW(inputJson.eraseIfKey(ifPrefix, false, path));
+        ASSERT_EQ(inputJson, expectedJson);
+    }
     else
     {
-        ASSERT_THROW(inputJson.erase(prefix, path), std::runtime_error);
+        ASSERT_THROW(inputJson.eraseIfKey(ifPrefix, false, path), std::runtime_error);
     }
 }
 
@@ -2459,5 +2463,5 @@ INSTANTIATE_TEST_SUITE_P(
         ErasePrefixT(true, R"({"a":1})", R"({"a":1})", '1', "/a"),
         ErasePrefixT(true, R"({"a":1, "_a":1, "b":1, "_b":1})", R"({"a":1, "b":1})", '_', ""),
         ErasePrefixT(true, R"({"a":1, "_a":1, "b":1, "_b":1, "c":1})", R"({"a":1, "b":1, "c":1})", '_', ""),
-        ErasePrefixT(true, R"({"a": {"a":1, "_a":1, "b":1, "_b":1, "c":1}})", R"({"a": {"a":1, "b":1, "c":1}})", '_', "/a")
-    ));
+        ErasePrefixT(
+            true, R"({"a": {"a":1, "_a":1, "b":1, "_b":1, "c":1}})", R"({"a": {"a":1, "b":1, "c":1}})", '_', "/a")));

--- a/src/engine/test/source/json/json_test.cpp
+++ b/src/engine/test/source/json/json_test.cpp
@@ -2421,7 +2421,12 @@ INSTANTIATE_TEST_SUITE_P(
         ParamsJEraseIfKey({R"({"no_key":123,"no_key2":"hi","no_key3":{}})",
                            true,
                            "",
-                           R"({"no_key":123,"no_key2":"hi","no_key3":{}})"})));
+                           R"({"no_key":123,"no_key2":"hi","no_key3":{}})"}),
+        ParamsJEraseIfKey(
+            {R"({"key1":"value1","key2":"value2","key3":{"key31":"value31","key32":"value32"},"no_key4":{"key41":"value41","key42":"value42"},"no_key5":"value5","no_key6":{"key61":"value61","key62":"value62","key63":{"key631":"value631","key632":"value632"},"no_key64":{"key641":"value641","key642":"value642","no_key643":{"key6431":"value6431","no_key6432":"value6432"}}}})",
+             true,
+             "/no_key6",
+             R"({"key1":"value1","key2":"value2","key3":{"key31":"value31","key32":"value32"},"no_key4":{"key41":"value41","key42":"value42"},"no_key5":"value5","no_key6":{"no_key64":{"no_key643":{"no_key6432":"value6432"}}}})"})));
 
 // Test parameter for erase with prefix [input json str, expected json str, prefix, path]
 using ErasePrefixT = std::tuple<bool, std::string, std::string, char, std::string>;

--- a/src/engine/test/source/logicExpression/logicExpressionParser_test.cpp
+++ b/src/engine/test/source/logicExpression/logicExpressionParser_test.cpp
@@ -248,16 +248,16 @@ term_11;
 TEST(LogicExpressionParser, ParseErrors)
 {
     const std::vector<std::string> expressions = {
-        R"(event.type=="test" AND (something)unexpectedTerm)",
-        R"(event.type=="test" AND OR (something))",
+        R"(event.type=="test" AND ( something ) unexpectedTerm )",
+        R"(event.type=="test" AND OR ( something ))",
         R"(AND term)",
         R"(term OR)",
-        R"(term AND (notClosedParenthesis)",
-        R"(term AND notOpenedParenthesis))",
+        R"(term AND ( notClosedParenthesis)",
+        R"(term AND notOpenedParenthesis ))",
         R"(NOT)",
         R"(AND)",
         R"(term NOT AND term),
-        R"(())",
+        R"(( ))",
         R"()",
     };
 
@@ -273,12 +273,12 @@ TEST(LogicExpressionParser, Parse)
         R"(onlyOneTerm)",
         R"(term AND term)",
         R"(term OR term)",
-        R"(term AND (term OR term))",
-        R"(term OR (term AND term))",
+        R"(term AND ( term OR term ))",
+        R"(term OR ( term AND term ))",
         R"(NOT term)",
-        R"(NOT (term AND term))",
-        R"(NOT (term OR term))",
-        R"(NOT (term AND (term OR term)))",
+        R"(NOT ( term AND term ))",
+        R"(NOT ( term OR term ))",
+        R"(NOT ( term AND ( term OR term ) ))",
         R"(term AND term OR term)",
         R"(term OR NOT term AND term)",
     };

--- a/src/engine/test/source/logicExpression/logicExpression_test.cpp
+++ b/src/engine/test/source/logicExpression/logicExpression_test.cpp
@@ -46,7 +46,7 @@ TEST(LogicExpression, buildDijstraEvaluator)
         }
     };
 
-    auto expression = "(EVEN OR ODD AND NOT GREAT5) AND GREAT1";
+    auto expression = "( EVEN OR ODD AND NOT GREAT5 ) AND GREAT1";
     std::function<bool(int)> evaluator;
     EXPECT_NO_THROW(evaluator = buildDijstraEvaluator<int>(expression, fakeTermBuilder));
 

--- a/src/engine/test/source/logpar/CMakeLists.txt
+++ b/src/engine/test/source/logpar/CMakeLists.txt
@@ -7,5 +7,5 @@ gtest_discover_tests(parsec_test)
 add_executable(logpar_test
     logpar_test.cpp
 )
-target_link_libraries(logpar_test logpar gtest_main)
+target_link_libraries(logpar_test logpar gtest_main schemf::mocks)
 gtest_discover_tests(logpar_test)

--- a/src/engine/test/source/router/fakeAssets.hpp
+++ b/src/engine/test/source/router/fakeAssets.hpp
@@ -12,7 +12,7 @@ auto constexpr DEC_1 = R"e({
     "metadata": {
         "description": "Queue 45/50"
     },
-    "check": "+exists/$wazuh.queue AND (+int_equal/$wazuh.queue/49 OR +int_equal/$wazuh.queue/50)",
+    "check": "exists($wazuh.queue) AND ( int_equal($wazuh.queue,49) OR int_equal($wazuh.queue,50) )",
     "normalize": [
         {
             "map": [
@@ -29,7 +29,7 @@ auto constexpr DEC_2 = R"e({
     "metadata": {
         "description": "Queue 45/50"
     },
-    "check": "+exists/$wazuh.queue AND (+int_equal/$wazuh.queue/51 OR +int_equal/$wazuh.queue/52)",
+    "check": "exists($wazuh.queue) AND ( int_equal($wazuh.queue,51) OR int_equal($wazuh.queue,52) )",
     "normalize": [
         {
             "map": [
@@ -46,7 +46,7 @@ auto constexpr DEC_3 = R"e({
     "metadata": {
         "description": "Queue 45/50"
     },
-    "check": "+exists/$wazuh.queue AND (+int_less/$wazuh.queue/49 OR +int_greater/$wazuh.queue/52)",
+    "check": "exists($wazuh.queue) AND ( int_less($wazuh.queue,49) OR int_greater($wazuh.queue,52) )",
     "normalize": [
         {
             "map": [
@@ -65,7 +65,7 @@ auto constexpr DEC_A1 = R"e({
     },
     "check": [
         {
-            "wazuh.queue": "+exists"
+            "wazuh.queue": "exists()"
         }
     ],
     "normalize": [
@@ -86,7 +86,7 @@ auto constexpr DEC_B2 = R"e({
     },
     "check": [
         {
-            "wazuh.queue": "+exists"
+            "wazuh.queue": "exists()"
         }
     ],
     "normalize": [
@@ -107,7 +107,7 @@ auto constexpr DEC_C3 = R"e({
     },
     "check": [
         {
-            "wazuh.queue": "+exists"
+            "wazuh.queue": "exists()"
         }
     ],
     "normalize": [
@@ -141,10 +141,10 @@ auto constexpr FIL_E_WAZUH_QUEUE = R"e({
     "name": "filter/e_wazuh_queue/0",
     "check": [
         {
-            "wazuh.queue": "+exists"
+            "wazuh.queue": "exists()"
         },
         {
-            "wazuh.no_queue": "+exists"
+            "wazuh.no_queue": "exists()"
         }
     ]
 })e";

--- a/src/engine/test/source/router/fakeAssets.hpp
+++ b/src/engine/test/source/router/fakeAssets.hpp
@@ -12,7 +12,7 @@ auto constexpr DEC_1 = R"e({
     "metadata": {
         "description": "Queue 45/50"
     },
-    "check": "+exists/wazuh.queue AND (+int_equal/wazuh.queue/49 OR +int_equal/wazuh.queue/50)",
+    "check": "+exists/$wazuh.queue AND (+int_equal/$wazuh.queue/49 OR +int_equal/$wazuh.queue/50)",
     "normalize": [
         {
             "map": [
@@ -29,7 +29,7 @@ auto constexpr DEC_2 = R"e({
     "metadata": {
         "description": "Queue 45/50"
     },
-    "check": "+exists/wazuh.queue AND (+int_equal/wazuh.queue/51 OR +int_equal/wazuh.queue/52)",
+    "check": "+exists/$wazuh.queue AND (+int_equal/$wazuh.queue/51 OR +int_equal/$wazuh.queue/52)",
     "normalize": [
         {
             "map": [
@@ -46,7 +46,7 @@ auto constexpr DEC_3 = R"e({
     "metadata": {
         "description": "Queue 45/50"
     },
-    "check": "+exists/wazuh.queue AND (+int_less/wazuh.queue/49 OR +int_greater/wazuh.queue/52)",
+    "check": "+exists/$wazuh.queue AND (+int_less/$wazuh.queue/49 OR +int_greater/$wazuh.queue/52)",
     "normalize": [
         {
             "map": [

--- a/src/engine/test/source/router/routerAuxiliarFunctions.hpp
+++ b/src/engine/test/source/router/routerAuxiliarFunctions.hpp
@@ -7,7 +7,7 @@
 #include <defs/idefinitions.hpp>
 #include <parseEvent.hpp>
 #include <queue/concurrentQueue.hpp>
-#include <schemf/mocks/emptySchema.hpp>
+#include <schemf/emptySchema.hpp>
 #include <store/mockStore.hpp>
 
 #include "utils/stringUtils.hpp"


### PR DESCRIPTION
|Related issue|
|---|
|#17980|

The proposed changes aim to improve the readability and functionality of the decoders. These changes include:

- Replacing 'Source' with 'Parent' to refer to the originating decoder.
- Revising the helper function to resemble a standard programming language format.
- Introducing the usage of the '$' symbol to reference event fields during the check stage.
- Variables, implemented as fields inside the event and deleted from the event at the end of the asset processing.
- Custom fields no longer start with an anchor character, any field not present in the schema is a custom field.
- Added helper to erase custom fields, intended to use on the wazuh-core output so index is only populated with schema fields.
