### PR TITLE
Use pip to install python packages

### DIFF
--- a/framework/setup.py
+++ b/framework/setup.py
@@ -36,8 +36,7 @@ class InstallCommand(install):
                        'installation_date': datetime.utcnow().replace(tzinfo=timezone.utc).strftime(
                            '%a %b %d %H:%M:%S UTC %Y')
                        }, f)
-        # install.run(self)  # OR: install.do_egg_install(self)
-        install.do_egg_install(self)
+        install.run(self)
 
 
 setup(name='wazuh',

--- a/src/Makefile
+++ b/src/Makefile
@@ -2270,12 +2270,12 @@ ifneq (,$(wildcard ${EXTERNAL_CPYTHON}))
 endif
 
 install_framework: install_python
-	cd ../framework && ${WPYTHON_DIR}/bin/python3 setup.py install --prefix=${WPYTHON_DIR} --wazuh-version=$(shell cat VERSION) --install-type=${TARGET} && rm -rf build/
+	cd ../framework && ${WPYTHON_DIR}/bin/python3 -m pip install . --prefix=${WPYTHON_DIR} --install-option="--wazuh-version=$(shell cat VERSION)" --install-option="--install-type=${TARGET}" && rm -rf build/
 	chown -R root:${WAZUH_GROUP} ${WPYTHON_DIR}
 	chmod -R o=- ${WPYTHON_DIR}
 
 install_api: install_python
-	cd ../api && ${WPYTHON_DIR}/bin/python3 setup.py install --prefix=${WPYTHON_DIR} && rm -rf build/
+	cd ../api && ${WPYTHON_DIR}/bin/python3 -m pip install . --prefix=${WPYTHON_DIR} && rm -rf build/
 
 install_mitre: install_python
 	cd ../tools/mitre && ${WPYTHON_DIR}/bin/python3 mitredb.py -d ${INSTALLDIR}/var/db/mitre.db

--- a/src/Makefile
+++ b/src/Makefile
@@ -2270,12 +2270,12 @@ ifneq (,$(wildcard ${EXTERNAL_CPYTHON}))
 endif
 
 install_framework: install_python
-	cd ../framework && ${WPYTHON_DIR}/bin/python3 -m pip install . --prefix=${WPYTHON_DIR} --install-option="--wazuh-version=$(shell cat VERSION)" --install-option="--install-type=${TARGET}" && rm -rf build/
+	cd ../framework && ${WPYTHON_DIR}/bin/python3 -m pip install . --use-pep517 --prefix=${WPYTHON_DIR} --config-settings="--wazuh-version=$(shell cat VERSION)" --config-settings="--install-type=${TARGET}" && rm -rf build/
 	chown -R root:${WAZUH_GROUP} ${WPYTHON_DIR}
 	chmod -R o=- ${WPYTHON_DIR}
 
 install_api: install_python
-	cd ../api && ${WPYTHON_DIR}/bin/python3 -m pip install . --prefix=${WPYTHON_DIR} && rm -rf build/
+	cd ../api && ${WPYTHON_DIR}/bin/python3 -m pip install . --use-pep517 --prefix=${WPYTHON_DIR} && rm -rf build/
 
 install_mitre: install_python
 	cd ../tools/mitre && ${WPYTHON_DIR}/bin/python3 mitredb.py -d ${INSTALLDIR}/var/db/mitre.db


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/17657 |

## Description

Replaced `setuptools` with `pip` to install python packages.

Note that the current solution will install `setuptools` and `wheel` in an isolated environment where it will attempt to build a wheel and install it. More information [here](https://github.com/pypa/pip/issues/8559).

## Logs/Alerts example

<details><summary>Installation logs</summary>

```console
root@ip-172-31-42-37:/home/ubuntu/wazuh-4.5.0/src# ./install.sh
...
Done building server

Wait for success...
success
Removing old SCA policies...
Installing SCA policies...
Installing additional SCA policies...
mkdir -p /var/ossec/framework/python
cp external/cpython.tar.gz /var/ossec/framework/python/cpython.tar.gz && tar -xf /var/ossec/framework/python/cpython.tar.gz -C /var/ossec/framework/python && rm -rf /var/ossec/framework/python/cpython.tar.gz
find /var/ossec/framework/python -name "*libpython3.9.so.1.0" -exec ln -f {} /var/ossec/lib/libpython3.9.so.1.0 \;
cd ../framework && /var/ossec/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/ossec/framework/python --config-settings="--wazuh-version=v4.5.0" --config-settings="--install-type=server" && rm -rf build/
Processing /home/ubuntu/wazuh-4.5.0/framework
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: wazuh
  Building wheel for wazuh (pyproject.toml) ... done
  Created wheel for wazuh: filename=wazuh-4.5.0-py3-none-any.whl size=274637 sha256=3054ff3bf2e5c3fd81ebee395671663cecf8c1a4de4ed0ec64e4b8660782d3a4
  Stored in directory: /tmp/pip-ephem-wheel-cache-93v5ndt5/wheels/e0/0c/f0/f9382858bde7897603b85a5435b5d070eefb9befd47b30d398
Successfully built wazuh
Installing collected packages: wazuh
Successfully installed wazuh-4.5.0

[notice] A new release of pip is available: 23.0.1 -> 23.2.1
[notice] To update, run: /var/ossec/framework/python/bin/python3 -m pip install --upgrade pip
chown -R root:wazuh /var/ossec/framework/python
chmod -R o=- /var/ossec/framework/python
cd ../api && /var/ossec/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/ossec/framework/python && rm -rf build/
Processing /home/ubuntu/wazuh-4.5.0/api
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: api
  Building wheel for api (pyproject.toml) ... done
  Created wheel for api: filename=api-4.5.0-py3-none-any.whl size=153190 sha256=2968c3432b44437e80096cf06d46f12d4f1a7ecf5aae3cf94c51fdebcfec2eb7
  Stored in directory: /tmp/pip-ephem-wheel-cache-6wy3ssry/wheels/36/d5/5a/434ddb3c1c9069b3a8e3bcd42e5853e76a445eafc1d68dbaeb
Successfully built api
Installing collected packages: api
Successfully installed api-4.5.0

[notice] A new release of pip is available: 23.0.1 -> 23.2.1
[notice] To update, run: /var/ossec/framework/python/bin/python3 -m pip install --upgrade pip
cd ../tools/mitre && /var/ossec/framework/python/bin/python3 mitredb.py -d /var/ossec/var/db/mitre.db
Generating self-signed certificate for wazuh-authd...


Starting Wazuh...
server

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---

```

</details>
