### PR TITLE
Fix package installation script from generating malformed wazuh.json file content

### DIFF
--- a/framework/setup.py
+++ b/framework/setup.py
@@ -13,41 +13,34 @@ from datetime import datetime, timezone
 from setuptools import setup, find_namespace_packages
 from setuptools.command.install import install
 
+WAZUH_VERSION='4.8.0'
+
 
 class InstallCommand(install):
-    user_options = install.user_options + [
-        ('wazuh-version=', None, 'Wazuh Version'),
-        ('install-type=', None, 'Installation type: server, local, hybrid')
-    ]
-
-    def initialize_options(self):
-        install.initialize_options(self)
-        self.wazuh_version = None
-        self.install_type = None
-
-    def finalize_options(self):
-        install.finalize_options(self)
+    """Inherited class. Overrides the run method to generate the wazuh.json file."""
 
     def run(self):
         here = os.path.abspath(os.path.dirname(__file__))
-        with open(os.path.join(here, 'wazuh', 'core', 'wazuh.json'), 'w') as f:
-            json.dump({'install_type': self.install_type,
-                       'wazuh_version': self.wazuh_version,
+        with open(os.path.join(here, 'wazuh', 'core', 'wazuh.json'), 
+                  encoding='utf-8', mode='w') as file:
+            json.dump({'install_type': 'server',
+                       'wazuh_version': f'v{WAZUH_VERSION}',
                        'installation_date': datetime.utcnow().replace(tzinfo=timezone.utc).strftime(
                            '%a %b %d %H:%M:%S UTC %Y')
-                       }, f)
+                       }, file)
         install.run(self)
 
 
 setup(name='wazuh',
-      version='4.8.0',
+      version=WAZUH_VERSION,
       description='Wazuh control with Python',
       url='https://github.com/wazuh',
       author='Wazuh',
       author_email='hello@wazuh.com',
       license='GPLv2',
       packages=find_namespace_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
-      package_data={'wazuh': ['core/wazuh.json', 'core/cluster/cluster.json', 'rbac/default/*.yaml']},
+      package_data={'wazuh': ['core/wazuh.json',
+                              'core/cluster/cluster.json', 'rbac/default/*.yaml']},
       include_package_data=True,
       install_requires=[],
       zip_safe=False,

--- a/src/Makefile
+++ b/src/Makefile
@@ -2270,7 +2270,7 @@ ifneq (,$(wildcard ${EXTERNAL_CPYTHON}))
 endif
 
 install_framework: install_python
-	cd ../framework && ${WPYTHON_DIR}/bin/python3 -m pip install . --use-pep517 --prefix=${WPYTHON_DIR} --config-settings="--wazuh-version=$(shell cat VERSION)" --config-settings="--install-type=${TARGET}" && rm -rf build/
+	cd ../framework && ${WPYTHON_DIR}/bin/python3 -m pip install . --use-pep517 --prefix=${WPYTHON_DIR} && rm -rf build/
 	chown -R root:${WAZUH_GROUP} ${WPYTHON_DIR}
 	chmod -R o=- ${WPYTHON_DIR}
 

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -122,7 +122,7 @@ then
 
     # Framework
 
-    sed -E -i'' -e "s/version='.+',/version='${version:1}',/g" $FW_SETUP
+    sed -E -i'' -e "s/WAZUH_VERSION='.+'/WAZUH_VERSION='${version:1}'/g" $FW_SETUP
     sed -E -i'' -e "s/__version__ = '.+'/__version__ = '${version:1}'/g" $FW_INIT
 
     # Cluster


### PR DESCRIPTION
|Related issue|
|---|
|#18785|

## Description
The package installation script creates a malformed wazuh.json file, making failures during the wazuh installation.

The configuration options were removed to fix this failure, changing the wazuh version by a variable and hardcoding the install_type to the 'server' value in the wazuh.json file.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors