### PR TITLE
Changed some errors logs related to GetSecurityInfo to debug msg

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -730,7 +730,7 @@ char *get_user(const char *path, char **sid, HANDLE hndl, SE_OBJECT_TYPE object_
     }
 
     if (dwRtnCode != ERROR_SUCCESS) {
-        merror("GetSecurityInfo error code = (%lu), '%s'", dwRtnCode, win_strerror(dwRtnCode));
+        mdebug1("GetSecurityInfo error code = (%lu), '%s'", dwRtnCode, win_strerror(dwRtnCode));
         *AcctName = '\0';
         goto end;
     }
@@ -1067,7 +1067,7 @@ char *get_registry_group(char **sid, HANDLE hndl) {
     }
 
     if (dwRtnCode != ERROR_SUCCESS) {
-        merror("GetSecurityInfo error code = (%lu), '%s'", dwRtnCode, win_strerror(dwRtnCode));
+        mdebug1("GetSecurityInfo error code = (%lu), '%s'", dwRtnCode, win_strerror(dwRtnCode));
         *GrpName = '\0';
         goto end;
     }

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -3595,7 +3595,7 @@ static void test_get_file_user_GetSecurityInfo_error(void **state) {
              "GetSecurityInfo error code = (%lu), 'Access denied.'",
              ERROR_ACCESS_DENIED);
 
-    expect_string(__wrap__merror, formatted_msg, error_msg);
+    expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
     array[0] = get_file_user("C:\\a\\path", &array[1]);
 
@@ -4117,7 +4117,7 @@ void test_get_registry_group_GetSecurityInfo_fails(void **state) {
              "GetSecurityInfo error code = (%lu), 'Access denied.'",
              ERROR_ACCESS_DENIED);
 
-    expect_string(__wrap__merror, formatted_msg, error_msg);
+    expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
     group = get_registry_group(&group_id, hndl);
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/19344|


## Description
This PR is to change an error log to a debug message to show the error codes of the `GetSecurityInfo` function. This is because this function tries to extract the user name from a file, and if it does not exist at that time (for example the stress test has deleted it during processing) the related event cannot be generated. During stress tests it is common to lose FIM events due to the big number of files added and deleted. Since this is not a critical error for the module we have converted it to a debug message.
