### PR TITLE
Add new syscall id from aarch64 to FIM whodata healthcheck 

### DIFF
--- a/src/syscheckd/src/whodata/audit_parse.c
+++ b/src/syscheckd/src/whodata/audit_parse.c
@@ -958,19 +958,22 @@ void audit_parse(char *buffer) {
             char *syscall = NULL;
             os_malloc(match_size + 1, syscall);
             snprintf(syscall, match_size + 1, "%.*s", match_size, buffer + match[1].rm_so);
-            if (!strcmp(syscall, "2") || !strcmp(syscall, "257") || !strcmp(syscall, "5") || !strcmp(syscall, "295")) {
+            if (!strcmp(syscall, "2") || !strcmp(syscall, "257") || !strcmp(syscall, "5") || 
+                !strcmp(syscall, "295") || !strcmp(syscall, "56")) {
                 // x86_64: 2 open
                 // x86_64: 257 openat
                 // i686: 5 open
                 // i686: 295 openat
+                // aarch64: 56 openat
                 mdebug2(FIM_HEALTHCHECK_CREATE, syscall);
                 atomic_int_set(&audit_health_check_creation, 1);
             } else if (!strcmp(syscall, "87") || !strcmp(syscall, "263") || !strcmp(syscall, "10") ||
-                       !strcmp(syscall, "301")) {
+                       !strcmp(syscall, "301") || !strcmp(syscall, "35")) {
                 // x86_64: 87 unlink
                 // x86_64: 263 unlinkat
                 // i686: 10 unlink
                 // i686: 301 unlinkat
+                // aarch64: 35 unlinkat
                 mdebug2(FIM_HEALTHCHECK_DELETE, syscall);
             } else {
                 mdebug2(FIM_HEALTHCHECK_UNRECOGNIZED_EVENT, syscall);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/19305|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR is to add the syscall ids needed for the whodata healthcheck to work correctly on the new aarch64 architecture.

VM requested: https://github.com/wazuh/internal-devel-requests/issues/323

## Configuration options

`<directories whodata="yes">/test</directories>`

## Logs/Alerts example
```
2023/10/02 12:20:49 wazuh-syscheckd[219207] audit_healthcheck.c:41 at audit_health_check(): DEBUG: (6279): Whodata health-check: Starting.
2023/10/02 12:20:49 wazuh-syscheckd[219207] pthreads_op.c:45 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2023/10/02 12:20:49 wazuh-syscheckd[219207] audit_healthcheck.c:102 at audit_healthcheck_thread(): DEBUG: (6255): Whodata health-check: Reading thread active.
2023/10/02 12:20:49 wazuh-syscheckd[219207] audit_parse.c:326 at filterkey_audit_events(): DEBUG: (6251): Match audit_key: 'wazuh_hc'
2023/10/02 12:20:49 wazuh-syscheckd[219207] audit_parse.c:967 at audit_parse(): DEBUG: (6252): Whodata health-check: Detected file creation event (56)
2023/10/02 12:20:50 wazuh-syscheckd[219207] audit_healthcheck.c:73 at audit_health_check(): DEBUG: (6261): Whodata health-check: Success.
2023/10/02 12:20:50 wazuh-syscheckd[219207] audit_healthcheck.c:106 at audit_healthcheck_thread(): DEBUG: (6256): Whodata health-check: Reading thread finished.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
