### PR TITLE
Add API and Framework unit tests workflows to Github Actions

### DIFF
--- a/.github/workflows/api-unit-tests.yml
+++ b/.github/workflows/api-unit-tests.yml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9']
+    env:
+      PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework
     steps:
       - uses: actions/checkout@v3
 
@@ -28,4 +30,4 @@ jobs:
           pip install -r framework/requirements-dev.txt
 
       - name: Run API tests
-        run: python3 -m pytest api/api
+        run: python -m pytest api/api

--- a/.github/workflows/api-unit-tests.yml
+++ b/.github/workflows/api-unit-tests.yml
@@ -2,6 +2,11 @@ name: API unit tests
 
 on:
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
   pull_request:
     paths:
       - '.github/workflows/api-unit-tests.yml'

--- a/.github/workflows/api-unit-tests.yml
+++ b/.github/workflows/api-unit-tests.yml
@@ -1,9 +1,9 @@
-name: Framework unit tests
+name: API unit tests
 
 on:
   pull_request:
     paths: 
-    - 'framework/**'
+    - 'api/**'
 
 jobs:
   build: 
@@ -27,5 +27,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r framework/requirements.txt
 
-      - name: Run Framework tests
-        run: python3 -m pytest framework
+      - name: Run API tests
+        run: python3 -m pytest api/api

--- a/.github/workflows/api-unit-tests.yml
+++ b/.github/workflows/api-unit-tests.yml
@@ -20,12 +20,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: 'framework/requirements.txt'
+          cache-dependency-path: 'framework/requirements-dev.txt'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r framework/requirements.txt
+          pip install -r framework/requirements-dev.txt
 
       - name: Run API tests
         run: python3 -m pytest api/api

--- a/.github/workflows/api-unit-tests.yml
+++ b/.github/workflows/api-unit-tests.yml
@@ -1,9 +1,12 @@
 name: API unit tests
 
 on:
+  workflow_dispatch:
   pull_request:
-    paths: 
-    - 'api/**'
+    paths:
+      - '.github/workflows/api-unit-tests.yml'
+      - 'api/**'
+      - 'src/Makefile'
 
 jobs:
   build: 

--- a/.github/workflows/framework-unit-tests.yml
+++ b/.github/workflows/framework-unit-tests.yml
@@ -1,9 +1,12 @@
 name: Framework unit tests
 
 on:
+  workflow_dispatch:
   pull_request:
-    paths: 
-    - 'framework/**'
+    paths:
+      - '.github/workflows/framework-unit-tests.yml'
+      - 'framework/**'
+      - 'src/Makefile'
 
 jobs:
   build: 

--- a/.github/workflows/framework-unit-tests.yml
+++ b/.github/workflows/framework-unit-tests.yml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9']
+    env:
+      PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework
     steps:
       - uses: actions/checkout@v3
 
@@ -28,4 +30,4 @@ jobs:
           pip install -r framework/requirements-dev.txt
 
       - name: Run Framework tests
-        run: python3 -m pytest framework
+        run: python -m pytest framework

--- a/.github/workflows/framework-unit-tests.yml
+++ b/.github/workflows/framework-unit-tests.yml
@@ -20,12 +20,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: 'framework/requirements.txt'
+          cache-dependency-path: 'framework/requirements-dev.txt'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r framework/requirements.txt
+          pip install -r framework/requirements-dev.txt
 
       - name: Run Framework tests
         run: python3 -m pytest framework

--- a/.github/workflows/framework-unit-tests.yml
+++ b/.github/workflows/framework-unit-tests.yml
@@ -1,0 +1,44 @@
+name: Framework unit tests
+
+on:
+  pull_request:
+    paths: 
+    - 'api/**'
+    - 'framework/**'
+
+jobs:
+  build: 
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            api:
+              - 'api/**'
+            framework:
+              - 'framework/**'
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r framework/requirements.txt
+
+      - name: Run API tests
+        if: steps.filter.outputs.api == 'true'
+        run: python3 -m pytest api/api
+
+      - name: Run Framework tests
+        if: steps.filter.outputs.framework == 'true'
+        run: python3 -m pytest framework

--- a/.github/workflows/framework-unit-tests.yml
+++ b/.github/workflows/framework-unit-tests.yml
@@ -2,6 +2,11 @@ name: Framework unit tests
 
 on:
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
   pull_request:
     paths:
       - '.github/workflows/framework-unit-tests.yml'


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/17845 |

## Description

Add two workflow actions to run API and Framework unit tests on pull requests that modify  `api` or `framework` directories.

They `ubuntu-latest` and python `3.9` versions. Dependencies are cached using `setup-python` to avoid installing the same dependencies multiple times.

### Executions

The workflow actions added were run in the pull request https://github.com/wazuh/wazuh/pull/18162 to verify that they work as expected.