### PR TITLE
Check array limits in Logcollector's multiline reader before adding a separator

### DIFF
--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -86,7 +86,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
 
         /* Add to buffer */
         buffer_size = strlen(buffer);
-        if (buffer[0] != '\0') {
+        if (buffer[0] != '\0' && buffer_size < sizeof(buffer) - 1) {
             buffer[buffer_size] = ' ';
             buffer_size++;
         }

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -89,6 +89,14 @@ list(APPEND logcollector_flags "-Wl,--wrap,w_expression_match -Wl,--wrap,can_rea
                                 -Wl,--wrap,w_macos_set_log_settings -Wl,--wrap,w_macos_set_last_log_timestamp \
                                 -Wl,--wrap,w_macos_set_is_valid_data")
 
+list(APPEND logcollector_names "test_read_multiline")
+list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+                                -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc\
+                                -Wl,--wrap,time -Wl,--wrap,can_read -Wl,--wrap,w_ftell -Wl,--wrap,w_expression_match \
+                                -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status -Wl,--wrap,_merror \
+                                -Wl,--wrap=w_get_hash_context -Wl,--wrap=_fseeki64 -Wl,--wrap=OS_SHA1_Stream \
+                                -Wl,--wrap=w_fseek")
+
 list(LENGTH logcollector_names count)
 math(EXPR count "${count} - 1")
 foreach(counter RANGE ${count})

--- a/src/unit_tests/logcollector/test_read_multiline.c
+++ b/src/unit_tests/logcollector/test_read_multiline.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <time.h>
+
+#include "../../logcollector/logcollector.h"
+#include "../../headers/shared.h"
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/file_op_wrappers.h"
+#include "../wrappers/libc/stdio_wrappers.h"
+
+/* Setup & Teardown */
+
+static int group_setup(void ** state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int group_teardown(void ** state) {
+    test_mode = 0;
+    return 0;
+}
+
+/* Wraps */
+int __wrap_can_read() {
+    return mock_type(int);
+}
+
+bool __wrap_w_get_hash_context(const char * path, SHA_CTX * context, int64_t position) {
+    return mock_type(bool);
+}
+
+int __wrap_w_update_file_status(const char * path, int64_t pos, SHA_CTX * context) {
+    return mock_type(int);
+}
+
+void __wrap_OS_SHA1_Stream(SHA_CTX *c, os_sha1 output, char * buf) {
+    function_called();
+    return;
+}
+
+/* Tests */
+
+void test_buffer_space(void ** state) {
+    logreader lf = { .file = "test", .linecount = 3 };
+    int rc;
+    char * input_str = malloc(OS_MAX_LOG_SIZE);
+    memset(input_str, '.', OS_MAX_LOG_SIZE - 1);
+    input_str[OS_MAX_LOG_SIZE - 1] = '\0';
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_w_get_hash_context, true);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, input_str);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) OS_MAX_LOG_SIZE - 1);
+
+    expect_function_call(__wrap_OS_SHA1_Stream);
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, "\n");
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) OS_MAX_LOG_SIZE);
+
+    expect_function_call(__wrap_OS_SHA1_Stream);
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, input_str);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) (OS_MAX_LOG_SIZE) * 2 - 1);
+
+    expect_function_call(__wrap_OS_SHA1_Stream);
+
+    expect_any(__wrap__merror, formatted_msg);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, NULL);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) (OS_MAX_LOG_SIZE) * 2 - 1);
+
+    will_return(__wrap_can_read, 0);
+
+    will_return(__wrap_w_update_file_status, 0);
+
+    read_multiline(&lf, &rc, 1);
+
+    free(input_str);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_buffer_space),
+    };
+
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}


### PR DESCRIPTION
This PR aims to add an array size check to Logcollector.

## Rationale

The _multi-line_ log format reads up to 65.279 bytes (64 KiB - 256 B [header] - 1 B [terminator]) for each log's line, and then it tries to append them into a buffer containing every line. Also, it appends a whitespace between lines. For instance:

- Input:
```
Hello
World
```
- Buffer:
```c
"Hello World"
```

Logcollector verifies the buffer's limit when appending new lines. Unfortunately, it does not check the buffer's limit when adding a whitespace separator. This could cause a whitespace to be written beyond the buffer bounds.

## Tests

- [X] Added unit tests covering the code fixed.
- [X] Run unit tests on the unfixed version.
- [x] Run a Coverity scan.

### Unit tests coverage

![image](https://github.com/wazuh/wazuh/assets/10536251/7af699b2-9e00-46cb-afe2-58168567943b)

### Coverity

> Emitted 492 C/C++ compilation units (100%) successfully
>
> 492 C/C++ compilation units (100%) are ready for analysis
The cov-build utility completed successfully.
Version: v4.5.3-r40505
Branch: fix/logcollector-multiline (395ecd96f144bf8dd025576503580f751227f5f2)
Project: wazuh%2Fossec-wazuh (3sQ--QTA0tHNvZNG5FH3IQ)
Target: server

No related defects have been reported.