### PR TITLE
Fix to truncate overflow attempt when parsing XML feed

### DIFF
--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -27,7 +27,7 @@ static int _writememory(const char *str, XML_TYPE type, size_t size,
                         unsigned int parent, OS_XML *_lxml) __attribute__((nonnull));
 static int _xml_fgetc(FILE *fp, OS_XML *_lxml) __attribute__((nonnull));
 int _xml_sgetc(OS_XML *_lxml)  __attribute__((nonnull));
-static int _getattributes(unsigned int parent, OS_XML *_lxml) __attribute__((nonnull));
+static int _getattributes(unsigned int parent, OS_XML *_lxml, bool flag_truncate) __attribute__((nonnull));
 static void xml_error(OS_XML *_lxml, const char *msg, ...) __attribute__((format(printf, 2, 3), nonnull));
 
 /**
@@ -345,7 +345,7 @@ static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_
             }
             _currentlycont = _lxml->cur - 1;
             if (isspace(c)) {
-                if ((_ga = _getattributes(parent, _lxml)) < 0) {
+                if ((_ga = _getattributes(parent, _lxml, flag_truncate)) < 0) {
                     goto end;
                 }
             }
@@ -536,7 +536,7 @@ static int _writecontent(const char *str, __attribute__((unused)) size_t size, u
 }
 
 /* Read the attributes of an element */
-static int _getattributes(unsigned int parent, OS_XML *_lxml)
+static int _getattributes(unsigned int parent, OS_XML *_lxml, bool flag_truncate)
 {
     int location = 0;
     unsigned int count = 0;
@@ -551,6 +551,10 @@ static int _getattributes(unsigned int parent, OS_XML *_lxml)
 
     while ((c = xml_getc_fun(_lxml->fp, _lxml)) != EOF) {
         if (count >= XML_MAXSIZE) {
+            if (flag_truncate && 1 == location) {
+                value[count - 1] = '\0';
+                return (0);
+            }
             attr[count - 1] = '\0';
             xml_error(_lxml,
                       "XMLERR: Overflow attempt at attribute '%.20s'.", attr);
@@ -634,7 +638,7 @@ static int _getattributes(unsigned int parent, OS_XML *_lxml)
             }
             c = xml_getc_fun(_lxml->fp, _lxml);
             if (isspace(c)) {
-                return (_getattributes(parent, _lxml));
+                return (_getattributes(parent, _lxml, flag_truncate));
             } else if (c == _R_CONFE) {
                 return (0);
             } else if (c == '/') {

--- a/src/unit_tests/os_xml/test_os_xml.c
+++ b/src/unit_tests/os_xml/test_os_xml.c
@@ -993,6 +993,22 @@ void test_node_attribute_value_overflow(void **state) {
     assert_int_equal(data->xml.err_line, 1);
 }
 
+void test_node_attribute_value_truncate_overflow(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    char overflow_string[XML_MAXSIZE + 10];
+    memset(overflow_string, 'c', XML_MAXSIZE + 9);
+    overflow_string[XML_MAXSIZE + 9] = '\0';
+
+    char xml_string[2 * XML_MAXSIZE];
+    snprintf(xml_string, 2 * XML_MAXSIZE - 1, "<test attr=\"%s\"></test>", overflow_string);
+    create_xml_file(xml_string, data->xml_file_name, 256);
+    const char *xml_path[] = { "test", NULL };
+
+    assert_int_equal(OS_ReadXML_Ex(data->xml_file_name, &data->xml, true), 0);
+    assert_non_null(data->content1 = OS_GetAttributeContent(&data->xml, xml_path, "attr"));
+}
+
 void w_get_attr_val_by_name_null_attr(void ** state) {
 
     xml_node node = {0};
@@ -1209,6 +1225,9 @@ int main(void) {
 
         // Node attribute value inside XML overflow test
         cmocka_unit_test_setup_teardown(test_node_attribute_value_overflow, test_setup, test_teardown),
+
+        // Truncate node attribute value inside XML overflow test
+        cmocka_unit_test_setup_teardown(test_node_attribute_value_truncate_overflow, test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
|Related issue|
|---|
|#19127|

## Description

With this PR, at the moment of detecting an overflow attempt, we truncate the description obtained, to allow us to continue parsing the XML feed, so that VD can continue working correctly.

## Configuration options

The problem has been detected with the following two SUSE feeds:
- `SLES 15` and `SLED 15`.

So the corresponding configuration for testing the PR would be the following:
```xml
    <!-- SUSE OS vulnerabilities -->
    <provider name="suse">
      <enabled>yes</enabled>
      <os>15-server</os>
      <os>15-desktop</os>
      <update_interval>1h</update_interval>
    </provider>
```

## Logs/Alerts example

- Without the fix:
```
2023/09/22 08:42:47 wazuh-modulesd:vulnerability-detector[12094] wm_vuln_detector.c:4923 at wm_vuldet_fetch_oval(): DEBUG: (5407): The feed 'SUSE Linux Enterprise Server 15' is outdated. Fetching the last version.
2023/09/22 08:42:47 wazuh-modulesd:vulnerability-detector[12094] wm_vuln_detector.c:4703 at wm_vuldet_oval_process(): DEBUG: (5411): Starting preparse step of feed 'SLES15'
2023/09/22 08:42:48 wazuh-modulesd:vulnerability-detector[12094] wm_vuln_detector.c:4708 at wm_vuldet_oval_process(): DEBUG: (5412): Starting parse step of feed 'SLES15'
2023/09/22 08:43:20 wazuh-modulesd:vulnerability-detector[12094] wm_vuln_detector.c:4710 at wm_vuldet_oval_process(): ERROR: (5502): Could not load the CVE OVAL for 'SLES15'. 'XMLERR: Overflow attempt at attribute 'comment'.'
2023/09/22 08:43:20 wazuh-modulesd:vulnerability-detector[12094] wm_vuln_detector.c:4864 at wm_vuldet_index_feed(): DEBUG: remove(tmp/vuln-temp.bz2): No such file or directory
2023/09/22 08:43:20 wazuh-modulesd:vulnerability-detector[12094] wm_vuln_detector.c:5187 at wm_vuldet_check_feed(): DEBUG: (5521): Failed when updating 'suse SLES15' database. Retrying in '300' seconds.
2023/09/22 08:43:20 wazuh-modulesd:vulnerability-detector[12094] wm_vuln_detector.c:5846 at wm_vuldet_main(): ERROR: (5513): CVE database could not be updated.
```

- After the fix:
```
2023/09/25 15:43:16 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:4923 at wm_vuldet_fetch_oval(): DEBUG: (5407): The feed 'SUSE Linux Enterprise Server 15' is outdated. Fetching the last version.
2023/09/25 15:43:16 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:4703 at wm_vuldet_oval_process(): DEBUG: (5411): Starting preparse step of feed 'SLES15' 
2023/09/25 15:43:16 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:4708 at wm_vuldet_oval_process(): DEBUG: (5412): Starting parse step of feed 'SLES15'
2023/09/25 15:43:30 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:4846 at wm_vuldet_index_feed(): DEBUG: (5414): Refreshing 'SUSE Linux Enterprise Server 15' databases.
2023/09/25 15:43:30 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:3243 at wm_vuldet_insert(): DEBUG: (5415): Inserting vulnerabilities.
2023/09/25 15:43:30 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:3291 at wm_vuldet_insert(): DEBUG: (5492): Inserting 'SUSE' vulnerabilities dependencies.
2023/09/25 15:43:30 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:3299 at wm_vuldet_insert(): DEBUG: (5419): Inserting SUSE Linux Enterprise Server 15 vulnerabilities section.
2023/09/25 15:43:42 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:3400 at wm_vuldet_insert(): DEBUG: (5422): Inserting 'SUSE Linux Enterprise Server 15' vulnerabilities references.
2023/09/25 15:43:56 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:3453 at wm_vuldet_insert(): DEBUG: (5423): Inserting 'SUSE Linux Enterprise Server 15' vulnerabilities conditions.
2023/09/25 15:44:06 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:3527 at wm_vuldet_insert(): DEBUG: (5424): Inserting 'SUSE Linux Enterprise Server 15' vulnerabilities package names.
2023/09/25 15:44:15 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:3613 at wm_vuldet_insert(): DEBUG: (5426): Inserting 'SUSE Linux Enterprise Server 15' vulnerabilities information.
2023/09/25 15:44:16 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:4852 at wm_vuldet_index_feed(): DEBUG: (5427): Refresh of 'SUSE Linux Enterprise Server 15' database finished.
2023/09/25 15:44:16 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:4864 at wm_vuldet_index_feed(): DEBUG: remove(tmp/vuln-temp.bz2): No such file or directory
2023/09/25 15:44:16 wazuh-modulesd:vulnerability-detector[18749] wm_vuln_detector.c:5202 at wm_vuldet_check_feed(): INFO: (5430): The update of the 'SUSE Linux Enterprise Server 15' feed finished successfully.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
- [x] Stress test for affected components
