### PR TITLE
Add support for at symbol in query values

### DIFF
--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -1509,6 +1509,23 @@ stages:
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
+  
+  - name: Filter groups using q parameter with special character
+    request:
+      verify: False
+      <<: *general_groups_request
+      params:
+        q: "name=admin@338"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - id: "intrusion-set--16ade1aa-0ea1-4bb7-88cc-9079df2ae756"
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
 
   - name: Filter groups using q parameter (complex query)
     request:

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -65,7 +65,7 @@ input_array = [
     },
     {
         "count": 0,
-        "name": "test_nested2",
+        "name": "test@nested2",
         "mergedSum": {
             "nestedSum1": "value"
         },
@@ -1608,7 +1608,8 @@ def test_WazuhDBQueryGroupBy_protected_add_select_to_query(mock_parse, mock_add,
     ('mergedSum.nestedSum1=value', 2),
     ('configSum.nestedSum1.nestedSum11=value', 1),
     ('configSum.nestedSum2.nestedSum21=value1', 1),
-    ('configSum.nestedSum2.nestedSum21=value2', 1)
+    ('configSum.nestedSum2.nestedSum21=value2', 1),
+    ('name=test@nested2', 1),
 ])
 def test_filter_array_by_query(q, return_length):
     """Test filter by query in an array."""

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1071,7 +1071,7 @@ def filter_array_by_query(q: str, input_array: typing.List) -> typing.List:
 
     # compile regular expression only one time when function is called
     # get elements in a clause
-    re_get_elements = re.compile(r'([\w\-]+)(?:\.?)((?:[\w\-](?:\.[\w\-])*)*)(=|!=|<|>|~)([\w\-./: ]+)')
+    re_get_elements = re.compile(r'([\w\-]+)(?:\.?)((?:[\w\-](?:\.[\w\-])*)*)(=|!=|<|>|~)([\w\-./: @]+)')
     # get a list with OR clauses
     or_clauses = q.split(',')
     output_array = []


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/18221 |

## Description

Allow receiving values with the `@` character for the `q` API parameter in `process_array`.

## Tests

<details><summary>test_mitre_endpoints.tavern.yaml</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_mitre_endpoints.tavern.yaml
========================================================== test session starts ==========================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.2.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 7 items                                                                                                                       

test_mitre_endpoints.tavern.yaml::GET /mitre/metadata PASSED                                                                      [ 14%]
test_mitre_endpoints.tavern.yaml::GET /mitre/mitigations PASSED                                                                   [ 28%]
test_mitre_endpoints.tavern.yaml::GET /mitre/references PASSED                                                                    [ 42%]
test_mitre_endpoints.tavern.yaml::GET /mitre/tactics PASSED                                                                       [ 57%]
test_mitre_endpoints.tavern.yaml::GET /mitre/techniques PASSED                                                                    [ 71%]
test_mitre_endpoints.tavern.yaml::GET /mitre/groups PASSED                                                                        [ 85%]
test_mitre_endpoints.tavern.yaml::GET /mitre/software PASSED                                                                      [100%]

=============================================== 7 passed, 2 warnings in 481.40s (0:08:01) ===============================================
```

</details>

> Github actions API integration tests failures are not related to the changes introduced.