### PR TITLE
Update template with missing host.os.* fields

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "wazuh-states-vulnerabilities"
+    "vulnerability-state-*"
   ],
   "priority": 1,
   "template": {

--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "vulnerability-state-*"
+    "wazuh-states-vulnerabilities"
   ],
   "priority": 1,
   "template": {
@@ -158,6 +158,52 @@
             "url": {
               "ignore_above": 1024,
               "type": "keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "os": {
+              "properties": {
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full": {
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
|Related issue|
|---|
| #14153 , https://github.com/wazuh/wazuh-indexer/issues/6|

## Description

This PR updates the index template new vulnerability detector with the missing fields for the operative system information.

Use this command to upload the template (change the name of the template as desired):

```bash
curl -u admin:admin -k -X PUT "https://localhost:9200/_index_template/wazuh-vulnerability-detector" -H "Content-Type: application/json" -d @legacy-template.json
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors