### PR TITLE
Scan build memory leak in MS Graph

### DIFF
--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -185,6 +185,7 @@ void wm_ms_graph_get_access_token(wm_ms_graph_auth* auth_config, const ssize_t c
         mtwarn(WM_MS_GRAPH_LOGTAG, "No response recieved when attempting to obtain access token.");
     }
 
+    os_free(payload);
     os_free(headers);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Resolves #18130|
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR resolves the memory leak reported by the `scan build`.

## Tests

Here are the results: 

- [scan-build-2023-07-28-150055-449503-1-linux-manager.zip](https://github.com/wazuh/wazuh/files/12216345/scan-build-2023-07-28-150055-449503-1-linux-manager.zip)
- [scan-build-2023-07-31-112347-771675-1-linux-agent.zip](https://github.com/wazuh/wazuh/files/12216346/scan-build-2023-07-31-112347-771675-1-linux-agent.zip)
- [scan-build-2023-07-31-114011-972152-1 windows-agent.zip](https://github.com/wazuh/wazuh/files/12216350/scan-build-2023-07-31-114011-972152-1.windows-agent.zip)

<!--

Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer
