### PR TITLE
Fix `agent_upgrade` when get agent version

### DIFF
--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -118,7 +118,7 @@ async def get_agent_version(agent_id: str) -> str:
         "limit": 1
     }
     result = await cluster_utils.forward_function(get_agents, f_kwargs=f_kwargs)
-    return result['version']
+    return result.affected_items[0]['version']
 
 
 def create_command() -> dict:

--- a/framework/scripts/tests/test_agent_upgrade.py
+++ b/framework/scripts/tests/test_agent_upgrade.py
@@ -89,6 +89,21 @@ async def test_get_agents_versions():
         assert all(result[agent] == {'prev_version': mocked_version, 'new_version': None} for agent in agents_list)
 
 
+@pytest.mark.asyncio
+async def test_get_agent_version():
+    class AffectedItems:
+        def __init__(self, affected_items):
+            self.affected_items = affected_items
+
+    agent_id = "001"
+    mocked_version = "v4.6.0"
+    affected_items = [{"id": agent_id, "version": mocked_version}]
+
+    with patch('scripts.agent_upgrade.cluster_utils.forward_function', return_value=AffectedItems(affected_items)):
+        result = await agent_upgrade.get_agent_version(agent_id)
+        assert result == mocked_version
+
+
 def test_create_command():
     """Check that expected result is returned in create_command function"""
     agent_upgrade.args = MagicMock()


### PR DESCRIPTION
|Related issue|
|---|
| #17934 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #17934, fix an error when the script tries to get the agent version. Now get the info from the `affected_items` list.

## Logs/Alerts example

```bash
root@ubuntu-jammy:/var/ossec# bin/agent_upgrade -a 001 -f /home/vagrant/wazuh_agent_v4.6.0_linux_x86_64.wpk -d

Upgrading...

Upgraded agents:
        Agent 001 upgraded: Wazuh v4.6.0 -> Wazuh v4.6.0
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

```python
(framework) ➜  wazuh git:(fix/17934_agent_upgrade_script) PYTHONPATH=$WAZUH_REPO/api:$WAZUH_REPO/framework python -m pytest --disable-warnings framework/scripts/tests/test_agent_upgrade.py
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.9.9, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/nstefani/git/wazuh/framework
plugins: aiohttp-0.3.0, trio-0.7.0, html-2.1.1, asyncio-0.15.1, metadata-2.0.4
collected 15 items

framework/scripts/tests/test_agent_upgrade.py ...............                                                                                                                                                 [100%]

========================================================================================== 15 passed, 11 warnings in 0.53s ==========================================================================================
```