### PR TITLE
IT migration - Reorder the way Windows launch its thread to work similarly to other OS

### DIFF
--- a/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
@@ -13,6 +13,7 @@ on:
         - "src/remoted/**"
         - "src/client-agent/**"
         - "src/shared/enrollment_op.c"
+        - "src/win32/**"
         - "src/Makefile"
         - "tests/integration/conftest.py"
         - "tests/integration/test_agentd/**"

--- a/.github/workflows/integration-tests-execd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-execd-tier-0-1-win.yml
@@ -11,6 +11,7 @@ on:
     paths:
         - ".github/workflows/integration-tests-execd-tier-0-1-win.yml"
         - "src/execd/**"
+        - "src/win32/**"
         - "src/Makefile"
         - "tests/integration/conftest.py"
         - "tests/integration/test_execd/**"

--- a/.github/workflows/integration-tests-github-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-github-tier-0-1-win.yml
@@ -12,6 +12,7 @@ on:
         - ".github/workflows/integration-tests-github-tier-0-1-win.yml"
         - "src/wazuh_modules/wm_github.h"
         - "src/wazuh_modules/wm_github.c"
+        - "src/win32/**"
         - "src/Makefile"
         - "tests/integration/conftest.py"
         - "tests/integration/test_github/**"

--- a/.github/workflows/integration-tests-office365-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-office365-tier-0-1-win.yml
@@ -12,6 +12,7 @@ on:
         - ".github/workflows/integration-tests-office365-tier-0-1-win.yml"
         - "src/wazuh_modules/wm_office365.h"
         - "src/wazuh_modules/wm_office365.c"
+        - "src/win32/**"
         - "src/Makefile"
         - "tests/integration/conftest.py"
         - "tests/integration/test_office365/**"

--- a/.github/workflows/integration-tests-sca-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-sca-tier-0-1-win.yml
@@ -9,13 +9,14 @@ on:
         default: 'main'
   pull_request:
     paths:
-      - ".github/workflows/integration-tests-sca-tier-0-1-win.yml"
-      - "src/wazuh_modules/wm_sca.c"
-      - "src/wazuh_modules/wm_sca.h"
-      - "src/config/wmodules-sca.c"
-      - "src/Makefile"
-      - "tests/integration/conftest.py"
-      - "tests/integration/test_sca/**"
+        - ".github/workflows/integration-tests-sca-tier-0-1-win.yml"
+        - "src/wazuh_modules/wm_sca.c"
+        - "src/wazuh_modules/wm_sca.h"
+        - "src/config/wmodules-sca.c"
+        - "src/win32/**"
+        - "src/Makefile"
+        - "tests/integration/conftest.py"
+        - "tests/integration/test_sca/**"
 
 
 jobs:

--- a/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
@@ -9,12 +9,13 @@ on:
         default: 'main'
   pull_request:
     paths:
-      - ".github/workflows/integration-tests-syscollector-tier-0-1-win.yml"
-      - "src/wazuh_modules/syscollector/**"
-      - "src/config/wmodules-syscollector.c"
-      - "src/Makefile"
-      - "tests/integration/conftest.py"
-      - "tests/integration/test_syscollector/**"
+        - ".github/workflows/integration-tests-syscollector-tier-0-1-win.yml"
+        - "src/wazuh_modules/syscollector/**"
+        - "src/config/wmodules-syscollector.c"
+        - "src/win32/**"
+        - "src/Makefile"
+        - "tests/integration/conftest.py"
+        - "tests/integration/test_syscollector/**"
 
 jobs:
   # Build the winagent on linux.

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -53,7 +53,8 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
             merror_exit(AG_NOKEYS_EXIT);
         }
     }
-    /* Read private keys  */
+
+    /* Read private keys */
     minfo(ENC_READ);
     OS_ReadKeys(&keys, W_DUAL_KEY, 0);
 

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -52,7 +52,7 @@ int receive_msg(void);
 
 /* Receiver messages for Windows */
 #ifdef WIN32
-DWORD WINAPI receiver_thread(LPVOID none);
+int receiver_messages(void);
 #endif
 
 /* Initialize agent buffer */

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -331,7 +331,7 @@ int receive_msg()
 
 #ifdef WIN32
 /* Receive events from the server */
-DWORD WINAPI receiver_thread(__attribute__((unused)) LPVOID none)
+int receiver_messages()
 {
     int rc = 0;
 

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -307,9 +307,6 @@ int Start_win32_Syscheck() {
     /* Some sync time */
     fim_initialize();
 
-    /* Wait if agent started properly */
-    os_wait();
-
     start_daemon();
 
     return 0;

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -221,7 +221,6 @@ list(APPEND syscheckd_tests_names "syscheck")
 if(${TARGET} STREQUAL "winagent")
   list(APPEND syscheckd_tests_flags "${SYSCHECK_BASE_FLAGS} \
                                     -Wl,--wrap=Read_Syscheck_Config \
-                                    -Wl,--wrap=os_wait \
                                     -Wl,--wrap=rootcheck_init \
                                     -Wl,--wrap=start_daemon \
                                     -Wl,--wrap=File_DateofChange \

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -157,11 +157,6 @@ int __wrap_rootcheck_init(int value, char * home_path)
     return mock();
 }
 
-void __wrap_os_wait()
-{
-    function_called();
-}
-
 void __wrap_start_daemon()
 {
     function_called();
@@ -207,7 +202,6 @@ void test_Start_win32_Syscheck_corrupted_config_file(void **state) {
     will_return(__wrap_rootcheck_init, 1);
 
     expect_wrapper_fim_db_init(0, 300, 3600, 30, 100000, 100000, 1, 1, 16384);
-    expect_function_call(__wrap_os_wait);
     expect_function_call(__wrap_start_daemon);
     assert_int_equal(Start_win32_Syscheck(), 0);
 }
@@ -239,7 +233,6 @@ void test_Start_win32_Syscheck_syscheck_disabled_1(void **state) {
 
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
     expect_string(__wrap__minfo, formatted_msg, info_msg);
-    expect_function_call(__wrap_os_wait);
     expect_function_call(__wrap_start_daemon);
     assert_int_equal(Start_win32_Syscheck(), 0);
 }
@@ -269,7 +262,6 @@ void test_Start_win32_Syscheck_syscheck_disabled_2(void **state) {
 
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
     expect_string(__wrap__minfo, formatted_msg, info_msg);
-    expect_function_call(__wrap_os_wait);
     expect_function_call(__wrap_start_daemon);
     assert_int_equal(Start_win32_Syscheck(), 0);
 }
@@ -336,7 +328,6 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
     expect_string(__wrap__minfo, formatted_msg, info_msg);
 
-    expect_function_call(__wrap_os_wait);
     expect_function_call(__wrap_start_daemon);
     assert_int_equal(Start_win32_Syscheck(), 0);
 
@@ -387,7 +378,6 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
 
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
     expect_string(__wrap__minfo, formatted_msg, info_msg);
-    expect_function_call(__wrap_os_wait);
     expect_function_call(__wrap_start_daemon);
     assert_int_equal(Start_win32_Syscheck(), 0);
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -216,7 +216,7 @@ int local_start()
 
     /* No sockets defined */
     if (logsk == NULL) {
-        os_calloc(2, sizeof(logsocket), logsk);
+        os_calloc(2, sizeof(socket_forwarder), logsk);
         logsk[0].name = NULL;
         logsk[0].location = NULL;
         logsk[0].mode = 0;

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -55,43 +55,6 @@ DWORD WINAPI logcollector_thread(__attribute__((unused)) LPVOID arg)
 void *logcollector_thread()
 #endif
 {
-    /* Read logcollector config file */
-    mdebug1("Reading logcollector configuration.");
-
-    /* Init message queue */
-    w_msg_hash_queues_init();
-
-    /* Read config file */
-    if (LogCollectorConfig(cfg) < 0) {
-        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
-    }
-
-    /* No file available to monitor -- continue */
-    if (logff == NULL) {
-        os_calloc(2, sizeof(logreader), logff);
-        logff[0].file = NULL;
-        logff[0].ffile = NULL;
-        logff[0].logformat = NULL;
-        logff[0].fp = NULL;
-        logff[1].file = NULL;
-        logff[1].logformat = NULL;
-
-        minfo(NO_FILE);
-    }
-
-    /* No sockets defined */
-    if (logsk == NULL) {
-        os_calloc(2, sizeof(socket_forwarder), logsk);
-        logsk[0].name = NULL;
-        logsk[0].location = NULL;
-        logsk[0].mode = 0;
-        logsk[0].prefix = NULL;
-        logsk[1].name = NULL;
-        logsk[1].location = NULL;
-        logsk[1].mode = 0;
-        logsk[1].prefix = NULL;
-    }
-
     LogCollectorStart();
 #ifdef WIN32
     return 0;
@@ -226,6 +189,43 @@ int local_start()
                      NULL,
                      0,
                      (LPDWORD)&threadID);
+
+    /* Read logcollector config file */
+    mdebug1("Reading logcollector configuration.");
+
+    /* Init message queue */
+    w_msg_hash_queues_init();
+
+    /* Read config file */
+    if (LogCollectorConfig(cfg) < 0) {
+        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
+    }
+
+    /* No file available to monitor -- continue */
+    if (logff == NULL) {
+        os_calloc(2, sizeof(logreader), logff);
+        logff[0].file = NULL;
+        logff[0].ffile = NULL;
+        logff[0].logformat = NULL;
+        logff[0].fp = NULL;
+        logff[1].file = NULL;
+        logff[1].logformat = NULL;
+
+        minfo(NO_FILE);
+    }
+
+    /* No sockets defined */
+    if (logsk == NULL) {
+        os_calloc(2, sizeof(logsocket), logsk);
+        logsk[0].name = NULL;
+        logsk[0].location = NULL;
+        logsk[0].mode = 0;
+        logsk[0].prefix = NULL;
+        logsk[1].name = NULL;
+        logsk[1].location = NULL;
+        logsk[1].mode = 0;
+        logsk[1].prefix = NULL;
+    }
 
     /* Start logcollector thread */
     w_create_thread(NULL,

--- a/tests/integration/test_sca/test_basic.py
+++ b/tests/integration/test_sca/test_basic.py
@@ -142,7 +142,7 @@ def test_sca_enabled(test_configuration, test_metadata, prepare_cis_policies_fil
     assert log_monitor.callback_result
     log_monitor.start(callback=callbacks.generate_callback(patterns.CB_SCA_SCAN_STARTED), timeout=10)
     assert log_monitor.callback_result
-    log_monitor.start(callback=callbacks.generate_callback(patterns.CB_SCA_SCAN_ENDED), timeout=10)
+    log_monitor.start(callback=callbacks.generate_callback(patterns.CB_SCA_SCAN_ENDED), timeout=30)
     assert log_monitor.callback_result
 
 


### PR DESCRIPTION
|Related issue|
|---|
|Part necessary of https://github.com/wazuh/wazuh/issues/22420|

## Description

This PR reorders the way that Windows starts all its threads. Now, it behaves similarly to other OSs.

Now, before trying to connect to the server, the following threads are launched:

- Execd
- FIM
- Logcollector
- Wazuh modules

These changes are necessary to allow the execution of Windows agent IT without needing it to be connected to a real manager. Besides, this unifies the behavior of the Wazuh startup in all OS. 

## Tests

- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
