### PR TITLE
Disable host's IP query by Logcollector when ip_update_interval=0

### DIFF
--- a/src/shared/log_builder.c
+++ b/src/shared/log_builder.c
@@ -238,7 +238,7 @@ int log_builder_update_host_ip(log_builder_t * builder) {
     static time_t last_update = 0;
     time_t now = time(NULL);
 
-    if ((now - last_update) >= g_ip_update_interval) {
+    if (g_ip_update_interval > 0 && (now - last_update) >= g_ip_update_interval) {
         last_update = now;
 #ifdef WIN32
         char * tmp_host_ip = get_agent_ip_legacy_win32();

--- a/src/shared/log_builder.c
+++ b/src/shared/log_builder.c
@@ -16,6 +16,17 @@
 #include "shared.h"
 #include "client-agent/agentd.h"
 
+#ifdef WAZUH_UNIT_TESTING
+// Remove static qualifier when unit testing
+#define STATIC
+#ifdef WIN32
+#define get_agent_ip_legacy_win32 wrap_get_agent_ip_legacy_win32
+#define getDefine_Int __wrap_getDefine_Int
+#endif
+#else
+#define STATIC static
+#endif
+
 /**
  * @brief Update the hostname value
  *
@@ -34,10 +45,10 @@ static int log_builder_update_hostname(log_builder_t * builder);
  * @retval 0 If the host IP was updated successfully.
  * @retval 1 If the host IP failed to be updated.
  */
-static int log_builder_update_host_ip(log_builder_t * builder);
+STATIC int log_builder_update_host_ip(log_builder_t * builder);
 
 /* Number of seconds of how often the IP must be updated. */
-static int g_ip_update_interval = 0;
+STATIC int g_ip_update_interval = 0;
 
 // Initialize a log builder structure
 log_builder_t * log_builder_init(bool update) {

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -172,7 +172,8 @@ list(APPEND shared_tests_flags "-Wl,--wrap,getDefine_Int -Wl,--wrap,syscom_dispa
                                 -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
                                 -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown")
 else()
-list(APPEND shared_tests_flags "-Wl,--wrap,getDefine_Int")
+list(APPEND shared_tests_flags "-Wl,--wrap,getDefine_Int,--wrap,control_check_connection,--wrap,send,--wrap,recv,--wrap,close \
+                                -Wl,--wrap,getpid,--wrap,fcntl")
 endif()
 
 list(APPEND shared_tests_names "test_custom_output_search_replace")

--- a/src/unit_tests/shared/test_log_builder.c
+++ b/src/unit_tests/shared/test_log_builder.c
@@ -17,6 +17,10 @@
 
 #include "../../headers/shared.h"
 #include "../wrappers/common.h"
+#include "../wrappers/wazuh/client-agent/notify_wrappers.h"
+
+extern int g_ip_update_interval;
+int log_builder_update_host_ip(log_builder_t * builder);
 
 // Tests
 
@@ -40,9 +44,49 @@ void test_log_builder(void **state)
     log_builder_destroy(builder);
 }
 
+void test_log_builder_update(void **state)
+{
+    will_return(__wrap_getDefine_Int, 1);
+    log_builder_t * builder = log_builder_init(false);
+    assert_int_equal(g_ip_update_interval, 1);
+    assert_non_null(builder);
+
+#ifdef WIN32
+    char * return_ip = "1.2.3.4";
+    time_mock_value = 1000;
+    will_return(wrap_get_agent_ip_legacy_win32, strdup(return_ip));
+#elif defined __linux__ || defined __MACH__ || defined sun || defined FreeBSD || defined OpenBSD
+    will_return(__wrap_control_check_connection, 16);
+    will_return(__wrap_send, 7);
+    will_return(__wrap_recv, 0);
+#endif
+
+    int r = log_builder_update_host_ip(builder);
+    assert_int_equal(r, 0);
+#ifdef WIN32
+    assert_string_equal(builder->host_ip, "1.2.3.4");
+#endif
+    log_builder_destroy(builder);
+}
+
+void test_log_builder_not_update(void **state) {
+    will_return(__wrap_getDefine_Int, 0);
+
+    log_builder_t * builder = log_builder_init(false);
+    assert_int_equal(g_ip_update_interval, 0);
+    assert_non_null(builder);
+
+    int r = log_builder_update_host_ip(builder);
+    assert_int_equal(r, 0);
+
+    log_builder_destroy(builder);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
             cmocka_unit_test(test_log_builder),
+            cmocka_unit_test(test_log_builder_update),
+            cmocka_unit_test(test_log_builder_not_update),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wrappers/wazuh/client-agent/notify_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/client-agent/notify_wrappers.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "shared.h"
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+char * wrap_get_agent_ip_legacy_win32() {
+    return mock_type(char *);
+}

--- a/src/unit_tests/wrappers/wazuh/client-agent/notify_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/client-agent/notify_wrappers.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef NOTIFY_WRAPPERS_H
+#define NOTIFY_WRAPPERS_H
+
+char * wrap_get_agent_ip_legacy_win32();
+
+#endif


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17684|

As discussed in the issue, this PR aims to change the behavior of the internal option `ip_update_interval` so that, if its value is 0, wazuh-logcollector does not query the host's IP.

## New behavior

- If `logcollector.ip_update_internal` is set to 0, the agent won't collect the host's IP.
- If that's set to a value in the range 1–3600, the agent will collect the host's IP within minimum intervals of such value, always every `logcollector.vcheck_files` seconds.

## Evidences

I've added the following INFO log (development only), just to check the behavior:

### 🟢 `ip_update_interval` < `vcheck_files`

|vcheck_files|ip_update_interval|
|---|---|
|2|1|

>2023/08/24 12:17:31 wazuh-logcollector: INFO: ---- Getting host's IP ----
2023/08/24 12:17:31 wazuh-logcollector: INFO: Started (pid: 159812).
2023/08/24 12:17:33 wazuh-logcollector: INFO: ---- Getting host's IP ----
2023/08/24 12:17:35 wazuh-logcollector: INFO: ---- Getting host's IP ----
2023/08/24 12:17:37 wazuh-logcollector: INFO: ---- Getting host's IP ----
2023/08/24 12:17:39 wazuh-logcollector: INFO: ---- Getting host's IP ----
2023/08/24 12:17:41 wazuh-logcollector: INFO: ---- Getting host's IP ----

### 🟢 `ip_update_interval` = 0

|vcheck_files|ip_update_interval|
|---|---|
|2|0|

2023/08/24 12:18:04 wazuh-logcollector: INFO: Started (pid: 160017).