### PR TITLE
Syscollector test setup fails due to neovim package - Implementation

### DIFF
--- a/.github/workflows/macos-syscollector-tests.yml
+++ b/.github/workflows/macos-syscollector-tests.yml
@@ -32,7 +32,7 @@ jobs:
           rm -rf MacPorts-2.8.1-11-BigSur.pkg
       - name: Install port
         run: |
-          sudo /opt/local/bin/port install neovim
+          sudo /opt/local/bin/port -b install nano
       - name: Run tests
         run: |
           cd src/data_provider


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19247|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes a failure during the environment setup of the **syscollector** tests for macOS.
The installation of `neovim` wasn't possible in BigSur due to a "lua" dependency, so another package was selected.
Also, the `-b` flag directly downloads the binary to avoid the compilation process.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->


- [x] QA templates contemplate the added capabilities
