### PR TITLE
Fix memory leak in Vuln Detector detected by Coverity

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -7079,10 +7079,6 @@ int wm_vuldet_insert_agent_data(sqlite3 *db,
         wm_vuldet_get_package_os(version, &os_major, &os_minor);
     }
 
-    if (agent->dist == FEED_WIN && !version) {
-        os_strdup("0", version);
-    }
-
     if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_AGENTS], -1, &stmt, NULL) != SQLITE_OK) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
         goto end;
@@ -7107,12 +7103,13 @@ int wm_vuldet_insert_agent_data(sqlite3 *db,
         sqlite3_bind_text(stmt, 6, normalized_name, -1, NULL);
         normalized_source = w_tolower_str(source);
         sqlite3_bind_text(stmt, 7, normalized_source, -1, NULL);
+        sqlite3_bind_text(stmt, 8, version, -1, NULL);
     } else {
         sqlite3_bind_text(stmt, 6, product, -1, NULL);
         sqlite3_bind_text(stmt, 7, source, -1, NULL);
+        sqlite3_bind_text(stmt, 8, version ? version : "0", -1, NULL);
     }
 
-    sqlite3_bind_text(stmt, 8, version, -1, NULL);
     sqlite3_bind_text(stmt, 9, src_version, -1, NULL);
     sqlite3_bind_text(stmt, 10, arch, -1, NULL);
     sqlite3_bind_text(stmt, 11, reference, -1, NULL);


### PR DESCRIPTION
|Related issue|
|---|
|#18359|

## Description

This PR fixes the memory leak detected by Coverity in the 4.6.0 branch.

The change made is as follows:
- Instead of storing the `"0"`, we insert it directly into the DB if `version` is empty and is in the case of _`FEED_WIN`_.

## Coverity report after the change
The defect has been eliminated:
- https://scan9.scan.coverity.com/reports.htm#v42681/p12779 - Snapshot ID: `70128`

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
