### PR TITLE
Fix worker to master connection in clusterd

### DIFF
--- a/framework/scripts/tests/test_wazuh_clusterd.py
+++ b/framework/scripts/tests/test_wazuh_clusterd.py
@@ -160,6 +160,14 @@ async def test_worker_main(asyncio_sleep_mock):
             self.send_file = send_file
             self.send_string = send_string
 
+    class TaskPoolMock:
+        def __init__(self):
+            self._max_workers = 1
+
+        def map(self, first, second):
+            assert first == cluster_utils.process_spawn_sleep
+            assert second == range(1)
+
     class LoggerMock:
         def __init__(self):
             pass
@@ -179,6 +187,7 @@ async def test_worker_main(asyncio_sleep_mock):
             assert logger == 'test_logger'
             assert cluster_items == {'intervals': {'worker': {'connection_retry': 34}}}
             assert task_pool is None
+            self.task_pool = TaskPoolMock()
 
         def start(self):
             return 'WORKER_START'

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -141,7 +141,8 @@ async def worker_main(args: argparse.Namespace, cluster_config: dict, cluster_it
                                                          concurrency_test=args.concurrency_test, node=my_client,
                                                          configuration=cluster_config, enable_ssl=args.ssl,
                                                          cluster_items=cluster_items)
-
+        if my_client.task_pool is not None:
+            my_client.task_pool.map(cluster_utils.process_spawn_sleep, range(my_client.task_pool._max_workers))
         try:
             await asyncio.gather(my_client.start(), my_local_server.start())
         except asyncio.CancelledError:

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -141,6 +141,7 @@ async def worker_main(args: argparse.Namespace, cluster_config: dict, cluster_it
                                                          concurrency_test=args.concurrency_test, node=my_client,
                                                          configuration=cluster_config, enable_ssl=args.ssl,
                                                          cluster_items=cluster_items)
+        # Spawn pool processes
         if my_client.task_pool is not None:
             my_client.task_pool.map(cluster_utils.process_spawn_sleep, range(my_client.task_pool._max_workers))
         try:


### PR DESCRIPTION
|Related issue|
|---|
| #15473  |

## Description

The issue running on #15473  appeared to be related to process concurrency, as multiple tasks were running in parallel. This was causing errors in completing tasks for the client process that was supposed to disconnect and for the process of the new client connecting to `clusterd`, resulting in a failure

As can be seen in the following Master logs, the first worker connects, and once the second worker is launched, it cancels pending tasks and connects the new worker to clusterd:

```
2023/09/14 17:38:38 INFO: [Worker] [Main] Connection from ('172.18.0.3', 34508)
2023/09/14 17:38:51 INFO: [Worker worker] [Main] Cancelling pending tasks.
2023/09/14 17:38:51 INFO: [Worker] [Main] Connection from ('172.18.0.3', 53340)
```

## Logs/Alerts example

` Cluster.log (master)`
```
root@wazuh-master:/# /var/ossec/bin/wazuh-clusterd -f
Starting cluster in foreground (pid: 77386)
2023/09/14 17:38:38 INFO: [Worker] [Main] Connection from ('172.18.0.3', 34508)
2023/09/14 17:38:47 INFO: [Worker worker] [Integrity check] Starting.
2023/09/14 17:38:47 INFO: [Worker worker] [Integrity check] Finished in 0.008s. Received metadata of 34 files. Sync not required.
2023/09/14 17:38:48 INFO: [Worker worker] [Agent-info sync] Starting.
2023/09/14 17:38:48 INFO: [Worker worker] [Agent-info sync] Finished in 0.006s. Updated 1 chunks.
2023/09/14 17:38:51 INFO: [Worker worker] [Main] Cancelling pending tasks.
2023/09/14 17:38:51 INFO: [Worker] [Main] Connection from ('172.18.0.3', 53340)
2023/09/14 17:39:00 INFO: [Worker worker] [Integrity check] Starting.
2023/09/14 17:39:00 INFO: [Worker worker] [Integrity check] Finished in 0.006s. Received metadata of 34 files. Sync not required.
```

`Cluster.log(worker)`
```
root@wazuh-worker1:/# /var/ossec/bin/wazuh-clusterd 
root@wazuh-worker1:/# /var/ossec/bin/wazuh-clusterd -f
wazuh-clusterd: Orphan child process 88390 was terminated.
wazuh-clusterd: Orphan child process 88391 was terminated.
Starting cluster in foreground (pid: 88527)
2023/09/14 17:38:51 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2023/09/14 17:38:51 INFO: [Worker worker] [Main] Successfully connected to master.
2023/09/14 17:39:00 INFO: [Worker worker] [Integrity check] Starting.
2023/09/14 17:39:00 INFO: [Worker worker] [Integrity check] Finished in 0.024s. Sync not required.
2023/09/14 17:39:01 INFO: [Worker worker] [Agent-info sync] Starting.
2023/09/14 17:39:01 INFO: [Worker worker] [Agent-info sync] Finished in 0.009s. Updated 1 chunks.
2023/09/14 17:39:03 INFO: [Worker worker] [Agent-groups recv] Starting.
2023/09/14 17:39:03 INFO: [Worker worker] [Agent-groups recv] Finished in 0.009s. Updated 1 chunks.
```





## Tests
```console
PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest framework/scripts/tests/test_wazuh_clusterd.py -v
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.9.16, pytest-7.4.0, pluggy-0.13.1 -- /home/wazuh/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-5.19.0-46-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.4.0', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '0.3.0', 'metadata': '3.0.0', 'html': '2.1.1', 'trio': '0.7.0', 'asyncio': '0.15.1'}}
rootdir: /home/wazuh/Git/wazuh/framework
plugins: aiohttp-0.3.0, metadata-3.0.0, html-2.1.1, trio-0.7.0, asyncio-0.15.1
collected 7 items                                                                                                                                                                                         

framework/scripts/tests/test_wazuh_clusterd.py::test_set_logging PASSED                                                                                                                             [ 14%]
framework/scripts/tests/test_wazuh_clusterd.py::test_print_version PASSED                                                                                                                           [ 28%]
framework/scripts/tests/test_wazuh_clusterd.py::test_exit_handler PASSED                                                                                                                            [ 42%]
framework/scripts/tests/test_wazuh_clusterd.py::test_master_main PASSED                                                                                                                             [ 57%]
framework/scripts/tests/test_wazuh_clusterd.py::test_worker_main PASSED                                                                                                                             [ 71%]
framework/scripts/tests/test_wazuh_clusterd.py::test_get_script_arguments PASSED                                                                                                                    [ 85%]
framework/scripts/tests/test_wazuh_clusterd.py::test_main PASSED                                                                                                                                    [100%]
```



