### PR TITLE
Remove undesired characters from rules group names

### DIFF
--- a/api/test/integration/test_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rule_endpoints.tavern.yaml
@@ -1514,6 +1514,23 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
+  - name: Filter search formatted name
+    request:
+      verify: False
+      <<: *groups_rules_request
+      params:
+        search: authentication_success
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - authentication_success
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
   - name: Invalid filter
     request:
       verify: False

--- a/framework/wazuh/core/rule.py
+++ b/framework/wazuh/core/rule.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import re
 from enum import Enum
 from glob import glob
 
@@ -55,15 +56,17 @@ def check_status(status):
 
 def set_groups(groups, general_groups, rule):
     groups.extend(general_groups)
-    for g in groups:
+    for group in groups:
+        # These characters are the ones Core replaces when reading XML tags
+        group = re.sub('[\n\r ]+', '', group)
         for req in RULE_REQUIREMENTS:
-            if g.startswith(req):
+            if group.startswith(req):
                 # We add the requirement to the rule
-                rule[req].append(g[len(req) + 1:]) if g[len(req) + 1:] not in rule[req] else None
+                rule[req].append(group[len(req) + 1:]) if group[len(req) + 1:] not in rule[req] else None
                 break
         else:
             # If a requirement is not found we add it to the rule as group
-            rule['groups'].append(g) if g != '' else None
+            rule['groups'].append(group) if group != '' else None
 
 
 def load_rules_from_file(rule_filename, rule_relative_path, rule_status):

--- a/framework/wazuh/core/rule.py
+++ b/framework/wazuh/core/rule.py
@@ -58,7 +58,8 @@ def set_groups(groups, general_groups, rule):
     groups.extend(general_groups)
     for group in groups:
         # These characters are the ones Core replaces when reading XML tags
-        group = re.sub('[\n\r ]+', '', group)
+        group = group.strip()
+        group = re.sub('[\n\r]+', '', group)
         for req in RULE_REQUIREMENTS:
             if group.startswith(req):
                 # We add the requirement to the rule

--- a/framework/wazuh/core/tests/test_rule.py
+++ b/framework/wazuh/core/tests/test_rule.py
@@ -182,14 +182,16 @@ def test_set_groups(groups, general_groups):
 
     assert empty_rule == expected_result
 
-@pytest.mark.parametrize('groups, general_groups', [
-    (['\n syslog', 'firewall\r'], ['amazon aws', '\n\r'])
+@pytest.mark.parametrize('groups, general_groups, expected_groups', [
+    (
+        ['\n syslog', 'firewall\r', 'azure\n log analytics '],
+        ['amazon   aws', '\n\r', ' gcp bucket '],
+        ['syslog', 'firewall', 'azure log analytics', 'amazon   aws', 'gcp bucket'],
+    )
 ])
-def test_set_groups_names_format(groups, general_groups):
+def test_set_groups_names_format(groups, general_groups, expected_groups):
     """Test set_groups names formatting."""
-    escaped_chars = ['\n', '\r', ' ']
     result = {'groups': []}
     rule.set_groups(groups, general_groups, result)
 
-    for group in result['groups']:
-        assert not any([x in group for x in escaped_chars])
+    assert result['groups'] == expected_groups

--- a/framework/wazuh/core/tests/test_rule.py
+++ b/framework/wazuh/core/tests/test_rule.py
@@ -181,3 +181,15 @@ def test_set_groups(groups, general_groups):
     rule.set_groups(groups, general_groups, empty_rule)
 
     assert empty_rule == expected_result
+
+@pytest.mark.parametrize('groups, general_groups', [
+    (['\n syslog', 'firewall\r'], ['amazon aws', '\n\r'])
+])
+def test_set_groups_names_format(groups, general_groups):
+    """Test set_groups names formatting."""
+    escaped_chars = ['\n', '\r', ' ']
+    result = {'groups': []}
+    rule.set_groups(groups, general_groups, result)
+
+    for group in result['groups']:
+        assert not any([x in group for x in escaped_chars])


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/17113 |

## Description

Removes `\n`. `\r` and white spaces from rules groups names. 

## Logs/Alerts example

`GET /rules/groups?search=authentication_success`

```json
{
    "data": {
        "affected_items": [
            "authentication_success"
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All groups in rules were returned",
    "error": 0
}
```

## Tests

<details><summary>test_rule_endpoints.tavern.yaml</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_rule_endpoints.tavern.yaml
================================================================= test session starts ==================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 15 items                                                                                                                                     

test_rule_endpoints.tavern.yaml::GET /rules PASSED                                                                                               [  6%]
test_rule_endpoints.tavern.yaml::GET /rules filters PASSED                                                                                       [ 13%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/pci_dss PASSED                                                                           [ 20%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/gdpr PASSED                                                                              [ 26%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/gpg13 PASSED                                                                             [ 33%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/hipaa PASSED                                                                             [ 40%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/nist-800-53 PASSED                                                                       [ 46%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/tsc PASSED                                                                               [ 53%]
test_rule_endpoints.tavern.yaml::GET /rules/requirement/mitre PASSED                                                                             [ 60%]
test_rule_endpoints.tavern.yaml::GET /rules/groups PASSED                                                                                        [ 66%]
test_rule_endpoints.tavern.yaml::GET /rules/files PASSED                                                                                         [ 73%]
test_rule_endpoints.tavern.yaml::GET /rules/files/(filename) PASSED                                                                              [ 80%]
test_rule_endpoints.tavern.yaml::PUT /rule/files/{filename} PASSED                                                                               [ 86%]
test_rule_endpoints.tavern.yaml::DELETE /rules/files/{filename} PASSED                                                                           [ 93%]
test_rule_endpoints.tavern.yaml::GET /rules?rule_ids PASSED                                                                                      [100%]

====================================================== 15 passed, 2 warnings in 472.63s (0:07:52) ======================================================
```

</details>