### PR TITLE
Remove CloudWatch Logs repeated debug message

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3124,7 +3124,6 @@ class AWSCloudWatchLogs(AWSService):
                         max_end_time = event['timestamp']
                     elif event['timestamp'] > max_end_time:
                         max_end_time = event['timestamp']
-                debug(f"+++ Sent {len(response['events'])} events to Analysisd", 1)
 
             if sent_events:
                 debug(f"+++ Sent {sent_events} events to Analysisd", 1)


### PR DESCRIPTION
|Related issue|
|---|
| #18110 |


## Description

Closes #18110. Removes a debug message that was deleted in `4.5.1` but reincluded in the `4.5.2` to `4.6.0` merge.


## Tests

Related testing in [the issue](https://github.com/wazuh/wazuh/issues/18110#issuecomment-1660540744).