### PR TITLE
Implemented APIDownloader class

### DIFF
--- a/src/shared_modules/content_manager/src/components/APIDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/APIDownloader.hpp
@@ -1,0 +1,126 @@
+/*
+ * Wazuh content manager
+ * Copyright (C) 2015, Wazuh Inc.
+ * May 02, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+#ifndef _API_DOWNLOADER_HPP
+#define _API_DOWNLOADER_HPP
+
+#include "IURLRequest.hpp"
+#include "updaterContext.hpp"
+#include "utils/chainOfResponsability.hpp"
+#include <iostream>
+#include <memory>
+
+/**
+ * @class APIDownloader
+ *
+ * @brief Class in charge of downloading the content from the API as a step of a chain of responsibility.
+ *
+ */
+class APIDownloader final : public AbstractHandler<std::shared_ptr<UpdaterContext>>
+{
+private:
+    /**
+     * @brief Download the content from the API.
+     *
+     * @param context updater context.
+     */
+    void download()
+    {
+        std::cout << "APIDownloader - Starting" << std::endl;
+        // Get the parameters needed to download the content.
+        getParameters();
+
+        // Download the content.
+        downloadContent();
+
+        // Save the path of the downloaded content in the context
+        m_context->data.at("paths").push_back(m_fullFilePath);
+
+        // Set the status of the stage
+        m_context->data.at("stageStatus").push_back(R"({"stage": "APIDownloader", "status": "ok"})"_json);
+
+        std::cout << "APIDownloader - Finishing - Download done successfully" << std::endl;
+    }
+
+    /**
+     * @brief Get the parameters needed to download the content.
+     *
+     */
+    void getParameters()
+    {
+        // URL of the API to connect to.
+        m_url = m_context->spUpdaterBaseContext->configData.at("url").get<std::string>();
+        // output folder where the file will be saved
+        std::string outputFolder {m_context->spUpdaterBaseContext->downloadsFolder};
+        if (m_context->spUpdaterBaseContext->configData.at("compressionType").get<std::string>().compare("raw") == 0)
+        {
+            outputFolder = m_context->spUpdaterBaseContext->contentsFolder;
+        }
+        // name of the file where the content will be saved
+        const auto fileName {m_context->spUpdaterBaseContext->configData.at("contentFileName").get<std::string>()};
+        // full path where the content will be saved
+        m_fullFilePath = outputFolder + "/" + fileName;
+    }
+
+    /**
+     * @brief Download the content from the API.
+     *
+     */
+    void downloadContent()
+    {
+        const auto onError {
+            [this](const std::string& message, [[maybe_unused]] const long statusCode)
+            {
+                // Set the status of the stage
+                m_context->data.at("stageStatus").push_back(R"({"stage": "APIDownloader", "status": "fail"})"_json);
+
+                throw std::runtime_error("APIDownloader - Could not get response from API because: " + message);
+            }};
+
+        // Run the request. Save the file on disk.
+        m_urlRequest.download(HttpURL(m_url), m_fullFilePath, onError);
+    }
+
+    std::string m_url {};                         ///< URL of the API to connect to.
+    std::string m_fullFilePath {};                ///< Full path where the content will be saved.
+    IURLRequest& m_urlRequest;                    ///< Interface to perform HTTP requests
+    std::shared_ptr<UpdaterContext> m_context {}; ///< updater context
+
+public:
+    // LCOV_EXCL_START
+    ~APIDownloader() override = default;
+    // LCOV_EXCL_STOP
+
+    /**
+     * @brief Class constructor.
+     *
+     * @param urlRequest Object to perform the HTTP requests to an API.
+     */
+    explicit APIDownloader(IURLRequest& urlRequest)
+        : m_urlRequest(urlRequest)
+    {
+    }
+
+    /**
+     * @brief Download the content from the API.
+     *
+     * @param context updater context.
+     * @return std::shared_ptr<UpdaterContext>
+     */
+    std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
+    {
+        m_context = context;
+        download();
+
+        return AbstractHandler<std::shared_ptr<UpdaterContext>>::handleRequest(context);
+    }
+};
+
+#endif // _API_DOWNLOADER_HPP

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -12,6 +12,7 @@
 #ifndef _FACTORY_DOWNLOADER_HPP
 #define _FACTORY_DOWNLOADER_HPP
 
+#include "APIDownloader.hpp"
 #include "CtiApiDownloader.hpp"
 #include "HTTPRequest.hpp"
 #include "S3Downloader.hpp"
@@ -41,6 +42,10 @@ public:
         auto const downloaderType {config.at("contentSource").get<std::string>()};
         std::cout << "Creating '" << downloaderType << "' downloader" << std::endl;
 
+        if (downloaderType.compare("api") == 0)
+        {
+            return std::make_shared<APIDownloader>(HTTPRequest::instance());
+        }
         if (downloaderType.compare("cti-api") == 0)
         {
             return std::make_shared<CtiApiDownloader>(HTTPRequest::instance());

--- a/src/shared_modules/content_manager/tests/unit/APIDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/APIDownloader_test.cpp
@@ -1,0 +1,187 @@
+/*
+ * Wazuh content manager - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * Jun 14, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "APIDownloader_test.hpp"
+#include "APIDownloader.hpp"
+#include "updaterContext.hpp"
+#include "gtest/gtest.h"
+#include <filesystem>
+
+/**
+ * @brief Tests handle a valid request with raw data.
+ */
+TEST_F(APIDownloaderTest, TestHandleValidRequestWithRawData)
+{
+    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
+
+    const auto expectedStageStatus = R"(
+        [
+            {
+                "stage": "APIDownloader",
+                "status": "ok"
+            }
+        ]
+    )"_json;
+
+    const auto& fileName {
+        m_spUpdaterContext->spUpdaterBaseContext->configData.at("contentFileName").get<std::string>()};
+    const auto contentPath {static_cast<std::string>(m_spUpdaterBaseContext->contentsFolder) + "/" + fileName};
+    const auto downloadPath {static_cast<std::string>(m_spUpdaterBaseContext->downloadsFolder) + "/" + fileName};
+
+    EXPECT_NO_THROW(m_spAPIDownloader->handleRequest(m_spUpdaterContext));
+
+    EXPECT_EQ(m_spUpdaterContext->data.at("paths").at(0), contentPath);
+
+    const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
+
+    EXPECT_EQ(stageStatus, expectedStageStatus);
+
+    // It's true because the compressionType is `raw`
+    EXPECT_TRUE(std::filesystem::exists(contentPath));
+
+    // It's false because the compressionType isn't `xz`
+    EXPECT_FALSE(std::filesystem::exists(downloadPath));
+}
+
+/**
+ * @brief Tests handle a valid request with compressed data.
+ */
+TEST_F(APIDownloaderTest, TestHandleValidRequestWithCompressedData)
+{
+    m_spUpdaterBaseContext->configData["url"] = "http://localhost:4444/xz";
+    m_spUpdaterBaseContext->configData["compressionType"] = "xz";
+
+    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
+
+    const auto expectedStageStatus = R"(
+        [
+            {
+                "stage": "APIDownloader",
+                "status": "ok"
+            }
+        ]
+    )"_json;
+
+    const auto& fileName {
+        m_spUpdaterContext->spUpdaterBaseContext->configData.at("contentFileName").get<std::string>()};
+    const auto contentPath {static_cast<std::string>(m_spUpdaterBaseContext->contentsFolder) + "/" + fileName};
+    const auto downloadPath {static_cast<std::string>(m_spUpdaterBaseContext->downloadsFolder) + "/" + fileName};
+
+    EXPECT_NO_THROW(m_spAPIDownloader->handleRequest(m_spUpdaterContext));
+
+    EXPECT_EQ(m_spUpdaterContext->data.at("paths").at(0), downloadPath);
+
+    const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
+
+    EXPECT_EQ(stageStatus, expectedStageStatus);
+
+    // It's false because the compressionType isn't `raw`
+    EXPECT_FALSE(std::filesystem::exists(contentPath));
+
+    // It's true because the compressionType is `xz`
+    EXPECT_TRUE(std::filesystem::exists(downloadPath));
+}
+
+/**
+ * @brief Tests handle a valid request with compressed data and invalid output folder.
+ */
+TEST_F(APIDownloaderTest, TestHandleValidRequestWithCompressedDataAndInvalidOutputFolder)
+{
+    m_spUpdaterBaseContext->configData["url"] = "http://localhost:4444/xz";
+    m_spUpdaterBaseContext->configData["compressionType"] = "xz";
+    m_spUpdaterBaseContext->configData["outputFolder"] = "/tmp/invalid-folder";
+    m_spUpdaterBaseContext->outputFolder = "/tmp/invalid-folder";
+    m_spUpdaterBaseContext->downloadsFolder = m_spUpdaterBaseContext->outputFolder / DOWNLOAD_FOLDER;
+    m_spUpdaterBaseContext->contentsFolder = m_spUpdaterBaseContext->outputFolder / CONTENTS_FOLDER;
+
+    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
+
+    const auto expectedStageStatus = R"(
+        [
+            {
+                "stage": "APIDownloader",
+                "status": "fail"
+            }
+        ]
+    )"_json;
+
+    EXPECT_THROW(m_spAPIDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    EXPECT_TRUE(m_spUpdaterContext->data.at("paths").empty());
+
+    const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
+
+    EXPECT_EQ(stageStatus, expectedStageStatus);
+}
+
+/**
+ * @brief Tests handle an empty url.
+ */
+TEST_F(APIDownloaderTest, TestHandleAnEmptyUrl)
+{
+    m_spUpdaterBaseContext->configData["url"] = "";
+    m_spUpdaterBaseContext->configData["compressionType"] = "xz";
+    m_spUpdaterBaseContext->configData["outputFolder"] = "/tmp/invalid-folder";
+    m_spUpdaterBaseContext->outputFolder = "/tmp/invalid-folder";
+    m_spUpdaterBaseContext->downloadsFolder = m_spUpdaterBaseContext->outputFolder / DOWNLOAD_FOLDER;
+    m_spUpdaterBaseContext->contentsFolder = m_spUpdaterBaseContext->outputFolder / CONTENTS_FOLDER;
+
+    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
+
+    const auto expectedStageStatus = R"(
+        [
+            {
+                "stage": "APIDownloader",
+                "status": "fail"
+            }
+        ]
+    )"_json;
+
+    EXPECT_THROW(m_spAPIDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    EXPECT_TRUE(m_spUpdaterContext->data.at("paths").empty());
+
+    const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
+
+    EXPECT_EQ(stageStatus, expectedStageStatus);
+}
+
+/**
+ * @brief Tests handle an invalid url.
+ */
+TEST_F(APIDownloaderTest, TestHandleAnInvalidUrl)
+{
+    m_spUpdaterBaseContext->configData["url"] = "http://localhost:4444/invalid-url";
+    m_spUpdaterBaseContext->configData["compressionType"] = "xz";
+    m_spUpdaterBaseContext->configData["outputFolder"] = "/tmp/invalid-folder";
+    m_spUpdaterBaseContext->outputFolder = "/tmp/invalid-folder";
+    m_spUpdaterBaseContext->downloadsFolder = m_spUpdaterBaseContext->outputFolder / DOWNLOAD_FOLDER;
+    m_spUpdaterBaseContext->contentsFolder = m_spUpdaterBaseContext->outputFolder / CONTENTS_FOLDER;
+
+    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
+
+    const auto expectedStageStatus = R"(
+        [
+            {
+                "stage": "APIDownloader",
+                "status": "fail"
+            }
+        ]
+    )"_json;
+
+    EXPECT_THROW(m_spAPIDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    EXPECT_TRUE(m_spUpdaterContext->data.at("paths").empty());
+
+    const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
+
+    EXPECT_EQ(stageStatus, expectedStageStatus);
+}

--- a/src/shared_modules/content_manager/tests/unit/APIDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/APIDownloader_test.hpp
@@ -1,0 +1,111 @@
+/*
+ * Wazuh content manager - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * Jun 08, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _API_DOWNLOADER_TEST_HPP
+#define _API_DOWNLOADER_TEST_HPP
+
+#include "APIDownloader.hpp"
+#include "HTTPRequest.hpp"
+#include "fakes/fakeServer.hpp"
+#include "updaterContext.hpp"
+#include "gtest/gtest.h"
+#include <memory>
+
+/**
+ * @brief Runs unit tests for APIDownloader
+ */
+class APIDownloaderTest : public ::testing::Test
+{
+protected:
+    APIDownloaderTest() = default;
+    ~APIDownloaderTest() override = default;
+
+    std::shared_ptr<UpdaterContext> m_spUpdaterContext; ///< UpdaterContext used on the merge pipeline.
+
+    std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on the merge pipeline.
+
+    std::shared_ptr<APIDownloader> m_spAPIDownloader; ///< APIDownloader used to download the content.
+
+    inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< pointer to FakeServer class
+
+    /**
+     * @brief Sets initial conditions for each test case.
+     *
+     */
+    // cppcheck-suppress unusedFunction
+    void SetUp() override
+    {
+        m_spAPIDownloader = std::make_shared<APIDownloader>(HTTPRequest::instance());
+        // Create a updater base context
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spUpdaterBaseContext->outputFolder = "/tmp/api-downloader-tests";
+        m_spUpdaterBaseContext->downloadsFolder = m_spUpdaterBaseContext->outputFolder / DOWNLOAD_FOLDER;
+        m_spUpdaterBaseContext->contentsFolder = m_spUpdaterBaseContext->outputFolder / CONTENTS_FOLDER;
+        m_spUpdaterBaseContext->configData = R"(
+            {
+                "contentSource": "api",
+                "compressionType": "raw",
+                "versionedContent": "false",
+                "deleteDownloadedContent": false,
+                "url": "http://localhost:4444/raw",
+                "outputFolder": "/tmp/api-downloader-tests",
+                "dataFormat": "json",
+                "contentFileName": "sample.json"
+            }
+        )"_json;
+        // Create a updater context
+        m_spUpdaterContext = std::make_shared<UpdaterContext>();
+        // Create folders
+        std::filesystem::create_directory(m_spUpdaterBaseContext->outputFolder);
+        std::filesystem::create_directory(m_spUpdaterBaseContext->downloadsFolder);
+        std::filesystem::create_directory(m_spUpdaterBaseContext->contentsFolder);
+    }
+
+    /**
+     * @brief Tear down routine for tests
+     *
+     */
+    // cppcheck-suppress unusedFunction
+    void TearDown() override
+    {
+        // Remove outputFolder
+        std::filesystem::remove_all(m_spUpdaterBaseContext->outputFolder);
+        // Reset APIDownloader
+        m_spAPIDownloader.reset();
+        // Reset UpdaterContext
+        m_spUpdaterContext.reset();
+        // Reset UpdaterBaseContext
+        m_spUpdaterBaseContext.reset();
+    }
+
+    /**
+     * @brief Creates the fakeServer for the runtime of the test suite
+     */
+    // cppcheck-suppress unusedFunction
+    static void SetUpTestSuite()
+    {
+        if (!m_spFakeServer)
+        {
+            m_spFakeServer = std::make_unique<FakeServer>("localhost", 4444);
+        }
+    }
+
+    /**
+     * @brief Resets fakeServer causing the shutdown of the test server.
+     */
+    // cppcheck-suppress unusedFunction
+    static void TearDownTestSuite()
+    {
+        m_spFakeServer.reset();
+    }
+};
+
+#endif //_API_DOWNLOADER_TEST_HPP

--- a/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
+++ b/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
@@ -69,6 +69,34 @@ public:
      */
     void run()
     {
+        m_server.Get("/raw",
+                     [](const httplib::Request& req, httplib::Response& res)
+                     {
+                         const auto response = R"(
+                         {
+                             "key": "value"
+                         })"_json;
+                         res.set_content(response.dump(), "text/plain");
+                     });
+        m_server.Get("/xz",
+                     [](const httplib::Request& req, httplib::Response& res)
+                     {
+                         const std::filesystem::path inputPath {std::filesystem::current_path() /
+                                                                "input_files/sample.xz"};
+                         std::ifstream in(inputPath, std::ios::in | std::ios::binary);
+                         if (in)
+                         {
+                             std::ostringstream response;
+                             response << in.rdbuf();
+                             in.close();
+                             res.set_content(response.str(), "application/octet-stream");
+                         }
+                         else
+                         {
+                             res.status = 404;
+                             res.set_content("File not found", "text/plain");
+                         }
+                     });
         m_server.Get("/xz/consumers",
                      [](const httplib::Request& req, httplib::Response& res)
                      {

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -28,7 +28,7 @@ static const nlohmann::json CONFIG_PARAMETERS =
             "ondemand": true,
             "configData":
             {
-                "contentSource": "cti-api",
+                "contentSource": "api",
                 "compressionType": "raw",
                 "versionedContent": "false",
                 "deleteDownloadedContent": true,


### PR DESCRIPTION
|Related issue|
|---|
|#19194|

## Description
This PR creates the APIDownloader class that will be used to get content from an API.

## Configuration options
To use this class, the following configuration parameters are directly related:

- "contentSource": sets the APIDownloader using `api`.
- "url": URL to the API. Ex: `https://jsonplaceholder.typicode.com/todos/1`
- "contentFileName": Base full name the content file must have. Ex: `example.json`,

## Tests
![image](https://github.com/wazuh/wazuh/assets/106940255/e3508f31-9697-4c0c-9e4f-6befce1d640c)
