### PR TITLE
Fix plain format file validation in 4.6.0

### DIFF
--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -113,7 +113,7 @@ def get_ossec_logs(limit: int = 2000) -> list:
     logs = []
 
     log_format = get_wazuh_active_logging_format()
-    if log_format == LoggingFormat.plain and exists(common.WAZUH_LOG_JSON):
+    if log_format == LoggingFormat.plain and exists(common.WAZUH_LOG):
         wazuh_log_content = tail(common.WAZUH_LOG, limit)
     elif log_format == LoggingFormat.json and exists(common.WAZUH_LOG_JSON):
         wazuh_log_content = tail(common.WAZUH_LOG_JSON, limit)


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/18939 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Backports the changes from https://github.com/wazuh/wazuh/pull/17946 to 4.6.0.

### Tests

<details><summary>test_manager_endpoints</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_manager_endpoints.tavern.yaml
====================================================== test session starts ======================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 32 items                                                                                                              

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                            [  3%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                              [  6%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                   [  9%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                     [ 12%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                  [ 15%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                  [ 18%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                  [ 21%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                   [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                  [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                   [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                  [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                      [ 43%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                 [ 46%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                             [ 50%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED                   [ 53%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                     [ 56%]
test_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                     [ 59%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                             [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                      [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                      [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                   [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                     [ 75%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                              [ 78%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                      [ 81%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                        [ 84%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                     [ 87%]
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED                                                   [ 90%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                         [ 93%]
test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                     [ 96%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                           [100%]

========================================== 32 passed, 2 warnings in 111.56s (0:01:51) ===========================================
```

</details>


<details><summary>test_rbac_black_manager_endpoints</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_rbac_black_manager_endpoints.tavern.yaml
====================================================== test session starts ======================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 16 items                                                                                                              

test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                          [  6%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration/validation PASSED                               [ 12%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED              [ 18%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                   [ 25%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                   [ 31%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                           [ 37%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                          [ 43%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                  [ 50%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                        [ 56%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                           [ 62%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                          [ 68%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                           [ 75%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                 [ 81%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                             [ 87%]
test_rbac_black_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                          [ 93%]
test_rbac_black_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                [100%]

========================================== 16 passed, 2 warnings in 358.82s (0:05:58) ===========================================
```

</details>


<details><summary>test_rbac_white_manager_endpoints</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_rbac_white_manager_endpoints.tavern.yaml
====================================================== test session starts ======================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 16 items                                                                                                              

test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                          [  6%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration/validation PASSED                               [ 12%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED              [ 18%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                   [ 25%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                   [ 31%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                           [ 37%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                          [ 43%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                  [ 50%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                        [ 56%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                           [ 62%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                          [ 68%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                           [ 75%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                 [ 81%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                             [ 87%]
test_rbac_white_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                          [ 93%]
test_rbac_white_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                [100%]

========================================== 16 passed, 2 warnings in 104.59s (0:01:44) ===========================================
```

</details>