### PR TITLE
AIX agent compilation is failing due to RTLD_NOLOAD flag - Implementation

### DIFF
--- a/src/headers/sym_load.h
+++ b/src/headers/sym_load.h
@@ -22,7 +22,8 @@ void* so_get_module_handle_on_path(const char *path, const char *so);
 void* so_get_module_handle(const char *so);
 /**
  * @brief Check if a module/library is already loaded. Must call a corresponding so_free_library()
- * if not used in WIN32.
+ * if not used in WIN32. If RTLD_NOLOAD isn't found in the system,
+ * the behavior is the same than so_get_module_handle().
  *
  * @param so The name of the module/library to check.
  * @return void* A handle to module if it is already loaded, NULL otherwise.

--- a/src/shared/sym_load.c
+++ b/src/shared/sym_load.c
@@ -1,6 +1,14 @@
 #include <stdio.h>
 #include "sym_load.h"
 
+#ifndef WIN32
+#ifdef RTLD_NOLOAD
+#define W_RTLD_NOLOAD RTLD_NOLOAD
+#else
+#define W_RTLD_NOLOAD 0x0
+#endif // RTLD_NOLOAD
+#endif // WIN32
+
 void* so_get_module_handle_on_path(const char *path, const char *so){
 #ifdef WIN32
     char file_name[MAX_PATH] = { 0 };
@@ -58,7 +66,7 @@ void* so_check_module_loaded(const char *so){
 #else
     snprintf(file_name, 4096-1, "lib%s.so", so);
 #endif
-    return dlopen(file_name, RTLD_NOLOAD | RTLD_LAZY);
+    return dlopen(file_name, W_RTLD_NOLOAD | RTLD_LAZY);
 #endif
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #18860|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR covers the case when the non-POSIX flag `RTLD_NOLOAD` isn't found in the system.
In that specific case, the behavior of the method that checks if a library is loaded is the same than the method that loads a library.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

Now the compilation is succesfull

![2023-09-11_23-52](https://github.com/wazuh/wazuh/assets/65046601/67d0be54-2077-4a92-ba61-5e511d3e64b1)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation


**Important**

After installing the agent, a runtime error was found. It'll be fixed in another issue (#18980)
![2023-09-11_23-53](https://github.com/wazuh/wazuh/assets/65046601/3640188c-307b-4bbf-b846-3946f2f5124d)


