### PR TITLE
Fix `lcov` input files in GA and increase test coverage

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -42,18 +42,20 @@ runs:
           # Set working directory
           arguments+="--directory . "
 
-          # Exclude files from outside the working directory
-          arguments+="--no-external "          
-
           # Set output file
           arguments+="--output-file build/coverage.info "
 
           # # Disable branch coverage
           arguments+="-rc lcov_branch_coverage=0 "
 
-          # Exclude test files
-          excludes=$(find . -type f \( -name "*.cpp" -o -name "*.hpp" \) -exec dirname {} \; | grep test | sort -u | sed "s|^./|--exclude=\"*|; s/$/\/\*\"/" | tr '\n' ' ')
-          arguments+="$excludes "
+          # Include test files
+          include_files=""
+          include_dirs=$(find src/ include/ -type f -regextype posix-extended -regex ".*/*\.(hpp|cpp|h|c)" -exec dirname {} \; | sort -u)
+          for dir in $include_dirs
+          do
+              include_files+="--include=$(pwd)/$dir/* "
+          done
+          arguments+="$include_files"
 
           echo "Executing: lcov $arguments"
           lcov $arguments

--- a/src/shared_modules/content_manager/tests/component/action_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.cpp
@@ -210,6 +210,10 @@ TEST_F(ActionTest, TestInstantiationOfTwoActionsWithTheSameTopicName)
     const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
     const auto& outputFolder {m_parameters.at("configData").at("outputFolder").get_ref<const std::string&>()};
 
+    // Both actions can't use RocksDB.
+    auto parametersWithoutDatabasePath = m_parameters;
+    parametersWithoutDatabasePath.at("configData").erase("databasePath");
+
     auto routerProvider {std::make_shared<RouterProvider>(topicName)};
 
     EXPECT_NO_THROW(routerProvider->start());
@@ -217,7 +221,7 @@ TEST_F(ActionTest, TestInstantiationOfTwoActionsWithTheSameTopicName)
     m_parameters["ondemand"] = true;
 
     auto action1 {std::make_shared<Action>(routerProvider, topicName, m_parameters)};
-    auto action2 {std::make_shared<Action>(routerProvider, topicName, m_parameters)};
+    auto action2 {std::make_shared<Action>(routerProvider, topicName, parametersWithoutDatabasePath)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 

--- a/src/shared_modules/content_manager/tests/component/action_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.hpp
@@ -51,7 +51,8 @@ protected:
                     "url": "http://localhost:4444/raw/consumers",
                     "outputFolder": "/tmp/action-tests",
                     "dataFormat": "json",
-                    "contentFileName": "sample.json"
+                    "contentFileName": "sample.json",
+                    "databasePath": "/tmp/action-tests/rocksdb"
                 }
             }
         )"_json;

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -106,6 +106,8 @@ public:
      *
      * @param configuration Manager configuration.
      */
+    // LCOV_EXCL_START
+    // TODO: remove the LCOV flags when the implementation of this class is completed.
     void initialize(const nlohmann::json& configuration)
     {
         loadConfiguration(configuration);
@@ -123,6 +125,7 @@ public:
                 call(m_configuration);
             });
     }
+    // LCOV_EXCL_STOP
 
     /**
      * @brief Loads configuration settings from a JSON object.

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
@@ -92,12 +92,15 @@ TEST_F(PolicyManagerTest, invalidFieldIndexer)
 
 TEST_F(PolicyManagerTest, invalidFieldEnabled)
 {
-    const auto& configJson {nlohmann::json::parse(R"({
-    "enabled": "invalidValue",
-    "index-status": "yes",
-    "feed-update-interval": "60m",
-    "offline-url": "file:///var/algo.tar.gz"
-    })")};
+    const auto& configJson = R"(
+      {
+        "enabled": "invalidValue",
+        "index-status": "yes",
+        "feed-update-interval": "60m",
+        "offline-url": "file:///var/algo.tar.gz"
+      }
+    )"_json;
+
     EXPECT_THROW(m_policyManager->validateAndConfigureVulnerabilityDetection(configJson), std::runtime_error);
 }
 
@@ -130,14 +133,14 @@ TEST_F(PolicyManagerTest, invalidConfiguration)
 TEST_F(PolicyManagerTest, invalidConfigurationNoIndexer)
 {
     // Configuration with missing "indexer" field.
-    const auto& configJson {nlohmann::json::parse(R"(
-    {
-      "vulnerability-detection":
+    const auto& configJson = R"(
       {
-        "dummy": true
+        "vulnerability-detection":
+        {
+          "dummy": true
+        }
       }
-    }
-  )")};
+    )"_json;
 
     ASSERT_NO_THROW(m_policyManager->loadConfiguration(configJson));
     EXPECT_THROW(m_policyManager->validateConfiguration(), std::runtime_error);
@@ -146,14 +149,14 @@ TEST_F(PolicyManagerTest, invalidConfigurationNoIndexer)
 TEST_F(PolicyManagerTest, invalidConfigurationNoVulnerabilityDetection)
 {
     // Configuration with missing "vulnerability-detection" field.
-    const auto& configJson {nlohmann::json::parse(R"(
-    {
-      "indexer":
+    const auto& configJson = R"(
       {
-        "dummy": true
+        "indexer":
+        {
+          "dummy": true
+        }
       }
-    }
-  )")};
+    )"_json;
 
     ASSERT_NO_THROW(m_policyManager->loadConfiguration(configJson));
     EXPECT_THROW(m_policyManager->validateConfiguration(), std::runtime_error);
@@ -161,22 +164,22 @@ TEST_F(PolicyManagerTest, invalidConfigurationNoVulnerabilityDetection)
 
 TEST_F(PolicyManagerTest, getUpdaterConfiguration)
 {
-    const auto& configJson {nlohmann::json::parse(R"(
-    {
-      "indexer":
+    const auto& configJson = R"(
       {
-        "config": "indexer"
-      },
-      "vulnerability-detection":
-      {
-        "config": "vulnerability-detection"
-      },
-      "updater":
-      {
-        "config": "updater"
+        "indexer":
+        {
+          "config": "indexer"
+        },
+        "vulnerability-detection":
+        {
+          "config": "vulnerability-detection"
+        },
+        "updater":
+        {
+          "config": "updater"
+        }
       }
-    }
-  )")};
+    )"_json;
 
     ASSERT_NO_THROW(m_policyManager->loadConfiguration(configJson));
     EXPECT_EQ(m_policyManager->getUpdaterConfiguration(), R"({"config":"updater"})"_json);

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
@@ -90,6 +90,17 @@ TEST_F(PolicyManagerTest, invalidFieldIndexer)
     EXPECT_THROW(m_policyManager->validateAndConfigureVulnerabilityDetection(configJson), std::runtime_error);
 }
 
+TEST_F(PolicyManagerTest, invalidFieldEnabled)
+{
+    const auto& configJson {nlohmann::json::parse(R"({
+    "enabled": "invalidValue",
+    "index-status": "yes",
+    "feed-update-interval": "60m",
+    "offline-url": "file:///var/algo.tar.gz"
+    })")};
+    EXPECT_THROW(m_policyManager->validateAndConfigureVulnerabilityDetection(configJson), std::runtime_error);
+}
+
 TEST_F(PolicyManagerTest, invalidConfiguration)
 {
     const auto& configJson {nlohmann::json::parse(R"({
@@ -114,6 +125,61 @@ TEST_F(PolicyManagerTest, invalidConfiguration)
 })")};
     m_policyManager->loadConfiguration(configJson);
     EXPECT_THROW(m_policyManager->validateConfiguration(), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, invalidConfigurationNoIndexer)
+{
+    // Configuration with missing "indexer" field.
+    const auto& configJson {nlohmann::json::parse(R"(
+    {
+      "vulnerability-detection":
+      {
+        "dummy": true
+      }
+    }
+  )")};
+
+    ASSERT_NO_THROW(m_policyManager->loadConfiguration(configJson));
+    EXPECT_THROW(m_policyManager->validateConfiguration(), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, invalidConfigurationNoVulnerabilityDetection)
+{
+    // Configuration with missing "vulnerability-detection" field.
+    const auto& configJson {nlohmann::json::parse(R"(
+    {
+      "indexer":
+      {
+        "dummy": true
+      }
+    }
+  )")};
+
+    ASSERT_NO_THROW(m_policyManager->loadConfiguration(configJson));
+    EXPECT_THROW(m_policyManager->validateConfiguration(), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, getUpdaterConfiguration)
+{
+    const auto& configJson {nlohmann::json::parse(R"(
+    {
+      "indexer":
+      {
+        "config": "indexer"
+      },
+      "vulnerability-detection":
+      {
+        "config": "vulnerability-detection"
+      },
+      "updater":
+      {
+        "config": "updater"
+      }
+    }
+  )")};
+
+    ASSERT_NO_THROW(m_policyManager->loadConfiguration(configJson));
+    EXPECT_EQ(m_policyManager->getUpdaterConfiguration(), R"({"config":"updater"})"_json);
 }
 
 TEST_F(PolicyManagerTest, invalidFieldIndexerSecondScenario)


### PR DESCRIPTION
|Related issue|
|---|
| #19309 |

## Description

This PR improves/fixes the input files from where the coverage is being calculated. The fix is made by using only the `lcov` **--include** parameter with the files we are interested in (currently we are using only the **--exclude** parameter).

Also, tests has been added/modified in order to achieve the 90% of test coverage.

## Results

### Content Manager
![image](https://github.com/wazuh/wazuh/assets/42682247/2313f17a-47a3-49d4-9ecc-d6f78368502a)

### Indexer Connector
![image](https://github.com/wazuh/wazuh/assets/42682247/c7873905-552a-4219-afe5-bd5e13693e60)

### Router
![image](https://github.com/wazuh/wazuh/assets/42682247/795688ed-749b-45c4-badd-e48efc43a059)

### Vulnerability Scanner
![image](https://github.com/wazuh/wazuh/assets/42682247/1e300b55-8a73-47b4-b489-bbc414d93984)

