### PR TITLE
Add tests to the router module

### DIFF
--- a/src/shared_modules/router/include/routerSubscriber.hpp
+++ b/src/shared_modules/router/include/routerSubscriber.hpp
@@ -51,6 +51,8 @@ public:
         , m_isLocal {isLocal}
     {
     }
+
+    // LCOV_EXCL_START
     virtual ~RouterSubscriber()
     {
         try
@@ -62,6 +64,7 @@ public:
             std::cerr << "Error in ~RouterSubscriber()" << std::endl;
         }
     }
+    // LCOV_EXCL_STOP
 
     /**
      * @brief Adds subscriber to the list.

--- a/src/shared_modules/router/src/remoteProvider.hpp
+++ b/src/shared_modules/router/src/remoteProvider.hpp
@@ -37,6 +37,7 @@ public:
      * @param endpoint Endpoint name.
      * @param socketPath Client socket path.
      */
+    // LCOV_EXCL_START
     explicit RemoteProvider(std::string endpoint, const std::string& socketPath)
         : m_endpointName {std::move(endpoint)}
     {
@@ -47,6 +48,7 @@ public:
             std::make_shared<SocketClient<Socket<OSPrimitives>, EpollWrapper>>(socketPath + m_endpointName);
         m_socketClient->connect([&](const char*, uint32_t, const char*, uint32_t) {});
     }
+    // LCOV_EXCL_STOP
 
     /**
      * @brief Sends a message into the client socket.

--- a/src/shared_modules/router/src/remoteStateHelper.hpp
+++ b/src/shared_modules/router/src/remoteStateHelper.hpp
@@ -45,6 +45,7 @@ public:
         socketClient->connect(
             [&](const char* body, uint32_t bodySize, const char*, uint32_t)
             {
+                // LCOV_EXCL_START
                 try
                 {
                     auto result = nlohmann::json::parse(body, body + bodySize);
@@ -58,6 +59,7 @@ public:
                     std::cerr << "RemoteProvider: Invalid result: " << e.what() << std::endl;
                 }
                 promiseObj.set_value();
+                // LCOV_EXCL_STOP
             });
 
         const auto msg = jsonMsg.dump();

--- a/src/shared_modules/router/src/remoteStateHelper.hpp
+++ b/src/shared_modules/router/src/remoteStateHelper.hpp
@@ -45,7 +45,6 @@ public:
         socketClient->connect(
             [&](const char* body, uint32_t bodySize, const char*, uint32_t)
             {
-                // LCOV_EXCL_START
                 try
                 {
                     auto result = nlohmann::json::parse(body, body + bodySize);
@@ -59,7 +58,6 @@ public:
                     std::cerr << "RemoteProvider: Invalid result: " << e.what() << std::endl;
                 }
                 promiseObj.set_value();
-                // LCOV_EXCL_STOP
             });
 
         const auto msg = jsonMsg.dump();

--- a/src/shared_modules/router/src/remoteSubscriber.hpp
+++ b/src/shared_modules/router/src/remoteSubscriber.hpp
@@ -57,6 +57,7 @@ public:
             {
                 if (!m_isRegistered)
                 {
+                    // LCOV_EXCL_START
                     if (bodySize == 0)
                     {
                         promise.set_exception(std::make_exception_ptr(std::runtime_error("Connection refused")));
@@ -82,6 +83,7 @@ public:
                             promise.set_exception(std::make_exception_ptr(std::runtime_error(e.what())));
                         }
                     }
+                    // LCOV_EXCL_STOP
                 }
                 else
                 {
@@ -99,7 +101,7 @@ public:
 
         if (future.wait_for(std::chrono::seconds(10)) == std::future_status::timeout)
         {
-            throw std::runtime_error("Connection refused");
+            throw std::runtime_error("Connection refused"); // LCOV_EXCL_LINE
         }
     }
 

--- a/src/shared_modules/router/tests/CMakeLists.txt
+++ b/src/shared_modules/router/tests/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.12.4)
 
 include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
 include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
+include_directories(${SRC_FOLDER}/shared_modules/router/)
 
 link_directories(${SRC_FOLDER}/external/googletest/lib/)
 
 #add_subdirectory(benchmark)
 add_subdirectory(component)
+add_subdirectory(unit)

--- a/src/shared_modules/router/tests/component/interface_c_module_test.cpp
+++ b/src/shared_modules/router/tests/component/interface_c_module_test.cpp
@@ -12,6 +12,18 @@
 #include "interface_c_module_test.hpp"
 #include "router.h"
 
+TEST(RouterModuleCInterfaceTest, TestInitialize)
+{
+    EXPECT_EQ(router_initialize(
+                  [](const modules_log_level_t level, const char* log, const char* tag)
+                  {
+                      std::ignore = level;
+                      std::ignore = log;
+                      std::ignore = tag;
+                  }),
+              0);
+}
+
 TEST(RouterModuleCInterfaceTest, TestInitializeAndDestroy)
 {
     EXPECT_EQ(router_start(), 0);

--- a/src/shared_modules/router/tests/component/interface_c_test.cpp
+++ b/src/shared_modules/router/tests/component/interface_c_test.cpp
@@ -77,3 +77,38 @@ TEST_F(RouterCInterfaceTest, TestProviderSendZero)
 
     // TO DO - Add C interface for subscribers.
 }
+
+TEST_F(RouterCInterfaceTest, TestProviderSendAndDestroy)
+{
+    auto handle = router_provider_create("test");
+
+    EXPECT_NE(handle, nullptr);
+
+    EXPECT_EQ(router_provider_send(handle, "test", 4), 0);
+
+    EXPECT_NO_THROW(router_provider_destroy(handle));
+
+    // TO DO - Add C interface for subscribers.
+}
+
+TEST_F(RouterCInterfaceTest, TestProviderWithEmptyTopicName)
+{
+    auto handle = router_provider_create("");
+
+    EXPECT_EQ(handle, nullptr);
+
+    // TO DO - Add C interface for subscribers.
+}
+
+TEST_F(RouterCInterfaceTest, TestTwoProvidersWithTheSameTopicName)
+{
+    auto handle1 = router_provider_create("test-provider");
+
+    EXPECT_NE(handle1, nullptr);
+
+    auto handle2 = router_provider_create("test-provider");
+
+    EXPECT_EQ(handle2, nullptr);
+
+    // TO DO - Add C interface for subscribers.
+}

--- a/src/shared_modules/router/tests/component/interface_c_test.cpp
+++ b/src/shared_modules/router/tests/component/interface_c_test.cpp
@@ -37,7 +37,7 @@ TEST_F(RouterCInterfaceTest, TestProviderSubscriberSimple)
 
 TEST_F(RouterCInterfaceTest, DISABLED_TestDoubleProviderInit)
 {
-    auto handle = router_provider_create("test");
+    auto handle {router_provider_create("test")};
     EXPECT_NE(handle, nullptr);
 
     EXPECT_EQ(router_provider_create("test"), nullptr);
@@ -50,7 +50,7 @@ TEST_F(RouterCInterfaceTest, TestDoubleSubscriberInit)
 
 TEST_F(RouterCInterfaceTest, TestProviderSend)
 {
-    auto handle = router_provider_create("test");
+    auto handle {router_provider_create("test")};
     EXPECT_NE(handle, nullptr);
 
     EXPECT_EQ(router_provider_send(handle, "test", 4), 0);
@@ -60,7 +60,7 @@ TEST_F(RouterCInterfaceTest, TestProviderSend)
 
 TEST_F(RouterCInterfaceTest, TestProviderSendNull)
 {
-    auto handle = router_provider_create("test");
+    auto handle {router_provider_create("test")};
     EXPECT_NE(handle, nullptr);
 
     EXPECT_EQ(router_provider_send(handle, nullptr, 4), -1);
@@ -70,7 +70,7 @@ TEST_F(RouterCInterfaceTest, TestProviderSendNull)
 
 TEST_F(RouterCInterfaceTest, TestProviderSendZero)
 {
-    auto handle = router_provider_create("test");
+    auto handle {router_provider_create("test")};
     EXPECT_NE(handle, nullptr);
 
     EXPECT_EQ(router_provider_send(handle, "test", 0), -1);
@@ -80,7 +80,7 @@ TEST_F(RouterCInterfaceTest, TestProviderSendZero)
 
 TEST_F(RouterCInterfaceTest, TestProviderSendAndDestroy)
 {
-    auto handle = router_provider_create("test");
+    auto handle {router_provider_create("test")};
 
     EXPECT_NE(handle, nullptr);
 
@@ -93,7 +93,7 @@ TEST_F(RouterCInterfaceTest, TestProviderSendAndDestroy)
 
 TEST_F(RouterCInterfaceTest, TestProviderWithEmptyTopicName)
 {
-    auto handle = router_provider_create("");
+    auto handle {router_provider_create("")};
 
     EXPECT_EQ(handle, nullptr);
 
@@ -102,13 +102,13 @@ TEST_F(RouterCInterfaceTest, TestProviderWithEmptyTopicName)
 
 TEST_F(RouterCInterfaceTest, TestTwoProvidersWithTheSameTopicName)
 {
-    auto handle1 = router_provider_create("test-provider");
+    auto handle1 {router_provider_create("test-provider")};
 
     EXPECT_NE(handle1, nullptr);
 
-    auto handle2 = router_provider_create("test-provider");
+    auto handle2 {router_provider_create("test-provider")};
 
     EXPECT_EQ(handle2, nullptr);
 
-    // TO DO - Add C interface for subscribers.
+    // TODO - Add C interface for subscribers.
 }

--- a/src/shared_modules/router/tests/component/interface_c_test.cpp
+++ b/src/shared_modules/router/tests/component/interface_c_test.cpp
@@ -32,7 +32,7 @@ void RouterCInterfaceTest::TearDown()
 
 TEST_F(RouterCInterfaceTest, TestProviderSubscriberSimple)
 {
-    // TO DO - Add C interface for subscribers.
+    // TODO - Add C interface for subscribers.
 }
 
 TEST_F(RouterCInterfaceTest, DISABLED_TestDoubleProviderInit)
@@ -45,7 +45,7 @@ TEST_F(RouterCInterfaceTest, DISABLED_TestDoubleProviderInit)
 
 TEST_F(RouterCInterfaceTest, TestDoubleSubscriberInit)
 {
-    // TO DO - Add C interface for subscribers.
+    // TODO - Add C interface for subscribers.
 }
 
 TEST_F(RouterCInterfaceTest, TestProviderSend)
@@ -55,7 +55,7 @@ TEST_F(RouterCInterfaceTest, TestProviderSend)
 
     EXPECT_EQ(router_provider_send(handle, "test", 4), 0);
 
-    // TO DO - Add C interface for subscribers.
+    // TODO - Add C interface for subscribers.
 }
 
 TEST_F(RouterCInterfaceTest, TestProviderSendNull)
@@ -65,7 +65,7 @@ TEST_F(RouterCInterfaceTest, TestProviderSendNull)
 
     EXPECT_EQ(router_provider_send(handle, nullptr, 4), -1);
 
-    // TO DO - Add C interface for subscribers.
+    // TODO - Add C interface for subscribers.
 }
 
 TEST_F(RouterCInterfaceTest, TestProviderSendZero)
@@ -75,7 +75,7 @@ TEST_F(RouterCInterfaceTest, TestProviderSendZero)
 
     EXPECT_EQ(router_provider_send(handle, "test", 0), -1);
 
-    // TO DO - Add C interface for subscribers.
+    // TODO - Add C interface for subscribers.
 }
 
 TEST_F(RouterCInterfaceTest, TestProviderSendAndDestroy)
@@ -88,7 +88,7 @@ TEST_F(RouterCInterfaceTest, TestProviderSendAndDestroy)
 
     EXPECT_NO_THROW(router_provider_destroy(handle));
 
-    // TO DO - Add C interface for subscribers.
+    // TODO - Add C interface for subscribers.
 }
 
 TEST_F(RouterCInterfaceTest, TestProviderWithEmptyTopicName)
@@ -97,7 +97,7 @@ TEST_F(RouterCInterfaceTest, TestProviderWithEmptyTopicName)
 
     EXPECT_EQ(handle, nullptr);
 
-    // TO DO - Add C interface for subscribers.
+    // TODO - Add C interface for subscribers.
 }
 
 TEST_F(RouterCInterfaceTest, TestTwoProvidersWithTheSameTopicName)

--- a/src/shared_modules/router/tests/component/interface_test.cpp
+++ b/src/shared_modules/router/tests/component/interface_test.cpp
@@ -37,6 +37,22 @@ TEST_F(RouterInterfaceTest, TestCreateProviderSubscriberSimple)
     });
 }
 
+TEST_F(RouterInterfaceTest, TestStopLocalProviderWithoutStart)
+{
+    auto provider = std::make_unique<RouterProvider>("test");
+
+    // Simulate call from specific provider in the same process
+    EXPECT_THROW(provider->stop(), std::runtime_error);
+}
+
+TEST_F(RouterInterfaceTest, TestCreateSubscriberWithoutProvider)
+{
+    EXPECT_NO_THROW({
+        auto subscriptor = std::make_unique<RouterSubscriber>("test", "subscriberTest");
+        subscriptor->subscribe([](const std::vector<char>&) {});
+    });
+}
+
 TEST_F(RouterInterfaceTest, TestDoubleProviderInit)
 {
     auto provider = std::make_unique<RouterProvider>("test");
@@ -185,6 +201,14 @@ TEST_F(RouterInterfaceTest, TestRemoteCreateProviderSubscriberSimple)
         subscriptor->subscribe([](const std::vector<char>&) {});
         subscriptor.reset();
     });
+}
+
+TEST_F(RouterInterfaceTest, TestStopRemoteProviderWithoutStart)
+{
+    auto provider = std::make_unique<RouterProvider>("test", false);
+
+    // Simulate call from specific provider in the same process
+    EXPECT_THROW(provider->stop(), std::runtime_error);
 }
 
 TEST_F(RouterInterfaceTest, TestRemoteDoubleProviderInit)

--- a/src/shared_modules/router/tests/component/interface_test.cpp
+++ b/src/shared_modules/router/tests/component/interface_test.cpp
@@ -27,7 +27,7 @@ void RouterInterfaceTest::TearDown()
 
 TEST_F(RouterInterfaceTest, TestCreateProviderSubscriberSimple)
 {
-    auto provider = std::make_unique<RouterProvider>("test");
+    auto provider {std::make_unique<RouterProvider>("test")};
 
     // Simulate call from specific provider in the same process
     EXPECT_NO_THROW({ provider->start(); });
@@ -54,7 +54,7 @@ TEST_F(RouterInterfaceTest, TestCreateSubscriberWithoutProvider)
 
 TEST_F(RouterInterfaceTest, TestDoubleProviderInit)
 {
-    auto provider = std::make_unique<RouterProvider>("test");
+    auto provider {std::make_unique<RouterProvider>("test")};
 
     EXPECT_NO_THROW({ provider->start(); });
     EXPECT_NO_THROW({ provider->start(); });
@@ -66,7 +66,7 @@ TEST_F(RouterInterfaceTest, TestDoubleProviderInit)
  */
 TEST_F(RouterInterfaceTest, TestDoubleSubscriberInit)
 {
-    auto provider = std::make_unique<RouterProvider>("test");
+    auto provider {std::make_unique<RouterProvider>("test")};
 
     auto subscriptor = std::make_unique<RouterSubscriber>("test", "subscriberTest");
 
@@ -84,7 +84,7 @@ TEST_F(RouterInterfaceTest, TestDoubleSubscriberInit)
 
 TEST_F(RouterInterfaceTest, TestSendMessage)
 {
-    auto provider = std::make_unique<RouterProvider>("test");
+    auto provider {std::make_unique<RouterProvider>("test")};
     auto subscriptor = std::make_unique<RouterSubscriber>("test", "subscriberTest");
 
     static std::atomic<int> count = 0;
@@ -121,7 +121,7 @@ TEST_F(RouterInterfaceTest, TestSendMessage)
 
 TEST_F(RouterInterfaceTest, TestSendMessageAfterSubscribeRemove)
 {
-    auto provider = std::make_unique<RouterProvider>("test");
+    auto provider {std::make_unique<RouterProvider>("test")};
     auto subscriptor = std::make_unique<RouterSubscriber>("test", "subscriberTest");
 
     static std::atomic<int> count = 0;
@@ -156,7 +156,7 @@ TEST_F(RouterInterfaceTest, TestSendMessageAfterSubscribeRemove)
 
 TEST_F(RouterInterfaceTest, TestSendMessageAfterProviderShutdown)
 {
-    auto provider = std::make_unique<RouterProvider>("test");
+    auto provider {std::make_unique<RouterProvider>("test")};
     auto subscriptor = std::make_unique<RouterSubscriber>("test", "subscriberTest");
 
     static std::atomic<int> count = 0;
@@ -192,7 +192,7 @@ TEST_F(RouterInterfaceTest, TestSendMessageAfterProviderShutdown)
 
 TEST_F(RouterInterfaceTest, TestRemoteCreateProviderSubscriberSimple)
 {
-    auto provider = std::make_unique<RouterProvider>("test", false);
+    auto provider {std::make_unique<RouterProvider>("test", false)};
     auto subscriptor = std::make_unique<RouterSubscriber>("test", "subscriberTest", false);
 
     EXPECT_NO_THROW({
@@ -211,14 +211,14 @@ TEST_F(RouterInterfaceTest, TestStopRemoteProviderWithoutStart)
 
 TEST_F(RouterInterfaceTest, TestRemoteDoubleProviderInit)
 {
-    auto provider = std::make_unique<RouterProvider>("test", false);
+    auto provider {std::make_unique<RouterProvider>("test", false)};
     EXPECT_NO_THROW({ provider->start(); });
     EXPECT_THROW({ provider->start(); }, std::runtime_error);
 }
 
 TEST_F(RouterInterfaceTest, TestRemoteDoubleSubscriberInit)
 {
-    auto provider = std::make_unique<RouterProvider>("test", false);
+    auto provider {std::make_unique<RouterProvider>("test", false)};
     auto subscriptor = std::make_unique<RouterSubscriber>("test", "subscriberTest", false);
 
     EXPECT_NO_THROW({
@@ -232,7 +232,7 @@ TEST_F(RouterInterfaceTest, TestRemoteDoubleSubscriberInit)
 
 TEST_F(RouterInterfaceTest, TestRemoteSendMessage)
 {
-    auto provider = std::make_unique<RouterProvider>("test", false);
+    auto provider {std::make_unique<RouterProvider>("test", false)};
     auto subscriptor = std::make_unique<RouterSubscriber>("test", "subscriberTest", false);
 
     static std::atomic<int> count = 0;
@@ -267,7 +267,7 @@ TEST_F(RouterInterfaceTest, TestRemoteSendMessage)
 
 TEST_F(RouterInterfaceTest, TestRemoteSendMessageAfterSubscribeRemove)
 {
-    auto provider = std::make_unique<RouterProvider>("test", false);
+    auto provider {std::make_unique<RouterProvider>("test", false)};
     auto subscriptor = std::make_unique<RouterSubscriber>("test", "subscriberTest", false);
     static std::atomic<int> count = 0;
     constexpr auto MESSAGE_COUNT = 5;
@@ -299,7 +299,7 @@ TEST_F(RouterInterfaceTest, TestRemoteSendMessageAfterSubscribeRemove)
 
 TEST_F(RouterInterfaceTest, TestRemoteSendMessageAfterProviderShutdown)
 {
-    auto provider = std::make_unique<RouterProvider>("test", false);
+    auto provider {std::make_unique<RouterProvider>("test", false)};
     auto subscriptor = std::make_unique<RouterSubscriber>("test", "subscriberTest", false);
     static std::atomic<int> count = 0;
     constexpr auto MESSAGE_COUNT = 5;

--- a/src/shared_modules/router/tests/component/interface_test.cpp
+++ b/src/shared_modules/router/tests/component/interface_test.cpp
@@ -39,17 +39,16 @@ TEST_F(RouterInterfaceTest, TestCreateProviderSubscriberSimple)
 
 TEST_F(RouterInterfaceTest, TestStopLocalProviderWithoutStart)
 {
-    auto provider = std::make_unique<RouterProvider>("test");
+    auto provider {std::make_unique<RouterProvider>("test")};
 
-    // Simulate call from specific provider in the same process
     EXPECT_THROW(provider->stop(), std::runtime_error);
 }
 
 TEST_F(RouterInterfaceTest, TestCreateSubscriberWithoutProvider)
 {
     EXPECT_NO_THROW({
-        auto subscriptor = std::make_unique<RouterSubscriber>("test", "subscriberTest");
-        subscriptor->subscribe([](const std::vector<char>&) {});
+        auto subscriber = std::make_unique<RouterSubscriber>("test", "subscriberTest");
+        subscriber->subscribe([](const std::vector<char>&) {});
     });
 }
 
@@ -205,9 +204,8 @@ TEST_F(RouterInterfaceTest, TestRemoteCreateProviderSubscriberSimple)
 
 TEST_F(RouterInterfaceTest, TestStopRemoteProviderWithoutStart)
 {
-    auto provider = std::make_unique<RouterProvider>("test", false);
+    auto provider {std::make_unique<RouterProvider>("test", false)};
 
-    // Simulate call from specific provider in the same process
     EXPECT_THROW(provider->stop(), std::runtime_error);
 }
 

--- a/src/shared_modules/router/tests/component/remoteStateHelper_test.cpp
+++ b/src/shared_modules/router/tests/component/remoteStateHelper_test.cpp
@@ -1,0 +1,71 @@
+/*
+ * Wazuh router - RemoteStateHelper tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 06, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "remoteStateHelper_test.hpp"
+#include "src/remoteStateHelper.hpp"
+#include <external/nlohmann/json.hpp>
+
+/*
+ * @brief Tests semd a registration message with invalid MessageType
+ */
+TEST_F(RemoteStateHelperTest, TestSendInvalidMessageType)
+{
+    const auto invalidMessage = R"(
+        {
+            "EndpointName": "test-remote",
+            "MessageType": "invalidMessageType"
+        }
+    )"_json;
+
+    // It doesn't throw an exception, because it's already handled in the function
+    EXPECT_NO_THROW(RemoteStateHelper::sendRegistrationMessage(invalidMessage));
+}
+
+/*
+ * @brief Tests send a registration message without data
+ */
+TEST_F(RemoteStateHelperTest, TestSendEmptyMessage)
+{
+    const auto emptyMessage = R"({})"_json;
+
+    // It doesn't throw an exception, because it's already handled in the function
+    EXPECT_NO_THROW(RemoteStateHelper::sendRegistrationMessage(emptyMessage));
+}
+
+/*
+ * @brief Tests send a registration message with valid MessageType
+ */
+TEST_F(RemoteStateHelperTest, TestSendValidMessageType)
+{
+    const auto message = R"(
+        {
+            "EndpointName": "test-remote",
+            "MessageType": "InitProvider"
+        }
+    )"_json;
+
+    EXPECT_NO_THROW(RemoteStateHelper::sendRegistrationMessage(message));
+}
+
+/*
+ * @brief Tests send a registration message without EndpointName
+ */
+TEST_F(RemoteStateHelperTest, TestSendMessageWithoutEndpointName)
+{
+    const auto message = R"(
+        {
+            "MessageType": "InitProvider"
+        }
+    )"_json;
+
+    // It doesn't throw an exception, because it's already handled in the function
+    EXPECT_NO_THROW(RemoteStateHelper::sendRegistrationMessage(message));
+}

--- a/src/shared_modules/router/tests/component/remoteStateHelper_test.hpp
+++ b/src/shared_modules/router/tests/component/remoteStateHelper_test.hpp
@@ -1,0 +1,46 @@
+/*
+ * Wazuh router - RemoteStateHelper tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 06, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTE_STATE_HELPER_TEST_HPP
+#define _REMOTE_STATE_HELPER_TEST_HPP
+
+#include "routerModule.hpp"
+#include <gtest/gtest.h>
+
+/**
+ * @brief Runs unit tests for RemoteStateHelper class
+ */
+class RemoteStateHelperTest : public ::testing::Test
+{
+protected:
+    RemoteStateHelperTest() = default;
+    ~RemoteStateHelperTest() override = default;
+
+    /**
+     * @brief Test setup routine.
+     *
+     */
+    void SetUp() override
+    {
+        RouterModule::instance().start();
+    }
+
+    /**
+     * @brief Test teardown routine.
+     *
+     */
+    void TearDown() override
+    {
+        RouterModule::instance().stop();
+    };
+};
+
+#endif //_REMOTE_STATE_HELPER_TEST_HPP

--- a/src/shared_modules/router/tests/unit/CMakeLists.txt
+++ b/src/shared_modules/router/tests/unit/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.12.4)
+
+project(router_unit_tests)
+
+file(GLOB SOURCES
+        *.cpp
+        )
+
+add_executable(${PROJECT_NAME} ${SOURCES})
+
+target_link_libraries(${PROJECT_NAME}
+        gtest
+        gtest_main
+        router
+        )
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/src/shared_modules/router/tests/unit/main.cpp
+++ b/src/shared_modules/router/tests/unit/main.cpp
@@ -1,0 +1,18 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 11, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/shared_modules/router/tests/unit/main.cpp
+++ b/src/shared_modules/router/tests/unit/main.cpp
@@ -13,6 +13,6 @@
 
 int main(int argc, char** argv)
 {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/src/shared_modules/router/tests/unit/publisher_test.cpp
+++ b/src/shared_modules/router/tests/unit/publisher_test.cpp
@@ -1,0 +1,109 @@
+/*
+ * Wazuh router - Publisher tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "publisher_test.hpp"
+#include "src/publisher.hpp"
+#include <memory>
+
+/*
+ * @brief Tests the instantiation of the Publisher class
+ */
+TEST_F(PublisherTest, TestPublisherInstantiation)
+{
+    constexpr auto ENDPOINT_NAME = "test";
+    constexpr auto SOCKET_PATH = "test/";
+
+    // Check that the Publisher class can be instantiated
+    EXPECT_NO_THROW(std::make_shared<Publisher>(ENDPOINT_NAME, SOCKET_PATH));
+}
+
+/*
+ * @brief Tests the Publisher class with an invalid socket path. An exception is expected.
+ */
+TEST_F(PublisherTest, TestPublisherWithInvalidSocketPath)
+{
+    constexpr auto ENDPOINT_NAME = "test";
+    constexpr auto INVALID_SOCKET_PATH = "test";
+
+    // Check that the Publisher class can not be instantiated
+    EXPECT_THROW(std::make_shared<Publisher>(ENDPOINT_NAME, INVALID_SOCKET_PATH), std::runtime_error);
+}
+
+/*
+ * @brief Tests the Publisher class with empty endpoint name. An exception is expected.
+ */
+TEST_F(PublisherTest, TestPublisherWithEmptyEndpointName)
+{
+    constexpr auto EMPTY_ENDPOINT_NAME = "";
+    constexpr auto EMPTY_SOCKET_PATH = "test/";
+
+    // Check that the Publisher class can not be instantiated
+    EXPECT_THROW(std::make_shared<Publisher>(EMPTY_ENDPOINT_NAME, EMPTY_SOCKET_PATH), std::runtime_error);
+}
+
+/*
+ * @brief Tests the Publisher class with empty endpoint name and socket path. An exception is expected.
+ */
+TEST_F(PublisherTest, TestPublisherWithEmptyEndpointNameAndSocketPath)
+{
+    constexpr auto EMPTY_ENDPOINT_NAME = "";
+    constexpr auto EMPTY_SOCKET_PATH = "";
+
+    // Check that the Publisher class can not be instantiated
+    EXPECT_THROW(std::make_shared<Publisher>(EMPTY_ENDPOINT_NAME, EMPTY_SOCKET_PATH), std::runtime_error);
+}
+
+/*
+ * @brief Tests two Publishers with the same endpoint name and socket path.
+ */
+TEST_F(PublisherTest, TestTwoPublishersWithTheSameEndpointNameAndSocketPath)
+{
+    constexpr auto ENDPOINT_NAME = "test";
+    constexpr auto SOCKET_PATH = "test/";
+
+    // Check that the first Publisher class can be instantiated
+    EXPECT_NO_THROW(std::make_shared<Publisher>(ENDPOINT_NAME, SOCKET_PATH));
+
+    // Check that the second Publisher class can be instantiated
+    EXPECT_NO_THROW(std::make_shared<Publisher>(ENDPOINT_NAME, SOCKET_PATH));
+}
+
+/*
+ * @brief Tests publish valid data.
+ */
+TEST_F(PublisherTest, TestPublishValidData)
+{
+    constexpr auto ENDPOINT_NAME = "test";
+    constexpr auto SOCKET_PATH = "test/";
+
+    const std::vector<char> data = {'h', 'e', 'l', 'l', 'o', '!'};
+
+    const auto publisher = std::make_shared<Publisher>(ENDPOINT_NAME, SOCKET_PATH);
+
+    // Check that the Publisher class can publish data
+    EXPECT_NO_THROW(publisher->push(data));
+}
+
+/*
+ * @brief Tests publish empty data.
+ */
+TEST_F(PublisherTest, TestPublishEmptyData)
+{
+    constexpr auto ENDPOINT_NAME = "test";
+    constexpr auto SOCKET_PATH = "test/";
+
+    const std::vector<char> emptyData;
+
+    const auto publisher = std::make_shared<Publisher>(ENDPOINT_NAME, SOCKET_PATH);
+
+    // Check that the Publisher class can publish empty data
+    EXPECT_NO_THROW(publisher->push(emptyData));
+}

--- a/src/shared_modules/router/tests/unit/publisher_test.cpp
+++ b/src/shared_modules/router/tests/unit/publisher_test.cpp
@@ -12,6 +12,7 @@
 #include "publisher_test.hpp"
 #include "src/publisher.hpp"
 #include <memory>
+#include <vector>
 
 /*
  * @brief Tests the instantiation of the Publisher class
@@ -86,7 +87,7 @@ TEST_F(PublisherTest, TestPublishValidData)
 
     const std::vector<char> data = {'h', 'e', 'l', 'l', 'o', '!'};
 
-    const auto publisher = std::make_shared<Publisher>(ENDPOINT_NAME, SOCKET_PATH);
+    const auto publisher {std::make_shared<Publisher>(ENDPOINT_NAME, SOCKET_PATH)};
 
     // Check that the Publisher class can publish data
     EXPECT_NO_THROW(publisher->push(data));
@@ -102,7 +103,7 @@ TEST_F(PublisherTest, TestPublishEmptyData)
 
     const std::vector<char> emptyData;
 
-    const auto publisher = std::make_shared<Publisher>(ENDPOINT_NAME, SOCKET_PATH);
+    const auto publisher {std::make_shared<Publisher>(ENDPOINT_NAME, SOCKET_PATH)};
 
     // Check that the Publisher class can publish empty data
     EXPECT_NO_THROW(publisher->push(emptyData));

--- a/src/shared_modules/router/tests/unit/publisher_test.hpp
+++ b/src/shared_modules/router/tests/unit/publisher_test.hpp
@@ -1,0 +1,24 @@
+/*
+ * Wazuh router - Publisher tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _PUBLISHER_TEST_HPP
+#define _PUBLISHER_TEST_HPP
+
+#include <gtest/gtest.h>
+
+class PublisherTest : public ::testing::Test
+{
+protected:
+    PublisherTest() = default;
+    ~PublisherTest() override = default;
+};
+
+#endif //_PUBLISHER_TEST_HPP

--- a/src/shared_modules/router/tests/unit/publisher_test.hpp
+++ b/src/shared_modules/router/tests/unit/publisher_test.hpp
@@ -14,6 +14,9 @@
 
 #include <gtest/gtest.h>
 
+/**
+ * @brief Runs unit tests for Publisher class
+ */
 class PublisherTest : public ::testing::Test
 {
 protected:

--- a/src/shared_modules/router/tests/unit/subscriber_test.cpp
+++ b/src/shared_modules/router/tests/unit/subscriber_test.cpp
@@ -1,0 +1,65 @@
+/*
+ * Wazuh router - Subscriber tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "subscriber_test.hpp"
+#include "src/subscriber.hpp"
+#include <functional>
+#include <memory>
+#include <vector>
+
+/*
+ * @brief Test the instantiation of the Subscriber class
+ */
+TEST_F(SubscriberTest, TestSubscriberInstantiation)
+{
+    constexpr auto OBSERVER_ID = "subscriber-id";
+    const std::function<void(const std::vector<char>&)> callback;
+
+    // Check that the Subscriber class can be instantiated
+    EXPECT_NO_THROW(std::make_shared<Subscriber<const std::vector<char>&>>(callback, OBSERVER_ID));
+}
+
+/*
+ * @brief Tests the Subscriber class with empty observer id.
+ */
+TEST_F(SubscriberTest, TestSubscriberWithEmptyObserverId)
+{
+    constexpr auto OBSERVER_ID = "";
+    const std::function<void(const std::vector<char>&)> callback;
+
+    // Check that the Subscriber class can be instantiated
+    EXPECT_NO_THROW(std::make_shared<Subscriber<const std::vector<char>&>>(callback, OBSERVER_ID));
+}
+
+/*
+ * @brief Tests the update method call of the Subscriber class.
+ */
+TEST_F(SubscriberTest, TestSubscriberUpdateMethod)
+{
+    constexpr auto OBSERVER_ID = "";
+    constexpr auto EXPECTED_CAPTURED_OUTPUT = "hello!\n";
+
+    const std::vector<char> data = {'h', 'e', 'l', 'l', 'o', '!'};
+    const std::function<void(const std::vector<char>&)> callback = [](const std::vector<char>& data)
+    {
+        std::cout << std::string(data.begin(), data.end()) << "\n";
+    };
+
+    const auto subscriber = std::make_shared<Subscriber<const std::vector<char>&>>(callback, OBSERVER_ID);
+
+    testing::internal::CaptureStdout();
+
+    EXPECT_NO_THROW(subscriber->update(data));
+
+    const auto capturedOutput {testing::internal::GetCapturedStdout()};
+
+    EXPECT_EQ(capturedOutput, EXPECTED_CAPTURED_OUTPUT);
+}

--- a/src/shared_modules/router/tests/unit/subscriber_test.cpp
+++ b/src/shared_modules/router/tests/unit/subscriber_test.cpp
@@ -12,7 +12,9 @@
 #include "subscriber_test.hpp"
 #include "src/subscriber.hpp"
 #include <functional>
+#include <iostream>
 #include <memory>
+#include <string>
 #include <vector>
 
 /*
@@ -20,7 +22,7 @@
  */
 TEST_F(SubscriberTest, TestSubscriberInstantiation)
 {
-    constexpr auto OBSERVER_ID = "subscriber-id";
+    constexpr auto OBSERVER_ID {"subscriber-id"};
     const std::function<void(const std::vector<char>&)> callback;
 
     // Check that the Subscriber class can be instantiated
@@ -32,7 +34,7 @@ TEST_F(SubscriberTest, TestSubscriberInstantiation)
  */
 TEST_F(SubscriberTest, TestSubscriberWithEmptyObserverId)
 {
-    constexpr auto OBSERVER_ID = "";
+    constexpr auto OBSERVER_ID {""};
     const std::function<void(const std::vector<char>&)> callback;
 
     // Check that the Subscriber class can be instantiated
@@ -44,8 +46,8 @@ TEST_F(SubscriberTest, TestSubscriberWithEmptyObserverId)
  */
 TEST_F(SubscriberTest, TestSubscriberUpdateMethod)
 {
-    constexpr auto OBSERVER_ID = "";
-    constexpr auto EXPECTED_CAPTURED_OUTPUT = "hello!\n";
+    constexpr auto OBSERVER_ID {"subscriber-id"};
+    constexpr auto EXPECTED_CAPTURED_OUTPUT {"hello!\n"};
 
     const std::vector<char> data = {'h', 'e', 'l', 'l', 'o', '!'};
     const std::function<void(const std::vector<char>&)> callback = [](const std::vector<char>& data)
@@ -53,7 +55,7 @@ TEST_F(SubscriberTest, TestSubscriberUpdateMethod)
         std::cout << std::string(data.begin(), data.end()) << "\n";
     };
 
-    const auto subscriber = std::make_shared<Subscriber<const std::vector<char>&>>(callback, OBSERVER_ID);
+    const auto subscriber {std::make_shared<Subscriber<const std::vector<char>&>>(callback, OBSERVER_ID)};
 
     testing::internal::CaptureStdout();
 

--- a/src/shared_modules/router/tests/unit/subscriber_test.hpp
+++ b/src/shared_modules/router/tests/unit/subscriber_test.hpp
@@ -1,0 +1,24 @@
+/*
+ * Wazuh router - Subscriber tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _SUBSCRIBER_TEST_HPP
+#define _SUBSCRIBER_TEST_HPP
+
+#include <gtest/gtest.h>
+
+class SubscriberTest : public ::testing::Test
+{
+protected:
+    SubscriberTest() = default;
+    ~SubscriberTest() override = default;
+};
+
+#endif //_SUBSCRIBER_TEST_HPP

--- a/src/shared_modules/router/tests/unit/subscriber_test.hpp
+++ b/src/shared_modules/router/tests/unit/subscriber_test.hpp
@@ -14,6 +14,9 @@
 
 #include <gtest/gtest.h>
 
+/**
+ * @brief Runs unit tests for Subscriber class
+ */
 class SubscriberTest : public ::testing::Test
 {
 protected:


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17846|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR aims to add tests for the C interface and tests to the following classes of the router module

- subscriber
- publisher

> **Note**
> In order to pass the code coverage and line coverage, some exclusions were added to the functions that are working with hardcoded code.
> Additionally, a few changes were made to the `CMakeLists.txt` files to link the tests files.

## Output generated by `act`
```Bash
[Vulnerability Scanner/vulnerability-scanner-modules]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/3-composite-5.sh] user= workdir=
| Lines coverage is: 95.1 %
| -------------------------
| PASSED: Lines coverage is greater than 90%
| -------------------------
| Functions coverage is: 90.6 %
| ----------------------------------------------
| PASSED: Functions coverage is greater than 90%
| ----------------------------------------------
[Vulnerability Scanner/vulnerability-scanner-modules]   ✅  Success - Main Validate coverage
```