### PR TITLE
Pointer member variable m_logFunction in loggerHelper.h initialized i…

### DIFF
--- a/src/shared_modules/utils/loggerHelper.h
+++ b/src/shared_modules/utils/loggerHelper.h
@@ -42,7 +42,10 @@ namespace Log
             std::string m_tag;
 
         protected:
-            Logger() = default;
+            Logger()
+            {
+                m_logFunction = nullptr;
+            }
 
         public:
             ~Logger() = default;


### PR DESCRIPTION
|Related issue|
|---|
|#18894|

## Description

This PR adds initialization to member variable m_logFunction in loggerHelper.h.
