### PR TITLE
Modify/adapt remoted code to publish information to the syscollector topic - Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ src/selinux/*.mod
 src/selinux/*.pp
 framework/wazuh/core/wazuh.json
 src/**/build/*
+src/generated_headers/*.h
+src/generated_headers/*.hpp
 
 # Compiled programs
 src/agent-auth

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ src/wazuh_modules/vulnerability_detector/msu.json.gz
 
 # Flatbuffers generated headers.
 src/shared_modules/utils/flatbuffers/include/
+src/wazuh_modules/syscollector/include/

--- a/src/Makefile
+++ b/src/Makefile
@@ -1931,7 +1931,7 @@ remoted_c := $(wildcard remoted/*.c)
 remoted_o := $(remoted_c:.c=.o)
 
 remoted/%.o: remoted/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -I./remoted -DARGV0=\"wazuh-remoted\" -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS}  -DPORTABLE_UNALIGNED_ACCESS=0 -I./remoted -DARGV0=\"wazuh-remoted\" -c $^ -o $@
 
 wazuh-remoted: ${remoted_o}
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} ${WAZUH_LDFLAGS} $^ ${OSSEC_LIBS} ${WAZUH_LIBS} -o $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -1681,6 +1681,8 @@ build_shared_modules: $(WAZUHEXT_LIB)
 .PHONY: flatbuffers_schemas
 flatbuffers_schemas: ${FLATCCRT_LIB}
 	${FLATCC_BIN} --json -a -g -o generated_headers/ wazuh_modules/syscollector/schemas/*.fbs
+	${FLATCC_BIN} --json -a -g -o generated_headers/ shared_modules/utils/flatbuffers/schemas/common/*.fbs
+	${FLATCC_BIN} --json -a -g -o generated_headers/ shared_modules/utils/flatbuffers/schemas/syscollectorDeltas/*.fbs
 
 #### Sysinfo ##
 build_sysinfo: $(WAZUHEXT_LIB)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1375,15 +1375,6 @@ external/$(CPYTHON).tar.gz:
 	rm $(patsubst %.gz,%,$@)
 endif
 
-FLATCC_REPO_BRANCH := master
-FLATCC_REPO_URL := https://github.com/dvidelabs/flatcc/tarball/$(FLATCC_REPO_BRANCH)
-
-external/flatcc.tar.gz:
-	$(CURL) $@ -L $(FLATCC_REPO_URL)
-	cd external && $(GUNZIP) $(patsubst external/%,%,$@)
-	cd external && $(TAR) $(patsubst external/%.gz,%,$@) --strip-components=1 --one-top-level
-	rm $(patsubst %.gz,%,$@)
-
 # Remaining dependencies
 ifneq (,$(PRECOMPILED_RES))
 external/%.tar.gz: external-precompiled/%.tar.gz

--- a/src/Makefile
+++ b/src/Makefile
@@ -1577,6 +1577,9 @@ wrappers_wazuh_remoted_o := $(wrappers_wazuh_remoted_c:.c=.o)
 wrappers_wazuh_analysisd_c := $(wildcard unit_tests/wrappers/wazuh/analysisd/*.c)
 wrappers_wazuh_analysisd_o := $(wrappers_wazuh_analysisd_c:.c=.o)
 
+wrappers_wazuh_shared_modules_c := $(wildcard unit_tests/wrappers/wazuh/shared_modules/*.c)
+wrappers_wazuh_shared_modules_o := $(wrappers_wazuh_shared_modules_c:.c=.o)
+
 ifneq (,$(filter ${TEST},YES yes y Y 1))
 	OSSEC_CFLAGS+=${CFLAGS_TEST}
 	OSSEC_LDFLAGS+=${CFLAGS_TEST}
@@ -1625,6 +1628,10 @@ ifneq (,$(filter ${TEST},YES yes y Y 1))
 		UNIT_TEST_WRAPPERS+=${wrappers_externals_audit_o}
 		UNIT_TEST_WRAPPERS+=${wrappers_externals_procpc_o}
 		UNIT_TEST_WRAPPERS+=${wrappers_linux_o}
+	endif
+
+	ifeq (${TARGET},server)
+		UNIT_TEST_WRAPPERS+=${wrappers_wazuh_shared_modules_o}
 	endif
 endif #TEST
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,7 @@ libgcc_s_path := $(shell sh -c 'g++ --print-file-name=libgcc_s.so.1 2>/dev/null 
 LIBSTDCPP_NAME := libstdc++.so.6
 LIBGCC_S_NAME := libgcc_s.so.1
 STRIP_TOOL := strip
+FLATCC_BIN = $(EXTERNAL_FLATCC)bin/flatcc
 endif
 
 ifeq (, $(filter ${libstdc++_path}, not ${LIBSTDCPP_NAME}))
@@ -62,6 +63,7 @@ EXTERNAL_BZIP2=external/bzip2/
 EXTERNAL_GOOGLE_TEST=external/googletest/
 EXTERNAL_ROCKSDB=external/rocksdb/
 EXTERNAL_FLATBUFFERS=external/flatbuffers/
+EXTERNAL_FLATCC=external/flatcc/
 EXTERNAL_LZMA=external/lzma/
 EXTERNAL_LIBPCRE2=external/libpcre2/
 ifneq (${TARGET},winagent)
@@ -369,8 +371,8 @@ else
 endif
 
 ifeq (${TARGET},server)
-	WAZUH_LIBS+=-lrouter
-	WAZUH_LDFLAGS+=-Lbuild/shared_modules/router
+	WAZUH_LIBS+=-lrouter -lflatccrt
+	WAZUH_LDFLAGS+=-Lbuild/shared_modules/router -L${EXTERNAL_FLATCC}lib
 endif
 
 ifneq (,$(filter ${CLEANFULL},YES yes y Y 1))
@@ -391,7 +393,7 @@ endif
 
 OSSEC_CFLAGS+=${DEFINES}
 OSSEC_CFLAGS+=-pipe -Wall -Wextra -std=gnu99
-OSSEC_CFLAGS+=-I./ -I./headers/ -I${EXTERNAL_OPENSSL}include -I$(EXTERNAL_JSON) -I${EXTERNAL_LIBYAML}include -I${EXTERNAL_CURL}include -I${EXTERNAL_MSGPACK}include -I${EXTERNAL_BZIP2} -I${SHARED_MODULES}common -I${DBSYNC}include -I${RSYNC}include -I${SYSCOLLECTOR}include  -I${SYSINFO}include  -I${EXTERNAL_LIBPCRE2}include -I${EXTERNAL_RPM}/builddir/output/include -I${SYSCHECK}include -I${ROUTER}include -I${CONTENT_MANAGER}include -I${VULNERABILITY_SCANNER}include
+OSSEC_CFLAGS+=-I./ -I./headers/ -I./generated_headers/ -I${EXTERNAL_OPENSSL}include -I$(EXTERNAL_JSON) -I${EXTERNAL_LIBYAML}include -I${EXTERNAL_CURL}include -I${EXTERNAL_MSGPACK}include -I${EXTERNAL_BZIP2} -I${SHARED_MODULES}common -I${DBSYNC}include -I${RSYNC}include -I${SYSCOLLECTOR}include  -I${SYSINFO}include  -I${EXTERNAL_LIBPCRE2}include -I${EXTERNAL_RPM}/builddir/output/include -I${SYSCHECK}include -I${ROUTER}include -I${CONTENT_MANAGER}include -I${VULNERABILITY_SCANNER}include -I${EXTERNAL_FLATCC}include/
 
 OSSEC_CFLAGS += ${CFLAGS}
 OSSEC_LDFLAGS += ${LDFLAGS}
@@ -780,7 +782,7 @@ ${WAZUH_LIB_OUTPUT_PATH}${LIBGCC_S_NAME}: ${libgcc_s_path}
 ifeq (${MAKECMDGOALS},server)
 $(error Do not use 'server' directly, use 'TARGET=server')
 endif
-server: external ${CPPLIBDEPS}
+server: external ${CPPLIBDEPS} flatbuffers_schemas
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 	${MAKE} ${BUILD_SERVER}
 
@@ -885,6 +887,7 @@ RPM_LIB = $(EXTERNAL_RPM)builddir/librpm.a
 JEMALLOC_LIB = $(EXTERNAL_JEMALLOC)lib/libjemalloc.so.2
 ROCKSDB_LIB = $(EXTERNAL_ROCKSDB)build/librocksdb.so
 FLATBUFFERS_LIB = $(EXTERNAL_FLATBUFFERS)build/libflatbuffers.a
+FLATCCRT_LIB = $(EXTERNAL_FLATCC)lib/libflatccrt.so
 LZMA_LIB = $(EXTERNAL_LZMA)build/liblzma.a
 
 EXTERNAL_LIBS := $(JSON_LIB) $(ZLIB_LIB) $(OPENSSL_LIB) $(CRYPTO_LIB) $(SQLITE_LIB) $(LIBYAML_LIB) $(LIBPCRE2_LIB)
@@ -900,7 +903,7 @@ endif
 
 # Adding rocksdb only for server
 ifeq (${TARGET},server)
-	EXTERNAL_LIBS_NO_WHOLE += $(ROCKSDB_LIB) $(FLATBUFFERS_LIB)
+	EXTERNAL_LIBS_NO_WHOLE += $(ROCKSDB_LIB) $(FLATBUFFERS_LIB) $(FLATCCRT_LIB)
 	EXTERNAL_LIBS += $(LZMA_LIB)
 endif
 
@@ -937,7 +940,7 @@ external: build_gtest
 endif
 
 ifeq (${TARGET},server)
-external: $(ROCKSDB_LIB)
+external: $(ROCKSDB_LIB) $(FLATCCRT_LIB)
 endif
 
 ifneq (${TARGET},winagent)
@@ -1001,6 +1004,10 @@ ${ROCKSDB_LIB}:
 ### flatbuffers ###
 ${FLATBUFFERS_LIB}:
 	cd $(EXTERNAL_FLATBUFFERS) && mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=0 -DFLATBUFFERS_INSTALL=0 -DCMAKE_POSITION_INDEPENDENT_CODE=1 && ${MAKE}
+
+### flatcc ###
+${FLATCCRT_LIB}:
+	cd $(EXTERNAL_FLATCC) && mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DFLATCC_TEST=OFF && ${MAKE}
 
 ### lzma ###
 ${LZMA_LIB}:
@@ -1326,7 +1333,7 @@ EXTERNAL_RES := cJSON curl libdb libffi libyaml openssl procps sqlite zlib audit
 ifneq (${TARGET},agent)
 ifneq (${TARGET},winagent)
 	# Manager extra dependency
-	EXTERNAL_RES += $(CPYTHON) jemalloc
+	EXTERNAL_RES += $(CPYTHON) jemalloc flatcc
 endif
 endif
 
@@ -1367,6 +1374,15 @@ external/$(CPYTHON).tar.gz:
 	cd external && $(TAR) $(patsubst external/%.gz,%,$@)
 	rm $(patsubst %.gz,%,$@)
 endif
+
+FLATCC_REPO_BRANCH := master
+FLATCC_REPO_URL := https://github.com/dvidelabs/flatcc/tarball/$(FLATCC_REPO_BRANCH)
+
+external/flatcc.tar.gz:
+	$(CURL) $@ -L $(FLATCC_REPO_URL)
+	cd external && $(GUNZIP) $(patsubst external/%,%,$@)
+	cd external && $(TAR) $(patsubst external/%.gz,%,$@) --strip-components=1 --one-top-level
+	rm $(patsubst %.gz,%,$@)
 
 # Remaining dependencies
 ifneq (,$(PRECOMPILED_RES))
@@ -1652,6 +1668,12 @@ config/%.o: config/%.c
 build_shared_modules: $(WAZUHEXT_LIB)
 	cd ${DBSYNC} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${DBSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
 	cd ${RSYNC} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${RSYNC_TEST} ${SOLARIS_CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
+
+#### Flatbuffers schemas ####
+
+.PHONY: flatbuffers_schemas
+flatbuffers_schemas: ${FLATCCRT_LIB}
+	${FLATCC_BIN} --json -a -g -o generated_headers/ wazuh_modules/syscollector/schemas/*.fbs
 
 #### Sysinfo ##
 build_sysinfo: $(WAZUHEXT_LIB)
@@ -2546,6 +2568,9 @@ ifneq ($(wildcard external/*/*),)
 	rm -rf $(EXTERNAL_GOOGLE_TEST)build
 	rm -rf $(EXTERNAL_ROCKSDB)build
 	rm -rf $(EXTERNAL_FLATBUFFERS)build
+	rm -rf $(EXTERNAL_FLATCC)build
+	rm -rf $(EXTERNAL_FLATCC)lib
+	rm -rf $(EXTERNAL_FLATCC)bin
 	rm -rf $(EXTERNAL_LZMA)build
 	-cd ${EXTERNAL_LIBPLIST} && ${MAKE} clean && rm -rf bin/*
 	-cd ${EXTERNAL_LIBPCRE2} && ${MAKE} distclean && rm include/*
@@ -2576,7 +2601,7 @@ ifneq ($(wildcard external/cpython/*),)
 endif
 
 clean-deps:
-	rm -rf $(EXTERNAL_DIR) $(EXTERNAL_CPYTHON) external/$(WPYTHON_TAR) $(EXTERNAL_ROCKSDB)
+	rm -rf $(EXTERNAL_DIR) $(EXTERNAL_CPYTHON) external/$(WPYTHON_TAR) $(EXTERNAL_ROCKSDB) $(EXTERNAL_FLATCC)
 
 clean-internals: clean-unit-tests
 	rm -f $(BUILD_SERVER)

--- a/src/Makefile
+++ b/src/Makefile
@@ -135,6 +135,7 @@ GTEST_RELEASE_TYPE=-DCMAKE_BUILD_TYPE=Debug
 SYSCOLLECTOR_RELEASE_TYPE=-DCMAKE_BUILD_TYPE=Debug
 SYSINFO_RELEASE_TYPE=-DCMAKE_BUILD_TYPE=Debug
 SYSCHECK_RELEASE_TYPE=-DCMAKE_BUILD_TYPE=Debug
+WAZUH_RELEASE_TYPE=-DCMAKE_BUILD_TYPE=Debug
 endif
 
 ifeq (${COVERITY}, YES)
@@ -882,7 +883,7 @@ LIBPCRE2_LIB = $(EXTERNAL_LIBPCRE2).libs/libpcre2-8.a
 POPT_LIB = $(EXTERNAL_POPT)build/output/src/.libs/libpopt.a
 RPM_LIB = $(EXTERNAL_RPM)builddir/librpm.a
 JEMALLOC_LIB = $(EXTERNAL_JEMALLOC)lib/libjemalloc.so.2
-ROCKSDB_LIB = $(EXTERNAL_ROCKSDB)/build/librocksdb.so
+ROCKSDB_LIB = $(EXTERNAL_ROCKSDB)build/librocksdb.so
 FLATBUFFERS_LIB = $(EXTERNAL_FLATBUFFERS)build/libflatbuffers.a
 LZMA_LIB = $(EXTERNAL_LZMA)build/liblzma.a
 
@@ -933,6 +934,10 @@ external: test_external $(EXTERNAL_LIBS) $(JEMALLOC_LIB)
 
 ifneq (,$(filter ${TEST},YES yes y Y 1))
 external: build_gtest
+endif
+
+ifeq (${TARGET},server)
+external: $(ROCKSDB_LIB)
 endif
 
 ifneq (${TARGET},winagent)
@@ -1660,7 +1665,7 @@ endif
 
 #### Wazuh cmake ###
 build_wazuh_cmake: $(WAZUHEXT_LIB) $(EXTERNAL_LIBS_NO_WHOLE)
-	mkdir -p build && cd build && cmake .. ${CMAKE_OPTS} && ${MAKE}
+	mkdir -p build && cd build && cmake .. ${CMAKE_OPTS} ${WAZUH_RELEASE_TYPE} && ${MAKE}
 
 #### Wazuh modules ##
 wmodules_c := $(wildcard wazuh_modules/wm*.c) $(wildcard wazuh_modules/agent_upgrade/*.c)

--- a/src/headers/flatcc_helpers.h
+++ b/src/headers/flatcc_helpers.h
@@ -1,0 +1,54 @@
+/*
+ * Flatcc helpers.
+ * Copyright (C) 2015, Wazuh Inc.
+ * Aug 25, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef FLATCC_HELPERS_H
+#define FLATCC_HELPERS_H
+
+#ifndef WIN32
+#ifndef CLIENT
+
+#include "flatcc/flatcc_json_parser.h"
+#include "flatcc/flatcc_json_printer.h"
+
+/**
+ * @brief
+ *
+ * @param msg_len
+ * @param msg
+ * @param flatbuffer_size
+ * @param flags
+ * @param parser
+ * @return void*
+ */
+void* w_flatcc_parse_json(size_t msg_len, const char* msg, size_t* flatbuffer_size, flatcc_json_parser_flags_t flags, flatcc_json_parser_table_f *parser);
+
+/**
+ * @brief
+ *
+ * @param flatbuffer
+ */
+void w_flatcc_free_buffer(void* flatbuffer);
+
+/**
+ * @brief
+ *
+ * @param flatbuffer
+ * @param flatbuffer_size
+ * @param buffer_size
+ * @param flags
+ * @param printer
+ * @return char*
+ */
+char* w_flatcc_print_json (void* flatbuffer, size_t flatbuffer_size, size_t *buffer_size, flatcc_json_printer_flags_t flags, flatcc_json_printer_table_f *printer);
+
+#endif /* CLIENT */
+#endif /* WIN32 */
+#endif /* FLATCC_HELPERS_H */

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1145,6 +1145,14 @@ InstallServer()
             chcon -t textrel_shlib_t ${INSTALLDIR}/lib/librocksdb.so.8
         fi
     fi
+    if [ -f external/flatcc/lib/libflatccrt.so ]
+    then
+        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} external/flatcc/lib/libflatccrt.so ${INSTALLDIR}/lib
+
+        if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]); then
+            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libflatccrt.so
+        fi
+    fi
 
     # Install cluster files
     ${INSTALL} -d -m 0770 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/cluster

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1159,6 +1159,7 @@ InstallServer()
     ${INSTALL} -m 0750 -o root -g 0 wazuh-authd ${INSTALLDIR}/bin
 
     ${INSTALL} -d -m 0770 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/rids
+    ${INSTALL} -d -m 0770 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/router
 
     if [ ! -f ${INSTALLDIR}/queue/agents-timestamp ]; then
         ${INSTALL} -m 0600 -o root -g ${WAZUH_GROUP} /dev/null ${INSTALLDIR}/queue/agents-timestamp

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -769,11 +769,13 @@ STATIC void HandleSecureMessage(const message_t *message, int *wdb_sock) {
 
     key_unlock();
 
-
+    if (sock_idle >= 0) {
+        _close_sock(&keys, sock_idle);
+    }
 
     /* If we can't send the message, try to connect to the
-    * socket again. If it not exit.
-    */
+     * socket again. If it not exit.
+     */
     if (SendMSG(logr.m_queue, tmp_msg, srcmsg, SECURE_MQ) < 0) {
         merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -841,7 +841,7 @@ void router_message_forward(char* msg, const char* agent_id) {
     char* msg_to_send = NULL;
 
     char* msg_start = msg + message_header_size;
-    size_t msg_size = strnlen(msg_start, OS_MAXSTR);
+    size_t msg_size = strnlen(msg_start, OS_MAXSTR - message_header_size);
     if ((msg_size + message_header_size) < OS_MAXSTR) {
         j_msg = cJSON_Parse(msg_start);
         if(!j_msg) {

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -872,8 +872,7 @@ void router_message_forward(char* msg, const char* agent_id) {
         size_t msg_to_send_len = strlen(msg_to_send);
         size_t flatbuffer_size;
 
-        void* flatbuffer = w_flatcc_parse_json(msg_to_send_len, msg_to_send, &flatbuffer_size,
-                                               flatcc_json_parser_f_skip_unknown, parser);
+        void* flatbuffer = w_flatcc_parse_json(msg_to_send_len, msg_to_send, &flatbuffer_size, 0, parser);
 
         if (flatbuffer) {
             router_provider_send(router_handle, flatbuffer, flatbuffer_size);

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -814,7 +814,7 @@ void router_message_forward(char* msg, const char* agent_id) {
         }
         router_handle = router_syscollector_handle;
         message_header_size = SYSCOLLECTOR_HEADER_SIZE;
-        parser = Syscollector_Syscollector_delta_parse_json_table;
+        parser = Syscollector_Delta_parse_json_table;
         w_mutex_unlock(&router_syscollector_mutex);
     } else if(strncmp(msg, DBSYNC_SYSCOLLECTOR_HEADER, DBSYNC_SYSCOLLECTOR_HEADER_SIZE) == 0) {
         w_mutex_lock(&router_rsync_mutex);
@@ -858,7 +858,7 @@ void router_message_forward(char* msg, const char* agent_id) {
         cJSON_AddItemToObject(j_msg_to_send, "data_type", cJSON_DetachItemFromObject(j_msg, "type"));
         cJSON_AddItemToObject(j_msg_to_send, "data", cJSON_DetachItemFromObject(j_msg, "data"));
 
-        if (parser == Syscollector_Syscollector_delta_parse_json_table) {
+        if (parser == Syscollector_Delta_parse_json_table) {
             cJSON_AddItemToObject(j_msg_to_send, "operation", cJSON_DetachItemFromObject(j_msg, "operation"));
         } else if (parser == Syscollector_SyncMsg_parse_json_table) {
             cJSON_AddItemToObject(cJSON_GetObjectItem(j_msg_to_send, "data"), "attributes_type", cJSON_DetachItemFromObject(j_msg, "component"));

--- a/src/shared/flatcc_helpers.c
+++ b/src/shared/flatcc_helpers.c
@@ -1,0 +1,53 @@
+/*
+ * Flatcc helpers.
+ * Copyright (C) 2015, Wazuh Inc.
+ * Aug 25, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef WIN32
+#ifndef CLIENT
+
+#include "flatcc_helpers.h"
+#include "flatcc/flatcc_json_parser.h"
+#include "flatcc/flatcc_json_printer.h"
+#include "debug_op.h"
+
+void* w_flatcc_parse_json(size_t msg_len, const char* msg, size_t* flatbuffer_size, flatcc_json_parser_flags_t flags, flatcc_json_parser_table_f *parser) {
+
+    flatcc_builder_t builder;
+    if(flatcc_builder_init(&builder)) {
+        mdebug1("Failed to initialize flatcc structure.");
+        return NULL;
+    }
+
+    flatcc_json_parser_t parser_ctx;
+    int err_code = flatcc_json_parser_table_as_root(&builder, &parser_ctx, msg, msg_len, flags, NULL, parser);
+    if (err_code) {
+        mdebug2("Failed to parse message with flatbuffer schema: %s", flatcc_json_parser_error_string(err_code));
+        return NULL;
+    } else {
+        return flatcc_builder_finalize_aligned_buffer(&builder, flatbuffer_size);
+    }
+}
+
+void w_flatcc_free_buffer(void* flatbuffer) {
+    flatcc_builder_aligned_free(flatbuffer);
+}
+
+char* w_flatcc_print_json (void* flatbuffer, size_t flatbuffer_size, size_t *buffer_size, flatcc_json_printer_flags_t flags, flatcc_json_printer_table_f *printer) {
+    flatcc_json_printer_t printer_ctx;
+    flatcc_json_printer_init_dynamic_buffer(&printer_ctx, 0);
+    flatcc_json_printer_set_flags(&printer_ctx, flags);
+
+    flatcc_json_printer_table_as_root(&printer_ctx, flatbuffer, flatbuffer_size, NULL, printer);
+
+    return flatcc_json_printer_finalize_dynamic_buffer(&printer_ctx, buffer_size);
+}
+
+#endif /* CLIENT */
+#endif /* WIN32 */

--- a/src/shared/flatcc_helpers.c
+++ b/src/shared/flatcc_helpers.c
@@ -29,9 +29,12 @@ void* w_flatcc_parse_json(size_t msg_len, const char* msg, size_t* flatbuffer_si
     int err_code = flatcc_json_parser_table_as_root(&builder, &parser_ctx, msg, msg_len, flags, NULL, parser);
     if (err_code) {
         mdebug2("Failed to parse message with flatbuffer schema: %s", flatcc_json_parser_error_string(err_code));
+        flatcc_builder_clear(&builder);
         return NULL;
     } else {
-        return flatcc_builder_finalize_aligned_buffer(&builder, flatbuffer_size);
+        void* ret = flatcc_builder_finalize_aligned_buffer(&builder, flatbuffer_size);
+        flatcc_builder_clear(&builder);
+        return ret;
     }
 }
 

--- a/src/shared_modules/router/src/router.cpp
+++ b/src/shared_modules/router/src/router.cpp
@@ -121,6 +121,7 @@ extern "C"
         {
             RouterModule::initialize([callbackLog](const modules_log_level_t level, const std::string& msg)
                                      { callbackLog(level, msg.c_str(), ":router"); });
+            logMessage(modules_log_level_t::LOG_DEBUG, "Router initialized successfully.");
         }
         catch (...)
         {
@@ -135,6 +136,7 @@ extern "C"
         try
         {
             RouterModule::instance().start();
+            logMessage(modules_log_level_t::LOG_DEBUG, "Router started successfully.");
         }
         catch (...)
         {

--- a/src/shared_modules/utils/osPrimitives.hpp
+++ b/src/shared_modules/utils/osPrimitives.hpp
@@ -18,6 +18,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <sys/stat.h>
 
 class OSPrimitives
 {
@@ -79,6 +80,14 @@ protected:
     inline int fcntl(int fd, int cmd, int arg)
     {
         return ::fcntl(fd, cmd, arg);
+    }
+
+    inline int fchmod(int fd, mode_t mode) {
+        return ::fchmod(fd, mode);
+    }
+
+    inline int chmod(const char* path, mode_t mode) {
+        return ::chmod(path, mode);
     }
 };
 

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -19,7 +19,10 @@ set_target_properties(
 
 link_directories(${SRC_FOLDER}/build/shared_modules/router)
 include_directories(${SRC_FOLDER}/shared_modules/router/include)
-target_link_libraries(REMOTED_O ${WAZUHLIB} ${WAZUHEXT} -lpthread -lrouter)
+include_directories(${SRC_FOLDER}/external/flatcc/include)
+include_directories(${SRC_FOLDER}/generated_headers)
+link_directories(${SRC_FOLDER}/external/flatcc/lib)
+target_link_libraries(REMOTED_O ${WAZUHLIB} ${WAZUHEXT} -lpthread -lrouter -lflatccrt)
 
 #include wrappers
 include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -19,7 +19,6 @@ set_target_properties(
 
 link_directories(${SRC_FOLDER}/build/shared_modules/router)
 include_directories(${SRC_FOLDER}/shared_modules/router/include)
-
 target_link_libraries(REMOTED_O ${WAZUHLIB} ${WAZUHEXT} -lpthread -lrouter)
 
 #include wrappers

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -2,6 +2,8 @@
 file(GLOB remoted_files
     ${SRC_FOLDER}/remoted/*.o)
 
+add_compile_options("-g")
+
 add_library(REMOTED_O STATIC ${remoted_files})
 
 set_source_files_properties(
@@ -73,7 +75,9 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accep
                             -Wl,--wrap,save_controlmsg -Wl,--wrap,sleep -Wl,--wrap,stat -Wl,--wrap,time \
                             -Wl,--wrap,w_mutex_lock -Wl,--wrap,w_mutex_unlock \
                             -Wl,--wrap,wnotify_add -Wl,--wrap,SendMSG -Wl,--wrap,rem_inc_recv_evt \
-                            -Wl,--wrap,OS_DupKeyEntry -Wl,--wrap,OS_FreeKey ${DEBUG_OP_WRAPPERS}")
+                            -Wl,--wrap,OS_DupKeyEntry -Wl,--wrap,OS_FreeKey ${DEBUG_OP_WRAPPERS} \
+                            -Wl,--wrap,router_provider_send -Wl,--wrap,router_provider_create \
+                            -Wl,--wrap,w_flatcc_parse_json -Wl,--wrap,w_flatcc_free_buffer")
 
 list(APPEND remoted_names "test_netbuffer")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,wnet_order -Wl,--wrap,wnotify_modify \

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -2027,7 +2027,7 @@ void test_router_message_forward_invalid_sync_json_message(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_SyncMsg_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, NULL);
 
@@ -2049,7 +2049,7 @@ void test_router_message_forward_valid_integrity_check_global(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_SyncMsg_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2074,7 +2074,7 @@ void test_router_message_forward_valid_integrity_check_left(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_SyncMsg_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2099,7 +2099,7 @@ void test_router_message_forward_valid_integrity_check_right(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_SyncMsg_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2122,7 +2122,7 @@ void test_router_message_forward_valid_integrity_clear(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_SyncMsg_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2167,7 +2167,7 @@ void test_router_message_forward_invalid_delta_json_message(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, NULL);
 
@@ -2192,7 +2192,7 @@ void test_router_message_forward_valid_delta_packages_json_message(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2220,7 +2220,7 @@ void test_router_message_forward_valid_delta_os_json_message(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2248,7 +2248,7 @@ void test_router_message_forward_valid_delta_netiface_json_message(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2274,7 +2274,7 @@ void test_router_message_forward_valid_delta_netproto_json_message(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2300,7 +2300,7 @@ void test_router_message_forward_valid_delta_netaddr_json_message(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2327,7 +2327,7 @@ void test_router_message_forward_valid_delta_hardware_json_message(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2353,7 +2353,7 @@ void test_router_message_forward_valid_delta_ports_json_message(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2379,7 +2379,7 @@ void test_router_message_forward_valid_delta_processes_json_message(void **state
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
@@ -2403,7 +2403,7 @@ void test_router_message_forward_valid_delta_hotfixes_json_message(void **state)
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
 
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
-    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, flags, 0);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -1985,7 +1985,6 @@ void test_handle_outgoing_data_to_tcp_socket_success(void **state)
 }
 
 // Tests router_message_forward
-
 void test_router_message_forward_non_syscollector_message(void **state)
 {
     char* agent_id = "001";
@@ -1995,7 +1994,19 @@ void test_router_message_forward_non_syscollector_message(void **state)
     router_message_forward(message, agent_id);
 }
 
-void test_router_message_forward_malformed_json_message(void **state)
+void test_router_message_forward_create_sync_handle_fail(void **state)
+{
+    char* agent_id = "001";
+    char* message = "5:syscollector:{\"message\":\"valid\"}";
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Failed to create router handle for 'rsync'.");
+    expect_string(__wrap_router_provider_create, name, "rsync");
+    will_return(__wrap_router_provider_create, NULL);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_malformed_sync_json_message(void **state)
 {
     char* agent_id = "001";
     char* message = "5:syscollector:{\"message\":fail";
@@ -2006,7 +2017,7 @@ void test_router_message_forward_malformed_json_message(void **state)
     router_message_forward(message, agent_id);
 }
 
-void test_router_message_forward_invalid_json_message(void **state)
+void test_router_message_forward_invalid_sync_json_message(void **state)
 {
     char* agent_id = "001";
     char* message = "5:syscollector:{\"message\":\"not_valid\"}";
@@ -2029,10 +2040,10 @@ void test_router_message_forward_valid_integrity_check_global(void **state)
 {
     char* agent_id = "001";
     char* message = "5:syscollector:{\"component\":\"syscollector_hwinfo\",\"data\":{\"begin\":\"0\",\"checksum\":\"b66d0703ee882571cd1865f393bd34f7d5940339\","
-                    "\"end\":\"0\",\"id\":1691259777},\"type\":\"integrity_check_global\"}";
+                                "\"end\":\"0\",\"id\":1691259777},\"type\":\"integrity_check_global\"}";
     char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"integrity_check_global\",\"data\":"
-                             "{\"begin\":\"0\",\"checksum\":\"b66d0703ee882571cd1865f393bd34f7d5940339\",\"end\":\"0\",\"id\":1691259777,\"attributes_type\":"
-                             "\"syscollector_hwinfo\"}}";
+                                                "{\"begin\":\"0\",\"checksum\":\"b66d0703ee882571cd1865f393bd34f7d5940339\",\"end\":\"0\",\"id\":1691259777,\"attributes_type\":"
+                                                "\"syscollector_hwinfo\"}}";
 
     expect_string(__wrap_router_provider_create, name, "rsync");
     will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
@@ -2040,6 +2051,360 @@ void test_router_message_forward_valid_integrity_check_global(void **state)
     expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
     expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
     expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_SyncMsg_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_integrity_check_left(void **state)
+{
+    char* agent_id = "001";
+    char* message = "5:syscollector:{\"component\":\"syscollector_packages\",\"data\":{\"begin\":\"01113a00fcdafa43d111ecb669202119c946ebe5\",\"checksum\":\"54c13892eb9ee18b0012086b76a89f41e73d64a1\","
+                                "\"end\":\"40795337f16a208e4d0a2280fbd5c794c9877dcb\",\"id\":1693338981,\"tail\":\"408cb243d2d52ad6414ba602e375b3b6b5f5cd77\"},\"type\":\"integrity_check_global\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"integrity_check_global\",\"data\":"
+                                                "{\"begin\":\"01113a00fcdafa43d111ecb669202119c946ebe5\",\"checksum\":\"54c13892eb9ee18b0012086b76a89f41e73d64a1\",\"end\":\"40795337f16a208e4d0a2280fbd5c794c9877dcb\",\"id\":1693338981,\"tail\":\"408cb243d2d52ad6414ba602e375b3b6b5f5cd77\",\"attributes_type\":"
+                                                "\"syscollector_packages\"}}";
+
+    expect_string(__wrap_router_provider_create, name, "rsync");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_SyncMsg_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_integrity_check_right(void **state)
+{
+    char* agent_id = "001";
+    char* message = "5:syscollector:{\"component\":\"syscollector_packages\",\"data\":{\"begin\":\"85c5676f6e5082ef99bba397b90559cd36fbbeca\",\"checksum\":\"d33c176f028188be38b394af5eed1e66bb8ad40e\","
+                                "\"end\":\"ffee8da05f37fa760fc5eee75dd0ea9e71228d05\",\"id\":1693338981},\"type\":\"integrity_check_right\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"integrity_check_right\",\"data\":"
+                                                "{\"begin\":\"85c5676f6e5082ef99bba397b90559cd36fbbeca\",\"checksum\":\"d33c176f028188be38b394af5eed1e66bb8ad40e\",\"end\":\"ffee8da05f37fa760fc5eee75dd0ea9e71228d05\",\"id\":1693338981,\"attributes_type\":"
+                                                "\"syscollector_packages\"}}";
+
+    expect_string(__wrap_router_provider_create, name, "rsync");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_SyncMsg_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_integrity_clear(void **state)
+{
+    char* agent_id = "001";
+    char* message = "5:syscollector:{\"component\":\"syscollector_hwinfo\",\"data\":{\"id\":1693338619},\"type\":\"integrity_check_clear\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"integrity_check_clear\",\"data\":"
+                                                "{\"id\":1693338619,\"attributes_type\":\"syscollector_hwinfo\"}}";
+
+    expect_string(__wrap_router_provider_create, name, "rsync");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_SyncMsg_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_create_delta_handle_fail(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"message\":\"valid\"}";
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Failed to create router handle for 'syscollector'.");
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, NULL);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_malformed_delta_json_message(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"message\":fail";
+
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_invalid_delta_json_message(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"message\":\"not_valid\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"}}";
+
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, NULL);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Unable to forward message for agent 001");
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_delta_packages_json_message(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"type\":\"dbsync_packages\",\"data\":{\"architecture\":\"amd64\",\"checksum\":\"1e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce\""
+                                ",\"description\":\"library for GIF images (library)\",\"format\":\"deb\",\"groups\":\"libs\",\"item_id\":\"ec465b7eb5fa011a336e95614072e4c7f1a65a53\""
+                                ",\"multiarch\":\"same\",\"name\":\"libgif7\",\"priority\":\"optional\",\"scan_time\":\"2023/08/04 19:56:11\",\"size\":72,\"source\":\"giflib\""
+                                ",\"vendor\":\"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>\",\"version\":\"5.1.9-1\"},\"operation\":\"INSERTED\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"dbsync_packages\",\"data\":{\"architecture\":\"amd64\",\"checksum\":\"1e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce\""
+                                                ",\"description\":\"library for GIF images (library)\",\"format\":\"deb\",\"groups\":\"libs\",\"item_id\":\"ec465b7eb5fa011a336e95614072e4c7f1a65a53\""
+                                                ",\"multiarch\":\"same\",\"name\":\"libgif7\",\"priority\":\"optional\",\"scan_time\":\"2023/08/04 19:56:11\",\"size\":72,\"source\":\"giflib\""
+                                                ",\"vendor\":\"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>\",\"version\":\"5.1.9-1\"},\"operation\":\"INSERTED\"}";
+
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_delta_os_json_message(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"type\":\"dbsync_packages\",\"data\":{\"architecture\":\"amd64\",\"checksum\":\"1e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce\""
+                                ",\"description\":\"library for GIF images (library)\",\"format\":\"deb\",\"groups\":\"libs\",\"item_id\":\"ec465b7eb5fa011a336e95614072e4c7f1a65a53\""
+                                ",\"multiarch\":\"same\",\"name\":\"libgif7\",\"priority\":\"optional\",\"scan_time\":\"2023/08/04 19:56:11\",\"size\":72,\"source\":\"giflib\""
+                                ",\"vendor\":\"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>\",\"version\":\"5.1.9-1\"},\"operation\":\"INSERTED\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"dbsync_packages\",\"data\":{\"architecture\":\"amd64\",\"checksum\":\"1e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce\""
+                                                ",\"description\":\"library for GIF images (library)\",\"format\":\"deb\",\"groups\":\"libs\",\"item_id\":\"ec465b7eb5fa011a336e95614072e4c7f1a65a53\""
+                                                ",\"multiarch\":\"same\",\"name\":\"libgif7\",\"priority\":\"optional\",\"scan_time\":\"2023/08/04 19:56:11\",\"size\":72,\"source\":\"giflib\""
+                                                ",\"vendor\":\"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>\",\"version\":\"5.1.9-1\"},\"operation\":\"INSERTED\"}";
+
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_delta_netiface_json_message(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"type\":\"dbsync_network_iface\",\"data\":{\"adapter\":null,\"checksum\":\"078143285c1aff98e196c8fe7e01f5677f44bd44\""
+                                ",\"item_id\":\"7a60750dd3c25c53f21ff7f44b4743664ddbb66a\",\"mac\":\"02:bf:67:45:e4:dd\",\"mtu\":1500,\"name\":\"enp0s3\",\"rx_bytes\":972800985"
+                                ",\"rx_dropped\":0,\"rx_errors\":0,\"rx_packets\":670863,\"scan_time\":\"2023/08/04 19:56:11\",\"state\":\"up\",\"tx_bytes\":6151606,\"tx_dropped\":0"
+                                ",\"tx_errors\":0,\"tx_packets\":84746,\"type\":\"ethernet\"},\"operation\":\"MODIFIED\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"dbsync_network_iface\",\"data\":{\"adapter\":null,\"checksum\":\"078143285c1aff98e196c8fe7e01f5677f44bd44\""
+                                                ",\"item_id\":\"7a60750dd3c25c53f21ff7f44b4743664ddbb66a\",\"mac\":\"02:bf:67:45:e4:dd\",\"mtu\":1500,\"name\":\"enp0s3\",\"rx_bytes\":972800985"
+                                                ",\"rx_dropped\":0,\"rx_errors\":0,\"rx_packets\":670863,\"scan_time\":\"2023/08/04 19:56:11\",\"state\":\"up\",\"tx_bytes\":6151606,\"tx_dropped\":0"
+                                                ",\"tx_errors\":0,\"tx_packets\":84746,\"type\":\"ethernet\"},\"operation\":\"MODIFIED\"}";
+
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_delta_netproto_json_message(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"type\":\"dbsync_network_protocol\",\"data\":{\"checksum\":\"ddd971d57316a79738a2cf93143966a4e51ede08\",\"dhcp\":\"unknown\""
+                                ",\"gateway\":\" \",\"iface\":\"enp0s9\",\"item_id\":\"33228317ee8778628d0f2f4fde53b75b92f15f1d\",\"metric\":\"0\",\"scan_time\":\"2023/08/07 15:02:36\""
+                                ",\"type\":\"ipv4\"},\"operation\":\"DELETED\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"dbsync_network_protocol\",\"data\":{\"checksum\":\"ddd971d57316a79738a2cf93143966a4e51ede08\",\"dhcp\":\"unknown\""
+                                                ",\"gateway\":\" \",\"iface\":\"enp0s9\",\"item_id\":\"33228317ee8778628d0f2f4fde53b75b92f15f1d\",\"metric\":\"0\",\"scan_time\":\"2023/08/07 15:02:36\""
+                                                ",\"type\":\"ipv4\"},\"operation\":\"DELETED\"}";
+
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_delta_netaddr_json_message(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"type\":\"dbsync_network_address\",\"data\":{\"address\":\"192.168.0.80\",\"broadcast\":\"192.168.0.255\""
+                                ",\"checksum\":\"c1f9511fa37815d19cee496f21524725ba84ab10\",\"iface\":\"enp0s9\",\"item_id\":\"b333013c47d28eb3878068dd59c42e00178bd475\""
+                                ",\"netmask\":\"255.255.255.0\",\"proto\":0,\"scan_time\":\"2023/08/07 15:02:36\"},\"operation\":\"DELETED\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"dbsync_network_address\",\"data\":{\"address\":\"192.168.0.80\",\"broadcast\":\"192.168.0.255\""
+                                                ",\"checksum\":\"c1f9511fa37815d19cee496f21524725ba84ab10\",\"iface\":\"enp0s9\",\"item_id\":\"b333013c47d28eb3878068dd59c42e00178bd475\""
+                                                ",\"netmask\":\"255.255.255.0\",\"proto\":0,\"scan_time\":\"2023/08/07 15:02:36\"},\"operation\":\"DELETED\"}";
+
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_delta_hardware_json_message(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"type\":\"dbsync_hwinfo\",\"data\":{\"board_serial\":\"0\",\"checksum\":\"f6eea592bc11465ecacc92ddaea188ef3faf0a1f\",\"cpu_cores\":8"
+                                ",\"cpu_mhz\":2592.0,\"cpu_name\":\"Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz\",\"ram_free\":11547184,\"ram_total\":12251492,\"ram_usage\":6"
+                                ",\"scan_time\":\"2023/08/04 19:56:11\"},\"operation\":\"MODIFIED\"}";
+    // Trailing zeros are truncated.
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"dbsync_hwinfo\",\"data\":{\"board_serial\":\"0\",\"checksum\":\"f6eea592bc11465ecacc92ddaea188ef3faf0a1f\",\"cpu_cores\":8"
+                                                ",\"cpu_mhz\":2592,\"cpu_name\":\"Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz\",\"ram_free\":11547184,\"ram_total\":12251492,\"ram_usage\":6"
+                                                ",\"scan_time\":\"2023/08/04 19:56:11\"},\"operation\":\"MODIFIED\"}";
+
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_delta_ports_json_message(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"type\":\"dbsync_ports\",\"data\":{\"checksum\":\"03f522cdccc8dfbab964981db59b176b178b9dfd\",\"inode\":39968"
+                                ",\"item_id\":\"7f98c21162b40ca7871a8292d177a1812ca97547\",\"local_ip\":\"10.0.2.15\",\"local_port\":68,\"pid\":0,\"process\":null,\"protocol\":\"udp\""
+                                ",\"remote_ip\":\"0.0.0.0\",\"remote_port\":0,\"rx_queue\":0,\"scan_time\":\"2023/08/07 12:42:41\",\"state\":null,\"tx_queue\":0},\"operation\":\"INSERTED\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"dbsync_ports\",\"data\":{\"checksum\":\"03f522cdccc8dfbab964981db59b176b178b9dfd\",\"inode\":39968"
+                                                ",\"item_id\":\"7f98c21162b40ca7871a8292d177a1812ca97547\",\"local_ip\":\"10.0.2.15\",\"local_port\":68,\"pid\":0,\"process\":null,\"protocol\":\"udp\""
+                                                ",\"remote_ip\":\"0.0.0.0\",\"remote_port\":0,\"rx_queue\":0,\"scan_time\":\"2023/08/07 12:42:41\",\"state\":null,\"tx_queue\":0},\"operation\":\"INSERTED\"}";
+
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_delta_processes_json_message(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"type\":\"dbsync_processes\",\"data\":{\"checksum\":\"5ca21c17ae78a0ef7463b3b2454126848473cf5b\",\"cmd\":\"C:\\\\Windows\\\\System32\\\\winlogon.exe\""
+                                ",\"name\":\"winlogon.exe\",\"nlwp\":6,\"pid\":\"604\",\"ppid\":496,\"priority\":13,\"scan_time\":\"2023/08/07 15:01:57\",\"session\":1,\"size\":3387392"
+                                ",\"start_time\":1691420428,\"stime\":0,\"utime\":0,\"vm_size\":14348288},\"operation\":\"MODIFIED\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"dbsync_processes\",\"data\":{\"checksum\":\"5ca21c17ae78a0ef7463b3b2454126848473cf5b\",\"cmd\":\"C:\\\\Windows\\\\System32\\\\winlogon.exe\""
+                                                ",\"name\":\"winlogon.exe\",\"nlwp\":6,\"pid\":\"604\",\"ppid\":496,\"priority\":13,\"scan_time\":\"2023/08/07 15:01:57\",\"session\":1,\"size\":3387392"
+                                                ",\"start_time\":1691420428,\"stime\":0,\"utime\":0,\"vm_size\":14348288},\"operation\":\"MODIFIED\"}";
+
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
+    will_return(__wrap_w_flatcc_parse_json, (void*)1);
+
+    expect_function_call(__wrap_router_provider_send);
+    will_return(__wrap_router_provider_send, 0);
+
+    expect_function_call(__wrap_w_flatcc_free_buffer);
+
+    router_message_forward(message, agent_id);
+}
+
+void test_router_message_forward_valid_delta_hotfixes_json_message(void **state)
+{
+    char* agent_id = "001";
+    char* message = "d:syscollector:{\"type\":\"dbsync_hotfixes\",\"data\":{\"checksum\":\"f6eea592bc11465ecacc92ddaea188ef3faf0a1f\",\"hotfix\":\"KB4502496\""
+                                ",\"scan_time\":\"2023/08/0419:56:11\"},\"operation\":\"MODIFIED\"}";
+    char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"},\"data_type\":\"dbsync_hotfixes\",\"data\":{\"checksum\":\"f6eea592bc11465ecacc92ddaea188ef3faf0a1f\",\"hotfix\":\"KB4502496\""
+                                                ",\"scan_time\":\"2023/08/0419:56:11\"},\"operation\":\"MODIFIED\"}";
+
+    expect_string(__wrap_router_provider_create, name, "syscollector");
+    will_return(__wrap_router_provider_create, (ROUTER_PROVIDER_HANDLE)(1));
+
+    expect_string(__wrap_w_flatcc_parse_json, msg, expected_message);
+    expect_value(__wrap_w_flatcc_parse_json, flags, flatcc_json_parser_f_skip_unknown);
+    expect_value(__wrap_w_flatcc_parse_json, parser, Syscollector_Delta_parse_json_table);
     will_return(__wrap_w_flatcc_parse_json, (void*)1);
 
     expect_function_call(__wrap_router_provider_send);
@@ -2099,10 +2464,26 @@ int main(void)
         cmocka_unit_test(test_handle_outgoing_data_to_tcp_socket_case_1_EPIPE),
         cmocka_unit_test(test_handle_outgoing_data_to_tcp_socket_success),
         // Tests router_message_forward
+        cmocka_unit_test_setup_teardown(test_router_message_forward_create_sync_handle_fail, setup_remoted_configuration, teardown_remoted_configuration),
         cmocka_unit_test_setup_teardown(test_router_message_forward_non_syscollector_message, setup_remoted_configuration, teardown_remoted_configuration),
-        cmocka_unit_test_setup_teardown(test_router_message_forward_malformed_json_message, setup_remoted_configuration, teardown_remoted_configuration),
-        cmocka_unit_test_setup_teardown(test_router_message_forward_invalid_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_malformed_sync_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_invalid_sync_json_message, setup_remoted_configuration, teardown_remoted_configuration),
         cmocka_unit_test_setup_teardown(test_router_message_forward_valid_integrity_check_global, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_integrity_check_left, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_integrity_check_right, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_integrity_clear, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_create_delta_handle_fail, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_malformed_delta_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_invalid_delta_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_packages_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_os_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_hardware_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_netiface_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_netproto_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_netaddr_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_ports_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_processes_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_hotfixes_json_message, setup_remoted_configuration, teardown_remoted_configuration),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -5,6 +5,9 @@ if(${TARGET} STREQUAL "winagent")
     link_directories(${SRC_FOLDER}/syscheckd/build/bin)
 endif(${TARGET} STREQUAL "winagent")
 
+#include flatcc definitions
+include_directories(${SRC_FOLDER}/external/flatcc/include/)
+
 # Tests list and flags
 list(APPEND shared_tests_names "test_list_op")
 set(LIST_OP_BASE_FLAGS "-Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,pthread_mutex_lock \
@@ -316,6 +319,11 @@ endif()
 list(APPEND shared_tests_names "test_rwlock_op")
 list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
 
+if(${TARGET} STREQUAL "server")
+    list(APPEND shared_tests_names "test_flatcc_helpers")
+    list(APPEND shared_tests_flags "-Wl,--wrap,mdebug2 ${DEBUG_OP_WRAPPERS}")
+endif()
+
 # Compiling tests
 list(LENGTH shared_tests_names count)
 math(EXPR count "${count} - 1")
@@ -325,6 +333,14 @@ foreach(counter RANGE ${count})
 
     add_executable(${test_name} ${test_name}.c)
 
+    if(${test_name} STREQUAL "test_flatcc_helpers")
+        add_definitions(${test_name} -DPORTABLE_UNALIGNED_ACCESS=0)
+        find_library(FLATCC_LIBRARY flatccrt HINTS ${SRC_FOLDER}/external/flatcc/lib)
+        target_link_libraries(
+            ${test_name}
+            ${FLATCC_LIBRARY}
+        )
+    endif()
     if(${TARGET} STREQUAL "server")
         target_link_libraries(
             ${test_name}

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -334,7 +334,7 @@ foreach(counter RANGE ${count})
     add_executable(${test_name} ${test_name}.c)
 
     if(${test_name} STREQUAL "test_flatcc_helpers")
-        add_definitions(${test_name} -DPORTABLE_UNALIGNED_ACCESS=0)
+        target_compile_definitions(${test_name} PRIVATE -DPORTABLE_UNALIGNED_ACCESS=0)
         find_library(FLATCC_LIBRARY flatccrt HINTS ${SRC_FOLDER}/external/flatcc/lib)
         target_link_libraries(
             ${test_name}

--- a/src/unit_tests/shared/test_flatcc_helpers.c
+++ b/src/unit_tests/shared/test_flatcc_helpers.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../generated_headers/common_agentInfo_builder.h"
+#include "../../generated_headers/common_agentInfo_json_parser.h"
+#include "../../generated_headers/common_agentInfo_json_printer.h"
+#include "../../generated_headers/common_agentInfo_verifier.h"
+#include "../../headers/flatcc_helpers.h"
+
+void test_w_flatcc_parse_json_parse_fail (void **state) {
+    const char* msg_to_send = "{\"agent_id\":\"001\",\"invalid_key\":\"random_value\"}";
+    const size_t msg_to_send_len = strlen(msg_to_send);
+
+    flatcc_json_parser_table_f *parser = AgentInfo_parse_json_table;
+    size_t buffer_size, flatbuffer_size;
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Failed to parse message with flatbuffer schema: unknown symbol");
+
+    void* flatbuffer = w_flatcc_parse_json(msg_to_send_len, msg_to_send, &flatbuffer_size, 0, parser);
+
+    assert_null(flatbuffer);
+}
+
+void test_w_flatcc_parse_json_success (void **state) {
+    const char* msg_to_send = "{\"agent_id\":\"001\",\"node_name\":\"test_node_name\"}";
+    const size_t msg_to_send_len = strlen(msg_to_send);
+
+    flatcc_json_parser_table_f *parser = AgentInfo_parse_json_table;
+    size_t buffer_size, flatbuffer_size;
+
+    void* flatbuffer = w_flatcc_parse_json(msg_to_send_len, msg_to_send, &flatbuffer_size, 0, parser);
+    char* output = w_flatcc_print_json(flatbuffer, flatbuffer_size, &buffer_size, 0, AgentInfo_print_json_table);
+
+    assert_string_equal(msg_to_send, output);
+    free(output);
+    w_flatcc_free_buffer(flatbuffer);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_w_flatcc_parse_json_parse_fail),
+        cmocka_unit_test(test_w_flatcc_parse_json_success)
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/flatcc_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/flatcc_helpers_wrappers.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ * Aug 29, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+
+#ifndef WIN32
+#ifndef CLIENT
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "flatcc/flatcc_json_parser.h"
+#include "flatcc/flatcc_json_printer.h"
+
+void* __wrap_w_flatcc_parse_json( __attribute__((unused)) size_t msg_len,
+                                 const char* msg,
+                                 __attribute__((unused)) size_t* flatbuffer_size,
+                                 flatcc_json_parser_flags_t flags,
+                                 flatcc_json_parser_table_f *parser) {
+    check_expected(msg);
+    check_expected(flags);
+    check_expected(parser);
+    return mock_ptr_type(void*);
+}
+
+void __wrap_w_flatcc_free_buffer(__attribute__((unused)) void* flatbuffer) {
+    function_called();
+}
+
+char* __wrap_w_flatcc_print_json (__attribute__((unused)) void* flatbuffer,
+                                  __attribute__((unused)) size_t flatbuffer_size,
+                                  __attribute__((unused)) size_t *buffer_size,
+                                  flatcc_json_printer_flags_t flags,
+                                  flatcc_json_printer_table_f *printer) {
+    check_expected(flags);
+    check_expected(printer);
+    return mock_ptr_type(char*);
+}
+
+#endif /* CLIENT */
+#endif /* WIN32 */

--- a/src/unit_tests/wrappers/wazuh/shared/flatcc_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/flatcc_helpers_wrappers.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ * Aug 29, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef FLATCC_HELPERS_WRAPPERS_H
+#define FLATCC_HELPERS_WRAPPERS_H
+
+#ifndef WIN32
+#ifndef CLIENT
+
+#include "flatcc/flatcc_json_parser.h"
+#include "flatcc/flatcc_json_printer.h"
+
+void* __wrap_w_flatcc_parse_json(size_t msg_len, const char* msg, size_t* flatbuffer_size, flatcc_json_parser_flags_t flags, flatcc_json_parser_table_f *parser);
+
+void __wrap_w_flatcc_free_buffer(void* flatbuffer);
+
+char* __wrap_w_flatcc_print_json (void* flatbuffer, size_t flatbuffer_size, size_t *buffer_size, flatcc_json_printer_flags_t flags, flatcc_json_printer_table_f *printer);
+
+#endif /* CLIENT */
+#endif /* WIN32 */
+
+#endif // FLATCC_HELPERS_WRAPPERS_H

--- a/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
@@ -1,0 +1,30 @@
+/*
+ * Wazuh router wrappers
+ * Copyright (C) 2015, Wazuh Inc.
+ * Aug 24, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "../../common.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdbool.h>
+#include "router.h"
+
+int __wrap_router_provider_send(__attribute__((unused)) ROUTER_PROVIDER_HANDLE handle,
+                                __attribute__((unused)) const char* message,
+                                __attribute__((unused)) unsigned int message_size) {
+    function_called();
+    return mock();
+}
+
+ROUTER_PROVIDER_HANDLE __wrap_router_provider_create(const char* name) {
+    check_expected(name);
+    return mock_ptr_type(ROUTER_PROVIDER_HANDLE);
+}

--- a/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.h
@@ -1,0 +1,23 @@
+/*
+ * Wazuh router wrappers
+ * Copyright (C) 2015, Wazuh Inc.
+ * Aug 29, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef ROUTER_WRAPPERS_H
+#define ROUTER_WRAPPERS_H
+
+#include "../../common.h"
+#include <stdbool.h>
+#include "router.h"
+
+int __wrap_router_provider_send(ROUTER_PROVIDER_HANDLE handle, const char* message, unsigned int message_size);
+
+ROUTER_PROVIDER_HANDLE __wrap_router_provider_create(const char* name);
+
+#endif // ROUTER_WRAPPERS_H

--- a/src/wazuh_modules/syscollector/schemas/syscollector_synchronization.fbs
+++ b/src/wazuh_modules/syscollector/schemas/syscollector_synchronization.fbs
@@ -9,7 +9,7 @@ include "package_synchronization.fbs";
 include "ports_synchronization.fbs";
 include "processes_synchronization.fbs";
 
-namespace Syscollector.SyncMessage;
+namespace Syscollector;
 
 union AttributesUnion
 {

--- a/src/wazuh_modules/wm_router.c
+++ b/src/wazuh_modules/wm_router.c
@@ -46,7 +46,7 @@ void* wm_router_main()
 
         if (router_initialize_ptr)
         {
-            router_initialize_ptr(NULL);
+            router_initialize_ptr(taggedLogFunction);
         }
         else
         {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17914 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR makes the following changes:
- The rocksdb library is added to the external target, just like `jemalloc`
- The folder for the router sockets is created during the installation as `root:wazuh` to allow `wazuh-remoted` to access the socket
- Remoted sends the syscollector messages to the router adding some extra information. Two topics were created "syscollector" and "rsync"
- Some extra log messages were added 
- The sockets created by the router module now have the required permissions to allow **remoted** write the socket
- The UT compilation was fixed

Some details about the implementation were analyzed but weren't completely solved:
- What would happen if the configuration values (node name for example) that will be used for indexing the messages change? Should this information be sanitized?
- What is the maximum length that the UNIX socket allows in one message?
- The messages are forwarded to the router AND sent to analysisd for now
- What happens with the syscollector messages from the manager it self? Are they sent to remoted?
- The remoted daemon hasn't a graceful shutdown
- Could we generate a cache of the JSON header to avoid generating it everytime?
- What would happen if remoted tries to send messages to the router but this module hasn't been started yet by modulesd?

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

To verify the implementation, the router test-tool was modified and it was subscribed to the "syscollector" and "rsync" topics.
These are examples of some messages received:

```
Data from 'syscollector' subscriber: {"component":"syscollector_hwinfo","data":{"begin":"0","checksum":"b66d0703ee882571cd1865f393bd34f7d5940339","end":"0","id":1691259777},"type":"integrity_check_global","agent_info":{"agent_id":"001","node_name":"node01"}}

Data from 'syscollector' subscriber: {"component":"syscollector_osinfo","data":{"begin":"Ubuntu","checksum":"32a10568d46f30c603d136c621b3429e246ae1cf","end":"Ubuntu","id":1691259777},"type":"integrity_check_global","agent_info":{"agent_id":"001","node_name":"node01"}}

Data from 'syscollector' subscriber: {"component":"syscollector_network_iface","data":{"begin":"7a60750dd3c25c53f21ff7f44b4743664ddbb66a","checksum":"c4cfa0924648b64b892d6e996b5117fdd8c80b6d","end":"c3cbf3edb7c5565edb919ccb2475845270839642","id":1691259777},"type":"integrity_check_global","agent_info":{"agent_id":"001","node_name":"node01"}}

Data from 'syscollector' subscriber: {"component":"syscollector_network_protocol","data":{"begin":"3f8713d26affaee20cd603053d8d78bb7884ff7e","checksum":"ac0e2d431465dd502dd8ef3e1ac888dd611e758b","end":"c03e890fae1fd4600166931ee4e58a14547f0efa","id":1691259777},"type":"integrity_check_global","agent_info":{"agent_id":"001","node_name":"node01"}}

Data from 'syscollector' subscriber: {"component":"syscollector_network_address","data":{"begin":"73fe1533b96d4e81b56e13df4f25a0684b473de7","checksum":"a5acaea7d3013d561721589d9139d2af97a83cf8","end":"f0c15a057d64164cdf784fe05185ca48fdeb2e1a","id":1691259777},"type":"integrity_check_global","agent_info":{"agent_id":"001","node_name":"node01"}}

Data from 'syscollector' subscriber: {"component":"syscollector_ports","data":{"begin":"cb8f094adf3aeb9630f2f51d1beeb5472eb0a8fb","checksum":"81e9e554238262d8731777efc9998be385f184b2","end":"cb8f094adf3aeb9630f2f51d1beeb5472eb0a8fb","id":1691259777,"tail":"e19973b991e6862d7f994bdf1d118f305f41f480"},"type":"integrity_check_left","agent_info":{"agent_id":"001","node_name":"node01"}}

Data from 'syscollector' subscriber: {"component":"syscollector_ports","data":{"attributes":{"checksum":"02d4570c4cf94ba0f79c34e8a52216fddf73a39a","inode":42468,"item_id":"cb8f094adf3aeb9630f2f51d1beeb5472eb0a8fb","local_ip":"192.168.0.10","local_port":37990,"pid":0,"process":null,"protocol":"udp","remote_ip":"192.168.0.30","remote_port":1514,"rx_queue":0,"scan_time":"2023/08/05 18:23:02","state":null,"tx_queue":0},"index":"cb8f094adf3aeb9630f2f51d1beeb5472eb0a8fb","timestamp":""},"type":"state","agent_info":{"agent_id":"001","node_name":"node01"}}


...

Data from 'rsync' subscriber: {"data":{"architecture":"x86_64","checksum":"1691259808112293736","hostname":"ubuntu-focal","os_codename":"focal","os_major":"20","os_minor":"04","os_name":"Ubuntu","os_patch":"2","os_platform":"ubuntu","os_version":"20.04.2 LTS (Focal Fossa)","release":"5.4.0-155-generic","scan_time":"2023/08/05 18:23:28","sysname":"Linux","version":"#172-Ubuntu SMP Fri Jul 7 16:10:02 UTC 2023"},"operation":"MODIFIED","type":"dbsync_osinfo","agent_info":{"agent_id":"001","node_name":"node01"}}

Data from 'rsync' subscriber: {"data":{"adapter":null,"checksum":"cd88c95ae5a4942f95f2a401172d5b6f2eace743","item_id":"7a60750dd3c25c53f21ff7f44b4743664ddbb66a","mac":"02:2f:5a:3d:99:5e","mtu":1500,"name":"enp0s3","rx_bytes":181158,"rx_dropped":0,"rx_errors":0,"rx_packets":1899,"scan_time":"2023/08/05 18:23:28","state":"up","tx_bytes":264700,"tx_dropped":0,"tx_errors":0,"tx_packets":1865,"type":"ethernet"},"operation":"MODIFIED","type":"dbsync_network_iface","agent_info":{"agent_id":"001","node_name":"node01"}}

Data from 'rsync' subscriber: {"data":{"argvs":null,"checksum":"6cc40d6da54427a36e42627ae8b9f77592c97b41","cmd":"/sbin/init","egroup":"root","euser":"root","fgroup":"root","name":"systemd","nice":0,"nlwp":1,"pgrp":1,"pid":"1","ppid":0,"priority":20,"processor":1,"resident":13240,"rgroup":"root","ruser":"root","scan_time":"2023/08/05 18:23:28","session":1,"sgroup":"root","share":2128,"size":25917,"start_time":1691259174,"state":"S","stime":123,"suser":"root","tgid":1,"tty":0,"utime":54,"vm_size":103668},"operation":"MODIFIED","type":"dbsync_processes","agent_info":{"agent_id":"001","node_name":"node01"}}

Data from 'rsync' subscriber: {"data":{"argvs":"./bin/wazuh-control restart","checksum":"d81916c7ed9d97bf4077dbe929ddb383a553cf3a","cmd":"/bin/sh","egroup":"root","euser":"root","fgroup":"root","name":"wazuh-control","nice":0,"nlwp":1,"pgrp":3508,"pid":"3508","ppid":2752,"priority":20,"processor":1,"resident":1740,"rgroup":"root","ruser":"root","scan_time":"2023/08/05 18:23:28","session":2470,"sgroup":"root","share":401,"size":652,"start_time":1691259771,"state":"S","stime":1,"suser":"root","tgid":3508,"tty":34816,"utime":0,"vm_size":2608},"operation":"DELETED","type":"dbsync_processes","agent_info":{"agent_id":"001","node_name":"node01"}}


```

## DoD 

Flag set 

<details><summary>Expand</summary>

![image](https://github.com/wazuh/wazuh/assets/13010397/a0e893af-b0b8-4b73-bb86-a7e09efcfe83)
![image](https://github.com/wazuh/wazuh/assets/13010397/72e89762-4ec8-4eef-9474-eb737185acb5)

</details>

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language