### PR TITLE
Adjust checks for cis_centos_8,cis_centos_9 SCA checks

### DIFF
--- a/ruleset/sca/centos/8/cis_centos8_linux.yml
+++ b/ruleset/sca/centos/8/cis_centos8_linux.yml
@@ -24,6 +24,8 @@ requirements:
   condition: any
   rules:
     - "f:/etc/redhat-release -> r:^Centos && r:release 8"
+    - "f:/etc/redhat-release -> r:^AlmaLinux && r:release 8"
+    - "f:/etc/redhat-release -> r:^Rocky Linux && r:release 8"
 
 variables:
   $sshd_file: /etc/ssh/sshd_config

--- a/ruleset/sca/rhel/8/cis_rhel8_linux.yml
+++ b/ruleset/sca/rhel/8/cis_rhel8_linux.yml
@@ -28,6 +28,8 @@ requirements:
     - "f:/etc/redhat-release -> r:^Oracle && r:release 8"
     - "f:/etc/redhat-release -> r:^Better && r:release 8"
     - "f:/etc/redhat-release -> r:^OpenVZ && r:release 8"
+    - "f:/etc/redhat-release -> r:^AlmaLinux && r:release 8"
+    - "f:/etc/redhat-release -> r:^Rocky Linux && r:release 8"
 
 variables:
   $sshd_file: /etc/ssh/sshd_config

--- a/ruleset/sca/rhel/9/cis_rhel9_linux.yml
+++ b/ruleset/sca/rhel/9/cis_rhel9_linux.yml
@@ -28,6 +28,8 @@ requirements:
     - "f:/etc/redhat-release -> r:^Oracle && r:release 9"
     - "f:/etc/redhat-release -> r:^Better && r:release 9"
     - "f:/etc/redhat-release -> r:^OpenVZ && r:release 9"
+    - "f:/etc/redhat-release -> r:^AlmaLinux && r:release 9"
+    - "f:/etc/redhat-release -> r:^Rocky Linux && r:release 9"
 
 variables:
   $sshd_file: /etc/ssh/sshd_config


### PR DESCRIPTION
## Description

When installing the agent for RHEL-based distributions, the RPM distributes a policy for the detected OS in `/var/ossec/ruleset/sca`. By default, the RPM will place the appropriate `cis_centosX_linux.yml`/`cis_rhelX_linux.yml` policy, which gets used by `wazuh-agent` by default.

In these policies, there are specific checks for the platform family. They compare the output of `/etc/redhat-release` for known good distributions. These should consider two of the most popular RHEL-based distributions, AlmaLinux & Rocky Linux.

This change will detect those OSs and run the SCA policies accordingly.
