### PR TITLE
Delete deprecated tag in VD API tests

### DIFF
--- a/api/test/integration/env/configurations/vulnerability/manager/configuration_files/nvd_providers.sh
+++ b/api/test/integration/env/configurations/vulnerability/manager/configuration_files/nvd_providers.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-nvd_year=$(date -d "3 months ago" +%Y)
 
 # Remove providers
 sed -i '/<os>xenial<\/os>/d' /var/ossec/etc/ossec.conf
 sed -i '/<os>trusty<\/os>/d' /var/ossec/etc/ossec.conf
 sed -i '/<os>bionic<\/os>/d' /var/ossec/etc/ossec.conf
-sed -i "s/NVD_FEED_YEAR/$nvd_year/g" /var/ossec/etc/ossec.conf


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/17983|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Deletes the deprecated flag `update_from_year ` for VD API tests.