### PR TITLE
Osinfo mismatch global and agent databases.

### DIFF
--- a/src/data_provider/src/osinfo/sysOsInfoInterface.h
+++ b/src/data_provider/src/osinfo/sysOsInfoInterface.h
@@ -51,6 +51,7 @@ class SysOsInfo
             output["os_release"] = osInfoProvider->release();
             output["os_display_version"] = osInfoProvider->displayVersion();
             output["architecture"] = osInfoProvider->machine();
+            output["os_platform"] = "windows";
         }
 };
 

--- a/src/data_provider/src/osinfo/sysOsInfoWin.cpp
+++ b/src/data_provider/src/osinfo/sysOsInfoWin.cpp
@@ -199,6 +199,7 @@ static std::string getName()
     std::string name;
     static const std::string MSFT_PREFIX{"Microsoft"};
     constexpr auto SM_SERVER32_VALUE{89};//www.docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getsystemmetrics
+    //https://learn.microsoft.com/en-us/windows/win32/winprog64/example-of-registry-reflection-and-redirection-on-wow64
     Utils::Registry currentVersion{HKEY_LOCAL_MACHINE, R"(SOFTWARE\Microsoft\Windows NT\CurrentVersion)", KEY_WOW64_64KEY | KEY_READ};
 
     if (currentVersion.string("ProductName", name))

--- a/src/data_provider/src/osinfo/sysOsInfoWin.cpp
+++ b/src/data_provider/src/osinfo/sysOsInfoWin.cpp
@@ -199,7 +199,7 @@ static std::string getName()
     std::string name;
     static const std::string MSFT_PREFIX{"Microsoft"};
     constexpr auto SM_SERVER32_VALUE{89};//www.docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getsystemmetrics
-    Utils::Registry currentVersion{HKEY_LOCAL_MACHINE, R"(SOFTWARE\Microsoft\Windows NT\CurrentVersion)"};
+    Utils::Registry currentVersion{HKEY_LOCAL_MACHINE, R"(SOFTWARE\Microsoft\Windows NT\CurrentVersion)", KEY_WOW64_64KEY | KEY_READ};
 
     if (currentVersion.string("ProductName", name))
     {

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -190,8 +190,11 @@ bool UbuntuOsParser::parseFile(std::istream& in, nlohmann::json& output)
 bool CentosOsParser::parseFile(std::istream& in, nlohmann::json& output)
 {
     constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
-    output["os_name"] = "Centos Linux";
-    output["os_platform"] = "centos";
+
+    if (!output.contains("os_name")) output["os_name"] = "Centos Linux";
+
+    if (!output.contains("os_platform")) output["os_platform"] = "centos";
+
     return findVersionInStream(in, output, PATTERN_MATCH);
 }
 

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -324,21 +324,21 @@ bool FedoraOsParser::parseFile(std::istream& in, nlohmann::json& output)
 
 bool SolarisOsParser::parseFile(std::istream& in, nlohmann::json& output)
 {
-    const std::string HEADER_STRING{"Oracle Solaris "};
+    const std::string HEADER_STRING{"Solaris "};
     output["os_name"] = "SunOS";
     output["os_platform"] = "sunos";
     std::string line;
-    bool ret{false};
+    size_t pos{std::string::npos};
 
-    while (!ret && std::getline(in, line))
+    while (pos == std::string::npos && std::getline(in, line))
     {
         line = Utils::trim(line);
-        ret = Utils::startsWith(line, HEADER_STRING);
+        pos = line.find(HEADER_STRING);
 
-        if (ret)
+        if (std::string::npos != pos)
         {
-            line = line.substr(HEADER_STRING.size());
-            const auto pos{line.find(" ")};
+            line = line.substr(pos + HEADER_STRING.size());
+            pos = line.find(" ");
 
             if (pos != std::string::npos)
             {
@@ -350,7 +350,7 @@ bool SolarisOsParser::parseFile(std::istream& in, nlohmann::json& output)
         }
     }
 
-    return ret;
+    return std::string::npos == pos ? false : true;
 }
 
 bool HpUxOsParser::parseUname(const std::string& in, nlohmann::json& output)

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -115,8 +115,6 @@ TEST_F(SysInfoParsersTest, UnixArch)
     EXPECT_EQ("arch", output["os_platform"]);
 }
 
-
-
 TEST_F(SysInfoParsersTest, Ubuntu)
 {
     constexpr auto UBUNTU_RELEASE_FILE
@@ -155,6 +153,79 @@ TEST_F(SysInfoParsersTest, Centos)
     EXPECT_EQ("8", output["os_major"]);
     EXPECT_EQ("2", output["os_minor"]);
     EXPECT_EQ("2004", output["os_patch"]);
+}
+
+TEST_F(SysInfoParsersTest, CentosStream)
+{
+    constexpr auto CENTOS_STREAM_RELEASE_FILE
+    {
+        "NAME=\"CentOS Stream\"\n"
+        "VERSION=\"9\"\n"
+        "ID=\"centos\"\n"
+        "ID_LIKE=\"rhel fedora\"\n"
+        "VERSION_ID=\"9\"\n"
+        "PLATFORM_ID=\"platform:el9\"\n"
+        "PRETTY_NAME=\"CentOS Stream 9\"\n"
+        "ANSI_COLOR=\"0;31\"\n"
+        "LOGO=\"fedora-logo-icon\"\n"
+        "CPE_NAME=\"cpe:/o:centos:centos:9\"\n"
+        "HOME_URL=\"https://centos.org/\"\n"
+        "BUG_REPORT_URL=\"https://bugzilla.redhat.com/\"\n"
+        "REDHAT_SUPPORT_PRODUCT=\"Red Hat Enterprise Linux 9\"\n"
+        "REDHAT_SUPPORT_PRODUCT_VERSION=\"CentOS Stream\"\n"
+    };
+    nlohmann::json output;
+    std::stringstream info{CENTOS_STREAM_RELEASE_FILE};
+    const auto spParser1{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser1->parseFile(info, output));
+    info.clear();
+    info.seekg(0, std::ios::beg);
+    info << CENTOS_STREAM_RELEASE_FILE;
+    const auto spParser2{FactorySysOsParser::create("centos")};
+    EXPECT_FALSE(spParser2->parseFile(info, output));
+    EXPECT_EQ("9", output["os_major"]);
+    EXPECT_EQ("CentOS Stream", output["os_name"]);
+    EXPECT_EQ("centos", output["os_platform"]);
+    EXPECT_EQ("9", output["os_version"]);
+}
+
+TEST_F(SysInfoParsersTest, CentosBased)
+{
+    constexpr auto ROCKY_LINUX_RELEASE_FILE
+    {
+        "NAME=\"Rocky Linux\"\n"
+        "VERSION=\"8.8 (Green Obsidian)\"\n"
+        "ID=\"rocky\"\n"
+        "ID_LIKE=\"rhel centos fedora\"\n"
+        "VERSION_ID=\"8.8\"\n"
+        "PLATFORM_ID=\"platform:el8\"\n"
+        "PRETTY_NAME=\"Rocky Linux 8.8 (Green Obsidian)\"\n"
+        "ANSI_COLOR=\"0;32\"\n"
+        "LOGO=\"fedora-logo-icon\"\n"
+        "CPE_NAME=\"cpe:/o:rocky:rocky:8:GA\"\n"
+        "HOME_URL=\"https://rockylinux.org/\"\n"
+        "BUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\n"
+        "SUPPORT_END=\"2029-05-31\"\n"
+        "ROCKY_SUPPORT_PRODUCT=\"Rocky-Linux-8\"\n"
+        "ROCKY_SUPPORT_PRODUCT_VERSION=\"8.8\"\n"
+        "REDHAT_SUPPORT_PRODUCT=\"Rocky Linux\"\n"
+        "REDHAT_SUPPORT_PRODUCT_VERSION=\"8.8\"\n"
+    };
+    nlohmann::json output;
+    std::stringstream info{ROCKY_LINUX_RELEASE_FILE};
+    const auto spParser1{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser1->parseFile(info, output));
+    info.clear();
+    info.seekg(0, std::ios::beg);
+    info << ROCKY_LINUX_RELEASE_FILE;
+    const auto spParser2{FactorySysOsParser::create("centos")};
+    EXPECT_TRUE(spParser2->parseFile(info, output));
+    EXPECT_EQ("Green Obsidian", output["os_codename"]);
+    EXPECT_EQ("8", output["os_major"]);
+    EXPECT_EQ("8", output["os_minor"]);
+    EXPECT_EQ("Rocky Linux", output["os_name"]);
+    EXPECT_EQ("rocky", output["os_platform"]);
+    EXPECT_EQ("8.8", output["os_version"]);
 }
 
 TEST_F(SysInfoParsersTest, BSDFreeBSD)
@@ -224,7 +295,6 @@ TEST_F(SysInfoParsersTest, RedHatFedora)
     EXPECT_EQ("22", output["os_major"]);
 }
 
-
 TEST_F(SysInfoParsersTest, RedHatServer)
 {
     constexpr auto REDHAT_RELEASE_FILE
@@ -259,7 +329,6 @@ TEST_F(SysInfoParsersTest, RedHatLinux)
     EXPECT_EQ("Taroon Update 4", output["os_codename"]);
     EXPECT_EQ("3", output["os_major"]);
 }
-
 
 TEST_F(SysInfoParsersTest, Debian)
 {

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -409,6 +409,27 @@ TEST_F(SysInfoParsersTest, Solaris1)
     EXPECT_EQ("10", output["os_major"]);
 }
 
+TEST_F(SysInfoParsersTest, Solaris2)
+{
+    constexpr auto SOLARIS_VERSION_FILE
+    {
+        R"(
+                            Solaris 10 5/09 s10x_u7wos_08 X86
+           Copyright 2009 Sun Microsystems, Inc. All rights reserved.
+                                Use is subject to license terms.
+                                Assembled 17 January 2013
+        )"
+    };
+    nlohmann::json output;
+    std::stringstream info{SOLARIS_VERSION_FILE};
+    const auto spParser{FactorySysOsParser::create("solaris")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("10", output["os_version"]);
+    EXPECT_EQ("SunOS", output["os_name"]);
+    EXPECT_EQ("sunos", output["os_platform"]);
+    EXPECT_EQ("10", output["os_major"]);
+}
+
 TEST_F(SysInfoParsersTest, HPUX)
 {
     // https://docstore.mik.ua/manuals/hp-ux/en/5992-4826/pr01s02.html

--- a/src/shared/remoted_op.c
+++ b/src/shared/remoted_op.c
@@ -75,7 +75,7 @@ void parse_uname_string (char *uname,
         }
 
         // Get os_build
-        if (w_regexec("^[0-9]+\\.[0-9]+\\.([0-9]+)\\.*", str_tmp, 2, match)) {
+        if (w_regexec("^[0-9]+\\.[0-9]+\\.([0-9]+(\\.[0-9]+)*)\\.*", str_tmp, 2, match)) {
             match_size = match[1].rm_eo - match[1].rm_so;
             os_malloc(match_size +1, osd->os_build);
             snprintf(osd->os_build, match_size + 1, "%.*s", match_size, str_tmp + match[1].rm_so);

--- a/src/unit_tests/shared/test_remoted_op.c
+++ b/src/unit_tests/shared/test_remoted_op.c
@@ -128,7 +128,7 @@ void test_get_os_arch_armv7(void **state)
 
 // Tests parse_uname_string
 
-void test_parse_uname_string_windows(void **state)
+void test_parse_uname_string_windows1(void **state)
 {
     char *uname = NULL;
     os_strdup("Microsoft Windows 10 Enterprise [Ver: 10.0.14393]", uname);
@@ -147,6 +147,38 @@ void test_parse_uname_string_windows(void **state)
     assert_string_equal("windows", osd->os_platform);
     assert_null(osd->os_arch);
     assert_string_equal("Microsoft Windows 10 Enterprise", uname);
+
+    os_free(osd->os_name);
+    os_free(osd->os_major);
+    os_free(osd->os_minor);
+    os_free(osd->os_build);
+    os_free(osd->os_version);
+    os_free(osd->os_codename);
+    os_free(osd->os_platform);
+    os_free(osd->os_arch);
+    os_free(osd);
+    os_free(uname);
+}
+
+void test_parse_uname_string_windows2(void **state)
+{
+    char *uname = NULL;
+    os_strdup("Microsoft Windows Server 2019 Datacenter Evaluation [Ver: 10.0.17763.1935]", uname);
+
+    os_data *osd = NULL;
+    os_calloc(1, sizeof(os_data), osd);
+
+    parse_uname_string(uname, osd);
+
+    assert_string_equal("Microsoft Windows Server 2019 Datacenter Evaluation", osd->os_name);
+    assert_string_equal("10", osd->os_major);
+    assert_string_equal("0", osd->os_minor);
+    assert_string_equal("17763.1935", osd->os_build);
+    assert_string_equal("10.0.17763.1935", osd->os_version);
+    assert_null(osd->os_codename);
+    assert_string_equal("windows", osd->os_platform);
+    assert_null(osd->os_arch);
+    assert_string_equal("Microsoft Windows Server 2019 Datacenter Evaluation", uname);
 
     os_free(osd->os_name);
     os_free(osd->os_major);
@@ -532,7 +564,8 @@ int main()
         cmocka_unit_test_setup_teardown(test_get_os_arch_armv6, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_get_os_arch_armv7, setup_remoted_op, teardown_remoted_op),
         // Tests parse_uname_string
-        cmocka_unit_test_setup_teardown(test_parse_uname_string_windows, setup_remoted_op, teardown_remoted_op),
+        cmocka_unit_test_setup_teardown(test_parse_uname_string_windows1, setup_remoted_op, teardown_remoted_op),
+        cmocka_unit_test_setup_teardown(test_parse_uname_string_windows2, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_uname_string_linux, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_uname_string_macos, setup_remoted_op, teardown_remoted_op),
         // Tests parse_agent_update_msg


### PR DESCRIPTION
|Related issue|
|---|
|#18784|

## Description

This PR fixes the OS info mismatch between global and agent databases and Solaris OS parsing prior to Oracle acquisition as well. 

## DoD

Windows 

32 bits

<details><summary>Expand</summary>

![2023-09-07_09-55](https://github.com/wazuh/wazuh/assets/13010397/fd878f41-f871-4039-a7d1-32529d6c59bb)

</details>

64 bits

<details><summary>Expand</summary>

![2023-09-07_09-58](https://github.com/wazuh/wazuh/assets/13010397/41c20cad-449c-4194-9e34-2baccfe63e76)

</details>

Linux 

<details><summary>Expand</summary>

![image](https://github.com/wazuh/wazuh/assets/13010397/37f93883-5460-4258-8788-401fca3576a3)
![image](https://github.com/wazuh/wazuh/assets/13010397/1abc78f5-a307-4a05-a381-dd85af1c5ddd)

</details>

## Update (09/12/23)

### test_start_agent

<details><summary>Expand</summary>

![image](https://github.com/wazuh/wazuh/assets/13010397/764c77c9-500f-4420-9b70-03714e9d3a3e)

</details>

### About exploratory

- Common 

  <details><summary>Expand</summary>

  - The empty `os_platform` value was fixed for data provider by setting a default value "windows"
  - These values are considered for Linux only
    ```
      sysname is empty in the agent DB
      release is empty in the agent DB
      version is empty in the agent DB
    ```
  - The `os_arch` information requires changes in the keepalive message and will be addressed later. 
    Windows example 
    ```
    Microsoft Windows XP Professional Service Pack 3 [Ver: 5.1.2600] - Wazuh v4.5.3 / ab73af41699f13fdd81903b5f23d8d00
    4a8724b20dee0124ff9656783c490c4e merged.mg
    #"_agent_ip":192.168.56.205
    ```
    Linux example
    ```
    Linux |rocky8 |4.18.0-477.13.1.el8_8.x86_64 |#1 SMP Tue May 30 22:15:39 UTC 2023 |x86_64 [Rocky Linux|rocky: 8.8 (Green Obsidian)] - Wazuh v4.5.0 / ab73af41699f13fdd81903b5f23d8d00
    4a8724b20dee0124ff9656783c490c4e merged.mg
    #"_agent_ip":10.0.2.15
    ```
  - The `os_build` now will consider a value like "123.456"
  
   </details>

- Windows XP 
  
  <details><summary>Expand</summary>

  This seems to be the only case where we are not seeing the edition in the data provider, the service pack version is included in another field. I didn't expect to have an identical string after this fix. For Windows Vista and 7, we do have the edition in the `os_name` field
  
  ![image](https://github.com/wazuh/wazuh/assets/13010397/e0764bb3-2f57-411f-b19c-31b2d9523c0e)

  </details>

- Windows 10 

  <details><summary>Expand</summary>
  
  ![image](https://github.com/wazuh/wazuh/assets/13010397/80b58004-bd4b-4ea6-b7b0-572fbc3e4a8e)

  </details>

- Windows Server 2019

  <details><summary>Expand</summary>
  
  ![image](https://github.com/wazuh/wazuh/assets/13010397/421353e6-65c1-47d6-8765-2b5532cb5451)

  </details>

- Windows 11

  <details><summary>Expand</summary>
  
  ![image](https://github.com/wazuh/wazuh/assets/13010397/9c2c8c2e-6d7b-4e6a-a309-0d1dd62d1f15)

  </details>


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
- [X] Source installation
- [X] Source upgrade
- [x] Added unit tests (for new features)