### PR TITLE
Add unit test to the indexer connector module

### DIFF
--- a/src/shared_modules/indexer_connector/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/CMakeLists.txt
@@ -47,4 +47,4 @@ set_target_properties(indexer_connector PROPERTIES
 )
 
 add_subdirectory(testtool)
-#add_subdirectory(tests)
+add_subdirectory(tests)

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -13,6 +13,8 @@
 #include "HTTPRequest.hpp"
 #include "shared_modules/indexer_connector/src/serverSelector.hpp"
 
+// TODO: remove the LCOV flags when the implementation of this class is completed
+// LCOV_EXCL_START
 std::unordered_map<IndexerConnector*, std::unique_ptr<ThreadDispatchQueue>> QUEUE_MAP;
 constexpr auto DATABASE_WORKERS = 1;
 
@@ -75,3 +77,4 @@ void IndexerConnector::publish(const std::string& message)
 {
     QUEUE_MAP[this]->push(message);
 }
+// LCOV_EXCL_STOP

--- a/src/shared_modules/indexer_connector/src/monitoring.hpp
+++ b/src/shared_modules/indexer_connector/src/monitoring.hpp
@@ -142,7 +142,7 @@ public:
                                     }
                                     else
                                     {
-                                        value.second = false;
+                                        value.second = false; // LCOV_EXCL_LINE
                                     }
                                 },
                                 [&](const std::string& error, const long /*statusCode*/) { value.second = false; });

--- a/src/shared_modules/indexer_connector/tests/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.12.4)
+
+include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
+include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
+include_directories(${SRC_FOLDER}/shared_modules/indexer_connector/include/)
+include_directories(${SRC_FOLDER}/shared_modules/indexer_connector/src/)
+
+link_directories(${SRC_FOLDER}/external/googletest/lib/)
+
+add_subdirectory(unit)

--- a/src/shared_modules/indexer_connector/tests/unit/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/tests/unit/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.12.4)
+
+project(indexer_connector_unit_tests)
+
+file(GLOB SOURCES
+        *.cpp
+)
+
+add_executable(${PROJECT_NAME} ${SOURCES})
+
+target_link_libraries(${PROJECT_NAME}
+        urlrequest
+        gtest
+        gtest_main
+        indexer_connector
+)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
@@ -64,8 +64,10 @@ public:
                      [this](const httplib::Request& req, httplib::Response& res)
                      {
                          std::stringstream ss;
-                         ss << "1694645550 22:52:30 opensearch-cluster " << m_health << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
-                         ss << "1694645550 22:52:30 opensearch-cluster " << m_health << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
+                         ss << "1694645550 22:52:30 opensearch-cluster " << m_health
+                            << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
+                         ss << "1694645550 22:52:30 opensearch-cluster " << m_health
+                            << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
                          res.set_content(ss.str(), "text/plain");
                      });
         m_server.set_keep_alive_max_count(1);

--- a/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
@@ -19,6 +19,9 @@
 #include <thread>
 #include <utility>
 
+/**
+ * @brief This class is a simple HTTP server that provides a fake OpenSearch server.
+ */
 class FakeOpenSearchServer
 {
 private:

--- a/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
@@ -70,16 +70,16 @@ public:
      */
     void run()
     {
-        m_server.Get("/_cat/health",
-                     [this](const httplib::Request& req, httplib::Response& res)
-                     {
-                         std::stringstream ss;
-                         ss << "1694645550 22:52:30 opensearch-cluster " << m_health
-                            << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
-                         ss << "1694645550 22:52:30 opensearch-cluster " << m_health
-                            << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
-                         res.set_content(ss.str(), "text/plain");
-                     });
+        m_server.Get(
+            "/_cat/health",
+            [this](const httplib::Request& req, httplib::Response& res)
+            {
+                std::stringstream ss;
+                ss << "epoch      timestamp cluster            status node.total node.data discovered_cluster_manager "
+                      "shards pri relo init unassign pending_tasks max_task_wait_time active_shards_percent\n";
+                ss << "1694645550 22:52:30 opensearch-cluster " << m_health << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
+                res.set_content(ss.str(), "text/plain");
+            });
         m_server.set_keep_alive_max_count(1);
         m_server.listen(m_host.c_str(), m_port);
     }

--- a/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
@@ -29,6 +29,13 @@ private:
     int m_port;
 
 public:
+    /**
+     * @brief Class constructor.
+     *
+     * @param host host of the fake OpenSearch server.
+     * @param port port of the fake OpenSearch server
+     * @param health health status of the fake OpenSearch server.
+     */
     FakeOpenSearchServer(std::string host, int port, std::string health = "green")
         : m_thread(&FakeOpenSearchServer::run, this)
         , m_host(std::move(host))

--- a/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
@@ -1,0 +1,76 @@
+/*
+ * Wazuh Indexer Connector - Fake OpenSearch Server
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 08, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _FAKE_OPEN_SEARCH_SERVER_HPP
+#define _FAKE_OPEN_SEARCH_SERVER_HPP
+
+#include <external/cpp-httplib/httplib.h>
+#include <external/nlohmann/json.hpp>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+
+class FakeOpenSearchServer
+{
+private:
+    httplib::Server m_server;
+    std::thread m_thread;
+    std::string m_host;
+    std::string m_health;
+    int m_port;
+
+public:
+    FakeOpenSearchServer(std::string host, int port, std::string health = "green")
+        : m_thread(&FakeOpenSearchServer::run, this)
+        , m_host(std::move(host))
+        , m_health(std::move(health))
+        , m_port(port)
+    {
+        // Wait until server is ready
+        while (!m_server.is_running())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+
+    ~FakeOpenSearchServer()
+    {
+        m_server.stop();
+        if (m_thread.joinable())
+        {
+            m_thread.join();
+        }
+    }
+
+    /**
+     * @brief Starts the server and listens for new connections.
+     *
+     * Setups a fake OpenSearch endpoint, configures the server and starts listening
+     * for new connections.
+     *
+     */
+    void run()
+    {
+        m_server.Get("/_cat/health",
+                     [this](const httplib::Request& req, httplib::Response& res)
+                     {
+                         std::stringstream ss;
+                         ss << "1694645550 22:52:30 opensearch-cluster " << m_health << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
+                         ss << "1694645550 22:52:30 opensearch-cluster " << m_health << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
+                         res.set_content(ss.str(), "text/plain");
+                     });
+        m_server.set_keep_alive_max_count(1);
+        m_server.listen(m_host.c_str(), m_port);
+    }
+};
+
+#endif // _FAKE_OPEN_SEARCH_SERVER_HPP

--- a/src/shared_modules/indexer_connector/tests/unit/main.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/main.cpp
@@ -1,0 +1,18 @@
+/*
+ * Wazuh - Indexer connector unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 08, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
@@ -1,0 +1,105 @@
+/*
+ * Wazuh Indexer Connector - Monitoring tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 08, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "monitoring_test.hpp"
+#include "monitoring.hpp"
+#include <chrono>
+#include <memory>
+#include <thread>
+
+/**
+ * @brief Test instantiation and check the availability of valid servers.
+ * 
+*/
+TEST_F(MonitoringTest, TestInstantiationWithValidServers)
+{
+    const auto hostGreenServer {m_servers.at(0)};
+    const auto hostRedServer {m_servers.at(1)};
+
+    EXPECT_NO_THROW(m_monitoring = std::make_shared<Monitoring>(m_servers));
+
+    // All servers are available the first time.
+    EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServer));
+    EXPECT_TRUE(m_monitoring->isAvailable(hostRedServer));
+
+    // Interval to check the health of the servers
+    std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
+
+    // It's true because the green server is available
+    EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServer));
+
+    // It's false because the red server isn't available
+    EXPECT_FALSE(m_monitoring->isAvailable(hostRedServer));
+}
+
+/**
+ * @brief Test instantiation without servers.
+ * 
+*/
+TEST_F(MonitoringTest, TestInstantiationWithoutServers)
+{
+    m_servers.clear();
+
+    // It doesn't throw an exception because the class Monitoring accepts vector without servers
+    EXPECT_NO_THROW(m_monitoring = std::make_shared<Monitoring>(m_servers));
+}
+
+/**
+ * @brief Test instantiation and check the availability of an invalid server.
+ * 
+*/
+TEST_F(MonitoringTest, TestInvalidServer)
+{
+    const auto invalidServer {"http://localhost:9400"};
+
+    m_servers.clear();
+    m_servers.emplace_back(invalidServer);
+
+    EXPECT_NO_THROW(m_monitoring = std::make_shared<Monitoring>(m_servers));
+
+    // All servers are available the first time
+    EXPECT_TRUE(m_monitoring->isAvailable(invalidServer));
+
+    // Interval to check the health of the servers
+    std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
+
+    // It's false because the server isn't valid
+    EXPECT_FALSE(m_monitoring->isAvailable(invalidServer));
+}
+
+/**
+ * @brief Test instantiation and check the availability of an unregustered server.
+ * 
+*/
+TEST_F(MonitoringTest, TestCheckIfAnUnregisteredServerIsAvailable)
+{
+    const auto unregisteredServer {"http://localhost:9400"};
+    const auto hostGreenServer {m_servers.at(0)};
+    const auto hostRedServer {m_servers.at(1)};
+
+    EXPECT_NO_THROW(m_monitoring = std::make_shared<Monitoring>(m_servers));
+
+    // All servers are available the first time
+    EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServer));
+    EXPECT_TRUE(m_monitoring->isAvailable(hostRedServer));
+
+    // Interval to check the health of the servers
+    std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
+
+    // It's true because the green server is available
+    EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServer));
+
+    // It's false because the red server isn't available
+    EXPECT_FALSE(m_monitoring->isAvailable(hostRedServer));
+
+    // It throws an exception because this is an unregistered server
+    EXPECT_THROW(m_monitoring->isAvailable(unregisteredServer), std::out_of_range);
+}

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
@@ -15,6 +15,9 @@
 #include <memory>
 #include <thread>
 
+// Healt check interval for the servers
+constexpr auto MONITORING_HEALTH_CHECK_INTERVAL {INTERVAL};
+
 /**
  * @brief Test instantiation and check the availability of valid servers.
  *
@@ -31,7 +34,7 @@ TEST_F(MonitoringTest, TestInstantiationWithValidServers)
     EXPECT_TRUE(m_monitoring->isAvailable(hostRedServer));
 
     // Interval to check the health of the servers
-    std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
+    std::this_thread::sleep_for(std::chrono::seconds(MONITORING_HEALTH_CHECK_INTERVAL + 5));
 
     // It's true because the green server is available
     EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServer));
@@ -69,7 +72,7 @@ TEST_F(MonitoringTest, TestInvalidServer)
     EXPECT_TRUE(m_monitoring->isAvailable(invalidServer));
 
     // Interval to check the health of the servers
-    std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
+    std::this_thread::sleep_for(std::chrono::seconds(MONITORING_HEALTH_CHECK_INTERVAL + 5));
 
     // It's false because the server isn't valid
     EXPECT_FALSE(m_monitoring->isAvailable(invalidServer));
@@ -92,7 +95,7 @@ TEST_F(MonitoringTest, TestCheckIfAnUnregisteredServerIsAvailable)
     EXPECT_TRUE(m_monitoring->isAvailable(hostRedServer));
 
     // Interval to check the health of the servers
-    std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
+    std::this_thread::sleep_for(std::chrono::seconds(MONITORING_HEALTH_CHECK_INTERVAL + 5));
 
     // It's true because the green server is available
     EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServer));

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
@@ -17,8 +17,8 @@
 
 /**
  * @brief Test instantiation and check the availability of valid servers.
- * 
-*/
+ *
+ */
 TEST_F(MonitoringTest, TestInstantiationWithValidServers)
 {
     const auto hostGreenServer {m_servers.at(0)};
@@ -42,8 +42,8 @@ TEST_F(MonitoringTest, TestInstantiationWithValidServers)
 
 /**
  * @brief Test instantiation without servers.
- * 
-*/
+ *
+ */
 TEST_F(MonitoringTest, TestInstantiationWithoutServers)
 {
     m_servers.clear();
@@ -54,8 +54,8 @@ TEST_F(MonitoringTest, TestInstantiationWithoutServers)
 
 /**
  * @brief Test instantiation and check the availability of an invalid server.
- * 
-*/
+ *
+ */
 TEST_F(MonitoringTest, TestInvalidServer)
 {
     const auto invalidServer {"http://localhost:9400"};
@@ -77,8 +77,8 @@ TEST_F(MonitoringTest, TestInvalidServer)
 
 /**
  * @brief Test instantiation and check the availability of an unregustered server.
- * 
-*/
+ *
+ */
 TEST_F(MonitoringTest, TestCheckIfAnUnregisteredServerIsAvailable)
 {
     const auto unregisteredServer {"http://localhost:9400"};

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
@@ -76,7 +76,7 @@ TEST_F(MonitoringTest, TestInvalidServer)
 }
 
 /**
- * @brief Test instantiation and check the availability of an unregustered server.
+ * @brief Test instantiation and check the availability of an unregistered server.
  *
  */
 TEST_F(MonitoringTest, TestCheckIfAnUnregisteredServerIsAvailable)

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.hpp
@@ -1,0 +1,75 @@
+/*
+ * Wazuh Indexer Connector - Monitoring tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 08, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _MONITORING_TEST_HPP
+#define _MONITORING_TEST_HPP
+
+#include "fakeOpenSearchServer.hpp"
+#include "monitoring.hpp"
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+/**
+ * @brief Runs unit tests for Monitoring class
+ */
+class MonitoringTest : public ::testing::Test
+{
+protected:
+    inline static std::unique_ptr<FakeOpenSearchServer> m_fakeOpenSearchGreenServer; ///< pointer to FakeOpenSearchServer class
+
+    inline static std::unique_ptr<FakeOpenSearchServer> m_fakeOpenSearchRedServer; ///< pointer to FakeOpenSearchServer class
+
+    std::shared_ptr<Monitoring> m_monitoring; ///< pointer to Monitoring class
+
+    std::vector<std::string> m_servers; ///< Servers
+
+    /**
+     * @brief Sets initial conditions for each test case.
+     */
+    // cppcheck-suppress unusedFunction
+    void SetUp() override
+    {
+        // Register the host and port of the green server
+        m_servers.emplace_back("http://localhost:9201");
+        // Register the host and port of the red server
+        m_servers.emplace_back("http://localhost:9202");
+    }
+
+    /**
+     * @brief Creates the fakeOpenSearchServers for the runtime of the test suite
+     */
+    // cppcheck-suppress unusedFunction
+    static void SetUpTestSuite()
+    {
+        if (!m_fakeOpenSearchGreenServer)
+        {
+            m_fakeOpenSearchGreenServer = std::make_unique<FakeOpenSearchServer>("localhost", 9201);
+        }
+        if (!m_fakeOpenSearchRedServer)
+        {
+            m_fakeOpenSearchRedServer = std::make_unique<FakeOpenSearchServer>("localhost", 9202, "red");
+        }
+    }
+
+    /**
+     * @brief Resets fakeOpenSearchServers causing the shutdown of the test server.
+     */
+    // cppcheck-suppress unusedFunction
+    static void TearDownTestSuite()
+    {
+        m_fakeOpenSearchGreenServer.reset();
+        m_fakeOpenSearchRedServer.reset();
+    }
+};
+
+#endif // _MONITORING_TEST_HPP

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.hpp
@@ -25,9 +25,11 @@
 class MonitoringTest : public ::testing::Test
 {
 protected:
-    inline static std::unique_ptr<FakeOpenSearchServer> m_fakeOpenSearchGreenServer; ///< pointer to FakeOpenSearchServer class
+    inline static std::unique_ptr<FakeOpenSearchServer>
+        m_fakeOpenSearchGreenServer; ///< pointer to FakeOpenSearchServer class
 
-    inline static std::unique_ptr<FakeOpenSearchServer> m_fakeOpenSearchRedServer; ///< pointer to FakeOpenSearchServer class
+    inline static std::unique_ptr<FakeOpenSearchServer>
+        m_fakeOpenSearchRedServer; ///< pointer to FakeOpenSearchServer class
 
     std::shared_ptr<Monitoring> m_monitoring; ///< pointer to Monitoring class
 

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
@@ -16,6 +16,9 @@
 #include <string>
 #include <thread>
 
+// Healt check interval for the servers
+constexpr auto SERVER_SELECTOR_HEALTH_CHECK_INTERVAL {INTERVAL};
+
 /**
  * @brief Test instantiation with valid servers.
  *
@@ -81,7 +84,7 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeAndAfterHealthCheck)
     EXPECT_EQ(nextServer, hostRedServer);
 
     // Interval to check the health of the servers
-    std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
+    std::this_thread::sleep_for(std::chrono::seconds(SERVER_SELECTOR_HEALTH_CHECK_INTERVAL + 5));
 
     // next server will be the green because it's available
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
@@ -112,7 +115,7 @@ TEST_F(ServerSelectorTest, TestGextNextWhenThereAreNoAvailableServers)
     EXPECT_EQ(nextServer, hostRedServer);
 
     // Interval to check the health of the servers
-    std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
+    std::this_thread::sleep_for(std::chrono::seconds(SERVER_SELECTOR_HEALTH_CHECK_INTERVAL + 5));
 
     // It throws an exception because there are no available servers
     EXPECT_THROW(nextServer = m_selector->getNext(), std::runtime_error);

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
@@ -46,18 +46,17 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeHealthCheck)
     const auto hostGreenServer {m_servers.at(0)};
     const auto hostRedServer {m_servers.at(1)};
 
-    std::string nextGreenServer;
-    std::string nextRedServer;
+    std::string nextServer;
 
     EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
 
-    // It doesn't thrown and exception because all servers are available before health check
-    EXPECT_NO_THROW(nextGreenServer = m_selector->getNext());
-    EXPECT_EQ(nextGreenServer, hostGreenServer);
+    // It doesn't thrown an exception because all servers are available before health check
+    EXPECT_NO_THROW(nextServer = m_selector->getNext());
+    EXPECT_EQ(nextServer, hostGreenServer);
 
-    // It doesn't thrown and exception because all servers are available before health check
-    EXPECT_NO_THROW(nextRedServer = m_selector->getNext());
-    EXPECT_EQ(nextRedServer, hostRedServer);
+    // It doesn't thrown an exception because all servers are available before health check
+    EXPECT_NO_THROW(nextServer = m_selector->getNext());
+    EXPECT_EQ(nextServer, hostRedServer);
 }
 
 /**
@@ -69,29 +68,28 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeAndAfterHealthCheck)
     const auto hostGreenServer {m_servers.at(0)};
     const auto hostRedServer {m_servers.at(1)};
 
-    std::string nextGreenServer;
-    std::string nextRedServer;
+    std::string nextServer;
 
     EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
 
-    // It doesn't thrown and exception because all servers are available before health check
-    EXPECT_NO_THROW(nextGreenServer = m_selector->getNext());
-    EXPECT_EQ(nextGreenServer, hostGreenServer);
+    // It doesn't thrown an exception because all servers are available before health check
+    EXPECT_NO_THROW(nextServer = m_selector->getNext());
+    EXPECT_EQ(nextServer, hostGreenServer);
 
-    // It doesn't thrown and exception because all servers are available before health check
-    EXPECT_NO_THROW(nextRedServer = m_selector->getNext());
-    EXPECT_EQ(nextRedServer, hostRedServer);
+    // It doesn't thrown an exception because all servers are available before health check
+    EXPECT_NO_THROW(nextServer = m_selector->getNext());
+    EXPECT_EQ(nextServer, hostRedServer);
 
     // Interval to check the health of the servers
     std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
 
     // next server will be the green because it's available
-    EXPECT_NO_THROW(nextGreenServer = m_selector->getNext());
-    EXPECT_EQ(nextGreenServer, hostGreenServer);
+    EXPECT_NO_THROW(nextServer = m_selector->getNext());
+    EXPECT_EQ(nextServer, hostGreenServer);
 
     // next server will be the green because the red server isn't available
-    EXPECT_NO_THROW(nextGreenServer = m_selector->getNext());
-    EXPECT_EQ(nextGreenServer, hostGreenServer);
+    EXPECT_NO_THROW(nextServer = m_selector->getNext());
+    EXPECT_EQ(nextServer, hostGreenServer);
 }
 
 /**
@@ -105,18 +103,17 @@ TEST_F(ServerSelectorTest, TestGextNextWhenThereAreNoAvailableServers)
     m_servers.clear();
     m_servers.emplace_back(hostRedServer);
 
-    std::string nextRedServer;
-    std::string nextGreenServer;
+    std::string nextServer;
 
     EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
 
-    // It doesn't thrown and exception because all servers are available before health check
-    EXPECT_NO_THROW(nextRedServer = m_selector->getNext());
-    EXPECT_EQ(nextRedServer, hostRedServer);
+    // It doesn't thrown an exception because all servers are available before health check
+    EXPECT_NO_THROW(nextServer = m_selector->getNext());
+    EXPECT_EQ(nextServer, hostRedServer);
 
     // Interval to check the health of the servers
     std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
 
     // It throws an exception because there are no available servers
-    EXPECT_THROW(nextRedServer = m_selector->getNext(), std::runtime_error);
+    EXPECT_THROW(nextServer = m_selector->getNext(), std::runtime_error);
 }

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
@@ -11,15 +11,15 @@
 
 #include "serverSelector_test.hpp"
 #include "serverSelector.hpp"
+#include <chrono>
 #include <memory>
 #include <string>
-#include <chrono>
 #include <thread>
 
 /**
  * @brief Test instantiation with valid servers.
- * 
-*/
+ *
+ */
 TEST_F(ServerSelectorTest, TestInstantiation)
 {
     EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
@@ -27,8 +27,8 @@ TEST_F(ServerSelectorTest, TestInstantiation)
 
 /**
  * @brief Test instantiation without servers.
- * 
-*/
+ *
+ */
 TEST_F(ServerSelectorTest, TestInstantiationWithoutServers)
 {
     m_servers.clear();
@@ -39,8 +39,8 @@ TEST_F(ServerSelectorTest, TestInstantiationWithoutServers)
 
 /**
  * @brief Test instantiation and getNext server before health check.
- * 
-*/
+ *
+ */
 TEST_F(ServerSelectorTest, TestGetNextBeforeHealthCheck)
 {
     const auto hostGreenServer {m_servers.at(0)};
@@ -62,8 +62,8 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeHealthCheck)
 
 /**
  * @brief Test instantiation and getNext server before and after health check.
- * 
-*/
+ *
+ */
 TEST_F(ServerSelectorTest, TestGetNextBeforeAndAfterHealthCheck)
 {
     const auto hostGreenServer {m_servers.at(0)};
@@ -96,8 +96,8 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeAndAfterHealthCheck)
 
 /**
  * @brief Test instantiation and getNext when there are no available servers.
- * 
-*/
+ *
+ */
 TEST_F(ServerSelectorTest, TestGextNextWhenThereAreNoAvailableServers)
 {
     const auto hostRedServer {m_servers.at(1)};

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
@@ -1,0 +1,122 @@
+/*
+ * Wazuh Indexer Connector - ServerSelector tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 08, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "serverSelector_test.hpp"
+#include "serverSelector.hpp"
+#include <memory>
+#include <string>
+#include <chrono>
+#include <thread>
+
+/**
+ * @brief Test instantiation with valid servers.
+ * 
+*/
+TEST_F(ServerSelectorTest, TestInstantiation)
+{
+    EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
+}
+
+/**
+ * @brief Test instantiation without servers.
+ * 
+*/
+TEST_F(ServerSelectorTest, TestInstantiationWithoutServers)
+{
+    m_servers.clear();
+
+    // It doesn't throw an exception because the class ServerSelector accepts vector without servers
+    EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
+}
+
+/**
+ * @brief Test instantiation and getNext server before health check.
+ * 
+*/
+TEST_F(ServerSelectorTest, TestGetNextBeforeHealthCheck)
+{
+    const auto hostGreenServer {m_servers.at(0)};
+    const auto hostRedServer {m_servers.at(1)};
+
+    std::string nextGreenServer;
+    std::string nextRedServer;
+
+    EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
+
+    // It doesn't thrown and exception because all servers are available before health check
+    EXPECT_NO_THROW(nextGreenServer = m_selector->getNext());
+    EXPECT_EQ(nextGreenServer, hostGreenServer);
+
+    // It doesn't thrown and exception because all servers are available before health check
+    EXPECT_NO_THROW(nextRedServer = m_selector->getNext());
+    EXPECT_EQ(nextRedServer, hostRedServer);
+}
+
+/**
+ * @brief Test instantiation and getNext server before and after health check.
+ * 
+*/
+TEST_F(ServerSelectorTest, TestGetNextBeforeAndAfterHealthCheck)
+{
+    const auto hostGreenServer {m_servers.at(0)};
+    const auto hostRedServer {m_servers.at(1)};
+
+    std::string nextGreenServer;
+    std::string nextRedServer;
+
+    EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
+
+    // It doesn't thrown and exception because all servers are available before health check
+    EXPECT_NO_THROW(nextGreenServer = m_selector->getNext());
+    EXPECT_EQ(nextGreenServer, hostGreenServer);
+
+    // It doesn't thrown and exception because all servers are available before health check
+    EXPECT_NO_THROW(nextRedServer = m_selector->getNext());
+    EXPECT_EQ(nextRedServer, hostRedServer);
+
+    // Interval to check the health of the servers
+    std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
+
+    // next server will be the green because it's available
+    EXPECT_NO_THROW(nextGreenServer = m_selector->getNext());
+    EXPECT_EQ(nextGreenServer, hostGreenServer);
+
+    // next server will be the green because the red server isn't available
+    EXPECT_NO_THROW(nextGreenServer = m_selector->getNext());
+    EXPECT_EQ(nextGreenServer, hostGreenServer);
+}
+
+/**
+ * @brief Test instantiation and getNext when there are no available servers.
+ * 
+*/
+TEST_F(ServerSelectorTest, TestGextNextWhenThereAreNoAvailableServers)
+{
+    const auto hostRedServer {m_servers.at(1)};
+
+    m_servers.clear();
+    m_servers.emplace_back(hostRedServer);
+
+    std::string nextRedServer;
+    std::string nextGreenServer;
+
+    EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
+
+    // It doesn't thrown and exception because all servers are available before health check
+    EXPECT_NO_THROW(nextRedServer = m_selector->getNext());
+    EXPECT_EQ(nextRedServer, hostRedServer);
+
+    // Interval to check the health of the servers
+    std::this_thread::sleep_for(std::chrono::seconds(INTERVAL + 5));
+
+    // It throws an exception because there are no available servers
+    EXPECT_THROW(nextRedServer = m_selector->getNext(), std::runtime_error);
+}

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
@@ -53,11 +53,11 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeHealthCheck)
 
     EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
 
-    // It doesn't thrown an exception because all servers are available before health check
+    // It doesn't throw an exception because all servers are available before health check
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostGreenServer);
 
-    // It doesn't thrown an exception because all servers are available before health check
+    // It doesn't throw an exception because all servers are available before health check
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostRedServer);
 }
@@ -75,11 +75,11 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeAndAfterHealthCheck)
 
     EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
 
-    // It doesn't thrown an exception because all servers are available before health check
+    // It doesn't throw an exception because all servers are available before health check
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostGreenServer);
 
-    // It doesn't thrown an exception because all servers are available before health check
+    // It doesn't throw an exception because all servers are available before health check
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostRedServer);
 
@@ -110,7 +110,7 @@ TEST_F(ServerSelectorTest, TestGextNextWhenThereAreNoAvailableServers)
 
     EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers));
 
-    // It doesn't thrown an exception because all servers are available before health check
+    // It doesn't throw an exception because all servers are available before health check
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostRedServer);
 

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.hpp
@@ -1,0 +1,74 @@
+/*
+ * Wazuh Indexer Connector - ServerSelector tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 08, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _SERVER_SELECTOR_TEST_HPP
+#define _SERVER_SELECTOR_TEST_HPP
+
+#include "fakeOpenSearchServer.hpp"
+#include "serverSelector.hpp"
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+/**
+ * @brief Runs unit tests for ServerSelector class
+ */
+class ServerSelectorTest : public ::testing::Test
+{
+protected:
+    inline static std::unique_ptr<FakeOpenSearchServer> m_fakeOpenSearchGreenServer; ///< pointer to FakeOpenSearchServer class
+
+    inline static std::unique_ptr<FakeOpenSearchServer> m_fakeOpenSearchRedServer; ///< pointer to FakeOpenSearchServer class
+
+    std::shared_ptr<ServerSelector> m_selector; ///< pointer to Selector class
+
+    std::vector<std::string> m_servers; ///< Servers
+
+    /**
+     * @brief Sets initial conditions for each test case.
+     */
+    // cppcheck-suppress unusedFunction
+    void SetUp() override
+    {
+        // Register the host and port of the green server
+        m_servers.emplace_back("http://localhost:9201");
+        // Register the host and port of the red server
+        m_servers.emplace_back("http://localhost:9202");
+    }
+
+    /**
+     * @brief Creates the fakeOpenSearchServers for the runtime of the test suite
+     */
+    // cppcheck-suppress unusedFunction
+    static void SetUpTestSuite()
+    {
+        if (!m_fakeOpenSearchGreenServer)
+        {
+            m_fakeOpenSearchGreenServer = std::make_unique<FakeOpenSearchServer>("localhost", 9201);
+        }
+        if (!m_fakeOpenSearchRedServer)
+        {
+            m_fakeOpenSearchRedServer = std::make_unique<FakeOpenSearchServer>("localhost", 9202, "red");
+        }
+    }
+
+    /**
+     * @brief Resets fakeOpenSearchServers causing the shutdown of the test server.
+     */
+    // cppcheck-suppress unusedFunction
+    static void TearDownTestSuite()
+    {
+        m_fakeOpenSearchGreenServer.reset();
+        m_fakeOpenSearchRedServer.reset();
+    }
+};
+
+#endif // _SERVER_SELECTOR_TEST_HPP

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.hpp
@@ -24,9 +24,11 @@
 class ServerSelectorTest : public ::testing::Test
 {
 protected:
-    inline static std::unique_ptr<FakeOpenSearchServer> m_fakeOpenSearchGreenServer; ///< pointer to FakeOpenSearchServer class
+    inline static std::unique_ptr<FakeOpenSearchServer>
+        m_fakeOpenSearchGreenServer; ///< pointer to FakeOpenSearchServer class
 
-    inline static std::unique_ptr<FakeOpenSearchServer> m_fakeOpenSearchRedServer; ///< pointer to FakeOpenSearchServer class
+    inline static std::unique_ptr<FakeOpenSearchServer>
+        m_fakeOpenSearchRedServer; ///< pointer to FakeOpenSearchServer class
 
     std::shared_ptr<ServerSelector> m_selector; ///< pointer to Selector class
 

--- a/src/shared_modules/indexer_connector/testtool/main.cpp
+++ b/src/shared_modules/indexer_connector/testtool/main.cpp
@@ -9,23 +9,27 @@ int main()
             "http://localhost:9200",
             "http://localhost:9300"
         ],
-        "database_path": "/tmp/indexerConnector"
+        "databasePath": "/tmp/indexerConnector"
     })"_json);
 
     indexerConnector.publish(R"(
     {
-        "type": "test",
+        "type": "test-index",
         "data": {
             "message": "Hello world!"
-        }
+        },
+        "id": "1",
+        "operation": ""
     })");
 
     indexerConnector.publish(R"(
     {
-        "type": "test",
+        "type": "test-index",
         "data": {
             "message": "World hello!"
-        }
+        },
+        "id": "3",
+        "operation": ""
     })");
 
     // \cond


### PR DESCRIPTION
|Related issue|
|---|
|Closes #18799|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR aims to add unit tests for the Monitoring class and ServerSelector class. To achieve these results, a FakeOpenSearchServer was implemented to simulate the health check API of OpenSearch (The [response for this API](https://github.com/wazuh/wazuh/blob/ba2c82f815cd9dba326a3c7a8912fba854de87f7/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp#L77C1-L81C57) was implemented according to [OpenSearch](https://opensearch.org/docs/latest/api-reference/cat/cat-health/#response)). Currently, there are no tests for the IndexerConnector class because the implementation of this class isn't complete.

> **Note**
> - Due to the fact that the IndexerConnector class is not implemented, this class was [excluded from the coverage](https://github.com/wazuh/wazuh/blob/83de7553bc93d2429dcfd53c91492b99adfb657e/src/shared_modules/indexer_connector/src/indexerConnector.cpp#L17), and a [TODO](https://github.com/wazuh/wazuh/blob/83de7553bc93d2429dcfd53c91492b99adfb657e/src/shared_modules/indexer_connector/src/indexerConnector.cpp#L16) was added to remove the LCOV flags and add UT when the implementation of this class continues.
> - Due to the existence of an interval for checking server health, a sleep thread was added to some tests.

## Results

```Bash
server@server:~/wazuh/src/build/shared_modules/indexer_connector/tests/unit$ ./indexer_connector_unit_tests 
[==========] Running 9 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 4 tests from MonitoringTest
[ RUN      ] MonitoringTest.TestInstantiationWithValidServers
[       OK ] MonitoringTest.TestInstantiationWithValidServers (65000 ms)
[ RUN      ] MonitoringTest.TestInstantiationWithoutServers
[       OK ] MonitoringTest.TestInstantiationWithoutServers (0 ms)
[ RUN      ] MonitoringTest.TestInvalidServer
[       OK ] MonitoringTest.TestInvalidServer (65000 ms)
[ RUN      ] MonitoringTest.TestCheckIfAnUnregisteredServerIsAvailable
[       OK ] MonitoringTest.TestCheckIfAnUnregisteredServerIsAvailable (65000 ms)
[----------] 4 tests from MonitoringTest (195001 ms total)

[----------] 5 tests from ServerSelectorTest
[ RUN      ] ServerSelectorTest.TestInstantiation
[       OK ] ServerSelectorTest.TestInstantiation (0 ms)
[ RUN      ] ServerSelectorTest.TestInstantiationWithoutServers
[       OK ] ServerSelectorTest.TestInstantiationWithoutServers (0 ms)
[ RUN      ] ServerSelectorTest.TestGetNextBeforeHealthCheck
[       OK ] ServerSelectorTest.TestGetNextBeforeHealthCheck (0 ms)
[ RUN      ] ServerSelectorTest.TestGetNextBeforeAndAfterHealthCheck
[       OK ] ServerSelectorTest.TestGetNextBeforeAndAfterHealthCheck (65000 ms)
[ RUN      ] ServerSelectorTest.TestGextNextWhenThereAreNoAvailableServers
[       OK ] ServerSelectorTest.TestGextNextWhenThereAreNoAvailableServers (65000 ms)
[----------] 5 tests from ServerSelectorTest (130001 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 2 test suites ran. (325010 ms total)
[  PASSED  ] 9 tests.
```

![image](https://github.com/wazuh/wazuh/assets/28254614/53436f83-15c5-40a2-acfa-c952faca9252)
![image](https://github.com/wazuh/wazuh/assets/28254614/b780aef7-209a-4816-8021-d6af675f7081)
