### PR TITLE
Fix cluster endpoints API integration tests

### DIFF
--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -566,7 +566,7 @@ marks:
 
 stages:
 
-  - name: Request {master-node}
+  - name: Request (master-node)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"


### PR DESCRIPTION
|Related issue|
|---|
|Closes #18317  |


## Description

Replaces brackets with parenthesis on one stage name to avoid it being interpreted as a variable by tavern.

## Tests

<details><summary>test_cluster_endpoints.tavern.yaml</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_cluster_endpoints.tavern.yaml
================================================== test session starts ===================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.2.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 49 items                                                                                                       

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                               [  2%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                [  4%]
test_cluster_endpoints.tavern.yaml::GET /cluster/ruleset/synchronization PASSED                                    [  6%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                 [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                      [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                         [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                             [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                             [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                           [ 18%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                         [ 20%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                         [ 22%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                      [ 24%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                     [ 26%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                    [ 28%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                   [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                 [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED        [ 34%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                [ 36%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                    [ 38%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                    [ 40%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                [ 42%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                    [ 44%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                    [ 46%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                            [ 48%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                            [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[master-node] PASSED                       [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker1] PASSED                           [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker2] PASSED                           [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                               [ 59%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                   [ 61%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                   [ 63%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                           [ 65%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                     [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                         [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                         [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                        [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                            [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                            [ 77%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                       [ 79%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                           [ 81%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                           [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                        [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                            [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                            [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                              [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                  [ 93%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                  [ 95%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                    [ 97%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                    [100%]

================================== 49 passed, 3 warnings in 491.85s (0:08:11) ==================================
```
</details>