### PR TITLE
Introduce a mechanism to retry the deletion of the database.

### DIFF
--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -571,13 +571,14 @@ bool SQLiteDBEngine::cleanDB(const std::string& path)
     {
         if (std::ifstream(path))
         {
-            for (uint8_t amountTries = 0; amountTries < MAX_TRIES && (isRemoved = std::remove(path.c_str()));amountTries++)
+            for (uint8_t amountTries = 0; amountTries < MAX_TRIES && (isRemoved = std::remove(path.c_str())); amountTries++)
             {
                 std::this_thread::sleep_for(1s); //< Sleep for 1s
             }
+
             if (!isRemoved)
             {
-                return false;
+                ret = false;
             }
         }
     }

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -572,6 +572,7 @@ bool SQLiteDBEngine::cleanDB(const std::string& path)
         if (std::ifstream(path))
         {
             isRemoved = std::remove(path.c_str());
+
             for (uint8_t amountTries = 0; amountTries < MAX_TRIES && isRemoved; amountTries++)
             {
                 std::this_thread::sleep_for(1s); //< Sleep for 1s

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -571,12 +571,15 @@ bool SQLiteDBEngine::cleanDB(const std::string& path)
     {
         if (std::ifstream(path))
         {
-            for (uint8_t amountTries = 0; amountTries < MAX_TRIES && (isRemoved = std::remove(path.c_str())); amountTries++)
+            isRemoved = std::remove(path.c_str());
+            for (uint8_t amountTries = 0; amountTries < MAX_TRIES && isRemoved; amountTries++)
             {
                 std::this_thread::sleep_for(1s); //< Sleep for 1s
+                std::cerr << "Sleep for 1s and try to delete database again.\n";
+                isRemoved = std::remove(path.c_str());
             }
 
-            if (!isRemoved)
+            if (isRemoved)
             {
                 ret = false;
             }

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -18,6 +18,9 @@
 #include "stringHelper.h"
 #include "commonDefs.h"
 
+using namespace std::chrono_literals;
+auto constexpr MAX_TRIES = 5;
+
 SQLiteDBEngine::SQLiteDBEngine(const std::shared_ptr<ISQLiteFactory>& sqliteFactory,
                                const std::string& path,
                                const std::string& tableStmtCreation)
@@ -562,14 +565,19 @@ void SQLiteDBEngine::initialize(const std::string& path,
 bool SQLiteDBEngine::cleanDB(const std::string& path)
 {
     auto ret { true };
+    auto isRemoved {0};
 
     if (path.compare(":memory") != 0)
     {
         if (std::ifstream(path))
         {
-            if (0 != std::remove(path.c_str()))
+            for (uint8_t amountTries = 0; amountTries < MAX_TRIES && (isRemoved = std::remove(path.c_str()));amountTries++)
             {
-                ret = false;
+                std::this_thread::sleep_for(1s); //< Sleep for 1s
+            }
+            if (!isRemoved)
+            {
+                return false;
             }
         }
     }


### PR DESCRIPTION
|Related issue|
|---|
|#18968|

## Objective

The primary objective of this pull request is to enhance the reliability and robustness of the integration tests for Wazuh version `4.6.0-alpha1`.
During this test stage, we found that in Windows environments a potentially shared resource between two different processes in the database causes an error in the `std::remove` function and for convenience makes the agent fail in a restart operation.
Similar behavior was found in

- https://github.com/wazuh/wazuh/issues/4692

A similar approach was taken in this solution.


## Description
- Added a one-second timer that attempts to remove the database file five times in order to mitigate potential issues caused by the host operating system.

## Quality Assurance
Pending validation from QA team

No test were added or modified in this PR.

### Check summary
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Style and quality of SCA
