### PR TITLE
Remove deprecated plain text auth from AWS and Azure wodles

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -657,7 +657,8 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 os_strdup(aws_config->bucket, cur_bucket->bucket);
             }
         }
-        else if (aws_config->remove_from_bucket) {
+
+        if (aws_config->remove_from_bucket) {
             cur_bucket->remove_from_bucket = aws_config->remove_from_bucket;
         }
 

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -17,8 +17,6 @@ static const char *XML_SERVICE = "service";
 static const char *XML_SUBSCRIBER = "subscriber";
 static const char *XML_SUBSCRIBER_TYPE = "type";
 static const char *XML_SUBSCRIBER_QUEUE = "sqs_name";
-static const char *XML_ACCESS_KEY = "access_key";
-static const char *XML_SECRET_KEY = "secret_key";
 static const char *XML_RUN_ON_START = "run_on_start";
 static const char *XML_REMOVE_FORM_BUCKET = "remove_from_bucket";
 static const char *XML_SKIP_ON_ERROR = "skip_on_error";
@@ -60,9 +58,6 @@ static const char *CLOUDWATCHLOGS_SERVICE_TYPE = "cloudwatchlogs";
 static const char *CISCO_UMBRELLA_BUCKET_TYPE = "cisco_umbrella";
 static const char *SECURITY_LAKE_SUBSCRIBER_TYPE = "security_lake";
 static const char *BUCKETS_SUBSCRIBER_TYPE = "buckets";
-
-static const char *AUTHENTICATION_OPTIONS_URL = "https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html";
-static const char *DEPRECATED_MESSAGE = "Deprecated tag <%s> found at module '%s'. This tag was deprecated in %s; please use a different authentication method. Check %s for more information.";
 
 // Parse XML
 
@@ -134,16 +129,6 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             else {
                 merror("Invalid content for tag '%s' at module '%s'.", XML_REMOVE_FORM_BUCKET, WM_AWS_CONTEXT.name);
                 return OS_INVALID;
-            }
-        } else if (!strcmp(nodes[i]->element, XML_ACCESS_KEY)) {
-            if (strlen(nodes[i]->content) != 0) {
-                free(aws_config->access_key);
-                os_strdup(nodes[i]->content, aws_config->access_key);
-            }
-        } else if (!strcmp(nodes[i]->element, XML_SECRET_KEY)) {
-            if (strlen(nodes[i]->content) != 0) {
-                free(aws_config->secret_key);
-                os_strdup(nodes[i]->content, aws_config->secret_key);
             }
         } else if (!strcmp(nodes[i]->element, XML_BUCKET)) {
             if (!nodes[i]->attributes) { // Legacy
@@ -244,22 +229,10 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                             OS_ClearNode(children);
                             return OS_INVALID;
                         }
-                    } else if (!strcmp(children[j]->element, XML_ACCESS_KEY)) {
-                        if (strlen(children[j]->content) != 0) {
-                            mwarn(DEPRECATED_MESSAGE, children[j]->element, WM_AWS_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
-                            free(cur_bucket->access_key);
-                            os_strdup(children[j]->content, cur_bucket->access_key);
-                        }
                     } else if (!strcmp(children[j]->element, XML_AWS_ACCOUNT_ALIAS)) {
                         if (strlen(children[j]->content) != 0) {
                             free(cur_bucket->aws_account_alias);
                             os_strdup(children[j]->content, cur_bucket->aws_account_alias);
-                        }
-                    } else if (!strcmp(children[j]->element, XML_SECRET_KEY)) {
-                        if (strlen(children[j]->content) != 0) {
-                            mwarn(DEPRECATED_MESSAGE, children[j]->element, WM_AWS_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
-                            free(cur_bucket->secret_key);
-                            os_strdup(children[j]->content, cur_bucket->secret_key);
                         }
                     } else if (!strcmp(children[j]->element, XML_AWS_PROFILE)) {
                         if (strlen(children[j]->content) != 0) {
@@ -406,22 +379,10 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     }
                     free(cur_service->aws_account_id);
                     os_strdup(children[j]->content, cur_service->aws_account_id);
-                } else if (!strcmp(children[j]->element, XML_ACCESS_KEY)) {
-                    if (strlen(children[j]->content) != 0) {
-                        mwarn(DEPRECATED_MESSAGE, children[j]->element, WM_AWS_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
-                        free(cur_service->access_key);
-                        os_strdup(children[j]->content, cur_service->access_key);
-                    }
                 } else if (!strcmp(children[j]->element, XML_AWS_ACCOUNT_ALIAS)) {
                     if (strlen(children[j]->content) != 0) {
                         free(cur_service->aws_account_alias);
                         os_strdup(children[j]->content, cur_service->aws_account_alias);
-                    }
-                } else if (!strcmp(children[j]->element, XML_SECRET_KEY)) {
-                    if (strlen(children[j]->content) != 0) {
-                        mwarn(DEPRECATED_MESSAGE, children[j]->element, WM_AWS_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
-                        free(cur_service->secret_key);
-                        os_strdup(children[j]->content, cur_service->secret_key);
                     }
                 } else if (!strcmp(children[j]->element, XML_AWS_PROFILE)) {
                     if (strlen(children[j]->content) != 0) {
@@ -696,18 +657,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                 os_strdup(aws_config->bucket, cur_bucket->bucket);
             }
         }
-        if (aws_config->secret_key) {
-            if (strlen(aws_config->secret_key) != 0) {
-                free(cur_bucket->secret_key);
-                os_strdup(aws_config->secret_key, cur_bucket->secret_key);
-            }
-        }
-        if (aws_config->access_key) {
-            if (strlen(aws_config->access_key) != 0) {
-                free(cur_bucket->access_key);
-                os_strdup(aws_config->access_key, cur_bucket->access_key);
-            }
-        } else if (aws_config->remove_from_bucket) {
+        else if (aws_config->remove_from_bucket) {
             cur_bucket->remove_from_bucket = aws_config->remove_from_bucket;
         }
 

--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -20,14 +20,10 @@ static const char *XML_LOG_ANALYTICS = "log_analytics";
 static const char *XML_GRAPH = "graph";
 static const char *XML_STORAGE = "storage";
 
-static const char *XML_APP_ID = "application_id";
-static const char *XML_APP_KEY = "application_key";
 static const char *XML_AUTH_PATH = "auth_path";
 static const char *XML_TENANTDOMAIN = "tenantdomain";
 static const char *XML_REQUEST = "request";
 
-static const char *XML_ACCOUNT_NAME = "account_name";
-static const char *XML_ACCOUNT_KEY = "account_key";
 static const char *XML_TAG = "tag";
 static const char *XML_CONTAINER = "container";
 static const char *XML_CONTAINER_NAME = "name";
@@ -48,9 +44,6 @@ static void wm_clean_api(wm_azure_api_t * api_config);
 static void wm_clean_request(wm_azure_request_t * request);
 static void wm_clean_storage(wm_azure_storage_t * storage);
 static void wm_clean_container(wm_azure_container_t * container);
-
-static const char *AUTHENTICATION_OPTIONS_URL = "https://documentation.wazuh.com/current/azure/activity-services/prerequisites/credentials.html";
-static const char *DEPRECATED_MESSAGE = "Deprecated tag <%s> found at module '%s'. This tag was deprecated in %s; please use a different authentication method. Check %s for more information.";
 
 // Parse XML
 
@@ -223,8 +216,6 @@ int wm_azure_api_read(const OS_XML *xml, XML_NODE nodes, wm_azure_api_t * api_co
     wm_azure_request_t *request = NULL;
     wm_azure_request_t *request_prev = NULL;
 
-    api_config->application_id = NULL;
-    api_config->application_key = NULL;
     api_config->auth_path = NULL;
     api_config->tenantdomain = NULL;
 
@@ -239,16 +230,6 @@ int wm_azure_api_read(const OS_XML *xml, XML_NODE nodes, wm_azure_api_t * api_co
             merror(XML_VALUENULL, nodes[i]->element);
             return OS_INVALID;
 
-        } else if (!strcmp(nodes[i]->element, XML_APP_ID)) {
-            if (*nodes[i]->content != '\0') {
-                mwarn(DEPRECATED_MESSAGE, nodes[i]->element, WM_AZURE_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
-                os_strdup(nodes[i]->content, api_config->application_id);
-            }
-        } else if (!strcmp(nodes[i]->element, XML_APP_KEY)) {
-            if (*nodes[i]->content != '\0') {
-                mwarn(DEPRECATED_MESSAGE, nodes[i]->element, WM_AZURE_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
-                os_strdup(nodes[i]->content, api_config->application_key);
-            }
         } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
             if (*nodes[i]->content != '\0')
                 os_strdup(nodes[i]->content, api_config->auth_path);
@@ -292,10 +273,8 @@ int wm_azure_api_read(const OS_XML *xml, XML_NODE nodes, wm_azure_api_t * api_co
 
     /* Validation process */
     if (!api_config->auth_path) {
-        if (!api_config->application_id || !api_config->application_key) {
-            merror("At module '%s': No authentication method provided. Skipping block...", WM_AZURE_CONTEXT.name);
-            return OS_INVALID;
-        }
+        merror("At module '%s': No authentication method provided. Skipping block...", WM_AZURE_CONTEXT.name);
+        return OS_INVALID;
     }
 
     if (!api_config->tenantdomain) {
@@ -407,8 +386,6 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
     wm_azure_container_t *container = NULL;
     wm_azure_container_t *container_prev = NULL;
 
-    storage->account_name = NULL;
-    storage->account_key = NULL;
     storage->auth_path = NULL;
     storage->tag = NULL;
 
@@ -476,13 +453,7 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
             }
 
         } else if (nodes[i]->content != NULL && *nodes[i]->content != '\0') {
-            if (!strcmp(nodes[i]->element, XML_ACCOUNT_NAME)) {
-                mwarn(DEPRECATED_MESSAGE, nodes[i]->element, WM_AZURE_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
-                os_strdup(nodes[i]->content, storage->account_name);
-            } else if (!strcmp(nodes[i]->element, XML_ACCOUNT_KEY)) {
-                mwarn(DEPRECATED_MESSAGE, nodes[i]->element, WM_AZURE_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
-                os_strdup(nodes[i]->content, storage->account_key);
-            } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
+            if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
                 os_strdup(nodes[i]->content, storage->auth_path);
             } else if (!strcmp(nodes[i]->element, XML_TAG)) {
                 os_strdup(nodes[i]->content, storage->tag);
@@ -499,10 +470,7 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
 
     /* Validation process */
     if (!storage->auth_path) {
-        if (!storage->account_name || !storage->account_key) {
-            merror("At module '%s': No authentication method provided. Skipping block...", WM_AZURE_CONTEXT.name);
-            return OS_INVALID;
-        }
+        merror("At module '%s': No authentication method provided. Skipping block...", WM_AZURE_CONTEXT.name);
     }
 
     if (!storage->tag) {
@@ -604,10 +572,6 @@ void wm_clean_api(wm_azure_api_t * api_config) {
     wm_azure_request_t *curr_request = NULL;
     wm_azure_request_t *next_request = NULL;
 
-    if (api_config->application_id)
-        free(api_config->application_id);
-    if (api_config->application_key)
-        free(api_config->application_key);
     if (api_config->auth_path)
         free(api_config->auth_path);
     if (api_config->tenantdomain)
@@ -642,10 +606,6 @@ void wm_clean_storage(wm_azure_storage_t * storage) {
     wm_azure_container_t *curr_container = NULL;
     wm_azure_container_t *next_container = NULL;
 
-    if (storage->account_name)
-        free(storage->account_name);
-    if (storage->account_key)
-        free(storage->account_key);
     if (storage->auth_path)
         free(storage->auth_path);
     if (storage->tag)

--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -471,6 +471,7 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
     /* Validation process */
     if (!storage->auth_path) {
         merror("At module '%s': No authentication method provided. Skipping block...", WM_AZURE_CONTEXT.name);
+        return OS_INVALID;
     }
 
     if (!storage->tag) {

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -228,8 +228,6 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
         for (iter = aws_config->buckets; iter; iter = iter->next) {
             cJSON *buck = cJSON_CreateObject();
             if (iter->bucket) cJSON_AddStringToObject(buck,"name",iter->bucket);
-            if (iter->access_key) cJSON_AddStringToObject(buck,"access_key",iter->access_key);
-            if (iter->secret_key) cJSON_AddStringToObject(buck,"secret_key",iter->secret_key);
             if (iter->aws_profile) cJSON_AddStringToObject(buck,"aws_profile",iter->aws_profile);
             if (iter->iam_role_arn) cJSON_AddStringToObject(buck,"iam_role_arn",iter->iam_role_arn);
             if (iter->iam_role_duration) cJSON_AddStringToObject(buck, "iam_role_duration",iter->iam_role_duration);
@@ -259,8 +257,6 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
         for (iter = aws_config->services; iter; iter = iter->next) {
             cJSON *service = cJSON_CreateObject();
             if (iter->type) cJSON_AddStringToObject(service,"type",iter->type); // type is the name of the service
-            if (iter->access_key) cJSON_AddStringToObject(service,"access_key",iter->access_key);
-            if (iter->secret_key) cJSON_AddStringToObject(service,"secret_key",iter->secret_key);
             if (iter->aws_profile) cJSON_AddStringToObject(service,"aws_profile",iter->aws_profile);
             if (iter->iam_role_arn) cJSON_AddStringToObject(service,"iam_role_arn",iter->iam_role_arn);
             if (iter->iam_role_duration) cJSON_AddStringToObject(service, "iam_role_duration",iter->iam_role_duration);
@@ -394,14 +390,6 @@ void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *exec_bucket) {
     // bucket arguments
     if (exec_bucket->remove_from_bucket) {
         wm_strcat(&command, "--remove", ' ');
-    }
-    if (exec_bucket->access_key) {
-        wm_strcat(&command, "--access_key", ' ');
-        wm_strcat(&command, exec_bucket->access_key, ' ');
-    }
-    if (exec_bucket->secret_key) {
-        wm_strcat(&command, "--secret_key", ' ');
-        wm_strcat(&command, exec_bucket->secret_key, ' ');
     }
     if (exec_bucket->aws_profile) {
         wm_strcat(&command, "--aws_profile", ' ');
@@ -571,14 +559,6 @@ void wm_aws_run_service(wm_aws *aws_config, wm_aws_service *exec_service) {
     wm_strcat(&command, exec_service->type, ' ');
 
     // service arguments
-    if (exec_service->access_key) {
-        wm_strcat(&command, "--access_key", ' ');
-        wm_strcat(&command, exec_service->access_key, ' ');
-    }
-    if (exec_service->secret_key) {
-        wm_strcat(&command, "--secret_key", ' ');
-        wm_strcat(&command, exec_service->secret_key, ' ');
-    }
     if (exec_service->aws_profile) {
         wm_strcat(&command, "--aws_profile", ' ');
         wm_strcat(&command, exec_service->aws_profile, ' ');

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -24,8 +24,6 @@ typedef struct wm_aws_state_t {
 
 typedef struct wm_aws_bucket {
     char *bucket;                       // S3 bucket
-    char *access_key;                   // IAM access key
-    char *secret_key;                   // IAM secret key
     char *aws_profile;                  // AWS credentials profile
     char *iam_role_arn;                 // IAM role
     char *iam_role_duration;            // IAM role session duration
@@ -48,8 +46,6 @@ typedef struct wm_aws_bucket {
 
 typedef struct wm_aws_service {
     char *type;                         // String defining service type.
-    char *access_key;                   // IAM access key
-    char *secret_key;                   // IAM secret key
     char *aws_profile;                  // AWS credentials profile
     char *iam_role_arn;                 // IAM role
     char *iam_role_duration;            // IAM role session duration
@@ -83,8 +79,6 @@ typedef struct wm_aws_subscriber {
 typedef struct wm_aws {
     sched_scan_config scan_config;
     char *bucket;                       // DEPRECATE
-    char *access_key;                   // DEPRECATE
-    char *secret_key;                   // DEPRECATE
     int queue_fd;
     unsigned int enabled:1;
     unsigned int run_on_start:1;

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -129,11 +129,6 @@ void wm_azure_log_analytics(wm_azure_api_t *log_analytics) {
         if (log_analytics->auth_path) {
             wm_strcat(&command, "--la_auth_path", ' ');
             wm_strcat(&command, log_analytics->auth_path, ' ');
-        } else {
-            wm_strcat(&command, "--la_id", ' ');
-            wm_strcat(&command, log_analytics->application_id, ' ');
-            wm_strcat(&command, "--la_key", ' ');
-            wm_strcat(&command, log_analytics->application_key, ' ');
         }
 
         wm_strcat(&command, "--la_tenant_domain", ' ');
@@ -218,11 +213,6 @@ void wm_azure_graphs(wm_azure_api_t *graph) {
         if (graph->auth_path) {
             wm_strcat(&command, "--graph_auth_path", ' ');
             wm_strcat(&command, graph->auth_path, ' ');
-        } else {
-            wm_strcat(&command, "--graph_id", ' ');
-            wm_strcat(&command, graph->application_id, ' ');
-            wm_strcat(&command, "--graph_key", ' ');
-            wm_strcat(&command, graph->application_key, ' ');
         }
 
         wm_strcat(&command, "--graph_tenant_domain", ' ');
@@ -306,11 +296,6 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
         if (storage->auth_path) {
             wm_strcat(&command, "--storage_auth_path", ' ');
             wm_strcat(&command, storage->auth_path, ' ');
-        } else {
-            wm_strcat(&command, "--account_name", ' ');
-            wm_strcat(&command, storage->account_name, ' ');
-            wm_strcat(&command, "--account_key", ' ');
-            wm_strcat(&command, storage->account_key, ' ');
         }
 
         wm_strcat(&command, "--container", ' ');
@@ -453,10 +438,6 @@ void wm_azure_destroy(wm_azure_t *azure_config) {
 
         next_api = curr_api->next;
         free(curr_api->tenantdomain);
-        if (curr_api->application_id)
-            free(curr_api->application_id);
-        if (curr_api->application_key)
-            free(curr_api->application_key);
         if (curr_api->auth_path)
             free(curr_api->auth_path);
 
@@ -482,10 +463,6 @@ void wm_azure_destroy(wm_azure_t *azure_config) {
 
         next_storage = curr_storage->next;
         free(curr_storage->tag);
-        if (curr_storage->account_name)
-            free(curr_storage->account_name);
-        if (curr_storage->account_key)
-            free(curr_storage->account_key);
         if (curr_storage->auth_path)
             free(curr_storage->auth_path);
 
@@ -531,8 +508,6 @@ cJSON *wm_azure_dump(const wm_azure_t * azure) {
             cJSON *api = cJSON_CreateObject();
             if (api_config->type == LOG_ANALYTICS) cJSON_AddStringToObject(api, "type", "log_analytics"); else cJSON_AddStringToObject(api, "type", "graph");
             cJSON_AddStringToObject(api, "tenantdomain", api_config->tenantdomain);
-            if (api_config->application_id) cJSON_AddStringToObject(api, "application_id", api_config->application_id);
-            if (api_config->application_key) cJSON_AddStringToObject(api, "application_key", api_config->application_key);
             if (api_config->auth_path) cJSON_AddStringToObject(api, "auth_path", api_config->auth_path);
             if (api_config->request) {
                 cJSON *requests = cJSON_CreateArray();
@@ -552,8 +527,6 @@ cJSON *wm_azure_dump(const wm_azure_t * azure) {
         for (storage_conf = azure->storage; storage_conf; storage_conf = storage_conf->next) {
             cJSON *storage = cJSON_CreateObject();
             cJSON_AddStringToObject(storage, "tag", storage_conf->tag);
-            if (storage_conf->account_name) cJSON_AddStringToObject(storage, "account_name", storage_conf->account_name);
-            if (storage_conf->account_key) cJSON_AddStringToObject(storage, "account_key", storage_conf->account_key);
             if (storage_conf->auth_path) cJSON_AddStringToObject(storage, "auth_path", storage_conf->auth_path);
             if (storage_conf->container) {
                 cJSON *containers = cJSON_CreateArray();

--- a/src/wazuh_modules/wm_azure.h
+++ b/src/wazuh_modules/wm_azure.h
@@ -40,8 +40,6 @@ typedef struct wm_azure_request_t {
 
 typedef struct wm_azure_api_t {
     unsigned int type:1;        // Type of API defined (Log analytics or graph)
-    char * application_id;      // Application ID
-    char * application_key;     // Application key
     char * auth_path;           // Authentication file with application ID and key
     char * tenantdomain;        // Domain
     wm_azure_request_t *request;  // Requests (linked list)
@@ -59,8 +57,6 @@ typedef struct wm_azure_container_t {
 } wm_azure_container_t;
 
 typedef struct wm_azure_storage_t {
-    char * account_name;    // Storage account name
-    char * account_key;     // Storage account key
     char * auth_path;       // Authentication file with account name and key
     char * tag;             // Storage tag
     wm_azure_container_t *container;  // Storage container

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -74,8 +74,7 @@ def main(argv):
                 bucket_type = buckets_s3.server_access.AWSServerAccess
             else:
                 raise Exception("Invalid type of bucket")
-            bucket = bucket_type(reparse=options.reparse, access_key=options.access_key,
-                                 secret_key=options.secret_key,
+            bucket = bucket_type(reparse=options.reparse,
                                  profile=options.aws_profile,
                                  iam_role_arn=options.iam_role_arn,
                                  bucket=options.logBucket,
@@ -133,8 +132,6 @@ def main(argv):
                 aws_tools.debug('+++ Getting alerts from "{}" region.'.format(region), 1)
 
                 service = service_type(reparse=options.reparse,
-                                       access_key=options.access_key,
-                                       secret_key=options.secret_key,
                                        profile=options.aws_profile,
                                        iam_role_arn=options.iam_role_arn,
                                        only_logs_after=options.only_logs_after,

--- a/wodles/aws/aws_tools.py
+++ b/wodles/aws/aws_tools.py
@@ -16,9 +16,6 @@ import sys
 import re
 
 DEFAULT_AWS_CONFIG_PATH = path.join(path.expanduser('~'), '.aws', 'config')
-CREDENTIALS_URL = 'https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html'
-DEPRECATED_MESSAGE = 'The {name} authentication parameter was deprecated in {release}. ' \
-                     'Please use another authentication method instead. Check {url} for more information.'
 SECURITY_LAKE_IAM_ROLE_AUTHENTICATION_URL = 'https://documentation.wazuh.com/current/cloud-security/amazon/services/' \
                                         'supported-services/security-lake.html#configuring-an-iam-role'
 
@@ -341,12 +338,6 @@ def get_script_arguments():
                         help='AWS Account ID for logs', required=False,
                         type=arg_valid_accountid)
     parser.add_argument('-d', '--debug', action='store', dest='debug', default=0, help='Enable debug')
-    parser.add_argument('-a', '--access_key', dest='access_key', default=None,
-                        help='S3 Access key credential. '
-                             f'{DEPRECATED_MESSAGE.format(name="access_key", release="4.4", url=CREDENTIALS_URL)}')
-    parser.add_argument('-k', '--secret_key', dest='secret_key', default=None,
-                        help='S3 Access key credential. '
-                             f'{DEPRECATED_MESSAGE.format(name="secret_key", release="4.4", url=CREDENTIALS_URL)}')
     # Beware, once you delete history it's gone.
     parser.add_argument('-R', '--remove', action='store_true', dest='deleteFile',
                         help='Remove processed files from the AWS S3 bucket', default=False)

--- a/wodles/aws/buckets_s3/aws_bucket.py
+++ b/wodles/aws/buckets_s3/aws_bucket.py
@@ -51,10 +51,6 @@ class AWSBucket(wazuh_integration.WazuhAWSDatabase):
     ----------
     reparse : bool
         Whether to parse already parsed logs or not.
-    access_key : str
-        AWS access key id.
-    secret_key : str
-        AWS secret access key.
     profile : str
         AWS profile.
     iam_role_arn : str
@@ -87,7 +83,7 @@ class AWSBucket(wazuh_integration.WazuhAWSDatabase):
     """
     empty_bucket_message_template = "+++ No logs to process in bucket: {aws_account_id}/{aws_region}"
 
-    def __init__(self, db_table_name, bucket, reparse, access_key, secret_key, profile, iam_role_arn,
+    def __init__(self, db_table_name, bucket, reparse, profile, iam_role_arn,
                  only_logs_after, skip_on_error, account_alias, prefix, suffix, delete_file, aws_organization_id,
                  region, discard_field, discard_regex, sts_endpoint, service_endpoint, iam_role_duration=None):
         # common SQL queries
@@ -190,8 +186,6 @@ class AWSBucket(wazuh_integration.WazuhAWSDatabase):
         wazuh_integration.WazuhAWSDatabase.__init__(self,
                                                     db_name=self.db_name,
                                                     service_name='s3',
-                                                    access_key=access_key,
-                                                    secret_key=secret_key,
                                                     profile=profile,
                                                     iam_role_arn=iam_role_arn,
                                                     region=region,
@@ -739,10 +733,8 @@ class AWSCustomBucket(AWSBucket):
         AWSBucket.__init__(self, db_table_name=db_table_name if db_table_name else 'custom', **kwargs)
         self.retain_db_records = MAX_RECORD_RETENTION
         # get STS client
-        access_key = kwargs.get('access_key', None)
-        secret_key = kwargs.get('secret_key', None)
         profile = kwargs.get('profile', None)
-        self.sts_client = self.get_sts_client(access_key, secret_key, profile=profile)
+        self.sts_client = self.get_sts_client(profile=profile)
         # get account ID
         self.aws_account_id = self.sts_client.get_caller_identity().get('Account')
         self.macie_location_pattern = re.compile(r'"lat":(-?0+\d+\.\d+),"lon":(-?0+\d+\.\d+)')

--- a/wodles/aws/buckets_s3/vpcflow.py
+++ b/wodles/aws/buckets_s3/vpcflow.py
@@ -34,8 +34,6 @@ class AWSVPCFlowBucket(AWSLogsBucket):
         kwargs['db_table_name'] = 'vpcflow'
         AWSLogsBucket.__init__(self, **kwargs)
         self.service = 'vpcflowlogs'
-        self.access_key = kwargs['access_key']
-        self.secret_key = kwargs['secret_key']
         self.profile_name = kwargs['profile']
         # SQL queries for VPC must be after constructor call
         self.sql_already_processed = """
@@ -145,14 +143,11 @@ class AWSVPCFlowBucket(AWSLogsBucket):
 
             return result
 
-    def get_ec2_client(self, access_key, secret_key, region, profile_name=None):
+    def get_ec2_client(self, region, profile_name=None):
         conn_args = {}
         conn_args['region_name'] = region
 
-        if access_key is not None and secret_key is not None:
-            conn_args['aws_access_key_id'] = access_key
-            conn_args['aws_secret_access_key'] = secret_key
-        elif profile_name is not None:
+        if profile_name is not None:
             conn_args['profile_name'] = profile_name
 
         boto_session = boto3.Session(**conn_args)
@@ -168,9 +163,9 @@ class AWSVPCFlowBucket(AWSLogsBucket):
 
         return ec2_client
 
-    def get_flow_logs_ids(self, access_key, secret_key, region, account_id, profile_name=None):
+    def get_flow_logs_ids(self, region, account_id, profile_name=None):
         try:
-            ec2_client = self.get_ec2_client(access_key, secret_key, region, profile_name=profile_name)
+            ec2_client = self.get_ec2_client(region, profile_name=profile_name)
             return list(map(operator.itemgetter('FlowLogId'), ec2_client.describe_flow_logs()['FlowLogs']))
         except ValueError:
             aws_tools.debug(
@@ -205,7 +200,7 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                 aws_tools.debug("+++ Working on {} - {}".format(aws_account_id, aws_region), 1)
                 # get flow log ids for the current region
                 flow_logs_ids = self.get_flow_logs_ids(
-                    self.access_key, self.secret_key, aws_region, aws_account_id, profile_name=self.profile_name
+                    aws_region, aws_account_id, profile_name=self.profile_name
                 )
                 # for each flow log id
                 for flow_log_id in flow_logs_ids:

--- a/wodles/aws/services/aws_service.py
+++ b/wodles/aws/services/aws_service.py
@@ -29,10 +29,6 @@ class AWSService(wazuh_integration.WazuhAWSDatabase):
     ----------
     reparse : bool
         Whether to parse already parsed logs or not.
-    access_key : str
-        AWS access key id.
-    secret_key : str
-        AWS secret access key.
     profile : str
         AWS profile.
     iam_role_arn : str
@@ -57,7 +53,7 @@ class AWSService(wazuh_integration.WazuhAWSDatabase):
         The desired duration of the session that is going to be assumed.
     """
 
-    def __init__(self, reparse: bool, access_key: str, secret_key: str, profile: str, iam_role_arn: str,
+    def __init__(self, reparse: bool, profile: str, iam_role_arn: str,
                  service_name: str, only_logs_after: str, region: str, db_table_name: str = DEFAULT_TABLENAME,
                  discard_field: str = None, discard_regex: str = None, sts_endpoint: str = None,
                  service_endpoint: str = None,
@@ -68,7 +64,7 @@ class AWSService(wazuh_integration.WazuhAWSDatabase):
         self.db_table_name = db_table_name
 
         wazuh_integration.WazuhAWSDatabase.__init__(self, db_name=self.db_name, service_name=service_name,
-                                                    access_key=access_key, secret_key=secret_key, profile=profile,
+                                                    profile=profile,
                                                     iam_role_arn=iam_role_arn, region=region,
                                                     discard_field=discard_field, discard_regex=discard_regex,
                                                     sts_endpoint=sts_endpoint, service_endpoint=service_endpoint,
@@ -77,7 +73,7 @@ class AWSService(wazuh_integration.WazuhAWSDatabase):
         self.region = region
         self.service_name = service_name
         # get sts client (necessary for getting account ID)
-        self.sts_client = self.get_sts_client(access_key, secret_key, profile)
+        self.sts_client = self.get_sts_client(profile)
         # get account ID
         self.account_id = self.sts_client.get_caller_identity().get('Account')
         self.only_logs_after = only_logs_after

--- a/wodles/aws/services/cloudwatchlogs.py
+++ b/wodles/aws/services/cloudwatchlogs.py
@@ -25,10 +25,6 @@ class AWSCloudWatchLogs(aws_service.AWSService):
 
     Attributes
     ----------
-    access_key : str
-        AWS access key id.
-    secret_key : str
-        AWS secret access key.
     profile : str
         AWS profile.
     iam_role_arn : str
@@ -63,7 +59,7 @@ class AWSCloudWatchLogs(aws_service.AWSService):
         Query to delete a row from the DB.
     """
 
-    def __init__(self, reparse, access_key, secret_key, profile,
+    def __init__(self, reparse, profile,
                  iam_role_arn, only_logs_after, region, aws_log_groups,
                  remove_log_streams, discard_field=None, discard_regex=None, sts_endpoint=None, service_endpoint=None,
                  iam_role_duration=None, **kwargs):
@@ -135,8 +131,7 @@ class AWSCloudWatchLogs(aws_service.AWSService):
                 aws_log_stream=:aws_log_stream;"""
 
         aws_service.AWSService.__init__(self, db_table_name='cloudwatch_logs', service_name='cloudwatchlogs',
-                                        reparse=reparse, access_key=access_key, secret_key=secret_key,
-                                        profile=profile, iam_role_arn=iam_role_arn,
+                                        reparse=reparse, profile=profile, iam_role_arn=iam_role_arn,
                                         only_logs_after=only_logs_after, region=region, discard_field=discard_field,
                                         discard_regex=discard_regex, iam_role_duration=iam_role_duration,
                                         sts_endpoint=sts_endpoint, service_endpoint=service_endpoint)

--- a/wodles/aws/services/inspector.py
+++ b/wodles/aws/services/inspector.py
@@ -25,10 +25,6 @@ class AWSInspector(aws_service.AWSService):
 
     Parameters
     ----------
-    access_key : str
-        AWS access key id.
-    secret_key : str
-        AWS secret access key.
     profile : str
         AWS profile.
     iam_role_arn : str
@@ -44,15 +40,14 @@ class AWSInspector(aws_service.AWSService):
         The number of events collected and sent to analysisd.
     """
 
-    def __init__(self, reparse, access_key, secret_key, profile,
+    def __init__(self, reparse, profile,
                  iam_role_arn, only_logs_after, region, aws_log_groups=None,
                  remove_log_streams=None, discard_field=None, discard_regex=None,
                  sts_endpoint=None, service_endpoint=None, iam_role_duration=None, **kwargs):
 
         aws_service.AWSService.__init__(self, db_table_name=aws_service.DEFAULT_TABLENAME, service_name='inspector',
-                                        reparse=reparse, access_key=access_key, secret_key=secret_key,
-                                        profile=profile, iam_role_arn=iam_role_arn, only_logs_after=only_logs_after,
-                                        region=region, aws_log_groups=aws_log_groups,
+                                        reparse=reparse, profile=profile, iam_role_arn=iam_role_arn,
+                                        only_logs_after=only_logs_after, region=region, aws_log_groups=aws_log_groups,
                                         remove_log_streams=remove_log_streams, discard_field=discard_field,
                                         discard_regex=discard_regex, sts_endpoint=sts_endpoint,
                                         service_endpoint=service_endpoint, iam_role_duration=iam_role_duration)

--- a/wodles/aws/subscribers/s3_log_handler.py
+++ b/wodles/aws/subscribers/s3_log_handler.py
@@ -66,8 +66,7 @@ class AWSSubscriberBucket(wazuh_integration.WazuhIntegration, AWSS3LogHandler):
         IAM Role.
     """
     def __init__(self, service_endpoint: str = None, sts_endpoint: str = None, profile: str = None, **kwargs):
-        wazuh_integration.WazuhIntegration.__init__(self, access_key=None,
-                                                    secret_key=None,
+        wazuh_integration.WazuhIntegration.__init__(self,
                                                     profile=profile,
                                                     service_name='s3',
                                                     service_endpoint=service_endpoint,
@@ -244,10 +243,6 @@ class AWSSLSubscriberBucket(wazuh_integration.WazuhIntegration, AWSS3LogHandler)
 
     Attributes
     ----------
-    access_key : str
-        AWS access key id.
-    secret_key : str
-        AWS secret access key.
     profile : str
         AWS profile.
     iam_role_arn : str
@@ -255,8 +250,7 @@ class AWSSLSubscriberBucket(wazuh_integration.WazuhIntegration, AWSS3LogHandler)
     """
 
     def __init__(self, service_endpoint: str = None, sts_endpoint: str = None, profile: str = None, **kwargs):
-        wazuh_integration.WazuhIntegration.__init__(self, access_key=None,
-                                                    secret_key=None,
+        wazuh_integration.WazuhIntegration.__init__(self,
                                                     profile=profile,
                                                     service_name='s3',
                                                     service_endpoint=service_endpoint,

--- a/wodles/aws/subscribers/sqs_queue.py
+++ b/wodles/aws/subscribers/sqs_queue.py
@@ -26,10 +26,6 @@ class AWSSQSQueue(wazuh_integration.WazuhIntegration):
         Name of the SQS Queue.
     iam_role_arn : str
         IAM Role.
-    access_key : str
-        AWS access key id.
-    secret_key : str
-        AWS secret access key.
     external_id : str
         The name of the External ID to use.
     sts_endpoint : str
@@ -46,7 +42,7 @@ class AWSSQSQueue(wazuh_integration.WazuhIntegration):
                  sts_endpoint=None, service_endpoint=None, skip_on_error=False,
                  **kwargs):
         self.sqs_name = name
-        wazuh_integration.WazuhIntegration.__init__(self, access_key=None, secret_key=None,
+        wazuh_integration.WazuhIntegration.__init__(self,
                                                     iam_role_arn=iam_role_arn,
                                                     profile=profile, external_id=external_id, service_name='sqs',
                                                     sts_endpoint=sts_endpoint, skip_on_error=skip_on_error,

--- a/wodles/aws/tests/aws_utils.py
+++ b/wodles/aws/tests/aws_utils.py
@@ -22,8 +22,6 @@ import s3_log_handler
 
 TEST_TABLE_NAME = "cloudtrail"
 TEST_SERVICE_NAME = "s3"
-TEST_ACCESS_KEY = "test_access_key"
-TEST_SECRET_KEY = "test_secret_key"
 TEST_AWS_PROFILE = "test_aws_profile"
 TEST_IAM_ROLE_ARN = "arn:aws:iam::123455678912:role/Role"
 TEST_IAM_ROLE_DURATION = '3600'
@@ -104,7 +102,6 @@ INVALID_REGION_ERROR_CODE = 22
 
 
 def get_wazuh_integration_parameters(service_name: str = TEST_SERVICE_NAME, profile: str = TEST_AWS_PROFILE,
-                                     access_key: str = None, secret_key: str = None,
                                      iam_role_arn: str = None, region: str = None, discard_field: str = None,
                                      discard_regex: str = None, sts_endpoint: str = None, service_endpoint: str = None,
                                      iam_role_duration: str = None, external_id: str = None,
@@ -116,10 +113,6 @@ def get_wazuh_integration_parameters(service_name: str = TEST_SERVICE_NAME, prof
     ----------
     service_name : str
         Name of the service.
-    access_key : str
-        Access key value.
-    secret_key : str
-        Secret key value.
     profile : str
         AWS profile name.
     iam_role_arn : str
@@ -146,15 +139,14 @@ def get_wazuh_integration_parameters(service_name: str = TEST_SERVICE_NAME, prof
     dict
         A dict containing the configuration parameters with their default values.
     """
-    return {'service_name': service_name, 'access_key': access_key,
-            'secret_key': secret_key, 'profile': profile, 'iam_role_arn': iam_role_arn,
+    return {'service_name': service_name, 'profile': profile, 'iam_role_arn': iam_role_arn,
             'region': region, 'discard_field': discard_field, 'discard_regex': discard_regex,
             'sts_endpoint': sts_endpoint, 'service_endpoint': service_endpoint, 'iam_role_duration': iam_role_duration,
             'external_id': external_id, 'skip_on_error': skip_on_error}
 
 
 def get_wazuh_aws_database_parameters(service_name: str = TEST_SERVICE_NAME, profile: str = TEST_AWS_PROFILE,
-                                      db_name: str = TEST_DATABASE, access_key: str = None, secret_key: str = None,
+                                      db_name: str = TEST_DATABASE,
                                       iam_role_arn: str = None, region: str = None, discard_field: str = None,
                                       discard_regex: str = None, sts_endpoint: str = None, service_endpoint: str = None,
                                       iam_role_duration: str = None, external_id: str = None):
@@ -164,10 +156,6 @@ def get_wazuh_aws_database_parameters(service_name: str = TEST_SERVICE_NAME, pro
     ----------
     service_name : str
         Name of the service.
-    access_key : str
-        Access key value.
-    secret_key : str
-        Secret key value.
     profile : str
         AWS profile name.
     db_name : str
@@ -194,15 +182,14 @@ def get_wazuh_aws_database_parameters(service_name: str = TEST_SERVICE_NAME, pro
     dict
         A dict containing the configuration parameters with their default values.
     """
-    return {'service_name': service_name, 'access_key': access_key,
-            'secret_key': secret_key, 'profile': profile, 'db_name': db_name, 'iam_role_arn': iam_role_arn,
+    return {'service_name': service_name, 'profile': profile, 'db_name': db_name, 'iam_role_arn': iam_role_arn,
             'region': region, 'discard_field': discard_field, 'discard_regex': discard_regex,
             'sts_endpoint': sts_endpoint, 'service_endpoint': service_endpoint, 'iam_role_duration': iam_role_duration,
             'external_id': external_id}
 
 
 def get_aws_bucket_parameters(db_table_name: str = TEST_TABLE_NAME, bucket: str = TEST_BUCKET, reparse: bool = False,
-                              profile: str = TEST_AWS_PROFILE, access_key: str = None, secret_key: str = None,
+                              profile: str = TEST_AWS_PROFILE,
                               iam_role_arn: str = None, only_logs_after: str = None, skip_on_error: bool = False,
                               account_alias: str = None, prefix: str = "", suffix: str = "", delete_file: bool = False,
                               aws_organization_id: str = None, region: str = None, discard_field: str = None,
@@ -221,10 +208,6 @@ def get_aws_bucket_parameters(db_table_name: str = TEST_TABLE_NAME, bucket: str 
         Whether to parse already parsed logs or not.
     profile : str
         AWS profile name.
-    access_key : str
-        AWS access key id.
-    secret_key : str
-        Secret key value.
     iam_role_arn : str
         IAM Role ARN value.
     only_logs_after : str
@@ -260,7 +243,7 @@ def get_aws_bucket_parameters(db_table_name: str = TEST_TABLE_NAME, bucket: str 
         A dict containing the configuration parameters with their default values.
     """
     return {'db_table_name': db_table_name, 'bucket': bucket, 'reparse': reparse, 'profile': profile,
-            'access_key': access_key, 'secret_key': secret_key, 'iam_role_arn': iam_role_arn,
+            'iam_role_arn': iam_role_arn,
             'only_logs_after': only_logs_after, 'skip_on_error': skip_on_error, 'account_alias': account_alias,
             'prefix': prefix, 'suffix': suffix, 'delete_file': delete_file, 'aws_organization_id': aws_organization_id,
             'region': region, 'discard_field': discard_field, 'discard_regex': discard_regex,
@@ -268,7 +251,7 @@ def get_aws_bucket_parameters(db_table_name: str = TEST_TABLE_NAME, bucket: str 
 
 
 def get_aws_service_parameters(db_table_name: str = TEST_TABLE_NAME, service_name: str = 'cloudwatchlogs',
-                               reparse: bool = False, access_key: str = None, secret_key: str = None,
+                               reparse: bool = False,
                                profile: str = TEST_AWS_PROFILE, iam_role_arn: str = None,
                                only_logs_after: str = None, region: str = None, aws_log_groups: str = None,
                                remove_log_streams: bool = None, discard_field: str = None,
@@ -281,10 +264,6 @@ def get_aws_service_parameters(db_table_name: str = TEST_TABLE_NAME, service_nam
     ----------
     reparse : bool
         Whether to parse already parsed logs or not.
-    access_key : str
-        AWS access key id.
-    secret_key : str
-        AWS secret access key.
     profile : str
         AWS profile.
     iam_role_arn : str
@@ -317,8 +296,8 @@ def get_aws_service_parameters(db_table_name: str = TEST_TABLE_NAME, service_nam
     dict
         A dict containing the configuration parameters with their default values.
     """
-    return {'db_table_name': db_table_name, 'service_name': service_name, 'reparse': reparse, 'access_key': access_key,
-            'secret_key': secret_key, 'profile': profile, 'iam_role_arn': iam_role_arn,
+    return {'db_table_name': db_table_name, 'service_name': service_name, 'reparse': reparse,
+            'profile': profile, 'iam_role_arn': iam_role_arn,
             'only_logs_after': only_logs_after, 'region': region, 'aws_log_groups': aws_log_groups,
             'remove_log_streams': remove_log_streams, 'discard_field': discard_field,
             'discard_regex': discard_regex, 'sts_endpoint': sts_endpoint,

--- a/wodles/aws/tests/test_aws_service.py
+++ b/wodles/aws/tests/test_aws_service.py
@@ -36,7 +36,6 @@ def test_aws_service_initializes_properly(mock_wazuh_integration, mock_version, 
     mock_sts.return_value = mock_client
     kwargs = utils.get_aws_service_parameters(db_table_name=utils.TEST_TABLE_NAME,
                                               service_name=utils.TEST_SERVICE_NAME, reparse=True,
-                                              access_key=utils.TEST_ACCESS_KEY, secret_key=utils.TEST_SECRET_KEY,
                                               profile=utils.TEST_AWS_PROFILE, iam_role_arn=utils.TEST_IAM_ROLE_ARN,
                                               only_logs_after=utils.TEST_ONLY_LOGS_AFTER, region=utils.TEST_REGION,
                                               discard_field=utils.TEST_DISCARD_FIELD,
@@ -46,7 +45,6 @@ def test_aws_service_initializes_properly(mock_wazuh_integration, mock_version, 
                                               iam_role_duration=utils.TEST_IAM_ROLE_DURATION)
     instance = aws_service.AWSService(**kwargs)
     mock_wazuh_integration.assert_called_with(instance, service_name=utils.TEST_SERVICE_NAME,
-                                              access_key=kwargs["access_key"], secret_key=kwargs["secret_key"],
                                               profile=kwargs["profile"], iam_role_arn=kwargs["iam_role_arn"],
                                               region=kwargs["region"], discard_field=kwargs["discard_field"],
                                               discard_regex=kwargs["discard_regex"],
@@ -58,7 +56,7 @@ def test_aws_service_initializes_properly(mock_wazuh_integration, mock_version, 
     assert instance.reparse
     assert instance.region == utils.TEST_REGION
     assert instance.only_logs_after == utils.TEST_ONLY_LOGS_AFTER
-    mock_sts.assert_called_with(kwargs["access_key"], kwargs["secret_key"], kwargs["profile"])
+    mock_sts.assert_called_with(kwargs["profile"])
     mock_client.get_caller_identity.assert_called_once()
 
 

--- a/wodles/aws/tests/test_s3_log_handler.py
+++ b/wodles/aws/tests/test_s3_log_handler.py
@@ -49,7 +49,7 @@ def test_aws_sl_subscriber_bucket_initializes_properly(mock_wazuh_integration, m
 
     integration = s3_log_handler.AWSSLSubscriberBucket(**kwargs)
 
-    mock_wazuh_integration.assert_called_with(integration, access_key=None, secret_key=None,
+    mock_wazuh_integration.assert_called_with(integration,
                                               profile=None,
                                               service_name='s3',
                                               sts_endpoint=kwargs["sts_endpoint"],

--- a/wodles/aws/tests/test_sqs_queue.py
+++ b/wodles/aws/tests/test_sqs_queue.py
@@ -45,7 +45,6 @@ def test_aws_sqs_queue_initializes_properly(mock_wazuh_integration, mock_get_sqs
                                         bucket_handler=mock_bucket_log_handler_init,
                                         **kwargs)
     mock_wazuh_integration.assert_called_with(integration,
-                                              access_key=None, secret_key=None,
                                               iam_role_arn=kwargs["iam_role_arn"],
                                               profile=None,
                                               external_id=kwargs["external_id"],

--- a/wodles/aws/wazuh_integration.py
+++ b/wodles/aws/wazuh_integration.py
@@ -41,8 +41,6 @@ MESSAGE_HEADER = "1:Wazuh-AWS:"
 class WazuhIntegration:
     """
     Class with common methods.
-    :param access_key: AWS access key id.
-    :param secret_key: AWS secret access key.
     :param profile: AWS profile.
     :param iam_role_arn: IAM Role.
     :param service_name: Name of the service (s3 for services which stores logs in buckets).
@@ -52,7 +50,7 @@ class WazuhIntegration:
     :param skip_on_error: Whether to continue processing logs or stop when an error takes place.
     """
 
-    def __init__(self, access_key, secret_key, profile, iam_role_arn, service_name=None, region=None,
+    def __init__(self, profile, iam_role_arn, service_name=None, region=None,
                  discard_field=None, discard_regex=None, sts_endpoint=None,
                  service_endpoint=None, iam_role_duration=None, external_id=None, skip_on_error=False):
 
@@ -63,9 +61,7 @@ class WazuhIntegration:
         self.wazuh_wodle = path.join(self.wazuh_path, "wodles", "aws")
 
         self.connection_config = self.default_config(profile=profile)
-        self.client = self.get_client(access_key=access_key,
-                                      secret_key=secret_key,
-                                      profile=profile,
+        self.client = self.get_client(profile=profile,
                                       iam_role_arn=iam_role_arn,
                                       service_name=service_name,
                                       region=region,
@@ -186,15 +182,9 @@ class WazuhIntegration:
 
         return args
 
-    def get_client(self, access_key, secret_key, profile, iam_role_arn, service_name, region=None,
+    def get_client(self, profile, iam_role_arn, service_name, region=None,
                    sts_endpoint=None, service_endpoint=None, iam_role_duration=None, external_id=None):
         conn_args = {}
-
-        if access_key is not None and secret_key is not None:
-            print(aws_tools.DEPRECATED_MESSAGE.format(name="access_key and secret_key", release="4.4",
-                                                      url=aws_tools.CREDENTIALS_URL))
-            conn_args['aws_access_key_id'] = access_key
-            conn_args['aws_secret_access_key'] = secret_key
 
         if profile is not None:
             conn_args['profile_name'] = profile
@@ -239,13 +229,10 @@ class WazuhIntegration:
             sys.exit(3)
         return client
 
-    def get_sts_client(self, access_key, secret_key, profile=None):
+    def get_sts_client(self, profile):
         conn_args = {}
 
-        if access_key is not None and secret_key is not None:
-            conn_args['aws_access_key_id'] = access_key
-            conn_args['aws_secret_access_key'] = secret_key
-        elif profile is not None:
+        if profile is not None:
             conn_args['profile_name'] = profile
 
         boto_session = boto3.Session(**conn_args)
@@ -386,8 +373,6 @@ class WazuhAWSDatabase(WazuhIntegration):
     """
     Class with methods for buckets or services instances using db files
     :param db_name: Database name when instantiating buckets or services
-    :param access_key: AWS access key id
-    :param secret_key: AWS secret access key
     :param profile: AWS profile
     :param iam_role_arn: IAM Role
     :param db_name: Name of the database file
@@ -396,7 +381,7 @@ class WazuhAWSDatabase(WazuhIntegration):
     :param iam_role_duration: The desired duration of the session that is going to be assumed.
     :param external_id: AWS external ID for IAM Role assumption
     """
-    def __init__(self, access_key, secret_key, profile, iam_role_arn, db_name,
+    def __init__(self, profile, iam_role_arn, db_name,
                  service_name=None, region=None, discard_field=None,
                  discard_regex=None, sts_endpoint=None, service_endpoint=None, iam_role_duration=None,
                  external_id=None, skip_on_error=False):
@@ -457,8 +442,7 @@ class WazuhAWSDatabase(WazuhIntegration):
         self.sql_drop_table = "DROP TABLE {table_name};"
 
         WazuhIntegration.__init__(self, service_name=service_name,
-                                  access_key=access_key,
-                                  secret_key=secret_key, profile=profile,
+                                  profile=profile,
                                   iam_role_arn=iam_role_arn, region=region,
                                   discard_field=discard_field, discard_regex=discard_regex,
                                   sts_endpoint=sts_endpoint, service_endpoint=service_endpoint,

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -54,10 +54,6 @@ LOG_LEVELS = {0: logging.WARNING,
               1: logging.INFO,
               2: logging.DEBUG}
 
-CREDENTIALS_URL = 'https://documentation.wazuh.com/current/azure/activity-services/prerequisites/credentials.html'
-DEPRECATED_MESSAGE = 'The {name} authentication parameter was deprecated in {release}. ' \
-                     'Please use another authentication method instead. Check {url} for more information.'
-
 
 def set_logger():
     """Set the logger configuration."""
@@ -78,12 +74,6 @@ def get_script_arguments():
     group.add_argument("--storage", action="store_true", required=False, help="Activates Storage API call.")
 
     # Log Analytics arguments #
-    parser.add_argument("--la_id", metavar='ID', type=str, required=False,
-                        help="Application ID for Log Analytics authentication. "
-                             f"{DEPRECATED_MESSAGE.format(name='la_id', release='4.4', url=CREDENTIALS_URL)}")
-    parser.add_argument("--la_key", metavar="KEY", type=str, required=False,
-                        help="Application Key for Log Analytics authentication. "
-                             f"{DEPRECATED_MESSAGE.format(name='la_key', release='4.4', url=CREDENTIALS_URL)}")
     parser.add_argument("--la_auth_path", metavar="filepath", type=str, required=False,
                         help="Path of the file containing the credentials for authentication.")
     parser.add_argument("--la_tenant_domain", metavar="domain", type=str, required=False,
@@ -98,12 +88,6 @@ def get_script_arguments():
                         help="Time range for the request.")
 
     # Graph arguments #
-    parser.add_argument("--graph_id", metavar='ID', type=str, required=False,
-                        help="Application ID for Graph authentication. "
-                             f"{DEPRECATED_MESSAGE.format(name='graph_id', release='4.4', url=CREDENTIALS_URL)}")
-    parser.add_argument("--graph_key", metavar="KEY", type=str, required=False,
-                        help="Application KEY for Graph authentication. "
-                             f"{DEPRECATED_MESSAGE.format(name='graph_key', release='4.4', url=CREDENTIALS_URL)}")
     parser.add_argument("--graph_auth_path", metavar="filepath", type=str, required=False,
                         help="Path of the file containing the credentials authentication.")
     parser.add_argument("--graph_tenant_domain", metavar="domain", type=str, required=False,
@@ -116,12 +100,6 @@ def get_script_arguments():
                         help="Time range for the request.")
 
     # Storage arguments #
-    parser.add_argument("--account_name", metavar='account', type=str, required=False,
-                        help="Storage account name for authentication. "
-                             f"{DEPRECATED_MESSAGE.format(name='account_name', release='4.4', url=CREDENTIALS_URL)}")
-    parser.add_argument("--account_key", metavar='KEY', type=str, required=False,
-                        help="Storage account key for authentication. "
-                             f"{DEPRECATED_MESSAGE.format(name='account_key', release='4.4', url=CREDENTIALS_URL)}")
     parser.add_argument("--storage_auth_path", metavar="filepath", type=str, required=False,
                         help="Path of the file containing the credentials authentication.")
     parser.add_argument("--container", metavar="container", required=False, type=arg_valid_container_name,
@@ -293,10 +271,6 @@ def start_log_analytics():
     # Read credentials
     if args.la_auth_path and args.la_tenant_domain:
         client, secret = read_auth_file(auth_path=args.la_auth_path, fields=("application_id", "application_key"))
-    elif args.la_id and args.la_key and args.la_tenant_domain:
-        logging.warning(DEPRECATED_MESSAGE.format(name="la_id and la_key", release="4.4", url=CREDENTIALS_URL))
-        client = args.la_id
-        secret = args.la_key
     else:
         logging.error("Log Analytics: No parameters have been provided for authentication.")
         sys.exit(1)
@@ -470,10 +444,6 @@ def start_graph():
     # Read credentials
     if args.graph_auth_path and args.graph_tenant_domain:
         client, secret = read_auth_file(auth_path=args.graph_auth_path, fields=("application_id", "application_key"))
-    elif args.graph_id and args.graph_key and args.graph_tenant_domain:
-        logging.warning(DEPRECATED_MESSAGE.format(name="graph_id and graph_key", release="4.4", url=CREDENTIALS_URL))
-        client = args.graph_id
-        secret = args.graph_key
     else:
         logging.error("Graph: No parameters have been provided for authentication.")
         sys.exit(1)
@@ -604,10 +574,6 @@ def start_storage():
     logging.info("Storage: Authenticating.")
     if args.storage_auth_path:
         name, key = read_auth_file(auth_path=args.storage_auth_path, fields=("account_name", "account_key"))
-    elif args.account_name and args.account_key:
-        logging.warning(DEPRECATED_MESSAGE.format(name="account_name and account_key", release="4.4", url=CREDENTIALS_URL))
-        name = args.account_name
-        key = args.account_key
     else:
         logging.error("Storage: No parameters have been provided for authentication.")
         sys.exit(1)


### PR DESCRIPTION
|Related issue|
|---|
|#17975|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #17975. Removes the deprecated plain text methods for AWS and Azure integrations.
