### PR TITLE
Fix to check function output in case of error

### DIFF
--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -754,7 +754,9 @@ int UnmergeFiles(const char *finalpath, const char *optdir, int mode, const char
         }
 
         /* Mv to original name */
-        rename_ex(tmp_file, final_name);
+        if (rename_ex(tmp_file, final_name) != 0) {
+            ret = 0;
+        }
 
         if (unmerged_files != NULL) {
             /* Removes path from file name */

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -755,7 +755,9 @@ int UnmergeFiles(const char *finalpath, const char *optdir, int mode, const char
 
         /* Mv to original name */
         if (rename_ex(tmp_file, final_name) != 0) {
+            unlink(tmp_file);
             ret = 0;
+            break;
         }
 
         if (unmerged_files != NULL) {


### PR DESCRIPTION
|Related issue|
|---|
|#18896|


## Description

With this PR, we avoid the bug reported by Coverity, because it was not checking the return value of the `rename_ex` function, which tells you if the action has been performed correctly or if there is an error when executing the `rename`.

|Snapshot ID|Coverity version|Platform|Total detected|Newly detected|Newly eliminated|
|---|---|---|---|---|---|
|🔴|1567823|Unchecked return value|Medium|September 7, 2023|Shared|#8309|**#18896**|

-> `Fixed`

## Coverity report

- https://scan9.scan.coverity.com/reports.htm#v55589/p12779
 - Snapshot ID: `70941`
![image](https://github.com/wazuh/wazuh/assets/37207742/f4d6d61f-924e-430c-b989-d657a3c9a31e)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation


<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
