### PR TITLE
The dataprovider isn't properly managing heap memory during hardware scan on Windows - Implementation

### DIFF
--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -450,7 +450,7 @@ static std::string getSerialNumber()
                     {
                         PRawSMBIOSData smbios{reinterpret_cast<PRawSMBIOSData>(spBuff.get())};
                         // Parse SMBIOS structures
-                        ret = Utils::getSerialNumberFromSmbios(smbios->SMBIOSTableData, size);
+                        ret = Utils::getSerialNumberFromSmbios(smbios->SMBIOSTableData, smbios->Length);
                     }
                 }
             }


### PR DESCRIPTION
|Related issue|
|---|
|#18739|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes the size parameter of the call to `getSerialNumberFromSmbios()`.
The whole size of the `PRawSMBIOSData` table was being used, when the right field `Length` was required for accessing `SMBIOSTableData[]`.
This prevents a heap corruption in `memcpy()`.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

The same steps described in the issue for reproducing the exception were followed and the exception no longer occurs.
The `sysinfo` test tool gets the serial as before

![2023-09-04_23-51](https://github.com/wazuh/wazuh/assets/65046601/a93b9096-ac86-48cd-858d-230ebd96bf33)

The automated tests will be covered by:
- https://github.com/wazuh/wazuh/issues/18789

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [x] App Verifier
