### PR TITLE
Add SAX json array parser

### DIFF
--- a/src/shared_modules/utils/jsonArrayParser.hpp
+++ b/src/shared_modules/utils/jsonArrayParser.hpp
@@ -1,0 +1,452 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * October 6, 2023.
+ * 
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _JSON_ARRAY_PARSER_HPP
+#define _JSON_ARRAY_PARSER_HPP
+
+#include "json.hpp"
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <utility>
+
+namespace JsonArray
+{
+
+    /**
+     * @brief SAX interface implementation to parse JSON arrays without having to load the whole file in memory.
+     * @details This class implements a SAX interface (https://json.nlohmann.me/api/json_sax/) that invokes a
+     * callback for each item of the target array.
+     * This implementation is a modified version of the nlohmann's json_sax_dom_parser.
+     * Original implementation can be found at:
+     * https://github.com/nlohmann/json/blob/edffad036d5a93ab5a10f72a7d835eeb0d2948f9/single_include/nlohmann/json.hpp#L6733
+     */
+    class JsonSaxArrayParser
+    {
+    public:
+        /// Alias for integer type
+        using NumberIntegerT = typename nlohmann::json::number_integer_t;
+        /// Alias for unsigned type
+        using NumberUnsignedT = typename nlohmann::json::number_unsigned_t;
+        /// Alias for float type
+        using NumberFloatT = typename nlohmann::json::number_float_t;
+        /// Alias for string type
+        using StringT = typename nlohmann::json::string_t;
+        /// Alias for binary type
+        using BinaryT = typename nlohmann::json::binary_t;
+
+        /**
+         * @brief Construct a new Json Sax Array Parser object
+         *
+         * @param targetArrayPointer JSON Pointer to the target array.
+         * @param itemCallback Callback invoked for every item found on the target array. If the callback returns false
+         * the parsing stops.
+         * @param bodyCallback Callback invoked at the end of the parsing with the body of the JSON object. The body of
+         * the JSON object is the original JSON with the array items removed.
+         */
+        JsonSaxArrayParser(
+            nlohmann::json::json_pointer targetArrayPointer,
+            std::function<bool(nlohmann::json&&)> itemCallback,
+            std::function<void(nlohmann::json&&)> bodyCallback = [](nlohmann::json&&) {})
+            : m_targetArrayPointer(std::move(targetArrayPointer))
+            , m_itemCallback(std::move(itemCallback))
+            , m_bodyCallback(std::move(bodyCallback))
+            , m_refStackPtr(&m_bodyRefStack)
+        {
+        }
+
+        /// @cond make class move-only
+        JsonSaxArrayParser(const JsonSaxArrayParser&) = delete;
+        JsonSaxArrayParser(JsonSaxArrayParser&&) = default;
+        JsonSaxArrayParser& operator=(const JsonSaxArrayParser&) = delete;
+        JsonSaxArrayParser& operator=(JsonSaxArrayParser&&) = default;
+        ~JsonSaxArrayParser() = default;
+        /// @endcond
+
+        /**
+         * @brief Processes a null value.
+         *
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // cppcheck-suppress unusedFunction
+        bool null()
+        {
+            handleValue(nullptr);
+            return m_continueParsing;
+        }
+
+        /**
+         * @brief Processes a boolean value
+         *
+         * @param val boolean value
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // cppcheck-suppress unusedFunction
+        bool boolean(bool val)
+        {
+            handleValue(val);
+            return m_continueParsing;
+        }
+
+        /**
+         * @brief Processes an integer number
+         *
+         * @param val integer value
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // cppcheck-suppress unusedFunction
+        bool number_integer(NumberIntegerT val) // NOLINT
+        {
+            handleValue(val);
+            return m_continueParsing;
+        }
+
+        /**
+         * @brief Processes a unsigned integer number
+         *
+         * @param val unsigned integer value
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // cppcheck-suppress unusedFunction
+        bool number_unsigned(NumberUnsignedT val) // NOLINT
+        {
+            handleValue(val);
+            return m_continueParsing;
+        }
+
+        /**
+         * @brief Processes a floating-point number.
+         *
+         * @param val floating-point value
+         * @param s string representation of the original input
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // cppcheck-suppress unusedFunction
+        bool number_float(NumberFloatT val, [[maybe_unused]] const StringT& s) // NOLINT
+        {
+            handleValue(val);
+            return m_continueParsing;
+        }
+
+        /**
+         * @brief Processes a string value.
+         *
+         * @param val String value
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // cppcheck-suppress unusedFunction
+        bool string(const StringT& val)
+        {
+            handleValue(val);
+            return m_continueParsing;
+        }
+
+        /**
+         * @brief Processes a binary value.
+         *
+         * @param val Binary value
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // LCOV_EXCL_START
+        // cppcheck-suppress unusedFunction
+        bool binary(BinaryT& val)
+        {
+            handleValue(std::move(val));
+            return m_continueParsing;
+        }
+        // LCOV_EXCL_STOP
+
+        /**
+         * @brief Processes an object key.
+         *
+         * @param val Object key.
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // cppcheck-suppress unusedFunction
+        bool key(const StringT& val)
+        {
+            auto& object = m_refStackPtr->back();
+
+            // add null at given key and store the reference for later
+            m_objectElement = &(*object)[val];
+            return true;
+        }
+
+        /**
+         * @brief Processes the beginning of an object.
+         *
+         * @param len number of object elements or -1 if unknown
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // cppcheck-suppress unusedFunction
+        bool start_object(std::size_t len) // NOLINT
+        {
+            m_refStackPtr->push_back(handleValue(nlohmann::json::value_t::object));
+            if (len != static_cast<std::size_t>(-1) && len > m_refStackPtr->back()->max_size())
+            {
+                // LCOV_EXCL_START
+                throw std::runtime_error("Excessive object size. Number of elements: " + std::to_string(len));
+                // LCOV_EXCL_STOP
+            }
+
+            return true;
+        }
+
+        /**
+         * @brief Processes a the end of an object.
+         *
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // cppcheck-suppress unusedFunction
+        bool end_object() // NOLINT
+        {
+            m_refStackPtr->pop_back();
+
+            if (m_refStackPtr->empty())
+            {
+                if (m_inTargetArray)
+                {
+                    // This item is complete. Invoke the item callback.
+                    m_continueParsing = m_itemCallback(std::move(m_item));
+                }
+                else
+                {
+                    // This is the end of the file
+                    // If the target array was not found throw exception
+                    if (!m_targetArrayExists)
+                    {
+                        throw std::runtime_error {"The target array does not exist."};
+                    }
+                    // Return the body
+                    m_bodyCallback(std::move(m_body));
+                }
+            }
+            return m_continueParsing;
+        }
+
+        /**
+         * @brief Processes the beginning of an array
+         *
+         * @param len number of object elements or -1 if unknown
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // cppcheck-suppress unusedFunction
+        bool start_array(std::size_t len) // NOLINT
+        {
+            m_refStackPtr->push_back(handleValue(nlohmann::json::value_t::array));
+
+            if (len != static_cast<std::size_t>(-1) && len > m_refStackPtr->back()->max_size())
+            {
+                // LCOV_EXCL_START
+                throw std::runtime_error("Excessive array size. Number of elements: " + std::to_string(len));
+                // LCOV_EXCL_STOP
+            }
+
+            if (!m_inTargetArray && m_body.contains(m_targetArrayPointer))
+            {
+                if (m_refStackPtr->back() == &m_body.at(m_targetArrayPointer))
+                {
+                    // This is the start of the target array
+                    m_inTargetArray = true;
+                    m_targetArrayExists = true;
+
+                    // Point the stack to the item stack
+                    m_refStackPtr = &m_itemRefStack;
+                }
+            }
+
+            return true;
+        }
+
+        /**
+         * @brief Processes the end of an array
+         *
+         * @return true Continue parsing.
+         * @return false Stop parsing.
+         */
+        // cppcheck-suppress unusedFunction
+        bool end_array() // NOLINT
+        {
+            if (m_inTargetArray)
+            {
+                if (m_refStackPtr->empty())
+                {
+                    // This is the end of the target array
+                    m_inTargetArray = false;
+
+                    // Point the stack back to the body stack
+                    m_refStackPtr = &m_bodyRefStack;
+                }
+                else if (m_refStackPtr->size() == 1)
+                {
+                    // This is the end of an array item of the target array
+                    // This item is complete. Invoke the item callback.
+                    m_continueParsing = m_itemCallback(std::move(m_item));
+                }
+                m_refStackPtr->pop_back();
+            }
+            else
+            {
+                m_refStackPtr->pop_back();
+                if (m_refStackPtr->empty())
+                {
+                    // This is the end of the file
+                    // If the target array was not found throw exception
+                    if (!m_targetArrayExists)
+                    {
+                        throw std::runtime_error {"The target array does not exist."};
+                    }
+                    // Return the body
+                    m_bodyCallback(std::move(m_body));
+                }
+            }
+
+            return m_continueParsing;
+        }
+
+        /**
+         * @brief Processes a parse error. Throws the received exception object.
+         *
+         * @tparam Exception
+         */
+        template<class Exception>
+        bool parse_error(std::size_t /*unused*/, const std::string& /*unused*/, const Exception& ex) // NOLINT
+        {
+            throw ex;
+        }
+
+    private:
+        /**
+         * @brief Handle the received value
+         *
+         * @tparam Value
+         * @param value Received value
+         * @return nlohmann::json* Pointer to the processed element.
+         */
+        template<typename Value>
+        nlohmann::json* handleValue(Value&& value)
+        {
+            if (m_refStackPtr->empty())
+            {
+                if (m_inTargetArray)
+                {
+                    // This is the start of an item of the target array
+                    m_item = nlohmann::json(std::forward<Value>(value));
+
+                    if (!m_item.is_object() && !m_item.is_array())
+                    {
+                        // The item is a single value (Not an object or an array)
+                        m_continueParsing = m_itemCallback(std::move(m_item));
+                    }
+                    return &m_item;
+                }
+                else
+                {
+                    // This is the start of the JSON object body
+                    m_body = nlohmann::json(std::forward<Value>(value));
+                    return &m_body;
+                }
+            }
+
+            if (m_refStackPtr->back()->is_array())
+            {
+                // We are parsing an array, so insert this value
+                m_refStackPtr->back()->emplace_back(std::forward<Value>(value));
+
+                return &(m_refStackPtr->back()->back());
+            }
+
+            // Insert this value in the previously created key
+            *m_objectElement = nlohmann::json(std::forward<Value>(value));
+            return m_objectElement;
+        }
+
+        /// Current array item
+        nlohmann::json m_item;
+
+        /// JSON body
+        nlohmann::json m_body;
+
+        /// Track whether we are currently parsing the target array.
+        bool m_inTargetArray {false};
+
+        /// Track whether the target array was found on the parsed object.
+        bool m_targetArrayExists {false};
+
+        /// Flag to stop parsing when the item callback orders so.
+        bool m_continueParsing {true};
+
+        /// JSON Pointer to the target array
+        nlohmann::json::json_pointer m_targetArrayPointer;
+
+        /// Callback for each parsed item on the target array
+        std::function<bool(nlohmann::json&&)> m_itemCallback;
+
+        /// Callback for the object body at the end of the parsing
+        std::function<void(nlohmann::json&&)> m_bodyCallback;
+
+        /// Stack to model hierarchy of body values
+        std::vector<nlohmann::json*> m_bodyRefStack {};
+
+        /// Stack to model hierarchy of item values
+        std::vector<nlohmann::json*> m_itemRefStack {};
+
+        /// Pointer to the current stack: either the item values stack or the body values stack
+        std::vector<nlohmann::json*>* m_refStackPtr {};
+
+        /// Helper to hold the reference for the next object element
+        nlohmann::json* m_objectElement = nullptr;
+    };
+
+    /**
+     * @brief Parses a JSON file and invokes a callback for each item of the target array.
+     *
+     * @param filepath Path to the JSON file.
+     * @param processItemCallback Callback invoked for every item found on the target array. If the callback returns
+     * false the parsing stops.
+     * @param arrayPointer JSON Pointer to the target array.
+     * @param processBodyCallback Callback invoked at the end of the parsing with the body of the JSON object. The body
+     * of the JSON object is the original JSON with the array items removed. If the \p processItemCallback stops the
+     * parsing, the \p processBodyCallback will not be called.
+     */
+    static void parse(
+        const std::filesystem::path& filepath,
+        std::function<bool(nlohmann::json&&)> processItemCallback,
+        const nlohmann::json::json_pointer& arrayPointer = nlohmann::json::json_pointer(),
+        std::function<void(nlohmann::json&&)> processBodyCallback = [](nlohmann::json&&) {})
+    {
+        // Open the input file
+        std::ifstream file(filepath);
+        if (!file.is_open())
+        {
+            throw std::runtime_error("Unable to open input file: " + filepath.string());
+        }
+
+        // Create the sax array parser
+        JsonSaxArrayParser arrayParser(arrayPointer, std::move(processItemCallback), std::move(processBodyCallback));
+
+        // Parse the file
+        nlohmann::json::sax_parse(file, &arrayParser);
+    }
+
+} // namespace JsonArray
+#endif // _JSON_ARRAY_PARSER_HPP

--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ file(GLOB UTIL_CXX_UNITTEST_LINUX_SRC
     "rocksDBWrapper_test.cpp"
     "threadEventDispatcher_test.cpp"
     "xzHelper_test.cpp"
+    "jsonArrayParser_test.cpp"
 )
 
 file(COPY input_files DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/shared_modules/utils/tests/jsonArrayParser_test.cpp
+++ b/src/shared_modules/utils/tests/jsonArrayParser_test.cpp
@@ -1,0 +1,648 @@
+/*
+ * Wazuh - Shared Modules utils tests
+ * Copyright (C) 2015-2023, Wazuh Inc.
+ * October 6, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ */
+
+#include "jsonArrayParser_test.hpp"
+#include "json.hpp"
+#include "jsonArrayParser.hpp"
+#include "gtest/gtest.h"
+#include <queue>
+
+/**
+ * @brief Parse an array with simple objects
+ *
+ */
+TEST_F(JsonArrayParserTest, ArrayWithSimpleObjects)
+{
+    // Setup the input data
+    const auto testData {R"(
+    {"cves_array":
+            [
+                {"cve":"CVE-2005-AAAA"},
+                {"cve":"CVE-2008-AAAA"},
+                {"cve":"CVE-2012-AAAA"}
+            ]
+    }
+    )"};
+    const auto testArrayPointer {"/cves_array"_json_pointer};
+    const auto testFilepath {m_testFolder / "ArrayWithSimpleObjects.json"};
+    createTestFile(testData, testFilepath);
+
+    // Set the expected items
+    std::queue<nlohmann::json> expectedItems;
+    expectedItems.push(R"({"cve":"CVE-2005-AAAA"})"_json);
+    expectedItems.push(R"({"cve":"CVE-2008-AAAA"})"_json);
+    expectedItems.push(R"({"cve":"CVE-2012-AAAA"})"_json);
+
+    // This callback will validate the extracted items
+    auto callback = [&expectedItems](nlohmann::json&& item)
+    {
+        // Check that the current item equals the one at the front of the expected queue
+        EXPECT_EQ(expectedItems.front(), item);
+
+        // Remove item from queue
+        expectedItems.pop();
+
+        return true;
+    };
+
+    // Parse the JSON array
+    ASSERT_NO_THROW(JsonArray::parse(testFilepath, callback, testArrayPointer));
+
+    // At the end of the processing the expected queue must be empty
+    EXPECT_TRUE(expectedItems.empty());
+}
+
+/**
+ * @brief The target array is empty. The item callback should not be called.
+ *
+ */
+TEST_F(JsonArrayParserTest, ArrayIsEmpty)
+{
+    // Setup the input data
+    const auto testData {R"(
+    {
+        "test_array": []
+    }
+    )"};
+    const auto testArrayPointer {"/test_array"_json_pointer};
+    const auto testFilepath {m_testFolder / "ArrayIsEmpty.json"};
+    createTestFile(testData, testFilepath);
+
+    // The array is empty, this callback should never be called
+    auto callback = [](nlohmann::json&& /*item*/)
+    {
+        // Execution should never reach here
+        EXPECT_TRUE(false) << "The callback should not have been called.";
+
+        return true;
+    };
+
+    // Parse the JSON array
+    ASSERT_NO_THROW(JsonArray::parse(testFilepath, callback, testArrayPointer));
+}
+
+/**
+ * @brief The target array does not exist. Expect exception.
+ *
+ */
+TEST_F(JsonArrayParserTest, ArrayIsNotFound)
+{
+    // Setup the input data
+    const auto testData {R"(
+    {"test_array":
+            []
+    }
+    )"};
+
+    // The given array pointer does not exist on the json object
+    const auto testArrayPointer {"/wrong_array"_json_pointer};
+    const auto testFilepath {m_testFolder / "ArrayIsNotFound.json"};
+    createTestFile(testData, testFilepath);
+
+    // The array does not exist, this callback should never be called
+    auto callback = [](nlohmann::json&& /*item*/)
+    {
+        // Execution should never reach here
+        EXPECT_TRUE(false) << "The callback should not have been called.";
+
+        return true;
+    };
+
+    // Parse the JSON array and expect an exception
+    ASSERT_THROW(JsonArray::parse(testFilepath, callback, testArrayPointer), std::runtime_error);
+}
+
+/**
+ * @brief The target array inside a parent array does not exist. Expect exception.
+ *
+ */
+TEST_F(JsonArrayParserTest, TargetArrayInsideArrayIsNotFound)
+{
+    // Setup the input data
+    const auto testData {R"(
+    [
+        ["the", "first", "array"],
+        ["the", "second", "array"]
+    ]
+    )"};
+
+    // The given array pointer does not exist on the json object. The top array only has items index 0 and 1.
+    const auto testArrayPointer {"/2"_json_pointer};
+    const auto testFilepath {m_testFolder / "TargetArrayInsideArrayIsNotFound.json"};
+    createTestFile(testData, testFilepath);
+
+    // The array does not exist, this callback should never be called
+    auto callback = [](nlohmann::json&& /*item*/)
+    {
+        // Execution should never reach here
+        EXPECT_TRUE(false) << "The callback should not have been called.";
+
+        return true;
+    };
+
+    // Parse the JSON array and expect an exception
+    ASSERT_THROW(JsonArray::parse(testFilepath, callback, testArrayPointer), std::runtime_error);
+}
+
+/**
+ * @brief Parse an array with values of different types.
+ *
+ */
+TEST_F(JsonArrayParserTest, ArrayWithDifferentTypeValues)
+{
+    // Setup the input data
+    const auto testData {R"(
+    {"test_array":
+            [
+             1,"some string",false,true,["nested","array"],null,-34,0.56,{"key":"value"}
+            ]
+    }
+    )"};
+    const auto testArrayPointer {"/test_array"_json_pointer};
+    const auto testFilepath {m_testFolder / "ArrayWithDifferentTypeValues.json"};
+    createTestFile(testData, testFilepath);
+
+    // Set the expected items
+    std::queue<nlohmann::json> expectedItems;
+    expectedItems.push(R"(1)"_json);
+    expectedItems.push(R"("some string")"_json);
+    expectedItems.push(R"(false)"_json);
+    expectedItems.push(R"(true)"_json);
+    expectedItems.push(R"(["nested","array"])"_json);
+    expectedItems.push(R"(null)"_json);
+    expectedItems.push(R"(-34)"_json);
+    expectedItems.push(R"(0.56)"_json);
+    expectedItems.push(R"({"key":"value"})"_json);
+
+    // This callback will validate the extracted items
+    auto callback = [&expectedItems](nlohmann::json&& item)
+    {
+        // Check that the current item equals the one at the front of the expected queue
+        EXPECT_EQ(expectedItems.front(), item);
+
+        // Remove item from queue
+        expectedItems.pop();
+
+        return true;
+    };
+
+    // Parse the JSON array
+    ASSERT_NO_THROW(JsonArray::parse(testFilepath, callback, testArrayPointer));
+
+    // At the end of the processing the expected queue must be empty
+    EXPECT_TRUE(expectedItems.empty());
+}
+
+/**
+ * @brief Parse an array with more complex objects.
+ *
+ */
+TEST_F(JsonArrayParserTest, ArrayWithComplexObjects)
+{
+    // Setup the input data
+    const auto testData {R"(
+    {
+        "test_array":[
+            {"cve":{"id":"CVE-2005-AAAA","data":{"key":"value1"},"nestedArray":[3,4,5]}},
+            {"cve":{"id":"CVE-2006-AAAA","data":{"key":"value2"},"nestedArray":[6,7,8]}},
+            {"cve":{"id":"CVE-2007-AAAA","data":{"key":"value3"},"nestedArray":[9,10,11]}}
+            ]
+    }
+    )"};
+    const auto testArrayPointer {"/test_array"_json_pointer};
+    const auto testFilepath {m_testFolder / "ArrayWithComplexObjects.json"};
+    createTestFile(testData, testFilepath);
+
+    // Set the expected items
+    std::queue<nlohmann::json> expectedItems;
+    expectedItems.push(R"({"cve":{"id":"CVE-2005-AAAA","data":{"key":"value1"},"nestedArray":[3,4,5]}})"_json);
+    expectedItems.push(R"({"cve":{"id":"CVE-2006-AAAA","data":{"key":"value2"},"nestedArray":[6,7,8]}})"_json);
+    expectedItems.push(R"({"cve":{"id":"CVE-2007-AAAA","data":{"key":"value3"},"nestedArray":[9,10,11]}})"_json);
+
+    // This callback will validate the extracted items
+    auto callback = [&expectedItems](nlohmann::json&& item)
+    {
+        // Check that the current item equals the one at the front of the expected queue
+        EXPECT_EQ(expectedItems.front(), item);
+
+        // Remove item from queue
+        expectedItems.pop();
+
+        return true;
+    };
+
+    // Parse the JSON array
+    ASSERT_NO_THROW(JsonArray::parse(testFilepath, callback, testArrayPointer));
+
+    // At the end of the processing the expected queue must be empty
+    EXPECT_TRUE(expectedItems.empty());
+}
+
+/**
+ * @brief Check that the JSON body is received correctly.
+ *
+ */
+TEST_F(JsonArrayParserTest, ReceiveJsonBody)
+{
+    // Setup the input data
+    const auto testData {R"(
+    {
+        "some_key":"some_value",
+        "cves_array":
+            [
+                {"cve":"CVE-2005-AAAA"},
+                {"cve":"CVE-2008-AAAA"}
+            ],
+        "some_object":{"key":"value"}
+    }
+    )"};
+    const auto testArrayPointer {"/cves_array"_json_pointer};
+    const auto testFilepath {m_testFolder / "ReceiveJsonBody.json"};
+    createTestFile(testData, testFilepath);
+
+    // Set the expected items
+    std::queue<nlohmann::json> expectedItems;
+    expectedItems.push(R"({"cve":"CVE-2005-AAAA"})"_json);
+    expectedItems.push(R"({"cve":"CVE-2008-AAAA"})"_json);
+
+    // Set the expected json body, this is the original json without the array items
+    const auto expectedBody = R"(
+        {
+            "some_key": "some_value",
+            "cves_array": [],
+            "some_object": {
+                "key": "value"
+            }
+        }
+        )"_json;
+    const auto expectedBodyCallbackCount {1};
+    auto bodyCallbackCount {0};
+
+    // This callback will validate the extracted items
+    auto itemCallback = [&expectedItems](nlohmann::json&& item)
+    {
+        // Check that the current item equals the one at the front of the expected queue
+        EXPECT_EQ(expectedItems.front(), item);
+
+        // Remove item from queue
+        expectedItems.pop();
+
+        return true;
+    };
+
+    // This callback will validate the extracted json body
+    auto bodyCallback = [&expectedBody, &bodyCallbackCount](nlohmann::json&& item)
+    {
+        // Check that the body equals the expected one.
+        EXPECT_EQ(expectedBody, item);
+
+        // Increment the counter of this callback
+        ++bodyCallbackCount;
+    };
+
+    // Parse the JSON array
+    ASSERT_NO_THROW(JsonArray::parse(testFilepath, itemCallback, testArrayPointer, bodyCallback));
+
+    // At the end of the processing the expected queue must be empty
+    EXPECT_TRUE(expectedItems.empty());
+
+    // The body callback should have been called only once
+    EXPECT_EQ(bodyCallbackCount, expectedBodyCallbackCount);
+}
+
+/**
+ * @brief Check that the JSON body is received correctly when the top level is an array.
+ *
+ */
+TEST_F(JsonArrayParserTest, ReceiveJsonBodyTopLevelArray)
+{
+    // Setup the input data
+    const auto testData {R"(
+    [
+        ["the", "first", "array"],
+        ["the", "second", "array"],
+        ["the", "target","array"]
+    ]
+    )"};
+    const auto testArrayPointer {"/2"_json_pointer};
+    const auto testFilepath {m_testFolder / "ReceiveJsonBodyTopLevelArray.json"};
+    createTestFile(testData, testFilepath);
+
+    // Set the expected items
+    std::queue<nlohmann::json> expectedItems;
+    expectedItems.push(R"("the")"_json);
+    expectedItems.push(R"("target")"_json);
+    expectedItems.push(R"("array")"_json);
+
+    // Set the expected json body, this is the original json without the array items
+    const auto expectedBody = R"(
+        [
+            ["the", "first", "array"],
+            ["the", "second", "array"],
+            []
+        ]
+    )"_json;
+    auto bodyCallbackCount {0};
+
+    // This callback will validate the extracted items
+    auto itemCallback = [&expectedItems](nlohmann::json&& item)
+    {
+        // Check that the current item equals the one at the front of the expected queue
+        EXPECT_EQ(expectedItems.front(), item);
+
+        // Remove item from queue
+        expectedItems.pop();
+
+        return true;
+    };
+
+    // This callback will validate the extracted json body
+    auto bodyCallback = [&expectedBody, &bodyCallbackCount](nlohmann::json&& item)
+    {
+        // Check that the body equals the expected one.
+        EXPECT_EQ(expectedBody, item);
+
+        // Increment the counter of this callback
+        ++bodyCallbackCount;
+    };
+
+    // Parse the JSON array
+    ASSERT_NO_THROW(JsonArray::parse(testFilepath, itemCallback, testArrayPointer, bodyCallback));
+
+    // At the end of the processing the expected queue must be empty
+    EXPECT_TRUE(expectedItems.empty());
+
+    // The body callback should have been called only once
+    EXPECT_EQ(bodyCallbackCount, 1);
+}
+
+/**
+ * @brief Parse an array that is at the top level of the JSON object
+ *
+ */
+TEST_F(JsonArrayParserTest, TopLevelArray)
+{
+    // Setup the input data
+    const auto testData {R"(
+    [
+        {"cve":"CVE-2005-AAAA"},
+        {"cve":"CVE-2008-AAAA"},
+        {"cve":"CVE-2012-AAAA"}
+    ]
+    )"};
+    const auto testFilepath {m_testFolder / "TopLevelArray.json"};
+    createTestFile(testData, testFilepath);
+
+    // Set the expected items
+    std::queue<nlohmann::json> expectedItems;
+    expectedItems.push(R"({"cve":"CVE-2005-AAAA"})"_json);
+    expectedItems.push(R"({"cve":"CVE-2008-AAAA"})"_json);
+    expectedItems.push(R"({"cve":"CVE-2012-AAAA"})"_json);
+
+    // This callback will validate the extracted items
+    auto callback = [&expectedItems](nlohmann::json&& item)
+    {
+        // Check that the current item equals the one at the front of the expected queue
+        EXPECT_EQ(expectedItems.front(), item);
+
+        // Remove item from queue
+        expectedItems.pop();
+
+        return true;
+    };
+
+    // Parse the JSON array
+    ASSERT_NO_THROW(JsonArray::parse(testFilepath, callback));
+
+    // At the end of the processing the expected queue must be empty
+    EXPECT_TRUE(expectedItems.empty());
+}
+
+/**
+ * @brief Parse an array that is located on a deeper level.
+ *
+ */
+TEST_F(JsonArrayParserTest, ComplexJsonPointer)
+{
+    // Setup the input data
+    const auto testData {R"(
+        {
+        "some_key": "some_value",
+        "one_array":
+            [
+                {"some_object": {"key": "value"}},
+                {"cves_array":
+                    [
+                        {"cve": "CVE-2005-AAAA"},
+                        {"cve": "CVE-2008-AAAA"}
+                    ]
+                }
+            ]
+        }
+    )"};
+    const auto testArrayPointer {"/one_array/1/cves_array"_json_pointer};
+    const auto testFilepath {m_testFolder / "ComplexJsonPointer.json"};
+    createTestFile(testData, testFilepath);
+
+    // Set the expected items
+    std::queue<nlohmann::json> expectedItems;
+    expectedItems.push(R"({"cve":"CVE-2005-AAAA"})"_json);
+    expectedItems.push(R"({"cve":"CVE-2008-AAAA"})"_json);
+
+    // Set the expected json body, this is the original json without the array items
+    const auto expectedBody = R"(
+    {
+        "some_key": "some_value",
+        "one_array":
+            [
+                {"some_object": {"key": "value"}},
+                {"cves_array":
+                    []
+                }
+            ]
+    }
+    )"_json;
+    auto bodyCallbackCount {0};
+
+    // This callback will validate the extracted items
+    auto itemCallback = [&expectedItems](nlohmann::json&& item)
+    {
+        // Check that the current item equals the one at the front of the expected queue
+        EXPECT_EQ(expectedItems.front(), item);
+
+        // Remove item from queue
+        expectedItems.pop();
+
+        return true;
+    };
+
+    // This callback will validate the extracted json body
+    auto bodyCallback = [&expectedBody, &bodyCallbackCount](nlohmann::json&& item)
+    {
+        // Check that the body equals the expected one.
+        EXPECT_EQ(expectedBody, item);
+
+        // Increment the counter of this callback
+        ++bodyCallbackCount;
+    };
+
+    // Parse the JSON array
+    ASSERT_NO_THROW(JsonArray::parse(testFilepath, itemCallback, testArrayPointer, bodyCallback));
+
+    // At the end of the processing the expected queue must be empty
+    EXPECT_TRUE(expectedItems.empty());
+
+    // The body callback should have been called only once
+    EXPECT_EQ(bodyCallbackCount, 1);
+}
+
+/**
+ * @brief Stop the parsing when the callback returns false, the items are objects.
+ *
+ */
+TEST_F(JsonArrayParserTest, StopParsingWithObjectItems)
+{
+    // Setup the input data
+    const auto testData {R"(
+    {"cves_array":
+            [
+                {"cve":"CVE-2005-AAAA"},
+                {"cve":"CVE-2008-AAAA"},
+                {"cve":"CVE-2012-AAAA"},
+                {"cve":"CVE-2016-AAAA"},
+                {"cve":"CVE-2022-AAAA"}
+            ]
+    }
+    )"};
+    const auto testArrayPointer {"/cves_array"_json_pointer};
+    const auto testFilepath {m_testFolder / "StopParsingWithObjectItems.json"};
+    createTestFile(testData, testFilepath);
+
+    constexpr auto targetCve {"CVE-2012-AAAA"};
+    constexpr auto expectedItemsCallbacksCount {3};
+
+    auto itemCallbackCounter {0};
+
+    // This callback will return false and stop the parsing when the item with "CVE-2012-AAAA" is received
+    auto callback = [&itemCallbackCounter](nlohmann::json&& item)
+    {
+        // Increment callback counter
+        ++itemCallbackCounter;
+
+        if (item.at("cve") == targetCve)
+        {
+            // Item found, return false to stop the parsing
+            return false;
+        }
+        return true;
+    };
+
+    // Parse the JSON array
+    ASSERT_NO_THROW(JsonArray::parse(testFilepath, callback, testArrayPointer));
+
+    // At the end of the processing the callback must have been called three times because the parsing was stopped after
+    // the third item
+    EXPECT_EQ(itemCallbackCounter, expectedItemsCallbacksCount);
+}
+
+/**
+ * @brief Stop the parsing when the callback returns false, the items are simple values.
+ *
+ */
+TEST_F(JsonArrayParserTest, StopParsingWitValueItems)
+{
+    // Setup the input data
+    const auto testData {R"(
+    {"cves_array":
+            [
+                1,
+                2,
+                3
+            ]
+    }
+    )"};
+    const auto testArrayPointer {"/cves_array"_json_pointer};
+    const auto testFilepath {m_testFolder / "StopParsingWitValueItems.json"};
+    createTestFile(testData, testFilepath);
+
+    constexpr auto targetItem {2};
+    constexpr auto expectedItemCallbackCount {2};
+
+    auto itemCallbackCounter {0};
+
+    // This callback will return false and stop the parsing when two items are received
+    auto callback = [&itemCallbackCounter](nlohmann::json&& item)
+    {
+        // Increment callback counter
+        ++itemCallbackCounter;
+
+        if (item == targetItem)
+        {
+            // Item found, return false to stop the parsing
+            return false;
+        }
+        return true;
+    };
+
+    // Parse the JSON array
+    ASSERT_NO_THROW(JsonArray::parse(testFilepath, callback, testArrayPointer));
+
+    // At the end of the processing the callback must have been called two times because the parsing was stopped after
+    // the second item
+    EXPECT_EQ(itemCallbackCounter, expectedItemCallbackCount);
+}
+
+/**
+ * @brief The JSON file has wrong syntax. Expect exception.
+ *
+ */
+TEST_F(JsonArrayParserTest, JsonWithWrongSyntax)
+{
+    // Setup the input data
+    // testData has wrong syntax: extra comma
+    const auto testData {R"(
+    {"test_array":
+            ["1","2","3"]
+            ,
+    }
+    )"};
+    const auto testArrayPointer {"/test_array"_json_pointer};
+    const auto testFilepath {m_testFolder / "JsonWithWrongSyntax.json"};
+    createTestFile(testData, testFilepath);
+
+    auto callback = [](nlohmann::json&& /*item*/)
+    {
+        return true;
+    };
+
+    // Parse the JSON array and expect an exception
+    ASSERT_THROW(JsonArray::parse(testFilepath, callback, testArrayPointer), nlohmann::detail::parse_error);
+}
+
+/**
+ * @brief The JSON file does not exist. Expect exception.
+ *
+ */
+TEST_F(JsonArrayParserTest, InexistentFile)
+{
+    // Setup the input data
+    const auto testArrayPointer {"/test_array"_json_pointer};
+    const auto testFilepath {m_testFolder / "inexistent.json"};
+
+    auto callback = [](nlohmann::json&& /*item*/)
+    {
+        return true;
+    };
+
+    // Start the parse and expect an exception
+    ASSERT_THROW(JsonArray::parse(testFilepath, callback, testArrayPointer), std::runtime_error);
+}

--- a/src/shared_modules/utils/tests/jsonArrayParser_test.hpp
+++ b/src/shared_modules/utils/tests/jsonArrayParser_test.hpp
@@ -1,0 +1,62 @@
+/*
+ * Wazuh - Shared Modules utils tests
+ * Copyright (C) 2015-2023, Wazuh Inc.
+ * October 6, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _JSON_ARRAY_PARSER_TEST_HPP
+#define _JSON_ARRAY_PARSER_TEST_HPP
+
+#include "gtest/gtest.h"
+#include <filesystem>
+#include <fstream>
+
+/**
+ * @brief Tests for the JsonArrayParser class.
+ *
+ */
+class JsonArrayParserTest : public ::testing::Test
+{
+public:
+    JsonArrayParserTest() = default;
+    ~JsonArrayParserTest() override = default;
+
+protected:
+    /// Folder for the temporary files used in the tests
+    const std::filesystem::path m_testFolder {std::filesystem::temp_directory_path() /
+                                              "wazuh/test_files/json_array_parser"};
+
+    /**
+     * @brief Helper function to create a test file.
+     *
+     * @param data File content
+     * @param filepath File path
+     */
+    void createTestFile(const std::string& data, const std::filesystem::path& filepath)
+    {
+        std::ofstream file(filepath);
+        file << data;
+    }
+
+    /**
+     * @brief Sets up the test fixture.
+     */
+    void SetUp() override
+    {
+        std::filesystem::create_directories(m_testFolder);
+    }
+
+    /**
+     * @brief Tears down the test fixture.
+     */
+    void TearDown() override
+    {
+        std::filesystem::remove_all(m_testFolder);
+    }
+};
+#endif //_JSON_ARRAY_PARSER_TEST_HPP


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19472|

## Description

This PR adds a parser for JSON files that allows to processing of each item of an array without having to load the whole JSON file in memory. This is especially useful for large JSON files where only the items of an array are needed. 
This implementation is based on nlohmann's `json_sax_dom_parser` implementation that is used by the default parser. That implementation was modified to find the target array, and for each item of the target array invoke a callback with the already parsed item.

## Use cases
Consider the need to process a large JSON file that has an array with many thousands of items. With the default parser we have to load and parse the whole file in memory. With this array parser the memory needed to parse the file is determined by the size of each individual item.
Take for example the file at: https://feed.wazuh.com/vulnerability-detector/NVD/generated-feeds/complete_nvd_feed.json.gz
As of today it is a 1.1 GB JSON file with this structure (simplified):
```json
{
"vulnerabilities":[
  {"cve": {"configurations": [...],"id": "CVE-2020-23355","vulnStatus": "Analyzed"}},
  {"cve": {"configurations": [...],"id": "CVE-2020-23365","vulnStatus": "Analyzed"}},
 ...thousands of other items...
  ]
}
```

#### Count items

<details><summary>Demo: Count items for each vulnStatus</summary>

Code:
```cpp
        std::unordered_map<std::string, int> statusCount;
        auto countStatus = [&statusCount](nlohmann::json&& item)
        {
            const std::string status {item.at("cve").at("vulnStatus").get_ref<std::string&>()};

            if (statusCount.count(status) > 0)
            {
                statusCount.at(status)++;
            }
            else
            {
                statusCount.insert(std::make_pair(status, 1));
            }
            return true;
        };

        JsonArray::parse("/tmp/feed.json", countStatus, "/vulnerabilities"_json_pointer);
        
        for(auto& status: statusCount){
            std::cout<<status.first<<": "<<status.second<<'\n';
        }
```
Output:
```
Awaiting Analysis: 78
Deferred: 115
Undergoing Analysis: 144
Received: 44
Rejected: 13538
Analyzed: 138066
Modified: 74969
```

Memory profile:
![image](https://github.com/wazuh/intelligence-platform/assets/7939712/bbd0ed6c-7965-49af-8ff1-9d1d0591dc2a)


</details>

#### Filter out some fields before collecting the items for further processing
#### Find a specific item
<details><summary>Demo: Find a specific item and stop parsing when found</summary>

Code:
```cpp
        auto findCve = [](nlohmann::json&& item)
        {
            const std::string status {item.at("cve").at("vulnStatus").get_ref<std::string&>()};

            if (item.at("cve").at("id")=="CVE-2015-2023")
            {
                std::cout<<"CVE-2015-2023 Found!\n";
                std::cout<<item<<'\n';
                
                //Stop searching
                return false;
            }
            return true;
        };

        JsonArray::parse("/tmp/feed.json", findCve, "/vulnerabilities"_json_pointer);
```
Output:
```
CVE-2015-2023 Found!
{"cve":{"configurations":[{"nodes":[{"cpeMatch":[{"criteria":"cpe:2.3:a:ibm:i_access:7.1:*:*:*:*:*:*:*","matchCriteriaId":"B1638A59-EF61-4E7F-A667-9179D83355BD","versionEndExcluding":"","versionEndIncluding":"","versionStartExcluding":"","versionStartIncluding":"","vulnerable":true}],"negate":false,"operator":"OR"},{"cpeMatch":[{"criteria":"cpe:2.3:o:microsoft:windows:*:*:*:*:*:*:*:*","matchCriteriaId":"2CF61F35-5905-4BA9-AD7E-7DB261D2F256","versionEndExcluding":"","versionEndIncluding":"","versionStartExcluding":"","versionStartIncluding":"","vulnerable":false}],"negate":false,"operator":"OR"}],"operator":"AND"}],"descriptions":[{"lang":"en","value":"Buffer overflow in IBM i Access 7.1 on Windows allows local users to gain privileges via unspecified vectors."},{"lang":"es","value":"Desbordamiento de buffer en IBM i Access 7.1 en Windows permite a usuarios locales obtener privilegios a través de vectores no especificados."}],"id":"CVE-2015-2023","lastModified":"2017-09-13T01:29:01.037","metrics":{"cvssMetricV2":[{"acInsufInfo":true,"baseSeverity":"HIGH","cvssData":{"accessComplexity":"LOW","accessVector":"LOCAL","authentication":"NONE","availabilityImpact":"COMPLETE","baseScore":7.2,"confidentialityImpact":"COMPLETE","integrityImpact":"COMPLETE","vectorString":"AV:L/AC:L/Au:N/C:C/I:C/A:C","version":"2.0"},"exploitabilityScore":3.9,"impactScore":10,"obtainAllPrivilege":false,"obtainOtherPrivilege":false,"obtainUserPrivilege":false,"source":"nvd@nist.gov","type":"Primary","userInteractionRequired":false}],"cvssMetricV30":[{"cvssData":{"attackComplexity":"LOW","attackVector":"LOCAL","availabilityImpact":"HIGH","baseScore":8.8,"baseSeverity":"HIGH","confidentialityImpact":"HIGH","integrityImpact":"HIGH","privilegesRequired":"LOW","scope":"CHANGED","userInteraction":"NONE","vectorString":"CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H","version":"3.0"},"exploitabilityScore":2,"impactScore":6,"source":"nvd@nist.gov","type":"Primary"}],"cvssMetricV31":null},"published":"2016-01-02T21:59:01.093","references":[{"source":"psirt@us.ibm.com","tags":["Vendor Advisory"],"url":"http://www-01.ibm.com/support/docview.wss?uid=nas8N1020996"},{"source":"psirt@us.ibm.com","tags":null,"url":"http://www-01.ibm.com/support/docview.wss?uid=swg1SI57907"},{"source":"psirt@us.ibm.com","tags":null,"url":"https://www.exploit-db.com/exploits/38751/"}],"sourceIdentifier":"psirt@us.ibm.com","vulnStatus":"Modified","weaknesses":[{"description":[{"lang":"en","value":"CWE-119"}],"source":"nvd@nist.gov","type":"Primary"}]}}
```

Memory profile:
![image](https://github.com/wazuh/intelligence-platform/assets/7939712/4e85871d-6bff-4c50-8f8c-40b2f3aa4914)

</details>

#### Split a large array into several smaller files

