### PR TITLE
Add pypi to spec.yaml

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -4800,10 +4800,15 @@ components:
           type: string
           description: "Package format"
           enum:
+            - pacman
             - deb
             - rpm
             - win
             - pkg
+            - apk
+            - macports
+            - pypi
+            - npm
         multiarch:
           type: string
           description: "Whether the package has multi architecture support"


### PR DESCRIPTION
|Related issue|
|---|
| #18768  |

## Description

The `pypi` package was added to the list of `Package format` in `spec.yaml `due to it causing an error in the `GET /experimental/syscollector/packages` endpoint of `test_experimental_endpoints.tavern.yaml`. 
Additionally, the `pacman`, `apk`, `macports`, and `npm` packages were also added, which were not present either.
This happened because the package was added in the following issue: #17982 

![image](https://github.com/wazuh/wazuh/assets/96108386/715965d8-70ec-4076-8a04-b6f7ecc88624)


## Tests

```
pytest -vv test_experimental_endpoints.tavern.yaml

test_experimental_endpoints.tavern.yaml::DELETE /experimental/rootcheck PASSED                                                                                                                              [  8%]
test_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED                                                                                                                               [ 16%]
test_experimental_endpoints.tavern.yaml::GET /experimental/ciscat/results PASSED                                                                                                                            [ 25%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED                                                                                                                     [ 33%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED                                                                                                                      [ 41%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED                                                                                                                     [ 50%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED                                                                                                                     [ 58%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED                                                                                                                           [ 66%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED                                                                                                                     [ 75%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED                                                                                                                        [ 83%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED                                                                                                                    [ 91%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED                                                                                                                     [100%]


```
