### PR TITLE
Restore test case marked as xfail

### DIFF
--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -513,8 +513,7 @@ stages:
 test_name: GET /sca/{agent_id}/checks/{policy_id}
 
 stages:
-  - &get_policy_id
-    name: Get policy ID
+  - name: Get policy ID
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/001"
@@ -600,8 +599,7 @@ stages:
           expected_condition_command: data.affected_items[0].condition
           expected_command_command: data.affected_items[0].command
 
-  - &get_item_file_field
-    name: Get item with the file field (q="rules.type=file")
+  - name: Get item with the file field (q="rules.type=file")
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
@@ -995,27 +993,25 @@ stages:
           failed_items: [ ]
           total_failed_items: 0
 
-#  - name: Get SCA checks filtering by remediation
-#    request:
-#      verify: False
-#      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
-#      method: GET
-#      headers:
-#        Authorization: "Bearer {test_login_token}"
-#      params:
-#        remediation: "{expected_remediation_file:s}"
-#    response:
-#      status_code: 200
-#      json:
-#        error: 0
-#        data:
-#          affected_items:
-#            - <<: *sca_check_result_001_file
-#          total_affected_items: !anyint
-#          failed_items: [ ]
-#          total_failed_items: 0
-
-  # select tests
+  - name: Get SCA checks filtering by remediation
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        remediation: "{expected_remediation_file:s}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_check_result_001_file
+          total_affected_items: !anyint
+          failed_items: [ ]
+          total_failed_items: 0
 
   - name: Get SCA checks filtering by rationale
     request:
@@ -1033,37 +1029,6 @@ stages:
         data:
           affected_items:
             - <<: *sca_check_result_001_command
-          total_affected_items: !anyint
-          failed_items: [ ]
-          total_failed_items: 0
-
----
-test_name: GET /sca/{agent_id}/checks/{policy_id}?remediation
-
-marks:
-  - xfail # Getting SCA check filtering by remediation fails with some values - https://github.com/wazuh/wazuh/issues/15465
-
-stages:
-  - *get_policy_id
-
-  - *get_item_file_field
-
-  - name: Get SCA checks filtering by remediation
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        remediation: "{expected_remediation_file:s}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *sca_check_result_001_file
           total_affected_items: !anyint
           failed_items: [ ]
           total_failed_items: 0


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/18945 |

## Description

Restores the changes made in https://github.com/wazuh/wazuh/pull/15466 to mark the test case as XFAIL.

## Tests

<details><summary>test_sca_endpoints.tavern.yaml</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_sca_endpoints.tavern.yaml
============================== test session starts ===============================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 45 items                                                               

test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} for agents with Wazuh version >=4.2.0 (001) and <4.2.0 (006) PASSED [  2%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[policy_id] PASSED [  4%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[name] PASSED [  6%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[description] PASSED [  8%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[references] PASSED [ 11%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[pass] PASSED [ 13%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[fail] PASSED [ 15%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[score] PASSED [ 17%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[invalid] PASSED [ 20%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[total_checks] PASSED [ 22%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[hash_file] PASSED [ 24%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[end_scan] PASSED [ 26%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized)[start_scan] PASSED [ 28%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[policy_id] PASSED [ 31%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[name] PASSED [ 33%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[description] PASSED [ 35%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[references] PASSED [ 37%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[pass] PASSED [ 40%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[fail] PASSED [ 42%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[score] PASSED [ 44%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[invalid] PASSED [ 46%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[total_checks] PASSED [ 48%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[hash_file] PASSED [ 51%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[end_scan] PASSED [ 53%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id} using select (parametrized) and distinct[start_scan] PASSED [ 55%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} PASSED                                             [ 57%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[policy_id] PASSED [ 60%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[remediation] PASSED [ 62%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[condition] PASSED [ 64%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[rules.rule] PASSED [ 66%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[rationale] PASSED [ 68%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[id] PASSED [ 71%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[command] PASSED [ 73%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[title] PASSED [ 75%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[reason] PASSED [ 77%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[description] PASSED [ 80%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[registry] PASSED [ 82%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[process] PASSED [ 84%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[rules.type] PASSED [ 86%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[file] PASSED [ 88%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[compliance.value] PASSED [ 91%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[directory] PASSED [ 93%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[result] PASSED [ 95%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[compliance.key] PASSED [ 97%]
test_sca_endpoints.tavern.yaml::GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)[references] PASSED [100%]

========================================== 45 passed, 2 warnings in 427.01s (0:07:07) ===========================================
```

</details>
