### PR TITLE
Add fim_registry_key and fim_registry_value to wdb stats

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3031,6 +3031,12 @@ components:
                                 fim_registry:
                                   type: integer
                                   format: int32
+                                fim_registry_key:
+                                  type: integer
+                                  format: int32
+                                fim_registry_value:
+                                  type: integer
+                                  format: int32
                                 syscheck:
                                   type: integer
                                   format: int32
@@ -3355,6 +3361,12 @@ components:
                                   type: integer
                                   format: int32
                                 fim_registry:
+                                  type: integer
+                                  format: int32
+                                fim_registry_key:
+                                  type: integer
+                                  format: int32
+                                fim_registry_value:
                                   type: integer
                                   format: int32
                                 syscheck:
@@ -12014,6 +12026,8 @@ paths:
                               syscheck_queries: 2
                               fim_file_queries: 2
                               fim_registry_queries: 0
+                              fim_registry_key_queries: 0
+                              fim_registry_value_queries: 0
                             rootcheck_queries:
                               rootcheck_queries: 2
                             sca_queries:
@@ -12115,6 +12129,8 @@ paths:
                               syscheck_time: 49
                               fim_file_time: 30
                               fim_registry_time: 0
+                              fim_registry_key_time: 0
+                              fim_registry_value_time: 0
                             rootcheck_time:
                               rootcheck_time: 47
                             sca_time:

--- a/src/unit_tests/wazuh_db/test_wazuh_db_state.c
+++ b/src/unit_tests/wazuh_db/test_wazuh_db_state.c
@@ -36,6 +36,8 @@ static int test_setup(void ** state) {
     wdb_state.queries_breakdown.agent_breakdown.syscheck.syscheck_queries = 0;
     wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_file_queries = 6;
     wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_queries = 10;
+    wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_key_queries = 11;
+    wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_value_queries = 12;
     wdb_state.queries_breakdown.agent_breakdown.rootcheck.rootcheck_queries = 8;
     wdb_state.queries_breakdown.agent_breakdown.sca.sca_queries = 2;
     wdb_state.queries_breakdown.agent_breakdown.ciscat.ciscat_queries = 75;
@@ -79,6 +81,10 @@ static int test_setup(void ** state) {
     wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_file_time.tv_usec = 35121;
     wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_time.tv_sec = 0;
     wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_time.tv_usec = 221548;
+    wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_key_time.tv_sec = 0;
+    wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_key_time.tv_usec = 222548;
+    wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_value_time.tv_sec = 0;
+    wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_value_time.tv_usec = 223548;
     wdb_state.queries_breakdown.agent_breakdown.rootcheck.rootcheck_time.tv_sec = 1;
     wdb_state.queries_breakdown.agent_breakdown.rootcheck.rootcheck_time.tv_usec = 146684;
     wdb_state.queries_breakdown.agent_breakdown.sca.sca_time.tv_sec = 2;
@@ -311,6 +317,10 @@ void test_wazuhdb_create_state_json(void ** state) {
     assert_int_equal(cJSON_GetObjectItem(agent_syscheck_queries, "fim_file")->valueint, 6);
     assert_non_null(cJSON_GetObjectItem(agent_syscheck_queries, "fim_registry"));
     assert_int_equal(cJSON_GetObjectItem(agent_syscheck_queries, "fim_registry")->valueint, 10);
+    assert_non_null(cJSON_GetObjectItem(agent_syscheck_queries, "fim_registry_key"));
+    assert_int_equal(cJSON_GetObjectItem(agent_syscheck_queries, "fim_registry_key")->valueint, 11);
+    assert_non_null(cJSON_GetObjectItem(agent_syscheck_queries, "fim_registry_value"));
+    assert_int_equal(cJSON_GetObjectItem(agent_syscheck_queries, "fim_registry_value")->valueint, 12);
 
     cJSON* agent_rootcheck_queries = cJSON_GetObjectItem(agent_queries_tables, "rootcheck");
     assert_non_null(cJSON_GetObjectItem(agent_rootcheck_queries, "rootcheck"));
@@ -534,6 +544,10 @@ void test_wazuhdb_create_state_json(void ** state) {
     assert_int_equal(cJSON_GetObjectItem(agent_syscheck_time, "fim_file")->valueint, 35);
     assert_non_null(cJSON_GetObjectItem(agent_syscheck_time, "fim_registry"));
     assert_int_equal(cJSON_GetObjectItem(agent_syscheck_time, "fim_registry")->valueint, 221);
+    assert_non_null(cJSON_GetObjectItem(agent_syscheck_time, "fim_registry_key"));
+    assert_int_equal(cJSON_GetObjectItem(agent_syscheck_time, "fim_registry_value")->valueint, 222);
+    assert_non_null(cJSON_GetObjectItem(agent_syscheck_time, "fim_registry_key"));
+    assert_int_equal(cJSON_GetObjectItem(agent_syscheck_time, "fim_registry_value")->valueint, 223);
 
     cJSON* agent_rootcheck_time = cJSON_GetObjectItem(agent_time_tables, "rootcheck");
     assert_non_null(cJSON_GetObjectItem(agent_rootcheck_time, "rootcheck"));

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -339,22 +339,32 @@ int wdb_parse(char * input, char * output, int peer) {
                 w_inc_agent_fim_registry_time(diff);
             }
         } else if (strcmp(query, "fim_registry_key") == 0) {
+            w_inc_agent_fim_registry_key();
             if (!next) {
                 mdebug1("DB(%s) Invalid FIM registry key query syntax.", sagent_id);
                 mdebug2("DB(%s) FIM registry key query error near: %s", sagent_id, query);
                 snprintf(output, OS_MAXSTR + 1, "err Invalid Syscheck query syntax, near '%.32s'", query);
                 result = -1;
             } else {
+                gettimeofday(&begin, 0);
                 result = wdb_parse_syscheck(wdb, WDB_FIM_REGISTRY_KEY, next, output);
+                gettimeofday(&end, 0);
+                timersub(&end, &begin, &diff);
+                w_inc_agent_fim_registry_key_time(diff);
             }
         } else if (strcmp(query, "fim_registry_value") == 0) {
+            w_inc_agent_fim_registry_value();
             if (!next) {
                 mdebug1("DB(%s) Invalid FIM registry value query syntax.", sagent_id);
                 mdebug2("DB(%s) FIM registry value query error near: %s", sagent_id, query);
                 snprintf(output, OS_MAXSTR + 1, "err Invalid Syscheck query syntax, near '%.32s'", query);
                 result = -1;
             } else {
+                gettimeofday(&begin, 0);
                 result = wdb_parse_syscheck(wdb, WDB_FIM_REGISTRY_VALUE, next, output);
+                gettimeofday(&end, 0);
+                timersub(&end, &begin, &diff);
+                w_inc_agent_fim_registry_value_time(diff);
             }
         } else if (strcmp(query, "sca") == 0) {
             w_inc_agent_sca();

--- a/src/wazuh_db/wdb_state.c
+++ b/src/wazuh_db/wdb_state.c
@@ -247,6 +247,30 @@ void w_inc_agent_fim_registry_time(struct timeval time) {
     w_mutex_unlock(&db_state_t_mutex);
 }
 
+void w_inc_agent_fim_registry_key() {
+    w_mutex_lock(&db_state_t_mutex);
+    wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_key_queries++;
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
+void w_inc_agent_fim_registry_key_time(struct timeval time) {
+    w_mutex_lock(&db_state_t_mutex);
+    timeradd(&wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_key_time, &time, &wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_key_time);
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
+void w_inc_agent_fim_registry_value() {
+    w_mutex_lock(&db_state_t_mutex);
+    wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_value_queries++;
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
+void w_inc_agent_fim_registry_value_time(struct timeval time) {
+    w_mutex_lock(&db_state_t_mutex);
+    timeradd(&wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_value_time, &time, &wdb_state.queries_breakdown.agent_breakdown.syscheck.fim_registry_value_time);
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
 void w_inc_agent_syscollector_processes() {
     w_mutex_lock(&db_state_t_mutex);
     wdb_state.queries_breakdown.agent_breakdown.syscollector.syscollector_processes_queries++;
@@ -1040,6 +1064,8 @@ cJSON* wdb_create_state_json() {
 
     cJSON_AddNumberToObject(_agent_tables_syscheck, "fim_file", wdb_state_cpy.queries_breakdown.agent_breakdown.syscheck.fim_file_queries);
     cJSON_AddNumberToObject(_agent_tables_syscheck, "fim_registry", wdb_state_cpy.queries_breakdown.agent_breakdown.syscheck.fim_registry_queries);
+    cJSON_AddNumberToObject(_agent_tables_syscheck, "fim_registry_key", wdb_state_cpy.queries_breakdown.agent_breakdown.syscheck.fim_registry_key_queries);
+    cJSON_AddNumberToObject(_agent_tables_syscheck, "fim_registry_value", wdb_state_cpy.queries_breakdown.agent_breakdown.syscheck.fim_registry_value_queries);
     cJSON_AddNumberToObject(_agent_tables_syscheck, "syscheck", wdb_state_cpy.queries_breakdown.agent_breakdown.syscheck.syscheck_queries);
 
     cJSON *_agent_tables_syscollector = cJSON_CreateObject();
@@ -1230,6 +1256,8 @@ cJSON* wdb_create_state_json() {
 
     cJSON_AddNumberToObject(_agent_tables_syscheck_t, "fim_file", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.syscheck.fim_file_time));
     cJSON_AddNumberToObject(_agent_tables_syscheck_t, "fim_registry", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.syscheck.fim_registry_time));
+    cJSON_AddNumberToObject(_agent_tables_syscheck_t, "fim_registry_key", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.syscheck.fim_registry_key_time));
+    cJSON_AddNumberToObject(_agent_tables_syscheck_t, "fim_registry_value", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.syscheck.fim_registry_value_time));
     cJSON_AddNumberToObject(_agent_tables_syscheck_t, "syscheck", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.syscheck.syscheck_time));
 
     cJSON *_agent_tables_syscollector_t = cJSON_CreateObject();
@@ -1383,6 +1411,8 @@ STATIC uint64_t get_agent_time(wdb_state_t *state){
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.syscheck.syscheck_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.syscheck.fim_file_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.syscheck.fim_registry_time, &task_time);
+    timeradd(&task_time, &state->queries_breakdown.agent_breakdown.syscheck.fim_registry_key_time, &task_time);
+    timeradd(&task_time, &state->queries_breakdown.agent_breakdown.syscheck.fim_registry_value_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.rootcheck.rootcheck_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.sca.sca_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.ciscat.ciscat_time, &task_time);

--- a/src/wazuh_db/wdb_state.h
+++ b/src/wazuh_db/wdb_state.h
@@ -40,9 +40,13 @@ typedef struct _agent_sync_t {
 typedef struct _agent_syscheck_t {
     uint64_t fim_file_queries;
     uint64_t fim_registry_queries;
+    uint64_t fim_registry_key_queries;
+    uint64_t fim_registry_value_queries;
     uint64_t syscheck_queries;
     struct timeval fim_file_time;
     struct timeval fim_registry_time;
+    struct timeval fim_registry_key_time;
+    struct timeval fim_registry_value_time;
     struct timeval syscheck_time;
 } agent_syscheck_t;
 
@@ -482,6 +486,32 @@ void w_inc_agent_fim_registry();
  * @param time Value to increment the counter.
  */
 void w_inc_agent_fim_registry_time(struct timeval time);
+
+/**
+ * @brief Increment fim registry key agent queries counter
+ *
+ */
+void w_inc_agent_fim_registry_key();
+
+/**
+ * @brief Increment fim registry key agent time counter
+ *
+ * @param time Value to increment the counter.
+ */
+void w_inc_agent_fim_registry_key_time(struct timeval time);
+
+/**
+ * @brief Increment fim registry value agent queries counter
+ *
+ */
+void w_inc_agent_fim_registry_value();
+
+/**
+ * @brief Increment fim registry value agent time counter
+ *
+ * @param time Value to increment the counter.
+ */
+void w_inc_agent_fim_registry_value_time(struct timeval time);
 
 /**
  * @brief Increment syscollector processes agent queries counter


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/19040|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

In this PR we have added the necessary functionality to handle the wdb statistics related to the new queries introduced in this PR in FIM, fim_registry_key and fim_registry_value.

The unit tests of wazuh_db have also been modified after the changes.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Package installation
