### PR TITLE
Show original exception message for the RBAC corrupted database error

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -296,8 +296,8 @@ class DistributedAPI:
                     data = await asyncio.wait_for(task, timeout=timeout)
                 except asyncio.TimeoutError:
                     raise exception.WazuhInternalError(3021)
-                except OperationalError:
-                    raise exception.WazuhInternalError(2008)
+                except OperationalError as exc:
+                    raise exception.WazuhInternalError(2008, extra_message=str(exc.orig))
                 except process.BrokenProcessPool:
                     raise exception.WazuhInternalError(901)
             except json.decoder.JSONDecodeError:


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/18900 |

## Description

Adds sqlite exception messages to the API internal error response `2008` to give users more context about what has failed.

## Logs/Alerts example

Before

```json
{
    "title": "Wazuh Internal Error",
    "detail": "Corrupted RBAC database",
    "remediation": "Restart the Wazuh service to restore the RBAC database to default",
    "dapi_errors": {
        "node01": {
            "error": "Corrupted RBAC database",
            "logfile": "WAZUH_HOME/logs/api.log"
        }
    },
    "error": 2008
}
```

After

```json
{
    "title": "Wazuh Internal Error",
    "detail": "Corrupted RBAC database: database or disk is full",
    "remediation": "Restart the Wazuh service to restore the RBAC database to default",
    "dapi_errors": {
        "node01": {
            "error": "Corrupted RBAC database: database or disk is full",
            "logfile": "WAZUH_HOME/logs/api.log"
        }
    },
    "error": 2008
}
```