### PR TITLE
Fix output formatting of Api and cluster logs 

### DIFF
--- a/framework/wazuh/core/tests/test_wlogging.py
+++ b/framework/wazuh/core/tests/test_wlogging.py
@@ -30,7 +30,7 @@ def test_timebasedfilerotatinghandler_dorollover():
         today = date.today()
         backup_file = join(tmp_dir, 'test', str(today.year),
                            today.strftime("%b"),
-                           f"test.log-{today.day:02d}.gz")
+                           f"test-{int(today.day):02d}.log.gz")
 
         with gzip.open(backup_file, 'r') as backup:
             assert backup.read().decode() == test_str
@@ -56,7 +56,7 @@ def test_timebasedfilerotatinghandler_compute_log_directory(mock_mkdir, rotated_
         year = year.split('.')[2]
         month = calendar.month_abbr[int(month)]
         log_path = join(tmp_dir, 'test', year, month)
-        expected_name = join(log_path, f"test.log-{int(day):02d}.gz")
+        expected_name = join(log_path, f"test-{int(day):02d}.log.gz")
         computed_name = fh.compute_log_directory(rotated_file)
 
         assert expected_name == computed_name

--- a/framework/wazuh/core/wlogging.py
+++ b/framework/wazuh/core/wlogging.py
@@ -53,7 +53,7 @@ class TimeBasedFileRotatingHandler(logging.handlers.TimedRotatingFileHandler):
         if not os.path.exists(log_path):
             utils.mkdir_with_mode(log_path, 0o750)
 
-        return os.path.join(log_path, f"{os.path.basename(self.baseFilename)}-{day}.gz")
+        return f'{log_path}/{os.path.basename(self.baseFilename).replace(".log", "")}-{day}.log.gz'
 
 
 class SizeBasedFileRotatingHandler(logging.handlers.RotatingFileHandler):


### PR DESCRIPTION
|Related issue|
| https://github.com/wazuh/internal-devel-requests/issues/269 |



## Description

This PR closes https://github.com/wazuh/internal-devel-requests/issues/269. The ".log" extension has been removed from the base name of the original file before appending the date and the ".log.gz" extension to the log file path, which was modified in https://github.com/wazuh/wazuh/pull/13197.


![image](https://github.com/wazuh/wazuh/assets/96108386/f5913a45-f604-4261-b18b-c233a1839c64)



## Tests test_wlogging

```
platform linux -- Python 3.9.16, pytest-7.4.0, pluggy-0.13.1 -- /home/wazuh/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-32-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.4.0', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '0.3.0', 'metadata': '3.0.0', 'html': '2.1.1', 'trio': '0.7.0', 'asyncio': '0.15.1'}}
rootdir: /home/wazuh/Git/wazuh/framework
plugins: aiohttp-0.3.0, metadata-3.0.0, html-2.1.1, trio-0.7.0, asyncio-0.15.1
collected 12 items                                                                                                                                                                                                

framework/wazuh/core/tests/test_wlogging.py::test_timebasedfilerotatinghandler_dorollover PASSED                                                                                                            [  8%]
framework/wazuh/core/tests/test_wlogging.py::test_timebasedfilerotatinghandler_compute_log_directory[test.log.2021-08-03] PASSED                                                                            [ 16%]
framework/wazuh/core/tests/test_wlogging.py::test_timebasedfilerotatinghandler_compute_log_directory[test.log.2019-07-04] PASSED                                                                            [ 25%]
framework/wazuh/core/tests/test_wlogging.py::test_sizebasedfilerotatinghandler_dorollover PASSED                                                                                                            [ 33%]
framework/wazuh/core/tests/test_wlogging.py::test_sizebasedfilerotatinghandler_compute_log_directory PASSED                                                                                                 [ 41%]
framework/wazuh/core/tests/test_wlogging.py::test_wazuh_logger_setup_logger[0] PASSED                                                                                                                       [ 50%]
framework/wazuh/core/tests/test_wlogging.py::test_wazuh_logger_setup_logger[500] PASSED                                                                                                                     [ 58%]
framework/wazuh/core/tests/test_wlogging.py::test_wazuh_logger__init__ PASSED                                                                                                                               [ 66%]
framework/wazuh/core/tests/test_wlogging.py::test_wazuh_logger_getattr[level-None-0] PASSED                                                                                                                 [ 75%]
framework/wazuh/core/tests/test_wlogging.py::test_wazuh_logger_getattr[foreground_mode-None-True] PASSED                                                                                                    [ 83%]
framework/wazuh/core/tests/test_wlogging.py::test_wazuh_logger_getattr[doesnt_exists-AttributeError-None] PASSED                                                                                            [ 91%]
framework/wazuh/core/tests/test_wlogging.py::test_customfilter PASSED                                                                                                                                       [100%]
```
