### PR TITLE
Fix AWS module to be compatible with minimum Python version

### DIFF
--- a/wodles/aws/subscribers/s3_log_handler.py
+++ b/wodles/aws/subscribers/s3_log_handler.py
@@ -9,6 +9,7 @@ import re
 import sys
 
 from os import path
+from typing import List
 
 try:
     import pyarrow.parquet as pq
@@ -72,7 +73,7 @@ class AWSSubscriberBucket(wazuh_integration.WazuhIntegration, AWSS3LogHandler):
                                                     **kwargs)
 
     @staticmethod
-    def _process_jsonl(file: io.TextIOWrapper) -> list[dict]:
+    def _process_jsonl(file: io.TextIOWrapper) -> List[dict]:
         """Process JSON objects present in a JSONL file.
 
         Parameters
@@ -147,7 +148,7 @@ class AWSSubscriberBucket(wazuh_integration.WazuhIntegration, AWSS3LogHandler):
         # Check if the header row matches the regex pattern
         return not bool(not_header_pattern.match(header_row))
 
-    def obtain_logs(self, bucket: str, log_path: str) -> list[dict]:
+    def obtain_logs(self, bucket: str, log_path: str) -> List[dict]:
         """Fetch a file from a bucket and obtain a list of events from it.
 
         Parameters


### PR DESCRIPTION
|Related issue|
|---|
| #19039  |


## Description

This PR closes https://github.com/wazuh/wazuh/issues/19039. 
Some syntax in s3_log_handler.py was modified, which was not compatible with Python 3.7. It has been tested on Python 3.7 and 3.8

## Logs/Alerts example

```
File "var/ossec/wodles/aws/subscribers/s3_log_handler.py", line 76, in AWSSubscriberBucket
    def _process_jsonl(file: io.TextIOWrapper) -> list[dict]:
TypeError: 'type' object is not subscriptable
```

```
  File "var/ossec/wodles/aws/subscribers/s3_log_handler.py", line 151, in AWSSubscriberBucket
    def obtain_logs(self, bucket: str, log_path: str) -> list[dict]:
TypeError: 'type' object is not subscriptable
```

## Tests

```
wodles/aws/tests/test_s3_log_handler.py::test_aws_sl_subscriber_bucket_initializes_properly PASSED                                                                                                   [ 25%]
wodles/aws/tests/test_s3_log_handler.py::test_aws_sl_subscriber_bucket_obtain_logs PASSED                                                                                                            [ 50%]
wodles/aws/tests/test_s3_log_handler.py::test_aws_sl_subscriber_bucket_obtain_logs_handles_exception PASSED                                                                                          [ 75%]
wodles/aws/tests/test_s3_log_handler.py::test_aws_sl_subscriber_bucket_process_file PASSED                                                                                                           [100%]
```