### PR TITLE
Adding versioning info to Windows binaries to fix the MSI upgrade

### DIFF
--- a/.github/workflows/windows-file-details.yml
+++ b/.github/workflows/windows-file-details.yml
@@ -1,4 +1,4 @@
-name: Testing the details of the executables and libraries
+name: Windows binaries' details
 
 on:
   pull_request:
@@ -24,10 +24,7 @@ jobs:
           find src/win32/ -regex '.*wazuh-agent-[0-9]+.[0-9]+.[0-9]+\.exe$' -delete
           # We remove the executables that aren't distributed in the signed installer
           rm -f src/win32/setup-*.exe
-          # We remove the libraries that isn't compiled by Wazuh
-          rm -r src/win32/libwinpthread-1.dll
           cp src/win32/*.exe src/bin_files/
-          cp src/win32/*.dll src/bin_files/
           cp src/*.dll src/bin_files/
       - name: Upload Artifact binaries
         uses: actions/upload-artifact@v3

--- a/.github/workflows/windows-msi-upgrade-check.yml
+++ b/.github/workflows/windows-msi-upgrade-check.yml
@@ -1,4 +1,4 @@
-name: Testing that the expected files are replaced in the upgrade.
+name: Windows upgrade test
 
 on:
   pull_request:
@@ -17,13 +17,19 @@ jobs:
         run: make -C src deps TARGET=winagent -j2
       - name: make
         run: make -C src TARGET=winagent -j2
-      - name: Avoid signing files
-        run: sed -i 's+signtool+::signtool+g' src/win32/wazuh-installer-build-msi.bat
+      - name: Avoid signing files and pause
+        run: |
+          sed -i 's+signtool+::signtool+g' src/win32/wazuh-installer-build-msi.bat
+          sed -i 's+pause+::pause+g' src/win32/wazuh-installer-build-msi.bat
+      - name: Removing not required files
+        run: rm -rf src/external/* .git/
+      - name: Compress folder
+        run: 7z a win-agent-base.zip ./*
       - name: Upload base branch folder
         uses: actions/upload-artifact@v3
         with:
-          name: win-agent-base
-          path: src/**
+          name: win-agent-base.zip
+          path: win-agent-base.zip
 
   check_upgrade_result:
     strategy:
@@ -39,23 +45,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
-      - name: Download released .msi
-        run: |
-          mkdir C:\win-agent-released
-          python -m wget https://packages.wazuh.com/4.x/windows/wazuh-agent-${{ matrix.wazuh_version }}.msi -o C:\win-agent-released\
-      - name: Download base folder
-        uses: actions/download-artifact@v3
-        with:
-          name: win-agent-base
-          path: C:\win-agent-base\
-      - name: Create .msi package
-        run: |
-          cd C:\win-agent-base\
-          $VERSION = Get-Content .\VERSION -Raw
-          win32\wazuh-installer-build-msi.bat $VERSION 2
       - name: Install dependencies
         run: |
           pip install -r src/win32/qa/requirements.txt
+      - name: Download released .msi
+        run: |
+          mkdir C:\win-agent-released
+          python -m wget https://packages.wazuh.com/4.x/windows/wazuh-agent-${{ matrix.wazuh_version }}.msi -o C:\win-agent-released
+      - name: Download base folder
+        uses: actions/download-artifact@v3
+        with:
+          name: win-agent-base.zip
+          path: C:\win-agent-base
+      - name: Unzip base folder
+        run: 7z x C:\win-agent-base\win-agent-base.zip -oC:\win-agent-base
+      - name: Create .msi package
+        run: |
+          cd C:\win-agent-base\src\win32
+          $VERSION = Get-Content ..\VERSION
+          .\wazuh-installer-build-msi.bat $VERSION 0
+          cp *.msi C:\win-agent-base\
       - name: Run tests
         run: |
           cd src/win32/qa

--- a/.github/workflows/windows-msi-upgrade-check.yml
+++ b/.github/workflows/windows-msi-upgrade-check.yml
@@ -1,0 +1,74 @@
+name: Testing that the expected files are replaced in the upgrade.
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - ".github/workflows/windows-msi-upgrade-check.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install mingw
+        run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
+      - uses: actions/checkout@v3
+      - name: make deps
+        run: make -C src deps TARGET=winagent -j2
+      - name: make
+        run: make -C src TARGET=winagent -j2
+      - name: Avoid signing files
+        run: sed -i 's+signtool+::signtool+g' src/win32/wazuh-installer-build-msi.bat
+      - name: Upload base branch folder
+        uses: actions/upload-artifact@v3
+        with:
+          name: win-agent-base
+          path: src/**
+
+  check_upgrade_result:
+    strategy:
+          matrix:
+              wazuh_version: [4.5.2-1]
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version-file: ".github/workflows/.python-version"
+          architecture: x64
+      - name: Download released .msi
+        run: |
+          mkdir C:\win-agent-released
+          python -m wget https://packages.wazuh.com/4.x/windows/wazuh-agent-${{ matrix.wazuh_version }}.msi -o C:\win-agent-released\
+      - name: Download base folder
+        uses: actions/download-artifact@v3
+        with:
+          name: win-agent-base
+          path: C:\win-agent-base\
+      - name: Create .msi package
+        run: |
+          cd C:\win-agent-base\
+          $VERSION = Get-Content .\VERSION -Raw
+          win32\wazuh-installer-build-msi.bat $VERSION 2
+      - name: Install dependencies
+        run: |
+          pip install -r src/win32/qa/requirements.txt
+      - name: Run tests
+        run: |
+          cd src/win32/qa
+          python -m pytest -vv ./test_win_upgrade.py
+      - name: Upload release installation log
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: release_log
+          path: C:\win-agent-released\win-agent-released.log
+      - name: Upload base installation log
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: base_log
+          path: C:\win-agent-base\win-agent-base.log

--- a/src/Makefile
+++ b/src/Makefile
@@ -107,6 +107,7 @@ ifeq (${TARGET},winagent)
 CMAKE_OPTS=-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=${MING_BASE}${CC} -DCMAKE_CXX_COMPILER=${MING_BASE}${CXX}
 WIN_CMAKE_RULES+=win32/sysinfo
 WIN_CMAKE_RULES+=win32/shared_modules
+WIN_RESOURCE_OBJ=-DRESOURCE_OBJ=win32/version-dll.o
 ifeq (,$(filter ${DISABLE_SYSC},YES yes y Y 1))
 WIN_CMAKE_RULES+=win32/syscollector
 endif
@@ -805,7 +806,7 @@ ifeq (${MAKECMDGOALS},winagent)
 $(error Do not use 'winagent' directly, use 'TARGET=winagent')
 endif
 .PHONY: winagent
-winagent: external win32/libwinpthread-1.dll win32/libwinpthreadpatched.a ${WAZUH_LIB_OUTPUT_PATH}${LIBGCC_S_NAME} ${WAZUH_LIB_OUTPUT_PATH}${LIBSTDCPP_NAME}
+winagent: external win32/libwinpthread-1.dll win32/libwinpthreadpatched.a ${WAZUH_LIB_OUTPUT_PATH}${LIBGCC_S_NAME} ${WAZUH_LIB_OUTPUT_PATH}${LIBSTDCPP_NAME} win32/version-dll.o win32/version-app.o
 	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust"
 	${MAKE} ${WINDOWS_ACTIVE_RESPONSES} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust"
 	cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
@@ -817,9 +818,9 @@ winagent: external win32/libwinpthread-1.dll win32/libwinpthreadpatched.a ${WAZU
 	cd win32/ && ./unix2dos.pl ../REVISION > REVISION
 	cd win32/ && makensis wazuh-installer.nsi
 
-win32/shared_modules: $(WAZUHEXT_LIB)
-	cd ${DBSYNC} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${DBSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
-	cd ${RSYNC} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${RSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
+win32/shared_modules: $(WAZUHEXT_LIB) win32/version-dll.o
+	cd ${DBSYNC} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${DBSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} ${WIN_RESOURCE_OBJ} .. && ${MAKE}
+	cd ${RSYNC} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${RSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} ${WIN_RESOURCE_OBJ} .. && ${MAKE}
 ifneq (,$(filter ${TEST},YES yes y Y 1))
 ifneq (,$(filter ${DEBUG},YES yes y Y 1))
 	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
@@ -828,12 +829,12 @@ endif
 
 #### Sysinfo ##
 
-win32/sysinfo: $(WAZUHEXT_LIB)
-	cd ${SYSINFO} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSINFO_OS} ${SYSINFO_TEST} ${SYSINFO_RELEASE_TYPE} .. && ${MAKE}
+win32/sysinfo: $(WAZUHEXT_LIB) win32/version-dll.o
+	cd ${SYSINFO} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSINFO_OS} ${SYSINFO_TEST} ${SYSINFO_RELEASE_TYPE} ${WIN_RESOURCE_OBJ} .. && ${MAKE}
 
 #### Syscollector ##
-win32/syscollector: win32/shared_modules win32/sysinfo
-	cd ${SYSCOLLECTOR} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSCOLLECTOR_TEST} ${SYSCOLLECTOR_RELEASE_TYPE} .. && ${MAKE}
+win32/syscollector: win32/shared_modules win32/sysinfo win32/version-dll.o
+	cd ${SYSCOLLECTOR} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSCOLLECTOR_TEST} ${SYSCOLLECTOR_RELEASE_TYPE} ${WIN_RESOURCE_OBJ} .. && ${MAKE}
 
 win32/libwinpthread-1.dll: ${WIN_PTHREAD_LIB}
 	cp $< $@
@@ -1737,7 +1738,7 @@ ifeq (${TARGET}, winagent)
 $(WAZUHEXT_LIB): $(WAZUHEXT_DLL) $(WAZUHEXT_LIB_DEF)
 	$(DLLTOOL) -D $(WAZUHEXT_DLL) --def $(WAZUHEXT_LIB_DEF) --output-delaylib $@
 
-$(WAZUHEXT_DLL) $(WAZUHEXT_LIB_DEF): $(EXTERNAL_LIBS)
+$(WAZUHEXT_DLL) $(WAZUHEXT_LIB_DEF): $(EXTERNAL_LIBS) win32/version-dll.o
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $(WAZUHEXT_DLL) -static-libgcc -Wl,--export-all-symbols -Wl,--add-stdcall-alias -Wl,--whole-archive $^ -Wl,--no-whole-archive -Wl,--output-def,$(WAZUHEXT_LIB_DEF) ${OSSEC_LIBS}
 
 
@@ -1956,7 +1957,7 @@ $(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $(WAZUH_SHARED_SHFLAGS) -o $@ -Wl,-all_load $^ -Wl,-noall_load $(OSSEC_LIBS)
 else
 ifeq (${TARGET}, winagent)
-$(WAZUH_DLL) $(WAZUH_DEF) : $(WAZUHEXT_DLL) $(AR_PROGRAMS_DEPS)
+$(WAZUH_DLL) $(WAZUH_DEF) : $(WAZUHEXT_DLL) $(AR_PROGRAMS_DEPS) win32/version-dll.o
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -UOSSECHIDS -o $(WAZUH_DLL) -static-libgcc -Wl,--export-all-symbols -Wl,--add-stdcall-alias -Wl,--whole-archive $^ -Wl,--no-whole-archive -Wl,--output-def,$(WAZUH_DEF) ${OSSEC_LIBS}
 
 $(WAZUH_LIB): $(WAZUH_DLL) $(WAZUH_DEF)
@@ -2397,6 +2398,12 @@ test-rules:
 #### windows #######
 ####################
 
+win32/version-dll.o: win32/version.rc
+	${OSSEC_WINDRES} ${WIN_BUILD_VERSION} ${WIN_BUILD_TYPE} -DVER_TYPE=VFT_DLL -i $< -o $@
+
+win32/version-app.o: win32/version.rc
+	${OSSEC_WINDRES} ${WIN_BUILD_VERSION} ${WIN_BUILD_TYPE} -DVER_TYPE=VFT_APP -i $< -o $@
+
 # For security reasons, all executables must have a manifest
 # except those .exe files that aren't distributed in the final signed .msi
 
@@ -2444,13 +2451,13 @@ win32/ui/%.o: win32/ui/%.c
 
 # Executables
 
-win32/wazuh-agent.exe: win32/wazuh_agent_resource.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) $(filter-out os_execd/main.o, ${os_execd_o}) active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
+win32/wazuh-agent.exe: win32/wazuh_agent_resource.o win32/version-app.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) $(filter-out os_execd/main.o, ${os_execd_o}) active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
 	${OSSEC_CCBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/wazuh-agent-eventchannel.exe: win32/wazuh_agent_eventchannel_resource.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o $(filter-out syscheckd/main-event.o, ${syscheck_eventchannel_o}) ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) $(filter-out os_execd/main.o, ${os_execd_o}) active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
+win32/wazuh-agent-eventchannel.exe: win32/wazuh_agent_eventchannel_resource.o win32/version-app.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o $(filter-out syscheckd/main-event.o, ${syscheck_eventchannel_o}) ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) $(filter-out os_execd/main.o, ${os_execd_o}) active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
 	${OSSEC_CCBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/manage_agents.exe: win32/manage_agents_resource.o win32/win_service_rk.o ${addagent_o}
+win32/manage_agents.exe: win32/manage_agents_resource.o win32/version-app.o win32/win_service_rk.o ${addagent_o}
 	${OSSEC_CCBIN} -DARGV0=\"manage-agents\" -DMA ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 win32/setup-windows.exe: win32/win_service_rk.o win32/setup-win.o win32/setup-shared.o
@@ -2462,19 +2469,19 @@ win32/setup-syscheck.exe: win32/setup-syscheck.o win32/setup-shared.o
 win32/setup-iis.exe: win32/setup-iis.o
 	${OSSEC_CCBIN} -DARGV0=\"setup-iis\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/os_win32ui.exe: win32/ui_resource.o win32/win_service_rk.o ${win32_ui_o}
+win32/os_win32ui.exe: win32/ui_resource.o win32/version-app.o win32/win_service_rk.o ${win32_ui_o}
 	${OSSEC_CCBIN} -DARGV0=\"wazuh-win32ui\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -mwindows -o $@
 
-win32/agent-auth.exe: win32/auth_resource.o win32/win_service_rk.o os_auth/main-client.o os_auth/ssl.o os_auth/check_cert.o addagent/validate.o
+win32/agent-auth.exe: win32/auth_resource.o win32/version-app.o win32/win_service_rk.o os_auth/main-client.o os_auth/ssl.o os_auth/check_cert.o addagent/validate.o
 	${OSSEC_CCBIN} -DARGV0=\"agent-auth\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -lshlwapi -lwsock32 -lsecur32 -lws2_32 -flto -o $@
 
-win32/restart-wazuh.exe: win32/restart_wazuh_resource.o active-response/active_responses.o active-response/restart-wazuh.o shared/cryptography.o shared/dll_load_notify.o shared/debug_op_proc.o shared/time_op.o shared/file_op_proc.o ${WAZUH_LIB} ${WAZUHEXT_LIB}
+win32/restart-wazuh.exe: win32/restart_wazuh_resource.o win32/version-app.o active-response/active_responses.o active-response/restart-wazuh.o shared/cryptography.o shared/dll_load_notify.o shared/debug_op_proc.o shared/time_op.o shared/file_op_proc.o ${WAZUH_LIB} ${WAZUHEXT_LIB}
 	${OSSEC_CCBIN} -DARGV0=\"restart-wazuh\" ${AR_LDFLAGS} $^ -lwintrust -lpsapi -lcrypt32 -lshlwapi -o $@
 
-win32/route-null.exe: win32/route_null_resource.o active-response/active_responses.o active-response/route-null.o shared/cryptography.o shared/dll_load_notify.o shared/debug_op_proc.o shared/time_op.o shared/file_op_proc.o ${WAZUH_LIB} ${WAZUHEXT_LIB}
+win32/route-null.exe: win32/route_null_resource.o win32/version-app.o active-response/active_responses.o active-response/route-null.o shared/cryptography.o shared/dll_load_notify.o shared/debug_op_proc.o shared/time_op.o shared/file_op_proc.o ${WAZUH_LIB} ${WAZUHEXT_LIB}
 	${OSSEC_CCBIN} -DARGV0=\"route-null\" ${AR_LDFLAGS} $^ -lwintrust -lpsapi -lcrypt32 -lshlwapi -o $@
 
-win32/netsh.exe: win32/netsh_resource.o active-response/active_responses.o active-response/netsh.o shared/cryptography.o shared/dll_load_notify.o shared/debug_op_proc.o shared/time_op.o shared/file_op_proc.o ${WAZUH_LIB} ${WAZUHEXT_LIB}
+win32/netsh.exe: win32/netsh_resource.o win32/version-app.o active-response/active_responses.o active-response/netsh.o shared/cryptography.o shared/dll_load_notify.o shared/debug_op_proc.o shared/time_op.o shared/file_op_proc.o ${WAZUH_LIB} ${WAZUHEXT_LIB}
 	${OSSEC_CCBIN} -DARGV0=\"netsh\" ${AR_LDFLAGS} $^ -lwintrust -lpsapi -lcrypt32 -lshlwapi -o $@
 
 
@@ -2655,6 +2662,7 @@ clean-windows:
 	rm -f win32/wazuh-agent-*.exe
 	rm -f win32/libwinpthread-1.dll
 	rm -f win32/*.o
+	rm -f win32/version-*.o
 	rm -f win32/VERSION
 	rm -f win32/REVISION
 	rm -f win32/libstdc++-6.dll

--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -139,7 +139,8 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
 add_library(sysinfo SHARED
     ${SYSINFO_SRC}
-    ${CMAKE_SOURCE_DIR}/src/sysInfo.cpp )
+    ${CMAKE_SOURCE_DIR}/src/sysInfo.cpp
+    ${SRC_FOLDER}/${RESOURCE_OBJ})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   target_link_libraries(sysinfo psapi iphlpapi ws2_32)

--- a/src/shared_modules/dbsync/CMakeLists.txt
+++ b/src/shared_modules/dbsync/CMakeLists.txt
@@ -53,7 +53,8 @@ file(GLOB DBSYNC_SRC
     "${CMAKE_SOURCE_DIR}/src/sqlite/*.cpp")
 
 add_library(dbsync SHARED
-    ${DBSYNC_SRC} )
+    ${DBSYNC_SRC}
+    ${SRC_FOLDER}/${RESOURCE_OBJ})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_definitions(-DWIN_EXPORT)

--- a/src/shared_modules/rsync/CMakeLists.txt
+++ b/src/shared_modules/rsync/CMakeLists.txt
@@ -55,7 +55,8 @@ file(GLOB RSYNC_SRC
     "${CMAKE_SOURCE_DIR}/src/*.cpp")
 
 add_library(rsync SHARED
-    ${RSYNC_SRC} )
+    ${RSYNC_SRC}
+    ${SRC_FOLDER}/${RESOURCE_OBJ})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_definitions(-DWIN_EXPORT)

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -73,6 +73,7 @@ file(GLOB SYSCOLLECTOR_SRC
 
 add_library(syscollector SHARED
     ${SYSCOLLECTOR_SRC}
+    ${SRC_FOLDER}/${RESOURCE_OBJ}
     )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/src/win32/qa/test_bin_details.py
+++ b/src/win32/qa/test_bin_details.py
@@ -3,6 +3,7 @@ import pathlib
 import subprocess
 
 BIN_PATH = 'C:\\binaries'
+VERSION_FILE = '..\\..\\VERSION'
 
 
 @pytest.fixture(name='current_bin', scope='module', params=list(map(str, list(pathlib.Path(BIN_PATH).glob('*')))))
@@ -11,12 +12,31 @@ def get_bin_path(request):
 
 
 def test_bin_details(current_bin):
-    fields = ['FileDescription', 'ProductName', 'ProductVersion',
-              'FileVersion', 'OriginalFilename', 'LegalCopyright', 'Language']
+    # Get version from VERSION file
+    product_version = ''
+    with open(VERSION_FILE, 'r') as f:
+        product_version = f.readline().strip()
 
-    for field in fields:
-        cmd = f"(Get-Item {current_bin}).VersionInfo.{field}"
+    file_version_raw = product_version.replace('v', '').split('.')
+    file_version_major = file_version_raw[0]
+    file_version_minor = file_version_raw[1]
+    file_version_build = file_version_raw[2]
+    file_version_revision = '0'
+
+    fields_dict = {'FileDescription': 'Wazuh Windows Agent internal file',
+                   'ProductName': 'Wazuh Windows Agent',
+                   'ProductVersion': product_version,
+                   'FileVersionRaw.Major': file_version_major,
+                   'FileVersionRaw.Minor': file_version_minor,
+                   'FileVersionRaw.Build': file_version_build,
+                   'FileVersionRaw.Revision': file_version_revision,
+                   'OriginalFilename': '',
+                   'LegalCopyright': 'Copyright (C) 2015, Wazuh Inc.',
+                   'Language': 'English (United States)'}
+
+    for key in fields_dict:
+        cmd = f'(Get-Item "{current_bin}").VersionInfo.{key}'
         result = subprocess.run(
             ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
 
-        assert result.stdout.decode() == ''
+        assert result.stdout.decode().rstrip() == fields_dict[key], f"Failed in key: '{key}'"

--- a/src/win32/qa/test_bin_details.py
+++ b/src/win32/qa/test_bin_details.py
@@ -23,7 +23,7 @@ def test_bin_details(current_bin):
     file_version_build = file_version_raw[2]
     file_version_revision = '0'
 
-    fields_dict = {'FileDescription': 'Wazuh Windows Agent internal file',
+    fields_dict = {'FileDescription': 'Wazuh Agent',
                    'ProductName': 'Wazuh Windows Agent',
                    'ProductVersion': product_version,
                    'FileVersionRaw.Major': file_version_major,
@@ -31,7 +31,7 @@ def test_bin_details(current_bin):
                    'FileVersionRaw.Build': file_version_build,
                    'FileVersionRaw.Revision': file_version_revision,
                    'OriginalFilename': '',
-                   'LegalCopyright': 'Copyright (C) 2015, Wazuh Inc.',
+                   'LegalCopyright': 'Copyright (C) Wazuh, Inc.',
                    'Language': 'English (United States)'}
 
     for key in fields_dict:

--- a/src/win32/qa/test_win_upgrade.py
+++ b/src/win32/qa/test_win_upgrade.py
@@ -1,0 +1,77 @@
+import pathlib
+import os
+import subprocess
+
+RELEASED_PATH = 'C:\\win-agent-released\\'
+BASE_PATH = 'C:\\win-agent-base\\'
+INSTALL_PATH = 'C:\\Program Files (x86)\\ossec-agent\\'
+
+
+def populate_dict(dict, files_list):
+    for file in files_list:
+        # We skip this executable because the 'eventchannel' will be used instead
+        if file.name.count('WAZUH_AGENT.EXE') > 0:
+            continue
+        cmd = f'Get-FileHash -Path "{file}" -Algorithm SHA256 | Select-Object -ExpandProperty Hash'
+        result = subprocess.run(
+            ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
+        file_hash = result.stdout.decode().strip()
+        # It's required to normalize the name because the installation process changes it
+        dict[file.name.lower().replace('-', '_').replace('c++', 'cpp').replace(
+            '_dll', '.dll').replace('wazuh_agent_eventchannel.exe', 'wazuh_agent.exe')] = file_hash
+
+
+def test_win_upgrade():
+    # Find .msi in released directory
+    released_msi = list(pathlib.Path(RELEASED_PATH).glob('*.msi'))
+    assert len(released_msi) == 1
+    released_msi = released_msi[0]
+
+    # Find .msi in base directory
+    base_msi = list(pathlib.Path(BASE_PATH).glob('*.msi'))
+    assert len(base_msi) == 1
+    base_msi = base_msi[0]
+
+    # Install the released .msi
+    os.system(
+        f"start /wait msiexec /i {str(released_msi.resolve())} /qn /l*v win-agent-released.log")
+
+    # Upgrade Wazuh agent
+    os.system(
+        f"start /wait msiexec /i {str(base_msi.resolve())} /qn /l*v win-agent-base.log")
+
+    # Unzip base .msi to folder
+    os.system(f'7z e {str(base_msi.resolve())} "-o{BASE_PATH}"')
+
+    # List all .exe and .dll files in of the unzipped folder
+    exe_to_install = list(pathlib.Path(BASE_PATH).glob('**/*.exe'))
+    dll_to_install = list(pathlib.Path(BASE_PATH).glob('**/*dll*'))
+    files_to_install = exe_to_install + dll_to_install
+    assert len(files_to_install) >= 1
+
+    # Calculate hash of each file to install
+    files_to_install_dict = {}
+    populate_dict(files_to_install_dict, files_to_install)
+
+    # List all .exe and .dll files in of the installed folder
+    installed_exe = list(pathlib.Path(INSTALL_PATH).glob('**/*.exe'))
+    installed_dll = list(pathlib.Path(INSTALL_PATH).glob('**/*.dll'))
+    installed_files = installed_exe + installed_dll
+    assert len(installed_files) >= 1
+
+    # Calculate hash of each file to install
+    installed_files_dict = {}
+    populate_dict(installed_files_dict, installed_files)
+
+    assert len(installed_files_dict) == len(files_to_install_dict)
+
+    success = True
+    failed_keys = []
+    for key in files_to_install_dict:
+        # Compare hashes
+        if installed_files_dict[key] != files_to_install_dict[key]:
+            success = False
+            failed_keys.append(
+                tuple((key, installed_files_dict[key], files_to_install_dict[key])))
+
+    assert success, f"The following binaries have a hash mismatch: '{failed_keys}'"

--- a/src/win32/version.rc
+++ b/src/win32/version.rc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <winver.h>
+#include <ntdef.h>
+
+#ifdef RC_INVOKED
+
+#define Q(x) #x
+#define QUOTE(x) Q(x)
+
+#ifndef VER_PRODUCTVERSION
+#define VER_PRODUCTVERSION 4,5,3,0
+#endif
+
+#ifndef VER_PRODUCTVERSION_STR
+#define VER_PRODUCTVERSION_STR v4.5.3
+#endif
+
+#ifndef VER_FILEFLAGS
+#define VER_FILEFLAGS 0
+#endif
+
+#ifndef VER_TYPE
+#define VER_TYPE VFT_UNKNOWN
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION             VER_PRODUCTVERSION
+PRODUCTVERSION          VER_PRODUCTVERSION
+FILEFLAGSMASK           VS_FFI_FILEFLAGSMASK
+FILEFLAGS               VER_FILEFLAGS
+FILEOS                  VOS_NT
+FILETYPE                VER_TYPE
+BEGIN
+	BLOCK "StringFileInfo"
+	BEGIN
+		BLOCK "040904b0"
+        BEGIN
+		VALUE "CompanyName",        "Wazuh Inc."
+		VALUE "FileDescription",    "Wazuh Agent"
+		VALUE "FileVersion",        QUOTE(VER_PRODUCTVERSION_STR)
+		VALUE "LegalCopyright",     "Copyright (C) Wazuh, Inc."
+		VALUE "ProductName",        "Wazuh Windows Agent"
+		VALUE "ProductVersion",     QUOTE(VER_PRODUCTVERSION_STR)
+         VALUE "Info",               "https://www.wazuh.com"
+         VALUE "License",            "GPLv2"
+        END
+	END
+     BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+#endif

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -70,6 +70,7 @@ CLUSTER_INIT="../framework/wazuh/core/cluster/__init__.py"
 API_SETUP="../api/setup.py"
 API_SPEC="../api/api/spec/spec.yaml"
 VERSION_DOCU="../src/Doxyfile"
+WIN_RESOURCE="../src/win32/version.rc"
 
 if [ -n "$version" ]
 then
@@ -139,6 +140,18 @@ then
     # Documentation config file
 
     sed -E -i'' -e "s/PROJECT_NUMBER         = \".+\"/PROJECT_NUMBER         = \"$version\"/g" $VERSION_DOCU
+
+    # version.rc
+
+    egrep "^#define VER_PRODUCTVERSION_STR v.+" $WIN_RESOURCE > /dev/null
+
+    if [ $? != 0 ]
+    then
+        echo "Error: no suitable version definition found at file $WIN_RESOURCE"
+        exit 1
+    fi
+
+    sed -E -i'' -e "s/^(#define VER_PRODUCTVERSION_STR +)v.+/\1$version/" $WIN_RESOURCE
 fi
 
 if [ -n "$revision" ]
@@ -178,6 +191,19 @@ then
     # Documentation config file
 
     sed -E -i'' -e "s/PROJECT_NUMBER         = \".+\"/PROJECT_NUMBER         = \"$CURRENT_VERSION-$revision\"/g" $VERSION_DOCU
+
+    # version.rc
+
+    egrep "^#define VER_PRODUCTVERSION [[:digit:]]+,[[:digit:]]+,[[:digit:]]+,[[:digit:]]+" $WIN_RESOURCE > /dev/null
+
+    if [ $? != 0 ]
+    then
+        echo "Error: no suitable version definition found at file $WIN_RESOURCE"
+        exit 1
+    fi
+
+    product_commas=`echo $product | tr '.' ','`
+    sed -E -i'' -e "s/^(#define VER_PRODUCTVERSION +).+/\1$product_commas/" $WIN_RESOURCE
 fi
 
 if [ -n "$product" ]


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19379|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

It was found that the upgrade fails because the installer has an "omus" (https://learn.microsoft.com/en-us/windows/win32/msi/reinstallmode) behavior by default, and after restoring the files to their previous state (without version), the `.msi` installer ignores them after deleting the previous ones.

It was decided that modifying this setting in the installer might be dangerous, so the version info was added.
These changes were taken from #13017 (thank you @jnasselle ).




## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

The details are now filled
![2023-10-03_23-19](https://github.com/wazuh/wazuh/assets/65046601/a29d61ed-1d52-427d-9d78-0c80e505460e)


A future `v5.0.0-1` was simulated with the bump version script, and the upgrade was successfull
![2023-10-03_23-41](https://github.com/wazuh/wazuh/assets/65046601/dcccba27-5e92-47ea-ba21-4f8481da13d6)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Package installation
- [x] Package upgrade
- [x] QA templates contemplate the added capabilities

