### PR TITLE
Fixes WPK upgrade for MacOS ARM.

### DIFF
--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -182,13 +182,26 @@ void test_wm_agent_upgrade_validate_system_ubuntu_ok(void **state)
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
 }
 
-void test_wm_agent_upgrade_validate_system_darwin_ok(void **state)
+void test_wm_agent_upgrade_validate_system_darwin_x64_ok(void **state)
 {
     (void) state;
     char *platform = "darwin";
     char *os_major = "10";
     char *os_minor = "15";
     char *arch = "x64";
+
+    int ret = wm_agent_upgrade_validate_system(platform, os_major, os_minor, arch);
+
+    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+}
+
+void test_wm_agent_upgrade_validate_system_darwin_arm_ok(void **state)
+{
+    (void) state;
+    char *platform = "darwin";
+    char *os_major = "10";
+    char *os_minor = "15";
+    char *arch = "arm64";
 
     int ret = wm_agent_upgrade_validate_system(platform, os_major, os_minor, arch);
 
@@ -1327,7 +1340,8 @@ int main(void) {
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_windows_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_rhel_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_ubuntu_ok),
-        cmocka_unit_test(test_wm_agent_upgrade_validate_system_darwin_ok),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_system_darwin_x64_ok),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_system_darwin_arm_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_platform_solaris),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_platform_suse),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_platform_rhel),

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -61,7 +61,7 @@ int wm_agent_upgrade_validate_system(const char *platform, const char *os_major,
     int return_code = WM_UPGRADE_GLOBAL_DB_FAILURE;
 
     if (platform) {
-        if (!strcmp(platform, "windows") || (os_major && arch && (strcmp(platform, "ubuntu") || os_minor))) {
+        if (!strcmp(platform, "windows") || !strcmp(platform, "darwin") || (os_major && arch && (strcmp(platform, "ubuntu") || os_minor))) {
             return_code = WM_UPGRADE_SUCCESS;
 
             // Blacklist for invalid OS platforms


### PR DESCRIPTION
|Related issue|
|---|
|#18541|

## Description

This PR adds the changes to allow the WPK upgrade of a MacOS arm agent. It does NOT add the official wpk package, so upgrades must be done with custom packages. Prior to these changes it was not possible to upgrade even with custom wpks.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)



