### PR TITLE
implement `autostart_simulators` fixture in main conftest.py

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -535,11 +535,11 @@ def autostart_simulators(request: pytest.FixtureRequest) -> None:
         authd = AuthdSimulator() if create_authd else None
         remoted = RemotedSimulator() if create_remoted else None
 
-        authd.start() if authd else None
+        authd.start() if create_authd else None
         remoted.start() if create_remoted else None
 
     yield
 
     if services.get_service() is not WAZUH_MANAGER:
-        authd.shutdown() if authd else None
+        authd.shutdown() if create_authd else None
         remoted.shutdown() if create_remoted else None


### PR DESCRIPTION

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR implements a fixture to auto-start the required simulators to mock the `wazuh-agent` connection to a `wazuh-manager`.

The fixture will only be executed on agent executions and the simulators will only start when the specific simulator fixture is not being called by the test function, so it still is possible to declare one simulator fixture to interact with it when needed,
