### PR TITLE
Set the default RHEL 5 feed URL to feed.wazuh.com

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -18814,7 +18814,7 @@ void test_wm_vuldet_set_feed_update_url_redhat_5(void **state)
 
     ret = wm_vuldet_set_feed_update_url(update);
     assert_true(ret);
-    assert_string_equal(update->url, "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL5.xml.bz2");
+    assert_string_equal(update->url, "https://feed.wazuh.com/vulnerability-detector/RHEL/5/com.redhat.rhsa-RHEL5_v1.xml.bz2");
 
     os_free(update->url);
     os_free(update);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -63,7 +63,7 @@
 #define RHSA_DEFAULT_NUM 5
 #define JSON_RED_HAT_REPO  "https://access.redhat.com/labs/securitydataapi/cve.json?after=%d-01-01&per_page=%d&page=%d"
 #define RED_HAT_REPO "https://www.redhat.com/security/data/oval/v2/RHEL%s/rhel-%s-including-unpatched.oval.xml.bz2"
-#define RED_HAT5_REPO "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL5.xml.bz2"
+#define RED_HAT5_REPO "https://feed.wazuh.com/vulnerability-detector/RHEL/5/com.redhat.rhsa-RHEL5_v1.xml.bz2"
 #define ARCH_REPO_MAX_ATTEMPTS 3
 #define JSON_ARCH_REPO "https://security.archlinux.org/issues/all.json"
 #define NVD_CPE_REPO "https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz"


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17732|

Since yesterday, RHEL 5 (v1) feed URL started failing with a 404 error: 

> https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL5.xml.bz2

However, the archive file has a different format:

> https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz

In response to this, we have decided to upload a mirror of _com.redhat.rhsa-RHEL5.xml.bz2_ to our feed:

> https://feed.wazuh.com/vulnerability-detector/RHEL/5/com.redhat.rhsa-RHEL5_v1.xml.bz2

So, this PR aims to update the default URL to the mirror.

In other words, this configuration in version 4.5.1 and later:
```xml
<ossec_config>
  <vulnerability-detector>
    <provider name="redhat">
      <enabled>yes</enabled>
      <os>5</os>
    </provider>
  </vulnerability-detector>
</ossec_config>
```

It behaves the same as this other on 4.5.0 and before:
```xml
<ossec_config>
  <vulnerability-detector>
    <provider name="redhat">
      <enabled>yes</enabled>
      <os url="https://feed.wazuh.com/vulnerability-detector/RHEL/5/com.redhat.rhsa-RHEL5_v1.xml.bz2">5</os>
    </provider>
  </vulnerability-detector>
</ossec_config>
```

## Logs

<details><summary><h3>Settings</h3></summary>

```xml
<ossec_config>
  <vulnerability-detector>
    <enabled>yes</enabled>
    <interval>5m</interval>
    <min_full_scan_interval>6h</min_full_scan_interval>
    <run_on_start>yes</run_on_start>

    <!-- RedHat OS vulnerabilities -->
    <provider name="redhat">
      <enabled>yes</enabled>
      <os>5</os>
      <os>6</os>
      <os>7</os>
      <os>8</os>
      <os>9</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Aggregate vulnerabilities -->
    <provider name="nvd">
      <enabled>yes</enabled>
      <update_from_year>2010</update_from_year>
      <update_interval>1h</update_interval>
    </provider>

  </vulnerability-detector>
</ossec_config>
```


</details>



### Before this change

```
2023/07/28 12:24:04 wazuh-modulesd[83050] url.c:152 at wurl_get(): DEBUG: CURL ERROR: The requested URL returned error: 404 Not Found
```

### After this change

```
2023/07/28 12:25:26 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:5233 at wm_vuldet_check_feed(): INFO: (5400): Starting 'Red Hat Enterprise Linux 5' database update.
2023/07/28 12:25:26 wazuh-modulesd:download[83870] wm_download.c:231 at wm_download_dispatch(): DEBUG: Downloading 'https://feed.wazuh.com/vulnerability-detector/RHEL/5/com.redhat.rhsa-RHEL5_v1.xml.bz2' to 'tmp/req-1296681585'
2023/07/28 12:25:26 wazuh-modulesd:download[83870] wm_download.c:251 at wm_download_dispatch(): DEBUG: Download of 'https://feed.wazuh.com/vulnerability-detector/RHEL/5/com.redhat.rhsa-RHEL5_v1.xml.bz2' finished.
2023/07/28 12:25:26 wazuh-modulesd[83870] url.c:424 at wurl_request_uncompress_bz2_gz(): DEBUG: File from URL 'https://feed.wazuh.com/vulnerability-detector/RHEL/5/com.redhat.rhsa-RHEL5_v1.xml.bz2' was successfully uncompressed into 'tmp/vuln-temp'
2023/07/28 12:25:26 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:4970 at wm_vuldet_fetch_oval(): DEBUG: (5407): The feed 'Red Hat Enterprise Linux 5' is outdated. Fetching the last version.
2023/07/28 12:25:26 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:4747 at wm_vuldet_oval_process(): DEBUG: (5411): Starting preparse step of feed 'RHEL5'
2023/07/28 12:25:26 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:4752 at wm_vuldet_oval_process(): DEBUG: (5412): Starting parse step of feed 'RHEL5'
2023/07/28 12:25:27 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:4894 at wm_vuldet_index_feed(): DEBUG: (5414): Refreshing 'Red Hat Enterprise Linux 5' databases.
2023/07/28 12:25:27 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:3273 at wm_vuldet_insert(): DEBUG: (5415): Inserting vulnerabilities.
2023/07/28 12:25:27 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:3343 at wm_vuldet_insert(): DEBUG: (5419): Inserting Red Hat Enterprise Linux 5 vulnerabilities section.
2023/07/28 12:25:27 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:3444 at wm_vuldet_insert(): DEBUG: (5422): Inserting 'Red Hat Enterprise Linux 5' vulnerabilities references.
2023/07/28 12:25:28 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:3497 at wm_vuldet_insert(): DEBUG: (5423): Inserting 'Red Hat Enterprise Linux 5' vulnerabilities conditions.
2023/07/28 12:25:28 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:3571 at wm_vuldet_insert(): DEBUG: (5424): Inserting 'Red Hat Enterprise Linux 5' vulnerabilities package names.
2023/07/28 12:25:28 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:4900 at wm_vuldet_index_feed(): DEBUG: (5427): Refresh of 'Red Hat Enterprise Linux 5' database finished.
2023/07/28 12:25:28 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:4911 at wm_vuldet_index_feed(): DEBUG: remove(tmp/vuln-temp.bz2): No such file or directory
2023/07/28 12:25:28 wazuh-modulesd:vulnerability-detector[83870] wm_vuln_detector.c:5256 at wm_vuldet_check_feed(): INFO: (5430): The update of the 'Red Hat Enterprise Linux 5' feed finished successfully.
```

## Affected components

- _wazuh-modulesd_ / Vulnerability Detector.