### PR TITLE
Remove the NVD year filter in Vuln Detector

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -431,7 +431,6 @@
 #define VU_NVD_EMPTY                "(5582): Unavailable vulnerabilities at the NVD database. The scan is aborted."
 #define VU_DEB_STATUS_FEED_ERROR    "(5583): Couldn't get the Debian feed '%s' to check the vulnerable packages."
 #define VU_FILTER_VULN_NVD_ERROR    "(5584): Couldn't verify if the vulnerability '%s' is reported in the NVD feed."
-#define VU_GET_NVD_YEAR_ERROR       "(5585): Couldn't get the NVD configured year."
 #define VU_NO_ENABLED_FEEDS         "(5586): No feeds specified for '%s' provider. Enabling all the available ones."
 #define VU_OFFLINE_CONFLICT         "(5587): Feed conflict. Only '%s' will be updated offline."
 #define VU_VER_INVALID_FORMAT       "(5588): Invalid format of Wazuh version for agent '%.3d'"

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -3276,64 +3276,6 @@ void test_wm_vuldet_build_product_name(void ** state) {
     }
 }
 
-/* wm_vuldet_linux_oval_vulnerabilities */
-
-void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_nvd_configured_year(void **state)
-{
-    sqlite3 *db = (sqlite3 *)1;
-    scan_agent *agent = *state;
-    OSHash *cve_table = (OSHash *)1;
-    scan_ctx_t scan_ctx;
-    scan_ctx.agent_id = 0;
-
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
-
-    will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, NULL);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
-
-    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5585): Couldn't get the NVD configured year.");
-
-    will_return(__wrap_sqlite3_errmsg, "error");
-
-    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
-
-    assert_int_equal(OS_INVALID, ret);
-}
-
-void test_wm_vuldet_linux_oval_vulnerabilities_error_no_nvd_year(void **state)
-{
-    sqlite3 *db = (sqlite3 *)1;
-    scan_agent *agent = *state;
-    OSHash *cve_table = (OSHash *)1;
-    scan_ctx_t scan_ctx;
-    scan_ctx.agent_id = 0;
-
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
-
-    will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_DONE);
-
-    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5585): Couldn't get the NVD configured year.");
-
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
-
-    assert_int_equal(OS_INVALID, ret);
-}
-
 void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
@@ -3346,15 +3288,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare(void **state)
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, NULL);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
@@ -3387,15 +3320,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_rh(void **state)
 
     will_return(__wrap_time, (time_t)1);
 
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
-
     will_return(__wrap_sqlite3_prepare_v2, NULL);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
 
@@ -3427,15 +3351,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_deb(void **state)
 
     will_return(__wrap_time, (time_t)1);
 
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
-
     will_return(__wrap_sqlite3_prepare_v2, NULL);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
 
@@ -3466,15 +3381,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_amazon(void **state
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, NULL);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
@@ -3508,13 +3414,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_SUSE_dependencies(void **st
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-    expect_sqlite3_step_call(SQLITE_ROW);
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5494): Starting SUSE dependency analysis for agent '000'");
@@ -3553,15 +3452,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_step(void **state)
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -3607,15 +3497,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_step_done(void **state)
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
     will_return_always(__wrap_sqlite3_bind_text, 0);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     // building query
@@ -3649,15 +3530,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_no_data(void **state)
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -3731,15 +3603,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_bad_version(void **state)
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
     will_return_always(__wrap_sqlite3_bind_text, 0);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     // building query
@@ -3803,15 +3666,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_not_fixed(void **state)
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -3905,15 +3759,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_not_vulnerable(void **sta
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
     will_return_always(__wrap_sqlite3_bind_text, 0);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     // building query
@@ -3992,15 +3837,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_centos_not_vulnerable(voi
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -4088,15 +3924,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_error_comparing(void **st
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
     will_return_always(__wrap_sqlite3_bind_text, 0);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     // building query
@@ -4162,15 +3989,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_vulnerable(void **state)
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -4283,15 +4101,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_insert_package_error(void **state
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
     will_return_always(__wrap_sqlite3_bind_text, 0);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     // building query
@@ -4391,15 +4200,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package(void **state)
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -4520,15 +4320,6 @@ void test_wm_vuldet_linux_oval_duplicated_cve_false_positive(void **state)
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
     will_return_always(__wrap_sqlite3_bind_text, 0);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     // building query
@@ -4622,15 +4413,6 @@ void test_wm_vuldet_linux_oval_duplicated_cve_false_positive_os_invalid(void **s
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
     will_return_always(__wrap_sqlite3_bind_text, 0);
     will_return_always(__wrap_sqlite3_bind_int, 0);
     // building query
@@ -4714,15 +4496,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_external_vendor(void **state)
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -10642,15 +10415,6 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_oval_vulnerabilities_
 
     will_return(__wrap_time, (time_t)1);
 
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
-
     will_return(__wrap_sqlite3_prepare_v2, NULL);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
 
@@ -10696,15 +10460,6 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_nvd_vulnerabilities_e
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -10794,15 +10549,6 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_rm_false_positives_er
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -10921,15 +10667,6 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_process_agent_vulnerabiliti
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -11085,15 +10822,6 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_OK(void **state)
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
 
     will_return(__wrap_time, (time_t)1);
-
-    will_return(__wrap_sqlite3_prepare_v2, 1);
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    expect_sqlite3_step_call(SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -22683,8 +22411,6 @@ int main(void)
         // Tests wm_vuldet_build_product_name
         cmocka_unit_test(test_wm_vuldet_build_product_name),
         // Tests wm_vuldet_linux_oval_vulnerabilities
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_nvd_configured_year, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_no_nvd_year, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_prepare, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_rh, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_deb, setup_scan_agent, teardown_scan_agent),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2528,10 +2528,6 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, scan_agent *agents_it, OSH
             continue;
         }
 
-        // Considering that we correlate the vendor CVEs with the NVD CVEs,
-        // we will take as a reference the configured year for the NVD.
-        if (nvd_year > wm_vuldet_get_cve_year(cve)) continue;
-
         // If we have a source version, use it to find vulnerabilities.
         if (source && src_version) {
             version = src_version;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2409,33 +2409,10 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, scan_agent *agents_it, OSH
     cve_vuln_pkg *vuln_pkg = NULL;
     time_t start_time;
     int vuln_count = 0;
-    int nvd_year = 0;
-    char * nvd_year_str = NULL;
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_START_OVAL_AG_AN, scan_ctx->agent_id);
 
     start_time = time(NULL);
-
-    // Getting the configured NVD year
-    if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_CONFIGURED_YEAR], -1, &stmt, NULL) != SQLITE_OK) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_GET_NVD_YEAR_ERROR);
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
-        wdb_finalize(stmt);
-        return OS_INVALID;
-    }
-
-    if (SQLITE_ROW != wm_vuldet_step(stmt)) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_GET_NVD_YEAR_ERROR);
-        wdb_finalize(stmt);
-        return OS_INVALID;
-    }
-
-    nvd_year_str = (char *)sqlite3_column_text(stmt, 0);
-    if (nvd_year_str) {
-        nvd_year = atoi(nvd_year_str);
-    }
-
-    wdb_finalize(stmt);
 
     // Getting CVEs from database
     if (agents_it->dist == FEED_REDHAT) {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #18168|

As of the NVD API v2.0, every CVE from the NVD has the current year.

## Proposed fix

Vulnerability Detector shall not skip vulnerabilities with a `year` metadata greater than the OVAL feed.

## Evidences

We've installed a vulnerable PostgreSQL package (as shown at #18168.

```sql
SELECT name, version, cve FROM vuln_cves WHERE name = 'postgresql-14';
```

### 4.4.5

|name|version|cve|
|---|---|---|
|postgresql-14|14.4-0ubuntu0.22.04.1|CVE-2022-2625|
|postgresql-14|14.4-0ubuntu0.22.04.1|CVE-2023-2454|
|postgresql-14|14.4-0ubuntu0.22.04.1|CVE-2023-2455|
|postgresql-14|14.4-0ubuntu0.22.04.1|CVE-2022-41862|

### 4.5.0 (unfixed)

|name|version|cve|
|---|---|---|
|postgresql-14|14.4-0ubuntu0.22.04.1|CVE-2023-2454|
|postgresql-14|14.4-0ubuntu0.22.04.1|CVE-2023-2455|

### 4.5.0 (fixed)

|name|version|cve|
|---|---|---|
|postgresql-14|14.4-0ubuntu0.22.04.1|CVE-2022-2625|
|postgresql-14|14.4-0ubuntu0.22.04.1|CVE-2023-2454|
|postgresql-14|14.4-0ubuntu0.22.04.1|CVE-2023-2455|
|postgresql-14|14.4-0ubuntu0.22.04.1|CVE-2022-41862|
