### PR TITLE
Content Manager - Include libzma on CMakeLists

### DIFF
--- a/src/shared_modules/content_manager/CMakeLists.txt
+++ b/src/shared_modules/content_manager/CMakeLists.txt
@@ -19,6 +19,7 @@ include_directories(${SRC_FOLDER})
 include_directories(${SRC_FOLDER}/headers)
 include_directories(${SRC_FOLDER}/external/nlohmann)
 include_directories(${SRC_FOLDER}/external/curl/include/curl)
+include_directories(${SRC_FOLDER}/external/lzma/src/liblzma/api)
 
 include_directories(${SHARED_MODULES})
 include_directories(${SHARED_MODULES}/utils)
@@ -28,6 +29,7 @@ include_directories(${SHARED_MODULES}/content_manager/src/components)
 
 # Link directories
 link_directories(${SRC_FOLDER})
+link_directories(${SRC_FOLDER}/external/lzma/build/)
 link_directories(${SHARED_MODULES}/router/build)
 link_directories(${SHARED_MODULES}/http-request/build)
 


### PR DESCRIPTION
|Related issue|
|---|
| #19026 |

## Description

This PR fixes the compilation error of the Content Manager modules. There were missing directives on the CMake file.

## Results

See [checks](https://github.com/wazuh/wazuh/actions/runs/6198856363/job/16830210546).
