### PR TITLE
Fix a crash in wazuh-analysisd during startup

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -809,6 +809,8 @@ int main_analysisd(int argc, char **argv)
     /* Startup message */
     minfo(STARTUP_MSG, (int)getpid());
 
+    w_init_queues();
+
     // Start com request thread
     w_create_thread(asyscom_main, NULL);
 
@@ -924,8 +926,6 @@ void OS_ReadMSG_analysisd(int m_queue)
     if (Config.custom_alert_output) {
         mdebug1("Custom output found.!");
     }
-
-    w_init_queues();
 
     int num_decode_event_threads = getDefine_Int("analysisd", "event_threads", 0, 32);
     int num_decode_syscheck_threads = getDefine_Int("analysisd", "syscheck_threads", 0, 32);


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #18736|

Currently, wazuh-analysisd follows an initialization schema like this:
1. Load the ruleset.
2. Run query dispatcher.
3. Load the MITRE data from wazuh-db.
4. Initialize internal queues.

This means that there is a period of time (between steps 2 and 4) in which it is possible to make a request for statistics while the queues are uninitialized. This can cause a crash in the process.

## Proposed fix

This PR aims to move step 4 before step 2, this way:

1. Load the ruleset.
2. Initialize internal queues.
3. Run query dispatcher.
4. Load the MITRE data from wazuh-db.

## Tests

- [X] We cannot reproduce the crash anymore.
- [X] Run wazuh-analysisd on Valgrind.

### Valgrind report

```
==17324== LEAK SUMMARY:
==17324==    definitely lost: 0 bytes in 0 blocks
==17324==    indirectly lost: 0 bytes in 0 blocks
==17324==      possibly lost: 48,960 bytes in 85 blocks
==17324==    still reachable: 22,240,408 bytes in 121,747 blocks
==17324==         suppressed: 0 bytes in 0 blocks
```