### PR TITLE
Revoke JWT tokens endpoint internal error

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -336,11 +336,11 @@ class DistributedAPI:
 
         :return: client. Maybe an instance of LocalClient, WorkerHandler or MasterHandler
         """
-        if isinstance(self.node, local_client.LocalClient):
-            client = self.node
-        else:
+        if self.node == local_client:
             client = local_client.LocalClient()
             self.local_clients.append(client)
+        else:
+            client = self.node
 
         return client
 

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -336,11 +336,11 @@ class DistributedAPI:
 
         :return: client. Maybe an instance of LocalClient, WorkerHandler or MasterHandler
         """
-        if self.node == local_client:
+        if isinstance(self.node, local_client.LocalClient):
+            client = self.node
+        else:
             client = local_client.LocalClient()
             self.local_clients.append(client)
-        else:
-            client = self.node
 
         return client
 

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -355,7 +355,7 @@ def test_DistributedAPI_get_client(loop_mock):
 
     node = Node()
     dapi = DistributedAPI(f=agent.get_agents_summary_status, node=node, logger=logger)
-    assert isinstance(dapi.get_client(), local_client.LocalClient)
+    assert dapi.get_client()
 
 
 @patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'worker'})

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -347,7 +347,7 @@ def test_DistributedAPI_get_client(loop_mock):
             self.cluster_items = {"cluster_items": ["worker1", "worker2"]}
 
         def get_node(self):
-            return local_client.LocalClient()
+            pass
 
     logger = logging.getLogger("test")
     dapi = DistributedAPI(f=agent.get_agents_summary_status, logger=logger)
@@ -355,7 +355,7 @@ def test_DistributedAPI_get_client(loop_mock):
 
     node = Node()
     dapi = DistributedAPI(f=agent.get_agents_summary_status, node=node, logger=logger)
-    assert dapi.get_client() == node
+    assert isinstance(dapi.get_client(), local_client.LocalClient)
 
 
 @patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'worker'})

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -347,7 +347,7 @@ def test_DistributedAPI_get_client(loop_mock):
             self.cluster_items = {"cluster_items": ["worker1", "worker2"]}
 
         def get_node(self):
-            pass
+            return local_client.LocalClient()
 
     logger = logging.getLogger("test")
     dapi = DistributedAPI(f=agent.get_agents_summary_status, logger=logger)

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -301,7 +301,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         else:
             return super().process_request(command, data)
 
-    async def execute(self, command: bytes, data: bytes, wait_for_complete: bool = True) -> Dict:
+    async def execute(self, command: bytes, data: bytes, wait_for_complete: bool = False) -> Dict:
         """Send DAPI request and wait for response.
 
         Send a distributed API request and wait for a response in command dapi_res. Methods here are the same

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -301,7 +301,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         else:
             return super().process_request(command, data)
 
-    async def execute(self, command: bytes, data: bytes, wait_for_complete: bool) -> Dict:
+    async def execute(self, command: bytes, data: bytes, wait_for_complete: bool = True) -> Dict:
         """Send DAPI request and wait for response.
 
         Send a distributed API request and wait for a response in command dapi_res. Methods here are the same


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The internal server error 500 occurred because `execute()` was expecting the argument: `'wait_for_complete`':
**/var/ossec/logs/cluster.log**
```
File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.6.0-py3.9.egg/wazuh/core/cluster/control.py", line 55, in get_nodes
    response = await lc.execute(command=b'get_nodes', data=json.dumps(arguments).encode())
TypeError: execute() missing 1 required positional argument: 'wait_for_complete'
```

The `get_client()` function was modified to perform proper validation using `isinstance(self.node, local_client.LocalClient)`. This allowed to verify if self.node was already a valid instance of `local_client.LocalClient`. If it was, the function simply returned `self.node`. Otherwise, a new instance of `local_client.LocalClient()` was created and stored in a list before being returned as a result.

With this change, the `execute()` function was able to run correctly with the appropriate client, and the missing argument error was resolved.


## Logs/Alerts example

**Reply from var/ossec/logs/api.log obtained**
```
2023/08/02 09:41:08 INFO: wazuh 127.0.0.1 "POST /security/user/authenticate" with parameters {"raw": "true"} and body {} done in 0.466s: 200
2023/08/02 09:41:11 INFO: wazuh 127.0.0.1 "GET /agents" with parameters {} and body {} done in 0.103s: 200
2023/08/02 09:41:15 INFO: wazuh 127.0.0.1 "PUT /security/user/revoke" with parameters {} and body {} done in 0.106s: 200
2023/08/02 09:41:23 INFO: unknown_user 127.0.0.1 "GET /agents" with parameters {} and body {} done in 0.002s: 401
```


## Tests

```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/wazuh/Git/wazuh/framework
plugins: metadata-2.0.4, aiohttp-1.0.4, anyio-3.6.2, trio-0.7.0, html-3.0.0, asyncio-0.18.1, cov-2.12.0
asyncio: mode=auto
collected 32 items                                                                                                                                                                                                

framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                       [100%]

================================================================================================ warnings summary =================================================================================================
../../venv/unittest-env/lib/python3.10/site-packages/pytest_aiohttp/plugin.py:28
  /home/wazuh/venv/unittest-env/lib/python3.10/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

../../venv/unittest-env/lib/python3.10/site-packages/aiohttp_jinja2/helpers.py:24
  /home/wazuh/venv/unittest-env/lib/python3.10/site-packages/aiohttp_jinja2/helpers.py:24: DeprecationWarning: 'contextfunction' is renamed to 'pass_context', the old name will be removed in Jinja 3.1.
    def url_for(

../../venv/unittest-env/lib/python3.10/site-packages/aiohttp_jinja2/helpers.py:62
  /home/wazuh/venv/unittest-env/lib/python3.10/site-packages/aiohttp_jinja2/helpers.py:62: DeprecationWarning: 'contextfunction' is renamed to 'pass_context', the old name will be removed in Jinja 3.1.
    def static_url(context: _Context, static_file_path: str) -> str:

../../venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:48
  /home/wazuh/venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:48: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def problems_middleware(request, handler):

../../venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:169
  /home/wazuh/venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:169: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_json(self, request):

../../venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:177
  /home/wazuh/venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:177: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_yaml(self, request):

../../venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:236
  /home/wazuh/venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:236: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_home(self, req):

../../venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:246
  /home/wazuh/venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:246: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_config(self, req):

../../venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:295
  /home/wazuh/venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:295: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_request(cls, req):

../../venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:324
  /home/wazuh/venv/unittest-env/lib/python3.10/site-packages/connexion/apis/aiohttp_api.py:324: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_response(cls, response, mimetype=None, request=None):

framework/wazuh/core/database.py:8
  /home/wazuh/Git/wazuh/framework/wazuh/core/database.py:8: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils.version import LooseVersion

framework/wazuh/core/cluster/dapi/tests/test_dapi.py:39
  /home/wazuh/Git/wazuh/framework/wazuh/core/cluster/dapi/tests/test_dapi.py:39: DeprecationWarning: There is no current event loop
    loop = asyncio.get_event_loop()

framework/wazuh/core/cluster/dapi/tests/test_dapi.py:67
  /home/wazuh/Git/wazuh/framework/wazuh/core/cluster/dapi/tests/test_dapi.py:67: PytestCollectionWarning: cannot collect test class 'TestingLoggerParent' because it has a __init__ constructor (from: wazuh/core/cluster/dapi/tests/test_dapi.py)
    class TestingLoggerParent:

framework/wazuh/core/cluster/dapi/tests/test_dapi.py:73
  /home/wazuh/Git/wazuh/framework/wazuh/core/cluster/dapi/tests/test_dapi.py:73: PytestCollectionWarning: cannot collect test class 'TestingLogger' because it has a __init__ constructor (from: wazuh/core/cluster/dapi/tests/test_dapi.py)
    class TestingLogger:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================= 32 passed, 14 warnings in 0.45s =========================================================================================

```

