### PR TITLE
Fix  upload_decoder_file and upload_rule_file function when two different files have the same name

### DIFF
--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -17,7 +17,7 @@ from wazuh.core.exception import WazuhInternalError, WazuhError
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.rule import format_rule_decoder_file
 from wazuh.core.utils import process_array, safe_move, validate_wazuh_xml, \
-    delete_file_with_backup, upload_file, to_relative_path
+    upload_file, to_relative_path, full_copy
 from wazuh.rbac.decorators import expose_resources
 
 
@@ -354,7 +354,13 @@ def upload_decoder_file(filename: str, content: str, relative_dirname: str = Non
             raise WazuhError(1905)
         elif overwrite and exists(full_path):
             backup_file = f'{full_path}.backup'
-            delete_file_with_backup(backup_file, full_path, delete_decoder_file)
+            try:
+                full_copy(full_path, backup_file)
+            except IOError as exc:
+                raise WazuhError(1019) from exc
+            
+            delete_decoder_file(filename=filename,
+                                relative_dirname=relative_dirname)
 
         upload_file(content, to_relative_path(full_path))
         result.affected_items.append(to_relative_path(full_path))

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -358,7 +358,7 @@ def upload_decoder_file(filename: str, content: str, relative_dirname: str = Non
                 full_copy(full_path, backup_file)
             except IOError as exc:
                 raise WazuhError(1019) from exc
-            
+
             delete_decoder_file(filename=filename,
                                 relative_dirname=relative_dirname)
 

--- a/framework/wazuh/tests/test_decoder.py
+++ b/framework/wazuh/tests/test_decoder.py
@@ -251,13 +251,14 @@ def test_validate_upload_delete_dir(relative_dirname, res_path, err_code):
     ('test_new_decoders.xml', 'tests/data/etc/decoders/subpath/', False,
      'tests/data/etc/decoders/subpath/test_new_decoders.xml'),
 ])
-@patch('wazuh.decoder.delete_file_with_backup')
+@patch('wazuh.decoder.delete_decoder_file')
+@patch('wazuh.decoder.full_copy')
 @patch('wazuh.decoder.validate_wazuh_xml')
 @patch('wazuh.decoder.upload_file')
 @patch('wazuh.decoder.remove')
 @patch('wazuh.decoder.safe_move')
-def test_upload_file(mock_safe_move, mock_remove, mock_upload_file, 
-                     mock_xml, mock_delete, mock_wazuh_paths,
+def test_upload_file(mock_safe_move, mock_remove, mock_upload_file,
+                     mock_xml, mock_full_copy, mock_delete, mock_wazuh_paths,
                      file, relative_dirname, overwrite, decoder_path):
     """Test uploading a decoder file.
 
@@ -292,9 +293,11 @@ def test_upload_file(mock_safe_move, mock_remove, mock_upload_file,
             if overwrite:
                 full_path = os.path.join(wazuh.common.WAZUH_PATH, decoder_path)
                 backup_file = full_path+'.backup'
-                mock_delete.assert_called_once_with(backup_file, full_path,
-                                                    decoder.delete_decoder_file), \
-                'delete_decoder_file method not called with expected parameters'
+                mock_full_copy.assert_called_once_with(full_path, backup_file), \
+                'full_copy function not called with expected parameters'
+                mock_delete.assert_called_once_with(filename=file,
+                                                    relative_dirname=os.path.dirname(decoder_path)), \
+                'delete_decoder_file function not called with expected parameters'
                 mock_remove.assert_called_once()
                 mock_safe_move.assert_called_once()
 


### PR DESCRIPTION
|Related issue|
|---|
|#18312|


## Description
Fix upload_decoder_file and upload_rule_file functions. 

Updating a file in a subdirectory with the same name as a file in the base user ruleset directory wrongly deletes the file in the user base directory.