### PR TITLE
Fix SCA checks query with condition field

### DIFF
--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -586,6 +586,25 @@ stages:
           expected_rules_command: data.affected_items[0].rules
           expected_condition_command: data.affected_items[0].condition
           expected_command_command: data.affected_items[0].command
+  
+  - name: Get items with the condition 'all'
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        q: condition=all
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
 
   - &get_item_file_field
     name: Get item with the file field (q="rules.type=file")

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -144,7 +144,7 @@ class WazuhDBQueryAgents(WazuhDBQuery):
                                 'separator': 'AND' if len(value) <= 1 or len(value) == i + 1 else 'OR',
                                 'level': 0 if i == len(value) - 1 else 1}
                                for name, value in legacy_filters_as_list.items()
-                               for i, subvalue in enumerate(value) if not self._pass_filter(subvalue)]
+                               for i, subvalue in enumerate(value) if not self._pass_filter(name, subvalue)]
 
         if self.query_filters:
             # if only traditional filters have been defined, remove last AND from the query.
@@ -257,7 +257,7 @@ class WazuhDBQueryGroup(WazuhDBQuery):
                                 'separator': 'AND' if len(value) <= 1 or len(value) == i + 1 else 'OR',
                                 'level': 0 if i == len(value) - 1 else 1}
                                for name, value in legacy_filters_as_list.items()
-                               for i, subvalue in enumerate(value) if not self._pass_filter(subvalue)]
+                               for i, subvalue in enumerate(value) if not self._pass_filter(name, subvalue)]
 
         if self.query_filters:
             # if only traditional filters have been defined, remove last AND from the query.

--- a/framework/wazuh/core/rootcheck.py
+++ b/framework/wazuh/core/rootcheck.py
@@ -80,7 +80,7 @@ class WazuhDBQueryRootcheck(WazuhDBQuery):
             super()._process_filter(field_name, field_filter, q_filter)
 
     @staticmethod
-    def _pass_filter(db_filter):
+    def _pass_filter(field, value):
         return False
 
 

--- a/framework/wazuh/core/sca.py
+++ b/framework/wazuh/core/sca.py
@@ -194,6 +194,13 @@ class WazuhDBQuerySCACheckIDs(WazuhDBQuerySCA):
                                  search=search, count=True, get_data=True, select=[], default_query=self.DEFAULT_QUERY,
                                  fields=fields, default_sort_field='id', default_sort_order='ASC')
 
+    @staticmethod
+    def _pass_filter(field, value):
+        # Overwrite method to avoid skipping queries like 'condition=all'
+        if field == 'condition':
+            return False
+        return value == 'all'
+
 
 class WazuhDBQuerySCACheckRelational(WazuhDBQuerySCA):
     """Class used to get SCA rules or compliance items related to a given SCA checks IDs list."""

--- a/framework/wazuh/core/tests/test_sca.py
+++ b/framework/wazuh/core/tests/test_sca.py
@@ -197,6 +197,24 @@ def test_WazuhDBQuerySCACheckIDs__init__(mock_wdbqsca, query):
                                          else "policy_id=test_policy_id")
 
 
+@pytest.mark.parametrize('field, value, expected', [
+    ('condition', 'all', False),
+    ('condition', 'none', False),
+    ('condition', 'any', False),
+    ('rationale', 'all', True),
+    ('description', 'none', False),
+])
+@patch('wazuh.core.utils.WazuhDBBackend.__init__', return_value=None)
+@patch('wazuh.core.agent.Agent.get_basic_information')
+def test_WazuhDBQuerySCACheckIDs_protected_pass_filter(mock_get_basic_info, mock_backend, field, value, expected):
+    """Test WazuhDBQuerySCACheckIDs._pass_filter function."""
+    query = core_sca.WazuhDBQuerySCACheckIDs(agent_id='000', offset=10, limit=20, filters={'test': 'value'},
+                                     search={'value': 'test'}, query='', policy_id='test_policy_id', sort={})
+
+    skipped = query._pass_filter(field, value)
+    assert skipped == expected
+
+
 @pytest.mark.parametrize('sca_checks_test_list', [
     [1, 2, 3, 4], []
 ])

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1356,7 +1356,7 @@ def test_WazuhDBQuery_protected_default_count_query(mock_socket_conn, mock_isfil
     mock_conn_db.assert_called_once_with()
 
 
-@pytest.mark.parametrize('db_filter', [
+@pytest.mark.parametrize('value', [
     'all',
     'other_filter'
 ])
@@ -1366,7 +1366,7 @@ def test_WazuhDBQuery_protected_default_count_query(mock_socket_conn, mock_isfil
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_pass_filter(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob, mock_exists,
-                                            db_filter):
+                                            value):
     """Test utils.WazuhDBQuery._pass_filter function."""
     query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
                                search=None, select={'fields': {'os.name'}},
@@ -1375,7 +1375,7 @@ def test_WazuhDBQuery_protected_pass_filter(mock_socket_conn, mock_isfile, mock_
                                backend=utils.WazuhDBBackend(agent_id=1),
                                count=5, get_data='data')
 
-    result = query._pass_filter(db_filter)
+    result = query._pass_filter('os.name', value)
 
     assert isinstance(result, bool)
     mock_conn_db.assert_called_once_with()

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1376,7 +1376,7 @@ class WazuhDBQuery(object):
             if close_level:
                 level -= 1
 
-            if not self._pass_filter(value):
+            if not self._pass_filter(field, value):
                 op_index = len(list(filter(lambda x: field in x['field'], self.query_filters)))
                 self.query_filters.append({'value': None if value == "null" else value,
                                            'operator': self.query_operators[operator],
@@ -1406,7 +1406,7 @@ class WazuhDBQuery(object):
                                 'separator': 'AND' if len(value) <= 1 or len(value) == i + 1 else 'OR',
                                 'level': 0 if i == len(value) - 1 else 1}
                                for name, value in legacy_filters_as_list.items()
-                               for i, subvalue in enumerate(value) if not self._pass_filter(subvalue)]
+                               for i, subvalue in enumerate(value) if not self._pass_filter(name, subvalue)]
 
         if self.query_filters:
             # if only traditional filters have been defined, remove last AND from the query.
@@ -1588,8 +1588,9 @@ class WazuhDBQuery(object):
         return "SELECT COUNT(*) FROM ({0})"
 
     @staticmethod
-    def _pass_filter(db_filter):
-        return db_filter == "all"
+    def _pass_filter(field, value):
+        # field is used by child classes containing a field that may have a value equal to 'all'
+        return value == "all"
 
 
 class WazuhDBQueryDistinct(WazuhDBQuery):


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/18314 |


## Description

Overwrites the `_pass_filter` method on `WazuhDBQuerySCACheckIDs` to avoid skipping filters that have the field `condition` and the value `all`.

To do this, I added the `field` value to `_pass_filter` because overwriting the method to just return `False` would cause an undesired behavior when receiving queries to any other field with the value `all`.

For example, `policy_id=all` would return results with a `policy_id` equal to `all` instead of all of them (expected behaviour, as in all the other endpoints).

## Logs/Alerts example

`/sca/001/checks/cis_ubuntu20-04?q=condition=all`

```json
{
    "data": {
        "affected_items": [
            ...
        ],
        "total_affected_items": 169,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected sca/policy information was returned",
    "error": 0
}
```

## Tests

<details><summary>test_sca_endpoints.tavern.yaml</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_sca_endpoints.tavern.yaml
======================================================== test session starts ========================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 46 items                                                                                                                  

test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} for agents with Wazuh version >=4.2.0 (001) and <4.2.0 (006) PASSED       [  2%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[policy_id] PASSED                             [  4%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[name] PASSED                                  [  6%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[description] PASSED                           [  8%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[references] PASSED                            [ 10%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[pass] PASSED                                  [ 13%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[fail] PASSED                                  [ 15%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[score] PASSED                                 [ 17%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[invalid] PASSED                               [ 19%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[total_checks] PASSED                          [ 21%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[hash_file] PASSED                             [ 23%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[end_scan] PASSED                              [ 26%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[start_scan] PASSED                            [ 28%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[policy_id] PASSED                [ 30%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[name] PASSED                     [ 32%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[description] PASSED              [ 34%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[references] PASSED               [ 36%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[pass] PASSED                     [ 39%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[fail] PASSED                     [ 41%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[score] PASSED                    [ 43%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[invalid] PASSED                  [ 45%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[total_checks] PASSED             [ 47%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[hash_file] PASSED                [ 50%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[end_scan] PASSED                 [ 52%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[start_scan] PASSED               [ 54%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} PASSED                                                 [ 56%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id}?remediation XPASS                                      [ 58%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[policy_id] PASSED [ 60%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[remediation] PASSED [ 63%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[condition] PASSED [ 65%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[rules.rule] PASSED [ 67%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[rationale] PASSED [ 69%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[id] PASSED [ 71%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[command] PASSED [ 73%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[title] PASSED [ 76%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[reason] PASSED [ 78%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[description] PASSED [ 80%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[registry] PASSED [ 82%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[process] PASSED [ 84%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[rules.type] PASSED [ 86%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[file] PASSED [ 89%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[compliance.value] PASSED [ 91%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[directory] PASSED [ 93%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[result] PASSED [ 95%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[compliance.key] PASSED [ 97%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[references] PASSED [100%]

======================================= 45 passed, 1 xpassed, 2 warnings in 455.21s (0:07:35) =======================================
```

</details>