### PR TITLE
Fix issue with parameter in test_rootcheck_endpoints.tavern.yaml

### DIFF
--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -41,7 +41,6 @@ stages:
               log: !anystr
               date_first: !anystr
               date_last: !anystr
-              cis: !anystr
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -88,7 +87,6 @@ stages:
             - status: "{offset_item.status}"
               date_last: "{offset_item.date_last}"
               date_first: "{offset_item.date_first}"
-              cis: "{offset_item.cis}"
               log: "{offset_item.log}"
           failed_items: []
           total_affected_items: !anyint


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18045|


## Description

The `cis` parameter has been removed from the tests related to `GET /rootcheck/001` to avoid validation. When the related integration tests are executed, they pass successfully, as shown below.

## Tests

### test_rootcheck_endpoints.tavern.yaml

```
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.2.0 -- /home/wazuh/venv/api-it/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-5.19.0-46-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'metadata': '3.0.0', 'aiohttp': '1.0.4', 'html': '2.1.1', 'trio': '0.7.0', 'asyncio': '0.18.1', 'tavern': '1.23.5'}}
rootdir: /home/wazuh/Git/wazuh/api/test/integration
configfile: pytest.ini
plugins: metadata-3.0.0, aiohttp-1.0.4, html-2.1.1, trio-0.7.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 4 items                                                                                                                                                                                         

test_rootcheck_endpoints.tavern.yaml::GET /rootcheck/001 PASSED                                                                                                                                     [ 25%]
test_rootcheck_endpoints.tavern.yaml::GET /rootcheck/001/last_scan PASSED                                                                                                                           [ 50%]
test_rootcheck_endpoints.tavern.yaml::PUT /rootcheck PASSED                                                                                                                                         [ 75%]
test_rootcheck_endpoints.tavern.yaml::DELETE /rootcheck/{agent_id} PASSED                                                                                                                           [100%]
```

### test_rbac_white_rootcheck_endpoints.tavern.yaml

```
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.2.0 -- /home/wazuh/venv/api-it/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-5.19.0-46-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'metadata': '3.0.0', 'aiohttp': '1.0.4', 'html': '2.1.1', 'trio': '0.7.0', 'asyncio': '0.18.1', 'tavern': '1.23.5'}}
rootdir: /home/wazuh/Git/wazuh/api/test/integration
configfile: pytest.ini
plugins: metadata-3.0.0, aiohttp-1.0.4, html-2.1.1, trio-0.7.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 4 items                                                                                                                                                                                         

test_rbac_white_rootcheck_endpoints.tavern.yaml::GET /rootcheck PASSED                                                                                                                              [ 25%]
test_rbac_white_rootcheck_endpoints.tavern.yaml::GET /rootcheck/{agent_id}/last_scan PASSED                                                                                                         [ 50%]
test_rbac_white_rootcheck_endpoints.tavern.yaml::PUT /rootcheck PASSED                                                                                                                              [ 75%]
test_rbac_white_rootcheck_endpoints.tavern.yaml::DELETE /rootcheck/{agent_id} PASSED                                                                                                                [100%]
```

### test_rbac_black_rootcheck_endpoints.tavern.yaml

```
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.2.0 -- /home/wazuh/venv/api-it/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-5.19.0-46-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'metadata': '3.0.0', 'aiohttp': '1.0.4', 'html': '2.1.1', 'trio': '0.7.0', 'asyncio': '0.18.1', 'tavern': '1.23.5'}}
rootdir: /home/wazuh/Git/wazuh/api/test/integration
configfile: pytest.ini
plugins: metadata-3.0.0, aiohttp-1.0.4, html-2.1.1, trio-0.7.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 4 items                                                                                                                                                                                         

test_rbac_black_rootcheck_endpoints.tavern.yaml::GET /rootcheck PASSED                                                                                                                              [ 25%]
test_rbac_black_rootcheck_endpoints.tavern.yaml::DELETE /rootcheck/{agent_id} PASSED                                                                                                                [ 50%]
test_rbac_black_rootcheck_endpoints.tavern.yaml::GET /rootcheck/{agent_id}/last_scan PASSED                                                                                                         [ 75%]
test_rbac_black_rootcheck_endpoints.tavern.yaml::PUT /rootcheck PASSED                                                                                                                              [100%]
```