### PR TITLE
Fix GET /groups RBAC filter

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -605,35 +605,33 @@ def get_agent_groups(group_list: list = None, offset: int = 0, limit: int = None
             result.add_failed_item(id_=invalid_group, error=WazuhResourceNotFound(1710))
 
         rbac_filters = get_rbac_filters(system_resources=system_groups, permitted_resources=group_list)
-    else:
-        rbac_filters = dict()
 
-    with WazuhDBQueryGroup(**rbac_filters) as group_query:
-        query_data = group_query.run()
+        with WazuhDBQueryGroup(**rbac_filters) as group_query:
+            query_data = group_query.run()
 
-        for group in query_data['items']:
-            if group_list and group['name'] not in group_list:
-                continue
+            for group in query_data['items']:
+                if group_list and group['name'] not in group_list:
+                    continue
 
-            full_entry = path.join(common.SHARED_PATH, group['name'])
+                full_entry = path.join(common.SHARED_PATH, group['name'])
 
-            # merged.mg and agent.conf sum
-            merged_sum = get_hash(path.join(full_entry, "merged.mg"), hash_algorithm)
-            if merged_sum:
-                group['mergedSum'] = merged_sum
+                # merged.mg and agent.conf sum
+                merged_sum = get_hash(path.join(full_entry, "merged.mg"), hash_algorithm)
+                if merged_sum:
+                    group['mergedSum'] = merged_sum
 
-            conf_sum = get_hash(path.join(full_entry, "agent.conf"), hash_algorithm)
-            if conf_sum:
-                group['configSum'] = conf_sum
+                conf_sum = get_hash(path.join(full_entry, "agent.conf"), hash_algorithm)
+                if conf_sum:
+                    group['configSum'] = conf_sum
 
-            affected_groups.append(group)
+                affected_groups.append(group)
 
-    data = process_array(affected_groups, offset=offset, limit=limit, allowed_sort_fields=GROUP_FIELDS,
-                         sort_by=sort_by, sort_ascending=sort_ascending, search_text=search_text,
-                         complementary_search=complementary_search, q=q, allowed_select_fields=GROUP_FIELDS,
-                         select=select, distinct=distinct, required_fields=GROUP_REQUIRED_FIELDS)
-    result.affected_items = data['items']
-    result.total_affected_items = data['totalItems']
+        data = process_array(affected_groups, offset=offset, limit=limit, allowed_sort_fields=GROUP_FIELDS,
+                            sort_by=sort_by, sort_ascending=sort_ascending, search_text=search_text,
+                            complementary_search=complementary_search, q=q, allowed_select_fields=GROUP_FIELDS,
+                            select=select, distinct=distinct, required_fields=GROUP_REQUIRED_FIELDS)
+        result.affected_items = data['items']
+        result.total_affected_items = data['totalItems']
 
     return result
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -457,9 +457,9 @@ def test_agent_add_agent(manager_status_mock, socket_mock, name, agent_id, key, 
 @pytest.mark.parametrize('group_list, q, expected_result', [
     (['group-1', 'group-2'], None, ['group-1', 'group-2']),
     (['invalid_group'], None, []),
-    ([], 'name=group-empty', ['group-empty']),
-    ([], 'mergedSum=a336982f3c020cd558a16113f752fd5b', ['group-1', 'group-2']),
-    ([], 'count=0', ['group-empty'])
+    (['group-1', 'group-2'], 'name~1', ['group-1']),
+    (['group-1', 'group-2', 'group-3'], 'mergedSum=a336982f3c020cd558a16113f752fd5b', ['group-1', 'group-2']),
+    ([], '', []) # An empty group_list should return nothing
 ])
 @patch('wazuh.core.common.CLIENT_KEYS', new=os.path.join(test_agent_path, 'client.keys'))
 @patch('wazuh.core.common.SHARED_PATH', new=test_shared_path)


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/18537 |

## Description

Changes the logic of `GET /groups` to look for groups only if a list is provided. If not, instead of using empty RBAC filters, it returns an empty list.

## Tests

<details><summary>test_rbac_white_all_endpoints.tavern.yaml</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_rbac_white_all_endpoints.tavern.yaml
============================= test session starts ==============================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 167 items                                                            

test_rbac_white_all_endpoints.tavern.yaml::PUT /active-response PASSED                              [  0%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /agents PASSED                                    [  1%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents PASSED                                       [  1%]
test_rbac_white_all_endpoints.tavern.yaml::POST /agents PASSED                                      [  2%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED              [  2%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED [  3%]
test_rbac_white_all_endpoints.tavern.yaml::GET /vulnerability/{agent_id} PASSED                     [  4%]
test_rbac_white_all_endpoints.tavern.yaml::GET /vulnerability/{agent_id}/last_scan PASSED           [  4%]
test_rbac_white_all_endpoints.tavern.yaml::GET /vulnerability/{agent_id}/summary/severity PASSED    [  5%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /vulnerability PASSED                                [  5%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                   [  6%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED              [  7%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED        [  7%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED           [  8%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                        [  8%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                    [  9%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                               [ 10%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                        [ 10%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                        [ 11%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /agents/group PASSED                              [ 11%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/group PASSED                                 [ 12%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED              [ 13%]
test_rbac_white_all_endpoints.tavern.yaml::POST /agents/insert PASSED                               [ 13%]
test_rbac_white_all_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                         [ 14%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/no_group PASSED                              [ 14%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                [ 15%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/outdated PASSED                              [ 16%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/reconnect PASSED                             [ 16%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/restart PASSED                               [ 17%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                        [ 17%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/summary/os PASSED                            [ 18%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/summary/status PASSED                        [ 19%]
test_rbac_white_all_endpoints.tavern.yaml::GET /ciscat/{agent_id}/results PASSED                    [ 19%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/local/info PASSED                           [ 20%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                [ 20%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                          [ 21%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/ruleset/synchronization PASSED              [ 22%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/local/config PASSED                         [ 22%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/status PASSED                               [ 23%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/api/config PASSED                           [ 23%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/status PASSED                     [ 24%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/info PASSED                       [ 25%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED              [ 25%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED              [ 26%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats PASSED              [ 26%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/stats PASSED                      [ 27%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly PASSED               [ 28%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly PASSED               [ 28%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd PASSED            [ 29%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted PASSED              [ 29%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/logs PASSED                       [ 30%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary PASSED               [ 31%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /cluster/restart PASSED                              [ 31%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED             [ 32%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED [ 32%]
test_rbac_white_all_endpoints.tavern.yaml::GET /decoders PASSED                                     [ 33%]
test_rbac_white_all_endpoints.tavern.yaml::GET /decoders/files PASSED                               [ 34%]
test_rbac_white_all_endpoints.tavern.yaml::GET /decoders/files/{filename} PASSED                    [ 34%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /decoders/files/{filename} PASSED                 [ 35%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /decoders/files/{filename} PASSED                    [ 35%]
test_rbac_white_all_endpoints.tavern.yaml::GET /decoders/parents PASSED                             [ 36%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /experimental/rootcheck PASSED                    [ 37%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED                     [ 37%]
test_rbac_white_all_endpoints.tavern.yaml::GET /experimental/ciscat/results PASSED                  [ 38%]
test_rbac_white_all_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED           [ 38%]
test_rbac_white_all_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED            [ 39%]
test_rbac_white_all_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED           [ 40%]
test_rbac_white_all_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED           [ 40%]
test_rbac_white_all_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED                 [ 41%]
test_rbac_white_all_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED           [ 41%]
test_rbac_white_all_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED              [ 42%]
test_rbac_white_all_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED          [ 43%]
test_rbac_white_all_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED           [ 43%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /groups PASSED                                    [ 44%]
test_rbac_white_all_endpoints.tavern.yaml::GET /groups PASSED                                       [ 44%]
test_rbac_white_all_endpoints.tavern.yaml::POST /groups PASSED                                      [ 45%]
test_rbac_white_all_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                     [ 46%]
test_rbac_white_all_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED              [ 46%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED              [ 47%]
test_rbac_white_all_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED      [ 47%]
test_rbac_white_all_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED       [ 48%]
test_rbac_white_all_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                      [ 49%]
test_rbac_white_all_endpoints.tavern.yaml::GET /lists PASSED                                        [ 49%]
test_rbac_white_all_endpoints.tavern.yaml::GET /lists/files/{filename} PASSED                       [ 50%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /lists/files/{filename} PASSED                       [ 50%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /lists/files/{filename} PASSED                    [ 51%]
test_rbac_white_all_endpoints.tavern.yaml::GET /lists/files PASSED                                  [ 52%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /logtest PASSED                                      [ 52%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /logtest/sessions/{token} PASSED                  [ 53%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/status PASSED                               [ 53%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/info PASSED                                 [ 54%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/configuration PASSED                        [ 55%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /manager/configuration PASSED                        [ 55%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/stats PASSED                                [ 56%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/stats PASSED                                [ 56%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                         [ 56%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                         [ 57%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                      [ 58%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                        [ 58%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/logs PASSED                                 [ 59%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                         [ 59%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/api/config PASSED                           [ 60%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /manager/restart PASSED                              [ 61%]
test_rbac_white_all_endpoints.tavern.yaml::GET /managerer/configuration/{component}/{configuration} PASSED [ 61%]
test_rbac_white_all_endpoints.tavern.yaml::GET /manager/configuration/validation PASSED             [ 62%]
test_rbac_white_all_endpoints.tavern.yaml::GET /mitre/metadata PASSED                               [ 62%]
test_rbac_white_all_endpoints.tavern.yaml::GET /mitre/mitigations PASSED                            [ 63%]
test_rbac_white_all_endpoints.tavern.yaml::GET /mitre/references PASSED                             [ 64%]
test_rbac_white_all_endpoints.tavern.yaml::GET /mitre/techniques PASSED                             [ 64%]
test_rbac_white_all_endpoints.tavern.yaml::GET /mitre/tactics PASSED                                [ 65%]
test_rbac_white_all_endpoints.tavern.yaml::GET /mitre/groups PASSED                                 [ 65%]
test_rbac_white_all_endpoints.tavern.yaml::GET /mitre/software PASSED                               [ 66%]
test_rbac_white_all_endpoints.tavern.yaml::GET /overview/agents PASSED                              [ 67%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /rootcheck PASSED                                    [ 67%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /rootcheck/{agent_id} PASSED                      [ 68%]
test_rbac_white_all_endpoints.tavern.yaml::GET /rootcheck/{agent_id}/last_scan PASSED               [ 68%]
test_rbac_white_all_endpoints.tavern.yaml::GET /rootcheck/{agent_id} PASSED                         [ 69%]
test_rbac_white_all_endpoints.tavern.yaml::GET /rules PASSED                                        [ 70%]
test_rbac_white_all_endpoints.tavern.yaml::GET /rules/groups PASSED                                 [ 70%]
test_rbac_white_all_endpoints.tavern.yaml::GET /rules/requirement/{requirement} PASSED              [ 71%]
test_rbac_white_all_endpoints.tavern.yaml::GET /rules/files/{filename} PASSED                       [ 71%]
test_rbac_white_all_endpoints.tavern.yaml::GET /rules/files PASSED                                  [ 72%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /rules/files/{filename} PASSED                       [ 73%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /rules/files/{filename} PASSED                    [ 73%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/user/revoke PASSED                         [ 74%]
test_rbac_white_all_endpoints.tavern.yaml::GET /security/users PASSED                               [ 74%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/users PASSED                              [ 75%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/users/{user_id}/run_as PASSED              [ 76%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/users PASSED                            [ 76%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/users/{user_id} PASSED                     [ 77%]
test_rbac_white_all_endpoints.tavern.yaml::GET /security/roles PASSED                               [ 77%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/roles PASSED                              [ 78%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/roles PASSED                            [ 79%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/roles/{role_id} PASSED                     [ 79%]
test_rbac_white_all_endpoints.tavern.yaml::GET /security/rules PASSED                               [ 80%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/rules PASSED                              [ 80%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/rules/{rule_id} PASSED                     [ 81%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/rules PASSED                            [ 82%]
test_rbac_white_all_endpoints.tavern.yaml::GET /security/policies PASSED                            [ 82%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/policies PASSED                         [ 83%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/policies PASSED                           [ 83%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/policies/{policy_id} PASSED                [ 84%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/users/{user_id}/roles PASSED              [ 85%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/users/{user_id}/roles PASSED            [ 85%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/roles/{role_id}/policies PASSED           [ 86%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/roles/{role_id}/rules PASSED              [ 86%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/roles/{role_id}/policies PASSED         [ 87%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/roles/{role_id}/rules PASSED            [ 88%]
test_rbac_white_all_endpoints.tavern.yaml::GET /security/config PASSED                              [ 88%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/config PASSED                              [ 89%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/config PASSED                           [ 89%]
test_rbac_white_all_endpoints.tavern.yaml::GET /sca/{agent_id} PASSED                               [ 90%]
test_rbac_white_all_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} PASSED            [ 91%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /syscheck PASSED                                     [ 91%]
test_rbac_white_all_endpoints.tavern.yaml::GET /syscheck/{agent_id} PASSED                          [ 92%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /syscheck/{agent_id} PASSED                       [ 92%]
test_rbac_white_all_endpoints.tavern.yaml::GET /syscheck/{agent_id}/last_scan PASSED                [ 93%]
test_rbac_white_all_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware PASSED             [ 94%]
test_rbac_white_all_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hotfixes PASSED             [ 94%]
test_rbac_white_all_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr PASSED              [ 95%]
test_rbac_white_all_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface PASSED             [ 95%]
test_rbac_white_all_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto PASSED             [ 96%]
test_rbac_white_all_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os PASSED                   [ 97%]
test_rbac_white_all_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages PASSED             [ 97%]
test_rbac_white_all_endpoints.tavern.yaml::GET /syscollector/{agent_id}/ports PASSED                [ 98%]
test_rbac_white_all_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes PASSED            [ 98%]
test_rbac_white_all_endpoints.tavern.yaml::GET /tasks/status PASSED                                 [ 99%]

=============================== 167 passed, 2 warnings in 523.17s (0:08:43) ===============================
```

</details>