### PR TITLE
Remove FIM fields uid and gid if empty

### DIFF
--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -1465,11 +1465,11 @@ cJSON * fim_attributes_json(const fim_file_data * data) {
 #endif
     }
 
-    if (data->options & CHECK_OWNER) {
+    if (data->options & CHECK_OWNER && data->uid && *data->uid != '\0' ) {
         cJSON_AddStringToObject(attributes, "uid", data->uid);
     }
 
-    if (data->options & CHECK_GROUP) {
+    if (data->options & CHECK_GROUP && data->gid && *data->gid != '\0' ) {
         cJSON_AddStringToObject(attributes, "gid", data->gid);
     }
 

--- a/src/syscheckd/src/db/src/file.cpp
+++ b/src/syscheckd/src/db/src/file.cpp
@@ -75,12 +75,12 @@ nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohman
         jsonEvent["data"]["attributes"]["perm"] = data.at("perm");
     }
 
-    if (ctx->config->options & CHECK_OWNER)
+    if (data.contains("uid") && data.at("uid") != "" && ctx->config->options & CHECK_OWNER)
     {
         jsonEvent["data"]["attributes"]["uid"] = data.at("uid");
     }
 
-    if (ctx->config->options & CHECK_GROUP)
+    if (data.contains("gid") && data.at("gid") != "" && ctx->config->options & CHECK_GROUP)
     {
         jsonEvent["data"]["attributes"]["gid"] = data.at("gid");
     }
@@ -175,7 +175,7 @@ nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohman
             }
         }
 
-        if (ctx->config->options & CHECK_OWNER)
+        if (data.contains("uid") && data.at("uid") != "" && ctx->config->options & CHECK_OWNER)
         {
             if (old_data.contains("uid"))
             {
@@ -188,7 +188,7 @@ nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohman
             }
         }
 
-        if (ctx->config->options & CHECK_GROUP)
+        if (data.contains("gid") && data.at("gid") != "" && ctx->config->options & CHECK_GROUP)
         {
             if (old_data.contains("gid"))
             {


### PR DESCRIPTION
## Description
This PR is to ignore the gid and uid fields when they come with an empty string. This way the alert is cleaner, and we can take advantage of the current integration tests.

This happens because in Windows the gid field is not extracted for files.


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities
