### PR TITLE
Add an rtr workflow to the vulnerability scanner module - Implementation

### DIFF
--- a/.github/actions/compile_and_test/action.yml
+++ b/.github/actions/compile_and_test/action.yml
@@ -1,0 +1,24 @@
+name: "Compile and test"
+description: "Executes a compilation and test routine based on a path"
+
+inputs:
+  path:
+    required: true
+    description: "Path to compile and test"
+    default: src/
+      
+runs:
+  using: "composite"
+  steps:    
+      - name: Compile
+        run: |
+          cd ${{ inputs.path }}
+          mkdir -p build && cd build
+          cmake .. && make -j2
+        shell: bash
+      
+      - name: Test
+        run: |
+          cd ${{ inputs.path }}/build
+          ctest --output-on-failure
+        shell: bash

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -1,0 +1,100 @@
+name: Vulnerability Scanner
+
+on:
+  push:
+    paths:
+      - ".github/workflows/vulnerability-scanner-tests.yml"
+      - "src/shared_modules/router/**"
+      - "src/shared_modules/content_manager/**"
+      - "src/shared_modules/indexer_connector/**"
+      - "src/wazuh_modules/vulnerability_scanner/**"
+      - "src/wazuh_modules/wazuh-http-request/**"
+
+jobs:
+  vulnerability-scanner-modules:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 2 # We need to fetch 2 commits to get the diff.
+
+      # For this scenario ([see dependencies matrix](https://github.com/wazuh/wazuh/issues/17952#issuecomment-1645614459)) 
+      # we need to compile all the modules. This step is usefull for scenario where we can avoid the compilation of some steps
+      # - name: Check for compilation requirement
+      #   run: |
+      #     DIFFS=$(git diff --name-only HEAD HEAD~1)
+
+      #     if echo $DIFFS | grep 'src/shared_modules/router/'; then
+      #       echo "ROUTER=true" >> "$GITHUB_ENV"
+      #     else
+      #       echo "ROUTER=false" >> "$GITHUB_ENV"
+      #     fi
+
+      #     if echo $DIFFS | grep 'src/shared_modules/content_manager/'; then
+      #       echo "CONTENT_MANAGER=true" >> "$GITHUB_ENV"
+      #     else
+      #       echo "CONTENT_MANAGER=false" >> "$GITHUB_ENV"
+      #     fi
+
+      #     if echo $DIFFS | grep 'src/shared_modules/indexer_connector/'; then
+      #       echo "INDEXER_CONNECTOR=true" >> "$GITHUB_ENV"
+      #     else
+      #       echo "INDEXER_CONNECTOR=false" >> "$GITHUB_ENV"
+      #     fi
+
+      #     if echo $DIFFS | grep 'src/wazuh_modules/vulnerability_scanner/'; then
+      #       echo "VULNERABILITY_SCANNER=true" >> "$GITHUB_ENV"
+      #     else
+      #       echo "VULNERABILITY_SCANNER=false" >> "$GITHUB_ENV"
+      #     fi
+
+      - name: Prepare dependencies
+        run: |
+          cd src
+          make deps TARGET=server -j2
+          make build_gtest TARGET=server -j2
+
+          cd external
+          git clone https://github.com/yhirose/cpp-httplib.git
+          cd ..
+
+          cd shared_modules/wazuh-http-request
+          mkdir -p build && cd build && cmake .. && make
+
+      # All modules depend of the router. We compile it first
+      - name: Build router
+        run: |
+          cd src/shared_modules/router
+          mkdir -p build && cd build && cmake .. && make -j2
+          ctest
+
+      # Vulnerability scanner depends of the indexer_connector and content_manager
+      - name: Build indexer_connector and content_manager
+        run: |
+          cd src/shared_modules
+          
+          # Compile the 
+          cd indexer_connector
+          mkdir -p build && cd build && cmake .. && make -j2
+          ctest
+          cd ../..
+
+          cd content_manager
+          mkdir -p build && cd build && cmake .. && make -j2
+          ctest
+          cd ../..
+          
+          # Wait for the compilation to finish
+          wait
+
+      # Vulnerability scanner depends of all the modules. We compile it last
+      - name: Build vulnerability_scanner
+        run: |
+          cd src/wazuh_modules/vulnerability_scanner
+          mkdir -p build && cd build && cmake .. && make -j2
+          ctest
+
+# TODO add testing workflow

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -1,7 +1,11 @@
 name: Vulnerability Scanner
 
 on:
-  push:
+  pull_request:
+    # Pull request events
+    types: [synchronize, opened, reopened, ready_for_review]
+    
+    # Path filtering
     paths:
       - ".github/workflows/vulnerability-scanner-tests.yml"
       - "src/shared_modules/router/**"
@@ -21,35 +25,34 @@ jobs:
           submodules: recursive
           fetch-depth: 2 # We need to fetch 2 commits to get the diff.
 
-      # For this scenario ([see dependencies matrix](https://github.com/wazuh/wazuh/issues/17952#issuecomment-1645614459)) 
-      # we need to compile all the modules. This step is usefull for scenario where we can avoid the compilation of some steps
-      # - name: Check for compilation requirement
-      #   run: |
-      #     DIFFS=$(git diff --name-only HEAD HEAD~1)
+      # Checks which modules has changed
+      - name: Check changes
+        run: |
+          DIFFS=$(git diff --name-only HEAD HEAD~1)
 
-      #     if echo $DIFFS | grep 'src/shared_modules/router/'; then
-      #       echo "ROUTER=true" >> "$GITHUB_ENV"
-      #     else
-      #       echo "ROUTER=false" >> "$GITHUB_ENV"
-      #     fi
+          if echo $DIFFS | grep 'src/shared_modules/router/'; then
+            echo "ROUTER=true" >> "$GITHUB_ENV"
+          else
+            echo "ROUTER=false" >> "$GITHUB_ENV"
+          fi
 
-      #     if echo $DIFFS | grep 'src/shared_modules/content_manager/'; then
-      #       echo "CONTENT_MANAGER=true" >> "$GITHUB_ENV"
-      #     else
-      #       echo "CONTENT_MANAGER=false" >> "$GITHUB_ENV"
-      #     fi
+          if echo $DIFFS | grep 'src/shared_modules/content_manager/'; then
+            echo "CONTENT_MANAGER=true" >> "$GITHUB_ENV"
+          else
+            echo "CONTENT_MANAGER=false" >> "$GITHUB_ENV"
+          fi
 
-      #     if echo $DIFFS | grep 'src/shared_modules/indexer_connector/'; then
-      #       echo "INDEXER_CONNECTOR=true" >> "$GITHUB_ENV"
-      #     else
-      #       echo "INDEXER_CONNECTOR=false" >> "$GITHUB_ENV"
-      #     fi
+          if echo $DIFFS | grep 'src/shared_modules/indexer_connector/'; then
+            echo "INDEXER_CONNECTOR=true" >> "$GITHUB_ENV"
+          else
+            echo "INDEXER_CONNECTOR=false" >> "$GITHUB_ENV"
+          fi
 
-      #     if echo $DIFFS | grep 'src/wazuh_modules/vulnerability_scanner/'; then
-      #       echo "VULNERABILITY_SCANNER=true" >> "$GITHUB_ENV"
-      #     else
-      #       echo "VULNERABILITY_SCANNER=false" >> "$GITHUB_ENV"
-      #     fi
+          if echo $DIFFS | grep 'src/wazuh_modules/vulnerability_scanner/'; then
+            echo "VULNERABILITY_SCANNER=true" >> "$GITHUB_ENV"
+          else
+            echo "VULNERABILITY_SCANNER=false" >> "$GITHUB_ENV"
+          fi
 
       - name: Prepare dependencies
         run: |
@@ -64,37 +67,30 @@ jobs:
           cd shared_modules/wazuh-http-request
           mkdir -p build && cd build && cmake .. && make
 
-      # All modules depend of the router. We compile it first
-      - name: Build router
-        run: |
-          cd src/shared_modules/router
-          mkdir -p build && cd build && cmake .. && make -j2
-          ctest --output-on-failure
+      ########################
+      # Compilation and test #
+      ########################
 
-      # Vulnerability scanner depends of the indexer_connector and content_manager
-      - name: Build indexer_connector and content_manager
-        run: |
-          cd src/shared_modules
-          
-          # Compile the 
-          cd indexer_connector
-          mkdir -p build && cd build && cmake .. && make -j2
-          ctest --output-on-failure
-          cd ../..
+      # Router
+      - name: Router
+        uses: ./.github/actions/compile_and_test
+        with:
+          path: src/shared_modules/router
 
-          cd content_manager
-          mkdir -p build && cd build && cmake .. && make -j2
-          ctest --output-on-failure
-          cd ../..
-          
-          # Wait for the compilation to finish
-          wait
+      # indexer connector
+      - name: Indexer connector
+        uses: ./.github/actions/compile_and_test
+        with:
+          path: src/shared_modules/content_manager
 
-      # Vulnerability scanner depends of all the modules. We compile it last
-      - name: Build vulnerability_scanner
-        run: |
-          cd src/wazuh_modules/vulnerability_scanner
-          mkdir -p build && cd build && cmake .. && make -j2
-          ctest --output-on-failure
+      # content manager
+      - name: Content manager
+        uses: ./.github/actions/compile_and_test
+        with:
+          path: src/shared_modules/indexer_connector
 
-# TODO add testing workflow
+      # Vulnerability scanner
+      - name: Vulnerability scanner
+        uses: ./.github/actions/compile_and_test
+        with:
+          path: src/wazuh_modules/vulnerability_scanner

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -23,12 +23,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          fetch-depth: 2 # We need to fetch 2 commits to get the diff.
+          fetch-depth: 0
 
-      # Checks which modules has changed
+      # Checks which modules have changed
       - name: Check changes
         run: |
-          DIFFS=$(git diff --name-only HEAD HEAD~1)
+          DIFFS=$(git diff --name-only origin/${{ github.head_ref }} origin/${{ github.base_ref }})
 
           if echo $DIFFS | grep 'src/shared_modules/router/'; then
             echo "ROUTER=true" >> "$GITHUB_ENV"

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           cd src/shared_modules/router
           mkdir -p build && cd build && cmake .. && make -j2
-          ctest
+          ctest --output-on-failure
 
       # Vulnerability scanner depends of the indexer_connector and content_manager
       - name: Build indexer_connector and content_manager
@@ -79,12 +79,12 @@ jobs:
           # Compile the 
           cd indexer_connector
           mkdir -p build && cd build && cmake .. && make -j2
-          ctest
+          ctest --output-on-failure
           cd ../..
 
           cd content_manager
           mkdir -p build && cd build && cmake .. && make -j2
-          ctest
+          ctest --output-on-failure
           cd ../..
           
           # Wait for the compilation to finish
@@ -95,6 +95,6 @@ jobs:
         run: |
           cd src/wazuh_modules/vulnerability_scanner
           mkdir -p build && cd build && cmake .. && make -j2
-          ctest
+          ctest --output-on-failure
 
 # TODO add testing workflow

--- a/src/Makefile
+++ b/src/Makefile
@@ -1317,13 +1317,8 @@ EXTERNAL_RES := cJSON curl libdb libffi libyaml openssl procps sqlite zlib audit
 ifneq (${TARGET},agent)
 ifneq (${TARGET},winagent)
 	# Manager extra dependency
-	EXTERNAL_RES += $(CPYTHON) jemalloc
+	EXTERNAL_RES += $(CPYTHON) jemalloc rocksdb
 endif
-endif
-
-ifeq (${TARGET},server)
-	# Server extra dependency
-	EXTERNAL_RES += rocksdb
 endif
 
 EXTERNAL_DIR := $(EXTERNAL_RES:%=external/%)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1317,8 +1317,13 @@ EXTERNAL_RES := cJSON curl libdb libffi libyaml openssl procps sqlite zlib audit
 ifneq (${TARGET},agent)
 ifneq (${TARGET},winagent)
 	# Manager extra dependency
-	EXTERNAL_RES += $(CPYTHON) jemalloc rocksdb
+	EXTERNAL_RES += $(CPYTHON) jemalloc
 endif
+endif
+
+ifeq (${TARGET},server)
+	# Server extra dependency
+	EXTERNAL_RES += rocksdb
 endif
 
 EXTERNAL_DIR := $(EXTERNAL_RES:%=external/%)

--- a/src/shared_modules/content_manager/CMakeLists.txt
+++ b/src/shared_modules/content_manager/CMakeLists.txt
@@ -4,10 +4,27 @@ project(content_manager)
 
 enable_testing()
 
+get_filename_component(SRC_FOLDER     ${CMAKE_SOURCE_DIR}/../../ ABSOLUTE)
+get_filename_component(SHARED_MODULES ${SRC_FOLDER}/shared_modules/ ABSOLUTE)
+
+# Include directories
 include_directories(include)
-include_directories(${SRC_FOLDER}/shared_modules)
-include_directories(${SRC_FOLDER}/shared_modules/content_manager/tests)
-include_directories(${SRC_FOLDER}/shared_modules/content_manager/src/components)
+
+include_directories(${SRC_FOLDER})
+include_directories(${SRC_FOLDER}/headers)
+include_directories(${SRC_FOLDER}/external/nlohmann)
+include_directories(${SRC_FOLDER}/external/curl/include/curl)
+
+include_directories(${SHARED_MODULES})
+include_directories(${SHARED_MODULES}/utils)
+include_directories(${SHARED_MODULES}/router/include)
+include_directories(${SHARED_MODULES}/wazuh-http-request/include)
+include_directories(${SHARED_MODULES}/content_manager/src/components)
+
+# Link directories
+link_directories(${SRC_FOLDER}/external/curl/lib/.libs)
+link_directories(${SHARED_MODULES}/router/build)
+link_directories(${SHARED_MODULES}/wazuh-http-request/build)
 
 file(GLOB CONTENT_DOWNLOAD_SRC
     "src/*.cpp"
@@ -17,7 +34,7 @@ add_library(content_manager SHARED
     ${CONTENT_DOWNLOAD_SRC}
     )
 
-target_link_libraries(content_manager router urlrequest gcc_s)
+target_link_libraries(content_manager router urlrequest gcc_s curl)
 
 set_target_properties(content_manager PROPERTIES
         BUILD_RPATH_USE_ORIGIN TRUE

--- a/src/shared_modules/content_manager/tests/CMakeLists.txt
+++ b/src/shared_modules/content_manager/tests/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.12.4)
 
-include_directories(${SRC_FOLDER}/shared_modules/content_manager/src/)
+include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
+include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
+
+link_directories(${SRC_FOLDER}/external/googletest/lib/)
 
 add_subdirectory(unit)

--- a/src/shared_modules/content_manager/tests/unit/CMakeLists.txt
+++ b/src/shared_modules/content_manager/tests/unit/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(${PROJECT_NAME}
     gmock
     urlrequest
     router
+    curl
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/src/shared_modules/indexer_connector/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/CMakeLists.txt
@@ -6,8 +6,25 @@ enable_testing()
 
 add_definitions(-DPROMISE_TYPE=PromiseType::NORMAL)
 
-#add include directory
+get_filename_component(SRC_FOLDER     ${CMAKE_SOURCE_DIR}/../../ ABSOLUTE)
+get_filename_component(SHARED_MODULES ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+
+# Include directories
 include_directories(include)
+
+include_directories(${SRC_FOLDER})
+include_directories(${SRC_FOLDER}/external/cJSON)
+include_directories(${SRC_FOLDER}/external/nlohmann)
+include_directories(${SRC_FOLDER}/external/rocksdb/include)
+
+include_directories(${SHARED_MODULES}/utils)
+include_directories(${SHARED_MODULES}/common)
+include_directories(${SHARED_MODULES}/wazuh-http-request/include)
+
+# Link directories
+link_directories(${SRC_FOLDER}/external/rocksdb/build)
+link_directories(${SRC_FOLDER}/external/curl/lib/.libs)
+link_directories(${SHARED_MODULES}/wazuh-http-request/build)
 
 file(GLOB INDEXER_CONNECTOR_SRC
     "src/*.cpp"
@@ -17,7 +34,7 @@ add_library(indexer_connector SHARED
     ${INDEXER_CONNECTOR_SRC}
     )
 
-target_link_libraries(indexer_connector rocksdb urlrequest gcc_s)
+target_link_libraries(indexer_connector rocksdb urlrequest gcc_s curl)
 
 set_target_properties(indexer_connector PROPERTIES
         BUILD_RPATH_USE_ORIGIN TRUE

--- a/src/shared_modules/router/CMakeLists.txt
+++ b/src/shared_modules/router/CMakeLists.txt
@@ -6,8 +6,19 @@ enable_testing()
 
 add_definitions(-DPROMISE_TYPE=PromiseType::NORMAL)
 
-#add include directory
+get_filename_component(SRC_FOLDER     ${CMAKE_SOURCE_DIR}/../../ ABSOLUTE)
+get_filename_component(SHARED_MODULES ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+
+# Include directories
 include_directories(include)
+
+include_directories(${SRC_FOLDER})
+include_directories(${SRC_FOLDER}/headers)
+include_directories(${SRC_FOLDER}/external/rocksdb/include)
+include_directories(${SRC_FOLDER}/external/nlohmann)
+include_directories(${SRC_FOLDER}/external/cJSON)
+
+include_directories(${SHARED_MODULES}/utils)
 
 file(GLOB ROUTER_SRC
     "src/*.cpp"

--- a/src/shared_modules/router/tests/CMakeLists.txt
+++ b/src/shared_modules/router/tests/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.12.4)
 
-add_subdirectory(benchmark)
+include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
+include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
+
+link_directories(${SRC_FOLDER}/external/googletest/lib/)
+
+#add_subdirectory(benchmark)
 add_subdirectory(component)

--- a/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
@@ -6,7 +6,29 @@ enable_testing()
 
 add_definitions(-DPROMISE_TYPE=PromiseType::NORMAL)
 
+get_filename_component(SRC_FOLDER     ${CMAKE_SOURCE_DIR}/../../ ABSOLUTE)
+get_filename_component(SHARED_MODULES ${SRC_FOLDER}/shared_modules/ ABSOLUTE)
+
+# Include directories
 include_directories(include)
+
+include_directories(${SRC_FOLDER})
+include_directories(${SRC_FOLDER}/headers)
+include_directories(${SRC_FOLDER}/external/cJSON)
+include_directories(${SRC_FOLDER}/external/nlohmann)
+include_directories(${SRC_FOLDER}/external/rocksdb/include)
+
+include_directories(${SHARED_MODULES}/common)
+include_directories(${SHARED_MODULES}/utils)
+include_directories(${SHARED_MODULES}/router/include)
+include_directories(${SHARED_MODULES}/content_manager/include)
+include_directories(${SHARED_MODULES}/indexer_connector/include)
+
+# Link directories
+link_directories(${SRC_FOLDER}/external/rocksdb/build)
+link_directories(${SHARED_MODULES}/router/build)
+link_directories(${SHARED_MODULES}/content_manager/build)
+link_directories(${SHARED_MODULES}/indexer_connector/build)
 
 add_subdirectory("src/scanOrchestrator")
 add_subdirectory("src/databaseFeedManager")
@@ -19,7 +41,7 @@ add_library(vulnerability_scanner SHARED
     ${VULNERABILITY_SCANNER_SRC}
     )
 
-target_link_libraries(vulnerability_scanner scan_orchestrator database_feed router content_manager indexer_connector gcc_s)
+target_link_libraries(vulnerability_scanner scan_orchestrator database_feed router content_manager indexer_connector router gcc_s)
 
 set_target_properties(vulnerability_scanner PROPERTIES
         BUILD_RPATH_USE_ORIGIN TRUE


### PR DESCRIPTION
|Related issue|
|---|
| #17952 |

## Description
This PR aims to add the baseline for the vulnerability CI testing on GitHub actions.

It includes base testing, which is compiling the different modules and executing the associated tests

The CMake files were changed to allow the compilation of the individual modules separately