### PR TITLE
 Add agents allow_higher_versions API configuration

### DIFF
--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1962,8 +1962,14 @@ def test_check_wazuh_limits_unchanged(new_conf, unchanged_limits_conf, original_
 
 
 @pytest.mark.parametrize("new_conf", [
-    ("<ossec_config><agents><allow_higher_versions>yes</allow_higher_versions></agents></ossec_config>"),
-    ("<ossec_config><agents><allow_higher_versions>no</allow_higher_versions></agents></ossec_config>"),
+    ("<ossec_config><remote><agents><allow_higher_versions>yes</allow_higher_versions></agents></remote></ossec_config>"),
+    ("<ossec_config><auth><agents><allow_higher_versions>yes</allow_higher_versions></agents></auth></ossec_config>"),
+    ("<ossec_config><remote><agents><allow_higher_versions>no</allow_higher_versions></agents></remote></ossec_config>"),
+    ("<ossec_config><auth><agents><allow_higher_versions>no</allow_higher_versions></agents></auth></ossec_config>"),
+    ("<ossec_config><remote><agents><allow_higher_versions>yes</allow_higher_versions></agents></remote><auth>" \
+     "<agents><allow_higher_versions>yes</allow_higher_versions></agents></auth></ossec_config>"),
+     ("<ossec_config><remote><agents><allow_higher_versions>no</allow_higher_versions></agents></remote><auth>" \
+     "<agents><allow_higher_versions>no</allow_higher_versions></agents></auth></ossec_config>"),
 ])
 @pytest.mark.parametrize("agents_conf", [
     ({'allow_higher_versions': {'allow': True}}),

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -961,8 +961,11 @@ def check_agents_allow_higher_versions(data: str):
             pass
 
     if not blocked_configurations['agents']['allow_higher_versions']['allow']:
-        agents_section = re.compile(r"<agents>(.*)</agents>", flags=re.MULTILINE | re.DOTALL)
-        check_section(agents_section, split_section='</agents>')
+        remote_section = re.compile(r"<remote>(.*)</remote>", flags=re.MULTILINE | re.DOTALL)
+        check_section(remote_section, split_section='</remote>')
+
+        auth_section = re.compile(r"<auth>(.*)</auth>", flags=re.MULTILINE | re.DOTALL)
+        check_section(auth_section, split_section='</auth>')
 
 
 def load_wazuh_xml(xml_path, data=None):


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/18139 |

## Description

Adapted the logic to the `<remote>` and `<auth>` sections of the configuration where the value `agents.allow_higher_versions` will be specified. 

### Tests

There were no changes to the API configuration, so no integration tests were affected.