### PR TITLE
Coordinate Data Provider Schema with Syscollector API Schema - Implementation

### DIFF
--- a/src/data_provider/qa/packages_schema.json
+++ b/src/data_provider/qa/packages_schema.json
@@ -24,8 +24,7 @@
                         "minLength": 1
                     },
                     "multiarch": {
-                        "type": "string",
-                        "minLength": 1
+                        "type": "string"
                     },
                     "name": {
                         "type": "string",
@@ -60,7 +59,6 @@
                     "description",
                     "format",
                     "groups",
-                    "multiarch",
                     "name",
                     "priority",
                     "size",

--- a/src/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelper.h
@@ -48,7 +48,8 @@ namespace PackageLinuxHelper
 
             std::string priority {UNKNOWN_VALUE};
             std::string groups {UNKNOWN_VALUE};
-            std::string multiarch {UNKNOWN_VALUE};
+            // The multiarch field won't have a default value
+            std::string multiarch;
             std::string architecture {UNKNOWN_VALUE};
             std::string source {UNKNOWN_VALUE};
             std::string version {UNKNOWN_VALUE};

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -35,7 +35,6 @@ class PKGWrapper final : public IPackageWrapper
             , m_format{"pkg"}
             , m_source {UNKNOWN_VALUE}
             , m_location {UNKNOWN_VALUE}
-            , m_multiarch {UNKNOWN_VALUE}
             , m_priority {UNKNOWN_VALUE}
             , m_size {0}
             , m_vendor{UNKNOWN_VALUE}

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -389,7 +389,6 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, std::f
                     packageJson["install_time"] = install_time.empty() ? UNKNOWN_VALUE : std::move(install_time);
                     packageJson["location"]     = location.empty() ? UNKNOWN_VALUE : std::move(location);
                     packageJson["architecture"] = std::move(architecture);
-                    packageJson["multiarch"]     = UNKNOWN_VALUE;
                     packageJson["format"]       = "win";
 
                     returnCallback(packageJson);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #18323 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

It was found that adding a default value for the `multiarch` field for the packages retrieved by **syscollector** isn't compatible with the API restrictions for that field.

Considering this, the field will be optional in the `src/data_provider/qa/packages_schema.json` and it won't have a default value.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] QA templates contemplate the added capabilities
