### PR TITLE
Fix for downloading the Debian compressed feeds

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -16209,7 +16209,7 @@ void test_wm_vuldet_json_parser_json_nvd_parser_NULL(void **state)
     expect_string(__wrap_w_uncompress_bz2_gz_file, path, "/test");
     expect_string(__wrap_w_uncompress_bz2_gz_file, dest, VU_FIT_TEMP_FILE);
     will_return(__wrap_w_uncompress_bz2_gz_file, 1);
-    
+
     will_return(__wrap_wm_vuldet_json_nvd_parser, OS_INVALID);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
@@ -18494,7 +18494,7 @@ void test_wm_vuldet_set_feed_update_url_debian(void **state)
 
     ret = wm_vuldet_set_feed_update_url(update);
     assert_true(ret);
-    assert_string_equal(update->url, "https://www.debian.org/security/oval/oval-definitions-buster.xml");
+    assert_string_equal(update->url, "https://www.debian.org/security/oval/oval-definitions-buster.xml.bz2");
 
     os_free(update->url);
     os_free(update);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -42,7 +42,7 @@
 #define VU_MSU_FILE "queue/vulnerabilities/dictionaries/msu.json"
 #define VU_CPEHELPER_FORMAT_VERSION 1
 #define CANONICAL_REPO "https://security-metadata.canonical.com/oval/com.ubuntu.%s.cve.oval.xml.bz2"
-#define DEBIAN_REPO "https://www.debian.org/security/oval/oval-definitions-%s.xml"
+#define DEBIAN_REPO "https://www.debian.org/security/oval/oval-definitions-%s.xml.bz2"
 #define DEBIAN_REPO_STATUS "https://security-tracker.debian.org/tracker/data/json"
 #define ALAS_REPO "https://feed.wazuh.com/vulnerability-detector/ALAS/1/alas.json.gz"
 #define ALAS_REPO_META "https://feed.wazuh.com/vulnerability-detector/ALAS/1/alas.meta"


### PR DESCRIPTION
|Related issue|
|---|
|#18765|

## Description

Due to the removal of the plain XML feeds, discussed in issue 12, it has been necessary to apply a fix to modify the Debian feed URL to download the compressed feeds and get the Vulnerability Detector for the Debian provider working properly again.

> The compressed feeds can be found at the following link: 
> - [Debian OVAL repository](https://www.debian.org/security/oval/)

So it has been necessary to modify the following URL in the code:
https://github.com/wazuh/wazuh/blob/a1c50b5e40764f9f583140d99c838cbfe69e1cdf/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h#L45

> An increase in CPU usage is expected as the process of decompressing the file is added.


## Configuration options

```xml
        <!-- Debian OS vulnerabilities -->
        <provider name="debian">
          <enabled>yes</enabled>
          <os>buster</os>
          <os>bullseye</os>
          <update_interval>1h</update_interval>
        </provider>
```

## Logs/Alerts example

Next, I show the logs related to what is commented in the description:

> Download and insert vulnerabilities in the database
```
2023/09/04 14:50:15 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:5179 at wm_vuldet_check_feed(): INFO: (5400): Starting 'Debian Bullseye' database update.
2023/09/04 14:50:15 wazuh-modulesd:download[5656] wm_download.c:231 at wm_download_dispatch(): DEBUG: Downloading 'https://www.debian.org/security/oval/oval-definitions-bullseye.xml.bz2' to 'tmp/req-2178667576'
2023/09/04 14:50:21 wazuh-modulesd[5656] url.c:424 at wurl_request_uncompress_bz2_gz(): DEBUG: File from URL 'https://www.debian.org/security/oval/oval-definitions-bullseye.xml.bz2' was successfully uncompressed into 'tmp/vuln-temp'
2023/09/04 14:50:21 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:4923 at wm_vuldet_fetch_oval(): DEBUG: (5407): The feed 'Debian Bullseye' is outdated. Fetching the last version.
2023/09/04 14:50:21 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:4703 at wm_vuldet_oval_process(): DEBUG: (5411): Starting preparse step of feed 'BULLSEYE'
2023/09/04 14:50:21 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:4708 at wm_vuldet_oval_process(): DEBUG: (5412): Starting parse step of feed 'BULLSEYE'
2023/09/04 14:50:22 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:4846 at wm_vuldet_index_feed(): DEBUG: (5414): Refreshing 'Debian Bullseye' databases.
2023/09/04 14:50:22 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:3243 at wm_vuldet_insert(): DEBUG: (5415): Inserting vulnerabilities.
2023/09/04 14:50:22 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:3299 at wm_vuldet_insert(): DEBUG: (5419): Inserting Debian Bullseye vulnerabilities section.
2023/09/04 14:50:22 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:2975 at wm_vuldet_index_debian(): DEBUG: (5420): Indexing vulnerabilities from the Debian Security Tracker.
2023/09/04 14:50:22 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:5257 at wm_vuldet_get_debian_status_feed(): DEBUG: (5436): Fetching Debian Security Tracker from 'tmp/vuln-temp-deb'
2023/09/04 14:50:23 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:3613 at wm_vuldet_insert(): DEBUG: (5426): Inserting 'Debian Bullseye' vulnerabilities information.
2023/09/04 14:50:23 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:4852 at wm_vuldet_index_feed(): DEBUG: (5427): Refresh of 'Debian Bullseye' database finished.
2023/09/04 14:50:23 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:4864 at wm_vuldet_index_feed(): DEBUG: remove(tmp/vuln-temp.bz2): No such file or directory
2023/09/04 14:50:23 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:5202 at wm_vuldet_check_feed(): INFO: (5430): The update of the 'Debian Bullseye' feed finished successfully.
```

> Analyzing the vulnerabilities of a Debian Bullseye agent:
```xml
2023/09/04 16:05:31 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:2779 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5491): A baseline scan will be run on agent '009'
2023/09/04 16:05:31 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:5670 at wm_vuldet_collect_agent_software(): DEBUG: (5437): Collecting agent '009' software.
wm_vuldet_check_agent_vulnerabilities(): INFO: (5450): Analyzing agent '009' vulnerabilities.
...
2023/09/04 16:05:52 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:1692 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5482): A total of '187' vulnerabilities have been reported for agent '009' thanks to the 'NVD' feed.
2023/09/04 16:05:52 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:1693 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5482): A total of '202' vulnerabilities have been reported for agent '009' thanks to the 'vendor' feed.
2023/09/04 16:05:52 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:1695 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5469): A total of '204' vulnerabilities have been reported for agent '009'
2023/09/04 16:05:52 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:1696 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5470): It took '9' seconds to 'report' vulnerabilities in agent '009'
2023/09/04 16:05:52 wazuh-modulesd:vulnerability-detector[5656] wm_vuln_detector.c:2826 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5471): Finished vulnerability assessment for agent '009'
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
