### PR TITLE
Ignored Syscheck event is shown with mdebug instead of warning

### DIFF
--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -410,7 +410,7 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
                                             changed_attributes);
 
             if (cJSON_GetArraySize(changed_attributes) == 0) {
-                mwarn(FIM_EMPTY_CHANGED_ATTRIBUTES, path);
+                mdebug2(FIM_EMPTY_CHANGED_ATTRIBUTES, path);
                 goto end;
             }
         }
@@ -816,7 +816,7 @@ void fim_event_callback(void* data, void * ctx)
 
         cJSON *changed_attributes = cJSON_GetObjectItem(data_json, "changed_attributes");
         if (changed_attributes && cJSON_GetArraySize(changed_attributes) == 0) {
-            mwarn(FIM_EMPTY_CHANGED_ATTRIBUTES, path);
+            mdebug2(FIM_EMPTY_CHANGED_ATTRIBUTES, path);
             return;
         }
 

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -178,7 +178,7 @@ static void registry_key_transaction_callback(ReturnTypeCallback resultType,
                                             old_attributes);
 
         if (cJSON_GetArraySize(changed_attributes) == 0) {
-            mwarn(FIM_EMPTY_CHANGED_ATTRIBUTES, path);
+            mdebug2(FIM_EMPTY_CHANGED_ATTRIBUTES, path);
             goto end;
         }
     }
@@ -322,7 +322,7 @@ static void registry_value_transaction_callback(ReturnTypeCallback resultType,
                                               old_attributes);
 
         if (cJSON_GetArraySize(changed_attributes) == 0) {
-            mwarn(FIM_EMPTY_CHANGED_ATTRIBUTES, path);
+            mdebug2(FIM_EMPTY_CHANGED_ATTRIBUTES, path);
             goto end;
         }
     }

--- a/src/unit_tests/syscheckd/registry/test_registry.c
+++ b/src/unit_tests/syscheckd/registry/test_registry.c
@@ -863,7 +863,7 @@ static void test_fim_registry_key_transaction_callback_empty_changed_attributes(
     const cJSON *result_json = cJSON_Parse("{\"new\":{\"path\":\"HKEY_LOCAL_MACHINE\\\\Software\\\\Classes\\\\batfile\",\"arch\":\"[x64]\",\"last_event\":12345, \"hash_full_path\":\"234567890ABCDEF1234567890ABCDEF123456111\"},\"old\":{\"path\":\"HKEY_LOCAL_MACHINE\\\\Software\\\\Classes\\\\batfile\", \"arch\":\"[x64]\"}}");
     fim_key_txn_context_t user_data = {.key = &key, .evt_data = &event_data};
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6954): Entry 'HKEY_LOCAL_MACHINE\\Software\\Classes\\batfile' does not have any modified fields. No event will be generated.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6954): Entry 'HKEY_LOCAL_MACHINE\\Software\\Classes\\batfile' does not have any modified fields. No event will be generated.");
 
     registry_key_transaction_callback(resultType, result_json, &user_data);
 }
@@ -969,7 +969,7 @@ static void test_fim_registry_value_transaction_callback_empty_changed_attribute
     const cJSON *result_json = cJSON_Parse("{\"new\":{\"path\":\"HKEY_LOCAL_MACHINE\\\\Software\\\\Classes\\\\batfile\",\"arch\":\"[x64]\",\"name\":\"mock_name_value\",\"last_event\":12345, \"hash_full_path\":\"234567890ABCDEF1234567890ABCDEF123456111\"},\"old\":{\"path\":\"HKEY_LOCAL_MACHINE\\\\Software\\\\Classes\\\\batfile\", \"arch\":\"[x64]\",\"name\":\"mock_name_value\"}}");
     fim_val_txn_context_t user_data = {.data = &value, .evt_data = &event_data, .diff = NULL};
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6954): Entry 'HKEY_LOCAL_MACHINE\\Software\\Classes\\batfile' does not have any modified fields. No event will be generated.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6954): Entry 'HKEY_LOCAL_MACHINE\\Software\\Classes\\batfile' does not have any modified fields. No event will be generated.");
 
     registry_value_transaction_callback(resultType, result_json, &user_data);
 }

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -3821,9 +3821,9 @@ static void test_transaction_callback_modify_empty_changed_attributes(void **sta
 #endif
 
 #ifndef TEST_WINAGENT
-    expect_string(__wrap__mwarn, formatted_msg, "(6954): Entry '/etc/a_test_file.txt' does not have any modified fields. No event will be generated.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6954): Entry '/etc/a_test_file.txt' does not have any modified fields. No event will be generated.");
 #else
-    expect_string(__wrap__mwarn, formatted_msg, "(6954): Entry 'c:\\windows\\a_test_file.txt' does not have any modified fields. No event will be generated.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6954): Entry 'c:\\windows\\a_test_file.txt' does not have any modified fields. No event will be generated.");
 #endif
     transaction_callback(MODIFIED, result, txn_context);
     assert_int_equal(txn_context->evt_data->type, FIM_MODIFICATION);
@@ -4044,7 +4044,7 @@ static void test_fim_event_callback_empty_changed_attributes(void **state) {
     cJSON_AddArrayToObject(data, "changed_attributes");
     cJSON_AddItemToObject(json_event, "data", data);
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6954): Entry '/path/to/file' does not have any modified fields. No event will be generated.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6954): Entry '/path/to/file' does not have any modified fields. No event will be generated.");
 
     fim_event_callback(json_event, &callback_ctx);
 


### PR DESCRIPTION
…gerous

|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18967|


## Description

This PR is to modify the type of log message that is displayed when a syscheck event that comes with an empty modified attributes field is to be ignored.

It is because this is expected behavior during communication with dbsync, so it is not a danger to be aware of and should be a debug message for developers.

## Logs/Alerts example

`wazuh-agent DEBUG: (6954): Entry 'c:\\test\\file1' does not have any modified fields. No event will be generated.`

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
