### PR TITLE
Change to avoid concurrent synchronizations.

### DIFF
--- a/src/shared_modules/rsync/src/rsyncImplementation.cpp
+++ b/src/shared_modules/rsync/src/rsyncImplementation.cpp
@@ -22,8 +22,8 @@ using namespace RSync;
 
 void RSyncImplementation::release()
 {
-    SynchronizationController::instance().clear();
     std::lock_guard<std::mutex> lock{ m_mutex };
+    SynchronizationController::instance().clear();
 
     for (const auto& ctx : m_remoteSyncContexts)
     {
@@ -36,10 +36,10 @@ void RSyncImplementation::release()
 
 void RSyncImplementation::releaseContext(const RSYNC_HANDLE handle)
 {
-    SynchronizationController::instance().stop(handle);
     m_registrationController.removeComponentByHandle(handle);
     remoteSyncContext(handle)->m_msgDispatcher->rundown();
     std::lock_guard<std::mutex> lock{ m_mutex };
+    SynchronizationController::instance().stop(handle);
     m_remoteSyncContexts.erase(handle);
 }
 

--- a/src/shared_modules/rsync/src/rsyncImplementation.cpp
+++ b/src/shared_modules/rsync/src/rsyncImplementation.cpp
@@ -22,6 +22,7 @@ using namespace RSync;
 
 void RSyncImplementation::release()
 {
+    SynchronizationController::instance().clear();
     std::lock_guard<std::mutex> lock{ m_mutex };
 
     for (const auto& ctx : m_remoteSyncContexts)
@@ -35,6 +36,7 @@ void RSyncImplementation::release()
 
 void RSyncImplementation::releaseContext(const RSYNC_HANDLE handle)
 {
+    SynchronizationController::instance().stop(handle);
     m_registrationController.removeComponentByHandle(handle);
     remoteSyncContext(handle)->m_msgDispatcher->rundown();
     std::lock_guard<std::mutex> lock{ m_mutex };

--- a/src/shared_modules/rsync/src/rsyncImplementation.cpp
+++ b/src/shared_modules/rsync/src/rsyncImplementation.cpp
@@ -164,7 +164,7 @@ void RSyncImplementation::registerSyncId(const RSYNC_HANDLE handle,
                 if (syncData.id > SynchronizationController::instance().get(handle))
                 {
                     Log::debugVerbose << "Sync id: " << std::to_string(syncData.id) << " is not the current id: "
-                        << std::to_string(SynchronizationController::instance().get(handle)) << LogEndl;
+                                      << std::to_string(SynchronizationController::instance().get(handle)) << LogEndl;
                 }
                 else
                 {

--- a/src/shared_modules/rsync/src/rsyncImplementation.cpp
+++ b/src/shared_modules/rsync/src/rsyncImplementation.cpp
@@ -112,7 +112,7 @@ void RSyncImplementation::startRSync(const RSYNC_HANDLE handle,
             checksumCtx.rightCtx.type = IntegrityMsgType::INTEGRITY_CLEAR;
         }
 
-        m_synchronizationController.start(handle, checksumCtx.rightCtx.id);
+        m_synchronizationController.start(handle, jsStartParamsTable, checksumCtx.rightCtx.id);
         // rightCtx will have the final checksum based on fillChecksum method. After processing all checksum select data
         // checksumCtx.rightCtx will have the needed (final) information
         messageCreator->send(callbackWrapper, startConfiguration, checksumCtx.rightCtx);
@@ -160,7 +160,7 @@ void RSyncImplementation::registerSyncId(const RSYNC_HANDLE handle,
         {
             try
             {
-                m_synchronizationController.checkId(handle, syncData.id);
+                m_synchronizationController.checkId(handle, syncConfiguration.at("table"), syncData.id);
 
                 if (0 == syncData.command.compare("checksum_fail"))
                 {

--- a/src/shared_modules/rsync/src/rsyncImplementation.h
+++ b/src/shared_modules/rsync/src/rsyncImplementation.h
@@ -24,6 +24,7 @@
 #include "syncDecoder.h"
 #include "dbsyncWrapper.h"
 #include "cjsonSmartDeleter.hpp"
+#include "synchronizationController.hpp"
 
 namespace RSync
 {
@@ -157,6 +158,7 @@ namespace RSync
             std::map<RSYNC_HANDLE, std::shared_ptr<RSyncContext>> m_remoteSyncContexts;
             std::mutex m_mutex;
             RegistrationController m_registrationController;
+            static SynchronizationController m_synchronizationController;
     };
 }// namespace RSync
 

--- a/src/shared_modules/rsync/src/rsyncImplementation.h
+++ b/src/shared_modules/rsync/src/rsyncImplementation.h
@@ -157,6 +157,7 @@ namespace RSync
             std::map<RSYNC_HANDLE, std::shared_ptr<RSyncContext>> m_remoteSyncContexts;
             std::mutex m_mutex;
             RegistrationController m_registrationController;
+            std::unordered_map<RSYNC_HANDLE, std::atomic<int32_t>> m_currentSyncId;
     };
 }// namespace RSync
 

--- a/src/shared_modules/rsync/src/rsyncImplementation.h
+++ b/src/shared_modules/rsync/src/rsyncImplementation.h
@@ -157,7 +157,6 @@ namespace RSync
             std::map<RSYNC_HANDLE, std::shared_ptr<RSyncContext>> m_remoteSyncContexts;
             std::mutex m_mutex;
             RegistrationController m_registrationController;
-            std::unordered_map<RSYNC_HANDLE, std::atomic<int32_t>> m_currentSyncId;
     };
 }// namespace RSync
 

--- a/src/shared_modules/rsync/src/rsync_exception.h
+++ b/src/shared_modules/rsync/src/rsync_exception.h
@@ -53,6 +53,10 @@ namespace RSync
     {
         std::make_pair(9, "Component already registered." )
     };
+    constexpr auto HANDLE_NOT_FOUND
+    {
+        std::make_pair(10, "Handle not found." )
+    };
 
     /**
      *   This class should be used by concrete types to report errors.

--- a/src/shared_modules/rsync/src/synchronizationController.hpp
+++ b/src/shared_modules/rsync/src/synchronizationController.hpp
@@ -18,11 +18,10 @@
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
-#include <singleton.hpp>
 
 namespace RSync
 {
-    class SynchronizationController final : public Singleton<SynchronizationController>
+    class SynchronizationController final
     {
         public:
             void start(const RSYNC_HANDLE key, const int32_t value)

--- a/src/shared_modules/rsync/src/synchronizationController.hpp
+++ b/src/shared_modules/rsync/src/synchronizationController.hpp
@@ -31,6 +31,21 @@ namespace RSync
                 m_data[key] = value;
             }
 
+            void stop(const RSYNC_HANDLE key)
+            {
+                std::lock_guard<std::mutex> lock{ m_mutex };
+                if (m_data.find(key) != m_data.end())
+                {
+                    m_data.erase(key);
+                }
+            }
+
+            void clear()
+            {
+                std::lock_guard<std::mutex> lock{ m_mutex };
+                m_data.clear();
+            }
+
             void checkId(const RSYNC_HANDLE key, const int32_t value)
             {
                 std::lock_guard<std::mutex> lock{ m_mutex };

--- a/src/shared_modules/rsync/src/synchronizationController.hpp
+++ b/src/shared_modules/rsync/src/synchronizationController.hpp
@@ -1,0 +1,47 @@
+/*
+ * Wazuh RSYNC
+ * Copyright (C) 2015, Wazuh Inc.
+ * October 2, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _SYNCHRONIZATION_CONTROLLER_HPP
+#define _SYNCHRONIZATION_CONTROLLER_HPP
+
+#include "commonDefs.h"
+#include "rsync_exception.h"
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+#include <singleton.hpp>
+
+namespace RSync
+{
+    class SynchronizationController final : public Singleton<SynchronizationController>
+    {
+        public:
+            void set(const RSYNC_HANDLE key, const int32_t value)
+            {
+                std::lock_guard<std::shared_timed_mutex> lock{ mutex };
+                data[key] = value;
+            }
+
+            int32_t get(const RSYNC_HANDLE key)
+            {
+                std::shared_lock<std::shared_timed_mutex> lock{ mutex };
+                if (data.find(key) == data.end())
+                {
+                    throw rsync_error { HANDLE_NOT_FOUND };
+                }
+                return data[key];
+            }
+        private:
+            std::unordered_map<RSYNC_HANDLE, int32_t> data;
+            std::shared_timed_mutex mutex;
+    };
+} // namespace RSync
+#endif // _SYNCHRONIZATION_CONTROLLER_HPP

--- a/src/shared_modules/rsync/tests/implementation/rsyncImplementationTest.cpp
+++ b/src/shared_modules/rsync/tests/implementation/rsyncImplementationTest.cpp
@@ -13,6 +13,7 @@
 #include "rsyncImplementationTest.h"
 #include "rsyncImplementation.h"
 #include "rsync_exception.h"
+#include "rsync.hpp"
 #include "../mocks/dbsyncmock.h"
 
 using ::testing::_;
@@ -65,7 +66,7 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedNoData)
     const auto config { R"({"decoder_type":"JSON_RANGE", "component":"test_decoder","table":"test","no_data_query_json":{"row_filter":"","column_list":"","distinct_opt":"","order_by_opt":""}})" };
     auto mockDbSync { std::make_shared<MockDBSync>() };
 
-    EXPECT_CALL(*mockDbSync, select(_, _));
+    EXPECT_CALL(*mockDbSync, select(_, _)).Times(3);
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().registerSyncId(handle, "test_id", mockDbSync, nlohmann::json::parse(config), {}));
 
     std::string buffer{R"(test_id no_data {"begin":"1","end":"2","id":1})"};
@@ -73,6 +74,56 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedNoData)
     const auto first{reinterpret_cast<const unsigned char*>(buffer.data())};
     const auto last{first + buffer.size()};
     const std::vector<unsigned char> data{first, last};
+
+    const auto startConfigStmt =
+        R"({"table":"entry_path",
+            "first_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path ASC",
+                    "count_opt":1
+                },
+            "last_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path DESC",
+                    "count_opt":1
+                },
+            "component":"test_id",
+            "index":"path",
+            "last_event":"last_event",
+            "checksum_field":"checksum",
+            "range_checksum_query_json":
+                {
+                    "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
+                    "column_list":["path, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                }
+            })"_json;
+
+    std::function<void(const std::string&)> callbackWrapper
+    {
+        [&](const std::string & payload)
+        {
+            EXPECT_FALSE(payload.empty());
+        }
+    };
+
+    SyncCallbackData callbackData
+    {
+        [&callbackWrapper](const std::string & payload)
+        {
+            callbackWrapper(payload);
+        }
+    };
+
+    EXPECT_NO_THROW(RSync::RSyncImplementation::instance().startRSync(handle, mockDbSync, startConfigStmt, callbackData));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
 
@@ -130,7 +181,20 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumFail)
 
     auto mockDbSync { std::make_shared<MockDBSync>() };
 
+    //EXPECT_CALL(wrapper, callbackMock(SELECTED, nlohmann::json::parse(R"({"pid":4,"name":"System1", "tid":100, "cpu_percentage":10.7})"))).Times(1);
     EXPECT_CALL(*mockDbSync, select(_, _)).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data = R"({"path":"test_path", "checksum":"test_checksum"})"_json;
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data = R"({"path":"test_path", "checksum":"test_checksum"})"_json;
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data["checksum"] = "test_checksum";
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
     {
         data["count_field"] = 1;
         callback(ReturnTypeCallback::GENERIC, data);
@@ -156,6 +220,56 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumFail)
     const auto first{reinterpret_cast<const unsigned char*>(buffer.data())};
     const auto last{first + buffer.size()};
     const std::vector<unsigned char> data{first, last};
+
+    const auto startConfigStmt =
+        R"({"table":"entry_path",
+            "first_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path ASC",
+                    "count_opt":1
+                },
+            "last_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path DESC",
+                    "count_opt":1
+                },
+            "component":"test_id",
+            "index":"path",
+            "last_event":"last_event",
+            "checksum_field":"checksum",
+            "range_checksum_query_json":
+                {
+                    "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
+                    "column_list":["path, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                }
+            })"_json;
+
+    std::function<void(const std::string&)> callbackWrapper2
+    {
+        [&](const std::string & payload)
+        {
+            EXPECT_FALSE(payload.empty());
+        }
+    };
+
+    SyncCallbackData callbackData
+    {
+        [&callbackWrapper2](const std::string & payload)
+        {
+            callbackWrapper2(payload);
+        }
+    };
+
+    EXPECT_NO_THROW(RSync::RSyncImplementation::instance().startRSync(handle, mockDbSync, startConfigStmt, callbackData));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
 
@@ -221,6 +335,18 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumFailToSplit)
 
     EXPECT_CALL(*mockDbSync, select(_, _)).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
     {
+        data = R"({"path":"test_path", "checksum":"test_checksum"})"_json;
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data = R"({"path":"test_path", "checksum":"test_checksum"})"_json;
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data["checksum"] = "test_checksum";
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
         data["count_field"] = 2;
         callback(ReturnTypeCallback::GENERIC, data);
     })).WillOnce(testing::DoAll(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
@@ -272,6 +398,56 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumFailToSplit)
     const auto last{first + buffer.size()};
     const std::vector<unsigned char> data{first, last};
 
+    const auto startConfigStmt =
+        R"({"table":"entry_path",
+            "first_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path ASC",
+                    "count_opt":1
+                },
+            "last_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path DESC",
+                    "count_opt":1
+                },
+            "component":"test_id",
+            "index":"path",
+            "last_event":"last_event",
+            "checksum_field":"checksum",
+            "range_checksum_query_json":
+                {
+                    "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
+                    "column_list":["path, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                }
+            })"_json;
+
+    std::function<void(const std::string&)> callbackWrapper2
+    {
+        [&](const std::string & payload)
+        {
+            EXPECT_FALSE(payload.empty());
+        }
+    };
+
+    SyncCallbackData callbackData
+    {
+        [&callbackWrapper2](const std::string & payload)
+        {
+            callbackWrapper2(payload);
+        }
+    };
+
+    EXPECT_NO_THROW(RSync::RSyncImplementation::instance().startRSync(handle, mockDbSync, startConfigStmt, callbackData));
+
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().release());
@@ -318,7 +494,19 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumInvalidOperation)
 
     auto mockDbSync { std::make_shared<MockDBSync>() };
 
-    EXPECT_CALL(*mockDbSync, select(_, _)).Times(0);
+    EXPECT_CALL(*mockDbSync, select(_, _)).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data = R"({"path":"test_path", "checksum":"test_checksum"})"_json;
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data = R"({"path":"test_path", "checksum":"test_checksum"})"_json;
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data["checksum"] = "test_checksum";
+        callback(ReturnTypeCallback::GENERIC, data);
+    }));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().registerSyncId(handle, "test_id", mockDbSync, nlohmann::json::parse(config), nullptr));
 
@@ -327,6 +515,56 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumInvalidOperation)
     const auto first{reinterpret_cast<const unsigned char*>(buffer.data())};
     const auto last{first + buffer.size()};
     const std::vector<unsigned char> data{first, last};
+
+    const auto startConfigStmt =
+        R"({"table":"entry_path",
+            "first_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path ASC",
+                    "count_opt":1
+                },
+            "last_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path DESC",
+                    "count_opt":1
+                },
+            "component":"test_id",
+            "index":"path",
+            "last_event":"last_event",
+            "checksum_field":"checksum",
+            "range_checksum_query_json":
+                {
+                    "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
+                    "column_list":["path, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                }
+            })"_json;
+
+    std::function<void(const std::string&)> callbackWrapper2
+    {
+        [&](const std::string & payload)
+        {
+            EXPECT_FALSE(payload.empty());
+        }
+    };
+
+    SyncCallbackData callbackData
+    {
+        [&callbackWrapper2](const std::string & payload)
+        {
+            callbackWrapper2(payload);
+        }
+    };
+
+    EXPECT_NO_THROW(RSync::RSyncImplementation::instance().startRSync(handle, mockDbSync, startConfigStmt, callbackData));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
 
@@ -375,6 +613,18 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumNoData)
 
     EXPECT_CALL(*mockDbSync, select(_, _)).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
     {
+        data = R"({"path":"test_path", "checksum":"test_checksum"})"_json;
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data = R"({"path":"test_path", "checksum":"test_checksum"})"_json;
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data["checksum"] = "test_checksum";
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
         data["count_field"] = 0;
         callback(ReturnTypeCallback::GENERIC, data);
     }));
@@ -387,6 +637,56 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumNoData)
     const auto last{first + buffer.size()};
     const std::vector<unsigned char> data{first, last};
 
+    const auto startConfigStmt =
+        R"({"table":"entry_path",
+            "first_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path ASC",
+                    "count_opt":1
+                },
+            "last_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path DESC",
+                    "count_opt":1
+                },
+            "component":"test_id",
+            "index":"path",
+            "last_event":"last_event",
+            "checksum_field":"checksum",
+            "range_checksum_query_json":
+                {
+                    "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
+                    "column_list":["path, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                }
+            })"_json;
+
+    std::function<void(const std::string&)> callbackWrapper2
+    {
+        [&](const std::string & payload)
+        {
+            EXPECT_FALSE(payload.empty());
+        }
+    };
+
+    SyncCallbackData callbackData
+    {
+        [&callbackWrapper2](const std::string & payload)
+        {
+            callbackWrapper2(payload);
+        }
+    };
+
+    EXPECT_NO_THROW(RSync::RSyncImplementation::instance().startRSync(handle, mockDbSync, startConfigStmt, callbackData));
+
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().release());
@@ -398,11 +698,77 @@ TEST_F(RSyncImplementationTest, InvalidPushData)
 {
     const auto handle { RSync::RSyncImplementation::instance().create() };
 
+    auto mockDbSync { std::make_shared<MockDBSync>() };
+
+    EXPECT_CALL(*mockDbSync, select(_, _)).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data = R"({"path":"test_path", "checksum":"test_checksum"})"_json;
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data = R"({"path":"test_path", "checksum":"test_checksum"})"_json;
+        callback(ReturnTypeCallback::GENERIC, data);
+    })).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
+    {
+        data["checksum"] = "test_checksum";
+        callback(ReturnTypeCallback::GENERIC, data);
+    }));
+
+    const auto startConfigStmt =
+        R"({"table":"entry_path",
+            "first_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path ASC",
+                    "count_opt":1
+                },
+            "last_query":
+                {
+                    "column_list":["path"],
+                    "row_filter":"WHERE path is null",
+                    "distinct_opt":false,
+                    "order_by_opt":"path DESC",
+                    "count_opt":1
+                },
+            "component":"test_id",
+            "index":"path",
+            "last_event":"last_event",
+            "checksum_field":"checksum",
+            "range_checksum_query_json":
+                {
+                    "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
+                    "column_list":["path, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                }
+            })"_json;
+
+    std::function<void(const std::string&)> callbackWrapper2
+    {
+        [&](const std::string & payload)
+        {
+            EXPECT_FALSE(payload.empty());
+        }
+    };
+
+    SyncCallbackData callbackData
+    {
+        [&callbackWrapper2](const std::string & payload)
+        {
+            callbackWrapper2(payload);
+        }
+    };
+
     std::string buffer{R"(test_id)"};
 
     const auto first{reinterpret_cast<const unsigned char*>(buffer.data())};
     const auto last{first + buffer.size()};
     const std::vector<unsigned char> data{first, last};
+
+    EXPECT_NO_THROW(RSync::RSyncImplementation::instance().startRSync(handle, mockDbSync, startConfigStmt, callbackData));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
 

--- a/src/shared_modules/rsync/tests/implementation/rsyncImplementationTest.cpp
+++ b/src/shared_modules/rsync/tests/implementation/rsyncImplementationTest.cpp
@@ -127,6 +127,8 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedNoData)
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
 
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().release());
 }
 
@@ -271,6 +273,8 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumFail)
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().startRSync(handle, mockDbSync, startConfigStmt, callbackData));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().release());
 }
@@ -449,6 +453,8 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumFailToSplit)
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
 
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().release());
 
     EXPECT_EQ(TOTAL_EXPECTED_MESSAGES, messageCounter.load());
@@ -566,6 +572,8 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumInvalidOperation)
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().startRSync(handle, mockDbSync, startConfigStmt, callbackData));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().release());
 }
@@ -687,6 +695,8 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumNoData)
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().startRSync(handle, mockDbSync, startConfigStmt, callbackData));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().release());
 

--- a/src/shared_modules/rsync/tests/implementation/rsyncImplementationTest.cpp
+++ b/src/shared_modules/rsync/tests/implementation/rsyncImplementationTest.cpp
@@ -181,7 +181,6 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumFail)
 
     auto mockDbSync { std::make_shared<MockDBSync>() };
 
-    //EXPECT_CALL(wrapper, callbackMock(SELECTED, nlohmann::json::parse(R"({"pid":4,"name":"System1", "tid":100, "cpu_percentage":10.7})"))).Times(1);
     EXPECT_CALL(*mockDbSync, select(_, _)).WillOnce(testing::Invoke([](nlohmann::json & data, ResultCallbackData callback)
     {
         data = R"({"path":"test_path", "checksum":"test_checksum"})"_json;

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -1509,6 +1509,7 @@ TEST_F(RSyncTest, RegisterAndPushShutdownCPP)
     std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer3.begin(), buffer3.end() }));
 
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     remoteSync.reset();
 }
 

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -126,7 +126,7 @@ static void callbackDiff(const void* data,
                          const size_t /*size*/,
                          void* ctx)
 {
-    auto json = nlohmann::json::parse(reinterpret_cast<const char *>(data));
+    auto json = nlohmann::json::parse(reinterpret_cast<const char*>(data));
     auto diff = json.diff(json, *reinterpret_cast<nlohmann::json*>(ctx));
 
     for (const auto& element : diff)

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -38,6 +38,74 @@ constexpr auto SQL_STMT_INFO
 constexpr size_t MAX_QUEUE_SIZE {32378};
 constexpr unsigned int THREAD_POOL_SIZE {2};
 
+constexpr auto START_CONFIG_STMT_PATH
+{
+    R"({"table":"entry_path",
+        "first_query":
+            {
+                "column_list":["path"],
+                "row_filter":"WHERE path is not null",
+                "distinct_opt":false,
+                "order_by_opt":"path ASC",
+                "count_opt":1
+            },
+        "last_query":
+            {
+                "column_list":["path"],
+                "row_filter":"WHERE path is not null",
+                "distinct_opt":false,
+                "order_by_opt":"path DESC",
+                "count_opt":1
+            },
+        "component":"test_id",
+        "index":"path",
+        "last_event":"last_event",
+        "checksum_field":"checksum",
+        "range_checksum_query_json":
+            {
+                "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
+                "column_list":["path, checksum"],
+                "distinct_opt":false,
+                "order_by_opt":"",
+                "count_opt":100
+            }
+        })"
+};
+const auto START_CONFIG_STMT_INODE
+{
+    R"({"table":"entry_path",
+        "first_query":
+            {
+                "column_list":["inode_id"],
+                "row_filter":" ",
+                "distinct_opt":false,
+                "order_by_opt":"inode_id ASC",
+                "count_opt":1
+            },
+        "last_query":
+            {
+                "column_list":["inode_id"],
+                "row_filter":" ",
+                "distinct_opt":false,
+                "order_by_opt":"inode_id DESC",
+                "count_opt":1
+            },
+        "component":"test_id",
+        "index":"inode_id",
+        "last_event":"last_event",
+        "checksum_field":"checksum",
+        "range_checksum_query_json":
+            {
+                "row_filter":"WHERE inode_id BETWEEN '?' and '?' ORDER BY inode_id",
+                "column_list":["inode_id, checksum"],
+                "distinct_opt":false,
+                "order_by_opt":"",
+                "count_opt":100
+            }
+        })"
+};
+
+
 class CallbackMock
 {
     public:
@@ -52,6 +120,22 @@ static void callback(const void* data,
 {
     CallbackMock* wrapper { reinterpret_cast<CallbackMock*>(ctx)};
     wrapper->callbackMock(reinterpret_cast<const char*>(data));
+}
+
+static void callbackDiff(const void* data,
+                         const size_t /*size*/,
+                         void* ctx)
+{
+    auto json = nlohmann::json::parse(reinterpret_cast<const char *>(data));
+    auto diff = json.diff(json, *reinterpret_cast<nlohmann::json*>(ctx));
+
+    for (const auto& element : diff)
+    {
+        if (element.at("path") != "/data/id")
+        {
+            FAIL();
+        }
+    }
 }
 
 static void callbackRSyncWrapper(const void* payload, size_t size, void* userData)
@@ -502,6 +586,10 @@ TEST_F(RSyncTest, RegisterIncorrectQueryAndPush)
     const auto handle_rsync { rsync_create(THREAD_POOL_SIZE, MAX_QUEUE_SIZE) };
     ASSERT_NE(nullptr, handle_rsync);
 
+    auto expectedGlobalResponse =
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
+
+
     const auto registerConfigStmt
     {
         R"({"decoder_type":"JSON_RANGE",
@@ -550,8 +638,13 @@ TEST_F(RSyncTest, RegisterIncorrectQueryAndPush)
 
     sync_callback_data_t callbackData { callback, &wrapper };
 
+    sync_callback_data_t callbackDataDiff { callbackDiff, reinterpret_cast<void*>(&expectedGlobalResponse) };
+
     const std::unique_ptr<cJSON, CJsonSmartDeleter> spRegisterConfigStmt{ cJSON_Parse(registerConfigStmt) };
     ASSERT_EQ(0, rsync_register_sync_id(handle_rsync, "test_id", handle_dbsync, spRegisterConfigStmt.get(), callbackData));
+
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> spStartConfigStmt{ cJSON_Parse(START_CONFIG_STMT_PATH) };
+    ASSERT_EQ(0, rsync_start_sync(handle_rsync, handle_dbsync, spStartConfigStmt.get(), callbackDataDiff));
 
     std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
 
@@ -574,6 +667,9 @@ TEST_F(RSyncTest, RegisterAndPushCPP)
 
     std::unique_ptr<RemoteSync> remoteSync;
     EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
+
+    auto expectedGlobalResponse =
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
 
     const auto expectedResult1
     {
@@ -662,6 +758,8 @@ TEST_F(RSyncTest, RegisterAndPushCPP)
             wrapper.callbackMock(data);
         }
     };
+
+
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult3)).Times(2);
@@ -670,7 +768,17 @@ TEST_F(RSyncTest, RegisterAndPushCPP)
     EXPECT_CALL(wrapper, callbackMock(expectedResult6)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult7)).Times(1);
 
+    SyncCallbackData callbackDataDiff
+    {
+        [&](const std::string & data)
+        {
+            callbackDiff(data.c_str(), 0, &expectedGlobalResponse);
+        }
+    };
+
     ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), nlohmann::json::parse(registerConfigStmt), callbackData));
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(START_CONFIG_STMT_PATH), callbackDataDiff));
 
     std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
 
@@ -797,40 +905,6 @@ TEST_F(RSyncTest, startSyncWithIntegrityClearCPPSelectByInode)
     std::unique_ptr<RemoteSync> remoteSync;
     EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
 
-    const auto startConfigStmt
-    {
-        R"({"table":"entry_path",
-            "first_query":
-                {
-                    "column_list":["inode_id"],
-                    "row_filter":" ",
-                    "distinct_opt":false,
-                    "order_by_opt":"inode_id ASC",
-                    "count_opt":1
-                },
-            "last_query":
-                {
-                    "column_list":["inode_id"],
-                    "row_filter":" ",
-                    "distinct_opt":false,
-                    "order_by_opt":"inode_id DESC",
-                    "count_opt":1
-                },
-            "component":"test_id",
-            "index":"inode_id",
-            "last_event":"last_event",
-            "checksum_field":"checksum",
-            "range_checksum_query_json":
-                {
-                    "row_filter":"WHERE inode_id BETWEEN '?' and '?' ORDER BY inode_id",
-                    "column_list":["inode_id, checksum"],
-                    "distinct_opt":false,
-                    "order_by_opt":"",
-                    "count_opt":100
-                }
-            })"
-    };
-
     std::function<void(const std::string&)> callbackWrapper
     {
         [&](const std::string & payload)
@@ -847,7 +921,7 @@ TEST_F(RSyncTest, startSyncWithIntegrityClearCPPSelectByInode)
         }
     };
 
-    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(startConfigStmt), callbackData));
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(START_CONFIG_STMT_PATH), callbackData));
 }
 
 TEST_F(RSyncTest, constructorWithHandle)
@@ -874,6 +948,9 @@ TEST_F(RSyncTest, RegisterAndPushCPPByInode)
 
     std::unique_ptr<RemoteSync> remoteSync;
     EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
+
+    auto expectedGlobalResponse =
+        R"({"component":"test_id","data":{"begin":"5","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"1","id":1696459065},"type":"integrity_check_global"})"_json;
 
     const auto expectedResult1
     {
@@ -962,6 +1039,7 @@ TEST_F(RSyncTest, RegisterAndPushCPPByInode)
             wrapper.callbackMock(data);
         }
     };
+
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult3)).Times(2);
@@ -971,6 +1049,16 @@ TEST_F(RSyncTest, RegisterAndPushCPPByInode)
     EXPECT_CALL(wrapper, callbackMock(expectedResult7)).Times(1);
 
     ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), nlohmann::json::parse(registerConfigStmt), callbackData));
+
+    SyncCallbackData callbackDataDiff
+    {
+        [&](const std::string & data)
+        {
+            callbackDiff(data.c_str(), 0, &expectedGlobalResponse);
+        }
+    };
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(START_CONFIG_STMT_INODE), callbackDataDiff));
 
     std::string buffer1{R"(test_id checksum_fail {"begin":1,"end":5,"id":1})"};
 
@@ -994,6 +1082,9 @@ TEST_F(RSyncTest, RegisterAndPushCPPByInodePartialNODataRange)
     std::unique_ptr<RemoteSync> remoteSync;
     EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
 
+    auto expectedGlobalResponse =
+        R"({"component":"test_id","data":{"begin":"5","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"1","id":1696459065},"type":"integrity_check_global"})"_json;
+
     const auto expectedResult1
     {
         R"({"component":"test_id","data":{"attributes":{"checksum":"96482cde495f716fcd66a71a601fbb905c13b426","entry_type":0,"inode_id":1,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/fonts/unicode.pf2","scanned":1},"index":1,"timestamp":1596489273},"type":"state"})"
@@ -1008,7 +1099,6 @@ TEST_F(RSyncTest, RegisterAndPushCPPByInodePartialNODataRange)
     {
         R"({"component":"test_id","data":{"attributes":{"checksum":"f83bc87319566e270fcece2fae4910bc18fe7355","entry_type":0,"inode_id":3,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/i386-pc/datehook.mod","scanned":1},"index":3,"timestamp":1596489273},"type":"state"})"
     };
-
 
     const auto registerConfigStmt
     {
@@ -1067,6 +1157,16 @@ TEST_F(RSyncTest, RegisterAndPushCPPByInodePartialNODataRange)
     EXPECT_CALL(wrapper, callbackMock(expectedResult3)).Times(1);
 
     ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), nlohmann::json::parse(registerConfigStmt), callbackData));
+
+    SyncCallbackData callbackDataDiff
+    {
+        [&](const std::string & data)
+        {
+            callbackDiff(data.c_str(), 0, &expectedGlobalResponse);
+        }
+    };
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(START_CONFIG_STMT_INODE), callbackDataDiff));
 
     std::string buffer3{R"(test_id no_data {"begin":1,"end":3,"id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer3.begin(), buffer3.end() }));
@@ -1149,6 +1249,9 @@ TEST_F(RSyncTest, RegisterAndPushShutdownCPP)
     std::unique_ptr<RemoteSync> remoteSync;
     EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
 
+    auto expectedGlobalResponse =
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
+
     const auto registerConfigStmt
     {
         R"({"decoder_type":"JSON_RANGE",
@@ -1204,6 +1307,16 @@ TEST_F(RSyncTest, RegisterAndPushShutdownCPP)
 
     ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), nlohmann::json::parse(registerConfigStmt), callbackData));
 
+    SyncCallbackData callbackDataDiff
+    {
+        [&](const std::string & data)
+        {
+            callbackDiff(data.c_str(), 0, &expectedGlobalResponse);
+        }
+    };
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(START_CONFIG_STMT_PATH), callbackDataDiff));
+
     std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer3.begin(), buffer3.end() }));
 
@@ -1220,6 +1333,9 @@ TEST_F(RSyncTest, RegisterAndPushWithDoubleHandleDisconnect)
 
     std::unique_ptr<RemoteSync> remoteSyncToDelete;
     EXPECT_NO_THROW(remoteSyncToDelete = std::make_unique<RemoteSync>());
+
+    auto expectedGlobalResponse =
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
 
     const auto expectedResult1
     {
@@ -1352,6 +1468,17 @@ TEST_F(RSyncTest, RegisterAndPushWithDoubleHandleDisconnect)
     ASSERT_NO_THROW(remoteSyncToDelete->registerSyncID("test_id_to_delete", dbSync->handle(), nlohmann::json::parse(registerConfigStmtToDelete), callbackData));
 
     remoteSyncToDelete.reset();
+
+    SyncCallbackData callbackDataDiff
+    {
+        [&](const std::string & data)
+        {
+            callbackDiff(data.c_str(), 0, &expectedGlobalResponse);
+        }
+    };
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(START_CONFIG_STMT_PATH), callbackDataDiff));
+
     std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer3.begin(), buffer3.end() }));
 
@@ -1426,3 +1553,193 @@ TEST(RSyncBuilderStartSyncConfigurationTest, TestExpectedHappyCase)
     EXPECT_EQ(startSyncConfig.config().dump(),
               R"({"checksum_field":"checksum","component":"syscollector_osinfo","first_query":{"column_list":["os_name"],"count_opt":1,"distinct_opt":false,"order_by_opt":"os_name DESC","row_filter":" "},"index":"os_name","last_event":"last_event","last_query":{"column_list":["os_name"],"count_opt":1,"distinct_opt":false,"order_by_opt":"os_name ASC","row_filter":" "},"range_checksum_query_json":{"column_list":["os_name","checksum"],"count_opt":100,"distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name BETWEEN '?' and '?' ORDER BY os_name"},"table":"dbsync_osinfo"})");
 }
+
+TEST_F(RSyncTest, RegisterAndPushWithoutStartCPP)
+{
+    std::unique_ptr<DBSync> dbSync;
+    EXPECT_NO_THROW(dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO));
+
+    std::unique_ptr<RemoteSync> remoteSync;
+    EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
+
+    const auto registerConfigStmt
+    {
+        R"({"decoder_type":"JSON_RANGE",
+            "table":"entry_path",
+            "component":"test_id",
+            "index":"path",
+            "last_event":"last_event",
+            "checksum_field":"checksum",
+            "no_data_query_json":
+                {
+                    "row_filter":" ",
+                    "column_list":["path, inode_id, mode, last_event, entry_type, scanned, options, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                },
+            "count_range_query_json":
+                {
+                    "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
+                    "count_field_name":"count",
+                    "column_list":["count(*) AS count "],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                },
+            "row_data_query_json":
+                {
+                    "row_filter":"WHERE path ='?'",
+                    "column_list":["path, inode_id, mode, last_event, entry_type, scanned, options, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                },
+            "range_checksum_query_json":
+                {
+                    "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
+                    "column_list":["path, inode_id, mode, last_event, entry_type, scanned, options, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                }
+        })"
+    };
+
+    CallbackMock wrapper;
+    constexpr auto EXPECTED_MESSAGES = 0;
+    auto messageCount = 0;
+    SyncCallbackData callbackData
+    {
+        [&](const std::string & data)
+        {
+            ++messageCount;
+            wrapper.callbackMock(data);
+        }
+    };
+
+    ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), nlohmann::json::parse(registerConfigStmt), callbackData));
+
+    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    ASSERT_NO_THROW(remoteSync->pushMessage({ buffer1.begin(), buffer1.end() }));
+
+    std::string buffer2{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/fonts/unicode.pf2","id":1})"};
+    ASSERT_NO_THROW(remoteSync->pushMessage({ buffer2.begin(), buffer2.end() }));
+
+    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    ASSERT_NO_THROW(remoteSync->pushMessage({ buffer3.begin(), buffer3.end() }));
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    EXPECT_EQ(messageCount, EXPECTED_MESSAGES);
+
+    remoteSync.reset();
+}
+
+TEST_F(RSyncTest, RegisterAndPushWithNewerIDCPP)
+{
+    std::unique_ptr<DBSync> dbSync;
+    EXPECT_NO_THROW(dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO));
+
+    std::unique_ptr<RemoteSync> remoteSync;
+    EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
+
+    auto expectedGlobalResponse =
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
+
+    const auto registerConfigStmt
+    {
+        R"({"decoder_type":"JSON_RANGE",
+            "table":"entry_path",
+            "component":"test_id",
+            "index":"path",
+            "last_event":"last_event",
+            "checksum_field":"checksum",
+            "no_data_query_json":
+                {
+                    "row_filter":" ",
+                    "column_list":["path, inode_id, mode, last_event, entry_type, scanned, options, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                },
+            "count_range_query_json":
+                {
+                    "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
+                    "count_field_name":"count",
+                    "column_list":["count(*) AS count "],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                },
+            "row_data_query_json":
+                {
+                    "row_filter":"WHERE path ='?'",
+                    "column_list":["path, inode_id, mode, last_event, entry_type, scanned, options, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                },
+            "range_checksum_query_json":
+                {
+                    "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
+                    "column_list":["path, inode_id, mode, last_event, entry_type, scanned, options, checksum"],
+                    "distinct_opt":false,
+                    "order_by_opt":"",
+                    "count_opt":100
+                }
+        })"
+    };
+
+    auto syncId = 0;
+    SyncCallbackData callbackDataDiff
+    {
+        [&](const std::string & data)
+        {
+            auto json = nlohmann::json::parse(data);
+
+            if (syncId == 0)
+            {
+                syncId = json.at("data").at("id");
+            }
+        }
+    };
+
+    CallbackMock wrapper;
+    SyncCallbackData callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            wrapper.callbackMock(data);
+        }
+    };
+
+    auto expectedResult1 =
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/fonts/unicode.pf2","checksum":"acfe3a5baf97f842838c13b32e7e61a11e144e64","end":"/boot/grub2/grubenv","id":1,"tail":"/boot/grub2/i386-pc/datehook.mod"},"type":"integrity_check_left"})"_json;
+
+    auto expectedResult2 =
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/datehook.mod","checksum":"891333533a9c7d989b92928d200ed8402fe67813","end":"/boot/grub2/i386-pc/gzio.mod","id":1},"type":"integrity_check_right"})"_json;
+
+
+    ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), nlohmann::json::parse(registerConfigStmt), callbackData));
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(START_CONFIG_STMT_PATH), callbackDataDiff));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(START_CONFIG_STMT_PATH), callbackDataDiff));
+
+    expectedResult1["data"]["id"] = syncId;
+    expectedResult2["data"]["id"] = syncId;
+
+    EXPECT_CALL(wrapper, callbackMock(expectedResult1.dump())).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult2.dump())).Times(1);
+
+    std::string buffer1 {R"(test_id checksum_fail )"};
+    auto buffer1Json = R"({"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod"})"_json;
+    buffer1Json["id"] = syncId;
+    buffer1 += buffer1Json.dump();
+    ASSERT_NO_THROW(remoteSync->pushMessage({ buffer1.begin(), buffer1.end() }));
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    remoteSync.reset();
+}
+
+

--- a/src/syscheckd/src/db/src/fimDB.cpp
+++ b/src/syscheckd/src/db/src/fimDB.cpp
@@ -151,6 +151,7 @@ void FIMDB::runIntegrity()
             sync();
             promise->set_value();
             std::unique_lock<std::mutex> lockCv{m_fimSyncMutex};
+
             while (!m_cv.wait_for(lockCv, std::chrono::seconds{m_currentSyncInterval}, [&]()
         {
             return m_stopping;

--- a/src/syscheckd/src/db/src/fimDB.cpp
+++ b/src/syscheckd/src/db/src/fimDB.cpp
@@ -151,7 +151,6 @@ void FIMDB::runIntegrity()
             sync();
             promise->set_value();
             std::unique_lock<std::mutex> lockCv{m_fimSyncMutex};
-
             while (!m_cv.wait_for(lockCv, std::chrono::seconds{m_currentSyncInterval}, [&]()
         {
             return m_stopping;
@@ -199,11 +198,11 @@ void FIMDB::pushMessage(const std::string& data)
 
 void FIMDB::teardown()
 {
-    std::unique_lock<std::shared_timed_mutex> lock(m_handlersMutex);
 
     try
     {
         stopIntegrity();
+        std::lock_guard<std::shared_timed_mutex> lock(m_handlersMutex);
         m_rsyncHandler = nullptr;
         m_dbsyncHandler = nullptr;
     }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19074|

## Description
This change is to avoid concurrent synchronization.

Basically, if there was a lot of congestion and a parallel synchronization was executed, only the oldest execution would be maintained.

This change avoids resynchronization that could cause uncontrollability of the agent, as well as the use of resources in the manager by performing more operations than it should do.