### PR TITLE
Fix Solaris 10 name not showing in dashboard

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -760,9 +760,9 @@ os_info *get_unix_version()
                       goto free_os_info;
                   } else {
                       char *base;
-                      char *found = NULL;
-                      char tag[] = "Solaris";
-                      if (found = strstr(buff, tag), found) {
+                      char tag[]  = "Solaris";
+                      char *found = strstr(buff, tag);
+                      if (found) {
                           for (found += strlen(tag); *found != '\0' && *found == ' '; found++);
                           for (base = found; *found != '\0' && *found != ' '; found++);
                           *found = '\0';

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -760,9 +760,11 @@ os_info *get_unix_version()
                       goto free_os_info;
                   } else {
                       char *base;
-                      char *found;
+                      char *found = NULL;
                       char tag[] = "Oracle Solaris";
-                      if (found = strstr(buff, tag), found) {
+                      char alt_tag[] = "Solaris";
+                      found = strstr(buff,tag) ? strstr(buff,alt_tag) : found;
+                      if (found) {
                           for (found += strlen(tag); *found != '\0' && *found == ' '; found++);
                           for (base = found; *found != '\0' && *found != ' '; found++);
                           *found = '\0';

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -761,10 +761,8 @@ os_info *get_unix_version()
                   } else {
                       char *base;
                       char *found = NULL;
-                      char tag[] = "Oracle Solaris";
-                      char alt_tag[] = "Solaris";
-                      found = strstr(buff,tag) ? strstr(buff,alt_tag) : found;
-                      if (found) {
+                      char tag[] = "Solaris";
+                      if (found = strstr(buff, tag), found) {
                           for (found += strlen(tag); *found != '\0' && *found == ' '; found++);
                           for (base = found; *found != '\0' && *found != ' '; found++);
                           *found = '\0';

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -1483,6 +1483,206 @@ void test_get_unix_version_fail_os_release_uname_sunos(void **state)
     assert_string_equal(ret->sysname, "Linux");
 }
 
+// Scenario two: The content of /etc/release is Solaris 10 x/y ...
+void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_one(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/debian_version
+    expect_string(__wrap_fopen, path, "/etc/debian_version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/slackware-version
+    expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/alpine-release
+    expect_string(__wrap_fopen, path, "/etc/alpine-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // uname
+    expect_string(__wrap_popen, command, "uname");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "SunOS\n");
+
+    // Open /etc/release
+    expect_string(__wrap_fopen, path, "/etc/release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Solaris 10 1/13");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "SunOS");
+    assert_string_equal(ret->os_major, "10");
+    assert_string_equal(ret->os_version, "10");
+    assert_string_equal(ret->os_platform, "sunos");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+// Scenario two: The content of /etc/release is Oracle Solaris 10 x/y ...
+void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_two(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/debian_version
+    expect_string(__wrap_fopen, path, "/etc/debian_version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/slackware-version
+    expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/alpine-release
+    expect_string(__wrap_fopen, path, "/etc/alpine-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // uname
+    expect_string(__wrap_popen, command, "uname");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "SunOS\n");
+
+    // Open /etc/release
+    expect_string(__wrap_fopen, path, "/etc/release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Oracle Solaris 10 1/13");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "SunOS");
+    assert_string_equal(ret->os_major, "10");
+    assert_string_equal(ret->os_version, "10");
+    assert_string_equal(ret->os_platform, "sunos");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
 void test_get_unix_version_fail_os_release_uname_hp_ux(void **state)
 {
     (void) state;
@@ -2051,6 +2251,8 @@ int main(void) {
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_darwin, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_darwin_no_key, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos_10_scenario_one, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos_10_scenario_two, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_hp_ux, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_bsd, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_zscaler, delete_os_info),


### PR DESCRIPTION
|Related issue|
|---|
|Closes #18544 |

## Objective

This PR fix the pattern to search in the `etc/release` in the old versions of Solaris 10 (Pior 1/13) .

The fix only apply for Solaris 10 OS.

## Description
The first approach was implement the following fix in the file `version_op.c`

<details><summary>Code snipped</summary>

```c
 char *base;
 char *found = NULL;
 char tag[] = "Oracle Solaris";
 char alt_tag[] = "Solaris";
 found = strstr(buff,tag) ? strstr(buff,alt_tag) : found;
 if (found) {
     for (found += strlen(tag); *found != '\0' && *found == found++);
     for (base = found; *found != '\0' && *found != ' '; found++);
     *found = '\0';
     os_strdup(base, info->os_version);
     fclose(os_release);
 } else {
     merror("Cannot get the Solaris version.");
     fclose(os_release);
     pclose(cmd_output);
     goto free_os_info;
 }
```
</details>

After a comment from team, we can see that the first pattern to search is `Oracle Solaris`, and if this is found, then the algorithm seek again the shortest tag `Solaris` which obviously will be found and the final result is incorrect.

Switching the order to search, that means:

<details><summary>Code snipped</summary>

```c
 char *base;
 char *found = NULL;
 char tag[] = "Solaris";
 char alt_tag[] = "Oracle Solaris";
 found = strstr(buff,tag) ? strstr(buff,alt_tag) : found;
 if (found) {
     for (found += strlen(tag); *found != '\0' && *found == found++);
     for (base = found; *found != '\0' && *found != ' '; found++);
     *found = '\0';
     os_strdup(base, info->os_version);
     fclose(os_release);
 } else {
     merror("Cannot get the Solaris version.");
     fclose(os_release);
     pclose(cmd_output);
     goto free_os_info;
 }
```

</details>

The result is correct partially, because the behavior is the same error that generate the issue.
Making a modification, the propose solution is the following

<details><summary>Code snipped</summary>

```c
char *base;
char tag[]  = "Solaris";
char *found = strstr(buff, tag);
if (found) {
    for (found += strlen(tag); *found != '\0' && *found == ' '; found++);
    for (base = found; *found != '\0' && *found != ' '; found++);
    *found = '\0';
    os_strdup(base, info->os_version);
    fclose(os_release);
} else {
    merror("Cannot get the Solaris version.");
    fclose(os_release);
    pclose(cmd_output);
    goto free_os_info;
}
```

</details>

> [!IMPORTANT]
> We are considering scenarios where the content of the `etc/release` file is `Oracle Solaris` or `Solaris`. It could exists another alternative where the keyword `Solaris` is duplicated. This existence has a very low probability.


## Quality Assurance
A new tests has been included to verify the correct behavior and backward compatibility of this solution proposal.

<details><summary>Output ctest</summary>

```bash
Test <agent_build>
      Start  1: test_start_agent
 1/65 Test  #1: test_start_agent ........................................   Passed    0.04 sec
      Start  2: test_notify
 2/65 Test  #2: test_notify .............................................   Passed    0.03 sec
      Start  3: test_agentd_state
 3/65 Test  #3: test_agentd_state .......................................   Passed    0.03 sec
      Start  4: test_buffer
 4/65 Test  #4: test_buffer .............................................   Passed    0.03 sec
      Start  5: test_logcollector
 5/65 Test  #5: test_logcollector .......................................   Passed    0.04 sec
      Start  6: test_read_multiline_regex
 6/65 Test  #6: test_read_multiline_regex ...............................   Passed    0.03 sec
      Start  7: test_localfile-config
 7/65 Test  #7: test_localfile-config ...................................   Passed    0.03 sec
      Start  8: test_state
 8/65 Test  #8: test_state ..............................................   Passed    0.01 sec
      Start  9: test_lccom
 9/65 Test  #9: test_lccom ..............................................   Passed    0.03 sec
      Start 10: test_macos_log
10/65 Test #10: test_macos_log ..........................................   Passed    0.03 sec
      Start 11: test_read_macos
11/65 Test #11: test_read_macos .........................................   Passed    0.03 sec
      Start 12: test_execd
12/65 Test #12: test_execd ..............................................   Passed    0.01 sec
      Start 13: test_get_command_by_name
13/65 Test #13: test_get_command_by_name ................................   Passed    0.01 sec
      Start 14: test_wm_control
14/65 Test #14: test_wm_control .........................................   Passed    0.03 sec
      Start 15: test_wm_github
15/65 Test #15: test_wm_github ..........................................   Passed    0.04 sec
      Start 16: test_wm_office365
16/65 Test #16: test_wm_office365 .......................................   Passed    0.06 sec
      Start 17: test_wm_osquery_already_running
17/65 Test #17: test_wm_osquery_already_running .........................   Passed    0.02 sec
      Start 18: test_syscom
18/65 Test #18: test_syscom .............................................   Passed    0.01 sec
      Start 19: test_fim_diff_changes
19/65 Test #19: test_fim_diff_changes ...................................   Passed    0.04 sec
      Start 20: test_run_realtime
20/65 Test #20: test_run_realtime .......................................   Passed    0.05 sec
      Start 21: test_config
21/65 Test #21: test_config .............................................   Passed    0.05 sec
      Start 22: test_syscheck
22/65 Test #22: test_syscheck ...........................................   Passed    0.03 sec
      Start 23: test_run_check
23/65 Test #23: test_run_check ..........................................   Passed    0.03 sec
      Start 24: test_create_db
24/65 Test #24: test_create_db ..........................................   Passed    0.06 sec
      Start 25: test_audit_healthcheck
25/65 Test #25: test_audit_healthcheck ..................................   Passed    0.03 sec
      Start 26: test_audit_rule_handling
26/65 Test #26: test_audit_rule_handling ................................   Passed    0.03 sec
      Start 27: test_syscheck_audit
27/65 Test #27: test_syscheck_audit .....................................   Passed    0.04 sec
      Start 28: test_audit_parse
28/65 Test #28: test_audit_parse ........................................   Passed    0.04 sec
      Start 29: test_list_op
29/65 Test #29: test_list_op ............................................   Passed    0.03 sec
      Start 30: test_file_op
30/65 Test #30: test_file_op ............................................   Passed    0.03 sec
      Start 31: test_integrity_op
31/65 Test #31: test_integrity_op .......................................   Passed    0.01 sec
      Start 32: test_rbtree_op
32/65 Test #32: test_rbtree_op ..........................................   Passed    0.01 sec
      Start 33: test_validate_op
33/65 Test #33: test_validate_op ........................................   Passed    0.02 sec
      Start 34: test_string_op
34/65 Test #34: test_string_op ..........................................   Passed    0.01 sec
      Start 35: test_expression
35/65 Test #35: test_expression .........................................   Passed    0.02 sec
      Start 36: test_version_op
36/65 Test #36: test_version_op .........................................   Passed    0.03 sec
      Start 37: test_queue_op
37/65 Test #37: test_queue_op ...........................................   Passed    0.01 sec
      Start 38: test_queue_linked_op
38/65 Test #38: test_queue_linked_op ....................................   Passed    0.01 sec
      Start 39: test_agent_op
39/65 Test #39: test_agent_op ...........................................   Passed    0.02 sec
      Start 40: test_enrollment_op
40/65 Test #40: test_enrollment_op ......................................   Passed    0.04 sec
      Start 41: test_time_op
41/65 Test #41: test_time_op ............................................   Passed    0.02 sec
      Start 42: test_buffer_op
42/65 Test #42: test_buffer_op ..........................................   Passed    0.01 sec
      Start 43: test_utf8_op
43/65 Test #43: test_utf8_op ............................................   Passed    0.02 sec
      Start 44: test_log_builder
44/65 Test #44: test_log_builder ........................................   Passed    0.01 sec
      Start 45: test_custom_output_search_replace
45/65 Test #45: test_custom_output_search_replace .......................   Passed    0.01 sec
      Start 46: test_syscheck_op
46/65 Test #46: test_syscheck_op ........................................   Passed    0.02 sec
      Start 47: test_json_op
47/65 Test #47: test_json_op ............................................   Passed    0.02 sec
      Start 48: test_audit_op
48/65 Test #48: test_audit_op ...........................................   Passed    0.02 sec
      Start 49: test_privsep_op
49/65 Test #49: test_privsep_op .........................................   Passed    0.02 sec
      Start 50: test_mq_op
50/65 Test #50: test_mq_op ..............................................   Passed    0.02 sec
      Start 51: test_remoted_op
51/65 Test #51: test_remoted_op .........................................   Passed    0.02 sec
      Start 52: test_atomic
52/65 Test #52: test_atomic .............................................   Passed    0.02 sec
      Start 53: test_limits
53/65 Test #53: test_limits .............................................   Passed    0.01 sec
      Start 54: test_url
54/65 Test #54: test_url ................................................   Passed    0.02 sec
      Start 55: test_sysinfo_utils
55/65 Test #55: test_sysinfo_utils ......................................   Passed    0.02 sec
      Start 56: test_rwlock_op
56/65 Test #56: test_rwlock_op ..........................................   Passed    0.04 sec
      Start 57: test_os_xml
57/65 Test #57: test_os_xml .............................................   Passed    0.05 sec
      Start 58: test_os_regex
58/65 Test #58: test_os_regex ...........................................   Passed    0.02 sec
      Start 59: test_os_regex_match
59/65 Test #59: test_os_regex_match .....................................   Passed    0.01 sec
      Start 60: test_os_regex_execute
60/65 Test #60: test_os_regex_execute ...................................   Passed    0.03 sec
      Start 61: test_os_zlib
61/65 Test #61: test_os_zlib ............................................   Passed    0.02 sec
      Start 62: test_client-config_validate_ipv6_link_local_interface
62/65 Test #62: test_client-config_validate_ipv6_link_local_interface ...   Passed    0.03 sec
      Start 63: test_os_net
63/65 Test #63: test_os_net .............................................   Passed    0.02 sec
      Start 64: test_fluentd_forwarder
64/65 Test #64: test_fluentd_forwarder ..................................   Passed    0.03 sec
      Start 65: test_active-response
65/65 Test #65: test_active-response ....................................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 65
```

</details>

Regarding with memory, no new memory allocations was introduced in this PR.

<details><summary>ScanBuild report</summary>

Command:

```bash
scan-build-15 -enable-checker alpha.core.CastSize -enable-checker alpha.core.CastToStruct -enable-checker alpha.core.Conversion -enable-checker alpha.core.IdenticalExpr -enable-checker alpha.core.SizeofPtr -enable-checker alpha.core.TestAfterDivZero --exclude external make TARGET=agent DEBUG=1 -j$(nproc)
```

```bash
Done building agent

scan-build: Analysis run complete.
scan-build: Removing directory '/tmp/scan-build-2023-08-28-152548-92114-1' because it contains no reports.
scan-build: No bugs found.
```

</details>

## Exploratory tests

|OS|Result|
|----|----------|
| [Solaris 10 & 11](https://github.com/wazuh/wazuh/pull/18642#issuecomment-1696520558) | 🟢  |


### Check summary

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [ ] Source installation
- [x] Package installation
- [ ] Source upgrade
- [x] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components