### PR TITLE
Fix Azure Storage blob skipping condition

### DIFF
--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -49,7 +49,7 @@ DATETIME_MASK = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 # Logger parameters
 LOGGING_MSG_FORMAT = '%(asctime)s azure: %(levelname)s: %(message)s'
-LOGGING_DATE_FORMAT = '%Y/%m/%d %I:%M:%S'
+LOGGING_DATE_FORMAT = '%Y/%m/%d %H:%M:%S'
 LOG_LEVELS = {0: logging.WARNING,
               1: logging.INFO,
               2: logging.DEBUG}
@@ -709,13 +709,13 @@ def get_blobs(
             if blob.properties.content_length == 0:
                 logging.debug(f"Empty blob {blob.name}, skipping")
                 continue
-            # Skip the blob if nested under prefix but prefix is not set
-            if prefix is None and len(blob.name.split("/")) > 1:
-                logging.debug(f"Skipped blob {blob.name}, nested under prefix but prefix is not set")
+            # Skip the blob if nested under the set prefix
+            if prefix is not None and len(blob.name.split("/")) > 2:
+                logging.debug(f"Skipped blob {blob.name}, nested under set prefix {prefix}")
                 continue
             # Skip the blob if its name has not the expected format
             if args.blobs and args.blobs not in blob.name:
-                logging.debug(f"Skipped blob, name {blob.name} does not match with {args.blob}")
+                logging.debug(f"Skipped blob, name {blob.name} does not match with the format '{args.blobs}'")
                 continue
 
             # Skip the blob if already processed

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -707,12 +707,15 @@ def get_blobs(
         for blob in blobs:
             # Skip if the blob is empty
             if blob.properties.content_length == 0:
+                logging.debug(f"Empty blob {blob.name}, skipping")
                 continue
-            # Skip the blob if nested under prefix but prefix is not setted
+            # Skip the blob if nested under prefix but prefix is not set
             if prefix is None and len(blob.name.split("/")) > 1:
+                logging.debug(f"Skipped blob {blob.name}, nested under prefix but prefix is not set")
                 continue
             # Skip the blob if its name has not the expected format
             if args.blobs and args.blobs not in blob.name:
+                logging.debug(f"Skipped blob, name {blob.name} does not match with {args.blob}")
                 continue
 
             # Skip the blob if already processed


### PR DESCRIPTION
|Related issue|
|---|
| #18936 |

## Description

Closes #18936. It modifies the condition taken into account by the Azure Storage `get_blobs` method to skip a blob. If a prefix is set, only the logs inside the path will be processed, and nested blobs inside of it will be skipped.
It also adds debugging messages for the blob skip cases and modifies the logging format since the hours were in a 12-hour clock format.

## Tests

Manual tests can be found in [this issue comment](https://github.com/wazuh/wazuh/issues/18936#issuecomment-1716303867).

### Unit tests

```
====================================================================== test session starts ======================================================================
platform linux -- Python 3.9.18, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh
plugins: cov-3.0.0, aiohttp-1.0.4, trio-0.7.0, anyio-3.6.2, metadata-2.0.2, html-3.0.0, asyncio-0.18.1
asyncio: mode=auto
collected 147 items                                                                                                                                             

wodles/azure/tests/test_azure.py ....................................................................................................................     [ 78%]
wodles/azure/tests/test_orm.py ...............................                                                                                            [100%]

================================================================ 147 passed, 1 warning in 0.63s =================================================================
```