### PR TITLE
Vulnerability Scanner - Create an RTR that runs the same test as in GitHub Actions - Implementation

### DIFF
--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -13,6 +13,14 @@ inputs:
 runs:
   using: "composite"
   steps:    
+      - name: Dependencies for local execution
+        if: env.ACT # Only run for local execution
+        shell: bash
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+          echo "deb http://deb.debian.org/debian/ testing main" >>  /etc/apt/sources.conf
+          sudo apt update
+
       # Dependencies for testing:
       # - clang-format 
       - name: Install dependencies
@@ -25,9 +33,8 @@ runs:
         shell: bash
         run: |
 
-          # Execute in dry-run and fail on warnings
+          # Don't apply changes, just check
           arguments="--dry-run "
-          #arguments+="-Werror "
 
           # Retrieve all the source files for the desired module
           sourceFiles=$(find ${{ inputs.path }} -type f \( -name "*.cpp" -o -name "*.hpp" \) | tr '\n' ' ')

--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -1,5 +1,5 @@
-name: "Codding style check"
-description: "Validates the codding style of a given module"
+name: "Coding style check"
+description: "Validates the Coding style of a given module"
 
 inputs:
   path:
@@ -29,7 +29,7 @@ runs:
           packages: clang-format 
           version: 1.0
 
-      - name: Check codding style
+      - name: Check Coding style
         shell: bash
         run: |
 

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -11,7 +11,16 @@ inputs:
 
 runs:
   using: "composite"
-  steps:    
+  steps:   
+      # Dependencies for local testing:
+      # - bc
+      - name: Install dependencies
+        if: env.ACT # Only run for local execution
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: bc
+          version: 1.0
+
       # Dependencies for testing:
       # - lcov
       - name: Install dependencies
@@ -82,23 +91,23 @@ runs:
           linesCoverage=$(echo "${coverageData[0]}" | sed 's/%//')
           echo "Lines coverage is: $linesCoverage %"
           if ! (( $(echo "$linesCoverage > 90" | bc -l) )); then
-            echo "-------------------------"
+            echo "----------------------------------------"
             echo "FAILED: Lines coverage is lower than 90%"
-            echo "-------------------------"
+            echo "----------------------------------------"
             exit 1
           else
-            echo "-------------------------"
+            echo "------------------------------------------"
             echo "PASSED: Lines coverage is greater than 90%"
-            echo "-------------------------"
+            echo "------------------------------------------"
           fi
           
           # Check if functions coverage is greater than 90%
           functionsCoverage=$(echo "${coverageData[1]}" | sed 's/%//')
           echo "Functions coverage is: $functionsCoverage %"
           if ! (( $(echo "$functionsCoverage > 90" | bc -l) )); then
-            echo "------------------------------"
+            echo "---------------------------------------------"
             echo "FAILED: Functions coverage is lower than 90%"
-            echo "------------------------------"
+            echo "--------------------------------------------"
             exit 1
           else
             echo "----------------------------------------------"

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -12,14 +12,14 @@ inputs:
 runs:
   using: "composite"
   steps:   
-      # Dependencies for local testing:
-      # - bc
-      - name: Install dependencies
+      - name: Dependencies for local execution
         if: env.ACT # Only run for local execution
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: bc
-          version: 1.0
+        shell: bash
+        run: |
+
+          # Update packages
+          sudo apt-get update
+          sudo apt-get install -y bc
 
       # Dependencies for testing:
       # - lcov

--- a/.github/actions/vulnerability_scanner_deps/action.yml
+++ b/.github/actions/vulnerability_scanner_deps/action.yml
@@ -4,7 +4,22 @@ description: "Download and compiles the dependencies for the vulnerability scann
 runs:
   using: "composite"
   steps:    
-      - name: External deps
+      - name: Dependencies for local execution
+        if: env.ACT # Only run for local execution
+        shell: bash
+        run: |
+
+          # Obtain a copy of the signing key
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+          
+          # Add the repository to your sources list
+          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+
+          # Update packages
+          sudo apt-get update
+          sudo apt-get install -y cmake
+
+      - name: Build external deps
         run: |
           cd src
           make deps TARGET=server -j2
@@ -12,7 +27,7 @@ runs:
           make libwazuhext.so TARGET=server -j2
         shell: bash
 
-      - name: http-request
+      - name: Build http-request
         run: |
           cd src
           SRC_FOLDER=$(pwd)

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -29,42 +29,49 @@ jobs:
       - name: Calculate deltas
         run: |
 
-          DIFFS=$(git diff --name-only origin/${{ github.head_ref }} origin/${{ github.base_ref }})
+          DIFFS=""
+          
+          # Get the list of modified files
+          if [ -z ${{ env.ACT }} ]; then
+            # CI execution
+            DIFFS=$(git diff --name-only HEAD origin/${{ github.base_ref }})
+            # Local execution
+          else
+            if [ -n "${{ env.REF_BRANCH }}" ]; then
+              # If REF_BRANCH is set, use it to calculate the diff
+              DIFFS=$(git diff --name-only HEAD origin/${{ env.REF_BRANCH }})  
+            else
+              # If REF_BRANCH is not set, use main as base 
+              DIFFS=$(git diff --name-only HEAD origin/main)  
+            fi
+          fi
 
           if echo $DIFFS | grep 'src/shared_modules/router/'; then
             echo "ROUTER=true" >> "$GITHUB_ENV"
-          else
-            echo "ROUTER=false" >> "$GITHUB_ENV"
           fi
 
           if echo $DIFFS | grep 'src/shared_modules/content_manager/'; then
             echo "CONTENT_MANAGER=true" >> "$GITHUB_ENV"
-          else
-            echo "CONTENT_MANAGER=false" >> "$GITHUB_ENV"
           fi
 
           if echo $DIFFS | grep 'src/shared_modules/indexer_connector/'; then
             echo "INDEXER_CONNECTOR=true" >> "$GITHUB_ENV"
-          else
-            echo "INDEXER_CONNECTOR=false" >> "$GITHUB_ENV"
           fi
 
           if echo $DIFFS | grep 'src/wazuh_modules/vulnerability_scanner/'; then
             echo "VULNERABILITY_SCANNER=true" >> "$GITHUB_ENV"
-          else
-            echo "VULNERABILITY_SCANNER=false" >> "$GITHUB_ENV"
           fi
 
       # Router
       - name: Router - Codding style
-        if: env.ROUTER == 'true'
+        if: env.ROUTER
         uses: ./.github/actions/clang_format
         with:
           path: src/shared_modules/router
           id: router
 
       - name: Router - Doxygen
-        if: env.ROUTER == 'true'
+        if: env.ROUTER
         uses: ./.github/actions/doxygen
         with:
           path: src/shared_modules/router
@@ -72,14 +79,14 @@ jobs:
 
       # Indexer connector
       - name: Indexer connector - Codding style
-        if: env.INDEXER_CONNECTOR == 'true'
+        if: env.INDEXER_CONNECTOR
         uses: ./.github/actions/clang_format
         with:
           path: src/shared_modules/indexer_connector
           id: indexer_connector
 
       - name: Indexer connector - Doxygen
-        if: env.INDEXER_CONNECTOR == 'true'
+        if: env.INDEXER_CONNECTOR
         uses: ./.github/actions/doxygen
         with:
           path: src/shared_modules/indexer_connector
@@ -87,14 +94,14 @@ jobs:
 
       # Content manager
       - name: Content manager - Codding style
-        if: env.CONTENT_MANAGER == 'true'
+        if: env.CONTENT_MANAGER
         uses: ./.github/actions/clang_format
         with:
           path: src/shared_modules/content_manager
           id: content_manager
 
       - name: Content manager - Doxygen
-        if: env.CONTENT_MANAGER == 'true'
+        if: env.CONTENT_MANAGER
         uses: ./.github/actions/doxygen
         with:
           path: src/shared_modules/content_manager
@@ -102,14 +109,14 @@ jobs:
 
       # Vulnerability scanner
       - name: Vulnerability scanner - Codding style
-        if: env.VULNERABILITY_SCANNER == 'true'
+        if: env.VULNERABILITY_SCANNER
         uses: ./.github/actions/clang_format
         with:
           path: src/wazuh_modules/vulnerability_scanner
           id: vulnerability_scanner
 
       - name: Vulnerability scanner - Doxygen
-        if: env.VULNERABILITY_SCANNER == 'true'
+        if: env.VULNERABILITY_SCANNER
         uses: ./.github/actions/doxygen
         with:
           path: src/wazuh_modules/vulnerability_scanner

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
       # Router
-      - name: Router - Codding style
+      - name: Router - Coding style
         if: env.ROUTER
         uses: ./.github/actions/clang_format
         with:
@@ -78,7 +78,7 @@ jobs:
           id: router
 
       # Indexer connector
-      - name: Indexer connector - Codding style
+      - name: Indexer connector - Coding style
         if: env.INDEXER_CONNECTOR
         uses: ./.github/actions/clang_format
         with:
@@ -93,7 +93,7 @@ jobs:
           id: indexer_connector
 
       # Content manager
-      - name: Content manager - Codding style
+      - name: Content manager - Coding style
         if: env.CONTENT_MANAGER
         uses: ./.github/actions/clang_format
         with:
@@ -108,7 +108,7 @@ jobs:
           id: content_manager
 
       # Vulnerability scanner
-      - name: Vulnerability scanner - Codding style
+      - name: Vulnerability scanner - Coding style
         if: env.VULNERABILITY_SCANNER
         uses: ./.github/actions/clang_format
         with:

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -42,7 +42,7 @@ jobs:
               DIFFS=$(git diff --name-only origin/${{ env.REF_BRANCH }})  
             else
               # If REF_BRANCH is not set, use main as base 
-              DIFFS=$(git diff --name-only origin/main)  
+              DIFFS=$(git diff --name-only origin/master)  
             fi
           fi
 

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -34,15 +34,15 @@ jobs:
           # Get the list of modified files
           if [ -z ${{ env.ACT }} ]; then
             # CI execution
-            DIFFS=$(git diff --name-only HEAD origin/${{ github.base_ref }})
-            # Local execution
+            DIFFS=$(git diff --name-only origin/${{ github.base_ref }})
           else
+            # Local execution
             if [ -n "${{ env.REF_BRANCH }}" ]; then
               # If REF_BRANCH is set, use it to calculate the diff
-              DIFFS=$(git diff --name-only HEAD origin/${{ env.REF_BRANCH }})  
+              DIFFS=$(git diff --name-only origin/${{ env.REF_BRANCH }})  
             else
               # If REF_BRANCH is not set, use main as base 
-              DIFFS=$(git diff --name-only HEAD origin/main)  
+              DIFFS=$(git diff --name-only origin/main)  
             fi
           fi
 

--- a/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
+++ b/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
@@ -8,6 +8,21 @@ Are tested in the [following wokflow](../../../../.github/workflows/vulnerabilit
 
 In order to facilitate the code development, the workflow is prepared to be executed locally (see [dependencies](#dependencies)).
 
+## Dependencies
+
+### ACT
+1. Download the binary: 
+  `wget -qO act.tar.gz https://github.com/nektos/act/releases/latest/download/act_Linux_x86_64.tar.gz`
+
+2. Extract the binary into the system binaries folder:
+  `sudo tar xf act.tar.gz -C /usr/local/bin act`
+
+3. Remove the unnecessary files:
+  `rm -rf act.tar.gz`
+  
+4. On the first execution, select the medium image
+
+
 ## Usage
 
 The following command will trigger the workflow and perform the exact same steps as the CI/CD pipeline:
@@ -32,17 +47,3 @@ act -W .github/workflows/vulnerability-scanner-tests.yml --artifact-server-path 
     find <path to the artifacts> -type f -name "*.gz__" | while read file; do mv "$file" "${file%.gz__}.gz"; done
     find <path to the artifacts> -type f -name "*.gz" -exec gunzip {} -f +
     ```
-
-## Dependencies
-
-### ACT
-1. Download the binary: 
-  `wget -qO act.tar.gz https://github.com/nektos/act/releases/latest/download/act_Linux_x86_64.tar.gz`
-
-2. Extract the binary into the system binaries folder:
-  `sudo tar xf act.tar.gz -C /usr/local/bin act`
-
-3. Remove the unnecessary files:
-  `rm -rf act.tar.gz`
-  
-4. On the first execution, select the medium image

--- a/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
+++ b/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
@@ -6,7 +6,7 @@ This module, and its dependencies:
 
 Are tested in the [following wokflow](../../../../.github/workflows/vulnerability-scanner-tests.yml).
 
-In order to fascilitate the code development, the workflow is prepared to be executed locally (see [dependencies](#dependencies)).
+In order to facilitate the code development, the workflow is prepared to be executed locally (see [dependencies](#dependencies)).
 
 ## Usage
 

--- a/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
+++ b/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
@@ -1,0 +1,44 @@
+# RTR
+This module, and its dependencies:
+- [router](../../../shared_modules/router/)
+- [indexer_connector](../../../shared_modules/indexer_connector/)
+- [content_manager](../../../shared_modules/content_manager/)
+
+Are tested in the [following wokflow](../../../../.github/workflows/vulnerability-scanner-tests.yml).
+
+In order to fascilitate the code development, the workflow is prepared to be executed locally (see [dependencies](#dependencies)).
+
+## Usage
+
+The following command will trigger the workflow and perform the exact same steps as the CI/CD pipeline:
+
+```bash
+# General usage
+act -W <path_to_workflow> --artifact-server-path <artifacts_location> --env REF_BRANCH=<base_branch (optional)>
+
+# Practical aplication
+act -W .github/workflows/vulnerability-scanner-tests.yml --artifact-server-path /tmp/artifacts
+```
+
+### Arguments
+- `--env REF_BRANCH`: The branch the changes are compared against. If not provided, the comparison is against the `master` branch.
+- `--artifact-server-path`: Path where the artifacts will be stored. This path must be accessible by the user running the workflow.
+    -  **Note**: Artifacts are compressed in a weird way (the extension of the generated files is gz__). In order to extract them, the following commands must be executed:
+    ```bash
+    find <path to the artifacts> -type f -name "*.gz__" | while read file; do mv "$file" "${file%.gz__}.gz"; done
+    find <path to the artifacts> -type f -name "*.gz" -exec gunzip {} -f +
+    ```
+
+## Dependencies
+
+### ACT
+1. Download the binary: 
+  `wget -qO act.tar.gz https://github.com/nektos/act/releases/latest/download/act_Linux_x86_64.tar.gz`
+
+2. Extract the binary into the system binaries folder:
+  `sudo tar xf act.tar.gz -C /usr/local/bin act`
+
+3. Remove the unnecessary files:
+  `rm -rf act.tar.gz`
+  
+4. On the first execution, select the medium image

--- a/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
+++ b/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
@@ -12,15 +12,19 @@ In order to facilitate the code development, the workflow is prepared to be exec
 
 The following command will trigger the workflow and perform the exact same steps as the CI/CD pipeline:
 
+> **Note**: These commands must be executed from the root of the repository.
+
 ```bash
 # General usage
-act -W <path_to_workflow> --artifact-server-path <artifacts_location> --env REF_BRANCH=<base_branch (optional)>
+act -W <path_to_workflow> --artifact-server-path <artifacts_location> --env REF_BRANCH=<base_branch> (optional) -v (optional)
 
 # Practical aplication
 act -W .github/workflows/vulnerability-scanner-tests.yml --artifact-server-path /tmp/artifacts
 ```
 
 ### Arguments
+- `-W <path_to_workflow>`: Path to the workflow to be executed.
+- `-v`: Enables the verbose mode. It's recommended to use it on the first run in order to see the progress of the docker images being pulled (it takes some time on the first run).
 - `--env REF_BRANCH`: The branch the changes are compared against. If not provided, the comparison is against the `master` branch.
 - `--artifact-server-path`: Path where the artifacts will be stored. This path must be accessible by the user running the workflow.
     -  **Note**: Artifacts are compressed in a weird way (the extension of the generated files is gz__). In order to extract them, the following commands must be executed:

--- a/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
+++ b/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
@@ -47,3 +47,148 @@ act -W .github/workflows/vulnerability-scanner-tests.yml --artifact-server-path 
     find <path to the artifacts> -type f -name "*.gz__" | while read file; do mv "$file" "${file%.gz__}.gz"; done
     find <path to the artifacts> -type f -name "*.gz" -exec gunzip {} -f +
     ```
+
+## Examples
+
+### Failed job
+<details>
+  <summary>Last log lines</summary>
+
+```bash
+| ---------------------------------
+| FAILED: Clang-format check failed
+| ---------------------------------
+[Vulnerability Scanner/style-and-documentation]   ❌  Failure - Main Check Coding style
+[Vulnerability Scanner/style-and-documentation] exitcode '1': failure
+[Vulnerability Scanner/style-and-documentation]   ☁  git clone 'https://github.com/actions/upload-artifact' # ref=v3
+[Vulnerability Scanner/style-and-documentation] ⭐ Run Main actions/upload-artifact@v3
+[Vulnerability Scanner/style-and-documentation]   🐳  docker cp src=/home/damangold/.cache/act/actions-upload-artifact@v3/ dst=/var/run/act/actions/actions-upload-artifact@v3/
+[Vulnerability Scanner/style-and-documentation]   🐳  docker exec cmd=[node /var/run/act/actions/actions-upload-artifact@v3/dist/index.js] user= workdir=
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::followSymbolicLinks 'true'
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::implicitDescendants 'true'
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::omitBrokenSymbolicLinks 'true'
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::followSymbolicLinks 'true'
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::implicitDescendants 'true'
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::matchDirectories 'true'
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::omitBrokenSymbolicLinks 'true'
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::Search path '/home/damangold/Wazuh/dev/wazuh/src/shared_modules/content_manager/clang_format_errors.txt'
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::File:/home/damangold/Wazuh/dev/wazuh/src/shared_modules/content_manager/clang_format_errors.txt was found using the provided searchPath
+| With the provided path, there will be 1 file uploaded
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::Root artifact directory is /home/damangold/Wazuh/dev/wazuh/src/shared_modules/content_manager
+| Starting artifact upload
+| For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging
+| Artifact name is valid!
+[Vulnerability Scanner/style-and-documentation]   🚧  ::warning::Retention days is greater than the max value allowed by the repository setting, reduce retention to 0 days
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::Artifact Url: http://192.168.100.233:34567/_apis/pipelines/workflows/1/artifacts?api-version=6.0-preview
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::Upload Resource URL: http://192.168.100.233:34567/upload/1
+| Container for artifact "Clang-format errors - content_manager" successfully created. Starting upload of file(s)
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::File Concurrency: 2, and Chunk Size: 8388608
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::/home/damangold/Wazuh/dev/wazuh/src/shared_modules/content_manager/clang_format_errors.txt is less than 64k in size. Creating a gzip file in-memory to potentially reduce the upload size
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::A gzip file created for /home/damangold/Wazuh/dev/wazuh/src/shared_modules/content_manager/clang_format_errors.txt helped with reducing the size of the original file. The file will be uploaded using gzip.
+| Total size of all the files uploaded is 233 bytes
+| File upload process has finished. Finalizing the artifact upload
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::Artifact Url: http://192.168.100.233:34567/_apis/pipelines/workflows/1/artifacts?api-version=6.0-preview
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::URL is http://192.168.100.233:34567/_apis/pipelines/workflows/1/artifacts?api-version=6.0-preview&artifactName=Clang-format+errors+-+content_manager
+[Vulnerability Scanner/style-and-documentation]   💬  ::debug::Artifact Clang-format errors - content_manager has been successfully uploaded, total size in bytes: 994
+| Artifact has been finalized. All files have been successfully uploaded!
+| 
+| The raw size of all the files that were specified for upload is 994 bytes
+| The size of all the files that were uploaded is 233 bytes. This takes into account any gzip compression used to reduce the upload size, time and storage
+| 
+| Note: The size of downloaded zips can differ significantly from the reported size. For more information see: https://github.com/actions/upload-artifact#zipped-artifact-downloads 
+| 
+| Artifact Clang-format errors - content_manager has been successfully uploaded!
+[Vulnerability Scanner/style-and-documentation]   ✅  Success - Main actions/upload-artifact@v3
+[Vulnerability Scanner/style-and-documentation]   ❌  Failure - Main Content manager - Coding style
+[Vulnerability Scanner/style-and-documentation] exitcode '1': failure
+[Vulnerability Scanner/style-and-documentation] ⭐ Run Post Content manager - Coding style
+[Vulnerability Scanner/style-and-documentation] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/style-and-documentation]   🐳  docker cp src=/home/damangold/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/style-and-documentation]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/style-and-documentation]   ✅  Success - Post Content manager - Coding style
+[Vulnerability Scanner/style-and-documentation] 🏁  Job failed
+Error: Job 'style-and-documentation' failed
+```
+</details>
+
+<details>
+  <summary>How to detect a failed run</summary>
+
+```bash
+[Vulnerability Scanner/style-and-documentation] 🏁  Job failed
+Error: Job 'style-and-documentation' failed
+```
+</details>
+
+### Successful job
+<details>
+  <summary>Last log lines</summary>
+
+```bash
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Main Validate coverage
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Main Vulnerability scanner - Coverage
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Vulnerability scanner - Coverage
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Vulnerability scanner - Coverage
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Vulnerability scanner - Compilation and test
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Vulnerability scanner - Compilation and test
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Content manager - Coverage
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Content manager - Coverage
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Content manager - Compilation and test
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Content manager - Compilation and test
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Indexer connector - Coverage
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Indexer connector - Coverage
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Indexer connector - Compilation and test
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Indexer connector - Compilation and test
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Router - Coverage
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Router - Coverage
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Router - Compilation and test
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   🐳  docker cp src=/home/vagrant/.cache/act/awalsh128-cache-apt-pkgs-action@latest/ dst=/var/run/act/actions/awalsh128-cache-apt-pkgs-action@latest/
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Install dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Router - Compilation and test
+[Vulnerability Scanner/vulnerability-scanner-modules     ] ⭐ Run Post Project dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ]   ✅  Success - Post Project dependencies
+[Vulnerability Scanner/vulnerability-scanner-modules     ] 🏁  Job succeeded
+```
+</details>
+
+<details>
+  <summary>How to detect a failed run</summary>
+
+```bash
+[Vulnerability Scanner/vulnerability-scanner-modules     ] 🏁  Job succeeded
+```
+</details>


### PR DESCRIPTION
|Related issue|
|---|
| #18328  |

## Description
This PR aims to adapt the workflows for the vulnerability scanner in order to allow them to be executed in a local environment

The workflows were adapted in order to run via [act](https://github.com/nektos/act) (a CLI application)

## Configuration options
Is necessary to install act. You can follow the following steps:
```
1. Download the binary: 
  wget -qO act.tar.gz https://github.com/nektos/act/releases/latest/download/act_Linux_x86_64.tar.gz

2. Extract the binary into the system binaries folder:
  sudo tar xf act.tar.gz -C /usr/local/bin act

3. Remove the unnecessary files:
  rm -rf act.tar.gz
  
4. On the first execution, select the medium image
```

## Executing
`act -W <path_to_workflow> --artifact-server-path <artifacts_location> --env REF_BRANCH=<base_branch (optional)>`

Example:
`act -W .github/workflows/vulnerability-scanner-tests.yml --artifact-server-path /tmp/artifacts`

If REF_BRANCH is not set, then the differences will be performed against main branch

## Tests

First run. Non compliant with clang-format
```
$ ls /tmp/artifacts/1/Clang-format\ errors\ -\ router/
total 4.0K
-rw-r--r-- 1 vagrant vagrant 133 Aug 15 19:37 clang_format_errors.txt.gz

$ cat clang_format_errors.txt 
src/shared_modules/router/tests/component/interface_c_test.cpp:79:2: warning: code should be clang-formatted [-Wclang-format-violations]
}
 ^
```

Second run. Now clang passed but doxygen fails
```
ls /tmp/artifacts/1/
total 4.0K
drwxrwxr-x 2 vagrant vagrant 4.0K Aug 15 19:49 Doxygen errors - router
```

### Extra notes about act
There are some dependencies that are not present on the docker images used by act. For this scenario, we need to install `bc` and `cmake` (packages that already exist on the GitHub actions container)

Event variables can be emulated via configuration file ([see documentation](https://github.com/nektos/act#events))

Artifacts are compressed in a weird way, the extension of the files uploaded is gz__, all files must be renamed (remove the __) in order to decompress them. Execute the following commands to perform this conversion:
```
find <path> -type f -name "*.gz__" | while read file; do mv "$file" "${file%.gz__}.gz"; done
find <path> -type f -name "*.gz" -exec gunzip {} -f +
```