### PR TITLE
Modify sys_programs tests table schema

### DIFF
--- a/framework/wazuh/tests/data/schema_syscollector_000.sql
+++ b/framework/wazuh/tests/data/schema_syscollector_000.sql
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS sys_hwinfo (
 CREATE TABLE IF NOT EXISTS sys_programs (
     scan_id INTEGER,
     scan_time TEXT,
-    format TEXT NOT NULL CHECK (format IN ('deb', 'rpm', 'win', 'pkg')),
+    format TEXT,
     name TEXT,
     priority TEXT,
     section TEXT,
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS sys_programs (
     description TEXT,
     location TEXT,
     triaged INTEGER(1),
-    PRIMARY KEY (scan_id, name, version, architecture)
+    PRIMARY KEY (scan_id, name, version, architecture, format, location)
 );
 
 CREATE TABLE IF NOT EXISTS sys_processes (


### PR DESCRIPTION
|Related issue|
|---|
|Closes #18540 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

As described in #18540, This PR tends to modify the sys_programs table schema in the framework sys_collector tests due to changes described in #18219.
  

<!--
Add a clear description of how the problem has been solved.
-->


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->


<details> <summary> Unit Test Results </summary>

- API UTs:

```
(unit-test) eduardoleon@pop-os:~/git/wazuh$ pytest api/api/ --disable-warnings
==================================== test session starts ====================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/eduardoleon/git/wazuh/api
plugins: anyio-3.6.2, aiohttp-1.0.4, trio-0.7.0, html-3.0.0, asyncio-0.18.1, cov-3.0.0, metadata-2.0.2
asyncio: mode=auto
collected 540 items

api/api/controllers/test/test_active_response_controller.py .                         [  0%]
api/api/controllers/test/test_agent_controller.py ................................... [  6%]
.........                                                                             [  8%]
api/api/controllers/test/test_cdb_list_controller.py ......                           [  9%]
api/api/controllers/test/test_ciscat_controller.py .                                  [  9%]
api/api/controllers/test/test_cluster_controller.py ........................          [ 14%]
api/api/controllers/test/test_decoder_controller.py .......                           [ 15%]
api/api/controllers/test/test_default_controller.py .                                 [ 15%]
api/api/controllers/test/test_experimental_controller.py ...............              [ 18%]
api/api/controllers/test/test_manager_controller.py ..................                [ 21%]
api/api/controllers/test/test_mitre_controller.py .......                             [ 22%]
api/api/controllers/test/test_overview_controller.py .                                [ 23%]
api/api/controllers/test/test_rootcheck_controller.py ....                            [ 23%]
api/api/controllers/test/test_rule_controller.py ........                             [ 25%]
api/api/controllers/test/test_sca_controller.py ..                                    [ 25%]
api/api/controllers/test/test_security_controller.py ................................ [ 31%]
...................                                                                   [ 35%]
api/api/controllers/test/test_syscheck_controller.py ....                             [ 35%]
api/api/controllers/test/test_syscollector_controller.py .........                    [ 37%]
api/api/controllers/test/test_task_controller.py .                                    [ 37%]
api/api/controllers/test/test_vulnerability_controller.py ....                        [ 38%]
api/api/models/test/test_model.py ...........................                         [ 43%]
api/api/test/test_alogging.py ..................                                      [ 46%]
api/api/test/test_authentication.py ...........                                       [ 48%]
api/api/test/test_configuration.py ..........................................         [ 56%]
api/api/test/test_encoder.py ...                                                      [ 57%]
api/api/test/test_middlewares.py ............                                         [ 59%]
api/api/test/test_uri_parser.py ...                                                   [ 60%]
api/api/test/test_util.py ........................................                    [ 67%]
api/api/test/test_validator.py ...................................................... [ 77%]
..................................................................................... [ 93%]
.....................................                                                 [100%]

============================= 540 passed, 18 warnings in 1.92s ==============================
```

- Framework UTs

```
(unit-test) eduardoleon@pop-os:~/git/wazuh$ pytest framework/ --disable-warnings
==================================== test session starts ====================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/eduardoleon/git/wazuh/framework
plugins: anyio-3.6.2, aiohttp-1.0.4, trio-0.7.0, html-3.0.0, asyncio-0.18.1, cov-3.0.0, metadata-2.0.2
asyncio: mode=auto
collected 2049 items

framework/scripts/tests/test_agent_groups.py ..............                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                         [  1%]
framework/scripts/tests/test_cluster_control.py ......                                [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................ [  4%]
                                                                                      [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py .................................. [  7%]
.                                                                                     [  7%]
framework/wazuh/core/cluster/tests/test_common.py ................................... [  8%]
........................................                                              [ 10%]
framework/wazuh/core/cluster/tests/test_control.py ......                             [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                 [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................      [ 12%]
framework/wazuh/core/cluster/tests/test_master.py ................................... [ 14%]
..........                                                                            [ 15%]
framework/wazuh/core/cluster/tests/test_server.py ...................                 [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                          [ 16%]
framework/wazuh/core/cluster/tests/test_worker.py ................................... [ 18%]
.                                                                                     [ 18%]
framework/wazuh/core/tests/test_active_response.py ..............                     [ 19%]
framework/wazuh/core/tests/test_agent.py ............................................ [ 21%]
..................................................................................... [ 25%]
.................                                                                     [ 26%]
framework/wazuh/core/tests/test_cdb_list.py ......................................    [ 28%]
framework/wazuh/core/tests/test_common.py .......                                     [ 28%]
framework/wazuh/core/tests/test_configuration.py .................................... [ 30%]
..................................                                                    [ 31%]
framework/wazuh/core/tests/test_database.py .............                             [ 32%]
framework/wazuh/core/tests/test_decoder.py ................                           [ 33%]
framework/wazuh/core/tests/test_exception.py ...                                      [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                                         [ 33%]
framework/wazuh/core/tests/test_manager.py ...............                            [ 34%]
framework/wazuh/core/tests/test_mitre.py .............                                [ 34%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                               [ 35%]
framework/wazuh/core/tests/test_results.py ........................................   [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                            [ 37%]
framework/wazuh/core/tests/test_rule.py ......................                        [ 38%]
framework/wazuh/core/tests/test_sca.py ........................                       [ 40%]
framework/wazuh/core/tests/test_security.py ............                              [ 40%]
framework/wazuh/core/tests/test_stats.py .................                            [ 41%]
framework/wazuh/core/tests/test_syscheck.py .......                                   [ 41%]
framework/wazuh/core/tests/test_syscollector.py ...                                   [ 41%]
framework/wazuh/core/tests/test_task.py ........                                      [ 42%]
framework/wazuh/core/tests/test_utils.py ............................................ [ 44%]
..................................................................................... [ 48%]
..................................................................................... [ 52%]
............................                                                          [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                   [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                  [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                [ 57%]
framework/wazuh/core/tests/test_wlogging.py .........                                 [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                    [ 58%]
framework/wazuh/rbac/tests/test_decorators.py ....................................... [ 60%]
......................................................................                [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py ............................ [ 64%]
............................                                                          [ 66%]
framework/wazuh/rbac/tests/test_orm.py .............................................. [ 68%]
........                                                                              [ 68%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                           [ 69%]
framework/wazuh/tests/test_active_response.py ............                            [ 70%]
framework/wazuh/tests/test_agent.py ................................................. [ 72%]
....................................................................                  [ 75%]
framework/wazuh/tests/test_cdb_list.py .............................................. [ 77%]
.......                                                                               [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                [ 79%]
framework/wazuh/tests/test_cluster.py ..........                                      [ 80%]
framework/wazuh/tests/test_decoder.py ...................................             [ 82%]
framework/wazuh/tests/test_group.py .......                                           [ 82%]
framework/wazuh/tests/test_logtest.py ......                                          [ 82%]
framework/wazuh/tests/test_manager.py ....................................            [ 84%]
framework/wazuh/tests/test_mitre.py .......                                           [ 84%]
framework/wazuh/tests/test_rootcheck.py ............................................. [ 87%]
.....                                                                                 [ 87%]
framework/wazuh/tests/test_rule.py .................................................. [ 89%]
......                                                                                [ 90%]
framework/wazuh/tests/test_sca.py ...........                                         [ 90%]
framework/wazuh/tests/test_security.py .............................................. [ 92%]
...........................                                                           [ 94%]
framework/wazuh/tests/test_stats.py ...............                                   [ 94%]
framework/wazuh/tests/test_syscheck.py .........................                      [ 96%]
framework/wazuh/tests/test_syscollector.py ............                               [ 96%]
framework/wazuh/tests/test_task.py ............................                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................................  [100%]

======================= 2049 passed, 47 warnings in 175.54s (0:02:55) =======================
```

 </details>

<details> <summary> API Integration Tests </summary>

- test_rbac_white_syscollector_endpoints

```
(integration-tests) eduardoleon@pop-os:~/git/wazuh/api/test/integration$ pytest -vvs test_rbac_white_syscollector_endpoints.tavern.yaml
==================================== test session starts ====================================
platform linux -- Python 3.9.16, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/eduardoleon/.pyenv/versions/3.9.16/envs/integration-tests/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.4.6-76060406-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '5.4.3', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.2.2', 'html': '3.1.1', 'metadata': '2.0.2'}}
rootdir: /home/eduardoleon/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.2.2, html-3.1.1, metadata-2.0.2
collected 9 items

test_rbac_white_syscollector_endpoints.tavern.yaml::GET OS SYSCOLLECTOR RBAC PASSED
test_rbac_white_syscollector_endpoints.tavern.yaml::GET HARDWARE SYSCOLLECTOR RBAC PASSED
test_rbac_white_syscollector_endpoints.tavern.yaml::GET NETADDR SYSCOLLECTOR RBAC PASSED
test_rbac_white_syscollector_endpoints.tavern.yaml::GET NETIFACE SYSCOLLECTOR RBAC PASSED
test_rbac_white_syscollector_endpoints.tavern.yaml::GET NETPROTO SYSCOLLECTOR RBAC PASSED
test_rbac_white_syscollector_endpoints.tavern.yaml::GET PACKAGES SYSCOLLECTOR RBAC PASSED
test_rbac_white_syscollector_endpoints.tavern.yaml::GET PORTS SYSCOLLECTOR RBAC PASSED
test_rbac_white_syscollector_endpoints.tavern.yaml::GET PROCESSES SYSCOLLECTOR RBAC PASSED
test_rbac_white_syscollector_endpoints.tavern.yaml::GET HOTFIXES SYSCOLLECTOR RBAC PASSED

======================== 9 passed, 10 warnings in 126.98s (0:02:06) =========================
```

- test_rbac_black_syscollector_endpoints.tavern.yaml

```
(integration-tests) eduardoleon@pop-os:~/git/wazuh/api/test/integration$ pytest -vvs test_rbac_black_syscollector_endpoints.tavern.yaml --disable-warnings
==================================== test session starts ====================================
platform linux -- Python 3.9.16, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/eduardoleon/.pyenv/versions/3.9.16/envs/integration-tests/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.4.6-76060406-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '5.4.3', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.2.2', 'html': '3.1.1', 'metadata': '2.0.2'}}
rootdir: /home/eduardoleon/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.2.2, html-3.1.1, metadata-2.0.2
collected 9 items

test_rbac_black_syscollector_endpoints.tavern.yaml::GET OS SYSCOLLECTOR RBAC PASSED
test_rbac_black_syscollector_endpoints.tavern.yaml::GET HARDWARE SYSCOLLECTOR RBAC PASSED
test_rbac_black_syscollector_endpoints.tavern.yaml::GET NETADDR SYSCOLLECTOR RBAC PASSED
test_rbac_black_syscollector_endpoints.tavern.yaml::GET NETIFACE SYSCOLLECTOR RBAC PASSED
test_rbac_black_syscollector_endpoints.tavern.yaml::GET NETPROTO SYSCOLLECTOR RBAC PASSED
test_rbac_black_syscollector_endpoints.tavern.yaml::GET PACKAGES SYSCOLLECTOR RBAC PASSED
test_rbac_black_syscollector_endpoints.tavern.yaml::GET PORTS SYSCOLLECTOR RBAC PASSED
test_rbac_black_syscollector_endpoints.tavern.yaml::GET PROCESSES SYSCOLLECTOR RBAC PASSED
test_rbac_black_syscollector_endpoints.tavern.yaml::GET HOTFIXES SYSCOLLECTOR RBAC PASSED

======================== 9 passed, 10 warnings in 126.26s (0:02:06) =========================
```

- test_syscollector_endpoints

```
(integration-tests) eduardoleon@pop-os:~/git/wazuh/api/test/integration$ pytest -vvs test_syscollector_endpoints.tavern.yaml --disable-warnings
==================================== test session starts ====================================
platform linux -- Python 3.9.16, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/eduardoleon/.pyenv/versions/3.9.16/envs/integration-tests/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.4.6-76060406-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '5.4.3', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.2.2', 'html': '3.1.1', 'metadata': '2.0.2'}}
rootdir: /home/eduardoleon/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.2.2, html-3.1.1, metadata-2.0.2
collected 159 items

test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[architecture] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[hostname] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.codename] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.major] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.minor] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.name] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.platform] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.version] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[release] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.time] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[sysname] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[version] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.cores] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.mhz] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.name] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.free] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.total] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.usage] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.time] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[architecture] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[description] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[format] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[name] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[priority] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[scan.time] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[section] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[size] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[vendor] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[version] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[argvs] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[cmd] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[egroup] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[euser] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[fgroup] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[name] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[nice] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[nlwp] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[pgrp] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[pid] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[ppid] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[priority] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[processor] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[resident] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[rgroup] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[ruser] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[session] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[sgroup] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[share] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[size] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[start_time] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[state] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[stime] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[suser] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[tgid] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[tty] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[utime] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[vm_size] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/ports PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[inode] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[local.ip] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[local.port] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[protocol] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[remote.ip] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[remote.port] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[rx_queue] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[scan.time] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[state] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[tx_queue] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[address] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[broadcast] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[iface] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[netmask] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[proto] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[dhcp] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[gateway] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[iface] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[type] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mac] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mtu] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[name] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.bytes] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.dropped] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.errors] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.packets] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.time] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[state] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.bytes] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.dropped] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.errors] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.packets] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[type] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[architecture] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[hostname] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.codename] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.major] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.minor] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.name] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.platform] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.version] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[release] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.time] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[sysname] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[version] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.cores] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.mhz] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.name] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.free] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.total] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.usage] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.time] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[address] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[broadcast] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[iface] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[netmask] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[proto] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[dhcp] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[gateway] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[iface] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[type] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mac] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mtu] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[name] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.bytes] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.dropped] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.errors] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.packets] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.id] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.time] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[state] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.bytes] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.dropped] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.errors] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.packets] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[type] PASSED
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hotfixes PASSED

======================= 159 passed, 173 warnings in 159.97s (0:02:39) =======================
```

 </details>


