### PR TITLE
Improve EPS metrics

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2477,6 +2477,10 @@ components:
                   type: integer
                   format: int32
                   description: "Events discarded because the EPS limit was reached and queues were full"
+                events_dropped_not_eps:
+                  type: integer
+                  format: int32
+                  description: "Events discarded due to causes unrelated to EPS limit"
                 seconds_over_limit:
                   type: integer
                   format: int32

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2473,6 +2473,10 @@ components:
                   type: integer
                   format: int32
                   description: "Available credits to process events in the current timeframe"
+                available_credits_prev:
+                  type: integer
+                  format: int32
+                  description: "Available credits to process events in the previous timeframe"
                 events_dropped:
                   type: integer
                   format: int32

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1405,6 +1405,8 @@ void * ad_input_main(void * args) {
                             mdebug2("Queues are full and no EPS credits, dropping events.");
                         }
                         w_inc_eps_events_dropped();
+                    } else {
+                        w_inc_eps_events_dropped_not_eps();
                     }
                 } else {
                     w_inc_eps_events_dropped();

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -998,6 +998,7 @@ void OS_ReadMSG_analysisd(int m_queue)
     if (!analysisd_limits->enabled && !Config.eps.maximum_found && analysisd_limits->timeframe > 0) {
         mwarn("The EPS maximum value is missing in the configuration block.");
     }
+    w_set_available_credits_prev(Config.eps.maximum * Config.eps.timeframe);
 
     /* Create message handler thread */
     w_create_thread(ad_input_main, &m_queue);
@@ -1076,9 +1077,11 @@ void OS_ReadMSG_analysisd(int m_queue)
     while (1) {
         sleep(1);
 
-        if (limit_reached(analysisd_limits, NULL)) {
+        unsigned int credits = 0;
+        if (limit_reached(analysisd_limits, &credits)) {
             w_inc_eps_seconds_over_limit();
         }
+        w_set_available_credits_prev(credits);
 
         update_limits(analysisd_limits);
     }
@@ -1397,7 +1400,7 @@ void * ad_input_main(void * args) {
 
             if (result == -1) {
                 if (!reported_eps_drop) {
-                    if (limit_reached(analysisd_limits,NULL)) {
+                    if (limit_reached(analysisd_limits, NULL)) {
                         reported_eps_drop = 1;
                         if (!reported_eps_drop_hourly) {
                             mwarn("Queues are full and no EPS credits, dropping events.");

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -1425,6 +1425,12 @@ void w_inc_eps_events_dropped() {
     w_mutex_unlock(&state_mutex);
 }
 
+void w_inc_eps_events_dropped_not_eps() {
+    w_mutex_lock(&state_mutex);
+    analysisd_state.eps_state_breakdown.events_dropped_not_eps++;
+    w_mutex_unlock(&state_mutex);
+}
+
 void w_inc_eps_seconds_over_limit() {
     w_mutex_lock(&state_mutex);
     analysisd_state.eps_state_breakdown.seconds_over_limit++;
@@ -1470,6 +1476,7 @@ cJSON* asys_create_state_json() {
 
         cJSON_AddNumberToObject(_eps, "available_credits", available_credits);
         cJSON_AddNumberToObject(_eps, "events_dropped", state_cpy.eps_state_breakdown.events_dropped);
+        cJSON_AddNumberToObject(_eps, "events_dropped_not_eps", state_cpy.eps_state_breakdown.events_dropped_not_eps);
         cJSON_AddNumberToObject(_eps, "seconds_over_limit", state_cpy.eps_state_breakdown.seconds_over_limit);
     }
 

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -1437,6 +1437,12 @@ void w_inc_eps_seconds_over_limit() {
     w_mutex_unlock(&state_mutex);
 }
 
+void w_set_available_credits_prev(unsigned int credits) {
+    w_mutex_lock(&state_mutex);
+    analysisd_state.eps_state_breakdown.available_credits_prev = credits;
+    w_mutex_unlock(&state_mutex);
+}
+
 cJSON* asys_create_state_json() {
     analysisd_state_t state_cpy;
     queue_status_t queue_cpy;
@@ -1475,6 +1481,7 @@ cJSON* asys_create_state_json() {
         limit_reached(analysisd_limits, &available_credits);
 
         cJSON_AddNumberToObject(_eps, "available_credits", available_credits);
+        cJSON_AddNumberToObject(_eps, "available_credits_prev", state_cpy.eps_state_breakdown.available_credits_prev);
         cJSON_AddNumberToObject(_eps, "events_dropped", state_cpy.eps_state_breakdown.events_dropped);
         cJSON_AddNumberToObject(_eps, "events_dropped_not_eps", state_cpy.eps_state_breakdown.events_dropped_not_eps);
         cJSON_AddNumberToObject(_eps, "seconds_over_limit", state_cpy.eps_state_breakdown.seconds_over_limit);

--- a/src/analysisd/state.h
+++ b/src/analysisd/state.h
@@ -104,6 +104,7 @@ typedef struct _written_t {
 } written_t;
 
 typedef struct _eps_state_t {
+    uint64_t available_credits_prev;
     uint64_t events_dropped;
     uint64_t events_dropped_not_eps;
     uint64_t seconds_over_limit;
@@ -490,6 +491,12 @@ void w_inc_eps_events_dropped_not_eps();
  * @brief Increment seconds over eps limit
  */
 void w_inc_eps_seconds_over_limit();
+
+/**
+ * @brief Set available credits from previous interval
+ * @param credits Credits from previous interval
+ */
+void w_set_available_credits_prev(unsigned int credits);
 
 /**
  * @brief Create a JSON object with all the analysisd state information

--- a/src/analysisd/state.h
+++ b/src/analysisd/state.h
@@ -105,6 +105,7 @@ typedef struct _written_t {
 
 typedef struct _eps_state_t {
     uint64_t events_dropped;
+    uint64_t events_dropped_not_eps;
     uint64_t seconds_over_limit;
 } eps_state_t;
 
@@ -479,6 +480,11 @@ void w_inc_stats_written();
  * @brief Increment events dropped by eps
  */
 void w_inc_eps_events_dropped();
+
+/**
+ * @brief Increment events dropped by causes unrelated to eps
+ */
+void w_inc_eps_events_dropped_not_eps();
 
 /**
  * @brief Increment seconds over eps limit

--- a/src/headers/limits_op.h
+++ b/src/headers/limits_op.h
@@ -36,21 +36,21 @@ limits_t *init_limits(unsigned int eps, unsigned int timeframe);
 
 /**
  * @brief Update and validate limits
- * 
+ *
  * @param limits Pointer to the limits_t struct.
  */
 void update_limits(limits_t *limits);
 
 /**
  * @brief Get a credit to process an event
- * 
+ *
  * @param limits Pointer to the limits_t struct.
  */
 void get_eps_credit(limits_t *limits);
 
 /**
  * @brief Check if the limit has been reached
- * 
+ *
  * @param limits Pointer to the limits_t struct.
  * @param value store the current available credits
  * @return true if limit reached, false otherwise

--- a/src/shared/limits_op.c
+++ b/src/shared/limits_op.c
@@ -54,7 +54,7 @@ limits_t *init_limits(unsigned int eps, unsigned int timeframe) {
         limits->enabled = false;
         minfo("EPS limit disabled");
     }
-    
+
     return limits;
 }
 

--- a/src/unit_tests/analysisd/test_analysis-state.c
+++ b/src/unit_tests/analysisd/test_analysis-state.c
@@ -108,6 +108,7 @@ static int test_setup(void ** state) {
     analysisd_state.eps_state_breakdown.events_dropped = 552;
     analysisd_state.eps_state_breakdown.events_dropped_not_eps = 120;
     analysisd_state.eps_state_breakdown.seconds_over_limit = 1254;
+    analysisd_state.eps_state_breakdown.available_credits_prev = 12;
 
     decode_queue_syscheck_input = queue_init(4096);
     decode_queue_syscollector_input = queue_init(4096);
@@ -322,6 +323,9 @@ void test_asys_create_state_json(void ** state) {
 
     assert_non_null(cJSON_GetObjectItem(eps, "available_credits"));
     assert_int_equal(cJSON_GetObjectItem(eps, "available_credits")->valueint, 31);
+
+    assert_non_null(cJSON_GetObjectItem(eps, "available_credits_prev"));
+    assert_int_equal(cJSON_GetObjectItem(eps, "available_credits_prev")->valueint, 12);
 
     assert_non_null(cJSON_GetObjectItem(eps, "events_dropped"));
     assert_int_equal(cJSON_GetObjectItem(eps, "events_dropped")->valueint, 552);

--- a/src/unit_tests/analysisd/test_analysis-state.c
+++ b/src/unit_tests/analysisd/test_analysis-state.c
@@ -106,6 +106,7 @@ static int test_setup(void ** state) {
     analysisd_state.events_written_breakdown.stats_written = 564;
     analysisd_state.events_written_breakdown.archives_written = 4200;
     analysisd_state.eps_state_breakdown.events_dropped = 552;
+    analysisd_state.eps_state_breakdown.events_dropped_not_eps = 120;
     analysisd_state.eps_state_breakdown.seconds_over_limit = 1254;
 
     decode_queue_syscheck_input = queue_init(4096);
@@ -324,6 +325,9 @@ void test_asys_create_state_json(void ** state) {
 
     assert_non_null(cJSON_GetObjectItem(eps, "events_dropped"));
     assert_int_equal(cJSON_GetObjectItem(eps, "events_dropped")->valueint, 552);
+
+    assert_non_null(cJSON_GetObjectItem(eps, "events_dropped_not_eps"));
+    assert_int_equal(cJSON_GetObjectItem(eps, "events_dropped_not_eps")->valueint, 120);
 
     assert_non_null(cJSON_GetObjectItem(eps, "seconds_over_limit"));
     assert_int_equal(cJSON_GetObjectItem(eps, "seconds_over_limit")->valueint, 1254);

--- a/src/unit_tests/wrappers/wazuh/shared/limits_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/limits_op_wrappers.c
@@ -14,7 +14,7 @@
 #include <cmocka.h>
 #include "limits_op_wrappers.h"
 
-bool __wrap_limit_reached(void *limits, unsigned int *value) {
+bool __wrap_limit_reached(__attribute__((unused)) void *limits, unsigned int *value) {
     *value = mock_type(unsigned int);
     return mock_type(bool);
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18539|

## Description

This PR includes 2 new metrics for EPS control:

- `events_dropped_not_eps`: To identify dropped events for reasons not related to EPS.
- `available_credits_prev`: Available (or remaining) credits from the previous interval analyzed.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Configuration on demand reports new parameters
- [x] Added unit tests (for new features)