### PR TITLE
Engine - KVDB - Prefix Search

### DIFF
--- a/src/engine/source/api/include/api/kvdb/handlers.hpp
+++ b/src/engine/source/api/include/api/kvdb/handlers.hpp
@@ -17,6 +17,7 @@ api::Handler managerDump(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager,
 api::Handler dbGet(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const std::string& kvdbScopeName);
 api::Handler dbDelete(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const std::string& kvdbScopeName);
 api::Handler dbPut(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const std::string& kvdbScopeName);
+api::Handler dbSearch(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const std::string& kvdbScopeName);
 
 void registerHandlers(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const std::string& kvdbScopeName, std::shared_ptr<api::Api>);
 } // namespace api::kvdb::handlers

--- a/src/engine/source/api/src/kvdb/handlers.cpp
+++ b/src/engine/source/api/src/kvdb/handlers.cpp
@@ -15,6 +15,12 @@ namespace api::kvdb::handlers
 namespace eKVDB = ::com::wazuh::api::engine::kvdb;
 namespace eEngine = ::com::wazuh::api::engine;
 
+constexpr auto MESSAGE_DB_NOT_EXISTS = "The KVDB '{}' does not exist.";
+constexpr auto MESSAGE_MISSING_NAME = "Missing /name";
+constexpr auto MESSAGE_NAME_EMPTY = "Field /name is empty";
+constexpr auto MESSAGE_MISSING_KEY = "Missing /key";
+constexpr auto MESSAGE_KEY_EMPTY = "Field /key is empty";
+
 /* Manager Endpoint */
 
 api::Handler managerGet(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager)
@@ -66,8 +72,8 @@ api::Handler managerPost(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager)
 
         const auto& eRequest = std::get<RequestType>(res);
 
-        auto errorMsg = !eRequest.has_name()      ? std::make_optional("Missing /name")
-                        : eRequest.name().empty() ? std::make_optional("Field /name can not be empty")
+        auto errorMsg = !eRequest.has_name()      ? std::make_optional(MESSAGE_MISSING_NAME)
+                        : eRequest.name().empty() ? std::make_optional(MESSAGE_NAME_EMPTY)
                                                   : std::nullopt;
         if (errorMsg.has_value())
         {
@@ -118,8 +124,8 @@ api::Handler managerDelete(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManage
         }
         const auto& eRequest = std::get<RequestType>(res);
 
-        auto errorMsg = !eRequest.has_name()      ? std::make_optional("Missing /name")
-                        : eRequest.name().empty() ? std::make_optional("Field /name is empty")
+        auto errorMsg = !eRequest.has_name()      ? std::make_optional(MESSAGE_MISSING_NAME)
+                        : eRequest.name().empty() ? std::make_optional(MESSAGE_NAME_EMPTY)
                                                   : std::nullopt;
         if (errorMsg.has_value())
         {
@@ -129,7 +135,7 @@ api::Handler managerDelete(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManage
         if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
-                fmt::format("The KVDB '{}' does not exist.", eRequest.name()));
+                fmt::format(MESSAGE_DB_NOT_EXISTS, eRequest.name()));
         }
 
         const auto resultDelete = kvdbManager->deleteDB(eRequest.name());
@@ -158,7 +164,7 @@ api::Handler managerDump(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager,
         }
 
         const auto& eRequest = std::get<RequestType>(res);
-        auto errorMsg = !eRequest.has_name()      ? std::make_optional("Missing /name")
+        auto errorMsg = !eRequest.has_name()      ? std::make_optional(MESSAGE_MISSING_NAME)
                         : eRequest.name().empty() ? std::make_optional("Field /name cannot be empty")
                                                   : std::nullopt;
         if (errorMsg.has_value())
@@ -169,7 +175,7 @@ api::Handler managerDump(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager,
         if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
-                fmt::format("The KVDB '{}' does not exist.", eRequest.name()));
+                fmt::format(MESSAGE_DB_NOT_EXISTS, eRequest.name()));
         }
 
         auto resultHandler = kvdbManager->getKVDBHandler(eRequest.name(), kvdbScopeName);
@@ -231,10 +237,10 @@ api::Handler dbGet(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const
         const auto& eRequest = std::get<RequestType>(res);
 
         // Validate the params request
-        auto errorMsg = !eRequest.has_name()      ? std::make_optional("Missing /name")
-                        : eRequest.name().empty() ? std::make_optional("Field /name is empty")
-                        : !eRequest.has_key()     ? std::make_optional("Missing /key")
-                        : eRequest.key().empty()  ? std::make_optional("Field /key is empty")
+        auto errorMsg = !eRequest.has_name()      ? std::make_optional(MESSAGE_MISSING_NAME)
+                        : eRequest.name().empty() ? std::make_optional(MESSAGE_NAME_EMPTY)
+                        : !eRequest.has_key()     ? std::make_optional(MESSAGE_MISSING_KEY)
+                        : eRequest.key().empty()  ? std::make_optional(MESSAGE_KEY_EMPTY)
                                                   : std::nullopt;
         if (errorMsg.has_value())
         {
@@ -244,7 +250,7 @@ api::Handler dbGet(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const
         if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
-                fmt::format("The KVDB '{}' does not exist.", eRequest.name()));
+                fmt::format(MESSAGE_DB_NOT_EXISTS, eRequest.name()));
         }
 
         auto resultHandler = kvdbManager->getKVDBHandler(eRequest.name(), kvdbScopeName);
@@ -296,10 +302,10 @@ api::Handler dbDelete(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, co
         const auto& eRequest = std::get<RequestType>(res);
 
         // Validate the params request
-        auto errorMsg = !eRequest.has_name()      ? std::make_optional("Missing /name")
-                        : eRequest.name().empty() ? std::make_optional("Field /name is empty")
-                        : !eRequest.has_key()     ? std::make_optional("Missing /key")
-                        : eRequest.key().empty()  ? std::make_optional("Field /key is empty")
+        auto errorMsg = !eRequest.has_name()      ? std::make_optional(MESSAGE_MISSING_NAME)
+                        : eRequest.name().empty() ? std::make_optional(MESSAGE_NAME_EMPTY)
+                        : !eRequest.has_key()     ? std::make_optional(MESSAGE_MISSING_KEY)
+                        : eRequest.key().empty()  ? std::make_optional(MESSAGE_KEY_EMPTY)
                                                   : std::nullopt;
         if (errorMsg.has_value())
         {
@@ -309,7 +315,7 @@ api::Handler dbDelete(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, co
         if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
-                fmt::format("The KVDB '{}' does not exist.", eRequest.name()));
+                fmt::format(MESSAGE_DB_NOT_EXISTS, eRequest.name()));
         }
 
         auto resultHandler = kvdbManager->getKVDBHandler(eRequest.name(), kvdbScopeName);
@@ -347,8 +353,8 @@ api::Handler dbPut(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const
         }
         const auto& eRequest = std::get<RequestType>(res);
 
-        auto errorMsg = !eRequest.has_name()            ? std::make_optional("Missing /name")
-                        : eRequest.name().empty()       ? std::make_optional("Field /name is empty")
+        auto errorMsg = !eRequest.has_name()            ? std::make_optional(MESSAGE_MISSING_NAME)
+                        : eRequest.name().empty()       ? std::make_optional(MESSAGE_NAME_EMPTY)
                         : !eRequest.has_entry()         ? std::make_optional("Missing /entry")
                         : !eRequest.entry().has_key()   ? std::make_optional("Missing /entry/key")
                         : !eRequest.entry().has_value() ? std::make_optional("Missing /entry/value")
@@ -367,7 +373,7 @@ api::Handler dbPut(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const
 
         if (eRequest.entry().key().empty())
         {
-            return ::api::adapter::genericError<ResponseType>("Field /key is empty");
+            return ::api::adapter::genericError<ResponseType>(MESSAGE_KEY_EMPTY);
         }
 
         if (std::get<std::string>(value).empty())
@@ -378,7 +384,7 @@ api::Handler dbPut(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const
         if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
-                fmt::format("The KVDB '{}' does not exist.", eRequest.name()));
+                fmt::format(MESSAGE_DB_NOT_EXISTS, eRequest.name()));
         }
 
         auto resultHandler = kvdbManager->getKVDBHandler(eRequest.name(), kvdbScopeName);
@@ -416,8 +422,8 @@ api::Handler dbSearch(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, co
         const auto& eRequest = std::get<RequestType>(res);
 
         // Validate the params request
-        auto errorMsg = !eRequest.has_name()        ? std::make_optional("Missing /name")
-                        : eRequest.name().empty()   ? std::make_optional("Field /name is empty")
+        auto errorMsg = !eRequest.has_name()        ? std::make_optional(MESSAGE_MISSING_NAME)
+                        : eRequest.name().empty()   ? std::make_optional(MESSAGE_NAME_EMPTY)
                         : !eRequest.has_prefix()    ? std::make_optional("Missing /prefix")
                         : eRequest.prefix().empty() ? std::make_optional("Field /prefix is empty")
                                                     : std::nullopt;
@@ -430,7 +436,7 @@ api::Handler dbSearch(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, co
         if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
-                fmt::format("The KVDB '{}' does not exist.", eRequest.name()));
+                fmt::format(MESSAGE_DB_NOT_EXISTS, eRequest.name()));
         }
 
         auto resultHandler = kvdbManager->getKVDBHandler(eRequest.name(), kvdbScopeName);

--- a/src/engine/source/api/src/kvdb/handlers.cpp
+++ b/src/engine/source/api/src/kvdb/handlers.cpp
@@ -66,20 +66,15 @@ api::Handler managerPost(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager)
 
         const auto& eRequest = std::get<RequestType>(res);
 
-        // Validate the params request
-        if (!eRequest.has_name())
+        auto errorMsg = !eRequest.has_name()      ? std::make_optional("Missing /name")
+                        : eRequest.name().empty() ? std::make_optional("Field /name can not be empty")
+                                                  : std::nullopt;
+        if (errorMsg.has_value())
         {
-            return ::api::adapter::genericError<ResponseType>("Missing /name");
+            return ::api::adapter::genericError<ResponseType>(errorMsg.value());
         }
 
-        if (eRequest.name().empty())
-        {
-            return ::api::adapter::genericError<ResponseType>("Field /name can not be empty");
-        }
-
-        const auto resultExists = kvdbManager->existsDB(eRequest.name());
-
-        if (resultExists)
+        if (kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>("The Database already exists.");
         }
@@ -123,23 +118,18 @@ api::Handler managerDelete(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManage
         }
         const auto& eRequest = std::get<RequestType>(res);
 
-        // Validate the params request
-        if (!eRequest.has_name())
+        auto errorMsg = !eRequest.has_name()      ? std::make_optional("Missing /name")
+                        : eRequest.name().empty() ? std::make_optional("Field /name is empty")
+                                                  : std::nullopt;
+        if (errorMsg.has_value())
         {
-            return ::api::adapter::genericError<ResponseType>("Missing /name");
+            return ::api::adapter::genericError<ResponseType>(errorMsg.value());
         }
 
-        if (eRequest.name().empty())
-        {
-            return ::api::adapter::genericError<ResponseType>("Field /name is empty");
-        }
-
-        const auto resultExists = kvdbManager->existsDB(eRequest.name());
-
-        if (!resultExists)
+        if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
-                fmt::format("The KVDB {} does not exist.", eRequest.name()));
+                fmt::format("The KVDB '{}' does not exist.", eRequest.name()));
         }
 
         const auto resultDelete = kvdbManager->deleteDB(eRequest.name());
@@ -166,21 +156,17 @@ api::Handler managerDump(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager,
         {
             return std::move(std::get<api::wpResponse>(res));
         }
+
         const auto& eRequest = std::get<RequestType>(res);
-
-        // Validate the params request
-        if (!eRequest.has_name())
+        auto errorMsg = !eRequest.has_name()      ? std::make_optional("Missing /name")
+                        : eRequest.name().empty() ? std::make_optional("Field /name cannot be empty")
+                                                  : std::nullopt;
+        if (errorMsg.has_value())
         {
-            return ::api::adapter::genericError<ResponseType>("Missing /name");
-        }
-        if (eRequest.name().empty())
-        {
-            return ::api::adapter::genericError<ResponseType>("Field /name cannot be empty");
+            return ::api::adapter::genericError<ResponseType>(errorMsg.value());
         }
 
-        const auto resultExists = kvdbManager->existsDB(eRequest.name());
-
-        if (!resultExists)
+        if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
                 fmt::format("The KVDB '{}' does not exist.", eRequest.name()));
@@ -245,27 +231,17 @@ api::Handler dbGet(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const
         const auto& eRequest = std::get<RequestType>(res);
 
         // Validate the params request
-        auto errorMsg = !eRequest.has_name()  ? std::make_optional("Missing /name")
-                        : !eRequest.has_key() ? std::make_optional("Missing /key")
-                                              : std::nullopt;
+        auto errorMsg = !eRequest.has_name()      ? std::make_optional("Missing /name")
+                        : eRequest.name().empty() ? std::make_optional("Field /name is empty")
+                        : !eRequest.has_key()     ? std::make_optional("Missing /key")
+                        : eRequest.key().empty()  ? std::make_optional("Field /key is empty")
+                                                  : std::nullopt;
         if (errorMsg.has_value())
         {
             return ::api::adapter::genericError<ResponseType>(errorMsg.value());
         }
 
-        if (eRequest.name().empty())
-        {
-            return ::api::adapter::genericError<ResponseType>("Field /name is empty");
-        }
-
-        if (eRequest.key().empty())
-        {
-            return ::api::adapter::genericError<ResponseType>("Field /key is empty");
-        }
-
-        const auto resultExists = kvdbManager->existsDB(eRequest.name());
-
-        if (!resultExists)
+        if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
                 fmt::format("The KVDB '{}' does not exist.", eRequest.name()));
@@ -320,30 +296,20 @@ api::Handler dbDelete(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, co
         const auto& eRequest = std::get<RequestType>(res);
 
         // Validate the params request
-        auto errorMsg = !eRequest.has_name()  ? std::make_optional("Missing /name")
-                        : !eRequest.has_key() ? std::make_optional("Missing /key")
-                                              : std::nullopt;
+        auto errorMsg = !eRequest.has_name()      ? std::make_optional("Missing /name")
+                        : eRequest.name().empty() ? std::make_optional("Field /name is empty")
+                        : !eRequest.has_key()     ? std::make_optional("Missing /key")
+                        : eRequest.key().empty()  ? std::make_optional("Field /key is empty")
+                                                  : std::nullopt;
         if (errorMsg.has_value())
         {
             return ::api::adapter::genericError<ResponseType>(errorMsg.value());
         }
 
-        if (eRequest.name().empty())
-        {
-            return ::api::adapter::genericError<ResponseType>("Field /name is empty");
-        }
-
-        if (eRequest.key().empty())
-        {
-            return ::api::adapter::genericError<ResponseType>("Field /key is empty");
-        }
-
-        const auto resultExists = kvdbManager->existsDB(eRequest.name());
-
-        if (!resultExists)
+        if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
-                fmt::format("The KVDB {} does not exist.", eRequest.name()));
+                fmt::format("The KVDB '{}' does not exist.", eRequest.name()));
         }
 
         auto resultHandler = kvdbManager->getKVDBHandler(eRequest.name(), kvdbScopeName);
@@ -382,6 +348,7 @@ api::Handler dbPut(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const
         const auto& eRequest = std::get<RequestType>(res);
 
         auto errorMsg = !eRequest.has_name()            ? std::make_optional("Missing /name")
+                        : eRequest.name().empty()       ? std::make_optional("Field /name is empty")
                         : !eRequest.has_entry()         ? std::make_optional("Missing /entry")
                         : !eRequest.entry().has_key()   ? std::make_optional("Missing /entry/key")
                         : !eRequest.entry().has_value() ? std::make_optional("Missing /entry/value")
@@ -398,11 +365,6 @@ api::Handler dbPut(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const
             return ::api::adapter::genericError<ResponseType>(std::get<base::Error>(value).message);
         }
 
-        if (eRequest.name().empty())
-        {
-            return ::api::adapter::genericError<ResponseType>("Field /name is empty");
-        }
-
         if (eRequest.entry().key().empty())
         {
             return ::api::adapter::genericError<ResponseType>("Field /key is empty");
@@ -413,12 +375,10 @@ api::Handler dbPut(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, const
             return ::api::adapter::genericError<ResponseType>("Field /value is empty");
         }
 
-        const auto resultExists = kvdbManager->existsDB(eRequest.name());
-
-        if (!resultExists)
+        if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
-                fmt::format("The KVDB {} does not exist.", eRequest.name()));
+                fmt::format("The KVDB '{}' does not exist.", eRequest.name()));
         }
 
         auto resultHandler = kvdbManager->getKVDBHandler(eRequest.name(), kvdbScopeName);
@@ -456,27 +416,18 @@ api::Handler dbSearch(std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager, co
         const auto& eRequest = std::get<RequestType>(res);
 
         // Validate the params request
-        auto errorMsg = !eRequest.has_name()  ? std::make_optional("Missing /name")
-                        : !eRequest.has_prefix() ? std::make_optional("Missing /prefix")
-                                              : std::nullopt;
+        auto errorMsg = !eRequest.has_name()        ? std::make_optional("Missing /name")
+                        : eRequest.name().empty()   ? std::make_optional("Field /name is empty")
+                        : !eRequest.has_prefix()    ? std::make_optional("Missing /prefix")
+                        : eRequest.prefix().empty() ? std::make_optional("Field /prefix is empty")
+                                                    : std::nullopt;
+
         if (errorMsg.has_value())
         {
             return ::api::adapter::genericError<ResponseType>(errorMsg.value());
         }
 
-        if (eRequest.name().empty())
-        {
-            return ::api::adapter::genericError<ResponseType>("Field /name is empty");
-        }
-
-        if (eRequest.prefix().empty())
-        {
-            return ::api::adapter::genericError<ResponseType>("Field /prefix is empty");
-        }
-
-        const auto resultExists = kvdbManager->existsDB(eRequest.name());
-
-        if (!resultExists)
+        if (!kvdbManager->existsDB(eRequest.name()))
         {
             return ::api::adapter::genericError<ResponseType>(
                 fmt::format("The KVDB '{}' does not exist.", eRequest.name()));

--- a/src/engine/source/cmds/include/cmds/kvdb.hpp
+++ b/src/engine/source/cmds/include/cmds/kvdb.hpp
@@ -23,6 +23,7 @@ constexpr auto API_KVDB_GET_SUBCOMMAND {"get"};
 constexpr auto API_KVDB_INSERT_SUBCOMMAND {"insert"};
 constexpr auto API_KVDB_LIST_SUBCOMMAND {"list"};
 constexpr auto API_KVDB_REMOVE_SUBCOMMAND {"remove"};
+constexpr auto API_KVDB_SEARCH_SUBCOMMAND {"search"};
 
 } // namespace details
 
@@ -36,7 +37,7 @@ void runInsertKV(std::shared_ptr<apiclnt::Client> client,
                  const std::string& kvdbKey,
                  const std::string& kvdbValue);
 void runRemoveKV(std::shared_ptr<apiclnt::Client> client, const std::string& kvdbName, const std::string& kvdbKey);
-
+void runSearch(std::shared_ptr<apiclnt::Client> client, const std::string& kvdbName, const std::string& prefix);
 void configure(const CLI::App_p& app);
 
 } // namespace cmd::kvdb

--- a/src/engine/source/kvdb/include/kvdb/iKVDBHandler.hpp
+++ b/src/engine/source/kvdb/include/kvdb/iKVDBHandler.hpp
@@ -79,6 +79,14 @@ public:
      * @return std::variant<std::unordered_map<std::string, std::string>, base::Error> Map of key-value pairs. Specific error otherwise.
      */
     virtual std::variant<std::unordered_map<std::string, std::string>, base::Error> dump() = 0;
+
+    /**
+     * @brief Retrieves all filtered content.
+     *
+     * @param key Filter value.
+     * @return std::variant<std::unordered_map<std::string, std::string>, base::Error> Map of key-value pairs. Specific error otherwise.
+     */
+    virtual std::variant<std::unordered_map<std::string, std::string>, base::Error> search(const std::string& prefix) = 0;
 };
 
 } // namespace kvdbManager

--- a/src/engine/source/kvdb/include/kvdb/kvdbHandler.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdbHandler.hpp
@@ -94,6 +94,12 @@ public:
      */
     std::variant<std::unordered_map<std::string, std::string>, base::Error> dump() override;
 
+    /**
+     * @copydoc IKVDBHandler::search
+     *
+     */
+    std::variant<std::unordered_map<std::string, std::string>, base::Error> search(const std::string& filter) override;
+
 protected:
     /**
      *  @brief Weak Pointer to the RocksDB:ColumnFamilyHandle instance.

--- a/src/engine/source/kvdb/src/kvdbHandler.cpp
+++ b/src/engine/source/kvdb/src/kvdbHandler.cpp
@@ -168,10 +168,8 @@ std::variant<std::unordered_map<std::string, std::string>, base::Error> KVDBHand
 
             return content;
         }
-        else
-        {
-            return base::Error {"Cannot access RocksDB Column Family Handle"};
-        }
+
+        return base::Error {"Cannot access RocksDB Column Family Handle"};
     }
 
     return base::Error {"Cannot access RocksDB::DB"};
@@ -205,10 +203,8 @@ std::variant<std::unordered_map<std::string, std::string>, base::Error> KVDBHand
 
             return content;
         }
-        else
-        {
-            return base::Error {"Cannot access RocksDB Column Family Handle"};
-        }
+
+        return base::Error {"Cannot access RocksDB Column Family Handle"};
     }
 
     return base::Error {"Cannot access RocksDB::DB"};

--- a/src/engine/source/proto/include/eMessages/kvdb.pb.cc
+++ b/src/engine/source/proto/include/eMessages/kvdb.pb.cc
@@ -71,6 +71,37 @@ struct dbGet_ResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 dbGet_ResponseDefaultTypeInternal _dbGet_Response_default_instance_;
+PROTOBUF_CONSTEXPR dbSearch_Request::dbSearch_Request(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.name_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.prefix_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}} {}
+struct dbSearch_RequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR dbSearch_RequestDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~dbSearch_RequestDefaultTypeInternal() {}
+  union {
+    dbSearch_Request _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 dbSearch_RequestDefaultTypeInternal _dbSearch_Request_default_instance_;
+PROTOBUF_CONSTEXPR dbSearch_Response::dbSearch_Response(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.entries_)*/{}
+  , /*decltype(_impl_.error_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.status_)*/0} {}
+struct dbSearch_ResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR dbSearch_ResponseDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~dbSearch_ResponseDefaultTypeInternal() {}
+  union {
+    dbSearch_Response _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 dbSearch_ResponseDefaultTypeInternal _dbSearch_Response_default_instance_;
 PROTOBUF_CONSTEXPR dbDelete_Request::dbDelete_Request(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_._has_bits_)*/{}
@@ -196,7 +227,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORIT
 }  // namespace api
 }  // namespace wazuh
 }  // namespace com
-static ::_pb::Metadata file_level_metadata_kvdb_2eproto[11];
+static ::_pb::Metadata file_level_metadata_kvdb_2eproto[13];
 static constexpr ::_pb::EnumDescriptor const** file_level_enum_descriptors_kvdb_2eproto = nullptr;
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_kvdb_2eproto = nullptr;
 
@@ -233,6 +264,28 @@ const uint32_t TableStruct_kvdb_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(pro
   ~0u,
   0,
   1,
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::kvdb::dbSearch_Request, _impl_._has_bits_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::kvdb::dbSearch_Request, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::kvdb::dbSearch_Request, _impl_.name_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::kvdb::dbSearch_Request, _impl_.prefix_),
+  0,
+  1,
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::kvdb::dbSearch_Response, _impl_._has_bits_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::kvdb::dbSearch_Response, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::kvdb::dbSearch_Response, _impl_.status_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::kvdb::dbSearch_Response, _impl_.error_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::kvdb::dbSearch_Response, _impl_.entries_),
+  ~0u,
+  0,
+  ~0u,
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::kvdb::dbDelete_Request, _impl_._has_bits_),
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::kvdb::dbDelete_Request, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -318,20 +371,24 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 0, 8, -1, sizeof(::com::wazuh::api::engine::kvdb::Entry)},
   { 10, 18, -1, sizeof(::com::wazuh::api::engine::kvdb::dbGet_Request)},
   { 20, 29, -1, sizeof(::com::wazuh::api::engine::kvdb::dbGet_Response)},
-  { 32, 40, -1, sizeof(::com::wazuh::api::engine::kvdb::dbDelete_Request)},
-  { 42, 50, -1, sizeof(::com::wazuh::api::engine::kvdb::dbPut_Request)},
-  { 52, 60, -1, sizeof(::com::wazuh::api::engine::kvdb::managerGet_Request)},
-  { 62, 71, -1, sizeof(::com::wazuh::api::engine::kvdb::managerGet_Response)},
-  { 74, 82, -1, sizeof(::com::wazuh::api::engine::kvdb::managerPost_Request)},
-  { 84, 91, -1, sizeof(::com::wazuh::api::engine::kvdb::managerDelete_Request)},
-  { 92, 99, -1, sizeof(::com::wazuh::api::engine::kvdb::managerDump_Request)},
-  { 100, 109, -1, sizeof(::com::wazuh::api::engine::kvdb::managerDump_Response)},
+  { 32, 40, -1, sizeof(::com::wazuh::api::engine::kvdb::dbSearch_Request)},
+  { 42, 51, -1, sizeof(::com::wazuh::api::engine::kvdb::dbSearch_Response)},
+  { 54, 62, -1, sizeof(::com::wazuh::api::engine::kvdb::dbDelete_Request)},
+  { 64, 72, -1, sizeof(::com::wazuh::api::engine::kvdb::dbPut_Request)},
+  { 74, 82, -1, sizeof(::com::wazuh::api::engine::kvdb::managerGet_Request)},
+  { 84, 93, -1, sizeof(::com::wazuh::api::engine::kvdb::managerGet_Response)},
+  { 96, 104, -1, sizeof(::com::wazuh::api::engine::kvdb::managerPost_Request)},
+  { 106, 113, -1, sizeof(::com::wazuh::api::engine::kvdb::managerDelete_Request)},
+  { 114, 121, -1, sizeof(::com::wazuh::api::engine::kvdb::managerDump_Request)},
+  { 122, 131, -1, sizeof(::com::wazuh::api::engine::kvdb::managerDump_Response)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
   &::com::wazuh::api::engine::kvdb::_Entry_default_instance_._instance,
   &::com::wazuh::api::engine::kvdb::_dbGet_Request_default_instance_._instance,
   &::com::wazuh::api::engine::kvdb::_dbGet_Response_default_instance_._instance,
+  &::com::wazuh::api::engine::kvdb::_dbSearch_Request_default_instance_._instance,
+  &::com::wazuh::api::engine::kvdb::_dbSearch_Response_default_instance_._instance,
   &::com::wazuh::api::engine::kvdb::_dbDelete_Request_default_instance_._instance,
   &::com::wazuh::api::engine::kvdb::_dbPut_Request_default_instance_._instance,
   &::com::wazuh::api::engine::kvdb::_managerGet_Request_default_instance_._instance,
@@ -352,26 +409,32 @@ const char descriptor_table_protodef_kvdb_2eproto[] PROTOBUF_SECTION_VARIABLE(pr
   "key\"\230\001\n\016dbGet_Response\0222\n\006status\030\001 \001(\0162\""
   ".com.wazuh.api.engine.ReturnStatus\022\022\n\005er"
   "ror\030\002 \001(\tH\000\210\001\001\022*\n\005value\030\003 \001(\0132\026.google.p"
-  "rotobuf.ValueH\001\210\001\001B\010\n\006_errorB\010\n\006_value\"H"
-  "\n\020dbDelete_Request\022\021\n\004name\030\001 \001(\tH\000\210\001\001\022\020\n"
-  "\003key\030\002 \001(\tH\001\210\001\001B\007\n\005_nameB\006\n\004_key\"k\n\rdbPu"
-  "t_Request\022\021\n\004name\030\001 \001(\tH\000\210\001\001\0224\n\005entry\030\002 "
-  "\001(\0132 .com.wazuh.api.engine.kvdb.EntryH\001\210"
-  "\001\001B\007\n\005_nameB\010\n\006_entry\"\\\n\022managerGet_Requ"
-  "est\022\026\n\016must_be_loaded\030\001 \001(\010\022\033\n\016filter_by"
-  "_name\030\020 \001(\tH\000\210\001\001B\021\n\017_filter_by_name\"t\n\023m"
-  "anagerGet_Response\0222\n\006status\030\001 \001(\0162\".com"
-  ".wazuh.api.engine.ReturnStatus\022\022\n\005error\030"
-  "\002 \001(\tH\000\210\001\001\022\013\n\003dbs\030\003 \003(\tB\010\n\006_error\"M\n\023man"
-  "agerPost_Request\022\021\n\004name\030\001 \001(\tH\000\210\001\001\022\021\n\004p"
-  "ath\030\002 \001(\tH\001\210\001\001B\007\n\005_nameB\007\n\005_path\"3\n\025mana"
-  "gerDelete_Request\022\021\n\004name\030\001 \001(\tH\000\210\001\001B\007\n\005"
-  "_name\"1\n\023managerDump_Request\022\021\n\004name\030\001 \001"
-  "(\tH\000\210\001\001B\007\n\005_name\"\233\001\n\024managerDump_Respons"
-  "e\0222\n\006status\030\001 \001(\0162\".com.wazuh.api.engine"
-  ".ReturnStatus\022\022\n\005error\030\002 \001(\tH\000\210\001\001\0221\n\007ent"
-  "ries\030\003 \003(\0132 .com.wazuh.api.engine.kvdb.E"
-  "ntryB\010\n\006_errorb\006proto3"
+  "rotobuf.ValueH\001\210\001\001B\010\n\006_errorB\010\n\006_value\"N"
+  "\n\020dbSearch_Request\022\021\n\004name\030\001 \001(\tH\000\210\001\001\022\023\n"
+  "\006prefix\030\002 \001(\tH\001\210\001\001B\007\n\005_nameB\t\n\007_prefix\"\230"
+  "\001\n\021dbSearch_Response\0222\n\006status\030\001 \001(\0162\".c"
+  "om.wazuh.api.engine.ReturnStatus\022\022\n\005erro"
+  "r\030\002 \001(\tH\000\210\001\001\0221\n\007entries\030\003 \003(\0132 .com.wazu"
+  "h.api.engine.kvdb.EntryB\010\n\006_error\"H\n\020dbD"
+  "elete_Request\022\021\n\004name\030\001 \001(\tH\000\210\001\001\022\020\n\003key\030"
+  "\002 \001(\tH\001\210\001\001B\007\n\005_nameB\006\n\004_key\"k\n\rdbPut_Req"
+  "uest\022\021\n\004name\030\001 \001(\tH\000\210\001\001\0224\n\005entry\030\002 \001(\0132 "
+  ".com.wazuh.api.engine.kvdb.EntryH\001\210\001\001B\007\n"
+  "\005_nameB\010\n\006_entry\"\\\n\022managerGet_Request\022\026"
+  "\n\016must_be_loaded\030\001 \001(\010\022\033\n\016filter_by_name"
+  "\030\020 \001(\tH\000\210\001\001B\021\n\017_filter_by_name\"t\n\023manage"
+  "rGet_Response\0222\n\006status\030\001 \001(\0162\".com.wazu"
+  "h.api.engine.ReturnStatus\022\022\n\005error\030\002 \001(\t"
+  "H\000\210\001\001\022\013\n\003dbs\030\003 \003(\tB\010\n\006_error\"M\n\023managerP"
+  "ost_Request\022\021\n\004name\030\001 \001(\tH\000\210\001\001\022\021\n\004path\030\002"
+  " \001(\tH\001\210\001\001B\007\n\005_nameB\007\n\005_path\"3\n\025managerDe"
+  "lete_Request\022\021\n\004name\030\001 \001(\tH\000\210\001\001B\007\n\005_name"
+  "\"1\n\023managerDump_Request\022\021\n\004name\030\001 \001(\tH\000\210"
+  "\001\001B\007\n\005_name\"\233\001\n\024managerDump_Response\0222\n\006"
+  "status\030\001 \001(\0162\".com.wazuh.api.engine.Retu"
+  "rnStatus\022\022\n\005error\030\002 \001(\tH\000\210\001\001\0221\n\007entries\030"
+  "\003 \003(\0132 .com.wazuh.api.engine.kvdb.EntryB"
+  "\010\n\006_errorb\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_kvdb_2eproto_deps[2] = {
   &::descriptor_table_engine_2eproto,
@@ -379,9 +442,9 @@ static const ::_pbi::DescriptorTable* const descriptor_table_kvdb_2eproto_deps[2
 };
 static ::_pbi::once_flag descriptor_table_kvdb_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_kvdb_2eproto = {
-    false, false, 1142, descriptor_table_protodef_kvdb_2eproto,
+    false, false, 1377, descriptor_table_protodef_kvdb_2eproto,
     "kvdb.proto",
-    &descriptor_table_kvdb_2eproto_once, descriptor_table_kvdb_2eproto_deps, 2, 11,
+    &descriptor_table_kvdb_2eproto_once, descriptor_table_kvdb_2eproto_deps, 2, 13,
     schemas, file_default_instances, TableStruct_kvdb_2eproto::offsets,
     file_level_metadata_kvdb_2eproto, file_level_enum_descriptors_kvdb_2eproto,
     file_level_service_descriptors_kvdb_2eproto,
@@ -1259,6 +1322,566 @@ void dbGet_Response::InternalSwap(dbGet_Response* other) {
 
 // ===================================================================
 
+class dbSearch_Request::_Internal {
+ public:
+  using HasBits = decltype(std::declval<dbSearch_Request>()._impl_._has_bits_);
+  static void set_has_name(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+  static void set_has_prefix(HasBits* has_bits) {
+    (*has_bits)[0] |= 2u;
+  }
+};
+
+dbSearch_Request::dbSearch_Request(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:com.wazuh.api.engine.kvdb.dbSearch_Request)
+}
+dbSearch_Request::dbSearch_Request(const dbSearch_Request& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  dbSearch_Request* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.name_){}
+    , decltype(_impl_.prefix_){}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.name_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.name_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_name()) {
+    _this->_impl_.name_.Set(from._internal_name(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.prefix_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.prefix_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_prefix()) {
+    _this->_impl_.prefix_.Set(from._internal_prefix(), 
+      _this->GetArenaForAllocation());
+  }
+  // @@protoc_insertion_point(copy_constructor:com.wazuh.api.engine.kvdb.dbSearch_Request)
+}
+
+inline void dbSearch_Request::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.name_){}
+    , decltype(_impl_.prefix_){}
+  };
+  _impl_.name_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.name_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.prefix_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.prefix_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+dbSearch_Request::~dbSearch_Request() {
+  // @@protoc_insertion_point(destructor:com.wazuh.api.engine.kvdb.dbSearch_Request)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void dbSearch_Request::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.name_.Destroy();
+  _impl_.prefix_.Destroy();
+}
+
+void dbSearch_Request::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void dbSearch_Request::Clear() {
+// @@protoc_insertion_point(message_clear_start:com.wazuh.api.engine.kvdb.dbSearch_Request)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _impl_.name_.ClearNonDefaultToEmpty();
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _impl_.prefix_.ClearNonDefaultToEmpty();
+    }
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* dbSearch_Request::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // optional string name = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          auto str = _internal_mutable_name();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.kvdb.dbSearch_Request.name"));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string prefix = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_prefix();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.kvdb.dbSearch_Request.prefix"));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  _impl_._has_bits_.Or(has_bits);
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* dbSearch_Request::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:com.wazuh.api.engine.kvdb.dbSearch_Request)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // optional string name = 1;
+  if (_internal_has_name()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_name().data(), static_cast<int>(this->_internal_name().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.kvdb.dbSearch_Request.name");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_name(), target);
+  }
+
+  // optional string prefix = 2;
+  if (_internal_has_prefix()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_prefix().data(), static_cast<int>(this->_internal_prefix().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.kvdb.dbSearch_Request.prefix");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_prefix(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:com.wazuh.api.engine.kvdb.dbSearch_Request)
+  return target;
+}
+
+size_t dbSearch_Request::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:com.wazuh.api.engine.kvdb.dbSearch_Request)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    // optional string name = 1;
+    if (cached_has_bits & 0x00000001u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_name());
+    }
+
+    // optional string prefix = 2;
+    if (cached_has_bits & 0x00000002u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_prefix());
+    }
+
+  }
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData dbSearch_Request::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    dbSearch_Request::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*dbSearch_Request::GetClassData() const { return &_class_data_; }
+
+
+void dbSearch_Request::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<dbSearch_Request*>(&to_msg);
+  auto& from = static_cast<const dbSearch_Request&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:com.wazuh.api.engine.kvdb.dbSearch_Request)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _this->_internal_set_name(from._internal_name());
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _this->_internal_set_prefix(from._internal_prefix());
+    }
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void dbSearch_Request::CopyFrom(const dbSearch_Request& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:com.wazuh.api.engine.kvdb.dbSearch_Request)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool dbSearch_Request::IsInitialized() const {
+  return true;
+}
+
+void dbSearch_Request::InternalSwap(dbSearch_Request* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.name_, lhs_arena,
+      &other->_impl_.name_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.prefix_, lhs_arena,
+      &other->_impl_.prefix_, rhs_arena
+  );
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata dbSearch_Request::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_kvdb_2eproto_getter, &descriptor_table_kvdb_2eproto_once,
+      file_level_metadata_kvdb_2eproto[3]);
+}
+
+// ===================================================================
+
+class dbSearch_Response::_Internal {
+ public:
+  using HasBits = decltype(std::declval<dbSearch_Response>()._impl_._has_bits_);
+  static void set_has_error(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+};
+
+dbSearch_Response::dbSearch_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:com.wazuh.api.engine.kvdb.dbSearch_Response)
+}
+dbSearch_Response::dbSearch_Response(const dbSearch_Response& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  dbSearch_Response* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.entries_){from._impl_.entries_}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.status_){}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_error()) {
+    _this->_impl_.error_.Set(from._internal_error(), 
+      _this->GetArenaForAllocation());
+  }
+  _this->_impl_.status_ = from._impl_.status_;
+  // @@protoc_insertion_point(copy_constructor:com.wazuh.api.engine.kvdb.dbSearch_Response)
+}
+
+inline void dbSearch_Response::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.entries_){arena}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.status_){0}
+  };
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+dbSearch_Response::~dbSearch_Response() {
+  // @@protoc_insertion_point(destructor:com.wazuh.api.engine.kvdb.dbSearch_Response)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void dbSearch_Response::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.entries_.~RepeatedPtrField();
+  _impl_.error_.Destroy();
+}
+
+void dbSearch_Response::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void dbSearch_Response::Clear() {
+// @@protoc_insertion_point(message_clear_start:com.wazuh.api.engine.kvdb.dbSearch_Response)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.entries_.Clear();
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    _impl_.error_.ClearNonDefaultToEmpty();
+  }
+  _impl_.status_ = 0;
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* dbSearch_Response::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .com.wazuh.api.engine.ReturnStatus status = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_status(static_cast<::com::wazuh::api::engine::ReturnStatus>(val));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string error = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_error();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.kvdb.dbSearch_Response.error"));
+        } else
+          goto handle_unusual;
+        continue;
+      // repeated .com.wazuh.api.engine.kvdb.Entry entries = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_entries(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<26>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  _impl_._has_bits_.Or(has_bits);
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* dbSearch_Response::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:com.wazuh.api.engine.kvdb.dbSearch_Response)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      1, this->_internal_status(), target);
+  }
+
+  // optional string error = 2;
+  if (_internal_has_error()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_error().data(), static_cast<int>(this->_internal_error().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.kvdb.dbSearch_Response.error");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_error(), target);
+  }
+
+  // repeated .com.wazuh.api.engine.kvdb.Entry entries = 3;
+  for (unsigned i = 0,
+      n = static_cast<unsigned>(this->_internal_entries_size()); i < n; i++) {
+    const auto& repfield = this->_internal_entries(i);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+        InternalWriteMessage(3, repfield, repfield.GetCachedSize(), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:com.wazuh.api.engine.kvdb.dbSearch_Response)
+  return target;
+}
+
+size_t dbSearch_Response::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:com.wazuh.api.engine.kvdb.dbSearch_Response)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .com.wazuh.api.engine.kvdb.Entry entries = 3;
+  total_size += 1UL * this->_internal_entries_size();
+  for (const auto& msg : this->_impl_.entries_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // optional string error = 2;
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_error());
+  }
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    total_size += 1 +
+      ::_pbi::WireFormatLite::EnumSize(this->_internal_status());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData dbSearch_Response::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    dbSearch_Response::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*dbSearch_Response::GetClassData() const { return &_class_data_; }
+
+
+void dbSearch_Response::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<dbSearch_Response*>(&to_msg);
+  auto& from = static_cast<const dbSearch_Response&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:com.wazuh.api.engine.kvdb.dbSearch_Response)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  _this->_impl_.entries_.MergeFrom(from._impl_.entries_);
+  if (from._internal_has_error()) {
+    _this->_internal_set_error(from._internal_error());
+  }
+  if (from._internal_status() != 0) {
+    _this->_internal_set_status(from._internal_status());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void dbSearch_Response::CopyFrom(const dbSearch_Response& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:com.wazuh.api.engine.kvdb.dbSearch_Response)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool dbSearch_Response::IsInitialized() const {
+  return true;
+}
+
+void dbSearch_Response::InternalSwap(dbSearch_Response* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  _impl_.entries_.InternalSwap(&other->_impl_.entries_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.error_, lhs_arena,
+      &other->_impl_.error_, rhs_arena
+  );
+  swap(_impl_.status_, other->_impl_.status_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata dbSearch_Response::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_kvdb_2eproto_getter, &descriptor_table_kvdb_2eproto_once,
+      file_level_metadata_kvdb_2eproto[4]);
+}
+
+// ===================================================================
+
 class dbDelete_Request::_Internal {
  public:
   using HasBits = decltype(std::declval<dbDelete_Request>()._impl_._has_bits_);
@@ -1533,7 +2156,7 @@ void dbDelete_Request::InternalSwap(dbDelete_Request* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata dbDelete_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_kvdb_2eproto_getter, &descriptor_table_kvdb_2eproto_once,
-      file_level_metadata_kvdb_2eproto[3]);
+      file_level_metadata_kvdb_2eproto[5]);
 }
 
 // ===================================================================
@@ -1802,7 +2425,7 @@ void dbPut_Request::InternalSwap(dbPut_Request* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata dbPut_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_kvdb_2eproto_getter, &descriptor_table_kvdb_2eproto_once,
-      file_level_metadata_kvdb_2eproto[4]);
+      file_level_metadata_kvdb_2eproto[6]);
 }
 
 // ===================================================================
@@ -2046,7 +2669,7 @@ void managerGet_Request::InternalSwap(managerGet_Request* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata managerGet_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_kvdb_2eproto_getter, &descriptor_table_kvdb_2eproto_once,
-      file_level_metadata_kvdb_2eproto[5]);
+      file_level_metadata_kvdb_2eproto[7]);
 }
 
 // ===================================================================
@@ -2332,7 +2955,7 @@ void managerGet_Response::InternalSwap(managerGet_Response* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata managerGet_Response::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_kvdb_2eproto_getter, &descriptor_table_kvdb_2eproto_once,
-      file_level_metadata_kvdb_2eproto[6]);
+      file_level_metadata_kvdb_2eproto[8]);
 }
 
 // ===================================================================
@@ -2611,7 +3234,7 @@ void managerPost_Request::InternalSwap(managerPost_Request* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata managerPost_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_kvdb_2eproto_getter, &descriptor_table_kvdb_2eproto_once,
-      file_level_metadata_kvdb_2eproto[7]);
+      file_level_metadata_kvdb_2eproto[9]);
 }
 
 // ===================================================================
@@ -2828,7 +3451,7 @@ void managerDelete_Request::InternalSwap(managerDelete_Request* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata managerDelete_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_kvdb_2eproto_getter, &descriptor_table_kvdb_2eproto_once,
-      file_level_metadata_kvdb_2eproto[8]);
+      file_level_metadata_kvdb_2eproto[10]);
 }
 
 // ===================================================================
@@ -3045,7 +3668,7 @@ void managerDump_Request::InternalSwap(managerDump_Request* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata managerDump_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_kvdb_2eproto_getter, &descriptor_table_kvdb_2eproto_once,
-      file_level_metadata_kvdb_2eproto[9]);
+      file_level_metadata_kvdb_2eproto[11]);
 }
 
 // ===================================================================
@@ -3326,7 +3949,7 @@ void managerDump_Response::InternalSwap(managerDump_Response* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata managerDump_Response::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_kvdb_2eproto_getter, &descriptor_table_kvdb_2eproto_once,
-      file_level_metadata_kvdb_2eproto[10]);
+      file_level_metadata_kvdb_2eproto[12]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -3347,6 +3970,14 @@ Arena::CreateMaybeMessage< ::com::wazuh::api::engine::kvdb::dbGet_Request >(Aren
 template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::kvdb::dbGet_Response*
 Arena::CreateMaybeMessage< ::com::wazuh::api::engine::kvdb::dbGet_Response >(Arena* arena) {
   return Arena::CreateMessageInternal< ::com::wazuh::api::engine::kvdb::dbGet_Response >(arena);
+}
+template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::kvdb::dbSearch_Request*
+Arena::CreateMaybeMessage< ::com::wazuh::api::engine::kvdb::dbSearch_Request >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::com::wazuh::api::engine::kvdb::dbSearch_Request >(arena);
+}
+template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::kvdb::dbSearch_Response*
+Arena::CreateMaybeMessage< ::com::wazuh::api::engine::kvdb::dbSearch_Response >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::com::wazuh::api::engine::kvdb::dbSearch_Response >(arena);
 }
 template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::kvdb::dbDelete_Request*
 Arena::CreateMaybeMessage< ::com::wazuh::api::engine::kvdb::dbDelete_Request >(Arena* arena) {

--- a/src/engine/source/proto/include/eMessages/kvdb.pb.h
+++ b/src/engine/source/proto/include/eMessages/kvdb.pb.h
@@ -66,6 +66,12 @@ extern dbGet_ResponseDefaultTypeInternal _dbGet_Response_default_instance_;
 class dbPut_Request;
 struct dbPut_RequestDefaultTypeInternal;
 extern dbPut_RequestDefaultTypeInternal _dbPut_Request_default_instance_;
+class dbSearch_Request;
+struct dbSearch_RequestDefaultTypeInternal;
+extern dbSearch_RequestDefaultTypeInternal _dbSearch_Request_default_instance_;
+class dbSearch_Response;
+struct dbSearch_ResponseDefaultTypeInternal;
+extern dbSearch_ResponseDefaultTypeInternal _dbSearch_Response_default_instance_;
 class managerDelete_Request;
 struct managerDelete_RequestDefaultTypeInternal;
 extern managerDelete_RequestDefaultTypeInternal _managerDelete_Request_default_instance_;
@@ -95,6 +101,8 @@ template<> ::com::wazuh::api::engine::kvdb::dbDelete_Request* Arena::CreateMaybe
 template<> ::com::wazuh::api::engine::kvdb::dbGet_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::kvdb::dbGet_Request>(Arena*);
 template<> ::com::wazuh::api::engine::kvdb::dbGet_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::kvdb::dbGet_Response>(Arena*);
 template<> ::com::wazuh::api::engine::kvdb::dbPut_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::kvdb::dbPut_Request>(Arena*);
+template<> ::com::wazuh::api::engine::kvdb::dbSearch_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::kvdb::dbSearch_Request>(Arena*);
+template<> ::com::wazuh::api::engine::kvdb::dbSearch_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::kvdb::dbSearch_Response>(Arena*);
 template<> ::com::wazuh::api::engine::kvdb::managerDelete_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::kvdb::managerDelete_Request>(Arena*);
 template<> ::com::wazuh::api::engine::kvdb::managerDump_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::kvdb::managerDump_Request>(Arena*);
 template<> ::com::wazuh::api::engine::kvdb::managerDump_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::kvdb::managerDump_Response>(Arena*);
@@ -655,6 +663,373 @@ class dbGet_Response final :
 };
 // -------------------------------------------------------------------
 
+class dbSearch_Request final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.kvdb.dbSearch_Request) */ {
+ public:
+  inline dbSearch_Request() : dbSearch_Request(nullptr) {}
+  ~dbSearch_Request() override;
+  explicit PROTOBUF_CONSTEXPR dbSearch_Request(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  dbSearch_Request(const dbSearch_Request& from);
+  dbSearch_Request(dbSearch_Request&& from) noexcept
+    : dbSearch_Request() {
+    *this = ::std::move(from);
+  }
+
+  inline dbSearch_Request& operator=(const dbSearch_Request& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline dbSearch_Request& operator=(dbSearch_Request&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const dbSearch_Request& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const dbSearch_Request* internal_default_instance() {
+    return reinterpret_cast<const dbSearch_Request*>(
+               &_dbSearch_Request_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    3;
+
+  friend void swap(dbSearch_Request& a, dbSearch_Request& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(dbSearch_Request* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(dbSearch_Request* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  dbSearch_Request* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<dbSearch_Request>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const dbSearch_Request& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const dbSearch_Request& from) {
+    dbSearch_Request::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(dbSearch_Request* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "com.wazuh.api.engine.kvdb.dbSearch_Request";
+  }
+  protected:
+  explicit dbSearch_Request(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kNameFieldNumber = 1,
+    kPrefixFieldNumber = 2,
+  };
+  // optional string name = 1;
+  bool has_name() const;
+  private:
+  bool _internal_has_name() const;
+  public:
+  void clear_name();
+  const std::string& name() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_name(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_name();
+  PROTOBUF_NODISCARD std::string* release_name();
+  void set_allocated_name(std::string* name);
+  private:
+  const std::string& _internal_name() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_name(const std::string& value);
+  std::string* _internal_mutable_name();
+  public:
+
+  // optional string prefix = 2;
+  bool has_prefix() const;
+  private:
+  bool _internal_has_prefix() const;
+  public:
+  void clear_prefix();
+  const std::string& prefix() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_prefix(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_prefix();
+  PROTOBUF_NODISCARD std::string* release_prefix();
+  void set_allocated_prefix(std::string* prefix);
+  private:
+  const std::string& _internal_prefix() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_prefix(const std::string& value);
+  std::string* _internal_mutable_prefix();
+  public:
+
+  // @@protoc_insertion_point(class_scope:com.wazuh.api.engine.kvdb.dbSearch_Request)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr name_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr prefix_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_kvdb_2eproto;
+};
+// -------------------------------------------------------------------
+
+class dbSearch_Response final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.kvdb.dbSearch_Response) */ {
+ public:
+  inline dbSearch_Response() : dbSearch_Response(nullptr) {}
+  ~dbSearch_Response() override;
+  explicit PROTOBUF_CONSTEXPR dbSearch_Response(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  dbSearch_Response(const dbSearch_Response& from);
+  dbSearch_Response(dbSearch_Response&& from) noexcept
+    : dbSearch_Response() {
+    *this = ::std::move(from);
+  }
+
+  inline dbSearch_Response& operator=(const dbSearch_Response& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline dbSearch_Response& operator=(dbSearch_Response&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const dbSearch_Response& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const dbSearch_Response* internal_default_instance() {
+    return reinterpret_cast<const dbSearch_Response*>(
+               &_dbSearch_Response_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    4;
+
+  friend void swap(dbSearch_Response& a, dbSearch_Response& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(dbSearch_Response* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(dbSearch_Response* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  dbSearch_Response* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<dbSearch_Response>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const dbSearch_Response& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const dbSearch_Response& from) {
+    dbSearch_Response::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(dbSearch_Response* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "com.wazuh.api.engine.kvdb.dbSearch_Response";
+  }
+  protected:
+  explicit dbSearch_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kEntriesFieldNumber = 3,
+    kErrorFieldNumber = 2,
+    kStatusFieldNumber = 1,
+  };
+  // repeated .com.wazuh.api.engine.kvdb.Entry entries = 3;
+  int entries_size() const;
+  private:
+  int _internal_entries_size() const;
+  public:
+  void clear_entries();
+  ::com::wazuh::api::engine::kvdb::Entry* mutable_entries(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::com::wazuh::api::engine::kvdb::Entry >*
+      mutable_entries();
+  private:
+  const ::com::wazuh::api::engine::kvdb::Entry& _internal_entries(int index) const;
+  ::com::wazuh::api::engine::kvdb::Entry* _internal_add_entries();
+  public:
+  const ::com::wazuh::api::engine::kvdb::Entry& entries(int index) const;
+  ::com::wazuh::api::engine::kvdb::Entry* add_entries();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::com::wazuh::api::engine::kvdb::Entry >&
+      entries() const;
+
+  // optional string error = 2;
+  bool has_error() const;
+  private:
+  bool _internal_has_error() const;
+  public:
+  void clear_error();
+  const std::string& error() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_error(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_error();
+  PROTOBUF_NODISCARD std::string* release_error();
+  void set_allocated_error(std::string* error);
+  private:
+  const std::string& _internal_error() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_error(const std::string& value);
+  std::string* _internal_mutable_error();
+  public:
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  void clear_status();
+  ::com::wazuh::api::engine::ReturnStatus status() const;
+  void set_status(::com::wazuh::api::engine::ReturnStatus value);
+  private:
+  ::com::wazuh::api::engine::ReturnStatus _internal_status() const;
+  void _internal_set_status(::com::wazuh::api::engine::ReturnStatus value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:com.wazuh.api.engine.kvdb.dbSearch_Response)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::com::wazuh::api::engine::kvdb::Entry > entries_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr error_;
+    int status_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_kvdb_2eproto;
+};
+// -------------------------------------------------------------------
+
 class dbDelete_Request final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.kvdb.dbDelete_Request) */ {
  public:
@@ -703,7 +1078,7 @@ class dbDelete_Request final :
                &_dbDelete_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    3;
+    5;
 
   friend void swap(dbDelete_Request& a, dbDelete_Request& b) {
     a.Swap(&b);
@@ -881,7 +1256,7 @@ class dbPut_Request final :
                &_dbPut_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    4;
+    6;
 
   friend void swap(dbPut_Request& a, dbPut_Request& b) {
     a.Swap(&b);
@@ -1059,7 +1434,7 @@ class managerGet_Request final :
                &_managerGet_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    7;
 
   friend void swap(managerGet_Request& a, managerGet_Request& b) {
     a.Swap(&b);
@@ -1228,7 +1603,7 @@ class managerGet_Response final :
                &_managerGet_Response_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    8;
 
   friend void swap(managerGet_Response& a, managerGet_Response& b) {
     a.Swap(&b);
@@ -1423,7 +1798,7 @@ class managerPost_Request final :
                &_managerPost_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    7;
+    9;
 
   friend void swap(managerPost_Request& a, managerPost_Request& b) {
     a.Swap(&b);
@@ -1601,7 +1976,7 @@ class managerDelete_Request final :
                &_managerDelete_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    10;
 
   friend void swap(managerDelete_Request& a, managerDelete_Request& b) {
     a.Swap(&b);
@@ -1759,7 +2134,7 @@ class managerDump_Request final :
                &_managerDump_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    9;
+    11;
 
   friend void swap(managerDump_Request& a, managerDump_Request& b) {
     a.Swap(&b);
@@ -1917,7 +2292,7 @@ class managerDump_Response final :
                &_managerDump_Response_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    12;
 
   friend void swap(managerDump_Response& a, managerDump_Response& b) {
     a.Swap(&b);
@@ -2539,6 +2914,278 @@ inline void dbGet_Response::set_allocated_value(::PROTOBUF_NAMESPACE_ID::Value* 
   }
   _impl_.value_ = value;
   // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.kvdb.dbGet_Response.value)
+}
+
+// -------------------------------------------------------------------
+
+// dbSearch_Request
+
+// optional string name = 1;
+inline bool dbSearch_Request::_internal_has_name() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool dbSearch_Request::has_name() const {
+  return _internal_has_name();
+}
+inline void dbSearch_Request::clear_name() {
+  _impl_.name_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const std::string& dbSearch_Request::name() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.kvdb.dbSearch_Request.name)
+  return _internal_name();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void dbSearch_Request::set_name(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000001u;
+ _impl_.name_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.kvdb.dbSearch_Request.name)
+}
+inline std::string* dbSearch_Request::mutable_name() {
+  std::string* _s = _internal_mutable_name();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.kvdb.dbSearch_Request.name)
+  return _s;
+}
+inline const std::string& dbSearch_Request::_internal_name() const {
+  return _impl_.name_.Get();
+}
+inline void dbSearch_Request::_internal_set_name(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.name_.Set(value, GetArenaForAllocation());
+}
+inline std::string* dbSearch_Request::_internal_mutable_name() {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  return _impl_.name_.Mutable(GetArenaForAllocation());
+}
+inline std::string* dbSearch_Request::release_name() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.kvdb.dbSearch_Request.name)
+  if (!_internal_has_name()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  auto* p = _impl_.name_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.name_.IsDefault()) {
+    _impl_.name_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void dbSearch_Request::set_allocated_name(std::string* name) {
+  if (name != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  _impl_.name_.SetAllocated(name, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.name_.IsDefault()) {
+    _impl_.name_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.kvdb.dbSearch_Request.name)
+}
+
+// optional string prefix = 2;
+inline bool dbSearch_Request::_internal_has_prefix() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  return value;
+}
+inline bool dbSearch_Request::has_prefix() const {
+  return _internal_has_prefix();
+}
+inline void dbSearch_Request::clear_prefix() {
+  _impl_.prefix_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000002u;
+}
+inline const std::string& dbSearch_Request::prefix() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.kvdb.dbSearch_Request.prefix)
+  return _internal_prefix();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void dbSearch_Request::set_prefix(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000002u;
+ _impl_.prefix_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.kvdb.dbSearch_Request.prefix)
+}
+inline std::string* dbSearch_Request::mutable_prefix() {
+  std::string* _s = _internal_mutable_prefix();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.kvdb.dbSearch_Request.prefix)
+  return _s;
+}
+inline const std::string& dbSearch_Request::_internal_prefix() const {
+  return _impl_.prefix_.Get();
+}
+inline void dbSearch_Request::_internal_set_prefix(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  _impl_.prefix_.Set(value, GetArenaForAllocation());
+}
+inline std::string* dbSearch_Request::_internal_mutable_prefix() {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  return _impl_.prefix_.Mutable(GetArenaForAllocation());
+}
+inline std::string* dbSearch_Request::release_prefix() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.kvdb.dbSearch_Request.prefix)
+  if (!_internal_has_prefix()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000002u;
+  auto* p = _impl_.prefix_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.prefix_.IsDefault()) {
+    _impl_.prefix_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void dbSearch_Request::set_allocated_prefix(std::string* prefix) {
+  if (prefix != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000002u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000002u;
+  }
+  _impl_.prefix_.SetAllocated(prefix, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.prefix_.IsDefault()) {
+    _impl_.prefix_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.kvdb.dbSearch_Request.prefix)
+}
+
+// -------------------------------------------------------------------
+
+// dbSearch_Response
+
+// .com.wazuh.api.engine.ReturnStatus status = 1;
+inline void dbSearch_Response::clear_status() {
+  _impl_.status_ = 0;
+}
+inline ::com::wazuh::api::engine::ReturnStatus dbSearch_Response::_internal_status() const {
+  return static_cast< ::com::wazuh::api::engine::ReturnStatus >(_impl_.status_);
+}
+inline ::com::wazuh::api::engine::ReturnStatus dbSearch_Response::status() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.kvdb.dbSearch_Response.status)
+  return _internal_status();
+}
+inline void dbSearch_Response::_internal_set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  
+  _impl_.status_ = value;
+}
+inline void dbSearch_Response::set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  _internal_set_status(value);
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.kvdb.dbSearch_Response.status)
+}
+
+// optional string error = 2;
+inline bool dbSearch_Response::_internal_has_error() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool dbSearch_Response::has_error() const {
+  return _internal_has_error();
+}
+inline void dbSearch_Response::clear_error() {
+  _impl_.error_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const std::string& dbSearch_Response::error() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.kvdb.dbSearch_Response.error)
+  return _internal_error();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void dbSearch_Response::set_error(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000001u;
+ _impl_.error_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.kvdb.dbSearch_Response.error)
+}
+inline std::string* dbSearch_Response::mutable_error() {
+  std::string* _s = _internal_mutable_error();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.kvdb.dbSearch_Response.error)
+  return _s;
+}
+inline const std::string& dbSearch_Response::_internal_error() const {
+  return _impl_.error_.Get();
+}
+inline void dbSearch_Response::_internal_set_error(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.error_.Set(value, GetArenaForAllocation());
+}
+inline std::string* dbSearch_Response::_internal_mutable_error() {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  return _impl_.error_.Mutable(GetArenaForAllocation());
+}
+inline std::string* dbSearch_Response::release_error() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.kvdb.dbSearch_Response.error)
+  if (!_internal_has_error()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  auto* p = _impl_.error_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void dbSearch_Response::set_allocated_error(std::string* error) {
+  if (error != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  _impl_.error_.SetAllocated(error, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.kvdb.dbSearch_Response.error)
+}
+
+// repeated .com.wazuh.api.engine.kvdb.Entry entries = 3;
+inline int dbSearch_Response::_internal_entries_size() const {
+  return _impl_.entries_.size();
+}
+inline int dbSearch_Response::entries_size() const {
+  return _internal_entries_size();
+}
+inline void dbSearch_Response::clear_entries() {
+  _impl_.entries_.Clear();
+}
+inline ::com::wazuh::api::engine::kvdb::Entry* dbSearch_Response::mutable_entries(int index) {
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.kvdb.dbSearch_Response.entries)
+  return _impl_.entries_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::com::wazuh::api::engine::kvdb::Entry >*
+dbSearch_Response::mutable_entries() {
+  // @@protoc_insertion_point(field_mutable_list:com.wazuh.api.engine.kvdb.dbSearch_Response.entries)
+  return &_impl_.entries_;
+}
+inline const ::com::wazuh::api::engine::kvdb::Entry& dbSearch_Response::_internal_entries(int index) const {
+  return _impl_.entries_.Get(index);
+}
+inline const ::com::wazuh::api::engine::kvdb::Entry& dbSearch_Response::entries(int index) const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.kvdb.dbSearch_Response.entries)
+  return _internal_entries(index);
+}
+inline ::com::wazuh::api::engine::kvdb::Entry* dbSearch_Response::_internal_add_entries() {
+  return _impl_.entries_.Add();
+}
+inline ::com::wazuh::api::engine::kvdb::Entry* dbSearch_Response::add_entries() {
+  ::com::wazuh::api::engine::kvdb::Entry* _add = _internal_add_entries();
+  // @@protoc_insertion_point(field_add:com.wazuh.api.engine.kvdb.dbSearch_Response.entries)
+  return _add;
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::com::wazuh::api::engine::kvdb::Entry >&
+dbSearch_Response::entries() const {
+  // @@protoc_insertion_point(field_list:com.wazuh.api.engine.kvdb.dbSearch_Response.entries)
+  return _impl_.entries_;
 }
 
 // -------------------------------------------------------------------
@@ -3521,6 +4168,10 @@ managerDump_Response::entries() const {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/engine/source/proto/src/kvdb.proto
+++ b/src/engine/source/proto/src/kvdb.proto
@@ -32,6 +32,25 @@ message dbGet_Response
     optional google.protobuf.Value value = 3; // JSON value of the entry
 }
 
+/******************** Operation with a DB ********************/
+/***************************************************
+ * Get an entries filtered from a DB
+ *
+ * command: kvdb.db/search (<resource>/<action>)
+ **************************************************/
+message dbSearch_Request
+{
+    optional string name = 1;   // Name of the db to get the entry
+    optional string prefix = 2; // prefix of the entries to get
+}
+
+message dbSearch_Response
+{
+    ReturnStatus status = 1;    // Status of the query
+    optional string error = 2;  // Error message if status is ERROR
+    repeated Entry entries = 3; // List of entries if status is OK (Empty on error)
+}
+
 /***************************************************
  * Delete an entry from a DB
  *

--- a/src/engine/source/proto/src/kvdb.proto
+++ b/src/engine/source/proto/src/kvdb.proto
@@ -32,7 +32,6 @@ message dbGet_Response
     optional google.protobuf.Value value = 3; // JSON value of the entry
 }
 
-/******************** Operation with a DB ********************/
 /***************************************************
  * Get an entries filtered from a DB
  *

--- a/src/engine/test/source/api/kvdb/kvdb_api_test.cpp
+++ b/src/engine/test/source/api/kvdb/kvdb_api_test.cpp
@@ -437,7 +437,7 @@ TEST_F(KVDBApiTest, managerDeleteDBNotExists)
     kvdbManager->createDB(KVDB_TEST_2);
     ASSERT_NO_THROW(cmd = managerDelete(KVDBApiTest::kvdbManager));
     const auto response = cmd(commonWRequest(KVDB_TEST_1));
-    const auto expectedData = json::Json {R"({"status":"ERROR","error":"The KVDB test1 does not exist."})"};
+    const auto expectedData = json::Json {R"({"status":"ERROR","error":"The KVDB 'test1' does not exist."})"};
 
     ASSERT_TRUE(response.isValid());
     ASSERT_EQ(response.error(), 0);
@@ -883,7 +883,7 @@ TEST_F(KVDBApiTest, dbDeleteKeyDBNotExists)
 
     ASSERT_NO_THROW(cmd = dbDelete(KVDBApiTest::kvdbManager, "test"));
     const auto response = cmd(dbWRequest("default2", "key1"));
-    const auto expectedData = json::Json {R"({"status":"ERROR","error":"The KVDB default2 does not exist."})"};
+    const auto expectedData = json::Json {R"({"status":"ERROR","error":"The KVDB 'default2' does not exist."})"};
 
     ASSERT_TRUE(response.isValid());
     ASSERT_EQ(response.error(), 0);
@@ -1080,7 +1080,7 @@ TEST_F(KVDBApiTest, dbPutKeyDBNotExists)
 
     ASSERT_NO_THROW(cmd = dbPut(KVDBApiTest::kvdbManager, "test"));
     const auto response = cmd(dbWRequest("default2", "key1", "value1"));
-    const auto expectedData = json::Json {R"({"status":"ERROR","error":"The KVDB default2 does not exist."})"};
+    const auto expectedData = json::Json {R"({"status":"ERROR","error":"The KVDB 'default2' does not exist."})"};
 
     ASSERT_TRUE(response.isValid());
     ASSERT_EQ(response.error(), 0);


### PR DESCRIPTION
|Wazuh version|Component|Install type|Install method|Platform|
|---|---|---|---|---|
| 5.0 | Engine | Manager| - | - |

## Description

Enable usage of RocksDB's Prefix Search feature to drive a secondary index for keys in a single KVDB (Column Family). 
This way we could have grouped keys under certain prefix inside the same KVDB.
 
## DoD
 - [x] Unit test.
 - [x] Update the design document.
 - [x] Update the user manual.
 - [x] Memory Leak analysis.

## Unit Testing

### ctest -R KVDB

```
root@wazuh-engine:~/repos/wazuh/src/engine/build# ctest -R KVDB
Test project /root/repos/wazuh/src/engine/build
      Start  408: KVDBApiTest.startup
 1/99 Test  #408: KVDBApiTest.startup ...................................................   Passed    0.05 sec
      Start  409: KVDBApiTest.managerGetOk
 2/99 Test  #409: KVDBApiTest.managerGetOk ..............................................   Passed    0.04 sec
      Start  410: KVDBApiTest.managerGet
 3/99 Test  #410: KVDBApiTest.managerGet ................................................   Passed    0.06 sec
      Start  411: KVDBApiTest.managerGetWitMultipleDBsLoaded
 4/99 Test  #411: KVDBApiTest.managerGetWitMultipleDBsLoaded ............................   Passed    0.08 sec
      Start  412: KVDBApiTest.managerPostOk
 5/99 Test  #412: KVDBApiTest.managerPostOk .............................................   Passed    0.05 sec
      Start  413: KVDBApiTest.managerPostNameMissing
 6/99 Test  #413: KVDBApiTest.managerPostNameMissing ....................................   Passed    0.05 sec
      Start  414: KVDBApiTest.managerPostNameEmpty
 7/99 Test  #414: KVDBApiTest.managerPostNameEmpty ......................................   Passed    0.04 sec
      Start  415: KVDBApiTest.managerPost
 8/99 Test  #415: KVDBApiTest.managerPost ...............................................   Passed    0.06 sec
      Start  416: KVDBApiTest.managerPostWithJsonWithValueOK
 9/99 Test  #416: KVDBApiTest.managerPostWithJsonWithValueOK ............................   Passed    0.06 sec
      Start  417: KVDBApiTest.managerPostWithJsonWithoutValueOK
10/99 Test  #417: KVDBApiTest.managerPostWithJsonWithoutValueOK .........................   Passed    0.06 sec
      Start  418: KVDBApiTest.managerPostWithPathEmpty
11/99 Test  #418: KVDBApiTest.managerPostWithPathEmpty ..................................   Passed    0.06 sec
      Start  419: KVDBApiTest.managerPostWithJsonPathNotExists
12/99 Test  #419: KVDBApiTest.managerPostWithJsonPathNotExists ..........................   Passed    0.06 sec
      Start  420: KVDBApiTest.managerPostWithJsonNOK
13/99 Test  #420: KVDBApiTest.managerPostWithJsonNOK ....................................   Passed    0.06 sec
      Start  421: KVDBApiTest.managerPostDBExists
14/99 Test  #421: KVDBApiTest.managerPostDBExists .......................................   Passed    0.05 sec
      Start  422: KVDBApiTest.managerDeleteOk
15/99 Test  #422: KVDBApiTest.managerDeleteOk ...........................................   Passed    0.04 sec
      Start  423: KVDBApiTest.managerDeleteNameMissing
16/99 Test  #423: KVDBApiTest.managerDeleteNameMissing ..................................   Passed    0.05 sec
      Start  424: KVDBApiTest.managerDeleteNameEmpty
17/99 Test  #424: KVDBApiTest.managerDeleteNameEmpty ....................................   Passed    0.05 sec
      Start  425: KVDBApiTest.managerDelete
18/99 Test  #425: KVDBApiTest.managerDelete .............................................   Passed    0.07 sec
      Start  426: KVDBApiTest.managerDeleteDBNotExists
19/99 Test  #426: KVDBApiTest.managerDeleteDBNotExists ..................................   Passed    0.06 sec
      Start  427: KVDBApiTest.managerDeleteDBInUse
20/99 Test  #427: KVDBApiTest.managerDeleteDBInUse ......................................   Passed    0.06 sec
      Start  428: KVDBApiTest.managerDumpOk
21/99 Test  #428: KVDBApiTest.managerDumpOk .............................................   Passed    0.04 sec
      Start  429: KVDBApiTest.managerDumpNameMissing
22/99 Test  #429: KVDBApiTest.managerDumpNameMissing ....................................   Passed    0.06 sec
      Start  430: KVDBApiTest.managerDumpNameEmpty
23/99 Test  #430: KVDBApiTest.managerDumpNameEmpty ......................................   Passed    0.06 sec
      Start  431: KVDBApiTest.managerDump
24/99 Test  #431: KVDBApiTest.managerDump ...............................................   Passed    0.07 sec
      Start  432: KVDBApiTest.dbGetOk
25/99 Test  #432: KVDBApiTest.dbGetOk ...................................................   Passed    0.05 sec
      Start  433: KVDBApiTest.dbGetNameArrayNotString
26/99 Test  #433: KVDBApiTest.dbGetNameArrayNotString ...................................   Passed    0.06 sec
      Start  434: KVDBApiTest.dbGetNameMissing
27/99 Test  #434: KVDBApiTest.dbGetNameMissing ..........................................   Passed    0.06 sec
      Start  435: KVDBApiTest.dbGetNameEmpty
28/99 Test  #435: KVDBApiTest.dbGetNameEmpty ............................................   Passed    0.05 sec
      Start  436: KVDBApiTest.dbGetKeyMissing
29/99 Test  #436: KVDBApiTest.dbGetKeyMissing ...........................................   Passed    0.06 sec
      Start  437: KVDBApiTest.dbGetKeyEmpty
30/99 Test  #437: KVDBApiTest.dbGetKeyEmpty .............................................   Passed    0.06 sec
      Start  438: KVDBApiTest.dbGetOneKey
31/99 Test  #438: KVDBApiTest.dbGetOneKey ...............................................   Passed    0.07 sec
      Start  439: KVDBApiTest.dbGetRepeatKeyNoError
32/99 Test  #439: KVDBApiTest.dbGetRepeatKeyNoError .....................................   Passed    0.08 sec
      Start  440: KVDBApiTest.dbGetMoreThanOneKey
33/99 Test  #440: KVDBApiTest.dbGetMoreThanOneKey .......................................   Passed    0.07 sec
      Start  441: KVDBApiTest.dbGetKeyDBNotExists
34/99 Test  #441: KVDBApiTest.dbGetKeyDBNotExists .......................................   Passed    0.06 sec
      Start  442: KVDBApiTest.dbGetOneKeyNotExists
35/99 Test  #442: KVDBApiTest.dbGetOneKeyNotExists ......................................   Passed    0.06 sec
      Start  443: KVDBApiTest.dbDeleteOk
36/99 Test  #443: KVDBApiTest.dbDeleteOk ................................................   Passed    0.04 sec
      Start  444: KVDBApiTest.dbDeleteNameMissing
37/99 Test  #444: KVDBApiTest.dbDeleteNameMissing .......................................   Passed    0.04 sec
      Start  445: KVDBApiTest.dbDeleteNameArrayNotString
38/99 Test  #445: KVDBApiTest.dbDeleteNameArrayNotString ................................   Passed    0.05 sec
      Start  446: KVDBApiTest.dbDeleteNameEmpty
39/99 Test  #446: KVDBApiTest.dbDeleteNameEmpty .........................................   Passed    0.06 sec
      Start  447: KVDBApiTest.dbDeleteKeyMissing
40/99 Test  #447: KVDBApiTest.dbDeleteKeyMissing ........................................   Passed    0.06 sec
      Start  448: KVDBApiTest.dbDeleteKeyEmpty
41/99 Test  #448: KVDBApiTest.dbDeleteKeyEmpty ..........................................   Passed    0.06 sec
      Start  449: KVDBApiTest.dbDeleteOneKey
42/99 Test  #449: KVDBApiTest.dbDeleteOneKey ............................................   Passed    0.06 sec
      Start  450: KVDBApiTest.dbDeleteRepeatKeyNoError
43/99 Test  #450: KVDBApiTest.dbDeleteRepeatKeyNoError ..................................   Passed    0.06 sec
      Start  451: KVDBApiTest.dbDeleteMoreThanOneKey
44/99 Test  #451: KVDBApiTest.dbDeleteMoreThanOneKey ....................................   Passed    0.06 sec
      Start  452: KVDBApiTest.dbDeleteKeyDBNotExists
45/99 Test  #452: KVDBApiTest.dbDeleteKeyDBNotExists ....................................   Passed    0.06 sec
      Start  453: KVDBApiTest.dbDeleteOneKeyNotExists
46/99 Test  #453: KVDBApiTest.dbDeleteOneKeyNotExists ...................................   Passed    0.06 sec
      Start  454: KVDBApiTest.dbPutOk
47/99 Test  #454: KVDBApiTest.dbPutOk ...................................................   Passed    0.04 sec
      Start  455: KVDBApiTest.dbPutNameArrayNotString
48/99 Test  #455: KVDBApiTest.dbPutNameArrayNotString ...................................   Passed    0.05 sec
      Start  456: KVDBApiTest.dbPutNameMissing
49/99 Test  #456: KVDBApiTest.dbPutNameMissing ..........................................   Passed    0.05 sec
      Start  457: KVDBApiTest.dbPutNameEmpty
50/99 Test  #457: KVDBApiTest.dbPutNameEmpty ............................................   Passed    0.06 sec
      Start  458: KVDBApiTest.dbPutKeyMissing
51/99 Test  #458: KVDBApiTest.dbPutKeyMissing ...........................................   Passed    0.05 sec
      Start  459: KVDBApiTest.dbPutKeyEmpty
52/99 Test  #459: KVDBApiTest.dbPutKeyEmpty .............................................   Passed    0.05 sec
      Start  460: KVDBApiTest.dbPutValueMissing
53/99 Test  #460: KVDBApiTest.dbPutValueMissing .........................................   Passed    0.05 sec
      Start  461: KVDBApiTest.dbPutValueEmpty
54/99 Test  #461: KVDBApiTest.dbPutValueEmpty ...........................................   Passed    0.06 sec
      Start  462: KVDBApiTest.dbPutOneKey
55/99 Test  #462: KVDBApiTest.dbPutOneKey ...............................................   Passed    0.07 sec
      Start  463: KVDBApiTest.dbPutRepeatKeyNoError
56/99 Test  #463: KVDBApiTest.dbPutRepeatKeyNoError .....................................   Passed    0.06 sec
      Start  464: KVDBApiTest.dbPutMoreThanOneKey
57/99 Test  #464: KVDBApiTest.dbPutMoreThanOneKey .......................................   Passed    0.06 sec
      Start  465: KVDBApiTest.dbPutKeyDBNotExists
58/99 Test  #465: KVDBApiTest.dbPutKeyDBNotExists .......................................   Passed    0.06 sec
      Start  466: KVDBApiTest.registerHandlers
59/99 Test  #466: KVDBApiTest.registerHandlers ..........................................   Passed    0.07 sec
      Start  467: KVDBApiTest.dbSearchOk
60/99 Test  #467: KVDBApiTest.dbSearchOk ................................................   Passed    0.05 sec
      Start  468: KVDBApiTest.dbSearchNameArrayNotString
61/99 Test  #468: KVDBApiTest.dbSearchNameArrayNotString ................................   Passed    0.05 sec
      Start  469: KVDBApiTest.dbSearchNameMissing
62/99 Test  #469: KVDBApiTest.dbSearchNameMissing .......................................   Passed    0.05 sec
      Start  470: KVDBApiTest.dbSearchNameEmpty
63/99 Test  #470: KVDBApiTest.dbSearchNameEmpty .........................................   Passed    0.04 sec
      Start  471: KVDBApiTest.dbSearchPrefixMissing
64/99 Test  #471: KVDBApiTest.dbSearchPrefixMissing .....................................   Passed    0.05 sec
      Start  472: KVDBApiTest.dbSearchPrefixEmpty
65/99 Test  #472: KVDBApiTest.dbSearchPrefixEmpty .......................................   Passed    0.05 sec
      Start  473: KVDBApiTest.dbSearch
66/99 Test  #473: KVDBApiTest.dbSearch ..................................................   Passed    0.06 sec
      Start  474: KVDBApiTest.dbSearchNotResult
67/99 Test  #474: KVDBApiTest.dbSearchNotResult .........................................   Passed    0.06 sec
      Start  475: KVDBApiTest.dbSearchKeyDBNotExists
68/99 Test  #475: KVDBApiTest.dbSearchKeyDBNotExists ....................................   Passed    0.06 sec
      Start 1364: opBuilderKVDBDeleteTest.buildKVDBDeleteWithValue
69/99 Test #1364: opBuilderKVDBDeleteTest.buildKVDBDeleteWithValue ......................   Passed    0.07 sec
      Start 1365: opBuilderKVDBDeleteTest.buildKVDBDeleteWithReference
70/99 Test #1365: opBuilderKVDBDeleteTest.buildKVDBDeleteWithReference ..................   Passed    0.08 sec
      Start 1366: opBuilderKVDBDeleteTest.buildKVDBDeleteWrongAmountOfParametersError
71/99 Test #1366: opBuilderKVDBDeleteTest.buildKVDBDeleteWrongAmountOfParametersError ...   Passed    0.07 sec
      Start 1367: opBuilderKVDBDeleteTest.DeleteSuccessCases
72/99 Test #1367: opBuilderKVDBDeleteTest.DeleteSuccessCases ............................   Passed    0.07 sec
      Start 1368: opBuilderKVDBGetTest.BuildsGetI
73/99 Test #1368: opBuilderKVDBGetTest.BuildsGetI .......................................   Passed    0.06 sec
      Start 1369: opBuilderKVDBGetTest.BuildsGetII
74/99 Test #1369: opBuilderKVDBGetTest.BuildsGetII ......................................   Passed    0.07 sec
      Start 1370: opBuilderKVDBGetTest.WrongNumberOfParameters
75/99 Test #1370: opBuilderKVDBGetTest.WrongNumberOfParameters ..........................   Passed    0.06 sec
      Start 1371: opBuilderKVDBGetTest.GetSuccessCases
76/99 Test #1371: opBuilderKVDBGetTest.GetSuccessCases ..................................   Passed    0.08 sec
      Start 1372: opBuilderKVDBGetTest.GetFailKeyNotFound
77/99 Test #1372: opBuilderKVDBGetTest.GetFailKeyNotFound ...............................   Passed    0.08 sec
      Start 1373: opBuilderKVDBGetTest.GetMergeSuccessCases
78/99 Test #1373: opBuilderKVDBGetTest.GetMergeSuccessCases .............................   Passed    0.07 sec
      Start 1374: opBuilderKVDBGetTest.GetMergeFailKeyNotFound
79/99 Test #1374: opBuilderKVDBGetTest.GetMergeFailKeyNotFound ..........................   Passed    0.08 sec
      Start 1375: opBuilderKVDBGetTest.GetMergeFailTargetNotFound
80/99 Test #1375: opBuilderKVDBGetTest.GetMergeFailTargetNotFound .......................   Passed    0.08 sec
      Start 1376: opBuilderKVDBGetTest.GetMergeFailTypeErrors
81/99 Test #1376: opBuilderKVDBGetTest.GetMergeFailTypeErrors ...........................   Passed    0.07 sec
      Start 1377: opBuilderKVDBSetTest.buildKVDBSetWithValues
82/99 Test #1377: opBuilderKVDBSetTest.buildKVDBSetWithValues ...........................   Passed    0.07 sec
      Start 1378: opBuilderKVDBSetTest.buildKVDBSetWithReferences
83/99 Test #1378: opBuilderKVDBSetTest.buildKVDBSetWithReferences .......................   Passed    0.06 sec
      Start 1379: opBuilderKVDBSetTest.buildKVDBSetWrongAmountOfParametersError
84/99 Test #1379: opBuilderKVDBSetTest.buildKVDBSetWrongAmountOfParametersError .........   Passed    0.06 sec
      Start 1380: opBuilderKVDBSetTest.SetSuccessCases
85/99 Test #1380: opBuilderKVDBSetTest.SetSuccessCases ..................................   Passed    0.06 sec
      Start 3929: KVDBTest.Startup
86/99 Test #3929: KVDBTest.Startup ......................................................   Passed    0.04 sec
      Start 3930: KVDBTest.InitializeDBInUseWithSameManager
87/99 Test #3930: KVDBTest.InitializeDBInUseWithSameManager .............................   Passed    0.05 sec
      Start 3931: KVDBTest.InitializeDBInUseWithOtherManager
88/99 Test #3931: KVDBTest.InitializeDBInUseWithOtherManager ............................   Passed    0.04 sec
      Start 3932: KVDBTest.DeleteDB
89/99 Test #3932: KVDBTest.DeleteDB .....................................................   Passed    0.10 sec
      Start 3933: KVDBTest.DoubleDeleteDB
90/99 Test #3933: KVDBTest.DoubleDeleteDB ...............................................   Passed    0.11 sec
      Start 3934: KVDBTest.DeleteAndCreateSameDB
91/99 Test #3934: KVDBTest.DeleteAndCreateSameDB ........................................   Passed    0.11 sec
      Start 3935: KVDBTest.DeleteDataBaseNoRestart
92/99 Test #3935: KVDBTest.DeleteDataBaseNoRestart ......................................   Passed    0.06 sec
      Start 3936: KVDBTest.DeleteDataBaseWithRestart
93/99 Test #3936: KVDBTest.DeleteDataBaseWithRestart ....................................   Passed    0.08 sec
      Start 3937: KVDBTest.ScopeTest
94/99 Test #3937: KVDBTest.ScopeTest ....................................................   Passed    0.06 sec
      Start 3938: KVDBTest.ScopeInfoEmpty
95/99 Test #3938: KVDBTest.ScopeInfoEmpty ...............................................   Passed    0.04 sec
      Start 3939: KVDBTest.ScopeInfoSingle
96/99 Test #3939: KVDBTest.ScopeInfoSingle ..............................................   Passed    0.04 sec
      Start 3940: KVDBTest.ScopeInfoSingleOneHandler
97/99 Test #3940: KVDBTest.ScopeInfoSingleOneHandler ....................................   Passed    0.06 sec
      Start 3941: KVDBTest.SearchWithResultsOk
98/99 Test #3941: KVDBTest.SearchWithResultsOk ..........................................   Passed    0.05 sec
      Start 3942: KVDBTest.SearchWithoutResultsOk
99/99 Test #3942: KVDBTest.SearchWithoutResultsOk .......................................   Passed    0.06 sec

100% tests passed, 0 tests failed out of 99

Total Test time (real) =   6.18 sec
```
### ctest -R KVDB -j4

```
root@wazuh-engine:~/repos/wazuh/src/engine/build# ctest -R KVDB -j4
Test project /root/repos/wazuh/src/engine/build
      Start 1364: opBuilderKVDBDeleteTest.buildKVDBDeleteWithValue
      Start  408: KVDBApiTest.startup
      Start  475: KVDBApiTest.dbSearchKeyDBNotExists
      Start  474: KVDBApiTest.dbSearchNotResult
 1/99 Test  #408: KVDBApiTest.startup ...................................................   Passed    0.07 sec
      Start  473: KVDBApiTest.dbSearch
 2/99 Test  #475: KVDBApiTest.dbSearchKeyDBNotExists ....................................   Passed    0.09 sec
      Start 3941: KVDBTest.SearchWithResultsOk
 3/99 Test  #474: KVDBApiTest.dbSearchNotResult .........................................   Passed    0.09 sec
      Start  471: KVDBApiTest.dbSearchPrefixMissing
 4/99 Test #1364: opBuilderKVDBDeleteTest.buildKVDBDeleteWithValue ......................   Passed    0.10 sec
      Start  470: KVDBApiTest.dbSearchNameEmpty
 5/99 Test  #473: KVDBApiTest.dbSearch ..................................................   Passed    0.08 sec
      Start 3934: KVDBTest.DeleteAndCreateSameDB
 6/99 Test  #471: KVDBApiTest.dbSearchPrefixMissing .....................................   Passed    0.08 sec
      Start 3929: KVDBTest.Startup
 7/99 Test #3941: KVDBTest.SearchWithResultsOk ..........................................   Passed    0.08 sec
      Start 3942: KVDBTest.SearchWithoutResultsOk
 8/99 Test  #470: KVDBApiTest.dbSearchNameEmpty .........................................   Passed    0.07 sec
      Start  468: KVDBApiTest.dbSearchNameArrayNotString
 9/99 Test #3929: KVDBTest.Startup ......................................................   Passed    0.07 sec
      Start  472: KVDBApiTest.dbSearchPrefixEmpty
10/99 Test  #468: KVDBApiTest.dbSearchNameArrayNotString ................................   Passed    0.08 sec
      Start 3936: KVDBTest.DeleteDataBaseWithRestart
11/99 Test #3942: KVDBTest.SearchWithoutResultsOk .......................................   Passed    0.10 sec
      Start  469: KVDBApiTest.dbSearchNameMissing
12/99 Test  #472: KVDBApiTest.dbSearchPrefixEmpty .......................................   Passed    0.09 sec
      Start 3932: KVDBTest.DeleteDB
13/99 Test #3934: KVDBTest.DeleteAndCreateSameDB ........................................   Passed    0.19 sec
      Start  467: KVDBApiTest.dbSearchOk
14/99 Test  #469: KVDBApiTest.dbSearchNameMissing .......................................   Passed    0.08 sec
      Start 3933: KVDBTest.DoubleDeleteDB
15/99 Test #3936: KVDBTest.DeleteDataBaseWithRestart ....................................   Passed    0.15 sec
      Start 1365: opBuilderKVDBDeleteTest.buildKVDBDeleteWithReference
16/99 Test  #467: KVDBApiTest.dbSearchOk ................................................   Passed    0.07 sec
      Start 1378: opBuilderKVDBSetTest.buildKVDBSetWithReferences
17/99 Test #3932: KVDBTest.DeleteDB .....................................................   Passed    0.13 sec
      Start  417: KVDBApiTest.managerPostWithJsonWithoutValueOK
18/99 Test #3933: KVDBTest.DoubleDeleteDB ...............................................   Passed    0.14 sec
      Start 1369: opBuilderKVDBGetTest.BuildsGetII
19/99 Test #1378: opBuilderKVDBSetTest.buildKVDBSetWithReferences .......................   Passed    0.09 sec
      Start 1370: opBuilderKVDBGetTest.WrongNumberOfParameters
20/99 Test #1365: opBuilderKVDBDeleteTest.buildKVDBDeleteWithReference ..................   Passed    0.13 sec
      Start 3940: KVDBTest.ScopeInfoSingleOneHandler
21/99 Test  #417: KVDBApiTest.managerPostWithJsonWithoutValueOK .........................   Passed    0.09 sec
      Start 1366: opBuilderKVDBDeleteTest.buildKVDBDeleteWrongAmountOfParametersError
22/99 Test #1370: opBuilderKVDBGetTest.WrongNumberOfParameters ..........................   Passed    0.08 sec
      Start  450: KVDBApiTest.dbDeleteRepeatKeyNoError
23/99 Test #1369: opBuilderKVDBGetTest.BuildsGetII ......................................   Passed    0.08 sec
      Start 1371: opBuilderKVDBGetTest.GetSuccessCases
24/99 Test #3940: KVDBTest.ScopeInfoSingleOneHandler ....................................   Passed    0.07 sec
      Start 3935: KVDBTest.DeleteDataBaseNoRestart
25/99 Test  #450: KVDBApiTest.dbDeleteRepeatKeyNoError ..................................   Passed    0.08 sec
      Start 1376: opBuilderKVDBGetTest.GetMergeFailTypeErrors
26/99 Test #1371: opBuilderKVDBGetTest.GetSuccessCases ..................................   Passed    0.08 sec
      Start 1377: opBuilderKVDBSetTest.buildKVDBSetWithValues
27/99 Test #1366: opBuilderKVDBDeleteTest.buildKVDBDeleteWrongAmountOfParametersError ...   Passed    0.11 sec
      Start 1375: opBuilderKVDBGetTest.GetMergeFailTargetNotFound
28/99 Test #3935: KVDBTest.DeleteDataBaseNoRestart ......................................   Passed    0.09 sec
      Start  418: KVDBApiTest.managerPostWithPathEmpty
29/99 Test #1376: opBuilderKVDBGetTest.GetMergeFailTypeErrors ...........................   Passed    0.07 sec
      Start 1367: opBuilderKVDBDeleteTest.DeleteSuccessCases
30/99 Test #1375: opBuilderKVDBGetTest.GetMergeFailTargetNotFound .......................   Passed    0.08 sec
      Start  451: KVDBApiTest.dbDeleteMoreThanOneKey
31/99 Test #1377: opBuilderKVDBSetTest.buildKVDBSetWithValues ...........................   Passed    0.09 sec
      Start  431: KVDBApiTest.managerDump
32/99 Test  #418: KVDBApiTest.managerPostWithPathEmpty ..................................   Passed    0.08 sec
      Start 1372: opBuilderKVDBGetTest.GetFailKeyNotFound
33/99 Test  #451: KVDBApiTest.dbDeleteMoreThanOneKey ....................................   Passed    0.08 sec
      Start 1379: opBuilderKVDBSetTest.buildKVDBSetWrongAmountOfParametersError
34/99 Test  #431: KVDBApiTest.managerDump ...............................................   Passed    0.08 sec
      Start  420: KVDBApiTest.managerPostWithJsonNOK
35/99 Test #1367: opBuilderKVDBDeleteTest.DeleteSuccessCases ............................   Passed    0.10 sec
      Start  442: KVDBApiTest.dbGetOneKeyNotExists
36/99 Test #1372: opBuilderKVDBGetTest.GetFailKeyNotFound ...............................   Passed    0.08 sec
      Start  415: KVDBApiTest.managerPost
37/99 Test #1379: opBuilderKVDBSetTest.buildKVDBSetWrongAmountOfParametersError .........   Passed    0.08 sec
      Start  439: KVDBApiTest.dbGetRepeatKeyNoError
38/99 Test  #420: KVDBApiTest.managerPostWithJsonNOK ....................................   Passed    0.08 sec
      Start  411: KVDBApiTest.managerGetWitMultipleDBsLoaded
39/99 Test  #442: KVDBApiTest.dbGetOneKeyNotExists ......................................   Passed    0.08 sec
      Start  441: KVDBApiTest.dbGetKeyDBNotExists
40/99 Test  #415: KVDBApiTest.managerPost ...............................................   Passed    0.08 sec
      Start  436: KVDBApiTest.dbGetKeyMissing
41/99 Test  #411: KVDBApiTest.managerGetWitMultipleDBsLoaded ............................   Passed    0.08 sec
      Start  461: KVDBApiTest.dbPutValueEmpty
42/99 Test  #439: KVDBApiTest.dbGetRepeatKeyNoError .....................................   Passed    0.08 sec
      Start  419: KVDBApiTest.managerPostWithJsonPathNotExists
43/99 Test  #441: KVDBApiTest.dbGetKeyDBNotExists .......................................   Passed    0.08 sec
      Start  425: KVDBApiTest.managerDelete
44/99 Test  #436: KVDBApiTest.dbGetKeyMissing ...........................................   Passed    0.06 sec
      Start 1373: opBuilderKVDBGetTest.GetMergeSuccessCases
45/99 Test  #461: KVDBApiTest.dbPutValueEmpty ...........................................   Passed    0.08 sec
      Start  427: KVDBApiTest.managerDeleteDBInUse
46/99 Test  #419: KVDBApiTest.managerPostWithJsonPathNotExists ..........................   Passed    0.08 sec
      Start  452: KVDBApiTest.dbDeleteKeyDBNotExists
47/99 Test  #425: KVDBApiTest.managerDelete .............................................   Passed    0.09 sec
      Start 3931: KVDBTest.InitializeDBInUseWithOtherManager
48/99 Test #1373: opBuilderKVDBGetTest.GetMergeSuccessCases .............................   Passed    0.09 sec
      Start  426: KVDBApiTest.managerDeleteDBNotExists
49/99 Test  #427: KVDBApiTest.managerDeleteDBInUse ......................................   Passed    0.08 sec
      Start  464: KVDBApiTest.dbPutMoreThanOneKey
50/99 Test  #452: KVDBApiTest.dbDeleteKeyDBNotExists ....................................   Passed    0.08 sec
      Start  416: KVDBApiTest.managerPostWithJsonWithValueOK
51/99 Test #3931: KVDBTest.InitializeDBInUseWithOtherManager ............................   Passed    0.07 sec
      Start  456: KVDBApiTest.dbPutNameMissing
52/99 Test  #426: KVDBApiTest.managerDeleteDBNotExists ..................................   Passed    0.08 sec
      Start 1368: opBuilderKVDBGetTest.BuildsGetI
53/99 Test  #456: KVDBApiTest.dbPutNameMissing ..........................................   Passed    0.07 sec
      Start 1380: opBuilderKVDBSetTest.SetSuccessCases
54/99 Test  #416: KVDBApiTest.managerPostWithJsonWithValueOK ............................   Passed    0.09 sec
      Start  421: KVDBApiTest.managerPostDBExists
55/99 Test  #464: KVDBApiTest.dbPutMoreThanOneKey .......................................   Passed    0.11 sec
      Start  453: KVDBApiTest.dbDeleteOneKeyNotExists
56/99 Test #1368: opBuilderKVDBGetTest.BuildsGetI .......................................   Passed    0.12 sec
      Start  465: KVDBApiTest.dbPutKeyDBNotExists
57/99 Test #1380: opBuilderKVDBSetTest.SetSuccessCases ..................................   Passed    0.12 sec
      Start 3939: KVDBTest.ScopeInfoSingle
58/99 Test  #465: KVDBApiTest.dbPutKeyDBNotExists .......................................   Passed    0.08 sec
      Start 3937: KVDBTest.ScopeTest
59/99 Test  #421: KVDBApiTest.managerPostDBExists .......................................   Passed    0.13 sec
      Start  438: KVDBApiTest.dbGetOneKey
60/99 Test  #453: KVDBApiTest.dbDeleteOneKeyNotExists ...................................   Passed    0.12 sec
      Start  440: KVDBApiTest.dbGetMoreThanOneKey
61/99 Test #3939: KVDBTest.ScopeInfoSingle ..............................................   Passed    0.06 sec
      Start 1374: opBuilderKVDBGetTest.GetMergeFailKeyNotFound
62/99 Test #3937: KVDBTest.ScopeTest ....................................................   Passed    0.08 sec
      Start  445: KVDBApiTest.dbDeleteNameArrayNotString
63/99 Test  #438: KVDBApiTest.dbGetOneKey ...............................................   Passed    0.09 sec
      Start  455: KVDBApiTest.dbPutNameArrayNotString
64/99 Test  #440: KVDBApiTest.dbGetMoreThanOneKey .......................................   Passed    0.09 sec
      Start  466: KVDBApiTest.registerHandlers
65/99 Test #1374: opBuilderKVDBGetTest.GetMergeFailKeyNotFound ..........................   Passed    0.09 sec
      Start  432: KVDBApiTest.dbGetOk
66/99 Test  #445: KVDBApiTest.dbDeleteNameArrayNotString ................................   Passed    0.07 sec
      Start  437: KVDBApiTest.dbGetKeyEmpty
67/99 Test  #455: KVDBApiTest.dbPutNameArrayNotString ...................................   Passed    0.07 sec
      Start  463: KVDBApiTest.dbPutRepeatKeyNoError
68/99 Test  #466: KVDBApiTest.registerHandlers ..........................................   Passed    0.07 sec
      Start  410: KVDBApiTest.managerGet
69/99 Test  #432: KVDBApiTest.dbGetOk ...................................................   Passed    0.06 sec
      Start  449: KVDBApiTest.dbDeleteOneKey
70/99 Test  #437: KVDBApiTest.dbGetKeyEmpty .............................................   Passed    0.07 sec
      Start  457: KVDBApiTest.dbPutNameEmpty
71/99 Test  #410: KVDBApiTest.managerGet ................................................   Passed    0.07 sec
      Start  428: KVDBApiTest.managerDumpOk
72/99 Test  #463: KVDBApiTest.dbPutRepeatKeyNoError .....................................   Passed    0.09 sec
      Start  446: KVDBApiTest.dbDeleteNameEmpty
73/99 Test  #449: KVDBApiTest.dbDeleteOneKey ............................................   Passed    0.10 sec
      Start  423: KVDBApiTest.managerDeleteNameMissing
74/99 Test  #457: KVDBApiTest.dbPutNameEmpty ............................................   Passed    0.07 sec
      Start  430: KVDBApiTest.managerDumpNameEmpty
75/99 Test  #428: KVDBApiTest.managerDumpOk .............................................   Passed    0.07 sec
      Start 3938: KVDBTest.ScopeInfoEmpty
76/99 Test  #446: KVDBApiTest.dbDeleteNameEmpty .........................................   Passed    0.07 sec
      Start  433: KVDBApiTest.dbGetNameArrayNotString
77/99 Test  #423: KVDBApiTest.managerDeleteNameMissing ..................................   Passed    0.06 sec
      Start  459: KVDBApiTest.dbPutKeyEmpty
78/99 Test  #430: KVDBApiTest.managerDumpNameEmpty ......................................   Passed    0.07 sec
      Start  444: KVDBApiTest.dbDeleteNameMissing
79/99 Test #3938: KVDBTest.ScopeInfoEmpty ...............................................   Passed    0.07 sec
      Start  434: KVDBApiTest.dbGetNameMissing
80/99 Test  #433: KVDBApiTest.dbGetNameArrayNotString ...................................   Passed    0.08 sec
      Start  460: KVDBApiTest.dbPutValueMissing
81/99 Test  #459: KVDBApiTest.dbPutKeyEmpty .............................................   Passed    0.07 sec
      Start 3930: KVDBTest.InitializeDBInUseWithSameManager
82/99 Test  #444: KVDBApiTest.dbDeleteNameMissing .......................................   Passed    0.07 sec
      Start  462: KVDBApiTest.dbPutOneKey
83/99 Test  #434: KVDBApiTest.dbGetNameMissing ..........................................   Passed    0.07 sec
      Start  414: KVDBApiTest.managerPostNameEmpty
84/99 Test  #460: KVDBApiTest.dbPutValueMissing .........................................   Passed    0.07 sec
      Start  409: KVDBApiTest.managerGetOk
85/99 Test #3930: KVDBTest.InitializeDBInUseWithSameManager .............................   Passed    0.06 sec
      Start  454: KVDBApiTest.dbPutOk
86/99 Test  #414: KVDBApiTest.managerPostNameEmpty ......................................   Passed    0.07 sec
      Start  448: KVDBApiTest.dbDeleteKeyEmpty
87/99 Test  #462: KVDBApiTest.dbPutOneKey ...............................................   Passed    0.08 sec
      Start  443: KVDBApiTest.dbDeleteOk
88/99 Test  #409: KVDBApiTest.managerGetOk ..............................................   Passed    0.08 sec
      Start  429: KVDBApiTest.managerDumpNameMissing
89/99 Test  #454: KVDBApiTest.dbPutOk ...................................................   Passed    0.06 sec
      Start  413: KVDBApiTest.managerPostNameMissing
90/99 Test  #448: KVDBApiTest.dbDeleteKeyEmpty ..........................................   Passed    0.07 sec
      Start  422: KVDBApiTest.managerDeleteOk
91/99 Test  #443: KVDBApiTest.dbDeleteOk ................................................   Passed    0.06 sec
      Start  447: KVDBApiTest.dbDeleteKeyMissing
92/99 Test  #429: KVDBApiTest.managerDumpNameMissing ....................................   Passed    0.07 sec
      Start  424: KVDBApiTest.managerDeleteNameEmpty
93/99 Test  #413: KVDBApiTest.managerPostNameMissing ....................................   Passed    0.07 sec
      Start  412: KVDBApiTest.managerPostOk
94/99 Test  #422: KVDBApiTest.managerDeleteOk ...........................................   Passed    0.07 sec
      Start  435: KVDBApiTest.dbGetNameEmpty
95/99 Test  #447: KVDBApiTest.dbDeleteKeyMissing ........................................   Passed    0.08 sec
      Start  458: KVDBApiTest.dbPutKeyMissing
96/99 Test  #424: KVDBApiTest.managerDeleteNameEmpty ....................................   Passed    0.07 sec
97/99 Test  #412: KVDBApiTest.managerPostOk .............................................   Passed    0.06 sec
98/99 Test  #435: KVDBApiTest.dbGetNameEmpty ............................................   Passed    0.07 sec
99/99 Test  #458: KVDBApiTest.dbPutKeyMissing ...........................................   Passed    0.06 sec

100% tests passed, 0 tests failed out of 99

Total Test time (real) =   2.36 sec
```
### ctest -R KVDB -j7

```
root@wazuh-engine:~/repos/wazuh/src/engine/build# ctest -R KVDB -j7
Test project /root/repos/wazuh/src/engine/build
      Start  473: KVDBApiTest.dbSearch
      Start  475: KVDBApiTest.dbSearchKeyDBNotExists
      Start  474: KVDBApiTest.dbSearchNotResult
      Start 3934: KVDBTest.DeleteAndCreateSameDB
      Start 3933: KVDBTest.DoubleDeleteDB
      Start 3942: KVDBTest.SearchWithoutResultsOk
      Start 3932: KVDBTest.DeleteDB
 1/99 Test  #473: KVDBApiTest.dbSearch ..................................................   Passed    0.10 sec
      Start  472: KVDBApiTest.dbSearchPrefixEmpty
 2/99 Test #3942: KVDBTest.SearchWithoutResultsOk .......................................   Passed    0.09 sec
      Start  471: KVDBApiTest.dbSearchPrefixMissing
 3/99 Test  #474: KVDBApiTest.dbSearchNotResult .........................................   Passed    0.10 sec
      Start  468: KVDBApiTest.dbSearchNameArrayNotString
 4/99 Test  #475: KVDBApiTest.dbSearchKeyDBNotExists ....................................   Passed    0.11 sec
      Start 3941: KVDBTest.SearchWithResultsOk
 5/99 Test #3933: KVDBTest.DoubleDeleteDB ...............................................   Passed    0.17 sec
      Start  467: KVDBApiTest.dbSearchOk
 6/99 Test #3932: KVDBTest.DeleteDB .....................................................   Passed    0.17 sec
      Start 1365: opBuilderKVDBDeleteTest.buildKVDBDeleteWithReference
 7/99 Test  #472: KVDBApiTest.dbSearchPrefixEmpty .......................................   Passed    0.09 sec
      Start 1371: opBuilderKVDBGetTest.GetSuccessCases
 8/99 Test #3934: KVDBTest.DeleteAndCreateSameDB ........................................   Passed    0.19 sec
      Start 3936: KVDBTest.DeleteDataBaseWithRestart
 9/99 Test  #468: KVDBApiTest.dbSearchNameArrayNotString ................................   Passed    0.10 sec
      Start 1375: opBuilderKVDBGetTest.GetMergeFailTargetNotFound
10/99 Test  #471: KVDBApiTest.dbSearchPrefixMissing .....................................   Passed    0.11 sec
      Start  470: KVDBApiTest.dbSearchNameEmpty
11/99 Test #3941: KVDBTest.SearchWithResultsOk ..........................................   Passed    0.11 sec
      Start 1374: opBuilderKVDBGetTest.GetMergeFailKeyNotFound
12/99 Test  #467: KVDBApiTest.dbSearchOk ................................................   Passed    0.10 sec
      Start  411: KVDBApiTest.managerGetWitMultipleDBsLoaded
13/99 Test  #470: KVDBApiTest.dbSearchNameEmpty .........................................   Passed    0.12 sec
      Start  469: KVDBApiTest.dbSearchNameMissing
14/99 Test #1371: opBuilderKVDBGetTest.GetSuccessCases ..................................   Passed    0.16 sec
      Start 1372: opBuilderKVDBGetTest.GetFailKeyNotFound
15/99 Test #1375: opBuilderKVDBGetTest.GetMergeFailTargetNotFound .......................   Passed    0.15 sec
      Start  439: KVDBApiTest.dbGetRepeatKeyNoError
16/99 Test #1374: opBuilderKVDBGetTest.GetMergeFailKeyNotFound ..........................   Passed    0.16 sec
      Start 1367: opBuilderKVDBDeleteTest.DeleteSuccessCases
17/99 Test #1365: opBuilderKVDBDeleteTest.buildKVDBDeleteWithReference ..................   Passed    0.21 sec
      Start  438: KVDBApiTest.dbGetOneKey
18/99 Test  #411: KVDBApiTest.managerGetWitMultipleDBsLoaded ............................   Passed    0.14 sec
      Start 1373: opBuilderKVDBGetTest.GetMergeSuccessCases
19/99 Test #3936: KVDBTest.DeleteDataBaseWithRestart ....................................   Passed    0.22 sec
      Start  440: KVDBApiTest.dbGetMoreThanOneKey
20/99 Test  #469: KVDBApiTest.dbSearchNameMissing .......................................   Passed    0.10 sec
      Start  466: KVDBApiTest.registerHandlers
21/99 Test  #439: KVDBApiTest.dbGetRepeatKeyNoError .....................................   Passed    0.11 sec
      Start 1376: opBuilderKVDBGetTest.GetMergeFailTypeErrors
22/99 Test #1372: opBuilderKVDBGetTest.GetFailKeyNotFound ...............................   Passed    0.12 sec
      Start 1364: opBuilderKVDBDeleteTest.buildKVDBDeleteWithValue
23/99 Test #1367: opBuilderKVDBDeleteTest.DeleteSuccessCases ............................   Passed    0.13 sec
      Start 1377: opBuilderKVDBSetTest.buildKVDBSetWithValues
24/99 Test  #438: KVDBApiTest.dbGetOneKey ...............................................   Passed    0.12 sec
      Start  425: KVDBApiTest.managerDelete
25/99 Test #1373: opBuilderKVDBGetTest.GetMergeSuccessCases .............................   Passed    0.11 sec
      Start  462: KVDBApiTest.dbPutOneKey
26/99 Test  #466: KVDBApiTest.registerHandlers ..........................................   Passed    0.09 sec
      Start 1369: opBuilderKVDBGetTest.BuildsGetII
27/99 Test  #440: KVDBApiTest.dbGetMoreThanOneKey .......................................   Passed    0.13 sec
      Start  431: KVDBApiTest.managerDump
28/99 Test #1376: opBuilderKVDBGetTest.GetMergeFailTypeErrors ...........................   Passed    0.11 sec
      Start 1366: opBuilderKVDBDeleteTest.buildKVDBDeleteWrongAmountOfParametersError
29/99 Test #1364: opBuilderKVDBDeleteTest.buildKVDBDeleteWithValue ......................   Passed    0.15 sec
      Start  429: KVDBApiTest.managerDumpNameMissing
30/99 Test #1377: opBuilderKVDBSetTest.buildKVDBSetWithValues ...........................   Passed    0.11 sec
      Start 1378: opBuilderKVDBSetTest.buildKVDBSetWithReferences
31/99 Test #1369: opBuilderKVDBGetTest.BuildsGetII ......................................   Passed    0.11 sec
      Start 3935: KVDBTest.DeleteDataBaseNoRestart
32/99 Test  #462: KVDBApiTest.dbPutOneKey ...............................................   Passed    0.12 sec
      Start  457: KVDBApiTest.dbPutNameEmpty
33/99 Test  #425: KVDBApiTest.managerDelete .............................................   Passed    0.14 sec
      Start 1370: opBuilderKVDBGetTest.WrongNumberOfParameters
34/99 Test  #431: KVDBApiTest.managerDump ...............................................   Passed    0.12 sec
      Start  446: KVDBApiTest.dbDeleteNameEmpty
35/99 Test  #429: KVDBApiTest.managerDumpNameMissing ....................................   Passed    0.09 sec
      Start  410: KVDBApiTest.managerGet
36/99 Test #1366: opBuilderKVDBDeleteTest.buildKVDBDeleteWrongAmountOfParametersError ...   Passed    0.13 sec
      Start  416: KVDBApiTest.managerPostWithJsonWithValueOK
37/99 Test #1378: opBuilderKVDBSetTest.buildKVDBSetWithReferences .......................   Passed    0.11 sec
      Start  452: KVDBApiTest.dbDeleteKeyDBNotExists
38/99 Test  #457: KVDBApiTest.dbPutNameEmpty ............................................   Passed    0.09 sec
      Start  464: KVDBApiTest.dbPutMoreThanOneKey
39/99 Test  #446: KVDBApiTest.dbDeleteNameEmpty .........................................   Passed    0.08 sec
      Start  419: KVDBApiTest.managerPostWithJsonPathNotExists
40/99 Test #3935: KVDBTest.DeleteDataBaseNoRestart ......................................   Passed    0.12 sec
      Start  441: KVDBApiTest.dbGetKeyDBNotExists
41/99 Test #1370: opBuilderKVDBGetTest.WrongNumberOfParameters ..........................   Passed    0.11 sec
      Start  415: KVDBApiTest.managerPost
42/99 Test  #410: KVDBApiTest.managerGet ................................................   Passed    0.08 sec
      Start 1380: opBuilderKVDBSetTest.SetSuccessCases
43/99 Test  #416: KVDBApiTest.managerPostWithJsonWithValueOK ............................   Passed    0.11 sec
      Start  463: KVDBApiTest.dbPutRepeatKeyNoError
44/99 Test  #452: KVDBApiTest.dbDeleteKeyDBNotExists ....................................   Passed    0.10 sec
      Start  461: KVDBApiTest.dbPutValueEmpty
45/99 Test  #464: KVDBApiTest.dbPutMoreThanOneKey .......................................   Passed    0.11 sec
      Start  453: KVDBApiTest.dbDeleteOneKeyNotExists
46/99 Test  #419: KVDBApiTest.managerPostWithJsonPathNotExists ..........................   Passed    0.10 sec
      Start  430: KVDBApiTest.managerDumpNameEmpty
47/99 Test  #415: KVDBApiTest.managerPost ...............................................   Passed    0.09 sec
      Start  434: KVDBApiTest.dbGetNameMissing
48/99 Test  #441: KVDBApiTest.dbGetKeyDBNotExists .......................................   Passed    0.11 sec
      Start  447: KVDBApiTest.dbDeleteKeyMissing
49/99 Test #1380: opBuilderKVDBSetTest.SetSuccessCases ..................................   Passed    0.10 sec
      Start  442: KVDBApiTest.dbGetOneKeyNotExists
50/99 Test  #430: KVDBApiTest.managerDumpNameEmpty ......................................   Passed    0.08 sec
      Start  417: KVDBApiTest.managerPostWithJsonWithoutValueOK
51/99 Test  #463: KVDBApiTest.dbPutRepeatKeyNoError .....................................   Passed    0.10 sec
      Start 1379: opBuilderKVDBSetTest.buildKVDBSetWrongAmountOfParametersError
52/99 Test  #461: KVDBApiTest.dbPutValueEmpty ...........................................   Passed    0.10 sec
      Start 1368: opBuilderKVDBGetTest.BuildsGetI
53/99 Test  #434: KVDBApiTest.dbGetNameMissing ..........................................   Passed    0.09 sec
      Start  437: KVDBApiTest.dbGetKeyEmpty
54/99 Test  #453: KVDBApiTest.dbDeleteOneKeyNotExists ...................................   Passed    0.10 sec
      Start  465: KVDBApiTest.dbPutKeyDBNotExists
55/99 Test  #447: KVDBApiTest.dbDeleteKeyMissing ........................................   Passed    0.09 sec
      Start  418: KVDBApiTest.managerPostWithPathEmpty
56/99 Test  #442: KVDBApiTest.dbGetOneKeyNotExists ......................................   Passed    0.10 sec
      Start  449: KVDBApiTest.dbDeleteOneKey
57/99 Test #1368: opBuilderKVDBGetTest.BuildsGetI .......................................   Passed    0.09 sec
      Start  436: KVDBApiTest.dbGetKeyMissing
58/99 Test  #417: KVDBApiTest.managerPostWithJsonWithoutValueOK .........................   Passed    0.11 sec
      Start  433: KVDBApiTest.dbGetNameArrayNotString
59/99 Test  #465: KVDBApiTest.dbPutKeyDBNotExists .......................................   Passed    0.09 sec
      Start  426: KVDBApiTest.managerDeleteDBNotExists
60/99 Test #1379: opBuilderKVDBSetTest.buildKVDBSetWrongAmountOfParametersError .........   Passed    0.11 sec
      Start  451: KVDBApiTest.dbDeleteMoreThanOneKey
61/99 Test  #437: KVDBApiTest.dbGetKeyEmpty .............................................   Passed    0.10 sec
      Start 3937: KVDBTest.ScopeTest
62/99 Test  #418: KVDBApiTest.managerPostWithPathEmpty ..................................   Passed    0.10 sec
      Start  427: KVDBApiTest.managerDeleteDBInUse
63/99 Test  #449: KVDBApiTest.dbDeleteOneKey ............................................   Passed    0.11 sec
      Start  450: KVDBApiTest.dbDeleteRepeatKeyNoError
64/99 Test  #436: KVDBApiTest.dbGetKeyMissing ...........................................   Passed    0.09 sec
      Start  448: KVDBApiTest.dbDeleteKeyEmpty
65/99 Test  #433: KVDBApiTest.dbGetNameArrayNotString ...................................   Passed    0.09 sec
      Start  420: KVDBApiTest.managerPostWithJsonNOK
66/99 Test  #426: KVDBApiTest.managerDeleteDBNotExists ..................................   Passed    0.09 sec
      Start 3940: KVDBTest.ScopeInfoSingleOneHandler
67/99 Test  #451: KVDBApiTest.dbDeleteMoreThanOneKey ....................................   Passed    0.10 sec
      Start  458: KVDBApiTest.dbPutKeyMissing
68/99 Test #3937: KVDBTest.ScopeTest ....................................................   Passed    0.11 sec
      Start  435: KVDBApiTest.dbGetNameEmpty
69/99 Test  #427: KVDBApiTest.managerDeleteDBInUse ......................................   Passed    0.11 sec
      Start  421: KVDBApiTest.managerPostDBExists
70/99 Test  #450: KVDBApiTest.dbDeleteRepeatKeyNoError ..................................   Passed    0.10 sec
      Start  412: KVDBApiTest.managerPostOk
71/99 Test  #448: KVDBApiTest.dbDeleteKeyEmpty ..........................................   Passed    0.09 sec
      Start  408: KVDBApiTest.startup
72/99 Test  #458: KVDBApiTest.dbPutKeyMissing ...........................................   Passed    0.09 sec
      Start  459: KVDBApiTest.dbPutKeyEmpty
73/99 Test  #435: KVDBApiTest.dbGetNameEmpty ............................................   Passed    0.09 sec
      Start  460: KVDBApiTest.dbPutValueMissing
74/99 Test #3940: KVDBTest.ScopeInfoSingleOneHandler ....................................   Passed    0.12 sec
      Start  413: KVDBApiTest.managerPostNameMissing
75/99 Test  #420: KVDBApiTest.managerPostWithJsonNOK ....................................   Passed    0.13 sec
      Start  424: KVDBApiTest.managerDeleteNameEmpty
76/99 Test  #421: KVDBApiTest.managerPostDBExists .......................................   Passed    0.12 sec
      Start  445: KVDBApiTest.dbDeleteNameArrayNotString
77/99 Test  #408: KVDBApiTest.startup ...................................................   Passed    0.08 sec
      Start 3930: KVDBTest.InitializeDBInUseWithSameManager
78/99 Test  #412: KVDBApiTest.managerPostOk .............................................   Passed    0.09 sec
      Start  432: KVDBApiTest.dbGetOk
79/99 Test  #459: KVDBApiTest.dbPutKeyEmpty .............................................   Passed    0.09 sec
      Start  423: KVDBApiTest.managerDeleteNameMissing
80/99 Test  #460: KVDBApiTest.dbPutValueMissing .........................................   Passed    0.09 sec
      Start  456: KVDBApiTest.dbPutNameMissing
81/99 Test  #413: KVDBApiTest.managerPostNameMissing ....................................   Passed    0.09 sec
      Start  455: KVDBApiTest.dbPutNameArrayNotString
82/99 Test  #424: KVDBApiTest.managerDeleteNameEmpty ....................................   Passed    0.09 sec
      Start  422: KVDBApiTest.managerDeleteOk
83/99 Test #3930: KVDBTest.InitializeDBInUseWithSameManager .............................   Passed    0.08 sec
      Start  444: KVDBApiTest.dbDeleteNameMissing
84/99 Test  #432: KVDBApiTest.dbGetOk ...................................................   Passed    0.09 sec
      Start 3931: KVDBTest.InitializeDBInUseWithOtherManager
85/99 Test  #445: KVDBApiTest.dbDeleteNameArrayNotString ................................   Passed    0.11 sec
      Start 3938: KVDBTest.ScopeInfoEmpty
86/99 Test  #423: KVDBApiTest.managerDeleteNameMissing ..................................   Passed    0.12 sec
      Start  414: KVDBApiTest.managerPostNameEmpty
87/99 Test  #422: KVDBApiTest.managerDeleteOk ...........................................   Passed    0.11 sec
      Start  428: KVDBApiTest.managerDumpOk
88/99 Test  #456: KVDBApiTest.dbPutNameMissing ..........................................   Passed    0.13 sec
      Start  454: KVDBApiTest.dbPutOk
89/99 Test  #455: KVDBApiTest.dbPutNameArrayNotString ...................................   Passed    0.12 sec
      Start 3929: KVDBTest.Startup
90/99 Test  #444: KVDBApiTest.dbDeleteNameMissing .......................................   Passed    0.13 sec
      Start  409: KVDBApiTest.managerGetOk
91/99 Test #3938: KVDBTest.ScopeInfoEmpty ...............................................   Passed    0.11 sec
      Start  443: KVDBApiTest.dbDeleteOk
92/99 Test #3931: KVDBTest.InitializeDBInUseWithOtherManager ............................   Passed    0.12 sec
      Start 3939: KVDBTest.ScopeInfoSingle
93/99 Test  #454: KVDBApiTest.dbPutOk ...................................................   Passed    0.08 sec
94/99 Test  #428: KVDBApiTest.managerDumpOk .............................................   Passed    0.09 sec
95/99 Test  #414: KVDBApiTest.managerPostNameEmpty ......................................   Passed    0.11 sec
96/99 Test #3929: KVDBTest.Startup ......................................................   Passed    0.09 sec
97/99 Test  #443: KVDBApiTest.dbDeleteOk ................................................   Passed    0.08 sec
98/99 Test  #409: KVDBApiTest.managerGetOk ..............................................   Passed    0.09 sec
99/99 Test #3939: KVDBTest.ScopeInfoSingle ..............................................   Passed    0.08 sec

100% tests passed, 0 tests failed out of 99

Total Test time (real) =   1.79 sec
```

## KVDB Memory Report

#### Valgrind Execution

##### Command

```bash
valgrind -s --leak-check=full --show-leak-kinds=all --track-origins=yes --log-file=./ValgrindPRs.log.%p --num-callers=15 ./main server --log_level trace --queue_size 1000 --queue_flood_file "" --router_threads 1 start
```

##### Environment

```bash
origin/18046-engine-kvdb-prefix-search-feature
```

* After rebasing with 13334 including memory leaks fixes on json::Json library and others.

#### Memory Profiling Cases

##### Engine startup gone successfully. No operations on KVDB performed. Just initialization and shutdown.

###### Run 1 : Original Code in branch

```
==323015== LEAK SUMMARY:
==323015==    definitely lost: 0 bytes in 0 blocks
==323015==    indirectly lost: 0 bytes in 0 blocks
==323015==      possibly lost: 0 bytes in 0 blocks
==323015==    still reachable: 12,927 bytes in 175 blocks
==323015==         suppressed: 0 bytes in 0 blocks
```

###### Run 2 : Original Code in main branch: 11334-dev-new-wazuh-engine
```
==329414== LEAK SUMMARY:
==329414==    definitely lost: 0 bytes in 0 blocks
==329414==    indirectly lost: 0 bytes in 0 blocks
==329414==      possibly lost: 0 bytes in 0 blocks
==329414==    still reachable: 12,927 bytes in 175 blocks
==329414==         suppressed: 0 bytes in 0 blocks
```

##### Engine startup gone successfully. Operations of search on KVDB performed.

###### Run 1 : Original Code in branch

```
==323873== LEAK SUMMARY:
==323873==    definitely lost: 0 bytes in 0 blocks
==323873==    indirectly lost: 0 bytes in 0 blocks
==323873==      possibly lost: 0 bytes in 0 blocks
==323873==    still reachable: 12,927 bytes in 175 blocks
==323873==         suppressed: 0 bytes in 0 blocks
```

All of them returning 

```
still reachable: 12,927 bytes in 175 blocks
```
