### PR TITLE
Add support for Debian Bookworm in Vulnerability Detector

### DIFF
--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -20,6 +20,7 @@
       <enabled>no</enabled>
       <os>buster</os>
       <os>bullseye</os>
+      <os>bookworm</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -174,7 +174,12 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
         upd->dist_ref = FEED_UBUNTU;
 
     } else if (strcasestr(feed, vu_feed_tag[FEED_DEBIAN]) && version) {
-        if (!strcmp(version, "11") || strcasestr(version, vu_feed_tag[FEED_BULLSEYE])) {
+        if (!strcmp(version, "12") || strcasestr(version, vu_feed_tag[FEED_BOOKWORM])) {
+            os_index = CVE_BOOKWORM;
+            os_strdup(vu_feed_tag[FEED_BOOKWORM], upd->version);
+            upd->dist_tag_ref = FEED_BOOKWORM;
+            upd->dist_ext = vu_feed_ext[FEED_BOOKWORM];
+        } else if (!strcmp(version, "11") || strcasestr(version, vu_feed_tag[FEED_BULLSEYE])) {
             os_index = CVE_BULLSEYE;
             os_strdup(vu_feed_tag[FEED_BULLSEYE], upd->version);
             upd->dist_tag_ref = FEED_BULLSEYE;

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -19213,7 +19213,7 @@ void test_wm_vuldet_set_feed_update_url_debian(void **state)
 
     ret = wm_vuldet_set_feed_update_url(update);
     assert_true(ret);
-    assert_string_equal(update->url, "https://www.debian.org/security/oval/oval-definitions-buster.xml");
+    assert_string_equal(update->url, "https://www.debian.org/security/oval/oval-definitions-buster.xml.bz2");
 
     os_free(update->url);
     os_free(update);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -639,6 +639,7 @@ const char *vu_feed_tag[] = {
     // Debian versions
     "BUSTER",
     "BULLSEYE",
+    "BOOKWORM",
     // RedHat versions
     "RHEL5",
     "RHEL6",
@@ -706,6 +707,7 @@ const char *vu_feed_ext[] = {
     // Debian versions
     "Debian Buster",
     "Debian Bullseye",
+    "Debian Bookworm",
     // RedHat versions
     "Red Hat Enterprise Linux 5",
     "Red Hat Enterprise Linux 6",
@@ -6129,6 +6131,8 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
                 agent_dist_ver = FEED_BUSTER;
             } else if (strstr(agti_os_major, "11")) {
                 agent_dist_ver = FEED_BULLSEYE;
+            } else if (strstr(agti_os_major, "12")) {
+                agent_dist_ver = FEED_BOOKWORM;
             } else {
                 dist_error = FEED_DEBIAN;
             }
@@ -6902,6 +6906,7 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, scan_agent *agent) {
         break;
         case FEED_BUSTER:
         case FEED_BULLSEYE:
+        case FEED_BOOKWORM:
             product_name[0] = vu_os_product_name_list[PR_DEBIAN];
             vendor = vu_vendor_list[V_DEBIAN];
         break;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -42,7 +42,7 @@
 #define VU_MSU_FILE "queue/vulnerabilities/dictionaries/msu.json"
 #define VU_CPEHELPER_FORMAT_VERSION 1
 #define CANONICAL_REPO "https://security-metadata.canonical.com/oval/com.ubuntu.%s.cve.oval.xml.bz2"
-#define DEBIAN_REPO "https://www.debian.org/security/oval/oval-definitions-%s.xml"
+#define DEBIAN_REPO "https://www.debian.org/security/oval/oval-definitions-%s.xml.bz2"
 #define DEBIAN_REPO_STATUS "https://security-tracker.debian.org/tracker/data/json"
 #define ALAS_REPO "https://feed.wazuh.com/vulnerability-detector/ALAS/1/alas.json.gz"
 #define ALAS_REPO_META "https://feed.wazuh.com/vulnerability-detector/ALAS/1/alas.meta"
@@ -276,6 +276,7 @@ typedef enum vu_feed {
     // Debian versions
     FEED_BUSTER,
     FEED_BULLSEYE,
+    FEED_BOOKWORM,
     // RedHat versions
     FEED_RHEL5,
     FEED_RHEL6,
@@ -443,6 +444,7 @@ typedef enum cve_db {
     CVE_JAMMY,
     CVE_BUSTER,
     CVE_BULLSEYE,
+    CVE_BOOKWORM,
     CVE_REDHAT5,
     CVE_REDHAT6,
     CVE_REDHAT7,


### PR DESCRIPTION
|Related issue|
|---|
|#18516|


## Description

The purpose of this PR is to add support for **Debian 12 (Bookworm)** in the _vulnerability detector_ module.

First, the OVAL provided by Debian is downloaded: https://www.debian.org/security/oval/oval-definitions-bookworm.xml.bz2

Since there is no `oval-definitions-bookworm.xml` file in the [Debian OVAL repository](https://www.debian.org/security/oval/), we opted to switch to the `bz2` files for Debian OVALs:
https://github.com/wazuh/wazuh/blob/a1c50b5e40764f9f583140d99c838cbfe69e1cdf/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h#L45

The vulnerabilities are then parsed and inserted into the database.

And finally, when a _Debian Bookworm_ agent is detected, then if the configuration is well set, it scans the agent and reports the vulnerabilities it contains.

An increase in CPU usage is expected as the process of decompressing the file is added


## Configuration options

```xml
        <!-- Debian OS vulnerabilities -->
        <provider name="debian">
          <enabled>yes</enabled>
          <os>buster</os>
          <os>bullseye</os>
          <os>bookworm</os>
          <update_interval>1h</update_interval>
        </provider>
```

## Logs/Alerts example

Next, I show the logs related to what is commented in the description (the OS of agent `001` is _Debian Bookworm_):

> Correct configuration check
```
2023/08/22 18:08:37 wazuh-modulesd[138577] wmodules-vuln-detector.c:689 at wm_vuldet_read_provider(): DEBUG: Added debian (bookworm) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
```

> Download and insert vulnerabilities in the database
```
2023/08/22 18:08:37 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:5326 at wm_vuldet_check_feed(): INFO: (5400): Starting 'Debian Bookworm' database update.
2023/08/22 18:08:37 wazuh-modulesd:download[138577] wm_download.c:231 at wm_download_dispatch(): DEBUG: Downloading 'https://www.debian.org/security/oval/oval-definitions-bookworm.xml.bz2' to 'tmp/req-687618727'
2023/08/22 18:08:39 wazuh-modulesd:download[138577] wm_download.c:251 at wm_download_dispatch(): DEBUG: Download of 'https://www.debian.org/security/oval/oval-definitions-bookworm.xml.bz2' finished.
2023/08/22 18:08:39 wazuh-modulesd[138577] url.c:424 at wurl_request_uncompress_bz2_gz(): DEBUG: File from URL 'https://www.debian.org/security/oval/oval-definitions-bookworm.xml.bz2' was successfully uncompressed into 'tmp/vuln-temp'
2023/08/22 18:08:39 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:5046 at wm_vuldet_fetch_oval(): DEBUG: (5407): The feed 'Debian Bookworm' is outdated. Fetching the last version.
2023/08/22 18:08:39 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:4825 at wm_vuldet_oval_process(): DEBUG: (5411): Starting preparse step of feed 'BOOKWORM'
2023/08/22 18:08:39 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:4830 at wm_vuldet_oval_process(): DEBUG: (5412): Starting parse step of feed 'BOOKWORM'
2023/08/22 18:08:40 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:4969 at wm_vuldet_index_feed(): DEBUG: (5414): Refreshing 'Debian Bookworm' databases.
2023/08/22 18:08:40 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:3282 at wm_vuldet_insert(): DEBUG: (5415): Inserting vulnerabilities.
2023/08/22 18:08:40 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:3338 at wm_vuldet_insert(): DEBUG: (5419): Inserting Debian Bookworm vulnerabilities section.
2023/08/22 18:08:40 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:3012 at wm_vuldet_index_debian(): DEBUG: (5420): Indexing vulnerabilities from the Debian Security Tracker.
2023/08/22 18:08:40 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:5392 at wm_vuldet_get_debian_status_feed(): DEBUG: (5436): Fetching Debian Security Tracker from 'https://security-tracker.debian.org/tracker/data/json'
2023/08/22 18:08:40 wazuh-modulesd:download[138577] wm_download.c:231 at wm_download_dispatch(): DEBUG: Downloading 'https://security-tracker.debian.org/tracker/data/json' to 'tmp/vuln-temp-deb'
2023/08/22 18:08:46 wazuh-modulesd:download[138577] wm_download.c:251 at wm_download_dispatch(): DEBUG: Download of 'https://security-tracker.debian.org/tracker/data/json' finished.
2023/08/22 18:08:46 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:3677 at wm_vuldet_insert(): DEBUG: (5426): Inserting 'Debian Bookworm' vulnerabilities information.
2023/08/22 18:08:47 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:4975 at wm_vuldet_index_feed(): DEBUG: (5427): Refresh of 'Debian Bookworm' database finished.
2023/08/22 18:08:47 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:4987 at wm_vuldet_index_feed(): DEBUG: remove(tmp/vuln-temp.bz2): No such file or directory
2023/08/22 18:08:47 wazuh-modulesd:vulnerability-detector[138577] wm_vuln_detector.c:5349 at wm_vuldet_check_feed(): INFO: (5430): The update of the 'Debian Bookworm' feed finished successfully.
```
> Debian Bookworm agent scan
```
2023/08/22 18:23:52 wazuh-modulesd:vulnerability-detector[146476] wm_vuln_detector.c:2844 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5450): Analyzing agent '001' vulnerabilities.
2023/08/22 18:23:52 wazuh-modulesd:vulnerability-detector[146476] wm_vuln_detector.c:2450 at wm_vuldet_linux_oval_vulnerabilities(): DEBUG: (5456): Analyzing OVAL vulnerabilities for agent '001'
...
2023/08/22 18:23:54 wazuh-modulesd:vulnerability-detector[146476] wm_vuln_detector.c:1716 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5482): A total of '8' vulnerabilities have been reported for agent '001' thanks to the 'NVD' feed.
2023/08/22 18:23:54 wazuh-modulesd:vulnerability-detector[146476] wm_vuln_detector.c:1717 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5482): A total of '12' vulnerabilities have been reported for agent '001' thanks to the 'vendor' feed.
2023/08/22 18:23:54 wazuh-modulesd:vulnerability-detector[146476] wm_vuln_detector.c:1719 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5469): A total of '12' vulnerabilities have been reported for agent '001'
2023/08/22 18:23:54 wazuh-modulesd:vulnerability-detector[146476] wm_vuln_detector.c:1720 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5470): It took '0' seconds to 'report' vulnerabilities in agent '001'
2023/08/22 18:23:54 wazuh-modulesd:vulnerability-detector[146476] wm_vuln_detector.c:2863 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5471): Finished vulnerability assessment for agent '001'
2023/08/22 18:23:54 wazuh-modulesd:vulnerability-detector[146476] wm_vuln_detector.c:2864 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5470): It took '2' seconds to 'scan' vulnerabilities in agent '001'
2023/08/22 18:23:54 wazuh-modulesd:vulnerability-detector[146476] wm_vuln_detector.c:8664 at wm_vuldet_run_scan(): INFO: (5472): Vulnerability scan finished.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
<!--
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
-->