### PR TITLE
Add relative_dirname parameter to decoders and rules PUT & DELETE endpoints

### DIFF
--- a/api/api/controllers/decoder_controller.py
+++ b/api/api/controllers/decoder_controller.py
@@ -255,12 +255,14 @@ async def get_file(request, pretty: bool = False, wait_for_complete: bool = Fals
     if isinstance(data, AffectedItemsWazuhResult):
         response = web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
     else:
-        response = ConnexionResponse(body=data["message"], mimetype='application/xml', content_type='application/xml')
+        response = ConnexionResponse(body=data["message"], 
+                                     mimetype='application/xml', content_type='application/xml')
 
     return response
 
 
-async def put_file(request, body: dict, filename: str = None, overwrite: bool = False, pretty: bool = False,
+async def put_file(request, body: dict, filename: str = None, relative_dirname: str = None,
+                   overwrite: bool = False, pretty: bool = False,
                    wait_for_complete: bool = False) -> web.Response:
     """Upload a decoder file.
 
@@ -271,8 +273,11 @@ async def put_file(request, body: dict, filename: str = None, overwrite: bool = 
         Body request with the file content to be uploaded.
     filename : str
         Name of the file.
+    relative_dirname : str
+        Relative directory where the decoder is located.
     overwrite : bool
-        If set to false, an exception will be raised when updating contents of an already existing file.
+        If set to false, an exception will be raised when  
+        updating contents of an already existing file.
     pretty : bool
         Show results in human-readable format.
     wait_for_complete : bool
@@ -289,7 +294,8 @@ async def put_file(request, body: dict, filename: str = None, overwrite: bool = 
 
     f_kwargs = {'filename': filename,
                 'overwrite': overwrite,
-                'content': parsed_body}
+                'content': parsed_body,
+                'relative_dirname': relative_dirname}
 
     dapi = DistributedAPI(f=decoder_framework.upload_decoder_file,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -304,7 +310,9 @@ async def put_file(request, body: dict, filename: str = None, overwrite: bool = 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def delete_file(request, filename: str = None, pretty: bool = False,
+async def delete_file(request, filename: str = None, 
+                      relative_dirname: str = None,
+                      pretty: bool = False,
                       wait_for_complete: bool = False) -> web.Response:
     """Delete a decoder file.
 
@@ -313,6 +321,8 @@ async def delete_file(request, filename: str = None, pretty: bool = False,
     request : connexion.request
     filename : str
         Name of the file.
+    relative_dirname : str
+        Relative directory where the decoder is located.
     pretty : bool
         Show results in human-readable format.
     wait_for_complete : bool
@@ -323,7 +333,7 @@ async def delete_file(request, filename: str = None, pretty: bool = False,
     web.Response
         API response.
     """
-    f_kwargs = {'filename': filename}
+    f_kwargs = {'filename': filename, 'relative_dirname': relative_dirname}
 
     dapi = DistributedAPI(f=decoder_framework.delete_decoder_file,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/rule_controller.py
+++ b/api/api/controllers/rule_controller.py
@@ -295,7 +295,7 @@ async def get_file(request, pretty: bool = False, wait_for_complete: bool = Fals
     raw : bool, optional
         Whether to return the file content in raw or JSON format. Default `False`.
     relative_dirname : str
-        Relative directory where the rule is located. Default None.
+        Relative directory where the rule is located.
 
     Returns
     -------
@@ -324,7 +324,8 @@ async def get_file(request, pretty: bool = False, wait_for_complete: bool = Fals
     return response
 
 
-async def put_file(request, body: dict, filename: str = None, overwrite: bool = False, pretty: bool = False,
+async def put_file(request, body: dict, filename: str = None, overwrite: bool = False,
+                   pretty: bool = False, relative_dirname: str = None,
                    wait_for_complete: bool = False) -> web.Response:
     """Upload a rule file.
     
@@ -334,11 +335,14 @@ async def put_file(request, body: dict, filename: str = None, overwrite: bool = 
     body : dict
         Body request with the file content to be uploaded.
     filename : str, optional
-        Name of the file. Default `None`
+        Name of the file.
     overwrite : bool, optional
-        If set to false, an exception will be raised when updating contents of an already existing file. Default `False`
+        If set to false, an exception will be raised when updating 
+        contents of an already existing file. Default `False`
     pretty : bool, optional
         Show results in human-readable format. Default `False`
+    relative_dirname : str
+        Relative directory where the rule is located.
     wait_for_complete : bool, optional
         Disable timeout response. Default `False`
 
@@ -353,6 +357,7 @@ async def put_file(request, body: dict, filename: str = None, overwrite: bool = 
 
     f_kwargs = {'filename': filename,
                 'overwrite': overwrite,
+                'relative_dirname': relative_dirname,
                 'content': parsed_body}
 
     dapi = DistributedAPI(f=rule_framework.upload_rule_file,
@@ -368,7 +373,9 @@ async def put_file(request, body: dict, filename: str = None, overwrite: bool = 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def delete_file(request, filename: str = None, pretty: bool = False,
+async def delete_file(request, filename: str = None, 
+                      relative_dirname: str = None, 
+                      pretty: bool = False,
                       wait_for_complete: bool = False) -> web.Response:
     """Delete a rule file.
 
@@ -376,7 +383,9 @@ async def delete_file(request, filename: str = None, pretty: bool = False,
     ----------
     request : connexion.request
     filename : str, optional
-        Name of the file. Default `None`
+        Name of the file.
+    relative_dirname : str
+        Relative directory where the rule file is located.
     pretty : bool, optional
         Show results in human-readable format. Default `False`
     wait_for_complete : bool, optional
@@ -387,7 +396,7 @@ async def delete_file(request, filename: str = None, pretty: bool = False,
     web.Response
         API response.
     """
-    f_kwargs = {'filename': filename}
+    f_kwargs = {'filename': filename, 'relative_dirname': relative_dirname}
 
     dapi = DistributedAPI(f=rule_framework.delete_rule_file,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/test/test_decoder_controller.py
+++ b/api/api/controllers/test/test_decoder_controller.py
@@ -162,6 +162,7 @@ async def test_put_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_reque
             result = await put_file(request=mock_request,
                                     body={})
             f_kwargs = {'filename': None,
+                        'relative_dirname': None,
                         'overwrite': False,
                         'content': mock_dbody.return_value
                         }
@@ -186,8 +187,9 @@ async def test_put_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_reque
 async def test_delete_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request=MagicMock()):
     """Verify 'delete_file' endpoint is working as expected."""
     result = await delete_file(request=mock_request)
-    f_kwargs = {'filename': None
-                }
+    f_kwargs = {'filename': None,
+                'relative_dirname': None}
+    
     mock_dapi.assert_called_once_with(f=decoder_framework.delete_decoder_file,
                                       f_kwargs=mock_remove.return_value,
                                       request_type='local_master',

--- a/api/api/controllers/test/test_rule_controller.py
+++ b/api/api/controllers/test/test_rule_controller.py
@@ -202,6 +202,7 @@ async def test_put_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_reque
                                     body={})
             f_kwargs = {'filename': None,
                         'overwrite': False,
+                        'relative_dirname': None,
                         'content': mock_dbody.return_value
                         }
             mock_dapi.assert_called_once_with(f=rule_framework.upload_rule_file,
@@ -225,8 +226,9 @@ async def test_put_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_reque
 async def test_delete_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request=MagicMock()):
     """Verify 'delete_file' endpoint is working as expected."""
     result = await delete_file(request=mock_request)
-    f_kwargs = {'filename': None
-                }
+    f_kwargs = {'filename': None, 
+                'relative_dirname': None}
+    
     mock_dapi.assert_called_once_with(f=rule_framework.delete_rule_file,
                                       f_kwargs=mock_remove.return_value,
                                       request_type='local_master',

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -11657,7 +11657,7 @@ paths:
                       name: "wazuh"
                       node: "master-node"
                     full_log: "ERROR"
-                    decoder:
+                    decoder: None
                     location: "/var/log/syslog"
                   alert: false
                   codemsg: 1
@@ -14166,6 +14166,7 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/xml_filename_path'
         - $ref: '#/components/parameters/overwrite'
+        - $ref: '#/components/parameters/get_dirnames_path'
       requestBody:
         description: "Content of the rule to be uploaded"
         required: true
@@ -14221,6 +14222,7 @@ paths:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/xml_filename_path'
+        - $ref: '#/components/parameters/get_dirnames_path'
       responses:
         '200':
           description: "Confirmation message"
@@ -14943,6 +14945,7 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/xml_filename_path'
         - $ref: '#/components/parameters/overwrite'
+        - $ref: '#/components/parameters/get_dirnames_path'
       requestBody:
         description: "Content of the decoder to be uploaded"
         required: true
@@ -14998,6 +15001,7 @@ paths:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/xml_filename_path'
+        - $ref: '#/components/parameters/get_dirnames_path'
       responses:
         '200':
           description: "Confirmation message"

--- a/api/test/integration/env/.env
+++ b/api/test/integration/env/.env
@@ -1,0 +1,1 @@
+ENV_MODE=cluster

--- a/api/test/integration/env/.env
+++ b/api/test/integration/env/.env
@@ -1,1 +1,0 @@
-ENV_MODE=cluster

--- a/api/test/integration/env/configurations/decoder/manager/configuration_files/manager.sh
+++ b/api/test/integration/env/configurations/decoder/manager/configuration_files/manager.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [ "$HOSTNAME" == "wazuh-master" ]; then
+  mkdir -p /var/ossec/etc/decoders/subdir
+  chown -R wazuh:wazuh /var/ossec/etc/decoders/subdir
+  sed -i -e "/<decoder_dir>etc\/decoders<\/decoder_dir>/a \    <decoder_dir>etc/decoders/subdir</decoder_dir>" /var/ossec/etc/ossec.conf
+  mkdir -p /var/ossec/etc/rules/subdir
+  chown -R wazuh:wazuh /var/ossec/etc/rules/subdir
+  sed -i -e "/<rule_dir>etc\/rules<\/rule_dir>/a \   <rule_dir>etc/rules/subdir</rule_dir>" /var/ossec/etc/ossec.conf
+fi

--- a/api/test/integration/env/configurations/rule/manager/configuration_files/manager.sh
+++ b/api/test/integration/env/configurations/rule/manager/configuration_files/manager.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [ "$HOSTNAME" == "wazuh-master" ]; then
+  mkdir -p /var/ossec/etc/decoders/subdir
+  chown -R wazuh:wazuh /var/ossec/etc/decoders/subdir
+  sed -i -e "/<decoder_dir>etc\/decoders<\/decoder_dir>/a \    <decoder_dir>etc/decoders/subdir</decoder_dir>" /var/ossec/etc/ossec.conf
+  mkdir -p /var/ossec/etc/rules/subdir
+  chown -R wazuh:wazuh /var/ossec/etc/rules/subdir
+  sed -i -e "/<rule_dir>etc\/rules<\/rule_dir>/a \   <rule_dir>etc/rules/subdir</rule_dir>" /var/ossec/etc/ossec.conf
+fi

--- a/api/test/integration/test_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoder_endpoints.tavern.yaml
@@ -1132,7 +1132,7 @@ stages:
       status_code: 400
 
 ---
-test_name: PUT /rule/decoders/{filename}
+test_name: PUT /decoders/files/{filename}
 
 stages:
 
@@ -1193,6 +1193,29 @@ stages:
     response:
       <<: *upload_valid_decoder
 
+  - name: Upload decoder with relative_dirname
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder.xml"
+      method: PUT
+      data: "{new_decoder:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        overwrite: True
+        relative_dirname: 'etc/decoders/subdir'        
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - 'etc/decoders/subdir/new_decoder.xml'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+        error: 0
+
   - name: Upload decoder with invalid name
     request:
       verify: False
@@ -1246,6 +1269,26 @@ stages:
         data:
           affected_items:
             - "etc/decoders/new_decoder.xml"
+          total_affected_items: 1
+          failed_items: []
+          total_failed_items: 0
+        error: 0
+
+  - name: Delete user decoder in subdir
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder.xml"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        relative_dirname: 'etc/decoders/subdir'
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - "etc/decoders/subdir/new_decoder.xml"
           total_affected_items: 1
           failed_items: []
           total_failed_items: 0

--- a/api/test/integration/test_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rule_endpoints.tavern.yaml
@@ -1829,6 +1829,28 @@ stages:
           total_failed_items: 0
         error: 0
 
+  - name: Upload new valid rule in custom subdir
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      method: PUT
+      data: "{new_rules:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        relative_dirname: 'etc/rules/subdir'
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - 'etc/rules/subdir/new_rule.xml'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+        error: 0
+
   - name: Upload same rule (overwrite=False)
     request:
       verify: False
@@ -1922,6 +1944,26 @@ stages:
         data:
           affected_items:
             - "etc/rules/new_rule.xml"
+          total_affected_items: 1
+          failed_items: []
+          total_failed_items: 0
+        error: 0
+
+  - name: Delete user rule in subdir
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        relative_dirname: 'etc/rules/subdir'
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - "etc/rules/subdir/new_rule.xml"
           total_affected_items: 1
           failed_items: []
           total_failed_items: 0

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -152,7 +152,19 @@ class WazuhException(Exception):
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
                               ' to get more information about how to configure the rules'
                },
-
+        1209: {'message': 'Invalid relative directory, a rule_dir tag must be declared in '
+               'ossec.conf ruleset section.',
+               'remediation': f'Please, visit the official documentation '
+                              f'(https://documentation.wazuh.com/' 
+                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
+                              ' to get more information about the decoders'
+        },
+        1210: {'message': 'Uploading or deleting default rules is not allowed.',
+               'remediation': f'Please, visit the official documentation '
+                              f'(https://documentation.wazuh.com/' 
+                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
+                              ' to get more information about the decoders'
+        },
         # Stats: 1300 - 1399
         1307: {'message': 'Invalid parameters',
                'remediation': 'Please, check that the update is correct, there is a problem while reading the results, '
@@ -208,7 +220,21 @@ class WazuhException(Exception):
                'remediation': 'Please, use GET /decoders/files to list all available decoders'
                },
         1504: {'message': 'The decoder does not exist or you do not have permission to see it',
-               'remediation': f'Please, visit the official documentation (https://documentation.wazuh.com/'
+               'remediation': f'Please, visit the official documentation '
+                              f'(https://documentation.wazuh.com/'
+                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
+                              ' to get more information about the decoders'
+               },
+        1505: {'message': 'Invalid relative directory, '
+               'a decoder_dir tag must be declared in ossec.conf ruleset section.',
+               'remediation': f'Please, visit the official documentation'
+                               '(https://documentation.wazuh.com/'
+                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
+                              ' to get more information about the decoders'
+               },
+        1506: {'message': 'Uploading or deleting default decoders is not allowed.',
+               'remediation': f'Please, visit the official documentation'
+                               '(https://documentation.wazuh.com/'
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
                               ' to get more information about the decoders'
                },

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -166,7 +166,7 @@ class WazuhException(Exception):
                               ' to get more information about the rules'
         },
         1211: {'message': 'Invalid relative directory. A \'rule_dir\' tag is declared in ossec.conf '
-                          'ruleset section, but the directory does not exists.',
+                          'ruleset section, but the directory does not exist.',
                'remediation': f'Please, visit the official documentation'
                                '(https://documentation.wazuh.com/'
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'
@@ -247,7 +247,7 @@ class WazuhException(Exception):
                               ' to get more information about the decoders'
                },
         1507: {'message': 'Invalid relative directory. A \'decoder_dir\' tag is declared '
-                          'in ossec.conf ruleset section, but the directory does not exists.',
+                          'in ossec.conf ruleset section, but the directory does not exist.',
                'remediation': f'Please, visit the official documentation'
                                '(https://documentation.wazuh.com/'
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -152,19 +152,27 @@ class WazuhException(Exception):
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
                               ' to get more information about how to configure the rules'
                },
-        1209: {'message': 'Invalid relative directory, a rule_dir tag must be declared in '
-               'ossec.conf ruleset section.',
+        1209: {'message': 'Invalid relative directory. A \'rule_dir\' tag must '
+                          'be declared in ossec.conf ruleset section.',
                'remediation': f'Please, visit the official documentation '
                               f'(https://documentation.wazuh.com/' 
-                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
-                              ' to get more information about the decoders'
+                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'
+                              ' to get more information about the rules'
         },
-        1210: {'message': 'Uploading or deleting default rules is not allowed.',
+        1210: {'message': 'Uploading, updating or deleting default rules is not allowed.',
                'remediation': f'Please, visit the official documentation '
                               f'(https://documentation.wazuh.com/' 
-                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
-                              ' to get more information about the decoders'
+                              f'{DOCU_VERSION}/user-manual/ruleset/index.html)'
+                              ' to get more information about the rules'
         },
+        1211: {'message': 'Invalid relative directory. A \'rule_dir\' tag is declared in ossec.conf '
+                          'ruleset section, but the directory does not exists.',
+               'remediation': f'Please, visit the official documentation'
+                               '(https://documentation.wazuh.com/'
+                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'
+                              ' to get more information about the rules'
+               },
+
         # Stats: 1300 - 1399
         1307: {'message': 'Invalid parameters',
                'remediation': 'Please, check that the update is correct, there is a problem while reading the results, '
@@ -225,17 +233,24 @@ class WazuhException(Exception):
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
                               ' to get more information about the decoders'
                },
-        1505: {'message': 'Invalid relative directory, '
-               'a decoder_dir tag must be declared in ossec.conf ruleset section.',
+        1505: {'message': 'Invalid relative directory. A \'decoder_dir\' '
+                          'tag must be declared in ossec.conf ruleset section.',
                'remediation': f'Please, visit the official documentation'
                                '(https://documentation.wazuh.com/'
-                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
+                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'
                               ' to get more information about the decoders'
                },
-        1506: {'message': 'Uploading or deleting default decoders is not allowed.',
+        1506: {'message': 'Uploading, updating or deleting default decoders is not allowed.',
                'remediation': f'Please, visit the official documentation'
                                '(https://documentation.wazuh.com/'
-                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/index.html)'
+                              f'{DOCU_VERSION}/user-manual/ruleset/index.html)'
+                              ' to get more information about the decoders'
+               },
+        1507: {'message': 'Invalid relative directory. A \'decoder_dir\' tag is declared '
+                          'in ossec.conf ruleset section, but the directory does not exists.',
+               'remediation': f'Please, visit the official documentation'
+                               '(https://documentation.wazuh.com/'
+                              f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'
                               ' to get more information about the decoders'
                },
 

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -276,20 +276,20 @@ def get_decoder_file(filename: str, raw: bool = False,
 
 
 def validate_upload_delete_dir(relative_dirname: Union[str, None]) -> Tuple[str, WazuhError]:
-    """Validate relative_dirname parameter
+    """Validate relative_dirname parameter.
 
     Parameters
     ----------
     relative_dirname : str
-        relative path to validate.
+        Relative path to validate.
 
     Returns
     -------
     Tuple (str, WazuhError)
         The first element of the tuple is the normalized relative path.
-            if relative_dirname is None, return USER_DECODERS_PATH.
+            If relative_dirname is None, return USER_DECODERS_PATH.
             If relative_dirname is not None, return relative_dirname without trailing slash
-        The second element of the tuple is a WazuhError exception
+        The second element of the tuple is a WazuhError exception.
             If relative_dirname has no 'decoder_dir' tag in ruleset return WazuhError(1505).
             If relative_dirname is inside the default DECODERS_PATH return WazuhError(1506).
             If relative_dirname has a 'decoder_dir' tag in ruleset but it doesn't exists return WazuhError(1507).

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -402,18 +402,18 @@ def get_rule_file(filename: str = None, raw: bool = False,
 
 
 def validate_upload_delete_dir(relative_dirname: Union[str, None]) -> Tuple[str, WazuhError]:
-    """Validate relative_dirname parameter
+    """Validate relative_dirname parameter.
 
     Parameters
     ----------
     relative_dirname : str
-        relative path to validate.
+        Relative path to validate.
 
     Returns
     -------
     Tuple (str, WazuhError)
         The first element of the tuple is the normalized relative path.
-            if relative_dirname is None, return USER_RULES_PATH.
+            If relative_dirname is None, return USER_RULES_PATH.
             If relative_dirname is not None, return relative_dirname without trailing slash
         The second element of the tuple is a WazuhError exception
             If relative_dirname has no 'rule_dir' tag in ruleset return WazuhError(1505).

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+import glob
 from unittest.mock import patch, mock_open, MagicMock
 from wazuh.core.common import USER_RULES_PATH
 import pytest
@@ -23,11 +24,12 @@ with patch('wazuh.core.common.wazuh_uid'):
 
 # Variables
 parent_directory = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-data_path = 'core/tests/data/rules'
+core_data_path = 'core/tests/data/rules'
+tests_data_path = 'tests/data/etc/rules'
 
 rule_ossec_conf = {
   "ruleset": {
-    "rule_dir": ["core/tests/data/rules"],
+    "rule_dir": [core_data_path],
     "rule_exclude": ["0010-rules_config.xml"]
   }
 }
@@ -35,7 +37,7 @@ rule_ossec_conf = {
 other_rule_ossec_conf = {
     'ruleset': {
         'decoder_dir': ['ruleset/decoders', 'etc/decoders'],
-        'rule_dir': [data_path],
+        'rule_dir': [core_data_path],
         'rule_exclude': ['0010-rules_config.xml'],
         'list': ['etc/lists/audit-keys', 'etc/lists/amazon/aws-eventnames', 'etc/lists/security-eventchannel']
     }
@@ -44,9 +46,9 @@ other_rule_ossec_conf = {
 get_rule_file_ossec_conf = {
   "ruleset": {
     "rule_dir": [
-        "core/tests/data/rules",
-        "tests/data/etc/rules",
-        "tests/data/etc/rules/subpath",],
+        core_data_path,
+        tests_data_path,
+        os.path.join(tests_data_path, 'subpath'),],
     "rule_exclude": ["0010-rules_config.xml"]
   }
 }
@@ -69,16 +71,12 @@ rule_contents = '''
 
 
 @pytest.fixture(scope='module', autouse=True)
-def mock_wazuh_path():
-    with patch('wazuh.core.common.WAZUH_PATH', new=parent_directory):
-        yield
-
-
-@pytest.fixture(scope='module', autouse=True)
-def mock_rules_path():
-    with patch('wazuh.core.common.RULES_PATH', new=data_path):
-        yield
-
+def mock_wazuh_paths():
+    with patch('wazuh.core.common.RULES_PATH', new=os.path.join(parent_directory, core_data_path)):
+        with patch('wazuh.core.common.USER_RULES_PATH', new=os.path.join(parent_directory, tests_data_path)):
+            with patch('wazuh.core.common.WAZUH_PATH', new=parent_directory):
+                with patch('wazuh.rule.to_relative_path', side_effect=lambda x: os.path.relpath(x, parent_directory)):
+                    yield
 
 @pytest.mark.parametrize('func', [
     rule.get_rules_files,
@@ -241,8 +239,6 @@ def test_get_requirement_invalid(mocked_config, requirement):
     ('test_rules.xml', True, 'tests/data/etc/rules/subpath', 'NEW RULE SUBPATH'),
     ('test_rules.xml', True, 'tests/data/etc/rules/subpath/', 'NEW RULE SUBPATH'),
 ])
-@patch('wazuh.core.common.RULES_PATH', new=os.path.join(parent_directory, data_path))
-@patch('wazuh.core.common.USER_RULES_PATH', new=os.path.join(parent_directory, "tests","data", "etc", "rules"))
 def test_get_rule_file(filename, raw, relative_dirname, contains):
     """Test downloading a specified rule filter."""
     with patch('wazuh.core.configuration.get_ossec_conf', return_value=get_rule_file_ossec_conf):
@@ -257,8 +253,6 @@ def test_get_rule_file(filename, raw, relative_dirname, contains):
             assert not d_files.failed_items
 
 
-@patch('wazuh.core.common.RULES_PATH', new=os.path.join(parent_directory, data_path))
-@patch('wazuh.core.common.USER_RULES_PATH', new=os.path.join(parent_directory, "tests", "data", "etc", "rules"))
 def test_get_rule_file_exceptions():
     """Test file exceptions on get_rule_file method."""
     # File does not exist in default ruleset
@@ -277,7 +271,7 @@ def test_get_rule_file_exceptions():
                                     relative_dirname=USER_RULES_PATH)
         assert not result.affected_items
         assert result.render()['data']['failed_items'][0]['error']['code'] == 1415
-        
+
         # Invalid XML
         result = rule.get_rule_file(filename='wrong_rules.xml', raw=False)
         assert not result.affected_items
@@ -290,80 +284,127 @@ def test_get_rule_file_exceptions():
             assert result.render()['data']['failed_items'][0]['error']['code'] == 1414
 
 
-@pytest.mark.parametrize('file, overwrite', [
-    ('test.xml', False),
-    ('test_rules.xml', True),
+@pytest.mark.parametrize('file, relative_dirname, overwrite, rule_path', [
+    ('test_rules.xml', None, True, 'tests/data/etc/rules/test_rules.xml'),
+    ('test_rules.xml', 'tests/data/etc/rules/subpath', True, 'tests/data/etc/rules/subpath/test_rules.xml'),
+    ('test_new_rule.xml', None, False, 'tests/data/etc/rules/test_new_rule.xml'),
+    ('test_new_rule.xml', 'tests/data/etc/rules/subpath', False, 'tests/data/etc/rules/subpath/test_new_rule.xml'),    
 ])
-@patch('wazuh.rule.delete_rule_file')
+@patch('wazuh.rule.delete_file_with_backup')
 @patch('wazuh.rule.upload_file')
-@patch('wazuh.core.utils.full_copy')
 @patch('wazuh.rule.remove')
 @patch('wazuh.rule.safe_move')
-@patch('wazuh.core.utils.check_remote_commands')
-def test_upload_file(mock_remote_commands, mock_safe_move, mock_remove, mock_full_copy, mock_xml, mock_delete, file,
-                     overwrite):
+def test_upload_file(mock_safe_move, mock_remove, mock_xml, mock_delete, 
+                     file, relative_dirname, overwrite, rule_path):
     """Test uploading a rule file.
 
     Parameters
     ----------
     file : str
         Rule filename.
+    relative_dirname: str
+        Relative path of the file.
     overwrite : boolean
         True for updating existing files, False otherwise.
+    rule_path: str
+        Relative path of the file
     """
-    with patch('wazuh.rule.exists', return_value=overwrite):
-        result = rule.upload_rule_file(filename=file, content='test', overwrite=overwrite)
 
-        # Assert data match what was expected, type of the result and correct parameters in delete() method.
-        assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
-        rule_path = os.path.join('etc', 'rules', file)
-        assert result.affected_items[0] == rule_path, 'Expected item not found'
-        mock_xml.assert_called_once_with('test', rule_path)
-        if overwrite:
-            mock_delete.assert_called_once_with(filename=file), 'delete_rule_file method not called with expected ' \
-                                                                'parameter'
-            mock_remove.assert_called_once()
-            mock_safe_move.assert_called_once()
+    content = 'test'
+    with patch('wazuh.core.configuration.get_ossec_conf', return_value=get_rule_file_ossec_conf):
+        with patch('wazuh.rule.exists', return_value=overwrite):
+            result = rule.upload_rule_file(filename=file, relative_dirname=relative_dirname,
+                                            content=content, overwrite=overwrite)
+
+            # Assert data match what was expected, type of the result and correct parameters in delete() method.
+            assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
+            assert result.affected_items[0] == rule_path, 'Expected item not found'
+            mock_xml.assert_called_once_with(content, rule_path)
+            if overwrite:
+                full_path = os.path.join(wazuh.common.WAZUH_PATH, rule_path)
+                backup_file = full_path+'.backup'
+                mock_delete.assert_called_once_with(backup_file, full_path, rule.delete_rule_file), 'delete_rule_file method not called with expected ' \
+                                                                    'parameter'
+                mock_remove.assert_called_once()
+                mock_safe_move.assert_called_once()
 
 
-@patch('wazuh.rule.delete_rule_file')
+@patch('wazuh.rule.delete_rule_file', side_effect=WazuhError(1019))
 @patch('wazuh.rule.upload_file')
 @patch('wazuh.rule.safe_move')
 @patch('wazuh.core.utils.check_remote_commands')
-def test_upload_file_ko(mock_remote_commands, mock_safe_move, mock_xml, mock_delete):
+def test_upload_file_ko(*args):
     """Test exceptions on upload function."""
-    # Error when file exists and overwrite is not True
-    with patch('wazuh.rule.exists'):
-        result = rule.upload_rule_file(filename='test_rules.xml', content='test', overwrite=False)
+    content = 'test'
+    with patch('wazuh.core.configuration.get_ossec_conf', return_value=get_rule_file_ossec_conf):
+        # Error when file exists and overwrite is not True
+        result = rule.upload_rule_file(filename='test_rules.xml', content=content, overwrite=False)
         assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
         assert result.render()['data']['failed_items'][0]['error']['code'] == 1905, 'Error code not expected.'
 
-    # Error when content is empty
-    result = rule.upload_rule_file(filename='no_exist.xml', content='', overwrite=False)
-    assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
-    assert result.render()['data']['failed_items'][0]['error']['code'] == 1112, 'Error code not expected.'
+        # Error when content is empty
+        result = rule.upload_rule_file(filename='test_rules.xml', content='', overwrite=False)
+        assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
+        assert result.render()['data']['failed_items'][0]['error']['code'] == 1112, 'Error code not expected.'
 
-    # Error doing backup
-    with patch('wazuh.rule.exists'):
-        result = rule.upload_rule_file(filename='test_rules.xml', content='test', overwrite=True)
+        # Error doing backup
+        result = rule.upload_rule_file(filename='test_rules.xml', content=content, overwrite=True)
         assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
         assert result.render()['data']['failed_items'][0]['error']['code'] == 1019, 'Error code not expected.'
 
+        # Error uploading rule in default ruleset dir
+        result = rule.upload_rule_file(filename='test1_rules.xml', 
+                                       relative_dirname='core/tests/data/rules',
+                                       content=content, overwrite=True)
+        assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
+        assert result.render()['data']['failed_items'][0]['error']['code'] == 1210,\
+            'Error code not expected.'
 
-def test_delete_rule_file():
+    # clean backup files
+    search_pattern = os.path.join(wazuh.core.common.WAZUH_PATH, "**", "*.backup")
+    for bkp in glob.glob(search_pattern, recursive=True):
+        os.remove(bkp)
+
+
+@pytest.mark.parametrize('file, relative_dirname', [
+    ('test_rules.xml', None),
+    ('test_rules.xml', 'tests/data/etc/rules'),
+])
+def test_delete_rule_file(file, relative_dirname):
     """Test deleting a rule file."""
-    with patch('wazuh.rule.exists', return_value=True):
-        # Assert returned type is AffectedItemsWazuhResult when everything is correct
-        with patch('wazuh.rule.remove'):
-            assert(isinstance(rule.delete_rule_file(filename='file'), AffectedItemsWazuhResult))
+    with patch('wazuh.core.configuration.get_ossec_conf', return_value=get_rule_file_ossec_conf):
+        with patch('wazuh.rule.exists', return_value=True):
+            with patch('wazuh.rule.remove'):
+                # Assert returned type is AffectedItemsWazuhResult when everything is correct
+                assert(isinstance(rule.delete_rule_file(filename=file, relative_dirname=relative_dirname), 
+                                AffectedItemsWazuhResult))
+
+def test_delete_rule_file_ko():
+    """Delete rule file invalid test cases"""
+    with patch('wazuh.core.configuration.get_ossec_conf', return_value=get_rule_file_ossec_conf):
         # Assert error code when remove() method returns IOError
-        with patch('wazuh.manager.remove', side_effect=IOError()):
+        with patch('wazuh.rule.remove', side_effect=IOError()):
+            result = rule.delete_rule_file(filename='test_rules.xml')
+            assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
+            assert result.render()['data']['failed_items'][0]['error']['code'] == 1907,\
+                'Error code not expected.'
+
+        # Assert error code when exists() method returns False
+        with patch('wazuh.rule.exists', return_value=False):
             result = rule.delete_rule_file(filename='file')
             assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
-            assert result.render()['data']['failed_items'][0]['error']['code'] == 1907, 'Error code not expected.'
+            assert result.render()['data']['failed_items'][0]['error']['code'] == 1906,\
+                'Error code not expected.'
 
-    # Assert error code when exists() method returns False
-    with patch('wazuh.manager.exists', return_value=False):
-        result = rule.delete_rule_file(filename='file')
+        # Assert error code passing invalid relative_dirname
+        with pytest.raises(WazuhError) as exc_info:
+            result = rule.delete_rule_file(filename='test_rules.xml', 
+                                           relative_dirname='etc/not_exists')
+        assert exc_info.value.code == 1209
+
+        # Error uploading rule in default ruleset dir
+        result = rule.delete_rule_file(filename='test1_rules.xml',
+                                       relative_dirname='core/tests/data/rules')
         assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
-        assert result.render()['data']['failed_items'][0]['error']['code'] == 1906, 'Error code not expected.'
+        assert result.render()['data']['failed_items'][0]['error']['code'] == 1210,\
+            'Error code not expected.'


### PR DESCRIPTION
|Related issue|
|---|
|[#15994](https://github.com/wazuh/wazuh/issues/15994)|

## Description

Add relative_dirname parameter to decoders and rules PUT & DELETE endpoints to allow upload and deletion of files in custom user directories.

