### PR TITLE
Let the send error at wazuh-remoted print the error code

### DIFF
--- a/src/remoted/netbuffer.c
+++ b/src/remoted/netbuffer.c
@@ -167,7 +167,7 @@ int nb_send(netbuffer_t * buffer, int socket) {
     #endif
                 break;
             default:
-                merror("socket: %d, send fail", socket);
+                merror("Could not send data to socket %d: %s (%d)", socket, strerror(errno), errno);
             }
         }
 

--- a/src/unit_tests/remoted/test_netbuffer.c
+++ b/src/unit_tests/remoted/test_netbuffer.c
@@ -314,7 +314,7 @@ void test_nb_send_err(void ** state) {
 
     will_return(__wrap_send, -1);
 
-    expect_string(__wrap__merror, formatted_msg, "socket: 15, send fail");
+    expect_string(__wrap__merror, formatted_msg, "Could not send data to socket 15: Connection reset by peer (104)");
 
     expect_memory(__wrap_bqueue_used, queue, (bqueue_t *)netbuffer->buffers[sock].bqueue, sizeof(bqueue_t *));
     will_return(__wrap_bqueue_used, 0);


### PR DESCRIPTION
|Related issue|
|---|
|#19215|

This PR aims to replace this error log by Remoted:
> 2023/09/22 21:26:33 wazuh-remoted: ERROR: socket: 14, send fail

Into this one:
> 2023/09/27 09:02:17 wazuh-remoted: ERROR: Could not send data to socket 85: Bad file descriptor (9)