### PR TITLE
Fix temporary file renaming when unmerging files on Windows agent

### DIFF
--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -113,7 +113,7 @@ void run_rk_check()
             mterror(ARGV0, "No rootcheck_files file configured.");
 #endif
         } else {
-            fp = fopen(rootcheck.rootkit_files, "r");
+            fp = wfopen(rootcheck.rootkit_files, "r");
             if (!fp) {
                 mterror(ARGV0, "No rootcheck_files file: '%s'", rootcheck.rootkit_files);
             }
@@ -132,7 +132,7 @@ void run_rk_check()
             mterror(ARGV0, "No rootcheck_trojans file configured.");
 #endif
         } else {
-            fp = fopen(rootcheck.rootkit_trojans, "r");
+            fp = wfopen(rootcheck.rootkit_trojans, "r");
             if (!fp) {
                 mterror(ARGV0, "No rootcheck_trojans file: '%s'", rootcheck.rootkit_trojans);
             } else {
@@ -153,7 +153,7 @@ void run_rk_check()
         if (!rootcheck.winaudit) {
             mtinfo(ARGV0, "No winaudit file configured.");
         } else {
-            fp = fopen(rootcheck.winaudit, "r");
+            fp = wfopen(rootcheck.winaudit, "r");
             if (!fp) {
                 mterror(ARGV0, "No winaudit file: '%s'", rootcheck.winaudit);
             } else {
@@ -168,7 +168,7 @@ void run_rk_check()
         if (!rootcheck.winmalware) {
             mtinfo(ARGV0, "No winmalware file configured.");
         } else {
-            fp = fopen(rootcheck.winmalware, "r");
+            fp = wfopen(rootcheck.winmalware, "r");
             if (!fp) {
                 mterror(ARGV0, "No winmalware file: '%s'", rootcheck.winmalware);
             } else {
@@ -183,7 +183,7 @@ void run_rk_check()
         if (!rootcheck.winapps) {
             mtinfo(ARGV0, "No winapps file configured.");
         } else {
-            fp = fopen(rootcheck.winapps, "r");
+            fp = wfopen(rootcheck.winapps, "r");
             if (!fp) {
                 mterror(ARGV0, "No winapps file: '%s'", rootcheck.winapps);
             } else {
@@ -208,7 +208,7 @@ void run_rk_check()
 
             i = 0;
             while (rootcheck.unixaudit[i]) {
-                fp = fopen(rootcheck.unixaudit[i], "r");
+                fp = wfopen(rootcheck.unixaudit[i], "r");
                 if (!fp) {
                     mterror(ARGV0, "No unixaudit file: '%s'", rootcheck.unixaudit[i]);
                 } else {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19093|

The Windows agent experiences conflicts when receiving a new shared configuration (_merged.mg_) while running a Rootcheck scan. The cause of this issue is that Rootcheck holds the malware files open, preventing the agent from unmerging the shared file.

PR https://github.com/wazuh/wazuh/pull/15719 aimed to fix https://github.com/wazuh/wazuh/issues/8309 by unmerging the shared file into temporary files, and then renaming them as the target ones. Unfortunately, this produces a similar problem due to two causes:
1. The implementation of the C standard function `fopen()` prevents other processes from deleting the file.
2. Even so, `MoveFileEx()` seems to keep failing to rename open files.

## Proposed fix

1. Replace `fopen()` with `wfopen()` at Rootcheck scans. This function opens the files with the `SHARED_DELETE` flag.
2. Replace `MoveFileEx()` with `ReplaceFile()` which just requires the `SHARED_DELETE` flag if the target file is open.

### Notes

- `ReplaceFile()` requires the target file to exist. So, the agent will create it if it does not exist. In the event that the rename fails, the target file will be deleted if and only if it was expressly created.
- This may result in a TOCTOU condition, but the risk impact is low as it only involves deleting the target file in the event that the rename has failed.

## Tests

- [X] The error cannot be longer reproduced using the method described in the issue.

#### Before this fix

> 2023/09/21 13:09:02 rootcheck: INFO: Starting rootcheck scan.
2023/09/21 13:09:02 wazuh-agent: ERROR: Could not move (shared/win_malware_rcl.txta23332) to (shared/win_malware_rcl.txt) which returned (5)
2023/09/21 13:09:06 rootcheck: INFO: Ending rootcheck scan.

#### Applying this fix

> 2023/09/25 17:33:12 rootcheck: INFO: Starting rootcheck scan.
2023/09/25 17:33:13 wazuh-agent: INFO: Shared agent configuration has been updated.
2023/09/25 17:33:16 rootcheck: INFO: Ending rootcheck scan.