### PR TITLE
Save vulnerability description in rocksDB database

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -11,7 +11,7 @@ inputs:
 
 runs:
   using: "composite"
-  steps:   
+  steps:
       - name: Dependencies for local execution
         if: env.ACT # Only run for local execution
         shell: bash
@@ -38,7 +38,7 @@ runs:
 
           # Set arguments
           arguments="--capture "
-          
+
           # Set working directory
           arguments+="--directory . "
 
@@ -50,10 +50,11 @@ runs:
 
           # Include test files
           include_files=""
-          include_dirs=$(find src/ include/ -type f -regextype posix-extended -regex ".*/*\.(hpp|cpp|h|c)" -exec dirname {} \; | sort -u)
-          for dir in $include_dirs
+          for file in $(find src/ include/ -type f -regextype posix-extended -regex ".*/*\.(hpp|cpp|h|c)")
           do
-              include_files+="--include=$(pwd)/$dir/* "
+            if [[ ! "$file" =~ "_generated.h" ]]; then
+              include_files+="--include=$(pwd)$dir/$file "
+            fi
           done
           arguments+="$include_files"
 
@@ -102,7 +103,7 @@ runs:
             echo "PASSED: Lines coverage is greater than 90%"
             echo "------------------------------------------"
           fi
-          
+
           # Check if functions coverage is greater than 90%
           functionsCoverage=$(echo "${coverageData[1]}" | sed 's/%//')
           echo "Functions coverage is: $functionsCoverage %"

--- a/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
+++ b/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
@@ -80,14 +80,14 @@ table Other {
 
 table Scenario {
     lang: string;
-    value: string;    
+    value: string;
 }
 
 table Metric {
     format: string;
     scenarios: [Scenario];
     cvssV3_1: cvss.V3_1;
-    cvssV3_0: cvss.V2_0;
+    cvssV3_0: cvss.V3_0;
     cvssV2_0: cvss.V2_0;
     other: Other;
 }
@@ -152,7 +152,7 @@ table Adp {
     timeline: [Timeline];
     credits: [Credit];
     source: StringifiedObject;
-    tags: [string];    
+    tags: [string];
     taxonomyMappings: [TaxonomyMapping];
 }
 
@@ -174,7 +174,7 @@ table Cna {
     timeline: [Timeline];
     credits: [Credit];
     source: StringifiedObject;
-    tags: [string];        
+    tags: [string];
     taxonomyMappings: [TaxonomyMapping];
     x_remediations: Remediations;
 }

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -23,6 +23,7 @@
 #include "routerSubscriber.hpp"
 #include "scanDispatcher.hpp"
 #include "storeModel.hpp"
+#include "updateCVEDescription.hpp"
 #include "vulnerabilityCandidate_generated.h"
 #include "vulnerabilityDescription_generated.h"
 #include "vulnerabilityRemediations_generated.h"
@@ -32,7 +33,6 @@
 #include <string>
 #include <vector>
 
-constexpr auto DESCRIPTION_DATABASE_PATH {"queue/vd/descriptions"};
 constexpr auto REMEDIATIONS_DATABASE_PATH {"queue/vd/remediations"};
 constexpr auto CANDIDATES_DATABASE_PATH {"queue/vd/candidates"};
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/feedIndexer.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/feedIndexer.hpp
@@ -43,7 +43,6 @@ public:
         }
         return AbstractHandler<std::shared_ptr<EventContext>>::handleRequest(data);
     }
-    // LCOV_EXCL_STOP
 
     /**
      * @brief Constructor.
@@ -54,6 +53,7 @@ public:
         : m_indexerConnector(indexerConnector)
     {
     }
+    // LCOV_EXCL_STOP
 };
 
 #endif // _FEED_INDEXER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -41,83 +41,116 @@ public:
                                               const cve_v5::Entry* cve5Flatbuffer,
                                               Utils::RocksDBWrapper& rocksDBWrapper)
     {
-        auto metricsArray = cve5Flatbuffer->containers()->cna()->metrics();
-        const size_t sizeM = (nullptr != metricsArray) ? metricsArray->size() : 0;
-        auto descriptionArray = cve5Flatbuffer->containers()->cna()->descriptions();
-        const size_t sizeD = (nullptr != descriptionArray) ? descriptionArray->size() : 0;
-        auto referencesArray = cve5Flatbuffer->containers()->cna()->references();
-        const size_t sizeR = (nullptr != referencesArray) ? referencesArray->size() : 0;
-        size_t sizeT = (sizeM > sizeD) ? sizeM : sizeD;
-        sizeT = (sizeT > sizeR) ? sizeT : sizeR;
-
-        float VulnDescFBScoreBase = 0.0;
-        std::string VulnDescFBClassificationStr;
-        std::string VulnDescFBDescriptionStr;
-        std::string VulnDescFBSeverityStr;
-        std::string VulnDescFBScoreVersionStr;
-        std::string VulnDescFBReferenceStr;
-
-        bool cont = true;
-        for (size_t i = 0; i < sizeT; ++i)
+        auto containers = cve5Flatbuffer->containers();
+        auto cna = containers->cna();
+        if (containers && cna)
         {
-            if (i < sizeM)
+            auto metricsArray = cna->metrics();
+            const size_t sizeM = (nullptr != metricsArray) ? metricsArray->size() : 0;
+            auto descriptionArray = cna->descriptions();
+            const size_t sizeD = (nullptr != descriptionArray) ? descriptionArray->size() : 0;
+            auto referencesArray = cna->references();
+            const size_t sizeR = (nullptr != referencesArray) ? referencesArray->size() : 0;
+            size_t sizeT = (sizeM > sizeD) ? sizeM : sizeD;
+            sizeT = (sizeT > sizeR) ? sizeT : sizeR;
+
+            float VulnDescFBScoreBase = 0.0;
+            std::string VulnDescFBClassificationStr;
+            std::string VulnDescFBDescriptionStr;
+            std::string VulnDescFBSeverityStr;
+            std::string VulnDescFBScoreVersionStr;
+            std::string VulnDescFBReferenceStr;
+
+            bool cont = true;
+            bool exist = false;
+            for (size_t i = 0; i < sizeT; ++i)
             {
-                auto metric = metricsArray->Get(i);
-                if (metric->cvssV3_1())
+                if (i < sizeM && !exist)
                 {
-                    VulnDescFBScoreBase = metric->cvssV3_1()->baseScore();
-                    auto baseSeverity = metric->cvssV3_1()->baseSeverity();
-                    VulnDescFBSeverityStr = (nullptr != baseSeverity) ? baseSeverity->str() : "";
-                    auto version = metric->cvssV3_1()->version();
-                    VulnDescFBScoreVersionStr = (nullptr != version) ? version->str() : "";
-                    auto format = metric->format();
-                    VulnDescFBClassificationStr = (nullptr != format) ? format->str() : "";
+                    auto metric = metricsArray->Get(i);
+                    auto metricCVSSV3_1 = metric->cvssV3_1();
+                    auto metricCVSSV3_0 = metric->cvssV3_0();
+                    auto metricCVSSV2_0 = metric->cvssV2_0();
+                    if (metricCVSSV3_1)
+                    {
+                        VulnDescFBScoreBase = metricCVSSV3_1->baseScore();
+                        auto baseSeverity = metricCVSSV3_1->baseSeverity();
+                        VulnDescFBSeverityStr = (nullptr != baseSeverity) ? baseSeverity->str() : "";
+                        auto version = metricCVSSV3_1->version();
+                        VulnDescFBScoreVersionStr = (nullptr != version) ? version->str() : "";
+                        auto format = metric->format();
+                        VulnDescFBClassificationStr = (nullptr != format) ? format->str() : "";
+                        exist = true;
+                    }
+                    else if (metricCVSSV3_0)
+                    {
+                        VulnDescFBScoreBase = metricCVSSV3_0->baseScore();
+                        auto baseSeverity = metricCVSSV3_0->baseSeverity();
+                        VulnDescFBSeverityStr = (nullptr != baseSeverity) ? baseSeverity->str() : "";
+                        auto version = metricCVSSV3_0->version();
+                        VulnDescFBScoreVersionStr = (nullptr != version) ? version->str() : "";
+                        auto format = metric->format();
+                        VulnDescFBClassificationStr = (nullptr != format) ? format->str() : "";
+                        exist = true;
+                    }
+                    else if (metricCVSSV2_0)
+                    {
+                        VulnDescFBScoreBase = metricCVSSV2_0->baseScore();
+                        VulnDescFBSeverityStr = (VulnDescFBScoreBase < 4.0)   ? "LOW"
+                                                : (VulnDescFBScoreBase < 7.0) ? "MEDIUM"
+                                                                              : "HIGH";
+                        auto version = metricCVSSV2_0->version();
+                        VulnDescFBScoreVersionStr = (nullptr != version) ? version->str() : "";
+                        auto format = metric->format();
+                        VulnDescFBClassificationStr = (nullptr != format) ? format->str() : "";
+                        exist = true;
+                    }
+                }
+                if (i < sizeR)
+                {
+                    auto reference = referencesArray->Get(i);
+                    if (reference->url())
+                    {
+                        VulnDescFBReferenceStr = VulnDescFBReferenceStr + reference->url()->str() + ", ";
+                    }
+                }
+                if ((i < sizeD) && cont)
+                {
+                    auto description = descriptionArray->Get(i);
+                    if (description->lang()->str().compare("en") == 0)
+                    {
+                        VulnDescFBDescriptionStr = description->value()->str();
+                        cont = false;
+                    }
                 }
             }
-            if (i < sizeR)
-            {
-                auto reference = referencesArray->Get(i);
-                if (reference->url())
-                {
-                    VulnDescFBReferenceStr = VulnDescFBReferenceStr + reference->url()->str() + ", ";
-                }
-            }
-            if ((i < sizeD) && cont)
-            {
-                auto description = descriptionArray->Get(i);
-                if (description->lang()->str().compare("en") == 0)
-                {
-                    VulnDescFBDescriptionStr = description->value()->str();
-                    cont = false;
-                }
-            }
+            VulnDescFBReferenceStr = VulnDescFBReferenceStr.substr(0, VulnDescFBReferenceStr.size() - 2);
+
+            flatbuffers::FlatBufferBuilder builder;
+
+            auto VulnDescFBClassification {builder.CreateString(VulnDescFBClassificationStr)};
+            auto VulnDescFBDescription {builder.CreateString(VulnDescFBDescriptionStr)};
+            auto VulnDescFBSeverity {builder.CreateString(VulnDescFBSeverityStr)};
+            auto VulnDescFBScoreVersion {builder.CreateString(VulnDescFBScoreVersionStr)};
+            auto VulnDescFBReference {builder.CreateString(VulnDescFBReferenceStr)};
+
+            NSVulnerabilityScanner::VulnerabilityDescriptionBuilder vulnerabilityDescriptionBuilder(builder);
+            vulnerabilityDescriptionBuilder.add_scoreBase(VulnDescFBScoreBase);
+            vulnerabilityDescriptionBuilder.add_classification(VulnDescFBClassification);
+            vulnerabilityDescriptionBuilder.add_description(VulnDescFBDescription);
+            vulnerabilityDescriptionBuilder.add_severity(VulnDescFBSeverity);
+            vulnerabilityDescriptionBuilder.add_scoreVersion(VulnDescFBScoreVersion);
+            vulnerabilityDescriptionBuilder.add_reference(VulnDescFBReference);
+
+            auto vulnerabilityDescriptionFB = vulnerabilityDescriptionBuilder.Finish();
+            builder.Finish(vulnerabilityDescriptionFB);
+
+            const uint8_t* buffer = builder.GetBufferPointer();
+            size_t flatbufferSize = builder.GetSize();
+
+            const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer), flatbufferSize);
+            rocksDBWrapper.put(resource, VulnerabilityDescriptionSlice);
         }
-        VulnDescFBReferenceStr = VulnDescFBReferenceStr.substr(0, VulnDescFBReferenceStr.size() - 2);
-
-        flatbuffers::FlatBufferBuilder builder;
-
-        auto VulnDescFBClassification {builder.CreateString(VulnDescFBClassificationStr)};
-        auto VulnDescFBDescription {builder.CreateString(VulnDescFBDescriptionStr)};
-        auto VulnDescFBSeverity {builder.CreateString(VulnDescFBSeverityStr)};
-        auto VulnDescFBScoreVersion {builder.CreateString(VulnDescFBScoreVersionStr)};
-        auto VulnDescFBReference {builder.CreateString(VulnDescFBReferenceStr)};
-
-        NSVulnerabilityScanner::VulnerabilityDescriptionBuilder vulnerabilityDescriptionBuilder(builder);
-        vulnerabilityDescriptionBuilder.add_scoreBase(VulnDescFBScoreBase);
-        vulnerabilityDescriptionBuilder.add_classification(VulnDescFBClassification);
-        vulnerabilityDescriptionBuilder.add_description(VulnDescFBDescription);
-        vulnerabilityDescriptionBuilder.add_severity(VulnDescFBSeverity);
-        vulnerabilityDescriptionBuilder.add_scoreVersion(VulnDescFBScoreVersion);
-        vulnerabilityDescriptionBuilder.add_reference(VulnDescFBReference);
-
-        auto vulnerabilityDescriptionFB = vulnerabilityDescriptionBuilder.Finish();
-        builder.Finish(vulnerabilityDescriptionFB);
-
-        const uint8_t* buffer = builder.GetBufferPointer();
-        size_t flatbufferSize = builder.GetSize();
-
-        const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer), flatbufferSize);
-        rocksDBWrapper.put(resource, VulnerabilityDescriptionSlice);
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -118,7 +118,8 @@ public:
                 {
                     if (field->url())
                     {
-                        VulnDescFBReferenceStr = VulnDescFBReferenceStr + field->url()->str() + ", ";
+                        VulnDescFBReferenceStr += field->url()->str();
+                        VulnDescFBReferenceStr += ", ";
                     }
                 }
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -41,18 +41,13 @@ public:
                                               const cve_v5::Entry* cve5Flatbuffer,
                                               Utils::RocksDBWrapper& rocksDBWrapper)
     {
-        auto containers = cve5Flatbuffer->containers();
-        auto cna = containers->cna();
-        if (containers && cna)
+        if (cve5Flatbuffer->containers() && cve5Flatbuffer->containers()->cna())
         {
+            auto cna = cve5Flatbuffer->containers()->cna();
+            // Missing metrics object is valid in a CVE5 schema.
             auto metricsArray = cna->metrics();
-            const size_t sizeM = (nullptr != metricsArray) ? metricsArray->size() : 0;
             auto descriptionArray = cna->descriptions();
-            const size_t sizeD = (nullptr != descriptionArray) ? descriptionArray->size() : 0;
             auto referencesArray = cna->references();
-            const size_t sizeR = (nullptr != referencesArray) ? referencesArray->size() : 0;
-            size_t sizeT = (sizeM > sizeD) ? sizeM : sizeD;
-            sizeT = (sizeT > sizeR) ? sizeT : sizeR;
 
             float VulnDescFBScoreBase = 0.0;
             std::string VulnDescFBClassificationStr;
@@ -61,16 +56,13 @@ public:
             std::string VulnDescFBScoreVersionStr;
             std::string VulnDescFBReferenceStr;
 
-            bool cont = true;
-            bool exist = false;
-            for (size_t i = 0; i < sizeT; ++i)
+            if (metricsArray)
             {
-                if (i < sizeM && !exist)
+                for (const auto& field : *metricsArray)
                 {
-                    auto metric = metricsArray->Get(i);
-                    auto metricCVSSV3_1 = metric->cvssV3_1();
-                    auto metricCVSSV3_0 = metric->cvssV3_0();
-                    auto metricCVSSV2_0 = metric->cvssV2_0();
+                    auto metricCVSSV3_1 = field->cvssV3_1();
+                    auto metricCVSSV3_0 = field->cvssV3_0();
+                    auto metricCVSSV2_0 = field->cvssV2_0();
                     if (metricCVSSV3_1)
                     {
                         VulnDescFBScoreBase = metricCVSSV3_1->baseScore();
@@ -78,9 +70,9 @@ public:
                         VulnDescFBSeverityStr = (nullptr != baseSeverity) ? baseSeverity->str() : "";
                         auto version = metricCVSSV3_1->version();
                         VulnDescFBScoreVersionStr = (nullptr != version) ? version->str() : "";
-                        auto format = metric->format();
+                        auto format = field->format();
                         VulnDescFBClassificationStr = (nullptr != format) ? format->str() : "";
-                        exist = true;
+                        break;
                     }
                     else if (metricCVSSV3_0)
                     {
@@ -89,9 +81,9 @@ public:
                         VulnDescFBSeverityStr = (nullptr != baseSeverity) ? baseSeverity->str() : "";
                         auto version = metricCVSSV3_0->version();
                         VulnDescFBScoreVersionStr = (nullptr != version) ? version->str() : "";
-                        auto format = metric->format();
+                        auto format = field->format();
                         VulnDescFBClassificationStr = (nullptr != format) ? format->str() : "";
-                        exist = true;
+                        break;
                     }
                     else if (metricCVSSV2_0)
                     {
@@ -101,29 +93,36 @@ public:
                                                                               : "HIGH";
                         auto version = metricCVSSV2_0->version();
                         VulnDescFBScoreVersionStr = (nullptr != version) ? version->str() : "";
-                        auto format = metric->format();
+                        auto format = field->format();
                         VulnDescFBClassificationStr = (nullptr != format) ? format->str() : "";
-                        exist = true;
-                    }
-                }
-                if (i < sizeR)
-                {
-                    auto reference = referencesArray->Get(i);
-                    if (reference->url())
-                    {
-                        VulnDescFBReferenceStr = VulnDescFBReferenceStr + reference->url()->str() + ", ";
-                    }
-                }
-                if ((i < sizeD) && cont)
-                {
-                    auto description = descriptionArray->Get(i);
-                    if (description->lang()->str().compare("en") == 0)
-                    {
-                        VulnDescFBDescriptionStr = description->value()->str();
-                        cont = false;
+                        break;
                     }
                 }
             }
+
+            if (descriptionArray)
+            {
+                for (const auto& field : *descriptionArray)
+                {
+                    if (field->lang()->str().compare("en") == 0)
+                    {
+                        VulnDescFBDescriptionStr = field->value()->str();
+                        break;
+                    }
+                }
+            }
+
+            if (referencesArray)
+            {
+                for (const auto& field : *referencesArray)
+                {
+                    if (field->url())
+                    {
+                        VulnDescFBReferenceStr = VulnDescFBReferenceStr + field->url()->str() + ", ";
+                    }
+                }
+            }
+
             VulnDescFBReferenceStr = VulnDescFBReferenceStr.substr(0, VulnDescFBReferenceStr.size() - 2);
 
             flatbuffers::FlatBufferBuilder builder;

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -16,7 +16,6 @@
 #include "cve5_generated.h"
 #include "eventContext.hpp"
 #include "flatbuffers/flatbuffers.h"
-#include "flatbuffers/verifier.h"
 #include "rocksDBWrapper.hpp"
 #include "vulnerabilityDescription_generated.h"
 
@@ -27,7 +26,7 @@ constexpr auto CVE5_DATABASE_PATH {"queue/vd/cve5"};
  * @brief UpdateCVEDescription class.
  *
  */
-class UpdateCVEDescription final : public AbstractHandler<std::shared_ptr<EventContext>>
+class UpdateCVEDescription final
 {
 public:
     /**
@@ -35,102 +34,95 @@ public:
      * database.
      *
      * @param resource CVE ID.
-     * @param buf Flatbuffer pointer.
-     * @param size Flatbuffer size.
+     * @param cve5Flatbuffer CVE5 Flatbuffer.
      */
-    static void storeVulnerabilityDescription(const std::string& resource, uint8_t* buf, const size_t& size)
+    static void storeVulnerabilityDescription(const std::string& resource, const cve_v5::Entry* cve5Flatbuffer)
     {
-        flatbuffers::Verifier verifier(buf, size);
-        if (cve_v5::VerifyEntryBuffer(verifier))
+        auto metricsArray = cve5Flatbuffer->containers()->cna()->metrics();
+        const size_t sizeM = (nullptr != metricsArray) ? metricsArray->size() : 0;
+        auto descriptionArray = cve5Flatbuffer->containers()->cna()->descriptions();
+        const size_t sizeD = (nullptr != descriptionArray) ? descriptionArray->size() : 0;
+        auto referencesArray = cve5Flatbuffer->containers()->cna()->references();
+        const size_t sizeR = (nullptr != referencesArray) ? referencesArray->size() : 0;
+        size_t sizeT = (sizeM > sizeD) ? sizeM : sizeD;
+        sizeT = (sizeT > sizeR) ? sizeT : sizeR;
+
+        float VulnDescFBScoreBase = 0.0;
+        std::string VulnDescFBClassificationStr;
+        std::string VulnDescFBDescriptionStr;
+        std::string VulnDescFBSeverityStr;
+        std::string VulnDescFBScoreVersionStr;
+        std::string VulnDescFBReferenceStr;
+
+        bool cont = true;
+        for (size_t i = 0; i < sizeT; ++i)
         {
-            auto cve5Flatbuffer = cve_v5::GetEntry(buf);
-            auto metricsArray = cve5Flatbuffer->containers()->cna()->metrics();
-            const size_t sizeM = (nullptr != metricsArray) ? metricsArray->size() : 0;
-            auto descriptionArray = cve5Flatbuffer->containers()->cna()->descriptions();
-            const size_t sizeD = (nullptr != descriptionArray) ? descriptionArray->size() : 0;
-            auto referencesArray = cve5Flatbuffer->containers()->cna()->references();
-            const size_t sizeR = (nullptr != referencesArray) ? referencesArray->size() : 0;
-            size_t sizeT = (sizeM > sizeD) ? sizeM : sizeD;
-            sizeT = (sizeT > sizeR) ? sizeT : sizeR;
-
-            float VulnDescFBScoreBase = 0.0;
-            std::string VulnDescFBClassificationStr;
-            std::string VulnDescFBDescriptionStr;
-            std::string VulnDescFBSeverityStr;
-            std::string VulnDescFBScoreVersionStr;
-            std::string VulnDescFBReferenceStr;
-
-            bool cont = true;
-            for (size_t i = 0; i < sizeT; ++i)
+            if (i < sizeM)
             {
-                if (i < sizeM)
+                auto metric = metricsArray->Get(i);
+                if (metric->cvssV3_1())
                 {
-                    auto metric = metricsArray->Get(i);
-                    if (metric->cvssV3_1())
-                    {
-                        VulnDescFBScoreBase = metric->cvssV3_1()->baseScore();
-                        auto baseSeverity = metric->cvssV3_1()->baseSeverity();
-                        VulnDescFBSeverityStr = (nullptr != baseSeverity) ? baseSeverity->str() : "";
-                        auto version = metric->cvssV3_1()->version();
-                        VulnDescFBScoreVersionStr = (nullptr != version) ? version->str() : "";
-                        auto format = metric->format();
-                        VulnDescFBClassificationStr = (nullptr != format) ? format->str() : "";
-                    }
-                }
-                if (i < sizeR)
-                {
-                    auto reference = referencesArray->Get(i);
-                    if (reference->url())
-                    {
-                        VulnDescFBReferenceStr = VulnDescFBReferenceStr + reference->url()->str() + ", ";
-                    }
-                }
-                if ((i < sizeD) && cont)
-                {
-                    auto description = descriptionArray->Get(i);
-                    if (description->lang()->str().compare("en") == 0)
-                    {
-                        VulnDescFBDescriptionStr = description->value()->str();
-                        cont = false;
-                    }
+                    VulnDescFBScoreBase = metric->cvssV3_1()->baseScore();
+                    auto baseSeverity = metric->cvssV3_1()->baseSeverity();
+                    VulnDescFBSeverityStr = (nullptr != baseSeverity) ? baseSeverity->str() : "";
+                    auto version = metric->cvssV3_1()->version();
+                    VulnDescFBScoreVersionStr = (nullptr != version) ? version->str() : "";
+                    auto format = metric->format();
+                    VulnDescFBClassificationStr = (nullptr != format) ? format->str() : "";
                 }
             }
-            VulnDescFBReferenceStr = VulnDescFBReferenceStr.substr(0, VulnDescFBReferenceStr.size() - 2);
-
-            flatbuffers::FlatBufferBuilder builder;
-
-            auto VulnDescFBClassification {builder.CreateString(VulnDescFBClassificationStr)};
-            auto VulnDescFBDescription {builder.CreateString(VulnDescFBDescriptionStr)};
-            auto VulnDescFBSeverity {builder.CreateString(VulnDescFBSeverityStr)};
-            auto VulnDescFBScoreVersion {builder.CreateString(VulnDescFBScoreVersionStr)};
-            auto VulnDescFBReference {builder.CreateString(VulnDescFBReferenceStr)};
-
-            NSVulnerabilityScanner::VulnerabilityDescriptionBuilder vulnerabilityDescriptionBuilder(builder);
-            vulnerabilityDescriptionBuilder.add_scoreBase(VulnDescFBScoreBase);
-            vulnerabilityDescriptionBuilder.add_classification(VulnDescFBClassification);
-            vulnerabilityDescriptionBuilder.add_description(VulnDescFBDescription);
-            vulnerabilityDescriptionBuilder.add_severity(VulnDescFBSeverity);
-            vulnerabilityDescriptionBuilder.add_scoreVersion(VulnDescFBScoreVersion);
-            vulnerabilityDescriptionBuilder.add_reference(VulnDescFBReference);
-
-            auto vulnerabilityDescriptionFB = vulnerabilityDescriptionBuilder.Finish();
-            builder.Finish(vulnerabilityDescriptionFB);
-
-            const uint8_t* buffer = builder.GetBufferPointer();
-            size_t flatbufferSize = builder.GetSize();
-
-            try
+            if (i < sizeR)
             {
-                Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-
-                const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer),
-                                                                   flatbufferSize);
-                rocksDBWrapper.put(resource, VulnerabilityDescriptionSlice);
+                auto reference = referencesArray->Get(i);
+                if (reference->url())
+                {
+                    VulnDescFBReferenceStr = VulnDescFBReferenceStr + reference->url()->str() + ", ";
+                }
             }
-            catch (...)
+            if ((i < sizeD) && cont)
             {
-                std::cerr << "Couldn't save vulnerability description in database" << std::endl;
+                auto description = descriptionArray->Get(i);
+                if (description->lang()->str().compare("en") == 0)
+                {
+                    VulnDescFBDescriptionStr = description->value()->str();
+                    cont = false;
+                }
             }
+        }
+        VulnDescFBReferenceStr = VulnDescFBReferenceStr.substr(0, VulnDescFBReferenceStr.size() - 2);
+
+        flatbuffers::FlatBufferBuilder builder;
+
+        auto VulnDescFBClassification {builder.CreateString(VulnDescFBClassificationStr)};
+        auto VulnDescFBDescription {builder.CreateString(VulnDescFBDescriptionStr)};
+        auto VulnDescFBSeverity {builder.CreateString(VulnDescFBSeverityStr)};
+        auto VulnDescFBScoreVersion {builder.CreateString(VulnDescFBScoreVersionStr)};
+        auto VulnDescFBReference {builder.CreateString(VulnDescFBReferenceStr)};
+
+        NSVulnerabilityScanner::VulnerabilityDescriptionBuilder vulnerabilityDescriptionBuilder(builder);
+        vulnerabilityDescriptionBuilder.add_scoreBase(VulnDescFBScoreBase);
+        vulnerabilityDescriptionBuilder.add_classification(VulnDescFBClassification);
+        vulnerabilityDescriptionBuilder.add_description(VulnDescFBDescription);
+        vulnerabilityDescriptionBuilder.add_severity(VulnDescFBSeverity);
+        vulnerabilityDescriptionBuilder.add_scoreVersion(VulnDescFBScoreVersion);
+        vulnerabilityDescriptionBuilder.add_reference(VulnDescFBReference);
+
+        auto vulnerabilityDescriptionFB = vulnerabilityDescriptionBuilder.Finish();
+        builder.Finish(vulnerabilityDescriptionFB);
+
+        const uint8_t* buffer = builder.GetBufferPointer();
+        size_t flatbufferSize = builder.GetSize();
+
+        try
+        {
+            Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
+
+            const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer), flatbufferSize);
+            rocksDBWrapper.put(resource, VulnerabilityDescriptionSlice);
+        }
+        catch (...)
+        {
+            std::cerr << "Couldn't save vulnerability description in database" << std::endl;
         }
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -35,8 +35,11 @@ public:
      *
      * @param resource CVE ID.
      * @param cve5Flatbuffer CVE5 Flatbuffer.
+     * @param rocksDBWrapper rocksDB wrapper instance.
      */
-    static void storeVulnerabilityDescription(const std::string& resource, const cve_v5::Entry* cve5Flatbuffer)
+    static void storeVulnerabilityDescription(const std::string& resource,
+                                              const cve_v5::Entry* cve5Flatbuffer,
+                                              Utils::RocksDBWrapper& rocksDBWrapper)
     {
         auto metricsArray = cve5Flatbuffer->containers()->cna()->metrics();
         const size_t sizeM = (nullptr != metricsArray) ? metricsArray->size() : 0;
@@ -113,17 +116,8 @@ public:
         const uint8_t* buffer = builder.GetBufferPointer();
         size_t flatbufferSize = builder.GetSize();
 
-        try
-        {
-            Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-
-            const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer), flatbufferSize);
-            rocksDBWrapper.put(resource, VulnerabilityDescriptionSlice);
-        }
-        catch (...)
-        {
-            std::cerr << "Couldn't save vulnerability description in database" << std::endl;
-        }
+        const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer), flatbufferSize);
+        rocksDBWrapper.put(resource, VulnerabilityDescriptionSlice);
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -1,0 +1,138 @@
+/*
+ * Wazuh Vulnerability scanner - Database Feed Manager
+ * Copyright (C) 2015, Wazuh Inc.
+ * Oct 3, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _UPDATE_CVE_DESCRIPTION_HPP
+#define _UPDATE_CVE_DESCRIPTION_HPP
+
+#include "chainOfResponsability.hpp"
+#include "cve5_generated.h"
+#include "eventContext.hpp"
+#include "flatbuffers/flatbuffers.h"
+#include "flatbuffers/verifier.h"
+#include "rocksDBWrapper.hpp"
+#include "vulnerabilityDescription_generated.h"
+
+constexpr auto DESCRIPTION_DATABASE_PATH {"queue/vd/descriptions"};
+constexpr auto CVE5_DATABASE_PATH {"queue/vd/cve5"};
+
+/**
+ * @brief UpdateCVEDescription class.
+ *
+ */
+class UpdateCVEDescription final : public AbstractHandler<std::shared_ptr<EventContext>>
+{
+public:
+    /**
+     * @brief Reads CVE5 database, creates a vulnerability description flatbuffer and stores it in a specific RocksDB
+     * database.
+     *
+     * @param resource CVE ID.
+     * @param buf Flatbuffer pointer.
+     * @param size Flatbuffer size.
+     */
+    static void storeVulnerabilityDescription(const std::string& resource, uint8_t* buf, const size_t& size)
+    {
+        flatbuffers::Verifier verifier(buf, size);
+        if (cve_v5::VerifyEntryBuffer(verifier))
+        {
+            auto cve5Flatbuffer = cve_v5::GetEntry(buf);
+            auto metricsArray = cve5Flatbuffer->containers()->cna()->metrics();
+            const size_t sizeM = (nullptr != metricsArray) ? metricsArray->size() : 0;
+            auto descriptionArray = cve5Flatbuffer->containers()->cna()->descriptions();
+            const size_t sizeD = (nullptr != descriptionArray) ? descriptionArray->size() : 0;
+            auto referencesArray = cve5Flatbuffer->containers()->cna()->references();
+            const size_t sizeR = (nullptr != referencesArray) ? referencesArray->size() : 0;
+            size_t sizeT = (sizeM > sizeD) ? sizeM : sizeD;
+            sizeT = (sizeT > sizeR) ? sizeT : sizeR;
+
+            float VulnDescFBScoreBase = 0.0;
+            std::string VulnDescFBClassificationStr;
+            std::string VulnDescFBDescriptionStr;
+            std::string VulnDescFBSeverityStr;
+            std::string VulnDescFBScoreVersionStr;
+            std::string VulnDescFBReferenceStr;
+
+            bool cont = true;
+            for (size_t i = 0; i < sizeT; ++i)
+            {
+                if (i < sizeM)
+                {
+                    auto metric = metricsArray->Get(i);
+                    if (metric->cvssV3_1())
+                    {
+                        VulnDescFBScoreBase = metric->cvssV3_1()->baseScore();
+                        auto baseSeverity = metric->cvssV3_1()->baseSeverity();
+                        VulnDescFBSeverityStr = (nullptr != baseSeverity) ? baseSeverity->str() : "";
+                        auto version = metric->cvssV3_1()->version();
+                        VulnDescFBScoreVersionStr = (nullptr != version) ? version->str() : "";
+                        auto format = metric->format();
+                        VulnDescFBClassificationStr = (nullptr != format) ? format->str() : "";
+                    }
+                }
+                if (i < sizeR)
+                {
+                    auto reference = referencesArray->Get(i);
+                    if (reference->url())
+                    {
+                        VulnDescFBReferenceStr = VulnDescFBReferenceStr + reference->url()->str() + ", ";
+                    }
+                }
+                if ((i < sizeD) && cont)
+                {
+                    auto description = descriptionArray->Get(i);
+                    if (description->lang()->str().compare("en") == 0)
+                    {
+                        VulnDescFBDescriptionStr = description->value()->str();
+                        cont = false;
+                    }
+                }
+            }
+            VulnDescFBReferenceStr = VulnDescFBReferenceStr.substr(0, VulnDescFBReferenceStr.size() - 2);
+
+            flatbuffers::FlatBufferBuilder builder;
+
+            auto VulnDescFBClassification {builder.CreateString(VulnDescFBClassificationStr)};
+            auto VulnDescFBDescription {builder.CreateString(VulnDescFBDescriptionStr)};
+            auto VulnDescFBSeverity {builder.CreateString(VulnDescFBSeverityStr)};
+            auto VulnDescFBScoreVersion {builder.CreateString(VulnDescFBScoreVersionStr)};
+            auto VulnDescFBReference {builder.CreateString(VulnDescFBReferenceStr)};
+
+            NSVulnerabilityScanner::VulnerabilityDescriptionBuilder vulnerabilityDescriptionBuilder(builder);
+            vulnerabilityDescriptionBuilder.add_scoreBase(VulnDescFBScoreBase);
+            vulnerabilityDescriptionBuilder.add_classification(VulnDescFBClassification);
+            vulnerabilityDescriptionBuilder.add_description(VulnDescFBDescription);
+            vulnerabilityDescriptionBuilder.add_severity(VulnDescFBSeverity);
+            vulnerabilityDescriptionBuilder.add_scoreVersion(VulnDescFBScoreVersion);
+            vulnerabilityDescriptionBuilder.add_reference(VulnDescFBReference);
+
+            auto vulnerabilityDescriptionFB = vulnerabilityDescriptionBuilder.Finish();
+            builder.Finish(vulnerabilityDescriptionFB);
+
+            const uint8_t* buffer = builder.GetBufferPointer();
+            size_t flatbufferSize = builder.GetSize();
+
+            try
+            {
+                Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
+
+                const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer),
+                                                                   flatbufferSize);
+                rocksDBWrapper.put(resource, VulnerabilityDescriptionSlice);
+            }
+            catch (...)
+            {
+                std::cerr << "Couldn't save vulnerability description in database" << std::endl;
+            }
+        }
+    }
+};
+
+#endif // _UPDATE_CVE_DESCRIPTION_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -127,21 +127,15 @@ public:
 
             flatbuffers::FlatBufferBuilder builder;
 
-            auto VulnDescFBClassification {builder.CreateString(VulnDescFBClassificationStr)};
-            auto VulnDescFBDescription {builder.CreateString(VulnDescFBDescriptionStr)};
-            auto VulnDescFBSeverity {builder.CreateString(VulnDescFBSeverityStr)};
-            auto VulnDescFBScoreVersion {builder.CreateString(VulnDescFBScoreVersionStr)};
-            auto VulnDescFBReference {builder.CreateString(VulnDescFBReferenceStr)};
+            auto vulnerabilityDescriptionFB =
+                NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                             VulnDescFBScoreBase,
+                                                                             VulnDescFBClassificationStr.c_str(),
+                                                                             VulnDescFBDescriptionStr.c_str(),
+                                                                             VulnDescFBSeverityStr.c_str(),
+                                                                             VulnDescFBScoreVersionStr.c_str(),
+                                                                             VulnDescFBReferenceStr.c_str());
 
-            NSVulnerabilityScanner::VulnerabilityDescriptionBuilder vulnerabilityDescriptionBuilder(builder);
-            vulnerabilityDescriptionBuilder.add_scoreBase(VulnDescFBScoreBase);
-            vulnerabilityDescriptionBuilder.add_classification(VulnDescFBClassification);
-            vulnerabilityDescriptionBuilder.add_description(VulnDescFBDescription);
-            vulnerabilityDescriptionBuilder.add_severity(VulnDescFBSeverity);
-            vulnerabilityDescriptionBuilder.add_scoreVersion(VulnDescFBScoreVersion);
-            vulnerabilityDescriptionBuilder.add_reference(VulnDescFBReference);
-
-            auto vulnerabilityDescriptionFB = vulnerabilityDescriptionBuilder.Finish();
             builder.Finish(vulnerabilityDescriptionFB);
 
             const uint8_t* buffer = builder.GetBufferPointer();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
@@ -13,6 +13,8 @@
 #include "factoryOrchestrator.hpp"
 #include <iostream>
 
+// TODO: Remove LCOV flags once the implementation of 'ScanOrchestrator' is completed
+// LCOV_EXCL_START
 void ScanOrchestrator::run(const std::string& agentId,
                            const std::vector<char>& message,
                            std::shared_ptr<IndexerConnector> /*indexerConnector*/)
@@ -28,3 +30,4 @@ void ScanOrchestrator::run(const std::string& agentId,
     {
     }
 }
+// LCOV_EXCL_START

--- a/src/wazuh_modules/vulnerability_scanner/tests/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/tests/CMakeLists.txt
@@ -11,6 +11,8 @@ include_directories(${SRC_FOLDER}/wazuh_modules/vulnerability_scanner/src/)
 
 link_directories(${SRC_FOLDER}/external/googletest/lib/)
 
+set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage -fsanitize=address,leak,undefined")
+
 add_subdirectory(policyManager)
 add_subdirectory(unit)
 add_subdirectory(component)

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.12.4)
 
 project(vulnerability_scanner_unit_tests)
 
+include_directories(${SRC_FOLDER}/external/flatbuffers/include/)
+
 file(GLOB PROJECT_SOURCES
     *.cpp
     ${SRC_FOLDER}/vulnerability_scanner/src/*[!main]*.cpp
@@ -9,9 +11,12 @@ file(GLOB PROJECT_SOURCES
 
 add_executable(${PROJECT_NAME} ${PROJECT_SOURCES})
 
+target_compile_definitions(${PROJECT_NAME} PUBLIC FLATBUFFER_SCHEMAS_DIR="${SRC_FOLDER}/wazuh_modules/vulnerability_scanner/schemas")
+
 target_link_libraries(${PROJECT_NAME}
         gtest
         gtest_main
+        flatbuffers
         )
 
 target_link_libraries(${PROJECT_NAME} vulnerability_scanner)

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/CMakeLists.txt
@@ -9,6 +9,8 @@ file(GLOB PROJECT_SOURCES
     ${SRC_FOLDER}/vulnerability_scanner/src/*[!main]*.cpp
 )
 
+link_directories(${SRC_FOLDER}/external/rocksdb/build)
+
 add_executable(${PROJECT_NAME} ${PROJECT_SOURCES})
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC FLATBUFFER_SCHEMAS_DIR="${SRC_FOLDER}/wazuh_modules/vulnerability_scanner/schemas")
@@ -17,6 +19,7 @@ target_link_libraries(${PROJECT_NAME}
         gtest
         gtest_main
         flatbuffers
+        rocksdb
         )
 
 target_link_libraries(${PROJECT_NAME} vulnerability_scanner)

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -20,69 +20,10 @@
 const std::string cve5FlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
 const std::string cvssFlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/cvss.fbs"};
 const std::string vulnRemFlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/vulnerabilityRemediations.fbs"};
-const std::string DATABASE_DIR {"queue/vd"};
 const char* INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
 
-const std::string jsonStrInvalid {
-    R"({
-                "containers": {
-                    "cna": {
-                    "affected": [
-                        {
-                        "defaultStatus": "unaffected",
-                        "product": "vim",
-                        "vendor": "arch",
-                        "versions": [
-                            {
-                            "lessThan": "8.2.4651-1",
-                            "status": "affected",
-                            "version": "8.2.4464-1",
-                            "versionType": "custom"
-                            }
-                        ]
-                        },
-                        {
-                        "defaultStatus": "unaffected",
-                        "product": "gvim",
-                        "vendor": "arch",
-                        "versions": [
-                            {
-                            "lessThan": "8.2.4651-1",
-                            "status": "affected",
-                            "version": "8.2.4464-1",
-                            "versionType": "custom"
-                            }
-                        ]
-                        }
-                    ],
-                    "providerMetadata": {
-                        "orgId": "00000000-0000-4000-A000-000000000002",
-                        "shortName": "arch"
-                    },
-                    "references": [
-                        {
-                        "url": "https://security.archlinux.org/CVE-2022-1154"
-                        }
-                    ],
-                    "descriptions": [
-                        {
-                        "lang": "en",
-                        "value": "not defined"
-                        }
-                    ]
-                    }
-                },
-                "cveMetadata": {
-                    "assignerOrgId": "00000000-0000-4000-A000-000000000002",
-                    "assignerShortName": "arch",
-                    "cveId": "CVE-2022-1154",
-                    "state": "PUBLISHED"
-                },
-                "dataType": "CVE_RECORD",
-                "dataVersion": "5.0"
-})"};
-
-const std::string jsonStrValid {
+const std::string CVEJsonStrCVSSV3_1 {"CVE-2022-0605"};
+const std::string jsonStrCVSSV3_1 {
     R"({
                 "containers": {
                     "cna": {
@@ -191,14 +132,266 @@ const std::string jsonStrValid {
                 "dataVersion": "5.0"
 })"};
 
-const std::string resourceValid {"CVE-2022-0605"};
-const std::string resourceInvalid {"CVE-2022-1154"};
+const std::string CVEJsonStrCVSSV3_0 {"CVE-2019-0029"};
+const std::string jsonStrCVSSV3_0 {
+    R"({
+            "containers": {
+                "cna": {
+                    "affected": [
+                        {
+                            "cpes": [
+                                "cpe:2.3:o:juniper:advanced_threat_prevention:*:*:*:*:*:*:*:*"
+                            ],
+                            "defaultStatus": "unaffected",
+                            "platforms": [
+                                "cpe:2.3:h:juniper:atp700:-:*:*:*:*:*:*:*",
+                                "cpe:2.3:h:juniper:atp400:-:*:*:*:*:*:*:*"
+                            ],
+                            "product": "advanced_threat_prevention",
+                            "vendor": "juniper",
+                            "versions": [
+                                {
+                                    "lessThan": "5.0.3",
+                                    "status": "affected",
+                                    "version": "5.0.0",
+                                    "versionType": "custom"
+                                }
+                            ]
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                            "lang": "en",
+                            "value": "Juniper ATP Series Splunk credentials are logged in a file readable by authenticated local users. Using these credentials an attacker can access the Splunk server. This issue affects Juniper ATP 5.0 versions prior to 5.0.3."
+                        }
+                    ],
+                    "metrics": [
+                        {
+                            "cvssV3_0": {
+                                "attackComplexity": "LOW",
+                                "attackVector": "LOCAL",
+                                "availabilityImpact": "HIGH",
+                                "baseScore": 7.8,
+                                "baseSeverity": "HIGH",
+                                "confidentialityImpact": "HIGH",
+                                "integrityImpact": "HIGH",
+                                "privilegesRequired": "LOW",
+                                "scope": "UNCHANGED",
+                                "userInteraction": "NONE",
+                                "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                                "version": "3.0"
+                            },
+                            "format": "CVSS"
+                        },
+                        {
+                            "cvssV2_0": {
+                                "accessComplexity": "LOW",
+                                "accessVector": "LOCAL",
+                                "authentication": "NONE",
+                                "availabilityImpact": "NONE",
+                                "baseScore": 2.1,
+                                "confidentialityImpact": "PARTIAL",
+                                "integrityImpact": "NONE",
+                                "vectorString": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+                                "version": "2.0"
+                            },
+                            "format": "CVSS"
+                        }
+                    ],
+                    "problemTypes": [
+                        {
+                            "descriptions": [
+                                {
+                                    "description": "CWE-532",
+                                    "lang": "en"
+                                }
+                            ]
+                        }
+                    ],
+                    "providerMetadata": {
+                        "orgId": "00000000-0000-4000-A000-000000000003",
+                        "shortName": "nvd",
+                        "dateUpdated": "2020-08-24T17:37:00Z"
+                    },
+                    "references": [
+                        {
+                            "name": "https://kb.juniper.net/JSA10918",
+                            "tags": [
+                                "vendor-advisory"
+                            ],
+                            "url": "https://kb.juniper.net/JSA10918"
+                        }
+                    ]
+                }
+            },
+            "cveMetadata": {
+                "assignerOrgId": "00000000-0000-4000-A000-000000000003",
+                "assignerShortName": "nvd",
+                "cveId": "CVE-2019-0029",
+                "datePublished": "2019-01-15T21:29:00Z",
+                "dateUpdated": "2020-08-24T17:37:00Z",
+                "state": "PUBLISHED"
+            },
+            "dataType": "CVE_RECORD",
+            "dataVersion": "5.0"
+        })"};
 
-TEST_F(UpdateCVEDescriptionTest, StoreCVEDescription)
+const std::string CVEJsonStrCVSSV2_0 {"CVE-2022-24753"};
+const std::string jsonStrCVSSV2_0 {
+    R"(        {
+            "containers": {
+                "cna": {
+                    "affected": [
+                        {
+                            "cpes": [
+                                "cpe:2.3:a:stripe:stripe_cli:*:*:*:*:*:*:*:*"
+                            ],
+                            "defaultStatus": "unaffected",
+                            "platforms": [
+                                "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*"
+                            ],
+                            "product": "stripe_cli",
+                            "vendor": "stripe",
+                            "versions": [
+                                {
+                                    "lessThan": "1.7.13",
+                                    "status": "affected",
+                                    "version": "0",
+                                    "versionType": "custom"
+                                }
+                            ]
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                            "lang": "en",
+                            "value": "Stripe CLI is a command-line tool for the Stripe eCommerce platform. A vulnerability in Stripe CLI exists on Windows when certain commands are run in a directory where an attacker has planted files. The commands are `stripe login`, `stripe config -e`, `stripe community`, and `stripe open`. MacOS and Linux are unaffected. An attacker who successfully exploits the vulnerability can run arbitrary code in the context of the current user. The update addresses the vulnerability by throwing an error in these situations before the code can run.Users are advised to upgrade to version 1.7.13. There are no known workarounds for this issue."
+                        }
+                    ],
+                    "metrics": [
+                        {
+                            "cvssV2_0": {
+                                "accessComplexity": "MEDIUM",
+                                "accessVector": "LOCAL",
+                                "authentication": "NONE",
+                                "availabilityImpact": "PARTIAL",
+                                "baseScore": 4.4,
+                                "confidentialityImpact": "PARTIAL",
+                                "integrityImpact": "PARTIAL",
+                                "vectorString": "AV:L/AC:M/Au:N/C:P/I:P/A:P",
+                                "version": "2.0"
+                            },
+                            "format": "CVSS"
+                        }
+                    ],
+                    "problemTypes": [
+                        {
+                            "descriptions": [
+                                {
+                                    "description": "NVD-CWE-noinfo",
+                                    "lang": "en"
+                                }
+                            ]
+                        }
+                    ],
+                    "providerMetadata": {
+                        "orgId": "00000000-0000-4000-A000-000000000003",
+                        "shortName": "nvd",
+                        "dateUpdated": "2022-03-12T02:51:00Z"
+                    },
+                    "references": [
+                        {
+                            "name": "https://github.com/stripe/stripe-cli/commit/be38da5c0191adb77f661f769ffff2fbc7ddf6cd",
+                            "tags": [
+                                "patch",
+                                "third-party-advisory"
+                            ],
+                            "url": "https://github.com/stripe/stripe-cli/commit/be38da5c0191adb77f661f769ffff2fbc7ddf6cd"
+                        },
+                        {
+                            "name": "https://github.com/stripe/stripe-cli/security/advisories/GHSA-4cx6-fj7j-pjx9",
+                            "tags": [
+                                "third-party-advisory"
+                            ],
+                            "url": "https://github.com/stripe/stripe-cli/security/advisories/GHSA-4cx6-fj7j-pjx9"
+                        }
+                    ]
+                }
+            },
+            "cveMetadata": {
+                "assignerOrgId": "00000000-0000-4000-A000-000000000003",
+                "assignerShortName": "nvd",
+                "cveId": "CVE-2022-24753",
+                "datePublished": "2022-03-09T23:15:00Z",
+                "dateUpdated": "2022-03-12T02:51:00Z",
+                "state": "PUBLISHED"
+            },
+            "dataType": "CVE_RECORD",
+            "dataVersion": "5.0"
+        })"};
+
+const std::string CVEJsonStrMissingMetrics {"CVE-2022-1154"};
+const std::string jsonStrMissingMetrics {
+    R"({
+                "containers": {
+                    "cna": {
+                    "affected": [
+                        {
+                        "defaultStatus": "unaffected",
+                        "product": "vim",
+                        "vendor": "arch",
+                        "versions": [
+                            {
+                            "lessThan": "8.2.4651-1",
+                            "status": "affected",
+                            "version": "8.2.4464-1",
+                            "versionType": "custom"
+                            }
+                        ]
+                        },
+                        {
+                        "defaultStatus": "unaffected",
+                        "product": "gvim",
+                        "vendor": "arch",
+                        "versions": [
+                            {
+                            "lessThan": "8.2.4651-1",
+                            "status": "affected",
+                            "version": "8.2.4464-1",
+                            "versionType": "custom"
+                            }
+                        ]
+                        }
+                    ],
+                    "providerMetadata": {
+                        "orgId": "00000000-0000-4000-A000-000000000002",
+                        "shortName": "arch"
+                    },
+                    "references": [
+                        {
+                        "url": "https://security.archlinux.org/CVE-2022-1154"
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                        "lang": "en",
+                        "value": "not defined"
+                        }
+                    ]
+                    }
+                },
+                "cveMetadata": {
+                    "assignerOrgId": "00000000-0000-4000-A000-000000000002",
+                    "assignerShortName": "arch",
+                    "cveId": "CVE-2022-1154",
+                    "state": "PUBLISHED"
+                },
+                "dataType": "CVE_RECORD",
+                "dataVersion": "5.0"
+})"};
+
+TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
 {
-    // Create rocksDB base directory.
-    std::filesystem::create_directories(DATABASE_DIR);
-
     std::string cve5FlatbufferSchemaStr;
     std::string cvssFlatbufferSchemaStr;
 
@@ -206,11 +399,12 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescription)
     bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
                   flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
     ASSERT_EQ(valid, true);
-    ASSERT_EQ(jsonStrValid.empty(), false);
+    ASSERT_EQ(jsonStrCVSSV3_1.empty(), false);
 
     // Parse schemas and JSON example.
     flatbuffers::Parser parser;
-    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrValid.c_str()));
+    valid =
+        (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrCVSSV3_1.c_str()));
     ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
@@ -224,11 +418,11 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescription)
 
     // Call function.
     Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(resourceValid, cve5Flatbuffer, rocksDBWrapper);
+    UpdateCVEDescription::storeVulnerabilityDescription(CVEJsonStrCVSSV3_1, cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(resourceValid, vulnerabilityDescriptionFBStr);
+    rocksDBWrapper.get(CVEJsonStrCVSSV3_1, vulnerabilityDescriptionFBStr);
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -250,15 +444,10 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescription)
     EXPECT_EQ(vulnerabilityDescription->reference()->str(),
               "https://crbug.com/1286940, "
               "https://chromereleases.googleblog.com/2022/02/stable-channel-update-for-desktop_14.html");
-
-    std::filesystem::remove_all(DATABASE_DIR);
 }
 
-TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
+TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_0)
 {
-    // Create rocksDB base directory.
-    std::filesystem::create_directories(DATABASE_DIR);
-
     std::string cve5FlatbufferSchemaStr;
     std::string cvssFlatbufferSchemaStr;
 
@@ -266,12 +455,12 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
     bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
                   flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
     ASSERT_EQ(valid, true);
-    ASSERT_EQ(jsonStrValid.empty(), false);
+    ASSERT_EQ(jsonStrCVSSV3_0.empty(), false);
 
     // Parse schemas and JSON example.
     flatbuffers::Parser parser;
     valid =
-        (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrInvalid.c_str()));
+        (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrCVSSV3_0.c_str()));
     ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
@@ -285,11 +474,125 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
 
     // Call function.
     Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(resourceValid, cve5Flatbuffer, rocksDBWrapper);
+    UpdateCVEDescription::storeVulnerabilityDescription(CVEJsonStrCVSSV3_0, cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(resourceValid, vulnerabilityDescriptionFBStr);
+    rocksDBWrapper.get(CVEJsonStrCVSSV3_0, vulnerabilityDescriptionFBStr);
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
+                                           vulnerabilityDescriptionFBStr.size());
+    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
+
+    // Read flatbuffer values.
+    auto vulnerabilityDescription =
+        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
+
+    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "3.0");
+    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "HIGH");
+    EXPECT_EQ(vulnerabilityDescription->scoreBase(), (float)7.8);
+    EXPECT_EQ(vulnerabilityDescription->description()->str(),
+              "Juniper ATP Series Splunk credentials are logged in a file readable by authenticated local users. Using "
+              "these credentials an attacker can access the Splunk server. This issue affects Juniper ATP 5.0 versions "
+              "prior to 5.0.3.");
+    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "CVSS");
+    EXPECT_EQ(vulnerabilityDescription->reference()->str(), "https://kb.juniper.net/JSA10918");
+}
+
+TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV2_0)
+{
+    std::string cve5FlatbufferSchemaStr;
+    std::string cvssFlatbufferSchemaStr;
+
+    // Read schemas from filesystem.
+    bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
+                  flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
+    ASSERT_EQ(valid, true);
+    ASSERT_EQ(jsonStrCVSSV2_0.empty(), false);
+
+    // Parse schemas and JSON example.
+    flatbuffers::Parser parser;
+    valid =
+        (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrCVSSV2_0.c_str()));
+    ASSERT_EQ(valid, true);
+
+    // Get flatbuffer pointer
+    uint8_t* buf = parser.builder_.GetBufferPointer();
+    size_t flatbufferSize = parser.builder_.GetSize();
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
+    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
+    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
+
+    // Call function.
+    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(CVEJsonStrCVSSV2_0, cve5Flatbuffer, rocksDBWrapper);
+
+    // Get flatbuffer from vulnerability description database.
+    std::string vulnerabilityDescriptionFBStr;
+    rocksDBWrapper.get(CVEJsonStrCVSSV2_0, vulnerabilityDescriptionFBStr);
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
+                                           vulnerabilityDescriptionFBStr.size());
+    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
+
+    // Read flatbuffer values.
+    auto vulnerabilityDescription =
+        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
+
+    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "2.0");
+    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "MEDIUM");
+    EXPECT_EQ(vulnerabilityDescription->scoreBase(), (float)4.4);
+    EXPECT_EQ(
+        vulnerabilityDescription->description()->str(),
+        "Stripe CLI is a command-line tool for the Stripe eCommerce platform. A vulnerability in Stripe CLI exists on "
+        "Windows when certain commands are run in a directory where an attacker has planted files. The commands are "
+        "`stripe login`, `stripe config -e`, `stripe community`, and `stripe open`. MacOS and Linux are unaffected. An "
+        "attacker who successfully exploits the vulnerability can run arbitrary code in the context of the current "
+        "user. The update addresses the vulnerability by throwing an error in these situations before the code can "
+        "run.Users are advised to upgrade to version 1.7.13. There are no known workarounds for this issue.");
+    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "CVSS");
+    EXPECT_EQ(vulnerabilityDescription->reference()->str(),
+              "https://github.com/stripe/stripe-cli/commit/be38da5c0191adb77f661f769ffff2fbc7ddf6cd, "
+              "https://github.com/stripe/stripe-cli/security/advisories/GHSA-4cx6-fj7j-pjx9");
+}
+
+TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
+{
+    std::string cve5FlatbufferSchemaStr;
+    std::string cvssFlatbufferSchemaStr;
+
+    // Read schemas from filesystem.
+    bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
+                  flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
+    ASSERT_EQ(valid, true);
+    ASSERT_EQ(jsonStrMissingMetrics.empty(), false);
+
+    // Parse schemas and JSON example.
+    flatbuffers::Parser parser;
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
+             parser.Parse(jsonStrMissingMetrics.c_str()));
+    ASSERT_EQ(valid, true);
+
+    // Get flatbuffer pointer
+    uint8_t* buf = parser.builder_.GetBufferPointer();
+    size_t flatbufferSize = parser.builder_.GetSize();
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
+    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
+    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
+
+    // Call function.
+    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(CVEJsonStrMissingMetrics, cve5Flatbuffer, rocksDBWrapper);
+
+    // Get flatbuffer from vulnerability description database.
+    std::string vulnerabilityDescriptionFBStr;
+    rocksDBWrapper.get(CVEJsonStrMissingMetrics, vulnerabilityDescriptionFBStr);
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -306,6 +609,4 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
     EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
     EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
     EXPECT_EQ(vulnerabilityDescription->reference()->str(), "https://security.archlinux.org/CVE-2022-1154");
-
-    std::filesystem::remove_all(DATABASE_DIR);
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -1,0 +1,180 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * October 3, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "updateCVEDescription_test.hpp"
+#include "databaseFeedManager/databaseFeedManager.hpp"
+#include "databaseFeedManager/updateCVEDescription.hpp"
+#include "flatbuffers/flatbuffers.h"
+#include "flatbuffers/idl.h"
+#include "rocksDBWrapper.hpp"
+
+const std::string cve5FlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
+const std::string cvssFlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/cvss.fbs"};
+const std::string vulnRemFlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/vulnerabilityRemediations.fbs"};
+const std::string DATABASE_DIR {"queue/vd"};
+const char* INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
+
+const std::string jsonStrInvalid {
+    "{\"containers\":{\"cna\":{\"affected\":[{\"defaultStatus\":\"unaffected\",\"product\":\"vim\",\"vendor\":\"arch\","
+    "\"versions\":[{\"lessThan\":\"8.2.4651-1\",\"status\":\"affected\",\"version\":\"8.2.4464-1\",\"versionType\":"
+    "\"custom\"}]},"
+    "{\"defaultStatus\":\"unaffected\",\"product\":\"gvim\",\"vendor\":\"arch\",\"versions\":[{\"lessThan\":\"8.2.4651-"
+    "1\",\"status\":\"affected\","
+    "\"version\":\"8.2.4464-1\",\"versionType\":\"custom\"}]}],\"providerMetadata\":{\"orgId\":\"00000000-0000-4000-"
+    "A000-000000000002\",\"shortName\":\"arch\"},"
+    "\"references\":[{\"url\":\"https://security.archlinux.org/"
+    "CVE-2022-1160\"}],\"descriptions\":[{\"lang\":\"en\",\"value\":\"not defined\"}]}},"
+    "\"cveMetadata\":{\"assignerOrgId\":\"00000000-0000-4000-A000-000000000002\",\"assignerShortName\":\"arch\","
+    "\"cveId\":\"CVE-2022-1160\","
+    "\"state\":\"PUBLISHED\"},\"dataType\":\"CVE_RECORD\",\"dataVersion\":\"5.0\"}"};
+
+const std::string jsonStrValid {
+    "{\"containers\":{\"cna\":{\"affected\":[{\"cpes\":[\"cpe:2.3:a:arm:mbed_tls:3.0.0:preview1:*:*:*:*:*:*\"],"
+    "\"defaultStatus\":\"unaffected\",\"product\":\"mbed_tlspreview1\",\"vendor\":\"arm\",\"versions\":[{\"status\":"
+    "\"affected\",\"version\":\"3.0.0\"}]},{\"cpes\":[\"cpe:2.3:a:arm:mbed_tls:*:*:*:*:*:*:*:*\",\"cpe:2.3:a:arm:mbed_"
+    "tls:3.0.0:-:*:*:*:*:*:*\"],\"defaultStatus\":\"unaffected\",\"product\":\"mbed_tls\",\"vendor\":\"arm\","
+    "\"versions\":[{\"lessThan\":\"2.16.12\",\"status\":\"affected\",\"version\":\"0\",\"versionType\":\"custom\"},{"
+    "\"lessThan\":\"2.28.0\",\"status\":\"affected\",\"version\":\"2.17.0\",\"versionType\":\"custom\"},{\"status\":"
+    "\"affected\",\"version\":\"3.0.0\"}]}],\"descriptions\":[{\"lang\":\"en\",\"value\":\"Mbed TLS before 3.0.1 has a "
+    "double free incertain out-of-memory conditions, as demonstrated by an mbedtls_ssl_set_session() "
+    "failure.\"}],\"metrics\":[{\"cvssV3_1\":{\"attackComplexity\":\"LOW\",\"attackVector\":\"NETWORK\","
+    "\"availabilityImpact\":\"HIGH\",\"baseScore\":9.8,\"baseSeverity\":\"CRITICAL\",\"confidentialityImpact\":"
+    "\"HIGH\",\"integrityImpact\":\"HIGH\",\"privilegesRequired\":\"NONE\",\"scope\":\"UNCHANGED\",\"userInteraction\":"
+    "\"NONE\",\"vectorString\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/"
+    "A:H\",\"version\":\"3.1\"},\"format\":\"CVSS\"},{\"cvssV2_0\":{\"accessComplexity\":\"LOW\",\"accessVector\":"
+    "\"NETWORK\",\"authentication\":\"NONE\",\"availabilityImpact\":\"PARTIAL\",\"baseScore\":7.5,"
+    "\"confidentialityImpact\":\"PARTIAL\",\"integrityImpact\":\"PARTIAL\",\"vectorString\":\"AV:N/AC:L/Au:N/C:P/I:P/"
+    "A:P\",\"version\":\"2.0\"},\"format\":\"CVSS\"}],\"problemTypes\":[{\"descriptions\":[{\"description\":\"CWE-"
+    "415\",\"lang\":\"en\"}]}],\"providerMetadata\":{\"orgId\":\"00000000-0000-4000-A000-000000000000\",\"shortName\":"
+    "\"@mitre.org\"},\"references\":[{\"name\":\"https://github.com/ARMmbed/mbedtls/releases/tag/"
+    "v2.16.12\",\"tags\":[\"release-notes\",\"third-party-advisory\"],\"url\":\"https://github.com/ARMmbed/mbedtls/"
+    "releases/tag/v2.16.12\"},{\"name\":\"https://github.com/ARMmbed/mbedtls/"
+    "releases\",\"tags\":[\"release-notes\",\"third-party-advisory\"],\"url\":\"https://github.com/ARMmbed/mbedtls/"
+    "releases\"},{\"name\":\"https://github.com/ARMmbed/mbedtls/releases/tag/"
+    "v3.1.0\",\"tags\":[\"release-notes\",\"third-party-advisory\"],\"url\":\"https://github.com/ARMmbed/mbedtls/"
+    "releases/tag/v3.1.0\"},{\"name\":\"https://bugs.gentoo.org/"
+    "829660\",\"tags\":[\"issue-tracking\",\"mailing-list\",\"third-party-advisory\"],\"url\":\"https://"
+    "bugs.gentoo.org/829660\"},{\"name\":\"https://github.com/ARMmbed/mbedtls/releases/tag/"
+    "v2.28.0\",\"tags\":[\"release-notes\",\"third-party-advisory\"],\"url\":\"https://github.com/ARMmbed/mbedtls/"
+    "releases/tag/v2.28.0\"},{\"name\":\"https://tls.mbed.org/tech-updates/security-advisories/"
+    "mbedtls-security-advisory-2021-12\",\"tags\":[\"exploit\",\"mitigation\",\"third-party-advisory\"],\"url\":"
+    "\"https://tls.mbed.org/tech-updates/security-advisories/"
+    "mbedtls-security-advisory-2021-12\"}]}},\"cveMetadata\":{\"assignerOrgId\":\"00000000-0000-4000-A000-"
+    "000000000000\",\"assignerShortName\":\"@mitre.org\",\"cveId\":\"CVE-2021-44732\",\"datePublished\":\"2021-12-"
+    "20T08:15:00.000Z\",\"dateUpdated\":\"2021-12-29T18:48:00.000Z\",\"state\":\"PUBLISHED\"},\"dataType\":\"CVE_"
+    "RECORD\",\"dataVersion\":\"5.0\"}"};
+
+const std::string resource {"CVE-2021-44732"};
+
+TEST_F(UpdateCVEDescriptionTest, StoreCVEDescription)
+{
+    // Create rocksDB base directory.
+    std::filesystem::create_directories(DATABASE_DIR);
+
+    std::string cve5FlatbufferSchemaStr;
+    std::string cvssFlatbufferSchemaStr;
+
+    // Read schemas from filesystem.
+    bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
+                  flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
+    assert(valid == true);
+    assert(!jsonStrValid.empty());
+
+    // Parse schemas and JSON example.
+    flatbuffers::Parser parser;
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrValid.c_str()));
+    assert(valid == true);
+
+    // Get flatbuffer pointer
+    uint8_t* buf = parser.builder_.GetBufferPointer();
+    size_t flatbufferSize = parser.builder_.GetSize();
+
+    UpdateCVEDescription::storeVulnerabilityDescription(resource, buf, flatbufferSize);
+
+    // Get flatbuffer from vulnerability description database.
+    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
+    std::string vulnerabilityDescriptionFBStr;
+    rocksDBWrapper.get(resource, vulnerabilityDescriptionFBStr);
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
+                                   vulnerabilityDescriptionFBStr.size());
+    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier), true);
+
+    // Read flatbuffer values.
+    auto vulnerabilityDescription =
+        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
+
+    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "3.1");
+    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "CRITICAL");
+    EXPECT_EQ(vulnerabilityDescription->scoreBase(), (float)9.8);
+    EXPECT_EQ(vulnerabilityDescription->description()->str(),
+              "Mbed TLS before 3.0.1 has a double free incertain out-of-memory conditions, as demonstrated by an "
+              "mbedtls_ssl_set_session() failure.");
+    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "CVSS");
+    EXPECT_EQ(vulnerabilityDescription->reference()->str(),
+              "https://github.com/ARMmbed/mbedtls/releases/tag/v2.16.12, https://github.com/ARMmbed/mbedtls/releases, "
+              "https://github.com/ARMmbed/mbedtls/releases/tag/v3.1.0, https://bugs.gentoo.org/829660, "
+              "https://github.com/ARMmbed/mbedtls/releases/tag/v2.28.0, "
+              "https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2021-12");
+
+    std::filesystem::remove_all(DATABASE_DIR);
+}
+
+TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
+{
+    // Create rocksDB base directory.
+    std::filesystem::create_directories(DATABASE_DIR);
+
+    std::string cve5FlatbufferSchemaStr;
+    std::string cvssFlatbufferSchemaStr;
+
+    // Read schemas from filesystem.
+    bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
+                  flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
+    assert(valid == true);
+    assert(!jsonStrInvalid.empty());
+
+    // Parse schemas and JSON example.
+    flatbuffers::Parser parser;
+    valid =
+        (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrInvalid.c_str()));
+    assert(valid == true);
+
+    // Get flatbuffer pointer
+    uint8_t* buf = parser.builder_.GetBufferPointer();
+    size_t flatbufferSize = parser.builder_.GetSize();
+
+    UpdateCVEDescription::storeVulnerabilityDescription(resource, buf, flatbufferSize);
+
+    // Get flatbuffer from vulnerability description database.
+    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
+    std::string vulnerabilityDescriptionFBStr;
+    rocksDBWrapper.get(resource, vulnerabilityDescriptionFBStr);
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
+                                   vulnerabilityDescriptionFBStr.size());
+    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier), true);
+
+    // Read flatbuffer values.
+    auto vulnerabilityDescription =
+        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
+
+    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->scoreBase(), (float)0);
+    EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
+    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->reference()->str(), "https://security.archlinux.org/CVE-2022-1160");
+
+    std::filesystem::remove_all(DATABASE_DIR);
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -14,6 +14,7 @@
 #include "databaseFeedManager/updateCVEDescription.hpp"
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
+#include "flatbuffers/verifier.h"
 #include "rocksDBWrapper.hpp"
 
 const std::string cve5FlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
@@ -23,56 +24,175 @@ const std::string DATABASE_DIR {"queue/vd"};
 const char* INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
 
 const std::string jsonStrInvalid {
-    "{\"containers\":{\"cna\":{\"affected\":[{\"defaultStatus\":\"unaffected\",\"product\":\"vim\",\"vendor\":\"arch\","
-    "\"versions\":[{\"lessThan\":\"8.2.4651-1\",\"status\":\"affected\",\"version\":\"8.2.4464-1\",\"versionType\":"
-    "\"custom\"}]},"
-    "{\"defaultStatus\":\"unaffected\",\"product\":\"gvim\",\"vendor\":\"arch\",\"versions\":[{\"lessThan\":\"8.2.4651-"
-    "1\",\"status\":\"affected\","
-    "\"version\":\"8.2.4464-1\",\"versionType\":\"custom\"}]}],\"providerMetadata\":{\"orgId\":\"00000000-0000-4000-"
-    "A000-000000000002\",\"shortName\":\"arch\"},"
-    "\"references\":[{\"url\":\"https://security.archlinux.org/"
-    "CVE-2022-1160\"}],\"descriptions\":[{\"lang\":\"en\",\"value\":\"not defined\"}]}},"
-    "\"cveMetadata\":{\"assignerOrgId\":\"00000000-0000-4000-A000-000000000002\",\"assignerShortName\":\"arch\","
-    "\"cveId\":\"CVE-2022-1160\","
-    "\"state\":\"PUBLISHED\"},\"dataType\":\"CVE_RECORD\",\"dataVersion\":\"5.0\"}"};
+    R"({
+                "containers": {
+                    "cna": {
+                    "affected": [
+                        {
+                        "defaultStatus": "unaffected",
+                        "product": "vim",
+                        "vendor": "arch",
+                        "versions": [
+                            {
+                            "lessThan": "8.2.4651-1",
+                            "status": "affected",
+                            "version": "8.2.4464-1",
+                            "versionType": "custom"
+                            }
+                        ]
+                        },
+                        {
+                        "defaultStatus": "unaffected",
+                        "product": "gvim",
+                        "vendor": "arch",
+                        "versions": [
+                            {
+                            "lessThan": "8.2.4651-1",
+                            "status": "affected",
+                            "version": "8.2.4464-1",
+                            "versionType": "custom"
+                            }
+                        ]
+                        }
+                    ],
+                    "providerMetadata": {
+                        "orgId": "00000000-0000-4000-A000-000000000002",
+                        "shortName": "arch"
+                    },
+                    "references": [
+                        {
+                        "url": "https://security.archlinux.org/CVE-2022-1154"
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                        "lang": "en",
+                        "value": "not defined"
+                        }
+                    ]
+                    }
+                },
+                "cveMetadata": {
+                    "assignerOrgId": "00000000-0000-4000-A000-000000000002",
+                    "assignerShortName": "arch",
+                    "cveId": "CVE-2022-1154",
+                    "state": "PUBLISHED"
+                },
+                "dataType": "CVE_RECORD",
+                "dataVersion": "5.0"
+})"};
 
 const std::string jsonStrValid {
-    "{\"containers\":{\"cna\":{\"affected\":[{\"cpes\":[\"cpe:2.3:a:arm:mbed_tls:3.0.0:preview1:*:*:*:*:*:*\"],"
-    "\"defaultStatus\":\"unaffected\",\"product\":\"mbed_tlspreview1\",\"vendor\":\"arm\",\"versions\":[{\"status\":"
-    "\"affected\",\"version\":\"3.0.0\"}]},{\"cpes\":[\"cpe:2.3:a:arm:mbed_tls:*:*:*:*:*:*:*:*\",\"cpe:2.3:a:arm:mbed_"
-    "tls:3.0.0:-:*:*:*:*:*:*\"],\"defaultStatus\":\"unaffected\",\"product\":\"mbed_tls\",\"vendor\":\"arm\","
-    "\"versions\":[{\"lessThan\":\"2.16.12\",\"status\":\"affected\",\"version\":\"0\",\"versionType\":\"custom\"},{"
-    "\"lessThan\":\"2.28.0\",\"status\":\"affected\",\"version\":\"2.17.0\",\"versionType\":\"custom\"},{\"status\":"
-    "\"affected\",\"version\":\"3.0.0\"}]}],\"descriptions\":[{\"lang\":\"en\",\"value\":\"Mbed TLS before 3.0.1 has a "
-    "double free incertain out-of-memory conditions, as demonstrated by an mbedtls_ssl_set_session() "
-    "failure.\"}],\"metrics\":[{\"cvssV3_1\":{\"attackComplexity\":\"LOW\",\"attackVector\":\"NETWORK\","
-    "\"availabilityImpact\":\"HIGH\",\"baseScore\":9.8,\"baseSeverity\":\"CRITICAL\",\"confidentialityImpact\":"
-    "\"HIGH\",\"integrityImpact\":\"HIGH\",\"privilegesRequired\":\"NONE\",\"scope\":\"UNCHANGED\",\"userInteraction\":"
-    "\"NONE\",\"vectorString\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/"
-    "A:H\",\"version\":\"3.1\"},\"format\":\"CVSS\"},{\"cvssV2_0\":{\"accessComplexity\":\"LOW\",\"accessVector\":"
-    "\"NETWORK\",\"authentication\":\"NONE\",\"availabilityImpact\":\"PARTIAL\",\"baseScore\":7.5,"
-    "\"confidentialityImpact\":\"PARTIAL\",\"integrityImpact\":\"PARTIAL\",\"vectorString\":\"AV:N/AC:L/Au:N/C:P/I:P/"
-    "A:P\",\"version\":\"2.0\"},\"format\":\"CVSS\"}],\"problemTypes\":[{\"descriptions\":[{\"description\":\"CWE-"
-    "415\",\"lang\":\"en\"}]}],\"providerMetadata\":{\"orgId\":\"00000000-0000-4000-A000-000000000000\",\"shortName\":"
-    "\"@mitre.org\"},\"references\":[{\"name\":\"https://github.com/ARMmbed/mbedtls/releases/tag/"
-    "v2.16.12\",\"tags\":[\"release-notes\",\"third-party-advisory\"],\"url\":\"https://github.com/ARMmbed/mbedtls/"
-    "releases/tag/v2.16.12\"},{\"name\":\"https://github.com/ARMmbed/mbedtls/"
-    "releases\",\"tags\":[\"release-notes\",\"third-party-advisory\"],\"url\":\"https://github.com/ARMmbed/mbedtls/"
-    "releases\"},{\"name\":\"https://github.com/ARMmbed/mbedtls/releases/tag/"
-    "v3.1.0\",\"tags\":[\"release-notes\",\"third-party-advisory\"],\"url\":\"https://github.com/ARMmbed/mbedtls/"
-    "releases/tag/v3.1.0\"},{\"name\":\"https://bugs.gentoo.org/"
-    "829660\",\"tags\":[\"issue-tracking\",\"mailing-list\",\"third-party-advisory\"],\"url\":\"https://"
-    "bugs.gentoo.org/829660\"},{\"name\":\"https://github.com/ARMmbed/mbedtls/releases/tag/"
-    "v2.28.0\",\"tags\":[\"release-notes\",\"third-party-advisory\"],\"url\":\"https://github.com/ARMmbed/mbedtls/"
-    "releases/tag/v2.28.0\"},{\"name\":\"https://tls.mbed.org/tech-updates/security-advisories/"
-    "mbedtls-security-advisory-2021-12\",\"tags\":[\"exploit\",\"mitigation\",\"third-party-advisory\"],\"url\":"
-    "\"https://tls.mbed.org/tech-updates/security-advisories/"
-    "mbedtls-security-advisory-2021-12\"}]}},\"cveMetadata\":{\"assignerOrgId\":\"00000000-0000-4000-A000-"
-    "000000000000\",\"assignerShortName\":\"@mitre.org\",\"cveId\":\"CVE-2021-44732\",\"datePublished\":\"2021-12-"
-    "20T08:15:00.000Z\",\"dateUpdated\":\"2021-12-29T18:48:00.000Z\",\"state\":\"PUBLISHED\"},\"dataType\":\"CVE_"
-    "RECORD\",\"dataVersion\":\"5.0\"}"};
+    R"({
+                "containers": {
+                    "cna": {
+                    "affected": [
+                        {
+                        "cpes": [
+                            "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*"
+                        ],
+                        "defaultStatus": "unaffected",
+                        "product": "chrome",
+                        "vendor": "google",
+                        "versions": [
+                            {
+                            "lessThan": "98.0.4758.102",
+                            "status": "affected",
+                            "version": "0",
+                            "versionType": "custom"
+                            }
+                        ]
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                        "lang": "en",
+                        "value": "Use after free in Webstore API in Google Chrome prior to 98.0.4758.102 allowed an attacker who convinced a user to install a malicious extension and convinced a user to enage in specific user interaction to potentially exploit heap corruption via a crafted HTML page."
+                        }
+                    ],
+                    "metrics": [
+                        {
+                        "cvssV3_1": {
+                            "attackComplexity": "LOW",
+                            "attackVector": "NETWORK",
+                            "availabilityImpact": "HIGH",
+                            "baseScore": 8.8,
+                            "baseSeverity": "HIGH",
+                            "confidentialityImpact": "HIGH",
+                            "integrityImpact": "HIGH",
+                            "privilegesRequired": "NONE",
+                            "scope": "UNCHANGED",
+                            "userInteraction": "REQUIRED",
+                            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                            "version": "3.1"
+                        },
+                        "format": "CVSS"
+                        },
+                        {
+                        "cvssV2_0": {
+                            "accessComplexity": "MEDIUM",
+                            "accessVector": "NETWORK",
+                            "authentication": "NONE",
+                            "availabilityImpact": "PARTIAL",
+                            "baseScore": 6.8,
+                            "confidentialityImpact": "PARTIAL",
+                            "integrityImpact": "PARTIAL",
+                            "vectorString": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+                            "version": "2.0"
+                        },
+                        "format": "CVSS"
+                        }
+                    ],
+                    "problemTypes": [
+                        {
+                        "descriptions": [
+                            {
+                            "description": "CWE-416",
+                            "lang": "en"
+                            }
+                        ]
+                        }
+                    ],
+                    "providerMetadata": {
+                        "orgId": "00000000-0000-4000-A000-000000000003",
+                        "shortName": "nvd",
+                        "dateUpdated": "2022-04-11T09:33:00Z"
+                    },
+                    "references": [
+                        {
+                        "name": "https://crbug.com/1286940",
+                        "tags": [
+                            "issue-tracking",
+                            "permissions-required",
+                            "vendor-advisory"
+                        ],
+                        "url": "https://crbug.com/1286940"
+                        },
+                        {
+                        "name": "https://chromereleases.googleblog.com/2022/02/stable-channel-update-for-desktop_14.html",
+                        "tags": [
+                            "release-notes",
+                            "vendor-advisory"
+                        ],
+                        "url": "https://chromereleases.googleblog.com/2022/02/stable-channel-update-for-desktop_14.html"
+                        }
+                    ]
+                    }
+                },
+                "cveMetadata": {
+                    "assignerOrgId": "00000000-0000-4000-A000-000000000003",
+                    "assignerShortName": "nvd",
+                    "cveId": "CVE-2022-0605",
+                    "datePublished": "2022-04-05T00:15:00Z",
+                    "dateUpdated": "2022-04-11T09:33:00Z",
+                    "state": "PUBLISHED"
+                },
+                "dataType": "CVE_RECORD",
+                "dataVersion": "5.0"
+})"};
 
-const std::string resource {"CVE-2021-44732"};
+const std::string resourceValid {"CVE-2022-0605"};
+const std::string resourceInvalid {"CVE-2022-1154"};
 
 TEST_F(UpdateCVEDescriptionTest, StoreCVEDescription)
 {
@@ -85,46 +205,50 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescription)
     // Read schemas from filesystem.
     bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
                   flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
-    assert(valid == true);
-    assert(!jsonStrValid.empty());
+    ASSERT_EQ(valid, true);
+    ASSERT_EQ(jsonStrValid.empty(), false);
 
     // Parse schemas and JSON example.
     flatbuffers::Parser parser;
     valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrValid.c_str()));
-    assert(valid == true);
+    ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
     uint8_t* buf = parser.builder_.GetBufferPointer();
     size_t flatbufferSize = parser.builder_.GetSize();
 
-    UpdateCVEDescription::storeVulnerabilityDescription(resource, buf, flatbufferSize);
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
+    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
+    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
+
+    UpdateCVEDescription::storeVulnerabilityDescription(resourceValid, cve5Flatbuffer);
 
     // Get flatbuffer from vulnerability description database.
     Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(resource, vulnerabilityDescriptionFBStr);
+    rocksDBWrapper.get(resourceValid, vulnerabilityDescriptionFBStr);
 
     // Verify flatbuffer.
-    flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
-                                   vulnerabilityDescriptionFBStr.size());
-    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier), true);
+    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
+                                           vulnerabilityDescriptionFBStr.size());
+    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
 
     // Read flatbuffer values.
     auto vulnerabilityDescription =
         NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
 
     EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "3.1");
-    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "CRITICAL");
-    EXPECT_EQ(vulnerabilityDescription->scoreBase(), (float)9.8);
+    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "HIGH");
+    EXPECT_EQ(vulnerabilityDescription->scoreBase(), (float)8.8);
     EXPECT_EQ(vulnerabilityDescription->description()->str(),
-              "Mbed TLS before 3.0.1 has a double free incertain out-of-memory conditions, as demonstrated by an "
-              "mbedtls_ssl_set_session() failure.");
+              "Use after free in Webstore API in Google Chrome prior to 98.0.4758.102 allowed an attacker who "
+              "convinced a user to install a malicious extension and convinced a user to enage in specific user "
+              "interaction to potentially exploit heap corruption via a crafted HTML page.");
     EXPECT_EQ(vulnerabilityDescription->classification()->str(), "CVSS");
     EXPECT_EQ(vulnerabilityDescription->reference()->str(),
-              "https://github.com/ARMmbed/mbedtls/releases/tag/v2.16.12, https://github.com/ARMmbed/mbedtls/releases, "
-              "https://github.com/ARMmbed/mbedtls/releases/tag/v3.1.0, https://bugs.gentoo.org/829660, "
-              "https://github.com/ARMmbed/mbedtls/releases/tag/v2.28.0, "
-              "https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2021-12");
+              "https://crbug.com/1286940, "
+              "https://chromereleases.googleblog.com/2022/02/stable-channel-update-for-desktop_14.html");
 
     std::filesystem::remove_all(DATABASE_DIR);
 }
@@ -140,30 +264,35 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
     // Read schemas from filesystem.
     bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
                   flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
-    assert(valid == true);
-    assert(!jsonStrInvalid.empty());
+    ASSERT_EQ(valid, true);
+    ASSERT_EQ(jsonStrValid.empty(), false);
 
     // Parse schemas and JSON example.
     flatbuffers::Parser parser;
     valid =
         (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrInvalid.c_str()));
-    assert(valid == true);
+    ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
     uint8_t* buf = parser.builder_.GetBufferPointer();
     size_t flatbufferSize = parser.builder_.GetSize();
 
-    UpdateCVEDescription::storeVulnerabilityDescription(resource, buf, flatbufferSize);
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
+    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
+    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
+
+    UpdateCVEDescription::storeVulnerabilityDescription(resourceInvalid, cve5Flatbuffer);
 
     // Get flatbuffer from vulnerability description database.
     Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(resource, vulnerabilityDescriptionFBStr);
+    rocksDBWrapper.get(resourceInvalid, vulnerabilityDescriptionFBStr);
 
     // Verify flatbuffer.
-    flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
-                                   vulnerabilityDescriptionFBStr.size());
-    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier), true);
+    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
+                                           vulnerabilityDescriptionFBStr.size());
+    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
 
     // Read flatbuffer values.
     auto vulnerabilityDescription =
@@ -174,7 +303,7 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
     EXPECT_EQ(vulnerabilityDescription->scoreBase(), (float)0);
     EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
     EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->reference()->str(), "https://security.archlinux.org/CVE-2022-1160");
+    EXPECT_EQ(vulnerabilityDescription->reference()->str(), "https://security.archlinux.org/CVE-2022-1154");
 
     std::filesystem::remove_all(DATABASE_DIR);
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -17,13 +17,13 @@
 #include "flatbuffers/verifier.h"
 #include "rocksDBWrapper.hpp"
 
-const std::string cve5FlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
-const std::string cvssFlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/cvss.fbs"};
-const std::string vulnRemFlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/vulnerabilityRemediations.fbs"};
+const std::string CVE5_FLATBUFFER_SCHEMA_PATH {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
+const std::string CVSS_FLATBUFFER_SCHEMA_PATH {FLATBUFFER_SCHEMAS_DIR "/cvss.fbs"};
+const std::string VULN_REM_FLATBUFFER_SCHEMA_PATH {FLATBUFFER_SCHEMAS_DIR "/vulnerabilityRemediations.fbs"};
 const char* INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
 
-const std::string CVEJsonStrCVSSV3_1 {"CVE-2022-0605"};
-const std::string jsonStrCVSSV3_1 {
+const std::string CVE_JSON_STR_CVSS_V3_1 {"CVE-2022-0605"};
+const std::string JSON_STR_CVSS_V3_1 {
     R"({
                 "containers": {
                     "cna": {
@@ -132,8 +132,8 @@ const std::string jsonStrCVSSV3_1 {
                 "dataVersion": "5.0"
 })"};
 
-const std::string CVEJsonStrCVSSV3_0 {"CVE-2019-0029"};
-const std::string jsonStrCVSSV3_0 {
+const std::string CVE_JSON_STR_CVSS_V3_0 {"CVE-2019-0029"};
+const std::string JSON_STR_CVSS_V3_0 {
     R"({
             "containers": {
                 "cna": {
@@ -236,8 +236,8 @@ const std::string jsonStrCVSSV3_0 {
             "dataVersion": "5.0"
         })"};
 
-const std::string CVEJsonStrCVSSV2_0 {"CVE-2022-24753"};
-const std::string jsonStrCVSSV2_0 {
+const std::string CVE_JSON_STR_CVSS_V2_0 {"CVE-2022-24753"};
+const std::string JSON_STR_CVSS_V2_0 {
     R"(        {
             "containers": {
                 "cna": {
@@ -330,8 +330,8 @@ const std::string jsonStrCVSSV2_0 {
             "dataVersion": "5.0"
         })"};
 
-const std::string CVEJsonStrMissingMetrics {"CVE-2022-1154"};
-const std::string jsonStrMissingMetrics {
+const std::string CVE_JSON_STR_MISSING_METRICS {"CVE-2022-1154"};
+const std::string JSON_STR_MISSING_METRICS {
     R"({
                 "containers": {
                     "cna": {
@@ -396,15 +396,15 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
     std::string cvssFlatbufferSchemaStr;
 
     // Read schemas from filesystem.
-    bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
-                  flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
+    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr) &&
+                  flatbuffers::LoadFile(CVSS_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cvssFlatbufferSchemaStr));
     ASSERT_EQ(valid, true);
-    ASSERT_EQ(jsonStrCVSSV3_1.empty(), false);
+    ASSERT_EQ(JSON_STR_CVSS_V3_1.empty(), false);
 
     // Parse schemas and JSON example.
     flatbuffers::Parser parser;
-    valid =
-        (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrCVSSV3_1.c_str()));
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
+             parser.Parse(JSON_STR_CVSS_V3_1.c_str()));
     ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
@@ -418,11 +418,11 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
 
     // Call function.
     Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(CVEJsonStrCVSSV3_1, cve5Flatbuffer, rocksDBWrapper);
+    UpdateCVEDescription::storeVulnerabilityDescription(CVE_JSON_STR_CVSS_V3_1, cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(CVEJsonStrCVSSV3_1, vulnerabilityDescriptionFBStr);
+    rocksDBWrapper.get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr);
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -452,15 +452,15 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_0)
     std::string cvssFlatbufferSchemaStr;
 
     // Read schemas from filesystem.
-    bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
-                  flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
+    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr) &&
+                  flatbuffers::LoadFile(CVSS_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cvssFlatbufferSchemaStr));
     ASSERT_EQ(valid, true);
-    ASSERT_EQ(jsonStrCVSSV3_0.empty(), false);
+    ASSERT_EQ(JSON_STR_CVSS_V3_0.empty(), false);
 
     // Parse schemas and JSON example.
     flatbuffers::Parser parser;
-    valid =
-        (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrCVSSV3_0.c_str()));
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
+             parser.Parse(JSON_STR_CVSS_V3_0.c_str()));
     ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
@@ -474,11 +474,11 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_0)
 
     // Call function.
     Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(CVEJsonStrCVSSV3_0, cve5Flatbuffer, rocksDBWrapper);
+    UpdateCVEDescription::storeVulnerabilityDescription(CVE_JSON_STR_CVSS_V3_0, cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(CVEJsonStrCVSSV3_0, vulnerabilityDescriptionFBStr);
+    rocksDBWrapper.get(CVE_JSON_STR_CVSS_V3_0, vulnerabilityDescriptionFBStr);
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -506,15 +506,15 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV2_0)
     std::string cvssFlatbufferSchemaStr;
 
     // Read schemas from filesystem.
-    bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
-                  flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
+    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr) &&
+                  flatbuffers::LoadFile(CVSS_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cvssFlatbufferSchemaStr));
     ASSERT_EQ(valid, true);
-    ASSERT_EQ(jsonStrCVSSV2_0.empty(), false);
+    ASSERT_EQ(JSON_STR_CVSS_V2_0.empty(), false);
 
     // Parse schemas and JSON example.
     flatbuffers::Parser parser;
-    valid =
-        (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrCVSSV2_0.c_str()));
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
+             parser.Parse(JSON_STR_CVSS_V2_0.c_str()));
     ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
@@ -528,11 +528,11 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV2_0)
 
     // Call function.
     Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(CVEJsonStrCVSSV2_0, cve5Flatbuffer, rocksDBWrapper);
+    UpdateCVEDescription::storeVulnerabilityDescription(CVE_JSON_STR_CVSS_V2_0, cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(CVEJsonStrCVSSV2_0, vulnerabilityDescriptionFBStr);
+    rocksDBWrapper.get(CVE_JSON_STR_CVSS_V2_0, vulnerabilityDescriptionFBStr);
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -566,15 +566,15 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
     std::string cvssFlatbufferSchemaStr;
 
     // Read schemas from filesystem.
-    bool valid = (flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr) &&
-                  flatbuffers::LoadFile(cvssFlatbufferSchemaPath.c_str(), false, &cvssFlatbufferSchemaStr));
+    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr) &&
+                  flatbuffers::LoadFile(CVSS_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cvssFlatbufferSchemaStr));
     ASSERT_EQ(valid, true);
-    ASSERT_EQ(jsonStrMissingMetrics.empty(), false);
+    ASSERT_EQ(JSON_STR_MISSING_METRICS.empty(), false);
 
     // Parse schemas and JSON example.
     flatbuffers::Parser parser;
     valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
-             parser.Parse(jsonStrMissingMetrics.c_str()));
+             parser.Parse(JSON_STR_MISSING_METRICS.c_str()));
     ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
@@ -588,11 +588,11 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
 
     // Call function.
     Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(CVEJsonStrMissingMetrics, cve5Flatbuffer, rocksDBWrapper);
+    UpdateCVEDescription::storeVulnerabilityDescription(CVE_JSON_STR_MISSING_METRICS, cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(CVEJsonStrMissingMetrics, vulnerabilityDescriptionFBStr);
+    rocksDBWrapper.get(CVE_JSON_STR_MISSING_METRICS, vulnerabilityDescriptionFBStr);
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -222,10 +222,11 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescription)
     ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
     const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
-    UpdateCVEDescription::storeVulnerabilityDescription(resourceValid, cve5Flatbuffer);
+    // Call function.
+    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(resourceValid, cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
-    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
     std::string vulnerabilityDescriptionFBStr;
     rocksDBWrapper.get(resourceValid, vulnerabilityDescriptionFBStr);
 
@@ -282,12 +283,13 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
     ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
     const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
-    UpdateCVEDescription::storeVulnerabilityDescription(resourceInvalid, cve5Flatbuffer);
+    // Call function.
+    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(resourceValid, cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
-    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(resourceInvalid, vulnerabilityDescriptionFBStr);
+    rocksDBWrapper.get(resourceValid, vulnerabilityDescriptionFBStr);
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.hpp
@@ -1,0 +1,29 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * October 3, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _UPDATE_CVE_DESCRIPTION_TEST_HPP
+#define _UPDATE_CVE_DESCRIPTION_TEST_HPP
+
+#include "gtest/gtest.h"
+
+/**
+ * @brief Runs unit tests for StoreModel
+ */
+class UpdateCVEDescriptionTest : public ::testing::Test
+{
+protected:
+    // LCOV_EXCL_START
+    UpdateCVEDescriptionTest() = default;
+    ~UpdateCVEDescriptionTest() override = default;
+    // LCOV_EXCL_STOP
+};
+
+#endif // _UPDATE_CVE_DESCRIPTION_TEST_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.hpp
@@ -13,6 +13,9 @@
 #define _UPDATE_CVE_DESCRIPTION_TEST_HPP
 
 #include "gtest/gtest.h"
+#include <filesystem>
+
+const std::string DATABASE_DIR {"queue/vd"};
 
 /**
  * @brief UpdateCVEDescription test class.
@@ -24,6 +27,26 @@ protected:
     UpdateCVEDescriptionTest() = default;
     ~UpdateCVEDescriptionTest() override = default;
     // LCOV_EXCL_STOP
+
+    /**
+     * @brief SetUp Test Suite.
+     *
+     */
+    static void SetUpTestSuite()
+    {
+        // Create rocksDB base directory.
+        std::filesystem::create_directories(DATABASE_DIR);
+    }
+
+    /**
+     * @brief TearDown Test Suite.
+     *
+     */
+    static void TearDownTestSuite()
+    {
+        // Remove directory
+        std::filesystem::remove_all("queue");
+    }
 };
 
 #endif // _UPDATE_CVE_DESCRIPTION_TEST_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.hpp
@@ -15,7 +15,7 @@
 #include "gtest/gtest.h"
 
 /**
- * @brief Runs unit tests for StoreModel
+ * @brief UpdateCVEDescription test class.
  */
 class UpdateCVEDescriptionTest : public ::testing::Test
 {


### PR DESCRIPTION
|Related issue|
|---|
|#19045|

## Description

This PR adds the functionality to reads the CVE5 database, parse the information and create a new flatbuffer for vulnerability description that is then, saved into a specific rocksDB database.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Added unit tests (for new features)