### PR TITLE
Updating Windows tests with new libfimdb.dll

### DIFF
--- a/.github/workflows/windows-file-details.yml
+++ b/.github/workflows/windows-file-details.yml
@@ -25,7 +25,11 @@ jobs:
           # We remove the executables that aren't distributed in the signed installer
           rm -f src/win32/setup-*.exe
           cp src/win32/*.exe src/bin_files/
-          cp src/*.dll src/bin_files/
+          # We exclude the libraries that aren't built by Wazuh
+          rm -f src/win32/libwinpthread-1.dll
+          rm -f src/win32/libgcc_s_dw2-1.dll
+          rm -f src/win32/libstdc++-6.dll
+          find src/ -name "*.dll" -not -path "src/external/*" -not -path "src/win32/SimpleSC/*" -not -path "src/win32/nsProcess/*" -exec cp {} src/bin_files/ \;
       - name: Upload Artifact binaries
         uses: actions/upload-artifact@v3
         with:

--- a/src/Makefile
+++ b/src/Makefile
@@ -866,7 +866,7 @@ win32/syscollector: win32/shared_modules win32/sysinfo win32/version-dll.o
 	cd ${SYSCOLLECTOR} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSCOLLECTOR_TEST} ${SYSCOLLECTOR_RELEASE_TYPE} ${WIN_RESOURCE_OBJ} .. && ${MAKE}
 
 win32/syscheck: win32/shared_modules $(WAZUHEXT_LIB)
-	cd ${SYSCHECK} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSCHECK_TEST} ${SYSCHECK_RELEASE_TYPE} .. && ${MAKE}
+	cd ${SYSCHECK} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSCHECK_TEST} ${SYSCHECK_RELEASE_TYPE} ${WIN_RESOURCE_OBJ} .. && ${MAKE}
 
 win32/libwinpthread-1.dll: ${WIN_PTHREAD_LIB}
 	cp $< $@

--- a/src/syscheckd/src/db/CMakeLists.txt
+++ b/src/syscheckd/src/db/CMakeLists.txt
@@ -34,6 +34,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_library(fimdb SHARED ${DB_SRC}
                            ${CMAKE_SOURCE_DIR}/src/db/src/registry.cpp
                            ${CMAKE_SOURCE_DIR}/src/db/src/fimDBSpecializationWindows.cpp
+                           ${SRC_FOLDER}/${RESOURCE_OBJ}
                            )
 elseif(CMAKE_SYSTEM_NAME STREQUAL "HP-UX")
   add_definitions(-DOS_TYPE=OSType::OTHERS)

--- a/src/win32/qa/test_win_upgrade.py
+++ b/src/win32/qa/test_win_upgrade.py
@@ -1,6 +1,7 @@
 import pathlib
 import os
 import hashlib
+import pytest
 
 RELEASED_PATH = 'C:\\win-agent-released\\'
 BASE_PATH = 'C:\\win-agent-base\\'
@@ -18,7 +19,7 @@ def populate_dict(dict, files_list):
 
         # It's required to normalize the name because the installation process changes it
         dict[file.name.lower().replace('-', '_').replace('c++', 'cpp').replace(
-            '_dll', '.dll').replace('wazuh_agent_eventchannel.exe', 'wazuh_agent.exe')] = file_hash
+            '_dll', '.dll').replace('wazuh_agent_eventchannel.exe', 'wazuh_agent.exe').replace('libfimdb.dll', 'fimdb.dll')] = file_hash
 
 
 def test_win_upgrade():
@@ -63,12 +64,15 @@ def test_win_upgrade():
     installed_files_dict = {}
     populate_dict(installed_files_dict, installed_files)
 
-    assert len(installed_files_dict) == len(files_to_install_dict), f"Installed files: '{installed_files_dict}'\nFiles to install: '{files_to_install_dict}'"
+    assert len(installed_files_dict) == len(
+        files_to_install_dict), f"Installed files: '{installed_files_dict}'\nFiles to install: '{files_to_install_dict}'"
 
     success = True
     failed_keys = []
     for key in files_to_install_dict:
         # Compare hashes
+        if key not in installed_files_dict:
+            pytest.fail(f"File '{key}' not found in '{INSTALL_PATH}'\nInstalled files: '{installed_files_dict}'\nFiles to install: '{files_to_install_dict}'")
         if installed_files_dict[key] != files_to_install_dict[key]:
             success = False
             failed_keys.append(


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19453|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR updates all required tests with the new incorporation of `libfimdb.dll` in the Windows agent.
It also adds the corresponding file details to the library.


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] QA templates contemplate the added capabilities
