### PR TITLE
Catch Wazuh internal errors

### DIFF
--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -25,7 +25,7 @@ try:
     from wazuh.core import common
     from wazuh.core.agent import Agent
     from wazuh.core.cluster.dapi.dapi import DistributedAPI
-    from wazuh.core.exception import WazuhError
+    from wazuh.core.exception import WazuhException
 except Exception as e:
     print("Error importing 'Wazuh' package.\n\n{0}\n".format(e))
     exit()
@@ -228,7 +228,7 @@ def main():
         check_status(affected_agents=result.affected_items, result_dict=agents_versions,
                      failed_agents=failed_agents, silent=args.silent)
 
-    except WazuhError as e:
+    except WazuhException as e:
         print(f"Error {e.code}: {e.message}")
         if args.debug:
             raise

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -296,6 +296,8 @@ class DistributedAPI:
                     raise exception.WazuhInternalError(2008)
                 except process.BrokenProcessPool:
                     raise exception.WazuhInternalError(901)
+                except exception.WazuhInternalError as e:
+                    raise exception.WazuhError(1000, extra_message=str(e))
             except json.decoder.JSONDecodeError:
                 raise exception.WazuhInternalError(3036)
             except process.BrokenProcessPool:


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/18436 |

## Description

Catches the `WazuhInternalError` exceptions that are thrown from the framework side.

Used the generic `1000` error code since using the one from Core's (`1836`) is reserved. Also, raising the `WazuhInternalError` directly still showed the traceback for some reason that we couldn't identify.

## Logs/Alerts example

```console
root@ip-172-31-88-29:/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.1-py3.9.egg/scripts# /var/ossec/framework/python/bin/python3 /var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.1-py3.9.egg/scripts/agent_upgrade.py -a 001 -f /home/ubuntu/wazuh_agent_v4.5.1_macos_x86_64.wpk -F
Error 400: Wazuh Internal Error: Error 1836 - The WPK package used does not fit with the agent's architecture
```