### PR TITLE
Fix IT actions triggers - QA framework base branch - 4.7.0

### DIFF
--- a/.github/workflows/integration-tests-analysisd-tier-0-1.yml
+++ b/.github/workflows/integration-tests-analysisd-tier-0-1.yml
@@ -1,7 +1,12 @@
-name: Analisysd integration tests tier 0 and 1
+name: Integration tests for Analisysd - Tier 0 and 1
 
 on:
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
   pull_request:
     paths:
         - ".github/workflows/integration-tests-analysisd-tier-0-1.yml"
@@ -12,6 +17,9 @@ on:
 
 jobs:
   build:
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -60,9 +68,14 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
-          BRANCH_NAME=main
-          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${GITHUB_HEAD_REF}`" != "X" ]; then BRANCH_NAME=${GITHUB_HEAD_REF}; fi
-          git clone -b $BRANCH_NAME --single-branch https://github.com/wazuh/qa-integration-framework.git
+          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_NAME}
+          elif [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_BASE}
+          else
+              QA_BRANCH="main"
+          fi
+          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run analysisd integration tests.

--- a/.github/workflows/integration-tests-analysisd-tier-2.yml
+++ b/.github/workflows/integration-tests-analysisd-tier-2.yml
@@ -1,10 +1,18 @@
-name: Analisysd integration tests tier 2
+name: Integration tests for Analisysd - Tier 2
 
 on:
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
 
 jobs:
   build:
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -53,9 +61,14 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
-          BRANCH_NAME=main
-          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${GITHUB_REF#refs/heads/}`" != "X" ]; then BRANCH_NAME=${GITHUB_REF#refs/heads/}; fi
-          git clone -b $BRANCH_NAME --single-branch https://github.com/wazuh/qa-integration-framework.git
+          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_NAME}
+          elif [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_BASE}
+          else
+              QA_BRANCH="main"
+          fi
+          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run analysisd integration tests.

--- a/.github/workflows/integration-tests-api-tier-0-1.yml
+++ b/.github/workflows/integration-tests-api-tier-0-1.yml
@@ -2,6 +2,11 @@ name: Integration tests for API - Tier 0 and 1
 
 on:
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
   pull_request:
     paths:
         - ".github/workflows/integration-tests-api-tier-0-1.yml"
@@ -12,6 +17,9 @@ on:
 
 jobs:
   build:
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -60,9 +68,14 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
-          BRANCH_NAME=main
-          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${GITHUB_HEAD_REF}`" != "X" ]; then BRANCH_NAME=${GITHUB_HEAD_REF}; fi
-          git clone -b $BRANCH_NAME --single-branch https://github.com/wazuh/qa-integration-framework.git
+          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_NAME}
+          elif [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_BASE}
+          else
+              QA_BRANCH="main"
+          fi
+          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run integration tests.

--- a/.github/workflows/integration-tests-api-tier-2.yml
+++ b/.github/workflows/integration-tests-api-tier-2.yml
@@ -2,9 +2,17 @@ name: Integration tests for API - Tier 2
 
 on:
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
 
 jobs:
   build:
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -53,9 +61,14 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
-          BRANCH_NAME=main
-          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${GITHUB_HEAD_REF}`" != "X" ]; then BRANCH_NAME=${GITHUB_HEAD_REF}; fi
-          git clone -b $BRANCH_NAME --single-branch https://github.com/wazuh/qa-integration-framework.git
+          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_NAME}
+          elif [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_BASE}
+          else
+              QA_BRANCH="main"
+          fi
+          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run integration tests.

--- a/.github/workflows/integration-tests-execd-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-execd-tier-0-1-lin.yml
@@ -1,7 +1,12 @@
-name: Execd integration tests tier 0 and 1 on Linux
+name: Integration tests for Execd on Linux - Tier 0 and 1
 
 on:
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
   pull_request:
     paths:
         - ".github/workflows/integration-tests-execd-tier-0-1-lin.yml"
@@ -12,6 +17,9 @@ on:
 
 jobs:
   build:
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -58,9 +66,14 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
-          BRANCH_NAME=main
-          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${GITHUB_HEAD_REF}`" != "X" ]; then BRANCH_NAME=${GITHUB_HEAD_REF}; fi
-          git clone -b $BRANCH_NAME --single-branch https://github.com/wazuh/qa-integration-framework.git
+          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_NAME}
+          elif [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_BASE}
+          else
+              QA_BRANCH="main"
+          fi
+          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run execd integration tests.

--- a/.github/workflows/integration-tests-execd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-execd-tier-0-1-win.yml
@@ -1,7 +1,12 @@
-name: Execd integration tests tier 0 and 1 on Windows
+name: Integration tests for Execd on Windows - Tier 0 and 1
 
 on:
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
   pull_request:
     paths:
         - ".github/workflows/integration-tests-execd-tier-0-1-win.yml"
@@ -9,6 +14,7 @@ on:
         - "src/Makefile"
         - "tests/integration/conftest.py"
         - "tests/integration/test_execd/**"
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -40,6 +46,9 @@ jobs:
   # Execute the tests on windows.
   run-test:
     needs: build
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: windows-latest
     steps:
       - name: Checkout Repo
@@ -72,11 +81,14 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
         run: |
-          $BRANCH_NAME = "main"
-          if (git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git $env:GITHUB_HEAD_REF) {
-              $BRANCH_NAME = $env:GITHUB_HEAD_REF
+          if (git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
+              $QA_BRANCH = $env:BRANCH_NAME
+          } elseif (git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
+              $QA_BRANCH = $env:BRANCH_BASE
+          } else {
+              $QA_BRANCH = "main"
           }
-          git clone -b $BRANCH_NAME --single-branch https://github.com/wazuh/qa-integration-framework.git
+          git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
           rm qa-integration-framework/ -r -force
       # Run execd integration tests.

--- a/.github/workflows/integration-tests-rbac-tier-0-1.yml
+++ b/.github/workflows/integration-tests-rbac-tier-0-1.yml
@@ -2,13 +2,24 @@ name: Integration tests for RBAC (Framework) - Tier 0 and 1
 
 on:
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
   pull_request:
     paths:
-        - ".github/workflows/integration-tests-rbac.yml"
+        - ".github/workflows/integration-tests-rbac-tier-0-1.yml"
         - "framework/wazuh/rbac/"
+        - "src/Makefile"
+        - "tests/integration/conftest.py"
+        - "tests/integration/test_api/test_rbac/**"
 
 jobs:
   build:
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -57,9 +68,14 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
-          BRANCH_NAME=main
-          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${GITHUB_HEAD_REF}`" != "X" ]; then BRANCH_NAME=${GITHUB_HEAD_REF}; fi
-          git clone -b $BRANCH_NAME --single-branch https://github.com/wazuh/qa-integration-framework.git
+          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_NAME}
+          elif [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_BASE}
+          else
+              QA_BRANCH="main"
+          fi
+          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run integration tests.


### PR DESCRIPTION
## Description

This PR adds the capability of detecting the base branch of the QA framework. If manually triggered, the possibility to set it manually was also included.

Fix for 4.7.0

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
