### PR TITLE
Improve order in stage normalizer

### DIFF
--- a/src/engine/source/api/include/api/test/session.hpp
+++ b/src/engine/source/api/include/api/test/session.hpp
@@ -7,7 +7,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
-#include <vector>
+#include <list>
 
 namespace api::sessionManager
 {
@@ -33,12 +33,26 @@ struct OutputTraceDataSync
     std::vector<std::pair<std::string, std::string>> m_history;
 
     /**
-     * @brief Trace map that associates each asset with its set of traces.
+     * @struct Trace
      *
-     * The map stores output traces associated with each asset in the form of a vector of shared pointers to
-     * stringstream. Each stringstream contains an output trace of the asset.
+     * @brief Structure representing a trace object.
      */
-    std::unordered_map<std::string, std::vector<std::shared_ptr<std::stringstream>>> m_trace;
+    struct Trace
+    {
+        /**
+         * @brief Constructor for the Trace structure.
+         *
+         * @param asset     The asset associated with the trace.
+         * @param condition The shared pointer to the condition stream.
+         */
+        Trace(const std::string& asset, const std::shared_ptr<std::stringstream>& condition)
+            : m_asset(asset), m_spCondition(condition) {}
+
+        std::string m_asset; ///< The asset associated with the trace.
+        std::shared_ptr<std::stringstream> m_spCondition; ///< The shared pointer to the condition stream.
+    };
+
+    std::list<Trace> m_trace; ///< Vector that stores Trace objects.
 
     // Synchronization
     std::mutex m_sync;                ///< Mutex for synchronizing access to the data in this struct.


### PR DESCRIPTION
## Description

Because in test mode the traces of each asset did not appear in the order established in the asset itself, this improvement was made to allow debugging the decoders in a more comfortable way.

### Decoder

```
name: decoder/windows-event/0

parents:
  - decoder/core-windows/0

metadata:
  module: Windows
  title: Base decoder for Windows events.
  description: This Windows decoder normalizes common fields from Windows events.
  versions: [Vista, "7", "8", "10", "11", Server 2012, Server 2016, Server 2019, Server 2022]
  compatibility: This decoder has been tested on Wazuh version 4.3.
  author:
    name: Wazuh, Inc.
    date: 2023/01/23
  references:
    - https://learn.microsoft.com/en-us/windows/win32/events/windows-events

check:
  - event.module: windows

normalize:
  - map:
      - windows: parse_xml($event.original, windows)
      - event.dataset: general
      - event.start: $windows.System.TimeCreated.@SystemTime
      - event.code: $windows.System.EventID.#text
      - event.id: $windows.System.EventID.#text
      - event.kind: event
      - event.provider: $windows.System.Provider.@Name

      - host.name: $windows.System.Computer.#text

      - _MapWindowsLevelToLogLevel:
          "0": "Audit"
          "1": "Critical"
          "2": "Error"
          "3": "Warning"
          "4": "Information"
          "5": "Verbose"
      - log.level: get_value($_MapWindowsLevelToLogLevel, $windows.System.Level.#text)

      - wazuh.decoders: array_append(windows-event)
```

### Traces

```
Traces:
  - "[decoder/windows-event/0]":
    - [condition.value[/event/module=="windows"]] -> Success
    - [condition]:success
    - [helper.parse_xml[/windows, windows]] -> Success
    - [map.value[/event/dataset="general"]] -> Success
    - [map.reference[/event/start=/windows/System/TimeCreated/@SystemTime]] -> Success
    - [map.reference[/event/code=/windows/System/EventID/#text]] -> Success
    - [map.reference[/event/id=/windows/System/EventID/#text]] -> Success
    - [map.value[/event/kind="event"]] -> Success
    - [map.reference[/event/provider=/windows/System/Provider/@Name]] -> Success
    - [map.reference[/host/name=/windows/System/Computer/#text]] -> Success
    - [map.value[/_MapWindowsLevelToLogLevel={}]] -> Success
    - [map.value[/_MapWindowsLevelToLogLevel/0="Audit"]] -> Success
    - [map.value[/_MapWindowsLevelToLogLevel/1="Critical"]] -> Success
    - [map.value[/_MapWindowsLevelToLogLevel/2="Error"]] -> Success
    - [map.value[/_MapWindowsLevelToLogLevel/3="Warning"]] -> Success
    - [map.value[/_MapWindowsLevelToLogLevel/4="Information"]] -> Success
    - [map.value[/_MapWindowsLevelToLogLevel/5="Verbose"]] -> Success
    - [unmap.ifEmpty.value[/_MapWindowsLevelToLogLevel]] -> Success
    - [helper.get_value[/log/level, /_MapWindowsLevelToLogLevel, /windows/System/Level/#text]] -> Success
    - [helper.array_append[/wazuh/decoders, windows-event]] -> Success
```