### PR TITLE
Allow controling agents with higher versions than the manager

### DIFF
--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -18,8 +18,23 @@
 
 #ifndef WIN32
 
+#ifdef WAZUH_UNIT_TESTING
+// Remove STATIC qualifier from tests
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 static short eval_bool(const char *str);
 int w_read_force_config(XML_NODE node, authd_config_t *config);
+
+/**
+ * @brief gets the auth agents configuration
+ *
+ * @param node XML node
+ * @param config auth configuration structure
+ */
+STATIC void w_parse_agents(XML_NODE node, authd_config_t * config);
 
 int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
     /* XML Definitions */
@@ -40,6 +55,7 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
     static const char *xml_ssl_manager_key = "ssl_manager_key";
     static const char *xml_ssl_auto_negotiate = "ssl_auto_negotiate";
     static const char *xml_remote_enrollment = "remote_enrollment";
+    static const char *xml_agents = "agents";
 #ifndef CLIENT
     static const char *xml_key_request = "key_request";
 #endif
@@ -73,6 +89,8 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
     config->force_options.disconnected_time_enabled = true;
     config->force_options.disconnected_time = 3600;
     config->force_options.after_registration_time = 3600;
+    config->allow_higher_versions = AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
+
     short legacy_force_insert = -1;
     int legacy_force_time = -1;
     bool new_force_read = false;
@@ -224,6 +242,16 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             }
 
             config->flags.auto_negotiate = b;
+        } else if (strcasecmp(node[i]->element, xml_agents) == 0) {
+            xml_node **children = OS_GetElementsbyNode(xml, node[i]);
+            if (children == NULL) {
+                continue;
+            }
+
+            w_parse_agents(children, config);
+
+            OS_ClearNode(children);
+
         } else {
             merror(XML_INVELEM, node[i]->element);
             return OS_INVALID;
@@ -370,4 +398,25 @@ int w_read_force_config(XML_NODE node, authd_config_t *config) {
     }
     return OS_SUCCESS;
 }
+
+STATIC void w_parse_agents(XML_NODE node, authd_config_t * config) {
+    const char * ALLOW_HIGHER_VERSIONS = "allow_higher_versions";
+
+    int i = 0;
+    while (node[i]) {
+        if (strcasecmp(node[i]->element, ALLOW_HIGHER_VERSIONS) == 0) {
+            if (strcmp(node[i]->content, "no") == 0) {
+                config->allow_higher_versions = false;
+            }
+            else if (strcmp(node[i]->content, "yes") != 0) {
+                mwarn("Ignored invalid value '%s' for auth agent's 'allow_higher_versions'.", node[i]->content);
+            }
+        }
+        else {
+            mwarn("Invalid element in the auth agent's configuration: '%s'.", node[i]->element);
+        }
+        i++;
+    }
+}
+
 #endif

--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -34,7 +34,7 @@ int w_read_force_config(XML_NODE node, authd_config_t *config);
  * @param node XML node
  * @param config auth configuration structure
  */
-STATIC void w_parse_agents(XML_NODE node, authd_config_t * config);
+STATIC void w_authd_parse_agents(XML_NODE node, authd_config_t * config);
 
 int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
     /* XML Definitions */
@@ -248,7 +248,7 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
                 continue;
             }
 
-            w_parse_agents(children, config);
+            w_authd_parse_agents(children, config);
 
             OS_ClearNode(children);
 
@@ -399,7 +399,7 @@ int w_read_force_config(XML_NODE node, authd_config_t *config) {
     return OS_SUCCESS;
 }
 
-STATIC void w_parse_agents(XML_NODE node, authd_config_t * config) {
+STATIC void w_authd_parse_agents(XML_NODE node, authd_config_t * config) {
     const char * ALLOW_HIGHER_VERSIONS = "allow_higher_versions";
 
     int i = 0;

--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -89,7 +89,6 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
     config->force_options.disconnected_time_enabled = true;
     config->force_options.disconnected_time = 3600;
     config->force_options.after_registration_time = 3600;
-    config->allow_higher_versions = AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
 
     short legacy_force_insert = -1;
     int legacy_force_time = -1;

--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -407,12 +407,14 @@ STATIC void w_authd_parse_agents(XML_NODE node, authd_config_t * config) {
             if (strcmp(node[i]->content, "no") == 0) {
                 config->allow_higher_versions = false;
             }
-            else if (strcmp(node[i]->content, "yes") != 0) {
-                mwarn("Ignored invalid value '%s' for auth agent's 'allow_higher_versions'.", node[i]->content);
+            else if (strcmp(node[i]->content, "yes") == 0) {
+                config->allow_higher_versions = true;
+            } else {
+                mwarn(REMOTED_INV_VALUE_IGNORE, node[i]->content, ALLOW_HIGHER_VERSIONS);
             }
         }
         else {
-            mwarn("Invalid element in the auth agent's configuration: '%s'.", node[i]->element);
+            mwarn(XML_INVELEM, node[i]->element);
         }
         i++;
     }

--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -15,6 +15,8 @@
 #define AD_CONF_UNPARSED 3
 #define AD_CONF_UNDEFINED 2
 
+#define AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT true   ///< Default allow_higher_versions value (true)
+
 #include <time.h>
 
 /**
@@ -61,6 +63,7 @@ typedef struct authd_config_t {
     long timeout_usec;
     bool worker_node;
     bool ipv6;
+    bool allow_higher_versions;
 } authd_config_t;
 
 /**

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -129,7 +129,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
                 goto fail;
             }
         } else if (chld_node && (strcmp(node[i]->element, osremote) == 0)) {
-            if ((modules & CREMOTE) && (Read_Remote(chld_node, d1, d2) < 0)) {
+            if ((modules & CREMOTE) && (Read_Remote(xml, chld_node, d1, d2) < 0)) {
                 goto fail;
             }
         } else if (chld_node && (strcmp(node[i]->element, osclient) == 0)) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -75,7 +75,7 @@ int Read_CSyslog(XML_NODE node, void *config1, void *config2);
 int Read_CAgentless(XML_NODE node, void *config1, void *config2);
 int Read_Localfile(XML_NODE node, void *d1, void *d2);
 int Read_Integrator(XML_NODE node, void *config1, void *config2);
-int Read_Remote(XML_NODE node, void *d1, void *d2);
+int Read_Remote(const OS_XML *xml,XML_NODE node, void *d1, void *d2);
 int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
 int Read_ClientBuffer(XML_NODE node, void *d1, void *d2);
 int ReadActiveResponses(XML_NODE node, void *d1, void *d2);

--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -135,8 +135,6 @@ int Read_Remote(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
 
     logr->rids_closing_time = DEFAULT_RIDS_CLOSING_TIME;
 
-    logr->allow_higher_versions = REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
-
     while (node[i]) {
         if (!node[i]->element) {
             merror(XML_ELEMNULL);

--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -32,7 +32,7 @@ STATIC int w_remoted_get_net_protocol(const char * content);
  * @param node XML node
  * @param logr remoted configuration structure
  */
-STATIC void w_parse_agents(XML_NODE node, remoted * logr);
+STATIC void w_remoted_parse_agents(XML_NODE node, remoted * logr);
 
 /* Reads remote config */
 int Read_Remote(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
@@ -255,7 +255,7 @@ int Read_Remote(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
                 continue;
             }
 
-            w_parse_agents(children, logr);
+            w_remoted_parse_agents(children, logr);
 
             OS_ClearNode(children);
 
@@ -338,7 +338,7 @@ STATIC int w_remoted_get_net_protocol(const char * content) {
     return retval;
 }
 
-STATIC void w_parse_agents(XML_NODE node, remoted * logr) {
+STATIC void w_remoted_parse_agents(XML_NODE node, remoted * logr) {
     const char * ALLOW_HIGHER_VERSIONS = "allow_higher_versions";
 
     int i = 0;

--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -345,12 +345,14 @@ STATIC void w_remoted_parse_agents(XML_NODE node, remoted * logr) {
             if (strcmp(node[i]->content, "no") == 0) {
                 logr->allow_higher_versions = false;
             }
-            else if (strcmp(node[i]->content, "yes") != 0) {
-                mwarn("Ignored invalid value '%s' for remote agent's 'allow_higher_versions'.", node[i]->content);
+            else if (strcmp(node[i]->content, "yes") == 0) {
+                logr->allow_higher_versions = true;
+            } else {
+                mwarn(REMOTED_INV_VALUE_IGNORE, node[i]->content, ALLOW_HIGHER_VERSIONS);
             }
         }
         else {
-            mwarn("Invalid element in the remote agent's configuration: '%s'.", node[i]->element);
+            mwarn(XML_INVELEM, node[i]->element);
         }
         i++;
     }

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -26,6 +26,8 @@
 #define REMOTED_NET_PROTOCOL_TCP_UDP (REMOTED_NET_PROTOCOL_TCP | REMOTED_NET_PROTOCOL_UDP) ///< Either UDP or TCP
 #define REMOTED_RIDS_CLOSING_TIME_DEFAULT   (5 * 60) ///< Default rids_closing_time value (5 minutes)
 
+#define REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT true   ///< Default allow_higher_versions value (true)
+
 #include "shared.h"
 #include "global-config.h"
 
@@ -39,6 +41,8 @@ typedef struct _remoted {
     char **lip;
     os_ip **allowips;
     os_ip **denyips;
+
+    bool allow_higher_versions;
 
     int m_queue;
     int tcp_sock;       ///< This socket is used to receive requests over TCP

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -140,7 +140,7 @@ w_err_t w_auth_parse_data(const char* buf,
             return OS_INVALID;
         }
 
-        if (compare_wazuh_versions(__ossec_version, version, false) < 0) {
+        if (!config.allow_higher_versions && compare_wazuh_versions(__ossec_version, version, false) < 0) {
             merror("Incompatible version for new agent from: %s", ip);
             snprintf(response, OS_SIZE_2048, "ERROR: %s", HC_INVALID_VERSION_RESPONSE);
             return OS_INVALID;

--- a/src/os_auth/config.c
+++ b/src/os_auth/config.c
@@ -82,6 +82,11 @@ cJSON *getAuthdConfig(void) {
     cJSON_AddItemToObject(force, "disconnected_time", disconnected_time);
     if (config.force_options.after_registration_time) cJSON_AddNumberToObject(force, "after_registration_time", config.force_options.after_registration_time);
     cJSON_AddItemToObject(auth, "force", force);
+
+    cJSON * agents = cJSON_CreateObject();
+    cJSON_AddStringToObject(agents, "allow_higher_versions", config.allow_higher_versions ? "yes" : "no");
+    cJSON_AddItemToObject(auth, "agents", agents);
+
     cJSON_AddItemToObject(root,"auth",auth);
 
     return root;

--- a/src/os_auth/config.c
+++ b/src/os_auth/config.c
@@ -19,6 +19,7 @@ int authd_read_config(const char *path) {
     config.key_request.compatibility_flag = 0;
     config.key_request.exec_path = NULL;
     config.key_request.socket = NULL;
+    config.allow_higher_versions = AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
 
     mdebug2("Reading configuration '%s'", path);
 

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -37,6 +37,7 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
     cfg->denyips = NULL;
     cfg->nocmerged = 0;
     cfg->queue_size = 131072;
+    cfg->allow_higher_versions = REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
 
     receive_chunk = (unsigned)getDefine_Int("remoted", "receive_chunk", 1024, 16384);
     send_chunk = (unsigned)getDefine_Int("remoted", "send_chunk", 512, 16384);

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -105,7 +105,12 @@ cJSON *getRemoteConfig(void) {
             }
             if (logr.queue_size && (logr.conn[i] == SECURE_CONN)) {
                 sprintf(queue_size,"%ld",logr.queue_size);
-                cJSON_AddStringToObject(conn,"queue_size",queue_size); };
+                cJSON_AddStringToObject(conn,"queue_size", queue_size);
+
+                cJSON * agents = cJSON_CreateObject();
+                cJSON_AddStringToObject(agents, "allow_higher_versions", logr.allow_higher_versions ? "yes" : "no");
+                cJSON_AddItemToObject(conn, "agents", agents);
+            }
             if (logr.allowips && (int)i!=logr.position) {
                 cJSON *list = cJSON_CreateArray();
                 for(j=0;logr.allowips[j];j++){

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -302,8 +302,12 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
             if (agent_info = cJSON_Parse(strchr(r_msg, '{')), agent_info) {
                 cJSON *version = NULL;
                 if (version = cJSON_GetObjectItem(agent_info, "version"), cJSON_IsString(version)) {
-                    if (compare_wazuh_versions(__ossec_version, version->valuestring, false) < 0) {
-                        send_wrong_version_response(key->id, HC_INVALID_VERSION, INVALID_VERSION, version->valuestring, wdb_sock);
+                    if (!logr.allow_higher_versions &&
+                        compare_wazuh_versions(__ossec_version, version->valuestring, false) < 0) {
+
+                        send_wrong_version_response(key->id, HC_INVALID_VERSION,
+                                                    INVALID_VERSION, version->valuestring,
+                                                    wdb_sock);
                         cJSON_Delete(agent_info);
                         os_free(clean);
                         return;

--- a/src/unit_tests/os_auth/CMakeLists.txt
+++ b/src/unit_tests/os_auth/CMakeLists.txt
@@ -54,6 +54,8 @@ list (APPEND os_auth_flags "-Wl,--wrap,PEM_write_PrivateKey -Wl,--wrap,PEM_write
                             -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,fread \
                             -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,fgets \
                             -Wl,--wrap,RSA_new -Wl,--wrap,EVP_PKEY_new -Wl,--wrap,X509_new")
+list(APPEND os_auth_names "test_authd-config")
+list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS}")
 
 list(LENGTH os_auth_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/os_auth/test_authd-config.c
+++ b/src/unit_tests/os_auth/test_authd-config.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../os_auth/auth.h"
+#include "../../headers/shared.h"
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+
+void w_authd_parse_agents(XML_NODE node, authd_config_t * config);
+
+
+/* setup/teardown */
+
+
+/* wraps */
+
+
+/* tests */
+
+// Test w_authd_parse_agents
+
+authd_config_t config = {0};
+
+static void test_w_authd_parse_agents_no(void **state) {
+    config.allow_higher_versions = AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
+
+    XML_NODE node;
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("allow_higher_versions", node[0]->element);
+    os_strdup("no", node[0]->content);
+    node[1] = NULL;
+
+    w_authd_parse_agents(node, &config);
+    assert_false(config.allow_higher_versions);
+
+    os_free(node[0]->element);
+    os_free(node[0]->content);
+    os_free(node[0]);
+    os_free(node);
+}
+
+static void test_w_authd_parse_agents_yes(void **state) {
+    config.allow_higher_versions = AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
+
+    XML_NODE node;
+
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("allow_higher_versions", node[0]->element);
+    os_strdup("yes", node[0]->content);
+    node[1] = NULL;
+
+    w_authd_parse_agents(node, &config);
+    assert_true(config.allow_higher_versions);
+
+    os_free(node[0]->element);
+    os_free(node[0]->content);
+    os_free(node[0]);
+    os_free(node);
+}
+
+static void test_w_authd_parse_agents_invalid_value(void **state) {
+    config.allow_higher_versions = AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
+
+    XML_NODE node;
+
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("allow_higher_versions", node[0]->element);
+    os_strdup("invalid_value", node[0]->content);
+    node[1] = NULL;
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                 "Ignored invalid value 'invalid_value' for auth agent's 'allow_higher_versions'.");
+    w_authd_parse_agents(node, &config);
+    assert_true(config.allow_higher_versions);
+
+    os_free(node[0]->element);
+    os_free(node[0]->content);
+    os_free(node[0]);
+    os_free(node);
+}
+
+static void test_w_authd_parse_agents_invalid_element(void **state) {
+    config.allow_higher_versions = AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
+
+    XML_NODE node;
+
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("invalid_element", node[0]->element); // Use an invalid element name
+    os_strdup("no", node[0]->content);
+    node[1] = NULL;
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "Invalid element in the auth agent's configuration: 'invalid_element'.");
+    w_authd_parse_agents(node, &config);
+    assert_true(config.allow_higher_versions);
+
+    os_free(node[0]->element);
+    os_free(node[0]->content);
+    os_free(node[0]);
+    os_free(node);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        // Tests
+        cmocka_unit_test(test_w_authd_parse_agents_no),
+        cmocka_unit_test(test_w_authd_parse_agents_yes),
+        cmocka_unit_test(test_w_authd_parse_agents_invalid_value),
+        cmocka_unit_test(test_w_authd_parse_agents_invalid_element),
+
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/os_auth/test_authd-config.c
+++ b/src/unit_tests/os_auth/test_authd-config.c
@@ -86,7 +86,7 @@ static void test_w_authd_parse_agents_invalid_value(void **state) {
     node[1] = NULL;
 
     expect_string(__wrap__mwarn, formatted_msg,
-                 "Ignored invalid value 'invalid_value' for auth agent's 'allow_higher_versions'.");
+                 "(9001): Ignored invalid value 'invalid_value' for 'allow_higher_versions'.");
     w_authd_parse_agents(node, &config);
     assert_true(config.allow_higher_versions);
 
@@ -108,7 +108,7 @@ static void test_w_authd_parse_agents_invalid_element(void **state) {
     node[1] = NULL;
 
     expect_string(__wrap__mwarn, formatted_msg,
-                  "Invalid element in the auth agent's configuration: 'invalid_element'.");
+                  "(1230): Invalid element in the configuration: 'invalid_element'.");
     w_authd_parse_agents(node, &config);
     assert_true(config.allow_higher_versions);
 

--- a/src/unit_tests/remoted/test_remote-config.c
+++ b/src/unit_tests/remoted/test_remote-config.c
@@ -176,7 +176,7 @@ static void test_w_remoted_parse_agents_invalid_value(void **state) {
     node[1] = NULL;
 
     expect_string(__wrap__mwarn, formatted_msg,
-                  "Ignored invalid value 'invalid_value' for remote agent's 'allow_higher_versions'.");
+                  "(9001): Ignored invalid value 'invalid_value' for 'allow_higher_versions'.");
     w_remoted_parse_agents(node, &logr);
     assert_true(logr.allow_higher_versions);
 
@@ -198,7 +198,7 @@ static void test_w_remoted_parse_agents_invalid_element(void **state) {
     node[1] = NULL;
 
     expect_string(__wrap__mwarn, formatted_msg,
-                  "Invalid element in the remote agent's configuration: 'invalid_element'.");
+                  "(1230): Invalid element in the configuration: 'invalid_element'.");
     w_remoted_parse_agents(node, &logr);
     assert_true(logr.allow_higher_versions);
 

--- a/src/unit_tests/remoted/test_remote-config.c
+++ b/src/unit_tests/remoted/test_remote-config.c
@@ -21,9 +21,10 @@
 
 int w_remoted_get_net_protocol(const char * content);
 
+void w_remoted_parse_agents(XML_NODE node, remoted * logr);
+
 
 /* setup/teardown */
-
 
 
 /* wraps */
@@ -32,6 +33,7 @@ int w_remoted_get_net_protocol(const char * content);
 /* tests */
 
 // Test w_remoted_get_net_protocol
+
 void test_w_remoted_get_net_protocol_content_NULL(void **state)
 {
     const char * content = NULL;
@@ -122,6 +124,90 @@ void test_w_remoted_get_net_protocol_content_mix(void **state)
 
 }
 
+// Test w_remoted_parse_agents
+
+remoted logr = {0};
+
+static void test_w_remoted_parse_agents_no(void **state) {
+    logr.allow_higher_versions = REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
+    XML_NODE node;
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("allow_higher_versions", node[0]->element);
+    os_strdup("no", node[0]->content);
+    node[1] = NULL;
+
+    w_remoted_parse_agents(node, &logr);
+    assert_false(logr.allow_higher_versions);
+
+    os_free(node[0]->element);
+    os_free(node[0]->content);
+    os_free(node[0]);
+    os_free(node);
+}
+
+static void test_w_remoted_parse_agents_yes(void **state) {
+    logr.allow_higher_versions = REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
+    XML_NODE node;
+
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("allow_higher_versions", node[0]->element);
+    os_strdup("yes", node[0]->content);
+    node[1] = NULL;
+
+    w_remoted_parse_agents(node, &logr);
+    assert_true(logr.allow_higher_versions);
+
+    os_free(node[0]->element);
+    os_free(node[0]->content);
+    os_free(node[0]);
+    os_free(node);
+}
+
+static void test_w_remoted_parse_agents_invalid_value(void **state) {
+    logr.allow_higher_versions = REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
+    XML_NODE node;
+
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("allow_higher_versions", node[0]->element);
+    os_strdup("invalid_value", node[0]->content);
+    node[1] = NULL;
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "Ignored invalid value 'invalid_value' for remote agent's 'allow_higher_versions'.");
+    w_remoted_parse_agents(node, &logr);
+    assert_true(logr.allow_higher_versions);
+
+    os_free(node[0]->element);
+    os_free(node[0]->content);
+    os_free(node[0]);
+    os_free(node);
+}
+
+static void test_w_remoted_parse_agents_invalid_element(void **state) {
+    logr.allow_higher_versions = REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
+
+    XML_NODE node;
+
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("invalid_element", node[0]->element); // Use an invalid element name
+    os_strdup("no", node[0]->content);
+    node[1] = NULL;
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "Invalid element in the remote agent's configuration: 'invalid_element'.");
+    w_remoted_parse_agents(node, &logr);
+    assert_true(logr.allow_higher_versions);
+
+    os_free(node[0]->element);
+    os_free(node[0]->content);
+    os_free(node[0]);
+    os_free(node);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -134,6 +220,10 @@ int main(void)
         cmocka_unit_test(test_w_remoted_get_net_protocol_content_tcp_udp),
         cmocka_unit_test(test_w_remoted_get_net_protocol_content_udp_tcp),
         cmocka_unit_test(test_w_remoted_get_net_protocol_content_mix),
+        cmocka_unit_test(test_w_remoted_parse_agents_no),
+        cmocka_unit_test(test_w_remoted_parse_agents_yes),
+        cmocka_unit_test(test_w_remoted_parse_agents_invalid_value),
+        cmocka_unit_test(test_w_remoted_parse_agents_invalid_element),
 
     };
 


### PR DESCRIPTION
|Related issue|
|---|
|#18138|

## Description

As per the request in issue #18138, we need to implement configuration changes and code adaptations to enable the management of agents with versions higher than that of the manager.

## Configuration options

- `allow_higher_versions` can be set either to `yes` (default) or `no`.

```xml
<ossec_config>
  <remote>
    <connection>secure</connection>
    <agents>
      <allow_higher_versions>yes</allow_higher_versions>
    </agents>
  </remote>

  <auth>
    <agents>
      <allow_higher_versions>yes</allow_higher_versions>
    </agents>
  </auth>
</ossec_config>
```

## Logs/Alerts example

- Invalid option inside `<agents>`:
> 2023/08/10 16:26:00 wazuh-remoted: WARNING: Invalid element in the remote agent's configuration: 'swallow_higher_versions'.

> 2023/08/10 16:26:00 wazuh-authd: WARNING: Invalid element in the auth agent's configuration: 'swallow_higher_versions'.

- Invalid value at `<allow_higher_versions>`:
> 2023/08/10 16:26:40 wazuh-remoted: WARNING: Ignored invalid value 'pepe' for remote agent's 'allow_higher_versions'.

> 2023/08/10 16:26:40 wazuh-authd: WARNING: Ignored invalid value 'pepe' for auth agent's 'allow_higher_versions'.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors