### PR TITLE
Should be undefined for local installations.

### DIFF
--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -115,21 +115,27 @@ void* wm_database_main(wm_database *data) {
     // Manager name synchronization
     wm_sync_manager();
 
+    #ifndef LOCAL
     // During the startup, both workers and master nodes should perform the
     // agents synchronization with the database using the keys. In advance,
     // the agent addition and removal from the database will be held by authd
     // in the master.
     wm_sync_agents();
+    #endif
 
     // Groups synchronization with the database
     wdb_update_groups(SHAREDCFG_DIR, &wdb_wmdb_sock);
 
+    #ifndef LOCAL
     // Legacy agent-group files need to be synchronized with the database
     // and then removed in case an upgrade has just been performed.
     wm_sync_legacy_groups_files();
+    #endif
 
+    #ifndef LOCAL
     // Remove dangling agent databases
     wm_clean_dangling_wdb_dbs();
+    #endif
 
 #ifdef INOTIFY_ENABLED
     if (data->real_time) {


### PR DESCRIPTION
Building local installations fails with:

```
/usr/bin/ld: libwazuh.a(wm_database.o): in function `wm_database_main':
wm_database.c:(.text+0x8f5): undefined reference to `wm_sync_agents'
/usr/bin/ld: wm_database.c:(.text+0x90f): undefined reference to `wm_sync_legacy_groups_files'
/usr/bin/ld: wm_database.c:(.text+0x916): undefined reference to `wm_clean_dangling_wdb_dbs'
```

`wm_sync_agents`, `wm_sync_legacy_groups_files`, and `wm_clean_dangling_wdb_dbs` should be undefined for local installations.

