### PR TITLE
Add support for Amazon Linux 2023 in Vulnerability Detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ All notable changes to this project will be documented in this file.
 
 #### Added
 
-- Added support for Amazon Linux 2023 in Vulnerability Detector. [#17617](https://github.com/wazuh/wazuh/issues/17617)
 - Introduced native Maltiverse integration. ([#18026](https://github.com/wazuh/wazuh/pull/18026))
 - Added a file detailing the dependencies for the Wazuh RESTful API and wodles tests. ([#16513](https://github.com/wazuh/wazuh/pull/16513))
 - Added unit tests for the Syscollector legacy decoder. ([#15985](https://github.com/wazuh/wazuh/pull/15985))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 #### Added
 
+- Added support for Amazon Linux 2023 in Vulnerability Detector. [#17617](https://github.com/wazuh/wazuh/issues/17617)
 - Introduced native Maltiverse integration. ([#18026](https://github.com/wazuh/wazuh/pull/18026))
 - Added a file detailing the dependencies for the Wazuh RESTful API and wodles tests. ([#16513](https://github.com/wazuh/wazuh/pull/16513))
 - Added unit tests for the Syscollector legacy decoder. ([#15985](https://github.com/wazuh/wazuh/pull/15985))
@@ -61,7 +62,6 @@ All notable changes to this project will be documented in this file.
 #### Fixed
 
 - Fixed the signature of the internal function `OSHash_GetIndex()`. ([#17040](https://github.com/wazuh/wazuh/pull/17040))
-
 
 ## [v4.6.0]
 

--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -40,6 +40,7 @@
       <enabled>no</enabled>
       <os>amazon-linux</os>
       <os>amazon-linux-2</os>
+      <os>amazon-linux-2022</os>
       <os>amazon-linux-2023</os>
       <update_interval>1h</update_interval>
     </provider>

--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -41,6 +41,7 @@
       <os>amazon-linux</os>
       <os>amazon-linux-2</os>
       <os>amazon-linux-2022</os>
+      <os>amazon-linux-2023</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -40,7 +40,6 @@
       <enabled>no</enabled>
       <os>amazon-linux</os>
       <os>amazon-linux-2</os>
-      <os>amazon-linux-2022</os>
       <os>amazon-linux-2023</os>
       <update_interval>1h</update_interval>
     </provider>

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -282,6 +282,12 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
             upd->dist_tag_ref = FEED_ALAS2022;
             os_strdup(vu_feed_tag[FEED_ALAS2022], upd->version);
             upd->dist_ext = vu_feed_ext[FEED_ALAS2022];
+        // Amazon Linux 2023
+        } else if (!strcmp(version, "2023") || strcasestr(vu_feed_tag[FEED_ALAS2023], version)) {
+            os_index = CVE_ALAS2023;
+            upd->dist_tag_ref = FEED_ALAS2023;
+            os_strdup(vu_feed_tag[FEED_ALAS2023], upd->version);
+            upd->dist_ext = vu_feed_ext[FEED_ALAS2023];
         } else {
             merror("Invalid Amazon Linux version '%s'", version);
             retval = OS_INVALID;

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2542,6 +2542,9 @@ void test_wm_vuldet_generate_os_and_kernel_package_amazon_linux(void **state)
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     int dist_ver_ref[] = {FEED_ALAS1, FEED_ALAS2, FEED_ALAS2022, FEED_ALAS2023};
+    // char *alas_os_release[] = {"AMI", "2", "2023"};
+    // char *alas_os_package[] = {"linux", "linux_2", "linux_2023"};
+
     char *alas_os_release[] = {"AMI", "2", "2022", "2023"};
     char *alas_os_package[] = {"linux", "linux_2", "linux_2022", "linux_2023"};
 
@@ -2550,6 +2553,9 @@ void test_wm_vuldet_generate_os_and_kernel_package_amazon_linux(void **state)
     agent->arch = strdup("x86_64");
     agent->os_reference = strdup("94b6f7b3c1d905aae22a652448df6372da98e5b8");
 
+    will_return(__wrap_sqlite3_prepare_v2, 1);
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
@@ -2597,6 +2603,7 @@ void test_wm_vuldet_generate_os_and_kernel_package_amazon_linux(void **state)
             expect_sqlite3_step_call(SQLITE_DONE);
         }
 
+        
         expect_value(__wrap_sqlite3_bind_text, pos, 1);
         expect_string(__wrap_sqlite3_bind_text, buffer, "000");
         expect_value(__wrap_sqlite3_bind_text, pos, 2);
@@ -2617,7 +2624,8 @@ void test_wm_vuldet_generate_os_and_kernel_package_amazon_linux(void **state)
         expect_string(__wrap_sqlite3_bind_text, buffer, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
         expect_value(__wrap_sqlite3_bind_text, pos, 12);
         expect_string(__wrap_sqlite3_bind_text, buffer, "OS");
-
+       
+    
         // Kernel package
         expect_value(__wrap_sqlite3_bind_text, pos, 1);
         expect_string(__wrap_sqlite3_bind_text, buffer, "000");
@@ -21039,7 +21047,7 @@ void test_wm_vuldet_fetch_feed_metadata_invalid_dist_ref(void **state)
     os_free(update);
 }
 
-void test_wm_vuldet_fetch_feed_metadata_valid_attempt_HJJJH(void **state)
+void test_wm_vuldet_fetch_feed_metadata_valid_attempt_alas(void **state)
 {
     update_node *update = NULL;
     char        *repo   = NULL;
@@ -21048,6 +21056,33 @@ void test_wm_vuldet_fetch_feed_metadata_valid_attempt_HJJJH(void **state)
     update->dist_ref = FEED_ALAS;
     update->dist_tag_ref = FEED_ALAS2022;
     repo = ALAS2022_REPO_META;
+    update->timeout = 300;
+
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, 0);
+
+    char *path = VU_TEMP_FILE;
+    expect_string(__wrap_fopen, path, path);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, NULL);
+
+    feed_metadata *ret = wm_vuldet_fetch_feed_metadata(update);
+    assert_null(ret);
+
+    os_free(update);
+}
+
+void test_wm_vuldet_fetch_feed_metadata_valid_attempt_alas_2023(void **state)
+{
+    update_node *update = NULL;
+    char        *repo   = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_ALAS;
+    update->dist_tag_ref = FEED_ALAS2023;
+    repo = ALAS2023_REPO_META;
     update->timeout = 300;
 
     expect_string(__wrap_wurl_request, url, repo);
@@ -23712,6 +23747,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_feed_metadata_valid_attempt, setup_group, teardown_group),
         cmocka_unit_test(test_wm_vuldet_fetch_feed_metadata_invalid_dist_ref),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_feed_metadata_valid_attempt_alas, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_feed_metadata_valid_attempt_alas_2023, setup_group, teardown_group),
         cmocka_unit_test(test_wm_vuldet_fetch_feed_metadata_invalid_attempt_alas_dist_tag_ref),
         // Tests wm_vuldet_check_feed_metadata
         cmocka_unit_test_setup_teardown(test_wm_vuldet_check_feed_metadata_invalid_metadata, setup_group, teardown_group),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2541,9 +2541,9 @@ void test_wm_vuldet_generate_os_and_kernel_package_amazon_linux(void **state)
 {
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
-    int dist_ver_ref[] = {FEED_ALAS1, FEED_ALAS2, FEED_ALAS2022};
-    char *alas_os_release[] = {"AMI", "2", "2022"};
-    char *alas_os_package[] = {"linux", "linux_2", "linux_2022"};
+    int dist_ver_ref[] = {FEED_ALAS1, FEED_ALAS2, FEED_ALAS2022, FEED_ALAS2023};
+    char *alas_os_release[] = {"AMI", "2", "2022", "2023"};
+    char *alas_os_package[] = {"linux", "linux_2", "linux_2022", "linux_2023"};
 
     agent->dist = FEED_ALAS;
     agent->kernel_release = strdup("4.14.194");
@@ -19222,10 +19222,11 @@ void test_wm_vuldet_set_feed_update_url_debian(void **state)
 void test_wm_vuldet_set_feed_update_url_alas(void **state)
 {
     bool ret;
-    int dist_tag_ref[] = {FEED_ALAS1, FEED_ALAS2, FEED_ALAS2022};
+    int dist_tag_ref[] = {FEED_ALAS1, FEED_ALAS2, FEED_ALAS2022, FEED_ALAS2023};
     char *urls[] = {"https://feed.wazuh.com/vulnerability-detector/ALAS/1/alas.json.gz",
                     "https://feed.wazuh.com/vulnerability-detector/ALAS/2/alas2.json.gz",
-                    "https://feed.wazuh.com/vulnerability-detector/ALAS/2022/alas2022.json.gz"};
+                    "https://feed.wazuh.com/vulnerability-detector/ALAS/2022/alas2022.json.gz",
+                    "https://feed.wazuh.com/vulnerability-detector/ALAS/2023/alas2023.json.gz"};
     update_node *update = NULL;
 
     os_calloc(1, sizeof(update_node), update);
@@ -21038,7 +21039,7 @@ void test_wm_vuldet_fetch_feed_metadata_invalid_dist_ref(void **state)
     os_free(update);
 }
 
-void test_wm_vuldet_fetch_feed_metadata_valid_attempt_alas(void **state)
+void test_wm_vuldet_fetch_feed_metadata_valid_attempt_HJJJH(void **state)
 {
     update_node *update = NULL;
     char        *repo   = NULL;

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2542,9 +2542,6 @@ void test_wm_vuldet_generate_os_and_kernel_package_amazon_linux(void **state)
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     int dist_ver_ref[] = {FEED_ALAS1, FEED_ALAS2, FEED_ALAS2022, FEED_ALAS2023};
-    // char *alas_os_release[] = {"AMI", "2", "2023"};
-    // char *alas_os_package[] = {"linux", "linux_2", "linux_2023"};
-
     char *alas_os_release[] = {"AMI", "2", "2022", "2023"};
     char *alas_os_package[] = {"linux", "linux_2", "linux_2022", "linux_2023"};
 

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2599,8 +2599,6 @@ void test_wm_vuldet_generate_os_and_kernel_package_amazon_linux(void **state)
             expect_sqlite3_step_call(SQLITE_DONE);
             expect_sqlite3_step_call(SQLITE_DONE);
         }
-
-        
         expect_value(__wrap_sqlite3_bind_text, pos, 1);
         expect_string(__wrap_sqlite3_bind_text, buffer, "000");
         expect_value(__wrap_sqlite3_bind_text, pos, 2);

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2619,8 +2619,6 @@ void test_wm_vuldet_generate_os_and_kernel_package_amazon_linux(void **state)
         expect_string(__wrap_sqlite3_bind_text, buffer, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
         expect_value(__wrap_sqlite3_bind_text, pos, 12);
         expect_string(__wrap_sqlite3_bind_text, buffer, "OS");
-       
-    
         // Kernel package
         expect_value(__wrap_sqlite3_bind_text, pos, 1);
         expect_string(__wrap_sqlite3_bind_text, buffer, "000");

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -722,6 +722,7 @@ const char *vu_feed_ext[] = {
     "Amazon Linux 1",
     "Amazon Linux 2",
     "Amazon Linux 2022",
+    "Amazon Linux 2023",
     // SUSE versions
     "SUSE Linux Enterprise Server 15",
     "SUSE Linux Enterprise Desktop 15",

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -571,6 +571,7 @@ const char *vu_os_product_name_list[] = {
     "linux_1",
     "linux_2",
     "linux_2022",
+    "linux_2023",
     "linux_enterprise",
     "linux_enterprise_desktop",
     "suse_linux_enterprise_desktop",
@@ -652,6 +653,7 @@ const char *vu_feed_tag[] = {
     "Amazon-Linux",
     "Amazon-Linux-2",
     "Amazon-Linux-2022",
+    "Amazon-Linux-2023",
     // SUSE versions
     "SLES15",
     "SLED15",
@@ -5099,6 +5101,9 @@ bool wm_vuldet_set_feed_update_url(update_node *update) {
             case FEED_ALAS2022:
                 snprintf(repo, OS_SIZE_2048, ALAS2022_REPO);
             break;
+            case FEED_ALAS2023:
+                snprintf(repo, OS_SIZE_2048, ALAS2023_REPO);
+            break;
             default:
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_OS_VERSION_ERROR);
                 os_free(repo);
@@ -6163,6 +6168,8 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
                 agent_dist_ver = FEED_ALAS2;
             } else if (!strcmp(agti_os_major, "2022")) {
                 agent_dist_ver = FEED_ALAS2022;
+            } else if (!strcmp(agti_os_major, "2023")) {
+                agent_dist_ver = FEED_ALAS2023;
             } else if (strstr(agti_os_name, "AMI")) {
                 agent_dist_ver = FEED_ALAS1;
             } else {
@@ -6953,6 +6960,12 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, scan_agent *agent) {
             os_free(agent->os_release);
             os_strdup("*", agent->os_release);
         break;
+        case FEED_ALAS2023:
+            product_name[0] = vu_os_product_name_list[PR_AMAZON2023];
+            vendor = vu_vendor_list[V_AMAZON];
+            os_free(agent->os_release);
+            os_strdup("*", agent->os_release);
+        break;
         case FEED_SLED11:
         case FEED_SLED12:
         case FEED_SLED15:
@@ -7302,6 +7315,9 @@ feed_metadata * wm_vuldet_fetch_feed_metadata(update_node *update) {
                 break;
                 case FEED_ALAS2022:
                     metadata_repo = ALAS2022_REPO_META;
+                break;
+                case FEED_ALAS2023:
+                    metadata_repo = ALAS2023_REPO_META;
                 break;
                 default:
                     merror("No metadata feed available for (%s)", vu_feed_ext[update->dist_tag_ref]);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -50,6 +50,8 @@
 #define ALAS2_REPO_META "https://feed.wazuh.com/vulnerability-detector/ALAS/2/alas2.meta"
 #define ALAS2022_REPO "https://feed.wazuh.com/vulnerability-detector/ALAS/2022/alas2022.json.gz"
 #define ALAS2022_REPO_META "https://feed.wazuh.com/vulnerability-detector/ALAS/2022/alas2022.meta"
+#define ALAS2023_REPO "https://feed.wazuh.com/vulnerability-detector/ALAS/2023/alas2023.json.gz"
+#define ALAS2023_REPO_META "https://feed.wazuh.com/vulnerability-detector/ALAS/2023/alas2023.meta"
 #define SLES_REPO "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.%s.xml"
 #define SLED_REPO "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.%s.xml"
 #define ALMA_REPO "https://security.almalinux.org/oval/org.almalinux.alsa-%s.xml"
@@ -211,6 +213,7 @@ typedef enum vu_product_name {
     PR_AMAZON1,
     PR_AMAZON2,
     PR_AMAZON2022,
+    PR_AMAZON2023,
     PR_SUSE,
     PR_SLED1,
     PR_SLED2,
@@ -289,6 +292,7 @@ typedef enum vu_feed {
     FEED_ALAS1,
     FEED_ALAS2,
     FEED_ALAS2022,
+    FEED_ALAS2023,
     // SUSE versions
     FEED_SLES15,
     FEED_SLED15,
@@ -454,6 +458,7 @@ typedef enum cve_db {
     CVE_ALAS1,
     CVE_ALAS2,
     CVE_ALAS2022,
+    CVE_ALAS2023,
     CVE_SLES15,
     CVE_SLED15,
     CVE_SLES12,
@@ -903,7 +908,7 @@ typedef struct scan_ctx_t {
 #define wm_vuldet_silent_feed(x) (x == FEED_CPEW)
 #define wm_vuldet_is_product_name(bin_name) ({int ret = 0; for (; ret < PR_NOSYSTEM; ret++) \
                                             if (!strcmp(vu_os_product_name_list[ret], bin_name)) break; ret;})
-#define wm_vuldet_get_vendor_from_product(x) ({int ret = x; if (x == PR_AMAZON || x == PR_AMAZON1 || x == PR_AMAZON2 || x == PR_AMAZON2022) ret = V_AMAZON; \
+#define wm_vuldet_get_vendor_from_product(x) ({int ret = x; if (x == PR_AMAZON || x == PR_AMAZON1 || x == PR_AMAZON2 || x == PR_AMAZON2022 || x == PR_AMAZON2023) ret = V_AMAZON; \
                                             else if (x == PR_SUSE || x == PR_SLED1  || x == PR_SLED2 || x == PR_SLES1 || x == PR_SLES2) ret = V_SUSE; ret;})
 #define wm_vuldet_get_json_value(obj, key) ({void *ret = NULL; cJSON *it = cJSON_GetObjectItem(obj, key); \
                                             if (it) ret = it->valuestring; ret;})


### PR DESCRIPTION
|Related issue|
|---|
|[#18526](https://github.com/wazuh/wazuh/issues/18526)|

## Description

The purpose of this PR is to add support for Amazon Linux 2023 in the vulnerability detector module.

First, we generate our own feed in `JSON` format and upload it to the following links (from where we download it): 
[Amazon Linux 2023 feed](https://feed.wazuh.com/vulnerability-detector/ALAS/2023/alas2023.json.gz) and [Amazon Linux 2023 metadata](https://feed.wazuh.com/vulnerability-detector/ALAS/2023/alas2023.meta)

The vulnerabilities are then parsed and inserted into the database.

And finally, when an Amazon Linux 2023 agent is detected, then if the configuration is well set, it scans the agent and reports the vulnerabilities it contains.

## Configuration options

The Vulnerability Detector configuration has been extended to support the added OS (AL2023):
```xml
<vulnerability-detector>
    ...
    <!-- Amazon Linux OS vulnerabilities -->
    <provider name="alas">
      <enabled>yes</enabled>
      <os>amazon-linux</os>
      <os>amazon-linux-2</os>
      <os>amazon-linux-2022</os>
      <os>amazon-linux-2023</os>
      <update_interval>1h</update_interval>
    </provider>
    ...
</vulnerability-detector>
```

## Logs/Alerts example

Here we can see the logs when fetching the ALAS2023 feed:

```
2023/08/24 16:28:50 wazuh-modulesd:vulnerability-detector[221457] wm_vuln_detector.c:5330 at wm_vuldet_check_feed(): INFO: (5400): Starting 'Amazon Linux 2023' database update.
2023/08/24 16:28:50 wazuh-modulesd:vulnerability-detector[221457] wm_vuln_detector.c:5228 at wm_vuldet_fetch_feed(): DEBUG: (5484): Cleaning metadata for target 'Amazon-Linux-2023'
2023/08/24 16:28:50 wazuh-modulesd:vulnerability-detector[221457] wm_vuln_detector.c:5244 at wm_vuldet_fetch_feed(): DEBUG: (5403): Fetching feed from '/home/user/alas2023.json.gz'
2023/08/24 16:28:50 wazuh-modulesd:vulnerability-detector[221457] wm_vuln_detector.c:8244 at wm_vuldet_index_json(): DEBUG: (5408): Updating from '/home/user/alas2023.json.gz'
2023/08/24 16:28:50 wazuh-modulesd[221457] file_op.c:3392 at w_uncompress_bz2_gz_file(): DEBUG: The file '/home/user/alas2023.json.gz' was successfully uncompressed into 'tmp/vuln-temp-fitted'
2023/08/24 16:28:50 wazuh-modulesd:vulnerability-detector[221457] wm_vuln_detector.c:4970 at wm_vuldet_index_feed(): DEBUG: (5414): Refreshing 'Amazon Linux 2023' databases.
2023/08/24 16:28:50 wazuh-modulesd:vulnerability-detector[221457] wm_vuln_detector.c:3283 at wm_vuldet_insert(): DEBUG: (5415): Inserting vulnerabilities.
2023/08/24 16:28:50 wazuh-modulesd:vulnerability-detector[221457] wm_vuln_detector.c:3312 at wm_vuldet_insert(): DEBUG: (5419): Inserting ALAS vulnerabilities section.
2023/08/24 16:28:50 wazuh-modulesd:vulnerability-detector[221457] wm_vuln_detector.c:4976 at wm_vuldet_index_feed(): DEBUG: (5427): Refresh of 'Amazon Linux 2023' database finished.
2023/08/24 16:28:50 wazuh-modulesd:vulnerability-detector[221457] wm_vuln_detector.c:4982 at wm_vuldet_index_feed(): DEBUG: remove(tmp/vuln-temp): No such file or directory
2023/08/24 16:28:50 wazuh-modulesd:vulnerability-detector[221457] wm_vuln_detector.c:4988 at wm_vuldet_index_feed(): DEBUG: remove(tmp/vuln-temp.bz2): No such file or directory
2023/08/24 16:28:50 wazuh-modulesd:vulnerability-detector[221457] wm_vuln_detector.c:5353 at wm_vuldet_check_feed(): INFO: (5430): The update of the 'Amazon Linux 2023' feed finished successfully.

```

Vulnerability log displayed during Amazon Linux 2023 packages scan:

```
2023/09/06 10:21:07 wazuh-modulesd:vulnerability-detector[11838] wm_vuln_detector.c:1579 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5466): Sending vulnerabilities report for agent '001'
2023/09/06 10:21:07 wazuh-modulesd:vulnerability-detector[17501] wm_vuln_detector.c:1686 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5468): The 'vim-common' package (2:9.0.1160-1.amzn2023.0.2) from agent '001' is vulnerable to 'CVE-2022-47024'. Condition: 'Package less than 9.0.1314-1.amzn2023.0.2'
2023/09/06 10:21:07 wazuh-modulesd:vulnerability-detector[17501] wm_vuln_detector.c:1686 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5468): The 'vim-data' package (2:9.0.1160-1.amzn2023.0.2) from agent '001' is vulnerable to 'CVE-2022-47024'. Condition: 'Package less than 9.0.1314-1.amzn2023.0.2'
2023/09/06 10:21:08 wazuh-modulesd:vulnerability-detector[17501] wm_vuln_detector.c:1686 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5468): The 'vim-enhanced' package (2:9.0.1160-1.amzn2023.0.2) from agent '001' is vulnerable to 'CVE-2022-3324'. Condition: 'Package less than 9.0.1314-1.amzn2023.0.2'
2023/09/06 10:21:10 wazuh-modulesd:vulnerability-detector[17501] wm_vuln_detector.c:1717 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5482): A total of '0' vulnerabilities have been reported for agent '001' thanks to the 'NVD' feed.
2023/09/06 10:21:10 wazuh-modulesd:vulnerability-detector[17501] wm_vuln_detector.c:1718 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5482): A total of '66' vulnerabilities have been reported for agent '001' thanks to the 'vendor' feed.
2023/09/06 10:21:10 wazuh-modulesd:vulnerability-detector[17501] wm_vuln_detector.c:1720 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5469): A total of '66' vulnerabilities have been reported for agent '001'
```

## Tests

Minimum checks required 
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

Depending on the affected OS 
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

Checks for huge PRs that affect the product more generally 
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components
