### PR TITLE
Add Support for requester pays in Wazuh Wodle AWS S3

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -74,7 +74,9 @@ def main(argv):
                 bucket_type = buckets_s3.server_access.AWSServerAccess
             else:
                 raise Exception("Invalid type of bucket")
-            bucket = bucket_type(reparse=options.reparse, access_key=options.access_key,
+            bucket = bucket_type(requester_pays=options.requester_pays,
+                                 reparse=options.reparse,
+                                 access_key=options.access_key,
                                  secret_key=options.secret_key,
                                  profile=options.aws_profile,
                                  iam_role_arn=options.iam_role_arn,
@@ -124,7 +126,8 @@ def main(argv):
 
                 aws_tools.debug('+++ Getting alerts from "{}" region.'.format(region), 1)
 
-                service = service_type(reparse=options.reparse,
+                service = service_type(requester_pays=options.requester_pays,
+                                       reparse=options.reparse,
                                        access_key=options.access_key,
                                        secret_key=options.secret_key,
                                        profile=options.aws_profile,


### PR DESCRIPTION
|Related issue|
|---|
| #18723 |

## Description

Adds a new option in Wazuh Wodle, which allows to set the header `x-amz-request-payer` in order to be able to access Amazon S3 buckets where "Requester Pays" is enabled.

## Configuration options

This change introduces a new configuration option for https://documentation.wazuh.com/4.5/user-manual/reference/ossec-conf/wodle-s3.html:

`requester_pays`: `bool` (default should be `False`)

## Logs/Alerts example

N/A

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors