### PR TITLE
Allow unparented decoders to match

### DIFF
--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -78,60 +78,58 @@ void DecodeEvent(struct _Eventinfo *lf, OSHash *rules_hash, regex_matching *deco
             child_node = node;
         }
 
-        else {
-            /* Check if we have any child osdecoder */
-            while (child_node) {
-                nnode = child_node->osdecoder;
+        /* Check if we have any child osdecoder */
+        while (child_node) {
+            nnode = child_node->osdecoder;
 
-                /* If we have a pre match and it matches, keep
-                 * going. If we don't have a prematch, stop
-                 * and go for the regexes.
-                 */
-                if (nnode->prematch) {
-                    const char *llog2;
+            /* If we have a pre match and it matches, keep
+                * going. If we don't have a prematch, stop
+                * and go for the regexes.
+                */
+            if (nnode->prematch) {
+                const char *llog2;
 
-                    /* If we have an offset set, use it */
-                    if (nnode->prematch_offset & AFTER_PARENT) {
-                        llog2 = pmatch;
-                    } else {
-                        llog2 = lf->log;
-                    }
-
-                    if (w_expression_match(nnode->prematch, llog2, &cmatch, decoder_match)) {
-
-                        if (*cmatch != '\0') {
-                            cmatch++;
-                        }
-
-                        lf->decoder_info = nnode;
-                        lf->log_after_parent = pmatch;
-                        lf->log_after_prematch = cmatch;
-
-                        break;
-                    }
+                /* If we have an offset set, use it */
+                if (nnode->prematch_offset & AFTER_PARENT) {
+                    llog2 = pmatch;
                 } else {
-                    cmatch = pmatch;
+                    llog2 = lf->log;
+                }
+
+                if (w_expression_match(nnode->prematch, llog2, &cmatch, decoder_match)) {
+
+                    if (*cmatch != '\0') {
+                        cmatch++;
+                    }
+
+                    lf->decoder_info = nnode;
+                    lf->log_after_parent = pmatch;
+                    lf->log_after_prematch = cmatch;
+
                     break;
                 }
+            } else {
+                cmatch = pmatch;
+                break;
+            }
 
-                /* If we have multiple regex-only childs,
-                 * do not attempt to go any further with them.
-                 */
-                if (child_node->osdecoder->get_next) {
-                    do {
-                        child_node = child_node->next;
-                    } while (child_node && child_node->osdecoder->get_next);
-
-                    if (!child_node) {
-                        return;
-                    }
-
+            /* If we have multiple regex-only childs,
+                * do not attempt to go any further with them.
+                */
+            if (child_node->osdecoder->get_next) {
+                do {
                     child_node = child_node->next;
-                    nnode = NULL;
-                } else {
-                    child_node = child_node->next;
-                    nnode = NULL;
+                } while (child_node && child_node->osdecoder->get_next);
+
+                if (!child_node) {
+                    return;
                 }
+
+                child_node = child_node->next;
+                nnode = NULL;
+            } else {
+                child_node = child_node->next;
+                nnode = NULL;
             }
         }
 


### PR DESCRIPTION
This fixes a logic bug in the `decoders.c` for decoders lacking a `parent`. Prior to this patch, there is no way for them to match.

|Related issue|
|---|
| n/a |

## Description

Allow unparented decoders to match.

In `DecodeEvent()`, there is a check:

```
        /* If no child node is set, set the child node
         * as if it were the child (ugh)
         */
        if (!child_node) {
            child_node = node;
        }
```

Which sets, `child_node`, but later:

```
        /* Nothing matched */
        if (!nnode) {
            return;
        }
```

However, there is nothing setting `nnode` in the case where the `child_node` is set to `node`.  This removes the else wrapper, which I believe is the original intent.

## Tests

Master doesn't build on my M1 macOS 13.5.1 host, so I can't verify these builds.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors