### PR TITLE
Deletes reason field from sca_endpoints integration tests.

### DIFF
--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -539,7 +539,6 @@ stages:
               compliance: !anything
               rules: !anything
               condition: !anystr
-              reason: !anystr
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18684|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Deletes the `reason` field from expected values in the `sca_endpoints` integration test due to inconsistencies in the return JSON object.

<!--
Add a clear description of how the problem has been solved.
-->



