### PR TITLE
JSON syslog output very high CPU percentage

### DIFF
--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -111,26 +111,31 @@ void OS_CSyslogD(SyslogConfig **syslog_config)
             json_data = jqueue_next(&jfileq);
         }
 
-        /* Send via syslog */
+        if(al_data == NULL && json_data == NULL) {
+            sleep(1);
+        } else {
 
-        for (s = 0; syslog_config[s]; s++) {
-            if (syslog_config[s]->format == JSON_CSYSLOG) {
-                if (json_data) {
-                    OS_Alert_SendSyslog_JSON(json_data, syslog_config[s]);
+            /* Send via syslog */
+
+            for (s = 0; syslog_config[s]; s++) {
+                if (syslog_config[s]->format == JSON_CSYSLOG) {
+                    if (json_data) {
+                        OS_Alert_SendSyslog_JSON(json_data, syslog_config[s]);
+                    }
+                } else if (al_data) {
+                    OS_Alert_SendSyslog(al_data, syslog_config[s]);
                 }
-            } else if (al_data) {
-                OS_Alert_SendSyslog(al_data, syslog_config[s]);
             }
-        }
 
-        /* Clear the memory */
+            /* Clear the memory */
 
-        if (al_data) {
-            FreeAlertData(al_data);
-        }
+            if (al_data) {
+                FreeAlertData(al_data);
+            }
 
-        if (json_data) {
-            cJSON_Delete(json_data);
+            if (json_data) {
+                cJSON_Delete(json_data);
+            }
         }
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18471|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR fixes high CPU usage of **100-90%** when setting JSON `syslog_output`
<!--
Add a clear description of how the problem has been solved.
-->

Fix:
just wait when there is nothing to send in `src/os_csyslogd/csyslogd.c`:

```
        if (al_data == NULL && json_data == NULL) { 
            sleep(1);
        }
```
![fixed](https://github.com/wazuh/wazuh/assets/68856625/37a66eae-77e2-488b-9fa3-67a87c033a16)


## Configuration example
```
<syslog_output>
    <server>10.211.55.7</server>
    <level>7</level>
    <format>json</format>
</syslog_output>
```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors