### PR TITLE
Fix inconsistency when querying agents by group

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -396,7 +396,8 @@ def get_agents_in_group(group_list: list, offset: int = 0, limit: int = common.D
     if group_list[0] not in system_groups:
         raise WazuhResourceNotFound(1710)
 
-    q = 'group=' + group_list[0] + (';' + q if q else '')
+    q_group = 'group=' + group_list[0]
+    q = q_group + ';' + (q if q.startswith('(') and q.endswith(')') else f'({q})') if q else q_group
 
     return get_agents(offset=offset, limit=limit, sort=sort, search=search, select=select, filters=filters, q=q,
      distinct=distinct)

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -396,8 +396,10 @@ def get_agents_in_group(group_list: list, offset: int = 0, limit: int = common.D
     if group_list[0] not in system_groups:
         raise WazuhResourceNotFound(1710)
 
-    q_group = 'group=' + group_list[0]
-    q = q_group + ';' + (q if q.startswith('(') and q.endswith(')') else f'({q})') if q else q_group
+    q_group = f'group={group_list[0]}'
+    if q and not (q.startswith('(') and q.endswith(')')):
+        q = f'({q})'
+    q = f'{q_group};{q}' if q else q_group
 
     return get_agents(offset=offset, limit=limit, sort=sort, search=search, select=select, filters=filters, q=q,
      distinct=distinct)

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -397,9 +397,7 @@ def get_agents_in_group(group_list: list, offset: int = 0, limit: int = common.D
         raise WazuhResourceNotFound(1710)
 
     q_group = f'group={group_list[0]}'
-    if q and not (q.startswith('(') and q.endswith(')')):
-        q = f'({q})'
-    q = f'{q_group};{q}' if q else q_group
+    q = f'{q_group};({q})' if q else q_group
 
     return get_agents(offset=offset, limit=limit, sort=sort, search=search, select=select, filters=filters, q=q,
      distinct=distinct)

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -340,6 +340,36 @@ def test_agent_get_agents_in_group(socket_mock, send_mock, mock_get_groups, mock
             get_agents_in_group(group_list=[group])
 
 
+@pytest.mark.parametrize('group, q, expected_q', [
+    ('default', '(name~wazuh,status~active)', 'group=default;(name~wazuh,status~active)'),
+    ('default', 'name~wazuh,status~active', 'group=default;(name~wazuh,status~active)')
+])
+@patch('wazuh.agent.get_agents')
+@patch('wazuh.agent.get_groups')
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_in_group_formats_q(socket_mock, send_mock, mock_get_groups, mock_get_agents, group,
+                                             q, expected_q):
+    """Test the formatting of the `q` parameter in `get_agents_in_group` from agent module.
+
+    Parameters
+    ----------
+    group : str
+        Name of the group to which the agent belongs.
+    q : str
+        Value of the q parameter.
+    expected_q : str
+        Value of the expected q parameter used in the `get_agents` call.
+    """
+    mock_get_groups.return_value = ['default']
+    # Since the decorator is mocked, pass `group_list` using `call_args` from mock
+    get_agents_in_group(group_list=[group], q=q)
+    kwargs = mock_get_agents.call_args.kwargs
+
+    assert kwargs['q'] == expected_q
+
+
+
 @pytest.mark.parametrize('agent_list, expected_items', [
     (['001', '002', '003'], ['001', '002', '003']),
     (['001', '400', '002', '500'], ['001', '002'])

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -348,7 +348,7 @@ def test_agent_get_agents_in_group(socket_mock, send_mock, mock_get_groups, mock
 @patch('wazuh.agent.get_groups')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_get_agents_in_group_formats_q(socket_mock, send_mock, mock_get_groups, mock_get_agents, group,
+def test_agent_get_agents_in_group_q_formats(socket_mock, send_mock, mock_get_groups, mock_get_agents, group,
                                              q, expected_q):
     """Test the formatting of the `q` parameter in `get_agents_in_group` from agent module.
 
@@ -367,7 +367,6 @@ def test_agent_get_agents_in_group_formats_q(socket_mock, send_mock, mock_get_gr
     kwargs = mock_get_agents.call_args.kwargs
 
     assert kwargs['q'] == expected_q
-
 
 
 @pytest.mark.parametrize('agent_list, expected_items', [

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -341,7 +341,7 @@ def test_agent_get_agents_in_group(socket_mock, send_mock, mock_get_groups, mock
 
 
 @pytest.mark.parametrize('group, q, expected_q', [
-    ('default', '(name~wazuh,status~active)', 'group=default;(name~wazuh,status~active)'),
+    ('default', '(name~wazuh,status~active)', 'group=default;((name~wazuh,status~active))'),
     ('default', 'name~wazuh,status~active', 'group=default;(name~wazuh,status~active)')
 ])
 @patch('wazuh.agent.get_agents')

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -5,12 +5,12 @@
 import os
 import shutil
 import sys
+import pytest
+
 from grp import getgrnam
 from json import dumps
 from pwd import getpwnam
 from unittest.mock import MagicMock, patch, call
-
-import pytest
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..'))
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18331|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Fixes inconsistency in `groups/{groupId}/agents` when using the `q` parameter and added test cases for the edge cases.