### PR TITLE
Vulnerability scanner publish the results of tests and checks in artifact - Implementation

### DIFF
--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -6,6 +6,9 @@ inputs:
     required: true
     description: "Path to validate"
     default: src/
+  id:
+    required: true
+    description: "Module identifier, used to name the artifact"
 
 runs:
   using: "composite"
@@ -35,16 +38,20 @@ runs:
 
           # Check if there are errors
           if [ -s "${ERRORS_FILE}" ]; then
-            echo "Clang-format errors found"
+            echo "---------------------------------"
+            echo "FAILED: Clang-format check failed"
+            echo "---------------------------------"
             exit 1
           else
-            echo "Clang-format check passed successfully"
+            echo "---------------------------------"
+            echo "PASSED: Clang-format check passed"
+            echo "---------------------------------"
           fi
 
       # Upload errors as an artifact, when failed
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: Clang-format errors
+          name: Clang-format errors - ${{ inputs.id }}
           path: ${{ inputs.path }}/clang_format_errors.txt
           retention-days: 1

--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -19,6 +19,7 @@ runs:
           version: 1.0
 
       - name: Check codding style
+        shell: bash
         run: |
 
           # Execute in dry-run and fail on warnings
@@ -29,12 +30,21 @@ runs:
           sourceFiles=$(find ${{ inputs.path }} -type f \( -name "*.cpp" -o -name "*.hpp" \) | tr '\n' ' ')
           arguments+="-i $sourceFiles "
 
-          echo "Executing: clang-format $arguments"
-          clang-format $arguments
+          ERRORS_FILE=${{ inputs.path }}/clang_format_errors.txt
+          clang-format $arguments 2> ${ERRORS_FILE}
 
-          if [[ $? -ne 0 ]]; then
-            echo "Codding style check failed"
-            # exit 1
+          # Check if there are errors
+          if [ -s "${ERRORS_FILE}" ]; then
+            echo "Clang-format errors found"
+            exit 1
+          else
+            echo "Clang-format check passed successfully"
           fi
 
-        shell: bash
+      # Upload errors as an artifact, when failed
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Clang-format errors
+          path: ${{ inputs.path }}/clang_format_errors.txt
+          retention-days: 1

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -17,7 +17,9 @@ runs:
           packages: lcov
           version: 1.0
 
+      # Generate the coverage files
       - name: Generate coverage files
+        shell: bash
         run: |
 
           cd ${{ inputs.path }}
@@ -44,9 +46,28 @@ runs:
           echo "Executing: lcov $arguments"
           lcov $arguments
 
+      # Generate the HTML coverage report
+      - name: Generate coverage report
         shell: bash
-      
+        run: |
+
+          cd ${{ inputs.path }}/build
+
+          # Generate HTML report
+          genhtml coverage.info --output-directory coverage_report
+
+      # Upload the coverage report as an artifact
+      - name: Uploading coverage report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Coverage Report
+          path: ./${{ inputs.path }}/build/coverage_report
+          retention-days: 1
+
+      # Check whether the coverage is greater than 90% both for lines and functions
       - name: Validate coverage
+        shell: bash
         run: |
 
           cd ${{ inputs.path }}
@@ -59,7 +80,7 @@ runs:
           echo "Lines coverage is: $linesCoverage %"
           if ! (( $(echo "$linesCoverage > 90" | bc -l) )); then
               echo "ERROR: Low lines coverage"
-              #exit 1
+              exit 1
           fi
           
           # Check if functions coverage is greater than 90%
@@ -67,7 +88,5 @@ runs:
           echo "Functions coverage is: $functionsCoverage %"
           if ! (( $(echo "$functionsCoverage > 90" | bc -l) )); then
               echo "ERROR: Low functions coverage"
-              #exit 1
+              exit 1
           fi
-
-        shell: bash

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -5,6 +5,9 @@ inputs:
   path:
     required: true
     description: "Path to the module"
+  id:
+    required: true
+    description: "Module identifier, used to name the artifact"
 
 runs:
   using: "composite"
@@ -61,7 +64,7 @@ runs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: Coverage Report
+          name: Coverage Report - ${{ inputs.id }}
           path: ./${{ inputs.path }}/build/coverage_report
           retention-days: 1
 
@@ -79,14 +82,26 @@ runs:
           linesCoverage=$(echo "${coverageData[0]}" | sed 's/%//')
           echo "Lines coverage is: $linesCoverage %"
           if ! (( $(echo "$linesCoverage > 90" | bc -l) )); then
-              echo "ERROR: Low lines coverage"
-              exit 1
+            echo "-------------------------"
+            echo "FAILED: Lines coverage is lower than 90%"
+            echo "-------------------------"
+            exit 1
+          else
+            echo "-------------------------"
+            echo "PASSED: Lines coverage is greater than 90%"
+            echo "-------------------------"
           fi
           
           # Check if functions coverage is greater than 90%
           functionsCoverage=$(echo "${coverageData[1]}" | sed 's/%//')
           echo "Functions coverage is: $functionsCoverage %"
           if ! (( $(echo "$functionsCoverage > 90" | bc -l) )); then
-              echo "ERROR: Low functions coverage"
-              exit 1
+            echo "------------------------------"
+            echo "FAILED: Functions coverage is lower than 90%"
+            echo "------------------------------"
+            exit 1
+          else
+            echo "----------------------------------------------"
+            echo "PASSED: Functions coverage is greater than 90%"
+            echo "----------------------------------------------"
           fi

--- a/.github/actions/doxygen/action.yml
+++ b/.github/actions/doxygen/action.yml
@@ -10,6 +10,9 @@ inputs:
     required: true
     description: "Path to the doxygen configuration file"
     default: src/Doxyfile
+  id:
+    required: true
+    description: "Module identifier, used to name the artifact"
 
 runs:
   using: "composite"
@@ -40,17 +43,21 @@ runs:
 
           # Check if there are errors
           if [ -s "${ERRORS_FILE}" ]; then
-            echo "Documentation errors found"
+            echo "-----------------------------------------------"
+            echo "FAILED: Doxygen documentation generation failed"
+            echo "-----------------------------------------------"
             exit 1
           else
-            echo "Documentation generated successfully"
+            echo "---------------------------------------------------"
+            echo "PASSED: Doxygen documentation generated successfull"
+            echo "---------------------------------------------------"
           fi
 
       # Upload errors as an artifact, when failed
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: Doxygen errors
+          name: Doxygen errors - ${{ inputs.id }}
           path: ${{ inputs.path }}/doxygen_errors.txt
           retention-days: 1
 

--- a/.github/actions/doxygen/action.yml
+++ b/.github/actions/doxygen/action.yml
@@ -9,7 +9,7 @@ inputs:
   doxygen_config:
     required: true
     description: "Path to the doxygen configuration file"
-    default: Doxyfile
+    default: src/Doxyfile
 
 runs:
   using: "composite"
@@ -23,17 +23,41 @@ runs:
           version: 1.0
 
       - name: Generate documentation
+        shell: bash
         run: |
 
-          DOXYGEN_CONFIG=$(cat ${{ inputs.doxygen_config }}; echo -e "OUTPUT_DIRECTORY=${{ inputs.path }}/doc INPUT=${{ inputs.path }}" )
-          
-          errors=$(echo $DOXYGEN_CONFIG | doxygen - 2>) 
+          # Generate the doxygen configuration file
+          CONFIG_FILE=${{ inputs.path }}/doxygen_config.cfg
+          {
+              cat ${{ inputs.doxygen_config }}
+              echo "OUTPUT_DIRECTORY = ${{ inputs.path }}/doc"
+              echo "INPUT = ${{ inputs.path }}"
+          } > ${CONFIG_FILE}
 
-          if [ -n "$errors" ]; then
-            echo "Documentation generation failed: $errors"
+          # Generate the documentation
+          ERRORS_FILE=${{ inputs.path }}/doxygen_errors.txt
+          doxygen -s ${CONFIG_FILE} 2> ${ERRORS_FILE}
+
+          # Check if there are errors
+          if [ -s "${ERRORS_FILE}" ]; then
+            echo "Documentation errors found"
             exit 1
           else
             echo "Documentation generated successfully"
           fi
 
-        shell: bash
+      # Upload errors as an artifact, when failed
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Doxygen errors
+          path: ${{ inputs.path }}/doxygen_errors.txt
+          retention-days: 1
+
+      # Upload the documentation as an artifact, when successful
+      - uses: actions/upload-artifact@v3
+        if: success()
+        with:
+          name: Doxygen documentation
+          path: ${{ inputs.path }}/doc
+          retention-days: 1

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -61,12 +61,14 @@ jobs:
         uses: ./.github/actions/clang_format
         with:
           path: src/shared_modules/router
+          id: router
 
       - name: Router - Doxygen
         if: env.ROUTER == 'true'
         uses: ./.github/actions/doxygen
         with:
           path: src/shared_modules/router
+          id: router
 
       # Indexer connector
       - name: Indexer connector - Codding style
@@ -74,12 +76,14 @@ jobs:
         uses: ./.github/actions/clang_format
         with:
           path: src/shared_modules/indexer_connector
+          id: indexer_connector
 
       - name: Indexer connector - Doxygen
         if: env.INDEXER_CONNECTOR == 'true'
         uses: ./.github/actions/doxygen
         with:
           path: src/shared_modules/indexer_connector
+          id: indexer_connector
 
       # Content manager
       - name: Content manager - Codding style
@@ -87,12 +91,14 @@ jobs:
         uses: ./.github/actions/clang_format
         with:
           path: src/shared_modules/content_manager
+          id: content_manager
 
       - name: Content manager - Doxygen
         if: env.CONTENT_MANAGER == 'true'
         uses: ./.github/actions/doxygen
         with:
           path: src/shared_modules/content_manager
+          id: content_manager
 
       # Vulnerability scanner
       - name: Vulnerability scanner - Codding style
@@ -100,12 +106,14 @@ jobs:
         uses: ./.github/actions/clang_format
         with:
           path: src/wazuh_modules/vulnerability_scanner
+          id: vulnerability_scanner
 
       - name: Vulnerability scanner - Doxygen
         if: env.VULNERABILITY_SCANNER == 'true'
         uses: ./.github/actions/doxygen
         with:
           path: src/wazuh_modules/vulnerability_scanner
+          id: vulnerability_scanner
 
   vulnerability-scanner-modules:
     needs: style-and-documentation
@@ -134,6 +142,7 @@ jobs:
         uses: ./.github/actions/coverage
         with:
           path: src/shared_modules/router
+          id: router
 
       # Indexer connector
       - name: Indexer connector - Compilation and test
@@ -145,6 +154,7 @@ jobs:
         uses: ./.github/actions/coverage
         with:
           path: src/shared_modules/indexer_connector
+          id: indexer_connector
 
       # Content manager
       - name: Content manager - Compilation and test
@@ -156,6 +166,7 @@ jobs:
         uses: ./.github/actions/coverage
         with:
           path: src/shared_modules/content_manager
+          id: content_manager
 
       # Vulnerability scanner
       - name: Vulnerability scanner - Compilation and test
@@ -167,6 +178,7 @@ jobs:
         uses: ./.github/actions/coverage
         with:
           path: src/wazuh_modules/vulnerability_scanner
+          id: vulnerability_scanner
 
   vulnerability-scanner-modules-asan:
     needs: style-and-documentation


### PR DESCRIPTION
|Related issue|
|---|
|#18327|

## Description
This PR aims to improve the GitHub actions CI pipeline for the Vulnerability Scanner modules by adding the capability to upload artifacts with information for different scenarios:
- `Coverage HTML report -> Always`
- `Doxygen errors report -> When Doxygen fails`
- `Clang-format errors report -> When Clang-format fails`

## Tests
- [Failed Clang-format](https://github.com/wazuh/wazuh/actions/runs/5823992852)
- [Failed doxygen](https://github.com/wazuh/wazuh/actions/runs/5824108519)
- [Coverage](https://github.com/wazuh/wazuh/actions/runs/5824007989)
  - Only tested against failed coverage but the final result is the same