### PR TITLE
Multiple tenants in ms-graph

### DIFF
--- a/src/config/wmodules-ms-graph.c
+++ b/src/config/wmodules-ms-graph.c
@@ -54,7 +54,7 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 	wm_ms_graph_auth *it;	
 	int tenant = 0;
 
-	os_calloc(1, sizeof(wm_ms_graph_auth), ms_graph->auth_config); 
+	os_calloc(1, sizeof(wm_ms_graph_auth*), ms_graph->auth_config); 
 	os_malloc(sizeof(wm_ms_graph_resource) * 2, ms_graph->resources);
 	ms_graph->num_resources = 0;
 
@@ -118,11 +118,12 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 				merror("Empty content for tag '%s' at module '%s'.", XML_API_AUTH, WM_MS_GRAPH_CONTEXT.name);
 				return OS_CFGERR;
 			}
-		
-			os_realloc(ms_graph->auth_config, sizeof(wm_ms_graph_auth) * (tenant + 1), ms_graph->auth_config);	
+
+			os_realloc(ms_graph->auth_config, sizeof(wm_ms_graph_auth*) * (tenant + 2), ms_graph->auth_config);
 			os_calloc(1, sizeof(wm_ms_graph_auth), ms_graph->auth_config[tenant]);
+			ms_graph->auth_config[tenant + 1] = NULL;
 			it = ms_graph->auth_config[tenant];
-			tenant++;	
+			tenant++;
 
 			for (int j = 0; children[j]; j++) {							
 				if (!strcmp(children[j]->element, XML_CLIENT_ID)) {
@@ -181,7 +182,6 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 				}
 			}
 			OS_ClearNode(children);
-										
 
 			if (!it->client_id) {
 				merror(XML_NO_ELEM, XML_CLIENT_ID);

--- a/src/config/wmodules-ms-graph.c
+++ b/src/config/wmodules-ms-graph.c
@@ -264,12 +264,9 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
         return OS_INVALID;
     }
 	
-	for (e = 0; ms_graph->auth_config && ms_graph->auth_config[e]; e++) {
-		it = ms_graph->auth_config[e];
-		if (!it->client_id && !it->tenant_id && !it->secret_value) {
-			merror(XML_NO_ELEM, XML_API_AUTH);
-			return OS_NOTFOUND;
-		}
+	if (tenant == 0) {
+		merror(XML_NO_ELEM, XML_API_AUTH);
+		return OS_NOTFOUND;
 	}
 
 	if (ms_graph->num_resources == 0) {

--- a/src/config/wmodules-ms-graph.c
+++ b/src/config/wmodules-ms-graph.c
@@ -33,7 +33,6 @@ static const char* XML_RESOURCE_RELATIONSHIP = "relationship";
 
 int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 
-	int e;
 	wm_ms_graph* ms_graph;
 
 	if (!nodes) {
@@ -51,10 +50,10 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 
 	sched_scan_init(&(ms_graph->scan_config));
 	ms_graph->scan_config.interval = WM_DEF_INTERVAL;
-	wm_ms_graph_auth *it;	
+	wm_ms_graph_auth *it;
 	int tenant = 0;
 
-	os_calloc(1, sizeof(wm_ms_graph_auth*), ms_graph->auth_config); 
+	os_calloc(1, sizeof(wm_ms_graph_auth*), ms_graph->auth_config);
 	os_malloc(sizeof(wm_ms_graph_resource) * 2, ms_graph->resources);
 	ms_graph->num_resources = 0;
 
@@ -112,7 +111,6 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 				return OS_CFGERR;
 			}
 		} else if (!strcmp(nodes[i]->element, XML_API_AUTH)) {
-
 			if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
 				OS_ClearNode(children);
 				merror("Empty content for tag '%s' at module '%s'.", XML_API_AUTH, WM_MS_GRAPH_CONTEXT.name);
@@ -125,7 +123,7 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 			it = ms_graph->auth_config[tenant];
 			tenant++;
 
-			for (int j = 0; children[j]; j++) {							
+			for (int j = 0; children[j]; j++) {
 				if (!strcmp(children[j]->element, XML_CLIENT_ID)) {
 					if (strlen(children[j]->content) > 0 ) {
 						os_strdup(children[j]->content, it->client_id);
@@ -198,7 +196,7 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 				merror(XML_NO_ELEM, XML_API_TYPE);
 				return OS_NOTFOUND;
 			}
-			
+
 		} else if (!strcmp(nodes[i]->element, XML_RESOURCE)) {
 			if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
 				merror("Empty content for tag '%s' at module '%s'.", XML_RESOURCE, WM_MS_GRAPH_CONTEXT.name);
@@ -244,7 +242,6 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 				}
 			}
 
-
 			OS_ClearNode(children);
 			if (!name_set) {
 				merror(XML_NO_ELEM, XML_RESOURCE_NAME);
@@ -263,7 +260,7 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 		merror("Invalid content for tag '%s' at module '%s'.", XML_INTERVAL, WM_MS_GRAPH_CONTEXT.name);
         return OS_INVALID;
     }
-	
+
 	if (tenant == 0) {
 		merror(XML_NO_ELEM, XML_API_AUTH);
 		return OS_NOTFOUND;

--- a/src/config/wmodules-ms-graph.c
+++ b/src/config/wmodules-ms-graph.c
@@ -33,6 +33,7 @@ static const char* XML_RESOURCE_RELATIONSHIP = "relationship";
 
 int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 
+	int e;
 	wm_ms_graph* ms_graph;
 
 	if (!nodes) {
@@ -50,14 +51,10 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 
 	sched_scan_init(&(ms_graph->scan_config));
 	ms_graph->scan_config.interval = WM_DEF_INTERVAL;
+	wm_ms_graph_auth *it;	
+	int tenant = 0;
 
-	ms_graph->auth_config.client_id = NULL;
-	ms_graph->auth_config.tenant_id = NULL;
-	ms_graph->auth_config.secret_value = NULL;
-	ms_graph->auth_config.access_token = NULL;
-	ms_graph->auth_config.login_fqdn = NULL;
-	ms_graph->auth_config.query_fqdn = NULL;
-
+	os_calloc(1, sizeof(wm_ms_graph_auth), ms_graph->auth_config); 
 	os_malloc(sizeof(wm_ms_graph_resource) * 2, ms_graph->resources);
 	ms_graph->num_resources = 0;
 
@@ -67,7 +64,6 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 
 	for (int i = 0; nodes[i]; i++) {
 		XML_NODE children = NULL;
-
 		if (!nodes[i]->element) {
 			merror(XML_ELEMNULL);
 			return OS_CFGERR;
@@ -116,15 +112,20 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 				return OS_CFGERR;
 			}
 		} else if (!strcmp(nodes[i]->element, XML_API_AUTH)) {
+
 			if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
 				OS_ClearNode(children);
 				merror("Empty content for tag '%s' at module '%s'.", XML_API_AUTH, WM_MS_GRAPH_CONTEXT.name);
 				return OS_CFGERR;
 			}
-			for (int j = 0; children[j]; j++) {
+
+			os_calloc(1, sizeof(wm_ms_graph), ms_graph->auth_config[tenant]);
+			it = ms_graph->auth_config[tenant++];	
+
+			for (int j = 0; children[j]; j++) {							
 				if (!strcmp(children[j]->element, XML_CLIENT_ID)) {
 					if (strlen(children[j]->content) > 0 ) {
-						os_strdup(children[j]->content, ms_graph->auth_config.client_id);
+						os_strdup(children[j]->content, it->client_id);
 					} else {
 						merror("Empty content for tag '%s' at module '%s'.", XML_CLIENT_ID, WM_MS_GRAPH_CONTEXT.name);
 						OS_ClearNode(children);
@@ -132,7 +133,7 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 					}
 				} else if (!strcmp(children[j]->element, XML_TENANT_ID)) {
 					if (strlen(children[j]->content) > 0) {
-						os_strdup(children[j]->content, ms_graph->auth_config.tenant_id);
+						os_strdup(children[j]->content, it->tenant_id);
 					} else {
 						merror("Empty content for tag '%s' at module '%s'.", XML_TENANT_ID, WM_MS_GRAPH_CONTEXT.name);
 						OS_ClearNode(children);
@@ -140,7 +141,7 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 					}
 				} else if (!strcmp(children[j]->element, XML_SECRET_VALUE)) {
 					if (strlen(children[j]->content) > 0) {
-						os_strdup(children[j]->content, ms_graph->auth_config.secret_value);
+						os_strdup(children[j]->content, it->secret_value);
 					} else {
 						merror("Empty content for tag '%s' at module '%s'.", XML_SECRET_VALUE, WM_MS_GRAPH_CONTEXT.name);
 						OS_ClearNode(children);
@@ -152,20 +153,20 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 						OS_ClearNode(children);
 						return OS_CFGERR;
                     } else if (!strcmp(children[j]->content, "global")) {
-                        os_free(ms_graph->auth_config.login_fqdn);
-                        os_strdup(WM_MS_GRAPH_GLOBAL_API_LOGIN_FQDN, ms_graph->auth_config.login_fqdn);
-                        os_free(ms_graph->auth_config.query_fqdn);
-                        os_strdup(WM_MS_GRAPH_GLOBAL_API_QUERY_FQDN, ms_graph->auth_config.query_fqdn);
+                        os_free(it->login_fqdn);
+                        os_strdup(WM_MS_GRAPH_GLOBAL_API_LOGIN_FQDN, it->login_fqdn);
+                        os_free(it->query_fqdn);
+                        os_strdup(WM_MS_GRAPH_GLOBAL_API_QUERY_FQDN, it->query_fqdn);
                     } else if (!strcmp(children[j]->content, "gcc-high")) {
-                        os_free(ms_graph->auth_config.login_fqdn);
-                        os_strdup(WM_MS_GRAPH_GCC_HIGH_API_LOGIN_FQDN, ms_graph->auth_config.login_fqdn);
-                        os_free(ms_graph->auth_config.query_fqdn);
-                        os_strdup(WM_MS_GRAPH_GCC_HIGH_API_QUERY_FQDN, ms_graph->auth_config.query_fqdn);
+                        os_free(it->login_fqdn);
+                        os_strdup(WM_MS_GRAPH_GCC_HIGH_API_LOGIN_FQDN, it->login_fqdn);
+                        os_free(it->query_fqdn);
+                        os_strdup(WM_MS_GRAPH_GCC_HIGH_API_QUERY_FQDN, it->query_fqdn);
                     } else if (!strcmp(children[j]->content, "dod")) {
-                        os_free(ms_graph->auth_config.login_fqdn);
-                        os_strdup(WM_MS_GRAPH_DOD_API_LOGIN_FQDN, ms_graph->auth_config.login_fqdn);
-                        os_free(ms_graph->auth_config.query_fqdn);
-                        os_strdup(WM_MS_GRAPH_DOD_API_QUERY_FQDN, ms_graph->auth_config.query_fqdn);
+                        os_free(it->login_fqdn);
+                        os_strdup(WM_MS_GRAPH_DOD_API_LOGIN_FQDN, it->login_fqdn);
+                        os_free(it->query_fqdn);
+                        os_strdup(WM_MS_GRAPH_DOD_API_QUERY_FQDN, it->query_fqdn);
                     } else {
 						merror("Invalid content for tag '%s' at module '%s'.", XML_API_TYPE, WM_MS_GRAPH_CONTEXT.name);
                         OS_ClearNode(children);
@@ -178,23 +179,24 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 				}
 			}
 			OS_ClearNode(children);
+										
 
-			if (!ms_graph->auth_config.client_id) {
+			if (!it->client_id) {
 				merror(XML_NO_ELEM, XML_CLIENT_ID);
 				return OS_NOTFOUND;
-			} else if (!ms_graph->auth_config.tenant_id) {
+			} else if (!it->tenant_id) {
 				merror(XML_NO_ELEM, XML_TENANT_ID);
 				return OS_NOTFOUND;
-			} else if (!ms_graph->auth_config.secret_value) {
+			} else if (!it->secret_value) {
 				merror(XML_NO_ELEM, XML_SECRET_VALUE);
 				return OS_NOTFOUND;
 			}
 			// We only need to check one FQDN to see if the tag exists
-			else if (!ms_graph->auth_config.query_fqdn) {
+			else if (!it->query_fqdn) {
 				merror(XML_NO_ELEM, XML_API_TYPE);
 				return OS_NOTFOUND;
 			}
-
+			
 		} else if (!strcmp(nodes[i]->element, XML_RESOURCE)) {
 			if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
 				merror("Empty content for tag '%s' at module '%s'.", XML_RESOURCE, WM_MS_GRAPH_CONTEXT.name);
@@ -239,6 +241,8 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 					return OS_CFGERR;
 				}
 			}
+
+
 			OS_ClearNode(children);
 			if (!name_set) {
 				merror(XML_NO_ELEM, XML_RESOURCE_NAME);
@@ -258,9 +262,11 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
         return OS_INVALID;
     }
 	
-	if (!ms_graph->auth_config.client_id && !ms_graph->auth_config.tenant_id && !ms_graph->auth_config.secret_value) {
-		merror(XML_NO_ELEM, XML_API_AUTH);
-		return OS_NOTFOUND;
+	for (e = 0, it = ms_graph->auth_config[0]; it; e++, it = ms_graph->auth_config[e]) {
+		if (!it->client_id && !it->tenant_id && !it->secret_value) {
+			merror(XML_NO_ELEM, XML_API_AUTH);
+			return OS_NOTFOUND;
+		}
 	}
 
 	if (ms_graph->num_resources == 0) {

--- a/src/config/wmodules-ms-graph.c
+++ b/src/config/wmodules-ms-graph.c
@@ -118,9 +118,11 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 				merror("Empty content for tag '%s' at module '%s'.", XML_API_AUTH, WM_MS_GRAPH_CONTEXT.name);
 				return OS_CFGERR;
 			}
-
-			os_calloc(1, sizeof(wm_ms_graph), ms_graph->auth_config[tenant]);
-			it = ms_graph->auth_config[tenant++];	
+		
+			os_realloc(ms_graph->auth_config, sizeof(wm_ms_graph_auth) * (tenant + 1), ms_graph->auth_config);	
+			os_calloc(1, sizeof(wm_ms_graph_auth), ms_graph->auth_config[tenant]);
+			it = ms_graph->auth_config[tenant];
+			tenant++;	
 
 			for (int j = 0; children[j]; j++) {							
 				if (!strcmp(children[j]->element, XML_CLIENT_ID)) {
@@ -262,7 +264,8 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
         return OS_INVALID;
     }
 	
-	for (e = 0, it = ms_graph->auth_config[0]; it; e++, it = ms_graph->auth_config[e]) {
+	for (e = 0; ms_graph->auth_config && ms_graph->auth_config[e]; e++) {
+		it = ms_graph->auth_config[e];
 		if (!it->client_id && !it->tenant_id && !it->secret_value) {
 			merror(XML_NO_ELEM, XML_API_AUTH);
 			return OS_NOTFOUND;

--- a/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
+++ b/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
@@ -102,7 +102,6 @@ static int teardown_test_read(void **state) {
     return 0;
 }
 
-
 static int setup_conf(void **state) {
     wm_ms_graph* init_data = NULL;
     os_calloc(1,sizeof(wm_ms_graph), init_data);
@@ -228,7 +227,6 @@ void test_enabled_no(void **state) {
     assert_string_equal(module_data->auth_config[0]->tenant_id, "example_string");
     assert_string_equal(module_data->auth_config[0]->client_id, "example_string");
     assert_string_equal(module_data->auth_config[0]->secret_value, "example_string");
-
     assert_int_equal(module_data->num_resources, 2);
     assert_string_equal(module_data->resources[0].name, "security");
     assert_int_equal(module_data->resources[0].num_relationships, 2);
@@ -1011,7 +1009,6 @@ void test_missing_relationship(void **state) {
     expect_string(__wrap__merror, formatted_msg, "(1228): Element 'relationship' without any option.");
     test->nodes = string_to_xml_node(config, &(test->xml));
     assert_int_equal(wm_ms_graph_read(&(test->xml), test->nodes, test->module), OS_NOTFOUND);
-
 }
 
 void test_empty_relationship(void **state) {

--- a/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
+++ b/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
@@ -106,7 +106,7 @@ static int teardown_test_read(void **state) {
 static int setup_conf(void **state) {
     wm_ms_graph* init_data = NULL;
     os_calloc(1,sizeof(wm_ms_graph), init_data);
- 
+
     test_mode = true;
     *state = init_data;
     return 0;
@@ -224,7 +224,7 @@ void test_enabled_no(void **state) {
     assert_int_equal(module_data->curl_max_size, OS_SIZE_1048576);
     assert_int_equal(module_data->run_on_start, 1);
     assert_string_equal(module_data->version, "v1.0");
-    
+
     assert_string_equal(module_data->auth_config[0]->tenant_id, "example_string");
     assert_string_equal(module_data->auth_config[0]->client_id, "example_string");
     assert_string_equal(module_data->auth_config[0]->secret_value, "example_string");
@@ -1226,7 +1226,7 @@ void test_cleanup() {
 void test_setup_complete(void **state) {
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
     os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
 
     module_data->enabled = true;
@@ -1274,7 +1274,7 @@ void test_main_token(void **state) {
     current_time = 1;
     unsigned int run_on_start = 1;
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
     os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = false;
@@ -1343,7 +1343,7 @@ void test_main_token(void **state) {
     will_return(__wrap_wurl_http_request, response);
 
     will_return(__wrap_FOREVER, 0);
-    
+
     wm_ms_graph_main(module_data);
 
 }
@@ -1351,7 +1351,7 @@ void test_main_token(void **state) {
 void test_main_relationships(void **state) {
 
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
     os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = false;
@@ -1486,8 +1486,8 @@ void test_dump(void **state) {
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
@@ -1531,7 +1531,7 @@ void test_dump_gcc_configuration(void **state) {
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
     os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = false;
     module_data->only_future_events = true;
@@ -1576,8 +1576,8 @@ void test_dump_dod_configuration(void **state) {
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = false;
     module_data->only_future_events = true;
     module_data->curl_max_size = 1024L;
@@ -1617,8 +1617,8 @@ void test_wm_ms_graph_get_access_token_no_response(void **state) {
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
@@ -1676,8 +1676,8 @@ void test_wm_ms_graph_get_access_token_unsuccessful_status_code(void **state) {
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
@@ -1712,14 +1712,14 @@ void test_wm_ms_graph_get_access_token_unsuccessful_status_code(void **state) {
     expect_any(__wrap_wurl_http_request, max_size);
     expect_value(__wrap_wurl_http_request, timeout, WM_MS_GRAPH_DEFAULT_TIMEOUT);
     will_return(__wrap_wurl_http_request, response);
- 
+
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtwarn, formatted_msg, "Received unsuccessful status code when attempting to obtain access token: Status code was '400' & response was '{\"error\":\"bad_request\"}'");
 
     wm_ms_graph_get_access_token(module_data->auth_config[0], max_size);
 
     assert_null(module_data->auth_config[0]->access_token);
-   
+
 }
 
 void test_wm_ms_graph_get_access_token_curl_max_size(void **state) {
@@ -1741,8 +1741,8 @@ void test_wm_ms_graph_get_access_token_curl_max_size(void **state) {
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
@@ -1782,7 +1782,7 @@ void test_wm_ms_graph_get_access_token_curl_max_size(void **state) {
     expect_string(__wrap__mtwarn, formatted_msg, "Reached maximum CURL size when attempting to obtain access token. Consider increasing the value of 'curl_max_size'.");
 
     wm_ms_graph_get_access_token(module_data->auth_config[0], max_size);
- 
+
     assert_null(module_data->auth_config[0]->access_token);
 
 }
@@ -1806,8 +1806,8 @@ void test_wm_ms_graph_get_access_token_parse_json_fail(void **state) {
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
@@ -1870,8 +1870,8 @@ void test_wm_ms_graph_get_access_token_success(void **state) {
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
@@ -1939,8 +1939,8 @@ void test_wm_ms_graph_get_access_token_no_access_token(void **state) {
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
@@ -1979,7 +1979,7 @@ void test_wm_ms_graph_get_access_token_no_access_token(void **state) {
 
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtwarn, formatted_msg, "Incomplete access token response, value or expiration time not present.");
-    
+
     wm_ms_graph_get_access_token(module_data->auth_config[0], max_size);
 
 }
@@ -2003,8 +2003,8 @@ void test_wm_ms_graph_get_access_token_no_expire_time(void **state) {
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
@@ -2043,7 +2043,7 @@ void test_wm_ms_graph_get_access_token_no_expire_time(void **state) {
 
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtwarn, formatted_msg, "Incomplete access token response, value or expiration time not present.");
-    
+
     wm_ms_graph_get_access_token(module_data->auth_config[0], max_size);
 
 }
@@ -2067,8 +2067,8 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no(void **state) {
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
@@ -2136,8 +2136,8 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_yes_fail_write(void
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     module_data->enabled = true;
     module_data->only_future_events = true;
     module_data->curl_max_size = 1024L;
@@ -2195,10 +2195,10 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_res
       <relationship>alerts_v2</relationship>
     </resource>
     */
-    wm_ms_graph* module_data = (wm_ms_graph *)*state;    
+    wm_ms_graph* module_data = (wm_ms_graph *)*state;
     wm_ms_graph_state_t relationship_state_struc;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     relationship_state_struc.next_time = 10;
     module_data->enabled = true;
     module_data->only_future_events = false;
@@ -2273,8 +2273,8 @@ void test_wm_ms_graph_scan_relationships_single_no_initial_no_timestamp(void **s
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
     wm_ms_graph_state_t relationship_state_struc;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     relationship_state_struc.next_time = 10;
     module_data->enabled = true;
     module_data->only_future_events = false;
@@ -2344,8 +2344,8 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
     wm_ms_graph_state_t relationship_state_struc;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     relationship_state_struc.next_time = 10;
     module_data->enabled = true;
     module_data->only_future_events = false;
@@ -2400,9 +2400,9 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
 
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtwarn, formatted_msg, "Received unsuccessful status code when attempting to get relationship 'alerts_v2' logs: Status code was '400' & response was '{\"error\":\"bad_request\"}'");
-   
+
     wm_ms_graph_scan_relationships(module_data, initial);
- 
+
 }
 
 void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) {
@@ -2425,8 +2425,8 @@ void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) 
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
     wm_ms_graph_state_t relationship_state_struc;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     relationship_state_struc.next_time = 10;
     module_data->enabled = true;
     module_data->only_future_events = false;
@@ -2507,8 +2507,8 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
     wm_ms_graph_state_t relationship_state_struc;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     relationship_state_struc.next_time = 10;
     module_data->enabled = true;
     module_data->only_future_events = false;
@@ -2564,7 +2564,7 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
 
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtwarn, formatted_msg, "Failed to parse relationship 'alerts_v2' JSON body.");
-    
+
     wm_ms_graph_scan_relationships(module_data, initial);
 
 }
@@ -2589,8 +2589,8 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
     wm_ms_graph_state_t relationship_state_struc;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     relationship_state_struc.next_time = 10;
     module_data->enabled = true;
     module_data->only_future_events = false;
@@ -2687,8 +2687,8 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
     wm_ms_graph_state_t relationship_state_struc;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     relationship_state_struc.next_time = 10;
     module_data->enabled = true;
     module_data->only_future_events = false;
@@ -2770,7 +2770,7 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
-    
+
 
     wm_ms_graph_scan_relationships(module_data, initial);
 
@@ -2796,8 +2796,8 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
     wm_ms_graph_state_t relationship_state_struc;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     relationship_state_struc.next_time = 10;
     module_data->enabled = true;
     module_data->only_future_events = false;
@@ -2851,7 +2851,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     expect_any(__wrap_wurl_http_request, max_size);
     expect_value(__wrap_wurl_http_request, timeout, WM_MS_GRAPH_DEFAULT_TIMEOUT);
     will_return(__wrap_wurl_http_request, response);
-    
+
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"security\",\"relationship\":\"alerts_v2\"}}'");
@@ -2924,8 +2924,8 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
     wm_ms_graph_state_t relationship_state_struc;
     wm_ms_graph_state_t relationship_state_struc_2;
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config); 
-    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]); 
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
     relationship_state_struc.next_time = 10;
     relationship_state_struc_2.next_time = 10;
     module_data->enabled = true;
@@ -3044,7 +3044,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     expect_value(__wrap_wurl_http_request, timeout, WM_MS_GRAPH_DEFAULT_TIMEOUT);
     will_return(__wrap_wurl_http_request, response);
 
-    
+
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1_resource_2\",\"resource\":\"auditlogs\",\"relationship\":\"signIns\"}}'");
 
@@ -3071,14 +3071,14 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state.");
-    
+
     wm_ms_graph_scan_relationships(module_data, initial);
 
 }
 
 int main(void) {
 
-    const struct CMUnitTest tests_without_startup[] = { 
+    const struct CMUnitTest tests_without_startup[] = {
         cmocka_unit_test(test_cleanup),
         cmocka_unit_test_setup_teardown(test_bad_tag, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_empty_module, setup_test_read, teardown_test_read),
@@ -3113,7 +3113,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_invalid_attribute_resource, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_normal_config, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_normal_config_api_type_gcc, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_normal_config_api_type_dod, setup_test_read, teardown_test_read) 
+        cmocka_unit_test_setup_teardown(test_normal_config_api_type_dod, setup_test_read, teardown_test_read)
     };
 
     const struct CMUnitTest tests_with_startup[] = {
@@ -3146,9 +3146,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_success_two_resources, setup_conf, teardown_conf)
     };
     int result = 0;
-   
     result = cmocka_run_group_tests(tests_without_startup, NULL, NULL);
     result += cmocka_run_group_tests(tests_with_startup, NULL, NULL);
-
     return result;
 }

--- a/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
+++ b/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
@@ -1890,7 +1890,7 @@ void test_wm_ms_graph_get_access_token_success(void **state) {
 
     assert_string_equal(module_data->auth_config[0]->access_token, "token_value");
 #ifdef WIN32
-    assert_int_equal(module_data->auth_config.token_expiration_time, 123);
+    assert_int_equal(module_data->auth_config[0]->token_expiration_time, 123);
 #else
     assert_int_equal(module_data->auth_config[0]->token_expiration_time, 223);
 #endif

--- a/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
+++ b/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
@@ -24,7 +24,6 @@
 
 #include "../scheduling/wmodules_scheduling_helpers.h"
 #include "../../wrappers/common.h"
-
 #include "../../wrappers/libc/stdlib_wrappers.h"
 #include "../../wrappers/wazuh/shared/mq_op_wrappers.h"
 #include "../../wrappers/wazuh/wazuh_modules/wmodules_wrappers.h"
@@ -32,7 +31,6 @@
 #include "../../wrappers/wazuh/shared/url_wrappers.h"
 #include "../../wrappers/wazuh/shared/schedule_scan_wrappers.h"
 #include "../../wrappers/libc/time_wrappers.h"
-
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/wazuh_modules/wm_exec_wrappers.h"
 
@@ -62,7 +60,6 @@ static void wmodule_cleanup(wmodule *module){
             os_free(module_data->resources[resource].name);
         }
         os_free(module_data->resources);
-
         for(int i = 0; module_data->auth_config[i]; i++) {
             os_free(module_data->auth_config[i]->tenant_id);
             os_free(module_data->auth_config[i]->client_id);
@@ -75,7 +72,6 @@ static void wmodule_cleanup(wmodule *module){
         }
 
         os_free(module_data->auth_config);
-
         os_free(module_data);
     }
     os_free(module->tag);
@@ -105,7 +101,6 @@ static int teardown_test_read(void **state) {
 static int setup_conf(void **state) {
     wm_ms_graph* init_data = NULL;
     os_calloc(1,sizeof(wm_ms_graph), init_data);
-
     test_mode = true;
     *state = init_data;
     return 0;
@@ -119,7 +114,6 @@ static int teardown_conf(void **state) {
 }
 
 // XML reading tests
-
 void test_bad_tag(void **state) {
     const char* config =
         "<invalid>yes</invalid>\n"
@@ -151,9 +145,7 @@ void test_bad_tag(void **state) {
 }
 
 void test_empty_module(void **state) {
-    const char* config =
-        ""
-    ;
+    const char* config = "";
     test_structure *test = *state;
     expect_string(__wrap__merror, formatted_msg, "Empty configuration found in module 'ms-graph'.");
     test->nodes = string_to_xml_node(config, &(test->xml));
@@ -1070,7 +1062,6 @@ void test_invalid_attribute_resource(void **state) {
 }
 
 // Main program tests
-
 void test_normal_config(void **state) {
     const char* config =
         "<enabled>yes</enabled>\n"
@@ -1214,7 +1205,6 @@ void test_normal_config_api_type_dod(void **state) {
 }
 
 void test_cleanup() {
-
     expect_string(__wrap__mtinfo, tag, WM_MS_GRAPH_LOGTAG);
     expect_string(__wrap__mtinfo, formatted_msg, "Module shutdown.");
     wm_ms_graph_cleanup();
@@ -1263,11 +1253,9 @@ void test_setup_complete(void **state) {
     expect_string(__wrap__mterror, formatted_msg, "Unable to connect to Message Queue. Exiting...");
 
     wm_ms_graph_setup(module_data);
-
 }
 
 void test_main_token(void **state) {
-
     current_time = 1;
     unsigned int run_on_start = 1;
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
@@ -1342,11 +1330,9 @@ void test_main_token(void **state) {
     will_return(__wrap_FOREVER, 0);
 
     wm_ms_graph_main(module_data);
-
 }
 
 void test_main_relationships(void **state) {
-
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
     os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
     os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
@@ -1407,7 +1393,6 @@ void test_main_relationships(void **state) {
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -1423,8 +1408,6 @@ void test_main_relationships(void **state) {
     will_return(__wrap_FOREVER, 0);
 
     wm_ms_graph_main(module_data);
-
-
 }
 
 void test_disabled(void **state) {
@@ -1651,7 +1634,6 @@ void test_wm_ms_graph_get_access_token_no_response(void **state) {
     wm_ms_graph_get_access_token(module_data->auth_config[0], max_size);
 
     assert_null(module_data->auth_config[0]->access_token);
-
 }
 
 void test_wm_ms_graph_get_access_token_unsuccessful_status_code(void **state) {
@@ -1716,7 +1698,6 @@ void test_wm_ms_graph_get_access_token_unsuccessful_status_code(void **state) {
     wm_ms_graph_get_access_token(module_data->auth_config[0], max_size);
 
     assert_null(module_data->auth_config[0]->access_token);
-
 }
 
 void test_wm_ms_graph_get_access_token_curl_max_size(void **state) {
@@ -1781,7 +1762,6 @@ void test_wm_ms_graph_get_access_token_curl_max_size(void **state) {
     wm_ms_graph_get_access_token(module_data->auth_config[0], max_size);
 
     assert_null(module_data->auth_config[0]->access_token);
-
 }
 
 void test_wm_ms_graph_get_access_token_parse_json_fail(void **state) {
@@ -1914,7 +1894,6 @@ void test_wm_ms_graph_get_access_token_success(void **state) {
 #else
     assert_int_equal(module_data->auth_config[0]->token_expiration_time, 223);
 #endif
-
 }
 
 void test_wm_ms_graph_get_access_token_no_access_token(void **state) {
@@ -1978,7 +1957,6 @@ void test_wm_ms_graph_get_access_token_no_access_token(void **state) {
     expect_string(__wrap__mtwarn, formatted_msg, "Incomplete access token response, value or expiration time not present.");
 
     wm_ms_graph_get_access_token(module_data->auth_config[0], max_size);
-
 }
 
 void test_wm_ms_graph_get_access_token_no_expire_time(void **state) {
@@ -2042,7 +2020,6 @@ void test_wm_ms_graph_get_access_token_no_expire_time(void **state) {
     expect_string(__wrap__mtwarn, formatted_msg, "Incomplete access token response, value or expiration time not present.");
 
     wm_ms_graph_get_access_token(module_data->auth_config[0], max_size);
-
 }
 
 void test_wm_ms_graph_scan_relationships_single_initial_only_no(void **state) {
@@ -2097,7 +2074,6 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no(void **state) {
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2111,7 +2087,6 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no(void **state) {
     expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run first scan.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
-
 }
 
 void test_wm_ms_graph_scan_relationships_single_initial_only_yes_fail_write(void **state) {
@@ -2171,7 +2146,6 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_yes_fail_write(void
     expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
-
 }
 
 void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_response(void **state) {
@@ -2228,7 +2202,6 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_res
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2247,7 +2220,6 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_res
     expect_string(__wrap__mtwarn, formatted_msg, "No response received when attempting to get relationship 'alerts_v2' from resource 'security' on API version 'v1.0'.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
-
 }
 
 void test_wm_ms_graph_scan_relationships_single_no_initial_no_timestamp(void **state) {
@@ -2304,7 +2276,6 @@ void test_wm_ms_graph_scan_relationships_single_no_initial_no_timestamp(void **s
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2318,7 +2289,6 @@ void test_wm_ms_graph_scan_relationships_single_no_initial_no_timestamp(void **s
     expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run first scan.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
-
 }
 
 void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **state) {
@@ -2380,7 +2350,6 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2399,7 +2368,6 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
     expect_string(__wrap__mtwarn, formatted_msg, "Received unsuccessful status code when attempting to get relationship 'alerts_v2' logs: Status code was '400' & response was '{\"error\":\"bad_request\"}'");
 
     wm_ms_graph_scan_relationships(module_data, initial);
-
 }
 
 void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) {
@@ -2462,7 +2430,6 @@ void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) 
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2481,7 +2448,6 @@ void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) 
     expect_string(__wrap__mtwarn, formatted_msg, "Reached maximum CURL size when attempting to get relationship 'alerts_v2' logs. Consider increasing the value of 'curl_max_size'.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
-
 }
 
 void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
@@ -2544,7 +2510,6 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2563,7 +2528,6 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
     expect_string(__wrap__mtwarn, formatted_msg, "Failed to parse relationship 'alerts_v2' JSON body.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
-
 }
 
 void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
@@ -2626,7 +2590,6 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2647,7 +2610,6 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2661,7 +2623,6 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
-
 }
 
 void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
@@ -2725,7 +2686,6 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2755,7 +2715,6 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2768,9 +2727,7 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
 
-
     wm_ms_graph_scan_relationships(module_data, initial);
-
 }
 
 void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
@@ -2834,7 +2791,6 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2848,7 +2804,6 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     expect_any(__wrap_wurl_http_request, max_size);
     expect_value(__wrap_wurl_http_request, timeout, WM_MS_GRAPH_DEFAULT_TIMEOUT);
     will_return(__wrap_wurl_http_request, response);
-
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"security\",\"relationship\":\"alerts_v2\"}}'");
@@ -2879,7 +2834,6 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2893,7 +2847,6 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
-
 }
 
 void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **state) {
@@ -2967,7 +2920,6 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -2996,7 +2948,6 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -3026,7 +2977,6 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -3040,7 +2990,6 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     expect_any(__wrap_wurl_http_request, max_size);
     expect_value(__wrap_wurl_http_request, timeout, WM_MS_GRAPH_DEFAULT_TIMEOUT);
     will_return(__wrap_wurl_http_request, response);
-
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1_resource_2\",\"resource\":\"auditlogs\",\"relationship\":\"signIns\"}}'");
@@ -3056,7 +3005,6 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
 #ifndef WIN32
     will_return(__wrap_gmtime_r, 1);
 #endif
-
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
@@ -3070,11 +3018,9 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
-
 }
 
 int main(void) {
-
     const struct CMUnitTest tests_without_startup[] = {
         cmocka_unit_test(test_cleanup),
         cmocka_unit_test_setup_teardown(test_bad_tag, setup_test_read, teardown_test_read),
@@ -3112,7 +3058,6 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_normal_config_api_type_gcc, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_normal_config_api_type_dod, setup_test_read, teardown_test_read)
     };
-
     const struct CMUnitTest tests_with_startup[] = {
         cmocka_unit_test_setup_teardown(test_setup_complete, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_main_token, setup_conf, teardown_conf),

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -69,7 +69,7 @@ void* wm_ms_graph_main(wm_ms_graph* ms_graph) {
                 os_free(timestamp);
                 w_sleep_until(next_scan_time);
             }
-            
+
             for (i = 0; ms_graph->auth_config[i]; i++) {
                 it = ms_graph->auth_config[i];
 
@@ -207,7 +207,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_sc
 
             for (e = 0; ms_graph->auth_config[e]; e++) {
                 it = ms_graph->auth_config[e];
-            
+
                 snprintf(relationship_state_name, OS_SIZE_1024 -1, "%s-%s-%s-%s", WM_MS_GRAPH_CONTEXT.name,
                     it->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num]);
 
@@ -341,10 +341,9 @@ void wm_ms_graph_destroy(wm_ms_graph* ms_graph) {
 
     int e;
     wm_ms_graph_auth *it;
- 
-    for (e = 0; ms_graph->auth_config && ms_graph->auth_config[e]; e++) {        
+
+    for (e = 0; ms_graph->auth_config && ms_graph->auth_config[e]; e++) {
         it = ms_graph->auth_config[e];
-        
         os_free(it->tenant_id);
         os_free(it->client_id);
         os_free(it->secret_value);

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -157,7 +157,6 @@ void wm_ms_graph_get_access_token(wm_ms_graph_auth* auth_config, const ssize_t c
     snprintf(payload, OS_SIZE_8192 - 1, WM_MS_GRAPH_ACCESS_TOKEN_PAYLOAD, auth_config->query_fqdn, auth_config->client_id, auth_config->secret_value);
 
     response = wurl_http_request(WURL_POST_METHOD, headers, url, payload, curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
-    
     if (response) {
         if (response->status_code != 200) {
             char status_code[4];
@@ -323,9 +322,8 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_sc
                             start_time_str, it->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);
                     }
                 }
-
                 os_free(headers[0]);
-            }//for(e
+            }
         }
     }
 }
@@ -343,8 +341,8 @@ void wm_ms_graph_destroy(wm_ms_graph* ms_graph) {
 
     int e;
     wm_ms_graph_auth *it;
-
-    for (e = 0; ms_graph->auth_config[e]; e++) {        
+ 
+    for (e = 0; ms_graph->auth_config && ms_graph->auth_config[e]; e++) {        
         it = ms_graph->auth_config[e];
         
         os_free(it->tenant_id);
@@ -353,6 +351,8 @@ void wm_ms_graph_destroy(wm_ms_graph* ms_graph) {
         os_free(it->login_fqdn);
         os_free(it->query_fqdn);
         os_free(it->access_token);
+
+        os_free(it);
     }
 
     os_free(ms_graph->auth_config);

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -156,9 +156,8 @@ void wm_ms_graph_get_access_token(wm_ms_graph_auth* auth_config, const ssize_t c
     mtdebug1(WM_MS_GRAPH_LOGTAG, "Microsoft Graph API Access Token URL: '%s'", url);
     snprintf(payload, OS_SIZE_8192 - 1, WM_MS_GRAPH_ACCESS_TOKEN_PAYLOAD, auth_config->query_fqdn, auth_config->client_id, auth_config->secret_value);
 
-proxy(true);
     response = wurl_http_request(WURL_POST_METHOD, headers, url, payload, curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
-proxy(false);    
+    
     if (response) {
         if (response->status_code != 200) {
             char status_code[4];
@@ -252,9 +251,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_sc
                 mtdebug1(WM_MS_GRAPH_LOGTAG, "Microsoft Graph API Log URL: '%s'", url);
 
                 fail = true;
-proxy(true);
                 response = wurl_http_request(WURL_GET_METHOD, headers, url, "", ms_graph->curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
-proxy(false);
                 // It takes the time right after the response to be saved for the next scan.
                 now = time(0);
                 if (response) {

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -70,7 +70,9 @@ void* wm_ms_graph_main(wm_ms_graph* ms_graph) {
                 w_sleep_until(next_scan_time);
             }
             
-            for (i = 0, it = ms_graph->auth_config[0]; it; i++, it = ms_graph->auth_config[i]) {
+            for (i = 0; ms_graph->auth_config[i]; i++) {
+                it = ms_graph->auth_config[i];
+
                 if (!it->access_token || time(NULL) >= it->token_expiration_time) {
                     mtinfo(WM_MS_GRAPH_LOGTAG, "Obtaining access token.");
                     wm_ms_graph_get_access_token(it, ms_graph->curl_max_size);
@@ -205,7 +207,8 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_sc
             int e;
             wm_ms_graph_auth *it;
 
-            for (e = 0, it = ms_graph->auth_config[0]; it; e++, it = ms_graph->auth_config[e]) {
+            for (e = 0; ms_graph->auth_config[e]; e++) {
+                it = ms_graph->auth_config[e];
             
                 snprintf(relationship_state_name, OS_SIZE_1024 -1, "%s-%s-%s-%s", WM_MS_GRAPH_CONTEXT.name,
                     it->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num]);
@@ -344,7 +347,9 @@ void wm_ms_graph_destroy(wm_ms_graph* ms_graph) {
     int e;
     wm_ms_graph_auth *it;
 
-    for (e = 0, it = ms_graph->auth_config[0]; it; e++, it = ms_graph->auth_config[e]) {
+    for (e = 0; ms_graph->auth_config[e]; e++) {        
+        it = ms_graph->auth_config[e];
+        
         os_free(it->tenant_id);
         os_free(it->client_id);
         os_free(it->secret_value);
@@ -352,6 +357,8 @@ void wm_ms_graph_destroy(wm_ms_graph* ms_graph) {
         os_free(it->query_fqdn);
         os_free(it->access_token);
     }
+
+    os_free(ms_graph->auth_config);
 
     os_free(ms_graph->version);
 
@@ -394,7 +401,8 @@ cJSON* wm_ms_graph_dump(const wm_ms_graph* ms_graph) {
     int e;
     wm_ms_graph_auth *it;
 
-    for (e = 0, it = ms_graph->auth_config[0]; it; e++, it = ms_graph->auth_config[e]) {
+    for (e = 0; ms_graph->auth_config[e]; e++) {
+        it = ms_graph->auth_config[e];
 
         if (it->client_id) {
             cJSON_AddStringToObject(ms_graph_auth, "client_id", it->client_id);

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -43,7 +43,6 @@ const wm_context WM_MS_GRAPH_CONTEXT = {
     .query = NULL,
 };
 
-
 void* wm_ms_graph_main(wm_ms_graph* ms_graph) {
     char* timestamp = NULL;
 
@@ -53,6 +52,8 @@ void* wm_ms_graph_main(wm_ms_graph* ms_graph) {
         mtinfo(WM_MS_GRAPH_LOGTAG, "Started module.");
 
         bool initial = true;
+        int i;
+        wm_ms_graph_auth *it;
 
         while (FOREVER()) {
             const time_t time_sleep = sched_scan_get_time_until_next_scan(&ms_graph->scan_config, WM_MS_GRAPH_LOGTAG, ms_graph->run_on_start);
@@ -68,18 +69,19 @@ void* wm_ms_graph_main(wm_ms_graph* ms_graph) {
                 os_free(timestamp);
                 w_sleep_until(next_scan_time);
             }
+            
+            for (i = 0, it = ms_graph->auth_config[0]; it; i++, it = ms_graph->auth_config[i]) {
+                if (!it->access_token || time(NULL) >= it->token_expiration_time) {
+                    mtinfo(WM_MS_GRAPH_LOGTAG, "Obtaining access token.");
+                    wm_ms_graph_get_access_token(it, ms_graph->curl_max_size);
+                }
 
-            if (!ms_graph->auth_config.access_token || time(NULL) >= ms_graph->auth_config.token_expiration_time) {
-                mtinfo(WM_MS_GRAPH_LOGTAG, "Obtaining access token.");
-                wm_ms_graph_get_access_token(&ms_graph->auth_config, ms_graph->curl_max_size);
+                if (it->access_token && time(NULL) < it->token_expiration_time) {
+                    mtinfo(WM_MS_GRAPH_LOGTAG, "Scanning tenant '%s'", it->tenant_id);
+                    wm_ms_graph_scan_relationships(ms_graph, initial);
+                    initial = false;
+                }
             }
-
-            if (ms_graph->auth_config.access_token && time(NULL) < ms_graph->auth_config.token_expiration_time) {
-                mtinfo(WM_MS_GRAPH_LOGTAG, "Scanning tenant '%s'", ms_graph->auth_config.tenant_id);
-                wm_ms_graph_scan_relationships(ms_graph, initial);
-                initial = false;
-            }
-
         }
     }
     return NULL;
@@ -152,7 +154,9 @@ void wm_ms_graph_get_access_token(wm_ms_graph_auth* auth_config, const ssize_t c
     mtdebug1(WM_MS_GRAPH_LOGTAG, "Microsoft Graph API Access Token URL: '%s'", url);
     snprintf(payload, OS_SIZE_8192 - 1, WM_MS_GRAPH_ACCESS_TOKEN_PAYLOAD, auth_config->query_fqdn, auth_config->client_id, auth_config->secret_value);
 
+proxy(true);
     response = wurl_http_request(WURL_POST_METHOD, headers, url, payload, curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
+proxy(false);    
     if (response) {
         if (response->status_code != 200) {
             char status_code[4];
@@ -198,123 +202,130 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_sc
 
         for (unsigned int relationship_num = 0; relationship_num < ms_graph->resources[resource_num].num_relationships; relationship_num++) {
 
-            snprintf(relationship_state_name, OS_SIZE_1024 -1, "%s-%s-%s-%s", WM_MS_GRAPH_CONTEXT.name,
-                ms_graph->auth_config.tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num]);
+            int e;
+            wm_ms_graph_auth *it;
 
-            memset(&relationship_state_struc, 0, sizeof(relationship_state_struc));
+            for (e = 0, it = ms_graph->auth_config[0]; it; e++, it = ms_graph->auth_config[e]) {
+            
+                snprintf(relationship_state_name, OS_SIZE_1024 -1, "%s-%s-%s-%s", WM_MS_GRAPH_CONTEXT.name,
+                    it->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num]);
 
-            // Load state for tenant-resource-relationship
-            if (wm_state_io(relationship_state_name, WM_IO_READ, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
                 memset(&relationship_state_struc, 0, sizeof(relationship_state_struc));
-            }
 
-            now = time(0);
-
-            if ((initial_scan && (!relationship_state_struc.next_time || ms_graph->only_future_events)) ||
-                (!initial_scan && !relationship_state_struc.next_time)) {
-                relationship_state_struc.next_time = now;
-                if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
-                    mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
-                } else if (isDebug()) {
-                    gmtime_r(&now, &tm_aux);
-                    strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
-                    mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run first scan.",
-                        start_time_str, ms_graph->auth_config.tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);
+                // Load state for tenant-resource-relationship
+                if (wm_state_io(relationship_state_name, WM_IO_READ, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
+                    memset(&relationship_state_struc, 0, sizeof(relationship_state_struc));
                 }
-                continue;
-            }
 
-            gmtime_r(&relationship_state_struc.next_time, &tm_aux);
-            strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
+                now = time(0);
 
-            snprintf(auth_header, OS_SIZE_2048 - 1, "Authorization: Bearer %s", ms_graph->auth_config.access_token);
-            os_strdup(auth_header, headers[0]);
-
-            snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL,
-            ms_graph->auth_config.query_fqdn,
-            ms_graph->version,
-            ms_graph->resources[resource_num].name,
-            ms_graph->resources[resource_num].relationships[relationship_num],
-            start_time_str);
-
-            mtdebug1(WM_MS_GRAPH_LOGTAG, "Microsoft Graph API Log URL: '%s'", url);
-
-            fail = true;
-
-            response = wurl_http_request(WURL_GET_METHOD, headers, url, "", ms_graph->curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
-            // It takes the time right after the response to be saved for the next scan.
-            now = time(0);
-            if (response) {
-                if (response->status_code != 200) {
-                    char status_code[4];
-                    snprintf(status_code, 4, "%ld", response->status_code);
-                    mtwarn(WM_MS_GRAPH_LOGTAG, "Received unsuccessful status code when attempting to get relationship '%s' logs: Status code was '%s' & response was '%s'",
-                    ms_graph->resources[resource_num].relationships[relationship_num],
-                    status_code,
-                    response->body);
-                } else if (response->max_size_reached) {
-                    mtwarn(WM_MS_GRAPH_LOGTAG, "Reached maximum CURL size when attempting to get relationship '%s' logs. Consider increasing the value of 'curl_max_size'.",
-                    ms_graph->resources[resource_num].relationships[relationship_num]);
-                } else {
-                    cJSON* body_parse = NULL;
-                    if (body_parse = cJSON_Parse(response->body), body_parse) {
-                        cJSON* logs = cJSON_GetObjectItem(body_parse, "value");
-                        int num_logs = cJSON_GetArraySize(logs);
-                        if (num_logs > 0) {
-                            for (int log_index = 0; log_index < num_logs; log_index++) {
-                                cJSON* log = NULL;
-                                if (log = cJSON_GetArrayItem(logs, log_index), log) {
-                                    cJSON* full_log = cJSON_CreateObject();
-                                    char* payload;
-
-                                    cJSON_AddStringToObject(log, "resource", ms_graph->resources[resource_num].name);
-                                    cJSON_AddStringToObject(log, "relationship", ms_graph->resources[resource_num].relationships[relationship_num]);
-                                    cJSON_AddStringToObject(full_log, "integration", WM_MS_GRAPH_CONTEXT.name);
-                                    cJSON_AddItemToObject(full_log, WM_MS_GRAPH_CONTEXT.name, cJSON_Duplicate(log, true));
-
-                                    payload = cJSON_PrintUnformatted(full_log);
-                                    mtdebug2(WM_MS_GRAPH_LOGTAG, "Sending log: '%s'", payload);
-                                    if (wm_sendmsg(1000000 / wm_max_eps, queue_fd, payload, WM_MS_GRAPH_CONTEXT.name, LOCALFILE_MQ) < 0) {
-                                        mterror(WM_MS_GRAPH_LOGTAG, QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
-                                    }
-
-                                    os_free(payload);
-                                    cJSON_Delete(full_log);
-                                } else {
-                                    mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse log array into singular log.");
-                                }
-                            }
-                            fail = false;
-                        } else {
-                            mtdebug2(WM_MS_GRAPH_LOGTAG, "No new logs received.");
-                            fail = false;
-                        }
-                        cJSON_Delete(body_parse);
-                    } else {
-                        mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse relationship '%s' JSON body.", ms_graph->resources[resource_num].relationships[relationship_num]);
+                if ((initial_scan && (!relationship_state_struc.next_time || ms_graph->only_future_events)) ||
+                    (!initial_scan && !relationship_state_struc.next_time)) {
+                    relationship_state_struc.next_time = now;
+                    if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
+                        mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
+                    } else if (isDebug()) {
+                        gmtime_r(&now, &tm_aux);
+                        strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
+                        mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run first scan.",
+                            start_time_str, it->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);
                     }
+                    continue;
                 }
-                wurl_free_response(response);
-            } else {
-                mtwarn(WM_MS_GRAPH_LOGTAG, "No response received when attempting to get relationship '%s' from resource '%s' on API version '%s'.",
-                ms_graph->resources[resource_num].relationships[relationship_num],
-                ms_graph->resources[resource_num].name,
-                ms_graph->version);
-            }
 
-            if (!fail) {
-                relationship_state_struc.next_time = now;
                 gmtime_r(&relationship_state_struc.next_time, &tm_aux);
                 strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
-                if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
-                    mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
-                } else {
-                    mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run next scan.",
-                        start_time_str, ms_graph->auth_config.tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);
-                }
-            }
 
-            os_free(headers[0]);
+                snprintf(auth_header, OS_SIZE_2048 - 1, "Authorization: Bearer %s", it->access_token);
+                os_strdup(auth_header, headers[0]);
+
+                snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL,
+                it->query_fqdn,
+                ms_graph->version,
+                ms_graph->resources[resource_num].name,
+                ms_graph->resources[resource_num].relationships[relationship_num],
+                start_time_str);
+
+                mtdebug1(WM_MS_GRAPH_LOGTAG, "Microsoft Graph API Log URL: '%s'", url);
+
+                fail = true;
+proxy(true);
+                response = wurl_http_request(WURL_GET_METHOD, headers, url, "", ms_graph->curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
+proxy(false);
+                // It takes the time right after the response to be saved for the next scan.
+                now = time(0);
+                if (response) {
+                    if (response->status_code != 200) {
+                        char status_code[4];
+                        snprintf(status_code, 4, "%ld", response->status_code);
+                        mtwarn(WM_MS_GRAPH_LOGTAG, "Received unsuccessful status code when attempting to get relationship '%s' logs: Status code was '%s' & response was '%s'",
+                        ms_graph->resources[resource_num].relationships[relationship_num],
+                        status_code,
+                        response->body);
+                    } else if (response->max_size_reached) {
+                        mtwarn(WM_MS_GRAPH_LOGTAG, "Reached maximum CURL size when attempting to get relationship '%s' logs. Consider increasing the value of 'curl_max_size'.",
+                        ms_graph->resources[resource_num].relationships[relationship_num]);
+                    } else {
+                        cJSON* body_parse = NULL;
+                        if (body_parse = cJSON_Parse(response->body), body_parse) {
+                            cJSON* logs = cJSON_GetObjectItem(body_parse, "value");
+                            int num_logs = cJSON_GetArraySize(logs);
+                            if (num_logs > 0) {
+                                for (int log_index = 0; log_index < num_logs; log_index++) {
+                                    cJSON* log = NULL;
+                                    if (log = cJSON_GetArrayItem(logs, log_index), log) {
+                                        cJSON* full_log = cJSON_CreateObject();
+                                        char* payload;
+
+                                        cJSON_AddStringToObject(log, "resource", ms_graph->resources[resource_num].name);
+                                        cJSON_AddStringToObject(log, "relationship", ms_graph->resources[resource_num].relationships[relationship_num]);
+                                        cJSON_AddStringToObject(full_log, "integration", WM_MS_GRAPH_CONTEXT.name);
+                                        cJSON_AddItemToObject(full_log, WM_MS_GRAPH_CONTEXT.name, cJSON_Duplicate(log, true));
+
+                                        payload = cJSON_PrintUnformatted(full_log);
+                                        mtdebug2(WM_MS_GRAPH_LOGTAG, "Sending log: '%s'", payload);
+                                        if (wm_sendmsg(1000000 / wm_max_eps, queue_fd, payload, WM_MS_GRAPH_CONTEXT.name, LOCALFILE_MQ) < 0) {
+                                            mterror(WM_MS_GRAPH_LOGTAG, QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
+                                        }
+
+                                        os_free(payload);
+                                        cJSON_Delete(full_log);
+                                    } else {
+                                        mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse log array into singular log.");
+                                    }
+                                }
+                                fail = false;
+                            } else {
+                                mtdebug2(WM_MS_GRAPH_LOGTAG, "No new logs received.");
+                                fail = false;
+                            }
+                            cJSON_Delete(body_parse);
+                        } else {
+                            mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse relationship '%s' JSON body.", ms_graph->resources[resource_num].relationships[relationship_num]);
+                        }
+                    }
+                    wurl_free_response(response);
+                } else {
+                    mtwarn(WM_MS_GRAPH_LOGTAG, "No response received when attempting to get relationship '%s' from resource '%s' on API version '%s'.",
+                    ms_graph->resources[resource_num].relationships[relationship_num],
+                    ms_graph->resources[resource_num].name,
+                    ms_graph->version);
+                }
+
+                if (!fail) {
+                    relationship_state_struc.next_time = now;
+                    gmtime_r(&relationship_state_struc.next_time, &tm_aux);
+                    strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
+                    if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
+                        mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
+                    } else {
+                        mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run next scan.",
+                            start_time_str, it->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);
+                    }
+                }
+
+                os_free(headers[0]);
+            }//for(e
         }
     }
 }
@@ -330,12 +341,17 @@ void wm_ms_graph_destroy(wm_ms_graph* ms_graph) {
     }
     os_free(ms_graph->resources);
 
-    os_free(ms_graph->auth_config.tenant_id);
-    os_free(ms_graph->auth_config.client_id);
-    os_free(ms_graph->auth_config.secret_value);
-    os_free(ms_graph->auth_config.login_fqdn);
-    os_free(ms_graph->auth_config.query_fqdn);
-    os_free(ms_graph->auth_config.access_token);
+    int e;
+    wm_ms_graph_auth *it;
+
+    for (e = 0, it = ms_graph->auth_config[0]; it; e++, it = ms_graph->auth_config[e]) {
+        os_free(it->tenant_id);
+        os_free(it->client_id);
+        os_free(it->secret_value);
+        os_free(it->login_fqdn);
+        os_free(it->query_fqdn);
+        os_free(it->access_token);
+    }
 
     os_free(ms_graph->version);
 
@@ -375,22 +391,28 @@ cJSON* wm_ms_graph_dump(const wm_ms_graph* ms_graph) {
     }
     sched_scan_dump(&ms_graph->scan_config, ms_graph_info);
 
-    if (ms_graph->auth_config.client_id) {
-        cJSON_AddStringToObject(ms_graph_auth, "client_id", ms_graph->auth_config.client_id);
-    }
-    if (ms_graph->auth_config.tenant_id) {
-        cJSON_AddStringToObject(ms_graph_auth, "tenant_id", ms_graph->auth_config.tenant_id);
-    }
-    if (ms_graph->auth_config.secret_value) {
-        cJSON_AddStringToObject(ms_graph_auth, "secret_value", ms_graph->auth_config.secret_value);
-    }
-    // The FQDN used for querying the API is unique across types, so we can ignore the login FQDN
-    if (!strcmp(ms_graph->auth_config.query_fqdn, WM_MS_GRAPH_GLOBAL_API_QUERY_FQDN)) {
-        cJSON_AddStringToObject(ms_graph_auth, "api_type", "global");
-    } else if (!strcmp(ms_graph->auth_config.query_fqdn, WM_MS_GRAPH_GCC_HIGH_API_QUERY_FQDN)) {
-        cJSON_AddStringToObject(ms_graph_auth, "api_type", "gcc-high");
-    } else if (!strcmp(ms_graph->auth_config.query_fqdn, WM_MS_GRAPH_DOD_API_QUERY_FQDN)) {
-        cJSON_AddStringToObject(ms_graph_auth, "api_type", "dod");
+    int e;
+    wm_ms_graph_auth *it;
+
+    for (e = 0, it = ms_graph->auth_config[0]; it; e++, it = ms_graph->auth_config[e]) {
+
+        if (it->client_id) {
+            cJSON_AddStringToObject(ms_graph_auth, "client_id", it->client_id);
+        }
+        if (it->tenant_id) {
+            cJSON_AddStringToObject(ms_graph_auth, "tenant_id", it->tenant_id);
+        }
+        if (it->secret_value) {
+            cJSON_AddStringToObject(ms_graph_auth, "secret_value", it->secret_value);
+        }
+        // The FQDN used for querying the API is unique across types, so we can ignore the login FQDN
+        if (!strcmp(it->query_fqdn, WM_MS_GRAPH_GLOBAL_API_QUERY_FQDN)) {
+            cJSON_AddStringToObject(ms_graph_auth, "api_type", "global");
+        } else if (!strcmp(it->query_fqdn, WM_MS_GRAPH_GCC_HIGH_API_QUERY_FQDN)) {
+            cJSON_AddStringToObject(ms_graph_auth, "api_type", "gcc-high");
+        } else if (!strcmp(it->query_fqdn, WM_MS_GRAPH_DOD_API_QUERY_FQDN)) {
+            cJSON_AddStringToObject(ms_graph_auth, "api_type", "dod");
+        }
     }
     cJSON_AddItemToObject(ms_graph_info, "api_auth", ms_graph_auth);
 

--- a/src/wazuh_modules/wm_ms_graph.h
+++ b/src/wazuh_modules/wm_ms_graph.h
@@ -32,6 +32,7 @@
 #define WM_MS_GRAPH_DOD_API_LOGIN_FQDN "login.microsoftonline.us"
 #define WM_MS_GRAPH_DOD_API_QUERY_FQDN "dod-graph.microsoft.us"
 
+
 #define WM_MS_GRAPH_API_URL "https://%s/%s/%s/%s?$filter=createdDateTime+gt+%s"
 #define WM_MS_GRAPH_ACCESS_TOKEN_URL "https://%s/%s/oauth2/v2.0/token"
 #define WM_MS_GRAPH_ACCESS_TOKEN_PAYLOAD "scope=https://%s/.default&grant_type=client_credentials&client_id=%s&client_secret=%s"
@@ -63,7 +64,7 @@ typedef struct wm_ms_graph {
 	bool run_on_start;
 	char* version;
 	sched_scan_config scan_config;
-	wm_ms_graph_auth auth_config;
+	wm_ms_graph_auth **auth_config;
 	wm_ms_graph_resource* resources;
 	unsigned int num_resources;
 	wm_ms_graph_state_t state;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18202|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR adds multi-tenant capability to the **ms-graph** module.
For this, the `auth_config` member of the wm_ms_graph structure was converted into an array: 

```
typedef struct wm_ms_graph {
	bool enabled;
	bool only_future_events;
	ssize_t curl_max_size;
	bool run_on_start;
	char* version;
	sched_scan_config scan_config;
	wm_ms_graph_auth **auth_config;
	wm_ms_graph_resource* resources;
	unsigned int num_resources;
	wm_ms_graph_state_t state;
} wm_ms_graph;
```
and the functions of the ms-graph module were adapted.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->
The following configuration has been used to test the new feature:
```
<ms-graph>
    <enabled>yes</enabled>
    <only_future_events>no</only_future_events>
    <curl_max_size>10M</curl_max_size>
    <run_on_start>no</run_on_start>
    <interval>1m</interval>
    <version>v1.0</version>
    <api_auth>
      <tenant_id>tenant_1</tenant_id>
      <client_id>client_1</client_id>
      <secret_value>secret_1</secret_value>
      <api_type>global</api_type>
    </api_auth>
    <api_auth>
      <tenant_id>tenant_2</tenant_id>
      <client_id>client_2</client_id>
      <secret_value>secret_2</secret_value>
      <api_type>global</api_type>
    </api_auth>
    <api_auth>
      <tenant_id>tenant_3</tenant_id>
      <client_id>client_3</client_id>
      <secret_value>secret_3</secret_value>
      <api_type>global</api_type>
    </api_auth>
    <resource>
      <name>auditLogs</name>
      <relationship>signIns</relationship>
    </resource>
</ms-graph>
```

## Test Logs

**tenant_1:**
```
Mock responses for 5 url patterns loaded from /Users/lsayanes/Code/m365-developer-proxy-main/m365-developer-proxy/bin/Debug/net7.0/responses.json
Listening on 0.0.0.0:8000...
  WARNING: Configure your operating system to use this proxy's port and address
Press CTRL+C to stop the Microsoft 365 Developer Proxy

 request     POST http://login.microsoftonline.com/tenant_1/oauth2/v2.0/token
    mock   ╭ 200 http://login.microsoftonline.com/*/oauth2/v2.0/token
           ╰ POST http://login.microsoftonline.com/tenant_1/oauth2/v2.0/token
 request     GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
    mock   ╭ 403 http://*/*/*/*$filter=createdDateTime+gt+*
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
 request     GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
 warning   ╭ Another request to /v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z intercepted within 5 seconds.
           │ Last intercepted at 9/18/2023 4:04:18 PM.
           │ Consider using cache to avoid calling the API too often.
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
    mock   ╭ 403 http://*/*/*/*$filter=createdDateTime+gt+*
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
 request     GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T19:00:49Z
    mock   ╭ 403 http://*/*/*/*$filter=createdDateTime+gt+*
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T19:00:49Z
```
**tenant_2:**
```
 request     POST http://login.microsoftonline.com/tenant_2/oauth2/v2.0/token
    mock   ╭ 200 http://login.microsoftonline.com/*/oauth2/v2.0/token
           ╰ POST http://login.microsoftonline.com/tenant_2/oauth2/v2.0/token
 request     GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
 warning   ╭ Another request to /v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z intercepted within 5 seconds.
           │ Last intercepted at 9/18/2023 4:04:18 PM.
           │ Consider using cache to avoid calling the API too often.
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
    mock   ╭ 403 http://*/*/*/*$filter=createdDateTime+gt+*
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
 request     GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
 warning   ╭ Another request to /v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z intercepted within 5 seconds.
           │ Last intercepted at 9/18/2023 4:04:18 PM.
           │ Consider using cache to avoid calling the API too often.
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
    mock   ╭ 403 http://*/*/*/*$filter=createdDateTime+gt+*
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
 request     GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T19:00:49Z
 warning   ╭ Another request to /v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T19:00:49Z intercepted within 5 seconds.
           │ Last intercepted at 9/18/2023 4:04:18 PM.
           │ Consider using cache to avoid calling the API too often.
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T19:00:49Z
    mock   ╭ 403 http://*/*/*/*$filter=createdDateTime+gt+*
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T19:00:49Z
```
**tenant_3:**
```
 request     POST http://login.microsoftonline.com/tenant_3/oauth2/v2.0/token
    mock   ╭ 200 http://login.microsoftonline.com/*/oauth2/v2.0/token
           ╰ POST http://login.microsoftonline.com/tenant_3/oauth2/v2.0/token
 request     GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
 warning   ╭ Another request to /v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z intercepted within 5 seconds.
           │ Last intercepted at 9/18/2023 4:04:18 PM.
           │ Consider using cache to avoid calling the API too often.
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
    mock   ╭ 403 http://*/*/*/*$filter=createdDateTime+gt+*
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
 request     GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
 warning   ╭ Another request to /v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z intercepted within 5 seconds.
           │ Last intercepted at 9/18/2023 4:04:18 PM.
           │ Consider using cache to avoid calling the API too often.
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
    mock   ╭ 403 http://*/*/*/*$filter=createdDateTime+gt+*
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T18:55:45Z
 request     GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T19:00:49Z
 warning   ╭ Another request to /v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T19:00:49Z intercepted within 5 seconds.
           │ Last intercepted at 9/18/2023 4:04:18 PM.
           │ Consider using cache to avoid calling the API too often.
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T19:00:49Z
    mock   ╭ 403 http://*/*/*/*$filter=createdDateTime+gt+*
           ╰ GET http://graph.microsoft.com/v1.0/auditLogs/signIns?$filter=createdDateTime+gt+2023-09-18T19:00:49Z
```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer


[scan-build-2023-09-19-155305-1154327-1.zip](https://github.com/wazuh/wazuh/files/12667542/scan-build-2023-09-19-155305-1154327-1.zip)
[valgrind_ms-graph.log](https://github.com/wazuh/wazuh/files/12667544/valgrind_ms-graph.log)