### PR TITLE
Fixes in MS Graph integration

### DIFF
--- a/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
+++ b/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
@@ -17,9 +17,9 @@
 #include <time.h>
 
 #include "shared.h"
-#include "wazuh_modules/wmodules.h"
-#include "wazuh_modules/wm_ms_graph.h"
-#include "wazuh_modules/wm_ms_graph.c"
+#include "../../wazuh_modules/wmodules.h"
+#include "../../wazuh_modules/wm_ms_graph.h"
+#include "../../wazuh_modules/wm_ms_graph.c"
 
 #include "../scheduling/wmodules_scheduling_helpers.h"
 #include "../../wrappers/common.h"

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -194,7 +194,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan) {
     char** headers = NULL;
     curl_response* response;
     char relationship_state_name[OS_SIZE_1024];
-    char start_time_str[80];
+    char start_time_str[WM_MS_GRAPH_TIMESTAMP_SIZE_80];
     struct tm tm_aux = { .tm_sec = 0 };
     char* payload;
     wm_ms_graph_state_t relationship_state_struc;
@@ -224,7 +224,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan) {
                 if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
                     mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
                 } else if (isDebug()) {
-                    memset(start_time_str, '\0', 80);
+                    memset(start_time_str, '\0', WM_MS_GRAPH_TIMESTAMP_SIZE_80);
                     gmtime_r(&now, &tm_aux);
                     strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
                     mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run first scan.",
@@ -233,7 +233,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan) {
                 continue;
             }
 
-            memset(start_time_str, '\0', 80);
+            memset(start_time_str, '\0', WM_MS_GRAPH_TIMESTAMP_SIZE_80);
             gmtime_r(&relationship_state_struc.next_time, &tm_aux);
             strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
 
@@ -317,7 +317,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan) {
 
             if (!fail) {
                 relationship_state_struc.next_time = now;
-                memset(start_time_str, '\0', 80);
+                memset(start_time_str, '\0', WM_MS_GRAPH_TIMESTAMP_SIZE_80);
                 gmtime_r(&relationship_state_struc.next_time, &tm_aux);
                 strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
                 if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -26,13 +26,12 @@ static void* wm_ms_graph_main(wm_ms_graph* ms_graph);
 static bool wm_ms_graph_setup(wm_ms_graph* ms_graph);
 static bool wm_ms_graph_check();
 static void wm_ms_graph_get_access_token(wm_ms_graph_auth* auth_config, const ssize_t curl_max_size);
-static void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph);
+static void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan);
 static void wm_ms_graph_destroy(wm_ms_graph* ms_graph);
 static void wm_ms_graph_cleanup();
 cJSON* wm_ms_graph_dump(const wm_ms_graph* ms_graph);
 
 static int queue_fd; // Socket ID
-time_t last_scan;
 
 const wm_context WM_MS_GRAPH_CONTEXT = {
     .name = MS_GRAPH_WM_NAME,
@@ -52,8 +51,9 @@ void* wm_ms_graph_main(wm_ms_graph* ms_graph) {
         return NULL;
     }
     else{
-        last_scan = time(NULL);
         mtinfo(WM_MS_GRAPH_LOGTAG, "Started module.");
+
+        bool initial = true;
 
         while(FOREVER()){
             const time_t time_sleep = sched_scan_get_time_until_next_scan(&ms_graph->scan_config, WM_MS_GRAPH_LOGTAG, ms_graph->run_on_start);
@@ -77,7 +77,8 @@ void* wm_ms_graph_main(wm_ms_graph* ms_graph) {
 
             if(ms_graph->auth_config.access_token && time(NULL) < ms_graph->auth_config.token_expiration_time){
                 mtinfo(WM_MS_GRAPH_LOGTAG, "Scanning tenant '%s'", ms_graph->auth_config.tenant_id);
-            wm_ms_graph_scan_relationships(ms_graph);
+                wm_ms_graph_scan_relationships(ms_graph, initial);
+                initial = false;
             }
         }
     }    
@@ -187,22 +188,54 @@ void wm_ms_graph_get_access_token(wm_ms_graph_auth* auth_config, const ssize_t c
     os_free(headers);
 }
 
-void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph) {
+void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan) {
     char url[OS_SIZE_8192];
     char auth_header[OS_SIZE_2048];
     char** headers = NULL;
-    char last_scan_timestamp[OS_SIZE_32];
-    struct tm time_struct = { .tm_sec = 0 };
     curl_response* response;
+    char relationship_state_name[OS_SIZE_1024];
+    char start_time_str[80];
+    struct tm tm_aux = { .tm_sec = 0 };
     char* payload;
+    wm_ms_graph_state_t relationship_state_struc;
+    time_t now;
+    bool fail;
 
     for(unsigned int resource_num = 0; resource_num < ms_graph->num_resources; resource_num++){
         
         for(unsigned int relationship_num = 0; relationship_num < ms_graph->resources[resource_num].num_relationships; relationship_num++){
 
-            memset(last_scan_timestamp, '\0', OS_SIZE_32);
-            gmtime_r(&last_scan, &time_struct);
-            strftime(last_scan_timestamp, sizeof(last_scan_timestamp), "%Y-%m-%dT%H:%M:%SZ", &time_struct);
+            memset(relationship_state_name, '\0', OS_SIZE_1024);
+            snprintf(relationship_state_name, OS_SIZE_1024 -1, "%s-%s-%s-%s", WM_MS_GRAPH_CONTEXT.name,
+                ms_graph->auth_config.tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num]);
+
+            memset(&relationship_state_struc, 0, sizeof(relationship_state_struc));
+
+            // Load state for tenant-resource-relationship
+            if (wm_state_io(relationship_state_name, WM_IO_READ, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
+                memset(&relationship_state_struc, 0, sizeof(relationship_state_struc));
+            }
+
+            now = time(0);
+
+            if ((initial_scan && (!relationship_state_struc.next_time || ms_graph->only_future_events)) ||
+                (!initial_scan && !relationship_state_struc.next_time)) {
+                relationship_state_struc.next_time = now;
+                if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
+                    mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
+                } else if (isDebug()) {
+                    memset(start_time_str, '\0', 80);
+                    gmtime_r(&now, &tm_aux);
+                    strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
+                    mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run first scan.",
+                        start_time_str, ms_graph->auth_config.tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);
+                }
+                continue;
+            }
+
+            memset(start_time_str, '\0', 80);
+            gmtime_r(&relationship_state_struc.next_time, &tm_aux);
+            strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
 
             memset(auth_header, '\0', OS_SIZE_2048);
             snprintf(auth_header, OS_SIZE_2048 - 1, "Authorization: Bearer %s", ms_graph->auth_config.access_token);
@@ -216,20 +249,23 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph) {
             ms_graph->version,
             ms_graph->resources[resource_num].name,
             ms_graph->resources[resource_num].relationships[relationship_num],
-            ms_graph->only_future_events ? last_scan_timestamp : "1970-01-01T00:00:00Z");
+            start_time_str);
+
             mtdebug1(WM_MS_GRAPH_LOGTAG, "Microsoft Graph API Log URL: '%s'", url);
 
+            fail = true;
+
             response = wurl_http_request(WURL_GET_METHOD, headers, url, "", ms_graph->curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
+            // It takes the time right after the response to be saved for the next scan.
+            now = time(0);
             if(response){
                 if(response->status_code != 200){
                     char status_code[4];
                     snprintf(status_code, 4, "%ld", response->status_code);
-                    mtwarn(WM_MS_GRAPH_LOGTAG, "Recieved unsuccessful status code when attempting to get relationship '%s' logs: Status code was '%s' & response was '%s'",
+                    mtwarn(WM_MS_GRAPH_LOGTAG, "Received unsuccessful status code when attempting to get relationship '%s' logs: Status code was '%s' & response was '%s'",
                     ms_graph->resources[resource_num].relationships[relationship_num],
                     status_code,
                     response->body);
-                    wurl_free_response(response);
-                    goto failed;
                 }
                 else if (response->max_size_reached){
                     mtwarn(WM_MS_GRAPH_LOGTAG, "Reached maximum CURL size when attempting to get relationship '%s' logs. Consider increasing the value of 'curl_max_size'.",
@@ -264,9 +300,11 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph) {
                                 mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse log array into singular log.");
                                 }
                             }
+                            fail = false;
                         }
                         else{
-                            mtdebug2(WM_MS_GRAPH_LOGTAG, "No new logs recieved.");
+                            mtdebug2(WM_MS_GRAPH_LOGTAG, "No new logs received.");
+                            fail = false;
                         }
                         cJSON_Delete(logs);
                     }
@@ -277,17 +315,28 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph) {
                 wurl_free_response(response);
             }
             else{
-                mtwarn(WM_MS_GRAPH_LOGTAG, "No response recieved when attempting to get relationship '%s' from resource '%s' on API version '%s'.",
+                mtwarn(WM_MS_GRAPH_LOGTAG, "No response received when attempting to get relationship '%s' from resource '%s' on API version '%s'.",
                 ms_graph->resources[resource_num].relationships[relationship_num],
                 ms_graph->resources[resource_num].name,
                 ms_graph->version);
             }
+
+            if (!fail) {
+                relationship_state_struc.next_time = now;
+                memset(start_time_str, '\0', 80);
+                gmtime_r(&relationship_state_struc.next_time, &tm_aux);
+                strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
+                if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
+                    mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
+                } else {
+                    mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run next scan.",
+                        start_time_str, ms_graph->auth_config.tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);
+                }
+            }
+
+            os_free(headers[0]);
+            os_free(headers);
         }
-    }
-    last_scan = time(NULL);
-    failed:
-    if(headers){
-        os_free(headers);
     }
 }
 

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -26,7 +26,7 @@ static void* wm_ms_graph_main(wm_ms_graph* ms_graph);
 static bool wm_ms_graph_setup(wm_ms_graph* ms_graph);
 static bool wm_ms_graph_check();
 static void wm_ms_graph_get_access_token(wm_ms_graph_auth* auth_config, const ssize_t curl_max_size);
-static void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan);
+static void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_scan);
 static void wm_ms_graph_destroy(wm_ms_graph* ms_graph);
 static void wm_ms_graph_cleanup();
 cJSON* wm_ms_graph_dump(const wm_ms_graph* ms_graph);
@@ -81,7 +81,7 @@ void* wm_ms_graph_main(wm_ms_graph* ms_graph) {
                 initial = false;
             }
         }
-    }    
+    }
     return NULL;
 }
 
@@ -120,7 +120,7 @@ bool wm_ms_graph_check(wm_ms_graph* ms_graph) {
         #else
         pthread_exit(NULL);
         #endif
-        
+
     }
     else if (!ms_graph || !ms_graph->resources || ms_graph->num_resources == 0){
         mterror(WM_MS_GRAPH_LOGTAG, "Invalid module configuration (Missing API info, resources, relationships). Exiting...");
@@ -184,11 +184,11 @@ void wm_ms_graph_get_access_token(wm_ms_graph_auth* auth_config, const ssize_t c
     else{
         mtwarn(WM_MS_GRAPH_LOGTAG, "No response recieved when attempting to obtain access token.");
     }
-    
+
     os_free(headers);
 }
 
-void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan) {
+void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_scan) {
     char url[OS_SIZE_8192];
     char auth_header[OS_SIZE_2048];
     char** headers = NULL;
@@ -202,7 +202,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan) {
     bool fail;
 
     for (unsigned int resource_num = 0; resource_num < ms_graph->num_resources; resource_num++) {
-        
+
         for (unsigned int relationship_num = 0; relationship_num < ms_graph->resources[resource_num].num_relationships; relationship_num++) {
 
             memset(relationship_state_name, '\0', OS_SIZE_1024);

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -201,9 +201,9 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan) {
     time_t now;
     bool fail;
 
-    for(unsigned int resource_num = 0; resource_num < ms_graph->num_resources; resource_num++){
+    for (unsigned int resource_num = 0; resource_num < ms_graph->num_resources; resource_num++) {
         
-        for(unsigned int relationship_num = 0; relationship_num < ms_graph->resources[resource_num].num_relationships; relationship_num++){
+        for (unsigned int relationship_num = 0; relationship_num < ms_graph->resources[resource_num].num_relationships; relationship_num++) {
 
             memset(relationship_state_name, '\0', OS_SIZE_1024);
             snprintf(relationship_state_name, OS_SIZE_1024 -1, "%s-%s-%s-%s", WM_MS_GRAPH_CONTEXT.name,
@@ -258,28 +258,26 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan) {
             response = wurl_http_request(WURL_GET_METHOD, headers, url, "", ms_graph->curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
             // It takes the time right after the response to be saved for the next scan.
             now = time(0);
-            if(response){
-                if(response->status_code != 200){
+            if (response) {
+                if (response->status_code != 200) {
                     char status_code[4];
                     snprintf(status_code, 4, "%ld", response->status_code);
                     mtwarn(WM_MS_GRAPH_LOGTAG, "Received unsuccessful status code when attempting to get relationship '%s' logs: Status code was '%s' & response was '%s'",
                     ms_graph->resources[resource_num].relationships[relationship_num],
                     status_code,
                     response->body);
-                }
-                else if (response->max_size_reached){
+                } else if (response->max_size_reached) {
                     mtwarn(WM_MS_GRAPH_LOGTAG, "Reached maximum CURL size when attempting to get relationship '%s' logs. Consider increasing the value of 'curl_max_size'.",
                     ms_graph->resources[resource_num].relationships[relationship_num]);
-                }
-                else{
+                } else {
                     cJSON* logs = NULL;
-                    if(logs = cJSON_Parse(response->body), logs){
+                    if (logs = cJSON_Parse(response->body), logs) {
                         logs = cJSON_GetObjectItem(logs, "value");
                         int num_logs = cJSON_GetArraySize(logs);
-                        if(num_logs > 0){
-                            for(int log_index = 0; log_index < num_logs; log_index++){
+                        if (num_logs > 0) {
+                            for (int log_index = 0; log_index < num_logs; log_index++) {
                                 cJSON* log = NULL;
-                                if(log = cJSON_GetArrayItem(logs, log_index), log){
+                                if (log = cJSON_GetArrayItem(logs, log_index), log) {
                                     cJSON* full_log = cJSON_CreateObject();
 
                                     cJSON_AddStringToObject(log, "resource", ms_graph->resources[resource_num].name);
@@ -295,26 +293,22 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, bool initial_scan) {
 
                                     os_free(payload);
                                     cJSON_Delete(full_log);
-                                }
-                                else{
-                                mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse log array into singular log.");
+                                } else {
+                                    mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse log array into singular log.");
                                 }
                             }
                             fail = false;
-                        }
-                        else{
+                        } else {
                             mtdebug2(WM_MS_GRAPH_LOGTAG, "No new logs received.");
                             fail = false;
                         }
                         cJSON_Delete(logs);
-                    }
-                    else{
+                    } else {
                         mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse relationship '%s' JSON body.", ms_graph->resources[resource_num].relationships[relationship_num]);
                     }
                 }
                 wurl_free_response(response);
-            }
-            else{
+            } else {
                 mtwarn(WM_MS_GRAPH_LOGTAG, "No response received when attempting to get relationship '%s' from resource '%s' on API version '%s'.",
                 ms_graph->resources[resource_num].relationships[relationship_num],
                 ms_graph->resources[resource_num].name,

--- a/src/wazuh_modules/wm_ms_graph.h
+++ b/src/wazuh_modules/wm_ms_graph.h
@@ -23,6 +23,7 @@
 #define WM_MS_GRAPH_DEFAULT_VERSION "v1.0"
 
 #define WM_MS_GRAPH_DEFAULT_TIMEOUT 60L
+#define WM_MS_GRAPH_TIMESTAMP_SIZE_80 80
 
 #define WM_MS_GRAPH_GLOBAL_API_LOGIN_FQDN "login.microsoftonline.com"
 #define WM_MS_GRAPH_GLOBAL_API_QUERY_FQDN "graph.microsoft.com"


### PR DESCRIPTION
|Related issue|
|---|
|#18174|

## Description

This PR adds some fixes to the integration with MS Graph:

- Adds functionality to store/load the timestamp of the last successful scan inside a bookmark.
- Fixes the behavior of the only_future_events configuration option.
- Allows that in case of a query failure, the following resources/relationships are scanned

## Logs

### Bookmarks:
A bookmark is created for each `resource/relationship` inside the `ossec/var/wodles/` folder following the format `ms-graph-tenantID-resource-relationship`
```
ls -l /var/ossec/var/wodles/ms-graph-*
-rw-r--r-- 1 root root 8 ago  1 20:40 /var/ossec/var/wodles/ms-graph-tenant-auditLogs-signIns
-rw-r--r-- 1 root root 8 ago  1 19:38 /var/ossec/var/wodles/ms-graph-tenant-security-alerts_v2
-rw-r--r-- 1 root root 8 ago  1 19:38 /var/ossec/var/wodles/ms-graph-tenant-security-incidents
```

`wm_ms_graph.c:326 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2023-08-01T23:28:05Z' for tenant 'tenant' resource 'auditLogs' and relationship 'signIns', waiting '60' seconds to run next scan.`

### Behavior of the only_future_events configuration option
**<only_future_events>no</only_future_events>** :  after a restart of the manager/agent, the logs are requested from the date saved in the bookmark

Last saved timestamp:
`wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2023-08-01T23:40:04Z' for tenant 'tenant' resource 'auditLogs' and relationship 'signIns', waiting '60' seconds to run next scan.`

Wazuh service stop:
```
.....
wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
wazuh-analysisd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
wazuh-db: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
wazuh-authd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
wazuh-authd: INFO: Exiting...
```
Wazuh service start:
The first post-start query is made from the timestamp saved in the bookmark
```
wm_ms_graph_main(): INFO: Scanning tenant 'tenant'
wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-08-01T23:40:04Z'
wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2023-08-02T00:01:00Z' for tenant 'tenant' resource 'auditLogs' and relationship 'signIns', waiting '60' seconds to run next scan.
```

### Allows that in case of a query failure, the following resources/relationships are scanned:
Given the following configuration:
```
  <ms-graph>
    <enabled>yes</enabled>
    <only_future_events>no</only_future_events>
    <curl_max_size>10M</curl_max_size>
    <run_on_start>no</run_on_start>
    <interval>1m</interval>
    <version>v1.0</version>
    <api_auth>
      <tenant_id>tenant</tenant_id>
      <client_id>client</client_id>
      <secret_value>secret</secret_value>
      <api_type>global</api_type>
    </api_auth>
    <resource>
      <name>auditLogs</name>
      <relationship>signIns</relationship>
    </resource>
    <resource>
      <name>security</name>
      <relationship>alerts_v2</relationship>
      <relationship>incidents</relationship>
    </resource>
  </ms-graph>
```
As seen in the logs, if the `security/alerts_v2` scan fails, the following configured `resources/relationships` continue to be scanned, in this case with `security/incidents`:

```
wm_ms_graph_main(): INFO: Scanning tenant 'tenant'
wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-08-02T00:09:58Z'
wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2023-08-02T00:10:58Z' for tenant 'tenant' resource 'auditLogs' and relationship 'signIns', waiting '60' seconds to run next scan.
wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+gt+2023-08-01T22:38:04Z'
wm_ms_graph_scan_relationships(): WARNING: Received unsuccessful status code when attempting to get relationship 'alerts_v2' logs: Status code was '403' & response was '{"error":{"code":"Unauthorized","message":"..."}}}'
wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/incidents?$filter=createdDateTime+gt+2023-08-01T22:38:04Z'
wm_ms_graph_scan_relationships(): WARNING: Received unsuccessful status code when attempting to get relationship 'incidents' logs: Status code was '403' & response was '{"error":{"code":"Unauthorized","message":"..."}}}'
```


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- Memory tests for Windows
  - [x] Scan-build report
- Memory tests for macOS
  - [x] Scan-build report

