### PR TITLE
Fix Syscollector package inventory deltas.

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_delta_event.c
+++ b/src/unit_tests/wazuh_db/test_wdb_delta_event.c
@@ -473,6 +473,67 @@ void test_wdb_upsert_dbsync_default_regular_field_cannotbenull(void ** state) {
     assert_true(wdb_upsert_dbsync((wdb_t *) ANY_PTR_VALUE, &TEST_TABLE, delta));
     cJSON_Delete(delta);
 }
+
+void test_wdb_upsert_dbsync_packages_not_present_pk_field (void **state) {
+    struct column_list const TEST_FIELDS[] = {
+        // PKs.
+        {.value = {FIELD_INTEGER, 1, false, true, NULL, "test_1", {.integer = 0}, true}, .next = &TEST_FIELDS[1]},
+        { .value = { FIELD_TEXT, 2, false, true, NULL, "test_2", {.text = ""}, false}, .next = &TEST_FIELDS[2] },
+        // Regular field.
+        {.value = {FIELD_INTEGER, 3, false, false, NULL, "test_3", {.integer = 0}, true}, .next = NULL},
+    };
+
+    struct kv const TEST_TABLE = {"packages", "sys_programs", false, TEST_FIELDS};
+
+    cJSON * delta = cJSON_Parse("{\"test_1\":4321,\"test_3\":1234}");
+    will_return_always(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
+
+    will_return(__wrap_wdb_get_cache_stmt, (sqlite3_stmt *) ANY_PTR_VALUE);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, 4321);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    expect_value(__wrap_sqlite3_bind_int, index, 3);
+    expect_value(__wrap_sqlite3_bind_int, value, 1234);
+    // Not PKs or Aux fields
+    expect_value(__wrap_sqlite3_bind_int, index, 4);
+    expect_value(__wrap_sqlite3_bind_int, value, 1234);
+    will_return(__wrap_wdb_step, SQLITE_DONE);
+    assert_true(wdb_upsert_dbsync((wdb_t *) ANY_PTR_VALUE, &TEST_TABLE, delta));
+    cJSON_Delete(delta);
+}
+
+void test_wdb_upsert_dbsync_packages_null_pk_field (void **state) {
+    struct column_list const TEST_FIELDS[] = {
+        // PKs.
+        {.value = {FIELD_INTEGER, 1, false, true, NULL, "test_1", {.integer = 0}, true}, .next = &TEST_FIELDS[1]},
+        { .value = { FIELD_TEXT, 2, false, true, NULL, "test_2", {.text = ""}, false}, .next = &TEST_FIELDS[2] },
+        // Regular field.
+        {.value = {FIELD_INTEGER, 3, false, false, NULL, "test_3", {.integer = 0}, true}, .next = NULL},
+    };
+
+    struct kv const TEST_TABLE = {"packages", "sys_programs", false, TEST_FIELDS};
+
+    cJSON * delta = cJSON_Parse("{\"test_1\":4321,\"test_2\":null,\"test_3\":1234}");
+    will_return_always(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
+
+    will_return(__wrap_wdb_get_cache_stmt, (sqlite3_stmt *) ANY_PTR_VALUE);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, 4321);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    expect_value(__wrap_sqlite3_bind_int, index, 3);
+    expect_value(__wrap_sqlite3_bind_int, value, 1234);
+    // Not PKs or Aux fields
+    expect_value(__wrap_sqlite3_bind_int, index, 4);
+    expect_value(__wrap_sqlite3_bind_int, value, 1234);
+    will_return(__wrap_wdb_step, SQLITE_DONE);
+    assert_true(wdb_upsert_dbsync((wdb_t *) ANY_PTR_VALUE, &TEST_TABLE, delta));
+    cJSON_Delete(delta);
+}
+
 //
 // wdb_delete_dbsync
 //
@@ -582,6 +643,56 @@ void test_wdb_delete_dbsync_ok(void ** state) {
     cJSON_Delete(delta);
 }
 
+void test_wdb_delete_dbsync_packages_not_present_pk_field (void **state) {
+    struct column_list const TEST_FIELDS[] = {
+        // PKs.
+        {.value = {FIELD_INTEGER, 1, false, true, NULL, "test_1", {.integer = 0}, true}, .next = &TEST_FIELDS[1]},
+        { .value = { FIELD_TEXT, 2, false, true, NULL, "test_2", {.text = ""}, false}, .next = &TEST_FIELDS[2] },
+        // Regular field.
+        {.value = {FIELD_INTEGER, 3, false, false, NULL, "test_3", {.integer = 0}, true}, .next = NULL},
+    };
+
+    struct kv const TEST_TABLE = {"packages", "sys_programs", false, TEST_FIELDS};
+
+    cJSON * delta = cJSON_Parse("{\"test_1\":4321,\"test_3\":1234}");
+    will_return(__wrap_wdb_get_cache_stmt, (sqlite3_stmt *) ANY_PTR_VALUE);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, 4321);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return(__wrap_wdb_step, SQLITE_DONE);
+    assert_true(wdb_delete_dbsync((wdb_t *) ANY_PTR_VALUE, &TEST_TABLE, delta));
+    cJSON_Delete(delta);
+}
+
+void test_wdb_delete_dbsync_packages_null_pk_field (void **state) {
+    struct column_list const TEST_FIELDS[] = {
+        // PKs.
+        {.value = {FIELD_INTEGER, 1, false, true, NULL, "test_1", {.integer = 0}, true}, .next = &TEST_FIELDS[1]},
+        { .value = { FIELD_TEXT, 2, false, true, NULL, "test_2", {.text = ""}, false}, .next = &TEST_FIELDS[2] },
+        // Regular field.
+        {.value = {FIELD_INTEGER, 3, false, false, NULL, "test_3", {.integer = 0}, true}, .next = NULL},
+    };
+
+    struct kv const TEST_TABLE = {"packages", "sys_programs", false, TEST_FIELDS};
+
+    cJSON * delta = cJSON_Parse("{\"test_1\":4321,\"test_2\":null,\"test_3\":1234}");
+    will_return(__wrap_wdb_get_cache_stmt, (sqlite3_stmt *) ANY_PTR_VALUE);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, 4321);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return(__wrap_wdb_step, SQLITE_DONE);
+    assert_true(wdb_delete_dbsync((wdb_t *) ANY_PTR_VALUE, &TEST_TABLE, delta));
+    cJSON_Delete(delta);
+}
+
 /* wdb_dbsync_get_field_default */
 
 void test_wdb_dbsync_get_field_default_null(void ** state) { assert_null(wdb_dbsync_get_field_default(NULL)); }
@@ -681,10 +792,15 @@ int main() {
         cmocka_unit_test(test_wdb_upsert_dbsync_ok),
         cmocka_unit_test(test_wdb_upsert_dbsync_default_regular_field_canbenull),
         cmocka_unit_test(test_wdb_upsert_dbsync_default_regular_field_cannotbenull),
+        cmocka_unit_test(test_wdb_upsert_dbsync_packages_not_present_pk_field),
+        cmocka_unit_test(test_wdb_upsert_dbsync_packages_null_pk_field),
         /* wdb_delete_dbsync */
         cmocka_unit_test(test_wdb_delete_dbsync_err), cmocka_unit_test(test_wdb_delete_dbsync_bad_cache),
         cmocka_unit_test(test_wdb_delete_dbsync_step_nok), cmocka_unit_test(test_wdb_delete_dbsync_ok),
-        cmocka_unit_test(test_wdb_delete_dbsync_stmt_nok)};
+        cmocka_unit_test(test_wdb_delete_dbsync_stmt_nok),
+        cmocka_unit_test(test_wdb_delete_dbsync_packages_not_present_pk_field),
+        cmocka_unit_test(test_wdb_delete_dbsync_packages_null_pk_field),
+        };
 
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/wazuh_db/wdb_delta_event.c
+++ b/src/wazuh_db/wdb_delta_event.c
@@ -94,12 +94,15 @@ bool wdb_upsert_dbsync(wdb_t * wdb, struct kv const * kv_value, cJSON * data) {
                 } else {
                     field_value = cJSON_GetObjectItem(data, field_name);
                     if (NULL == field_value) {
-                        if (column->value.is_pk) {
+                        if (column->value.is_pk && 0 != strncmp(kv_value->value, "sys_programs", 12)) {
                             has_error = true;
                         } else {
                             field_value = wdb_dbsync_get_field_default(&column->value);
                             is_default = true;
                         }
+                    } else if (0 == strncmp(kv_value->value, "sys_programs", 12) && column->value.is_pk && cJSON_NULL == field_value->type) {
+                        field_value = wdb_dbsync_get_field_default(&column->value);
+                        is_default = true;
                     }
                 }
 
@@ -169,17 +172,30 @@ bool wdb_delete_dbsync(wdb_t * wdb, struct kv const * kv_value, cJSON * data) {
             bool has_error = false;
             int index = 1;
             for (column = kv_value->column_list; column && !has_error; column = column->next) {
+                bool is_default = false;
                 if (column->value.is_pk) {
                     const char * field_name = wdb_dbsync_translate_field(&column->value);
                     cJSON * field_value = cJSON_GetObjectItem(data, field_name);
                     if (NULL == field_value) {
-                        has_error = true;
-                    } else if (!wdb_dbsync_stmt_bind_from_json(stmt, index, column->value.type, field_value,
+                        if (0 != strncmp(kv_value->value, "sys_programs", 12)) {
+                            has_error = true;
+                        } else {
+                            field_value = wdb_dbsync_get_field_default(&column->value);
+                            is_default = true;
+                        }
+                    } else if (0 == strncmp(kv_value->value, "sys_programs", 12) && cJSON_NULL == field_value->type) {
+                        field_value = wdb_dbsync_get_field_default(&column->value);
+                        is_default = true;
+                    }
+                    if (!wdb_dbsync_stmt_bind_from_json(stmt, index, column->value.type, field_value,
                                                                column->value.convert_empty_string_as_null)) {
                         merror(DB_INVALID_DELTA_MSG, wdb->id, field_name, kv_value->key);
                         has_error = true;
                     }
                     ++index;
+                    if (is_default) {
+                        cJSON_Delete(field_value);
+                    }
                 }
             }
             ret_val = !has_error && SQLITE_DONE == wdb_step(stmt);

--- a/src/wazuh_db/wdb_delta_event.c
+++ b/src/wazuh_db/wdb_delta_event.c
@@ -93,14 +93,7 @@ bool wdb_upsert_dbsync(wdb_t * wdb, struct kv const * kv_value, cJSON * data) {
                     is_default = true;
                 } else {
                     field_value = cJSON_GetObjectItem(data, field_name);
-                    if (NULL == field_value) {
-                        if (column->value.is_pk && 0 != strncmp(kv_value->value, "sys_programs", 12)) {
-                            has_error = true;
-                        } else {
-                            field_value = wdb_dbsync_get_field_default(&column->value);
-                            is_default = true;
-                        }
-                    } else if (0 == strncmp(kv_value->value, "sys_programs", 12) && column->value.is_pk && cJSON_NULL == field_value->type) {
+                    if (NULL == field_value || (NULL != field_value && cJSON_NULL == field_value->type)) {
                         field_value = wdb_dbsync_get_field_default(&column->value);
                         is_default = true;
                     }
@@ -176,14 +169,7 @@ bool wdb_delete_dbsync(wdb_t * wdb, struct kv const * kv_value, cJSON * data) {
                 if (column->value.is_pk) {
                     const char * field_name = wdb_dbsync_translate_field(&column->value);
                     cJSON * field_value = cJSON_GetObjectItem(data, field_name);
-                    if (NULL == field_value) {
-                        if (0 != strncmp(kv_value->value, "sys_programs", 12)) {
-                            has_error = true;
-                        } else {
-                            field_value = wdb_dbsync_get_field_default(&column->value);
-                            is_default = true;
-                        }
-                    } else if (0 == strncmp(kv_value->value, "sys_programs", 12) && cJSON_NULL == field_value->type) {
+                    if (NULL == field_value || (NULL != field_value && cJSON_NULL == field_value->type)) {
                         field_value = wdb_dbsync_get_field_default(&column->value);
                         is_default = true;
                     }


### PR DESCRIPTION
|Related issue|
|---|
|#18714|

## Description

For old agents, it is possible to not receive a pk field in the delta information coming from the agent, or receive a null value. This PR set a default value `""` for those cases. 

## Logs/Alerts example

- Manager

[ossec.log](https://github.com/wazuh/wazuh/files/12500655/ossec.log)

- Agent 

[ossec.log](https://github.com/wazuh/wazuh/files/12500656/ossec.log)

## Dod 

- Database

<details><summary>Expand</summary>

![image](https://github.com/wazuh/wazuh/assets/13010397/770edb72-bd06-4112-b524-80c7dc5b3d35)

</details>

- API

<details><summary>Expand</summary>

![image](https://github.com/wazuh/wazuh/assets/13010397/73013acd-5410-4956-8020-7a819053d150)

</details>

- UI 

<details><summary>Expand</summary>

![image](https://github.com/wazuh/wazuh/assets/13010397/4fb87e7a-9c21-4089-a0f5-03852c3e8805)

</details>

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Added unit tests (for new features)