### PR TITLE
Content manager - Refactor published content - implementation

### DIFF
--- a/src/shared_modules/content_manager/src/components/S3Downloader.hpp
+++ b/src/shared_modules/content_manager/src/components/S3Downloader.hpp
@@ -31,7 +31,7 @@ private:
      *
      * @param context updater context.
      */
-    void download(const UpdaterContext& context) const
+    void download(UpdaterContext& context) const
     {
         const auto url {context.spUpdaterBaseContext->configData.at("url").get<std::string>()};
 
@@ -41,6 +41,13 @@ private:
         // 2.1 If the content is compressed, save it in the output folder (context.spUpdaterBaseContext->outputFolder)
         // 2.2 If the content is not compressed, save it in the context (context.data)
         std::ignore = url;
+
+        // Update the status of the stage
+        for (auto& element : context.data.at("stageStatus"))
+        {
+            if (element.at("stage").get<std::string>() == "S3Downloader")
+                element.at("status") = "ok";
+        }
     }
 
 public:
@@ -52,6 +59,8 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
+        // Pre-set the status of the stage to fail
+        context->data.at("stageStatus").push_back(R"({"stage": "S3Downloader", "status": "fail"})"_json);
 
         download(*context);
 

--- a/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
@@ -41,6 +41,13 @@ private:
         // 2. Save the decompressed content in the context (context.data)
         std::ignore = outputFolder;
         std::ignore = fileName;
+
+        // Update the status of the stage
+        for (auto& element : context.data.at("stageStatus"))
+        {
+            if (element.at("stage").get<std::string>() == "XZDecompressor")
+                element.at("status") = "ok";
+        }
     }
 
 public:
@@ -52,6 +59,8 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
+        // Pre-set the status of the stage to fail
+        context->data.at("stageStatus").push_back(R"({"stage": "XZDecompressor", "status": "fail"})"_json);
 
         decompress(*context);
 

--- a/src/shared_modules/content_manager/src/components/cleanUpContent.hpp
+++ b/src/shared_modules/content_manager/src/components/cleanUpContent.hpp
@@ -35,7 +35,7 @@ private:
     void cleanUp(const UpdaterContext& context) const
     {
         // Get the path to the folder.
-        const auto path = context.spUpdaterBaseContext->outputFolder;
+        const auto path = context.spUpdaterBaseContext->downloadsFolder;
 
         // Check if the path exists.
         if (!std::filesystem::exists(path))

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -58,10 +58,15 @@ private:
             std::filesystem::remove_all(outputFolderPath);
         }
 
-        // Create the output folder.
+        // Create the folders.
         std::filesystem::create_directory(outputFolderPath);
+        std::filesystem::create_directory(outputFolderPath / "downloads");
+        std::filesystem::create_directory(outputFolderPath / "contents");
 
-        std::cout << "Created output folder: " << outputFolderPath << std::endl;
+        context.downloadsFolder = outputFolderPath / "downloads";
+        context.contentsFolder = outputFolderPath / "contents";
+
+        std::cout << "Output folders created." << std::endl;
     }
 
 public:

--- a/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
+++ b/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
@@ -36,7 +36,10 @@ private:
         // If there is data to publish, send it
         if (!context.data.empty())
         {
-            context.spUpdaterBaseContext->spChannel->send(context.data);
+            // serialize the JSON object
+            const auto stringifyJson = context.data.dump();
+
+            context.spUpdaterBaseContext->spChannel->send({stringifyJson.begin(), stringifyJson.end()});
             std::cout << "PubSubPublisher - Data published" << std::endl;
         }
         else

--- a/src/shared_modules/content_manager/src/components/updaterContext.hpp
+++ b/src/shared_modules/content_manager/src/components/updaterContext.hpp
@@ -43,6 +43,18 @@ struct UpdaterBaseContext
     std::filesystem::path outputFolder;
 
     /**
+     * @brief Path to the folder where the compressed content will be downloaded.
+     *
+     */
+    std::filesystem::path downloadsFolder;
+
+    /**
+     * @brief Path to the folder where the content will be decompressed or the raw content will be stored.
+     *
+     */
+    std::filesystem::path contentsFolder;
+
+    /**
      * @brief For testing purposes. Delete it.
      */
     uint8_t download {1};      ///< download
@@ -66,8 +78,25 @@ struct UpdaterContext final : private UpdaterBaseContext
     /**
      * @brief Data to be published.
      *
+     * @details JSON file structure:
+     *  {
+     *      "paths":
+     *      [
+     *          {
+     *              "path": "/tmp/outputFolder/file1.json"
+     *          }
+     *      ],
+     *      "stageStatus":
+     *      [
+     *          {
+     *              "stage": "download",
+     *              "status": "ok"
+     *          }
+     *      ]
+     *  }
+     *
      */
-    std::vector<char> data;
+    nlohmann::json data = R"({ "paths": [], "stageStatus": [] })"_json;
 };
 
 #endif // _UPDATER_CONTEXT_HPP

--- a/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.cpp
@@ -39,7 +39,7 @@ TEST_F(PubSubPublisherTest, TestPublishEmptyData)
 
     m_spUpdaterBaseContext->spChannel->stop();
 
-    EXPECT_TRUE(m_spUpdaterContext->data.empty());
+    EXPECT_FALSE(m_spUpdaterContext->data.empty());
 }
 
 /*
@@ -47,13 +47,10 @@ TEST_F(PubSubPublisherTest, TestPublishEmptyData)
  */
 TEST_F(PubSubPublisherTest, TestPublishValidData)
 {
-    std::string data {"Hello World!"};
-
     m_spUpdaterBaseContext->spChannel = std::make_shared<RouterProvider>("component-tests");
     m_spUpdaterBaseContext->spChannel->start();
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
-    m_spUpdaterContext->data = std::vector<char>(data.begin(), data.end());
 
     EXPECT_NO_THROW(m_spPubSubPublisher->handleRequest(m_spUpdaterContext));
 
@@ -89,6 +86,7 @@ TEST_F(PubSubPublisherTest, TestPublishEmptyDataWithouStartTheRouterProvider)
     m_spUpdaterBaseContext->spChannel = std::make_shared<RouterProvider>("component-tests");
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
+    m_spUpdaterContext->data.clear();
 
     EXPECT_NO_THROW(m_spPubSubPublisher->handleRequest(m_spUpdaterContext));
 

--- a/src/shared_modules/content_manager/tests/unit/cleanUpContent_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/cleanUpContent_test.cpp
@@ -27,19 +27,18 @@ TEST_F(CleanUpContentTest, OutputPathNotSet)
  */
 TEST_F(CleanUpContentTest, OutputPathSet)
 {
-    // Set the output path
-    m_spUpdaterBaseContext->outputFolder = TEST_DIR;
-
-    // Create content in the folder
-    std::filesystem::create_directory(TEST_DIR + "/test1");
-    std::filesystem::create_directory(TEST_DIR + "/test2");
+    // Create content in the folders
+    std::filesystem::create_directory(DOWNLOAD_DIR + "/test1");
+    std::filesystem::create_directory(CONTENTS_DIR + "/test2");
 
     // Check if the output path is not empty
-    EXPECT_FALSE(std::filesystem::is_empty(TEST_DIR));
+    EXPECT_FALSE(std::filesystem::is_empty(DOWNLOAD_DIR));
+    EXPECT_FALSE(std::filesystem::is_empty(CONTENTS_DIR));
 
     // execute the cleanup
     EXPECT_NO_THROW(m_spCleanUpContent->handleRequest(m_spUpdaterContext));
 
-    // Check if the output path is empty
-    EXPECT_TRUE(std::filesystem::is_empty(TEST_DIR));
+    // Check the folder content
+    EXPECT_TRUE(std::filesystem::is_empty(DOWNLOAD_DIR));
+    EXPECT_FALSE(std::filesystem::is_empty(CONTENTS_DIR));
 }

--- a/src/shared_modules/content_manager/tests/unit/cleanUpContent_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/cleanUpContent_test.hpp
@@ -17,6 +17,8 @@
 #include <gtest/gtest.h>
 
 const std::string TEST_DIR {"/tmp/test"};
+const std::string DOWNLOAD_DIR {TEST_DIR + "/download"};
+const std::string CONTENTS_DIR {TEST_DIR + "/contents"};
 
 /**
  * @brief Runs unit tests for CleanUpContent
@@ -52,12 +54,16 @@ protected:
 
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
         m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
+        m_spUpdaterContext->spUpdaterBaseContext->downloadsFolder = DOWNLOAD_DIR;
+        m_spUpdaterContext->spUpdaterBaseContext->contentsFolder = CONTENTS_DIR;
 
         // Instance of the class to test
         m_spCleanUpContent = std::make_shared<CleanUpContent>();
 
         // Create the test directory
         std::filesystem::create_directory(TEST_DIR);
+        std::filesystem::create_directory(DOWNLOAD_DIR);
+        std::filesystem::create_directory(CONTENTS_DIR);
     }
 
     /**

--- a/src/shared_modules/content_manager/tests/unit/pubSubPublisher_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/pubSubPublisher_test.cpp
@@ -44,7 +44,7 @@ TEST_F(PubSubPublisherTest, TestPublishEmptyData)
 
     m_spUpdaterBaseContext->spChannel->stop();
 
-    EXPECT_TRUE(m_spUpdaterContext->data.empty());
+    EXPECT_FALSE(m_spUpdaterContext->data.empty());
 }
 
 /*
@@ -52,8 +52,6 @@ TEST_F(PubSubPublisherTest, TestPublishEmptyData)
  */
 TEST_F(PubSubPublisherTest, TestPublishValidData)
 {
-    std::string message {"Hello World!"};
-
     auto mockRouterProvider {std::make_shared<MockRouterProvider>()};
     EXPECT_CALL(*mockRouterProvider, start).Times(1);
     EXPECT_CALL(*mockRouterProvider, send(::testing::_)).Times(1);
@@ -63,7 +61,6 @@ TEST_F(PubSubPublisherTest, TestPublishValidData)
     m_spUpdaterBaseContext->spChannel->start();
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
-    m_spUpdaterContext->data = std::vector<char>(message.begin(), message.end());
 
     EXPECT_NO_THROW(m_spPubSubPublisher->handleRequest(m_spUpdaterContext));
 
@@ -112,5 +109,5 @@ TEST_F(PubSubPublisherTest, TestPublishEmptyDataWithouStartTheMockRouterProvider
 
     EXPECT_THROW(m_spUpdaterBaseContext->spChannel->stop(), std::runtime_error);
 
-    EXPECT_TRUE(m_spUpdaterContext->data.empty());
+    EXPECT_FALSE(m_spUpdaterContext->data.empty());
 }

--- a/src/shared_modules/content_manager/tests/unit/skipStep_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/skipStep_test.cpp
@@ -19,17 +19,17 @@ TEST_F(SkipStepTest, CheckBehaviour)
 {
     auto updaterContext {std::make_shared<UpdaterContext>()};
 
-    EXPECT_TRUE(updaterContext->data.empty());
+    EXPECT_FALSE(updaterContext->data.empty());
 
     SkipStep skipStep;
     skipStep.registerPreAction(
         [](std::shared_ptr<UpdaterContext> context)
         {
-            std::string data {"example data"};
-            context->data = std::vector<char>(data.begin(), data.end());
+            // delete the data content
+            context->data.clear();
         });
 
     EXPECT_NO_THROW(skipStep.handleRequest(updaterContext));
 
-    EXPECT_FALSE(updaterContext->data.empty());
+    EXPECT_TRUE(updaterContext->data.empty());
 }

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -1,13 +1,8 @@
 #include "contentManager.hpp"
 #include "contentRegister.hpp"
 #include <chrono>
-#include <filesystem>
-#include <fstream>
-#include <functional>
-#include <future>
 #include <iostream>
 #include <thread>
-#include <vector>
 
 /*
  * @brief Configuration parameters for the content provider.
@@ -23,7 +18,7 @@
  * @url: URL where the content is located.
  * @outputFolder: if defined, the content will be downloaded to this folder.
  * @dataFormat: Format of the content downloaded or after decompression.
- * @fileName: Name of the file to download.
+ * @fileName: Name of the file to download or file name in case of raw content.
  */
 static const nlohmann::json CONFIG_PARAMETERS =
     R"(
@@ -33,14 +28,14 @@ static const nlohmann::json CONFIG_PARAMETERS =
             "ondemand": true,
             "configData":
             {
-                "contentSource": "s3",
+                "contentSource": "api",
                 "compressionType": "raw",
                 "versionedContent": "false",
                 "deleteDownloadedContent": true,
-                "url": "url",
+                "url": "https://jsonplaceholder.typicode.com/todos/1",
                 "outputFolder": "/tmp/testProvider",
                 "dataFormat": "json",
-                "fileName": "s3_file"
+                "fileName": "example.json"
             }
         }
         )"_json;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18335|

## Description
This PR includes several updates to improve status tracking and handling of stages. 

In each relevant function of the shared_modules, a preset status of `fail` is added before the execution of the specific stage (`APIDownloader`, `S3Downloader`, `XZDecompressor`). Upon successful execution, the status is updated to `ok`. This allows better tracking of execution status at any given stage.

Next, a significant change includes modifications to store paths of downloaded or decompressed content in the context. 

There's also an update in the way data is published by `pubSubPublisher`, which now serializes JSON object before sending. 

`APIDownloader` also has been adjusted to download the file directly on disk, instead of saving the raw content in context.  

Final changes include additional attributes `downloadsFolder` and `contentsFolder` to the `UpdaterContext` and the usage of these new attributes while handling file storage in various stages and during the cleanup process. 