### PR TITLE
Improve unknown family address error message in Remoted

### DIFF
--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -77,6 +77,17 @@ static void _push_request(const char *request,const char *type);
 static int key_request_connect();
 static int key_request_reconnect();
 
+char *str_family_address[AF_MAX + 2] = {
+    "AF_UNSPEC", "AF_LOCAL/AF_UNIX/AF_FILE", "AF_INET", "AF_AX25", "AF_IPX",
+    "AF_APPLETALK","AF_NETROM", "AF_BRIDGE", "AF_ATMPVC", "AF_X25", "AF_INET6",
+    "AF_ROSE", "AF_DECnet", "AF_NETBEUI", "AF_SECURITY", "AF_KEY", "AF_NETLINK",
+    "AF_ROUTE", "AF_PACKET", "AF_ASH", "AF_ECONET", "AF_ATMSVC", "AF_RDS", "AF_SNA",
+    "AF_IRDA", "AF_PPPOX", "AF_WANPIPE", "AF_LLC", "AF_IB", "AF_MPLS", "AF_CAN",
+    "AF_TIPC", "AF_BLUETOOTH", "AF_IUCV", "AF_RXRPC", "AF_ISDN", "AF_PHONET",
+    "AF_IEEE802154", "AF_CAIF", "AF_ALG", "AF_NFC", "AF_VSOCK", "AF_KCM",
+    "AF_QIPCRTR", "AF_SMC", "AF_XDP", "AF_MCTP", "AF_MAX"
+};
+
 /* Handle secure connections */
 void HandleSecure()
 {
@@ -459,7 +470,13 @@ STATIC void HandleSecureMessage(const message_t *message, int *wdb_sock) {
         get_ipv6_string(((struct sockaddr_in6 *)&message->addr)->sin6_addr, srcip, IPSIZE);
         break;
     default:
-        merror("IP address family '%d' not supported.", message->addr.ss_family);
+        if (message->addr.ss_family < sizeof(str_family_address)/sizeof(str_family_address[0])) {
+            merror("IP address family '%d':'%s' not supported.", message->addr.ss_family, str_family_address[message->addr.ss_family]);
+        }
+        else {
+            merror("IP address family '%d' not found.", message->addr.ss_family);
+        }
+
         rem_inc_recv_unknown();
         return;
     }

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -459,7 +459,7 @@ STATIC void HandleSecureMessage(const message_t *message, int *wdb_sock) {
         get_ipv6_string(((struct sockaddr_in6 *)&message->addr)->sin6_addr, srcip, IPSIZE);
         break;
     default:
-        merror("IP address family not supported.");
+        merror("IP address family '%d' not supported.", message->addr.ss_family);
         rem_inc_recv_unknown();
         return;
     }

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -77,7 +77,9 @@ static void _push_request(const char *request,const char *type);
 static int key_request_connect();
 static int key_request_reconnect();
 
-char *str_family_address[AF_MAX + 2] = {
+/* Family address reference */
+#define FAMILY_ADDRESS_SIZE 47
+char *str_family_address[FAMILY_ADDRESS_SIZE] = {
     "AF_UNSPEC", "AF_LOCAL/AF_UNIX/AF_FILE", "AF_INET", "AF_AX25", "AF_IPX",
     "AF_APPLETALK","AF_NETROM", "AF_BRIDGE", "AF_ATMPVC", "AF_X25", "AF_INET6",
     "AF_ROSE", "AF_DECnet", "AF_NETBEUI", "AF_SECURITY", "AF_KEY", "AF_NETLINK",
@@ -85,7 +87,7 @@ char *str_family_address[AF_MAX + 2] = {
     "AF_IRDA", "AF_PPPOX", "AF_WANPIPE", "AF_LLC", "AF_IB", "AF_MPLS", "AF_CAN",
     "AF_TIPC", "AF_BLUETOOTH", "AF_IUCV", "AF_RXRPC", "AF_ISDN", "AF_PHONET",
     "AF_IEEE802154", "AF_CAIF", "AF_ALG", "AF_NFC", "AF_VSOCK", "AF_KCM",
-    "AF_QIPCRTR", "AF_SMC", "AF_XDP", "AF_MCTP", "AF_MAX"
+    "AF_QIPCRTR", "AF_SMC", "AF_XDP", "AF_MCTP"
 };
 
 /* Handle secure connections */

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -35,7 +35,7 @@
 extern keystore keys;
 extern remoted logr;
 extern wnotify_t * notify;
-extern char *str_family_address[AF_MAX + 2];
+extern char *str_family_address[FAMILY_ADDRESS_SIZE];
 
 void tmp_HandleSecureMessage_invalid_family_address(sa_family_t sin_family);
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18309|

## Description

This PR improves the log message that shows when a connection is unsupported in `wazuh-remoted`.

Now, the type of address (family address) is showed in the error log message.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade