### PR TITLE
Add API nested queries support

### DIFF
--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1066,8 +1066,8 @@ stages:
           affected_items:
             - id: '001'
             - id: '002'
-            - id: '012'
             - id: '011'
+            - id: '012'
           failed_items: []
           total_affected_items: 4
           total_failed_items: 0

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1031,6 +1031,47 @@ stages:
           total_affected_items: 4
           total_failed_items: 0
 
+  - name: Filter agents by nested queries (first)
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        q: id!=001;(status=active;(group=group1,group=group2))
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - id: '002'
+            - id: '005'
+            - id: '006'
+            - id: '007'
+            - id: '008'
+          failed_items: []
+          total_affected_items: 5
+          total_failed_items: 0
+  
+  - name: Filter agents by nested queries (second)
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        q: (status=never_connected,(id<4;(group=group1,group=group2)))
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - id: '001'
+            - id: '002'
+            - id: '012'
+            - id: '011'
+          failed_items: []
+          total_affected_items: 4
+          total_failed_items: 0
+
   - name: Try to show agents using an wrong query
     request:
       verify: False

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -963,6 +963,22 @@ def test_WazuhDBQuery_protected_add_select_to_query(mock_parse, mock_socket_conn
          {"value": "file", "operator": "=", "field": "type$0", "separator": "OR", "level": 1},
          {"value": "registry_key", "operator": "=", "field": "type$1", "separator": "", "level": 0}
      ]),
+    # Nested queries
+    ('id!=000;(status=active;(group=default2,group=default3))',
+     [{'value': '000', 'operator': '!=', 'field': 'id$0', 'separator': 'AND', 'level': 0},
+      {'value': 'active', 'operator': '=', 'field': 'status$0', 'separator': 'AND', 'level': 1},
+      {'value': 'default2', 'operator': '=', 'field': 'group$0', 'separator': 'OR', 'level': 2},
+      {'value': 'default3', 'operator': '=', 'field': 'group$1', 'separator': '', 'level': 0}]),
+    ('((group=default2,group=default3);id!=000);status=active',
+      [{'value': 'default2', 'operator': '=', 'field': 'group$0', 'separator': 'OR', 'level': 2},
+      {'value': 'default3', 'operator': '=', 'field': 'group$1', 'separator': 'AND', 'level': 1},
+      {'value': '000', 'operator': '!=', 'field': 'id$0', 'separator': 'AND', 'level': 0},
+      {'value': 'active', 'operator': '=', 'field': 'status$0', 'separator': '', 'level': 0}]),
+    ('(status=active,(id!=000;(group=default,group=default3)))',
+     [{'value': 'active', 'operator': '=', 'field': 'status$0', 'separator': 'OR', 'level': 1},
+      {'value': '000', 'operator': '!=', 'field': 'id$0', 'separator': 'AND', 'level': 2},
+      {'value': 'default', 'operator': '=', 'field': 'group$0', 'separator': 'OR', 'level': 3},
+      {'value': 'default3', 'operator': '=', 'field': 'group$1', 'separator': '', 'level': 0}]),
 ])
 @patch('wazuh.core.utils.path.exists', return_value=True)
 @patch('wazuh.core.utils.WazuhDBBackend.connect_to_db')
@@ -1118,6 +1134,72 @@ def test_WazuhDBQuery_protected_add_filters_to_query(mock_process, mock_socket_c
     query._add_filters_to_query()
 
     mock_conn_db.assert_called_once_with()
+
+@pytest.mark.parametrize('filters, expected_query', [
+    (
+        [
+            {'value': '000', 'operator': '!=', 'field': 'id$0', 'separator': 'AND', 'level': 0},
+            {'value': 'active', 'operator': '=', 'field': 'status$0', 'separator': 'AND', 'level': 1},
+            {'value': 'default2', 'operator': '=', 'field': 'group$0', 'separator': 'OR', 'level': 2},
+            {'value': 'default3', 'operator': '=', 'field': 'group$1', 'separator': '', 'level': 0}
+        ],
+        'SELECT {0} FROM agent WHERE (id != :id$0 COLLATE NOCASE) AND ((status = :status$0 COLLATE ' + \
+        'NOCASE) AND ((group = :group$0 COLLATE NOCASE) OR (group = :group$1 COLLATE NOCASE)))',
+    ),
+    (
+        [
+            {'value': 'default2', 'operator': '=', 'field': 'group$0', 'separator': 'OR', 'level': 2},
+            {'value': 'default3', 'operator': '=', 'field': 'group$1', 'separator': 'AND', 'level': 1},
+            {'value': '000', 'operator': '!=', 'field': 'id$0', 'separator': 'AND', 'level': 0},
+            {'value': 'active', 'operator': '=', 'field': 'status$0', 'separator': '', 'level': 0}
+        ],
+        'SELECT {0} FROM agent WHERE (((group = :group$0 COLLATE NOCASE) OR (group = :group$1 COLLATE ' + \
+        'NOCASE)) AND (id != :id$0 COLLATE NOCASE)) AND (status = :status$0 COLLATE NOCASE)',
+    ),
+    (
+        [
+            {'value': 'default2', 'operator': '=', 'field': 'group$0', 'separator': 'OR', 'level': 3},
+            {'value': 'default3', 'operator': '=', 'field': 'group$1', 'separator': 'OR', 'level': 2},
+            {'value': '001', 'operator': '=', 'field': 'id$0', 'separator': 'OR', 'level': 1},
+            {'value': '000', 'operator': '!=', 'field': 'id$1', 'separator': 'AND', 'level': 0},
+            {'value': 'active', 'operator': '=', 'field': 'status$0', 'separator': '', 'level': 0}
+        ],
+        'SELECT {0} FROM agent WHERE ((((group = :group$0 COLLATE NOCASE) OR (group = :group$1 COLLATE ' + \
+        'NOCASE)) OR (id = :id$0 COLLATE NOCASE)) OR (id != :id$1 COLLATE NOCASE)) AND ' + \
+        '(status = :status$0 COLLATE NOCASE)',
+    ),
+    (
+        [
+            {'value': 'default2', 'operator': '=', 'field': 'group$0', 'separator': 'OR', 'level': 1},
+            {'value': 'default3', 'operator': '=', 'field': 'group$1', 'separator': '', 'level': 0},
+        ],
+        'SELECT {0} FROM agent WHERE ((group = :group$0 COLLATE NOCASE) OR (group = :group$1 COLLATE NOCASE))',
+    ),
+    (
+        [
+            {'value': 'active', 'operator': '=', 'field': 'status$0', 'separator': 'OR', 'level': 1},
+            {'value': '000', 'operator': '!=', 'field': 'id$0', 'separator': 'AND', 'level': 2},
+            {'value': 'default', 'operator': '=', 'field': 'group$0', 'separator': 'OR', 'level': 3},
+            {'value': 'default3', 'operator': '=', 'field': 'group$1', 'separator': '', 'level': 0}
+        ],
+        'SELECT {0} FROM agent WHERE ((status = :status$0 COLLATE NOCASE) OR ((id != :id$0 COLLATE NOCASE) ' \
+        'AND ((group = :group$0 COLLATE NOCASE) OR (group = :group$1 COLLATE NOCASE))))',
+    ),
+])
+@patch('wazuh.core.utils.WazuhDBBackend.connect_to_db')
+@patch('wazuh.core.utils.path.exists', return_value=True)
+def test_WazuhDBQuery_protected_add_filters_to_query_final_query(mock_conn_db, mock_file_exists,
+                                                                 filters, expected_query):
+    """Test WazuhDBQuery._add_filters_to_query final query."""
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None, search=None, select=None,
+                               fields={'id': 'id', 'status': 'status', 'group': 'group'},
+                               default_sort_field=None, query='', backend=utils.WazuhDBBackend(agent_id=0),
+                               count=5, get_data=None)
+
+    query.query_filters = filters
+    query._add_filters_to_query()
+
+    assert query.query.rstrip(' ') == expected_query
 
 
 @patch('wazuh.core.utils.path.exists', return_value=True)

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -970,7 +970,7 @@ def test_WazuhDBQuery_protected_add_select_to_query(mock_parse, mock_socket_conn
       {'value': 'default2', 'operator': '=', 'field': 'group$0', 'separator': 'OR', 'level': 2},
       {'value': 'default3', 'operator': '=', 'field': 'group$1', 'separator': '', 'level': 0}]),
     ('((group=default2,group=default3);id!=000);status=active',
-      [{'value': 'default2', 'operator': '=', 'field': 'group$0', 'separator': 'OR', 'level': 2},
+     [{'value': 'default2', 'operator': '=', 'field': 'group$0', 'separator': 'OR', 'level': 2},
       {'value': 'default3', 'operator': '=', 'field': 'group$1', 'separator': 'AND', 'level': 1},
       {'value': '000', 'operator': '!=', 'field': 'id$0', 'separator': 'AND', 'level': 0},
       {'value': 'active', 'operator': '=', 'field': 'status$0', 'separator': '', 'level': 0}]),

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1246,8 +1246,8 @@ class WazuhDBQuery(object):
         #    id   > 5      ),
         #    group=webserver
         self.query_regex = re.compile(
-            # A ( character.
-            r"(\()?" +
+            # One or more ( characters.
+            r"(\(+)?" +
             # Field name: name of the field to look on DB.
             r"([\w.]+)" +
             # Operator: looks for '=', '!=', '<', '>' or '~'.
@@ -1256,12 +1256,11 @@ class WazuhDBQuery(object):
             r"((?:(?:\((?:\[[\[\]\w _\-.,:?\\/'\"=@%<>{}]*]|[\[\]\w _\-.:?\\/'\"=@%<>{}$]*)\))*"
             r"(?:\[[\[\]\w _\-.,:?\\/'\"=@%<>{}]*]|[\[\]\w _\-.:?\\/'\"=@%<>{}$]+)"
             r"(?:\((?:\[[\[\]\w _\-.,:?\\/'\"=@%<>{}]*]|[\[\]\w _\-.:?\\/'\"=@%<>{}$]*)\))*)+)"
-            # A ) character.
-            r"(\))?" +
+            # One or more ) characters.
+            r"(\)+)?" +
             # Separator: looks for ';', ',' or nothing.
             rf"([{''.join(self.query_separators.keys())}])?"
         )
-        self.date_regex = re.compile(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
         self.date_fields = date_fields
         self.extra_fields = extra_fields
         self.q = query
@@ -1372,9 +1371,9 @@ class WazuhDBQuery(object):
                                                                                  operator))
 
             if open_level:
-                level += 1
+                level += len(open_level)
             if close_level:
-                level -= 1
+                level -= len(close_level)
 
             if not self._pass_filter(value):
                 op_index = len(list(filter(lambda x: field in x['field'], self.query_filters)))
@@ -1444,18 +1443,30 @@ class WazuhDBQuery(object):
 
     def _add_filters_to_query(self):
         self._parse_filters()
+
         curr_level = 0
         for q_filter in self.query_filters:
             self._clean_filter(q_filter)
             field_name = q_filter['field'].split('$', 1)[0]
             field_filter = q_filter['field'].replace('.', '_')
+            level = q_filter['level']
 
-            self.query += '((' if curr_level < q_filter['level'] else '('
+            repeat_open = level + 1 - curr_level
+            if level == 0 or repeat_open == 0:
+                repeat_open = 1
+
+            self.query += '(' * repeat_open
 
             self._process_filter(field_name, field_filter, q_filter)
 
-            self.query += ('))' if curr_level > q_filter['level'] else ')') + ' {} '.format(q_filter['separator'])
-            curr_level = q_filter['level']
+            repeat_close = 1
+            if curr_level > level:
+                repeat_close += curr_level - level
+            
+            self.query += ')' * repeat_close
+            self.query += ' {} '.format(q_filter['separator'])
+            curr_level = level
+
         if self.distinct:
             self.query += ' WHERE ' if not self.q and 'WHERE' not in self.query else ' AND '
             self.query += ' AND '.join(


### PR DESCRIPTION
|Related issue|
|---|
|Closes #16909 |

## Description

Added support for nested queries in the `q` API parameter.

### Tests

<details><summary>test_agent_GET_endpoints.tavern.yaml</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_agent_GET_endpoints.tavern.yaml
======================================================== test session starts ========================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 93 items                                                                                                                  

test_agent_GET_endpoints.tavern.yaml::GET /agents PASSED                                                     [  1%]
test_agent_GET_endpoints.tavern.yaml::GET /agents with single agent id PASSED                                [  2%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED       [  3%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} (only cluster configuration) PASSED [  4%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                            [  5%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                      [  6%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                            [  7%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                        [  8%]
test_agent_GET_endpoints.tavern.yaml::GET /groups PASSED                                                     [  9%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED                                    [ 10%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED                                   [ 11%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED                                 [ 12%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED                                 [ 13%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED                                 [ 15%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED                                 [ 16%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED                                [ 17%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED                                [ 18%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED                               [ 19%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED                               [ 20%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED                               [ 21%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED                               [ 22%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                   [ 23%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED          [ 24%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED            [ 25%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED              [ 26%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED                 [ 27%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED                 [ 29%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED      [ 30%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED            [ 31%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED          [ 32%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED               [ 33%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED          [ 34%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED            [ 35%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED           [ 36%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED        [ 37%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED           [ 38%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED           [ 39%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED            [ 40%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED        [ 41%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED           [ 43%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED         [ 44%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED         [ 45%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED             [ 46%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED            [ 47%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                            [ 48%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                    [ 49%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED                   [ 50%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED                  [ 51%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED                [ 52%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED                [ 53%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED                [ 54%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED                [ 55%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED               [ 56%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED               [ 58%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED              [ 59%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED              [ 60%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED              [ 61%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED              [ 62%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                    [ 63%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                     [ 64%]
test_agent_GET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                     [ 65%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group PASSED                                            [ 66%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED                     [ 67%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED                          [ 68%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED                          [ 69%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED                        [ 70%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED                   [ 72%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED                  [ 73%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED                      [ 74%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/outdated PASSED                                            [ 75%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                      [ 76%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED                    [ 77%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED                         [ 78%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED                         [ 79%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED              [ 80%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED                    [ 81%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED                       [ 82%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED                  [ 83%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED                    [ 84%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED                   [ 86%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED                [ 87%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED                   [ 88%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED                   [ 89%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED                    [ 90%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED                [ 91%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED                   [ 92%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED                 [ 93%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED                 [ 94%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED                     [ 95%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED                    [ 96%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                      [ 97%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                          [ 98%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                      [100%]

================================================= warnings summary =================================================
../../../venv/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28
  /home/gasti/work/wazuh/venv/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

../../../venv/lib/python3.9/site-packages/_pytest/nodes.py:642
  /home/gasti/work/wazuh/venv/lib/python3.9/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================== 93 passed, 2 warnings in 220.95s (0:03:40) ====================================
```

</details>

#### Manual tests

<details><summary>Environment</summary>

```json
{
    "data": {
        "affected_items": [
            {
                "id": "000",
                "status": "active"
            },
            {
                "group": [
                    "default",
                    "group1"
                ],
                "id": "001",
                "status": "disconnected"
            },
            {
                "group": [
                    "default",
                    "group1"
                ],
                "id": "002",
                "status": "active"
            },
            {
                "group": [
                    "default",
                    "group2"
                ],
                "id": "003",
                "status": "disconnected"
            },
            {
                "group": [
                    "group2",
                    "group1"
                ],
                "id": "004",
                "status": "active"
            }
        ],
        "total_affected_items": 5,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected agents information was returned",
    "error": 0
}
```

</details>

<details><summary><code>GET /agents?q=id!=000;(status=active;(group=group1,group=group2))</code></summary>

```json
{
    "data": {
        "affected_items": [
            {
                "group": [
                    "default",
                    "group1"
                ],
                "id": "002",
                "status": "active"
            },
            {
                "group": [
                    "group2",
                    "group1"
                ],
                "id": "004",
                "status": "active"
            }
        ],
        "total_affected_items": 2,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected agents information was returned",
    "error": 0
}
```

</details>

<details><summary><code>GET /agents?q=((group=group1,group=group2);id!=000);status=disconnected</code></summary>

```json
{
    "data": {
        "affected_items": [
            {
                "group": [
                    "default",
                    "group1"
                ],
                "id": "001",
                "status": "disconnected"
            },
            {
                "group": [
                    "default",
                    "group2"
                ],
                "id": "003",
                "status": "disconnected"
            }
        ],
        "total_affected_items": 2,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected agents information was returned",
    "error": 0
}
```

</details>

<details><summary><code>GET /agents?q=(status=active,(id!=000;(group=group1,group=group2)))</code></summary>

```json
{
    "data": {
        "affected_items": [
            {
                "id": "000",
                "status": "active"
            },
            {
                "group": [
                    "default",
                    "group1"
                ],
                "id": "001",
                "status": "disconnected"
            },
            {
                "group": [
                    "default",
                    "group1"
                ],
                "id": "002",
                "status": "active"
            },
            {
                "group": [
                    "default",
                    "group2"
                ],
                "id": "003",
                "status": "disconnected"
            },
            {
                "group": [
                    "group2",
                    "group1"
                ],
                "id": "004",
                "status": "active"
            }
        ],
        "total_affected_items": 5,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected agents information was returned",
    "error": 0
}
```

</details>