### PR TITLE
Fix buffer overflow and stack corruption when analyze a folder tree

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -559,6 +559,7 @@
 #define FIM_ERROR_EXPAND_ENV_VAR                    "(6718): Could not expand the environment variable %s (%ld)."
 #endif
 #define FIM_ERROR_TRANSACTION                       "(6719): Could not start DBSync transaction (%s)"
+#define FIM_ERROR_PATH_TOO_LONG                     "(6720): The path '%s%s' is too long. The maximum length is %d characters."
 
 /* Wazuh Logtest error messsages */
 #define LOGTEST_ERROR_BIND_SOCK                     "(7300): Unable to bind to socket '%s'. Errno: (%d) %s"

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -789,6 +789,17 @@ int fim_directory(const char *dir,
         }
         *(s_name) = '\0';
         path_size = strlen(f_name);
+
+#ifdef WIN32
+        // Check if the full path is too long if it is, skip this file
+        // and log a warning, PATH_MAX is 260 on windows, but reserves 1 char
+        // for the null terminator.
+        if (path_size + strlen(entry->d_name) >= PATH_MAX) {
+            mwarn(FIM_ERROR_PATH_TOO_LONG, f_name, entry->d_name, PATH_MAX);
+            continue;
+        }
+#endif
+
         snprintf(s_name, PATH_MAX + 2 - path_size, "%s", entry->d_name);
 
 #ifdef WIN32


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19206 |

## Description

This PR aims to avoid a stackoverflow, when a path has 260 characters less, since when the size of PATH_MAX truncates the folder, it has the same input value, causing endless recursive calls.

Stack corruption also occurs since in calls to opendir, a path must have 259 characters since the null character termination is included in the 260 of PATH_MAX.