### PR TITLE
Windows agent binaries details are wrong - Implementation

### DIFF
--- a/.github/workflows/windows-file-details.yml
+++ b/.github/workflows/windows-file-details.yml
@@ -1,0 +1,59 @@
+name: Testing the details of the executables and libraries
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - ".github/workflows/windows-file-details.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install mingw
+        run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
+      - name: make deps
+        run: make -C src deps TARGET=winagent -j2
+      - name: make
+        run: make -C src TARGET=winagent -j2
+      - name: Copy binaries
+        run: |
+          mkdir -p src/bin_files
+          # We exclude the installer from the test
+          find src/win32/ -regex '.*wazuh-agent-[0-9]+.[0-9]+.[0-9]+\.exe$' -delete
+          # We remove the executables that aren't distributed in the signed installer
+          rm -f src/win32/setup-*.exe
+          # We remove the libraries that isn't compiled by Wazuh
+          rm -r src/win32/libwinpthread-1.dll
+          cp src/win32/*.exe src/bin_files/
+          cp src/win32/*.dll src/bin_files/
+          cp src/*.dll src/bin_files/
+      - name: Upload Artifact binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: src/bin_files
+  check_binaries_details:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version-file: ".github/workflows/.python-version"
+          architecture: x64
+      - name: Download Artifact binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: binaries
+          path: C:\binaries\
+      - name: Install dependencies
+        run: |
+          pip install -r src/win32/qa/requirements.txt
+      - name: Run tests
+        run: |
+          cd src/win32/qa
+          python -m pytest -vv ./test_bin_details.py

--- a/src/Makefile
+++ b/src/Makefile
@@ -302,9 +302,10 @@ else
 		# The workaround is to remove the __declspec(dllimport) from the function declaration in the executables (https://www.sourceware.org/bugzilla/show_bug.cgi?id=14339)
 		SHARED=dll
 		DEFINES_EVENTCHANNEL=-D_WIN32_WINNT=0x600
-		OSSEC_CFLAGS+=-Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive -Wl,-Bdynamic -ldelayimp -pthread -DBUILDING_LIBCURL="" -DPCRE2_EXP_DECL=""
-		OSSEC_LDFLAGS+=-Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive -Wl,-Bdynamic -ldelayimp -pthread -DBUILDING_LIBCURL="" -DPCRE2_EXP_DECL=""
-		AR_LDFLAGS+=-Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive -Wl,-Bdynamic -ldelayimp -pthread -DBUILDING_LIBCURL="" -DPCRE2_EXP_DECL=""
+		# We link against a patched libwinpthread.a library that no contains version.o (version.rc) to avoid including the resource in the executables due to the "--whole-archive" flag
+		OSSEC_CFLAGS+=-Wl,-L,win32/ -Wl,-Bstatic,--whole-archive -lwinpthreadpatched -Wl,--no-whole-archive -Wl,-Bdynamic -ldelayimp -pthread -DBUILDING_LIBCURL="" -DPCRE2_EXP_DECL=""
+		OSSEC_LDFLAGS+=-Wl,-L,win32/ -Wl,-Bstatic,--whole-archive -lwinpthreadpatched -Wl,--no-whole-archive -Wl,-Bdynamic -ldelayimp -pthread -DBUILDING_LIBCURL="" -DPCRE2_EXP_DECL=""
+		AR_LDFLAGS+=-Wl,-L,win32/ -Wl,-Bstatic,--whole-archive -lwinpthreadpatched -Wl,--no-whole-archive -Wl,-Bdynamic -ldelayimp -pthread -DBUILDING_LIBCURL="" -DPCRE2_EXP_DECL=""
 		PRECOMPILED_OS:=windows
 endif # winagent
 
@@ -447,14 +448,23 @@ ifneq (,$(wildcard /usr/i686-w64-mingw32/sys-root/mingw/bin/libwinpthread-1.dll)
 endif
 endif
 
+ifneq (,$(wildcard /usr/i686-w64-mingw32/lib/libwinpthread.a))
+	WIN_PTHREAD_STATIC_LIB:=/usr/i686-w64-mingw32/lib/libwinpthread.a
+else
+ifneq (,$(wildcard /usr/i686-w64-mingw32/sys-root/mingw/bin/libwinpthread.a))
+	WIN_PTHREAD_STATIC_LIB:=/usr/i686-w64-mingw32/sys-root/mingw/bin/libwinpthread.a
+endif
+endif
+
 endif #winagent
 
-OSSEC_CC      =${QUIET_CC}${MING_BASE}${CC}
-OSSEC_CCBIN   =${QUIET_CCBIN}${MING_BASE}${CC}
-OSSEC_SHARED  =${QUIET_CCBIN}${MING_BASE}${CC} -shared
-OSSEC_LINK    =${QUIET_LINK}${MING_BASE}ar -crus
-OSSEC_RANLIB  =${QUIET_RANLIB}${MING_BASE}ranlib
-OSSEC_WINDRES =${QUIET_CCBIN}${MING_BASE}windres
+OSSEC_CC      		=${QUIET_CC}${MING_BASE}${CC}
+OSSEC_CCBIN   		=${QUIET_CCBIN}${MING_BASE}${CC}
+OSSEC_SHARED  		=${QUIET_CCBIN}${MING_BASE}${CC} -shared
+OSSEC_LINK    		=${QUIET_LINK}${MING_BASE}ar -crus
+OSSEC_REMOVE_OBJECT =${QUIET_LINK}${MING_BASE}ar -d
+OSSEC_RANLIB  		=${QUIET_RANLIB}${MING_BASE}ranlib
+OSSEC_WINDRES 		=${QUIET_CCBIN}${MING_BASE}windres
 
 
 ifneq (,$(filter ${USE_INOTIFY},YES auto yes y Y 1))
@@ -795,7 +805,7 @@ ifeq (${MAKECMDGOALS},winagent)
 $(error Do not use 'winagent' directly, use 'TARGET=winagent')
 endif
 .PHONY: winagent
-winagent: external win32/libwinpthread-1.dll ${WAZUH_LIB_OUTPUT_PATH}${LIBGCC_S_NAME} ${WAZUH_LIB_OUTPUT_PATH}${LIBSTDCPP_NAME}
+winagent: external win32/libwinpthread-1.dll win32/libwinpthreadpatched.a ${WAZUH_LIB_OUTPUT_PATH}${LIBGCC_S_NAME} ${WAZUH_LIB_OUTPUT_PATH}${LIBSTDCPP_NAME}
 	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust"
 	${MAKE} ${WINDOWS_ACTIVE_RESPONSES} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust"
 	cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
@@ -827,6 +837,10 @@ win32/syscollector: win32/shared_modules win32/sysinfo
 
 win32/libwinpthread-1.dll: ${WIN_PTHREAD_LIB}
 	cp $< $@
+
+win32/libwinpthreadpatched.a: ${WIN_PTHREAD_STATIC_LIB}
+	cp $< $@
+	${OSSEC_REMOVE_OBJECT} $@ version.o
 
 ####################
 #### External ######

--- a/src/win32/qa/test_bin_details.py
+++ b/src/win32/qa/test_bin_details.py
@@ -1,0 +1,22 @@
+import pytest
+import pathlib
+import subprocess
+
+BIN_PATH = 'C:\\binaries'
+
+
+@pytest.fixture(name='current_bin', scope='module', params=list(map(str, list(pathlib.Path(BIN_PATH).glob('*')))))
+def get_bin_path(request):
+    return request.param
+
+
+def test_bin_details(current_bin):
+    fields = ['FileDescription', 'ProductName', 'ProductVersion',
+              'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
+
+    for field in fields:
+        cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
+        result = subprocess.run(
+            ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
+
+        assert result.stdout.decode() == ''


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-packages/issues/2480|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The flag `--whole-archive` is required to properly link `winpthread` statically, but this also introduces in all the binaries a resource (`version.o`) that modifies all the details of the files. Adding the same information in the `.rc` file doesn't solve the issue because the other resource has a higher priority.

The proposed solution consists in removing this object from the static library before the compilation of the Wazuh agent.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

Now the details are shown the same way than before

![2023-09-27_18-16_1](https://github.com/wazuh/wazuh/assets/65046601/1bbf462c-dff9-4166-9179-981ffe451249)

![2023-09-27_18-16](https://github.com/wazuh/wazuh/assets/65046601/c7e7aa6d-b91f-464c-8aba-5ca8f4a6f974)

Here we can see the failed tests without the changes

<details><summary>Details</summary>
<p>

```
2023-09-27T21:11:20.0207585Z ============================= test session starts =============================
2023-09-27T21:11:20.0208778Z platform win32 -- Python 3.11.5, pytest-7.2.2, pluggy-1.3.0 -- C:\hostedtoolcache\windows\Python\3.11.5\x64\python.exe
2023-09-27T21:11:20.0209332Z cachedir: .pytest_cache
2023-09-27T21:11:20.0209702Z rootdir: D:\a\wazuh\wazuh\src\win32\qa
2023-09-27T21:11:20.0308339Z collecting ... collected 12 items
2023-09-27T21:11:20.0308687Z 
2023-09-27T21:11:20.3835405Z test_bin_details.py::test_bin_details[C:\\binaries\\agent-auth.exe] FAILED [  8%]
2023-09-27T21:11:22.3113923Z test_bin_details.py::test_bin_details[C:\\binaries\\libgcc_s_dw2-1.dll] PASSED [ 16%]
2023-09-27T21:11:24.1742990Z test_bin_details.py::test_bin_details[C:\\binaries\\libstdc++-6.dll] PASSED [ 25%]
2023-09-27T21:11:24.4525809Z test_bin_details.py::test_bin_details[C:\\binaries\\libwazuhext.dll] FAILED [ 33%]
2023-09-27T21:11:24.7229707Z test_bin_details.py::test_bin_details[C:\\binaries\\libwazuhshared.dll] FAILED [ 41%]
2023-09-27T21:11:24.9944898Z test_bin_details.py::test_bin_details[C:\\binaries\\manage_agents.exe] FAILED [ 50%]
2023-09-27T21:11:25.2716653Z test_bin_details.py::test_bin_details[C:\\binaries\\netsh.exe] FAILED    [ 58%]
2023-09-27T21:11:25.5422219Z test_bin_details.py::test_bin_details[C:\\binaries\\os_win32ui.exe] FAILED [ 66%]
2023-09-27T21:11:25.8118946Z test_bin_details.py::test_bin_details[C:\\binaries\\restart-wazuh.exe] FAILED [ 75%]
2023-09-27T21:11:26.0791711Z test_bin_details.py::test_bin_details[C:\\binaries\\route-null.exe] FAILED [ 83%]
2023-09-27T21:11:26.3638661Z test_bin_details.py::test_bin_details[C:\\binaries\\wazuh-agent-eventchannel.exe] FAILED [ 91%]
2023-09-27T21:11:26.6424380Z test_bin_details.py::test_bin_details[C:\\binaries\\wazuh-agent.exe] FAILED [100%]
2023-09-27T21:11:26.6424859Z 
2023-09-27T21:11:26.6425054Z ================================== FAILURES ===================================
2023-09-27T21:11:26.6425760Z _______________ test_bin_details[C:\\binaries\\agent-auth.exe] ________________
2023-09-27T21:11:26.6426031Z 
2023-09-27T21:11:26.6426271Z current_bin = 'C:\\binaries\\agent-auth.exe'
2023-09-27T21:11:26.6426532Z 
2023-09-27T21:11:26.6426686Z     def test_bin_details(current_bin):
2023-09-27T21:11:26.6427225Z         fields = ['FileDescription', 'ProductName', 'ProductVersion',
2023-09-27T21:11:26.6427847Z                   'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
2023-09-27T21:11:26.6428191Z     
2023-09-27T21:11:26.6428452Z         for field in fields:
2023-09-27T21:11:26.6428993Z             cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
2023-09-27T21:11:26.6429378Z             result = subprocess.run(
2023-09-27T21:11:26.6429941Z                 ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
2023-09-27T21:11:26.6430280Z     
2023-09-27T21:11:26.6430640Z >           assert result.stdout.decode() == ''
2023-09-27T21:11:26.6431200Z E           AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6431609Z E             + POSIX WinThreads for Windows
2023-09-27T21:11:26.6431826Z 
2023-09-27T21:11:26.6434268Z test_bin_details.py:22: AssertionError
2023-09-27T21:11:26.6434869Z _______________ test_bin_details[C:\\binaries\\libwazuhext.dll] _______________
2023-09-27T21:11:26.6435143Z 
2023-09-27T21:11:26.6435469Z current_bin = 'C:\\binaries\\libwazuhext.dll'
2023-09-27T21:11:26.6435682Z 
2023-09-27T21:11:26.6435831Z     def test_bin_details(current_bin):
2023-09-27T21:11:26.6436350Z         fields = ['FileDescription', 'ProductName', 'ProductVersion',
2023-09-27T21:11:26.6436966Z                   'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
2023-09-27T21:11:26.6437323Z     
2023-09-27T21:11:26.6437584Z         for field in fields:
2023-09-27T21:11:26.6438046Z             cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
2023-09-27T21:11:26.6438409Z             result = subprocess.run(
2023-09-27T21:11:26.6438942Z                 ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
2023-09-27T21:11:26.6439302Z     
2023-09-27T21:11:26.6439641Z >           assert result.stdout.decode() == ''
2023-09-27T21:11:26.6440194Z E           AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6440622Z E             + POSIX WinThreads for Windows
2023-09-27T21:11:26.6440839Z 
2023-09-27T21:11:26.6440995Z test_bin_details.py:22: AssertionError
2023-09-27T21:11:26.6441404Z _____________ test_bin_details[C:\\binaries\\libwazuhshared.dll] ______________
2023-09-27T21:11:26.6441679Z 
2023-09-27T21:11:26.6441938Z current_bin = 'C:\\binaries\\libwazuhshared.dll'
2023-09-27T21:11:26.6442383Z 
2023-09-27T21:11:26.6442530Z     def test_bin_details(current_bin):
2023-09-27T21:11:26.6443053Z         fields = ['FileDescription', 'ProductName', 'ProductVersion',
2023-09-27T21:11:26.6443645Z                   'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
2023-09-27T21:11:26.6444008Z     
2023-09-27T21:11:26.6444269Z         for field in fields:
2023-09-27T21:11:26.6444711Z             cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
2023-09-27T21:11:26.6445144Z             result = subprocess.run(
2023-09-27T21:11:26.6445680Z                 ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
2023-09-27T21:11:26.6446015Z     
2023-09-27T21:11:26.6446362Z >           assert result.stdout.decode() == ''
2023-09-27T21:11:26.6446904Z E           AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6447308Z E             + POSIX WinThreads for Windows
2023-09-27T21:11:26.6447521Z 
2023-09-27T21:11:26.6447671Z test_bin_details.py:22: AssertionError
2023-09-27T21:11:26.6448101Z ______________ test_bin_details[C:\\binaries\\manage_agents.exe] ______________
2023-09-27T21:11:26.6448369Z 
2023-09-27T21:11:26.6448610Z current_bin = 'C:\\binaries\\manage_agents.exe'
2023-09-27T21:11:26.6448840Z 
2023-09-27T21:11:26.6448963Z     def test_bin_details(current_bin):
2023-09-27T21:11:26.6449474Z         fields = ['FileDescription', 'ProductName', 'ProductVersion',
2023-09-27T21:11:26.6450081Z                   'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
2023-09-27T21:11:26.6450422Z     
2023-09-27T21:11:26.6450684Z         for field in fields:
2023-09-27T21:11:26.6451144Z             cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
2023-09-27T21:11:26.6451524Z             result = subprocess.run(
2023-09-27T21:11:26.6452030Z                 ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
2023-09-27T21:11:26.6452393Z     
2023-09-27T21:11:26.6452766Z >           assert result.stdout.decode() == ''
2023-09-27T21:11:26.6453296Z E           AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6453718Z E             + POSIX WinThreads for Windows
2023-09-27T21:11:26.6453936Z 
2023-09-27T21:11:26.6454092Z test_bin_details.py:22: AssertionError
2023-09-27T21:11:26.6454479Z __________________ test_bin_details[C:\\binaries\\netsh.exe] __________________
2023-09-27T21:11:26.6454736Z 
2023-09-27T21:11:26.6455781Z current_bin = 'C:\\binaries\\netsh.exe'
2023-09-27T21:11:26.6456011Z 
2023-09-27T21:11:26.6456201Z     def test_bin_details(current_bin):
2023-09-27T21:11:26.6456740Z         fields = ['FileDescription', 'ProductName', 'ProductVersion',
2023-09-27T21:11:26.6457323Z                   'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
2023-09-27T21:11:26.6457692Z     
2023-09-27T21:11:26.6457960Z         for field in fields:
2023-09-27T21:11:26.6458403Z             cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
2023-09-27T21:11:26.6458793Z             result = subprocess.run(
2023-09-27T21:11:26.6459328Z                 ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
2023-09-27T21:11:26.6459688Z     
2023-09-27T21:11:26.6460016Z >           assert result.stdout.decode() == ''
2023-09-27T21:11:26.6460557Z E           AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6460988Z E             + POSIX WinThreads for Windows
2023-09-27T21:11:26.6461183Z 
2023-09-27T21:11:26.6461337Z test_bin_details.py:22: AssertionError
2023-09-27T21:11:26.6461750Z _______________ test_bin_details[C:\\binaries\\os_win32ui.exe] ________________
2023-09-27T21:11:26.6462012Z 
2023-09-27T21:11:26.6462247Z current_bin = 'C:\\binaries\\os_win32ui.exe'
2023-09-27T21:11:26.6462470Z 
2023-09-27T21:11:26.6462612Z     def test_bin_details(current_bin):
2023-09-27T21:11:26.6463103Z         fields = ['FileDescription', 'ProductName', 'ProductVersion',
2023-09-27T21:11:26.6463710Z                   'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
2023-09-27T21:11:26.6464214Z     
2023-09-27T21:11:26.6464452Z         for field in fields:
2023-09-27T21:11:26.6464914Z             cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
2023-09-27T21:11:26.6465293Z             result = subprocess.run(
2023-09-27T21:11:26.6465807Z                 ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
2023-09-27T21:11:26.6466177Z     
2023-09-27T21:11:26.6466520Z >           assert result.stdout.decode() == ''
2023-09-27T21:11:26.6467045Z E           AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6467478Z E             + POSIX WinThreads for Windows
2023-09-27T21:11:26.6467692Z 
2023-09-27T21:11:26.6467845Z test_bin_details.py:22: AssertionError
2023-09-27T21:11:26.6468376Z ______________ test_bin_details[C:\\binaries\\restart-wazuh.exe] ______________
2023-09-27T21:11:26.6468623Z 
2023-09-27T21:11:26.6468873Z current_bin = 'C:\\binaries\\restart-wazuh.exe'
2023-09-27T21:11:26.6469113Z 
2023-09-27T21:11:26.6469260Z     def test_bin_details(current_bin):
2023-09-27T21:11:26.6469770Z         fields = ['FileDescription', 'ProductName', 'ProductVersion',
2023-09-27T21:11:26.6470351Z                   'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
2023-09-27T21:11:26.6470710Z     
2023-09-27T21:11:26.6470971Z         for field in fields:
2023-09-27T21:11:26.6471436Z             cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
2023-09-27T21:11:26.6471791Z             result = subprocess.run(
2023-09-27T21:11:26.6472333Z                 ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
2023-09-27T21:11:26.6472694Z     
2023-09-27T21:11:26.6473017Z >           assert result.stdout.decode() == ''
2023-09-27T21:11:26.6473556Z E           AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6473987Z E             + POSIX WinThreads for Windows
2023-09-27T21:11:26.6474211Z 
2023-09-27T21:11:26.6474342Z test_bin_details.py:22: AssertionError
2023-09-27T21:11:26.6474854Z _______________ test_bin_details[C:\\binaries\\route-null.exe] ________________
2023-09-27T21:11:26.6475119Z 
2023-09-27T21:11:26.6475355Z current_bin = 'C:\\binaries\\route-null.exe'
2023-09-27T21:11:26.6475581Z 
2023-09-27T21:11:26.6475725Z     def test_bin_details(current_bin):
2023-09-27T21:11:26.6476353Z         fields = ['FileDescription', 'ProductName', 'ProductVersion',
2023-09-27T21:11:26.6476969Z                   'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
2023-09-27T21:11:26.6477328Z     
2023-09-27T21:11:26.6477566Z         for field in fields:
2023-09-27T21:11:26.6478025Z             cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
2023-09-27T21:11:26.6478407Z             result = subprocess.run(
2023-09-27T21:11:26.6478917Z                 ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
2023-09-27T21:11:26.6479283Z     
2023-09-27T21:11:26.6479626Z >           assert result.stdout.decode() == ''
2023-09-27T21:11:26.6480872Z E           AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6481472Z E             + POSIX WinThreads for Windows
2023-09-27T21:11:26.6481700Z 
2023-09-27T21:11:26.6481860Z test_bin_details.py:22: AssertionError
2023-09-27T21:11:26.6483320Z ________ test_bin_details[C:\\binaries\\wazuh-agent-eventchannel.exe] _________
2023-09-27T21:11:26.6483652Z 
2023-09-27T21:11:26.6483978Z current_bin = 'C:\\binaries\\wazuh-agent-eventchannel.exe'
2023-09-27T21:11:26.6484262Z 
2023-09-27T21:11:26.6484411Z     def test_bin_details(current_bin):
2023-09-27T21:11:26.6484941Z         fields = ['FileDescription', 'ProductName', 'ProductVersion',
2023-09-27T21:11:26.6485557Z                   'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
2023-09-27T21:11:26.6485903Z     
2023-09-27T21:11:26.6486167Z         for field in fields:
2023-09-27T21:11:26.6487023Z             cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
2023-09-27T21:11:26.6487407Z             result = subprocess.run(
2023-09-27T21:11:26.6487946Z                 ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
2023-09-27T21:11:26.6488286Z     
2023-09-27T21:11:26.6488641Z >           assert result.stdout.decode() == ''
2023-09-27T21:11:26.6489198Z E           AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6489607Z E             + POSIX WinThreads for Windows
2023-09-27T21:11:26.6489824Z 
2023-09-27T21:11:26.6489977Z test_bin_details.py:22: AssertionError
2023-09-27T21:11:26.6490493Z _______________ test_bin_details[C:\\binaries\\wazuh-agent.exe] _______________
2023-09-27T21:11:26.6490762Z 
2023-09-27T21:11:26.6491010Z current_bin = 'C:\\binaries\\wazuh-agent.exe'
2023-09-27T21:11:26.6491218Z 
2023-09-27T21:11:26.6491364Z     def test_bin_details(current_bin):
2023-09-27T21:11:26.6491874Z         fields = ['FileDescription', 'ProductName', 'ProductVersion',
2023-09-27T21:11:26.6492484Z                   'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
2023-09-27T21:11:26.6492827Z     
2023-09-27T21:11:26.6493092Z         for field in fields:
2023-09-27T21:11:26.6493547Z             cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
2023-09-27T21:11:26.6493908Z             result = subprocess.run(
2023-09-27T21:11:26.6494447Z                 ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
2023-09-27T21:11:26.6494806Z     
2023-09-27T21:11:26.6495189Z >           assert result.stdout.decode() == ''
2023-09-27T21:11:26.6495708Z E           AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6496140Z E             + POSIX WinThreads for Windows
2023-09-27T21:11:26.6496354Z 
2023-09-27T21:11:26.6496506Z test_bin_details.py:22: AssertionError
2023-09-27T21:11:26.6496870Z =========================== short test summary info ===========================
2023-09-27T21:11:26.6497665Z FAILED test_bin_details.py::test_bin_details[C:\\binaries\\agent-auth.exe] - AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6498212Z   + POSIX WinThreads for Windows
2023-09-27T21:11:26.6498926Z FAILED test_bin_details.py::test_bin_details[C:\\binaries\\libwazuhext.dll] - AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6499598Z   + POSIX WinThreads for Windows
2023-09-27T21:11:26.6500378Z FAILED test_bin_details.py::test_bin_details[C:\\binaries\\libwazuhshared.dll] - AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6500930Z   + POSIX WinThreads for Windows
2023-09-27T21:11:26.6501634Z FAILED test_bin_details.py::test_bin_details[C:\\binaries\\manage_agents.exe] - AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6502178Z   + POSIX WinThreads for Windows
2023-09-27T21:11:26.6502866Z FAILED test_bin_details.py::test_bin_details[C:\\binaries\\netsh.exe] - AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6503400Z   + POSIX WinThreads for Windows
2023-09-27T21:11:26.6504075Z FAILED test_bin_details.py::test_bin_details[C:\\binaries\\os_win32ui.exe] - AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6504611Z   + POSIX WinThreads for Windows
2023-09-27T21:11:26.6505344Z FAILED test_bin_details.py::test_bin_details[C:\\binaries\\restart-wazuh.exe] - AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6505867Z   + POSIX WinThreads for Windows
2023-09-27T21:11:26.6506566Z FAILED test_bin_details.py::test_bin_details[C:\\binaries\\route-null.exe] - AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6507101Z   + POSIX WinThreads for Windows
2023-09-27T21:11:26.6507867Z FAILED test_bin_details.py::test_bin_details[C:\\binaries\\wazuh-agent-eventchannel.exe] - AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6508555Z   + POSIX WinThreads for Windows
2023-09-27T21:11:26.6509270Z FAILED test_bin_details.py::test_bin_details[C:\\binaries\\wazuh-agent.exe] - AssertionError: assert 'POSIX WinThreads for Windows\r\n' == ''
2023-09-27T21:11:26.6509811Z   + POSIX WinThreads for Windows
2023-09-27T21:11:26.6510188Z ======================== 10 failed, 2 passed in 6.61s =========================
```

</p>
</details> 

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation

- [x] Added Github Actions test
