### PR TITLE
Add write interface for retrieving Vulnerability Remediation data

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -11,7 +11,7 @@ inputs:
 
 runs:
   using: "composite"
-  steps:   
+  steps:
       - name: Dependencies for local execution
         if: env.ACT # Only run for local execution
         shell: bash
@@ -38,7 +38,7 @@ runs:
 
           # Set arguments
           arguments="--capture "
-          
+
           # Set working directory
           arguments+="--directory . "
 
@@ -50,10 +50,11 @@ runs:
 
           # Include test files
           include_files=""
-          include_dirs=$(find src/ include/ -type f -regextype posix-extended -regex ".*/*\.(hpp|cpp|h|c)" -exec dirname {} \; | sort -u)
-          for dir in $include_dirs
+          for file in $(find src/ include/ -type f -regextype posix-extended -regex ".*/*\.(hpp|cpp|h|c)")
           do
-              include_files+="--include=$(pwd)/$dir/* "
+            if [[ ! "$file" =~ "_generated.h" ]]; then
+              include_files+="--include=$(pwd)$dir/$file "
+            fi
           done
           arguments+="$include_files"
 
@@ -102,7 +103,7 @@ runs:
             echo "PASSED: Lines coverage is greater than 90%"
             echo "------------------------------------------"
           fi
-          
+
           # Check if functions coverage is greater than 90%
           functionsCoverage=$(echo "${coverageData[1]}" | sed 's/%//')
           echo "Functions coverage is: $functionsCoverage %"

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -137,15 +137,14 @@ public:
      * @throws std::runtime_error if the retrieved data from the database is invalid or
      *         not in the expected FlatBuffers format.
      */
-    void getVulnerabilityRemediation(std::string_view cveId, FlatbufferDataPair<RemediationInfo>& dtoVulnRemediation)
+    void getVulnerabilityRemediation(const std::string& cveId, FlatbufferDataPair<RemediationInfo>& dtoVulnRemediation)
     {
-        std::string key_str {cveId};
 
-        auto result = m_remediationsDatabase->get(key_str, dtoVulnRemediation.slice);
+        auto result = m_remediationsDatabase->get(cveId, dtoVulnRemediation.slice);
 
         if (!result)
         {
-            throw std::runtime_error("Value for key " + key_str + " does not exist in database.");
+            throw std::runtime_error("Value for key " + cveId + " does not exist in database.");
         }
 
         flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(dtoVulnRemediation.slice.data()),

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -17,7 +17,6 @@
 #include "vulnerabilityRemediations_generated.h"
 
 using namespace NSVulnerabilityScanner;
-using namespace cve_v5;
 
 /**
  * @brief StoreRemediationsModel class.
@@ -56,58 +55,51 @@ public:
     * @see Entry - The data structure containing CVE and remediation information.
     * @see RocksDBWrapper - The utility class for interacting with RocksDB databases.
     */
-    static void updateRemediation(const Entry* data, Utils::RocksDBWrapper& m_remediationsDatabase)
+    static void updateRemediation(const cve_v5::Entry* data, Utils::RocksDBWrapper& remediationsDatabase)
     {
-        try
+        if (!(data->containers()->cna() && data->containers()->cna()->x_remediations()))
         {
-            if (!(data->containers()->cna() && data->containers()->cna()->x_remediations()))
-            {
-                std::cerr << "Fiel x_remediations not present.\n";
-                return;
-            }
+            std::cerr << "Fiel x_remediations not present.\n";
+            return;
+        }
 
-            auto remediations = data->containers()->cna()->x_remediations()->windows();
+        auto remediations = data->containers()->cna()->x_remediations()->windows();
 
-            if (!remediations)
-            {
-                std::cerr << "Empty remediations.\n";
-                return;
-            }
+        if (!remediations)
+        {
+            std::cerr << "Empty remediations.\n";
+            return;
+        }
 
-            std::string key_str {data->cveMetadata()->cveId()->str()};
+        std::string key {data->cveMetadata()->cveId()->str()};
 
-            std::for_each(remediations->begin(),
-                          remediations->end(),
-                          [&key_str, &m_remediationsDatabase](const Remediation* remediation)
+        std::for_each(remediations->begin(),
+                      remediations->end(),
+                      [&key, &remediationsDatabase](const cve_v5::Remediation* remediation)
+                      {
+                          auto updatesCve5 = remediation->anyOf();
+                          if (!updatesCve5)
                           {
-                              auto updatesCve5 = remediation->anyOf();
-                              if (!updatesCve5)
-                              {
-                                  std::cerr << "No updates available.\n";
-                                  return;
-                              }
-                              flatbuffers::FlatBufferBuilder builder;
+                              std::cerr << "No updates available.\n";
+                              return;
+                          }
+                          flatbuffers::FlatBufferBuilder builder;
 
-                              std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
+                          std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
 
-                              for (size_t idxUpdate = 0; idxUpdate < updatesCve5->size(); idxUpdate++)
-                              {
-                                  updates_vec.emplace_back(builder.CreateString(updatesCve5->Get(idxUpdate)->c_str()));
-                              }
+                          for (size_t idxUpdate = 0; idxUpdate < updatesCve5->size(); idxUpdate++)
+                          {
+                              updates_vec.emplace_back(builder.CreateString(updatesCve5->Get(idxUpdate)->c_str()));
+                          }
 
-                              auto updates = builder.CreateVector(updates_vec);
-                              auto fbbRemediation = CreateRemediationInfo(builder, updates);
-                              builder.Finish(fbbRemediation);
+                          auto updates = builder.CreateVector(updates_vec);
+                          auto fbbRemediation = CreateRemediationInfo(builder, updates);
+                          builder.Finish(fbbRemediation);
 
-                              rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()),
-                                                   builder.GetSize());
-                              m_remediationsDatabase.put(key_str, value);
-                          });
-        }
-        catch (...)
-        {
-            std::cerr << "Unable to store remediation in database.\n";
-        }
+                          rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()),
+                                               builder.GetSize());
+                          remediationsDatabase.put(key, value);
+                      });
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -60,6 +60,12 @@ public:
     {
         try
         {
+            if (!(data->containers()->cna() && data->containers()->cna()->x_remediations()))
+            {
+                std::cerr << "Fiel x_remediations not present.\n";
+                return;
+            }
+
             auto remediations = data->containers()->cna()->x_remediations()->windows();
 
             if (!remediations)

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -70,33 +70,33 @@ public:
 
             std::string key_str {data->cveMetadata()->cveId()->str()};
 
-            std::for_each(
-                remediations->begin(),
-                remediations->end(),
-                [&key_str, &m_remediationsDatabase](const Remediation* remediation)
-                {
-                    auto updatesCve5 = remediation->anyOf();
-                    if (!updatesCve5)
-                    {
-                        std::cerr << "No updates available.\n";
-                        return;
-                    }
-                    flatbuffers::FlatBufferBuilder builder;
+            std::for_each(remediations->begin(),
+                          remediations->end(),
+                          [&key_str, &m_remediationsDatabase](const Remediation* remediation)
+                          {
+                              auto updatesCve5 = remediation->anyOf();
+                              if (!updatesCve5)
+                              {
+                                  std::cerr << "No updates available.\n";
+                                  return;
+                              }
+                              flatbuffers::FlatBufferBuilder builder;
 
-                    std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
+                              std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
 
-                    for (size_t idxUpdate = 0; idxUpdate < updatesCve5->size(); idxUpdate++)
-                    {
-                        updates_vec.emplace_back(builder.CreateString(updatesCve5->GetAsString(idxUpdate)->str()));
-                    }
+                              for (size_t idxUpdate = 0; idxUpdate < updatesCve5->size(); idxUpdate++)
+                              {
+                                  updates_vec.emplace_back(builder.CreateString(updatesCve5->Get(idxUpdate)->c_str()));
+                              }
 
-                    auto updates = builder.CreateVector(updates_vec);
-                    auto fbbRemediation = CreateRemediationInfo(builder, updates);
-                    builder.Finish(fbbRemediation);
+                              auto updates = builder.CreateVector(updates_vec);
+                              auto fbbRemediation = CreateRemediationInfo(builder, updates);
+                              builder.Finish(fbbRemediation);
 
-                    rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()), builder.GetSize());
-                    m_remediationsDatabase.put(key_str, value);
-                });
+                              rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()),
+                                                   builder.GetSize());
+                              m_remediationsDatabase.put(key_str, value);
+                          });
         }
         catch (...)
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -1,7 +1,7 @@
 /*
- * Wazuh Vulnerability scanner - Database Feed Manager
+ * Wazuh storeRemediationsModel
  * Copyright (C) 2015, Wazuh Inc.
- * May 1, 2023.
+ * October 05, 2023.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
@@ -26,43 +26,77 @@ using namespace cve_v5;
 class StoreRemediationsModel final
 {
 public:
+    /**
+     * @brief Update Remediation Information in a RocksDB Database
+     *
+     * This function updates remediation information for a given vulnerability (CVE) in a RocksDB database.
+     * It extracts remediation data from a provided FlatBuffers 'Entry' object which is the CVE5 object and stores it in
+    the database.
+     * If no remediation data is available or an error occurs during the update process, it provides error messages.
+
+    * @param data Pointer to the 'Entry' object containing vulnerability and remediation information.
+    * @param m_remediationsDatabase Reference to the RocksDBWrapper object representing the database.
+    *
+    * @note The 'Entry' object should conform to the specified cve5 schema, including nested structures.
+    * @note The 'RocksDBWrapper' object should be properly initialized and connected to the target database.
+
+    * @details The function performs the following steps:
+    * 1. Attempts to access remediation data for Windows from the 'Entry' object.
+    * 2. If remediation data is not available (empty), it logs an error message to std::cerr and returns.
+    * 3. Extracts the CVE identifier (CVE-ID) from the 'Entry' object.
+    * 4. Iterates through the available remediation data for Windows:
+    *    - Builds a FlatBuffers object containing the remediation information.
+    *    - Serializes the FlatBuffers object into binary data.
+    *    - Stores the binary data in the RocksDB database, using the CVE-ID as the key.
+    * 5. If an exception occurs during this process, it logs an error message to std::cerr.
+    *
+    * @note This function assumes a specific data structure in the 'Entry' object, including nested objects.
+    *       Ensure that the 'Entry' object conforms to the expected schema to avoid runtime errors.
+    *
+    * @see Entry - The data structure containing CVE and remediation information.
+    * @see RocksDBWrapper - The utility class for interacting with RocksDB databases.
+    */
     static void updateRemediation(const Entry* data, Utils::RocksDBWrapper& m_remediationsDatabase)
     {
         try
         {
-            auto remediations = data->containers()->cna()->x_remediations();
+            auto remediations = data->containers()->cna()->x_remediations()->windows();
+
+            if (!remediations)
+            {
+                std::cerr << "Empty remediations.\n";
+                return;
+            }
 
             std::string key_str {data->cveMetadata()->cveId()->str()};
 
-            if (remediations->windows()->size())
-            {
-                std::for_each(remediations->windows()->begin(),
-                              remediations->windows()->end(),
-                              [&key_str, &m_remediationsDatabase](
-                                  const ::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>>* vector)
-                              {
-                                  flatbuffers::FlatBufferBuilder builder;
+            std::for_each(
+                remediations->begin(),
+                remediations->end(),
+                [&key_str, &m_remediationsDatabase](const Remediation* remediation)
+                {
+                    auto updatesCve5 = remediation->anyOf();
+                    if (!updatesCve5)
+                    {
+                        std::cerr << "No updates available.\n";
+                        return;
+                    }
+                    flatbuffers::FlatBufferBuilder builder;
 
-                                  std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
+                    std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
 
-                                  for (auto update = 0; update < vector->size(); update++)
-                                  {
-                                      updates_vec.emplace_back(vector->Get(update));
-                                  }
+                    for (size_t idxUpdate = 0; idxUpdate < updatesCve5->size(); idxUpdate++)
+                    {
+                        updates_vec.emplace_back(builder.CreateString(updatesCve5->GetAsString(idxUpdate)->str()));
+                    }
 
-                                  auto updates = builder.CreateVector(updates_vec);
-                                  auto remediation = CreateRemediationInfo(builder, updates);
-                                  builder.Finish(remediation);
+                    auto updates = builder.CreateVector(updates_vec);
+                    auto fbbRemediation = CreateRemediationInfo(builder, updates);
+                    builder.Finish(fbbRemediation);
 
-                                  rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()),
-                                                       builder.GetSize());
-                                  m_remediationsDatabase.put(key_str, value);
-                              });
-            }
-            else
-            {
-                std::cerr << "Empty remediations. Skipping.\n";
-            }
+                    rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()), builder.GetSize());
+                    m_remediationsDatabase.put(key_str, value);
+                });
         }
         catch (...)
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -30,31 +30,31 @@ public:
      *
      * This function updates remediation information for a given vulnerability (CVE) in a RocksDB database.
      * It extracts remediation data from a provided FlatBuffers 'Entry' object which is the CVE5 object and stores it in
-    the database.
+     * the database.
      * If no remediation data is available or an error occurs during the update process, it provides error messages.
-
-    * @param data Pointer to the 'Entry' object containing vulnerability and remediation information.
-    * @param m_remediationsDatabase Reference to the RocksDBWrapper object representing the database.
-    *
-    * @note The 'Entry' object should conform to the specified cve5 schema, including nested structures.
-    * @note The 'RocksDBWrapper' object should be properly initialized and connected to the target database.
-
-    * @details The function performs the following steps:
-    * 1. Attempts to access remediation data for Windows from the 'Entry' object.
-    * 2. If remediation data is not available (empty), it logs an error message to std::cerr and returns.
-    * 3. Extracts the CVE identifier (CVE-ID) from the 'Entry' object.
-    * 4. Iterates through the available remediation data for Windows:
-    *    - Builds a FlatBuffers object containing the remediation information.
-    *    - Serializes the FlatBuffers object into binary data.
-    *    - Stores the binary data in the RocksDB database, using the CVE-ID as the key.
-    * 5. If an exception occurs during this process, it logs an error message to std::cerr.
-    *
-    * @note This function assumes a specific data structure in the 'Entry' object, including nested objects.
-    *       Ensure that the 'Entry' object conforms to the expected schema to avoid runtime errors.
-    *
-    * @see Entry - The data structure containing CVE and remediation information.
-    * @see RocksDBWrapper - The utility class for interacting with RocksDB databases.
-    */
+     *
+     * @param data Pointer to the 'Entry' object containing vulnerability and remediation information.
+     * @param remediationsDatabase Reference to the RocksDBWrapper object representing the database.
+     *
+     * @note The 'Entry' object should conform to the specified cve5 schema, including nested structures.
+     * @note The 'RocksDBWrapper' object should be properly initialized and connected to the target database.
+     *
+     * @details The function performs the following steps:
+     * 1. Attempts to access remediation data for Windows from the 'Entry' object.
+     * 2. If remediation data is not available (empty), it logs an error message to std::cerr and returns.
+     * 3. Extracts the CVE identifier (CVE-ID) from the 'Entry' object.
+     * 4. Iterates through the available remediation data for Windows:
+     *    - Builds a FlatBuffers object containing the remediation information.
+     *    - Serializes the FlatBuffers object into binary data.
+     *    - Stores the binary data in the RocksDB database, using the CVE-ID as the key.
+     * 5. If an exception occurs during this process, it logs an error message to std::cerr.
+     *
+     * @note This function assumes a specific data structure in the 'Entry' object, including nested objects.
+     *       Ensure that the 'Entry' object conforms to the expected schema to avoid runtime errors.
+     *
+     * @see Entry - The data structure containing CVE and remediation information.
+     * @see RocksDBWrapper - The utility class for interacting with RocksDB databases.
+     */
     static void updateRemediation(const cve_v5::Entry* data, Utils::RocksDBWrapper& remediationsDatabase)
     {
         if (!(data->containers()->cna() && data->containers()->cna()->x_remediations()))

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -12,9 +12,9 @@
 #ifndef _STORE_REMEDIATIONS_MODEL_HPP
 #define _STORE_REMEDIATIONS_MODEL_HPP
 
-#include "vulnerabilityRemediations_generated.h"
 #include "cve5_generated.h"
 #include "databaseFeedManager.hpp"
+#include "vulnerabilityRemediations_generated.h"
 
 using namespace NSVulnerabilityScanner;
 using namespace cve_v5;
@@ -26,7 +26,7 @@ using namespace cve_v5;
 class StoreRemediationsModel final
 {
 public:
-    static void updateRemediation(const Entry* data, std::shared_ptr<Utils::RocksDBWrapper> m_remediationsDatabase)
+    static void updateRemediation(const Entry* data, Utils::RocksDBWrapper& m_remediationsDatabase)
     {
         try
         {
@@ -36,32 +36,37 @@ public:
 
             if (remediations->windows()->size())
             {
-                std::for_each(remediations->windows()->begin(), remediations->windows()->end(),
-                [&key_str, &m_remediationsDatabase](const ::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>> *vector)
-                {
-                    flatbuffers::FlatBufferBuilder builder;
+                std::for_each(remediations->windows()->begin(),
+                              remediations->windows()->end(),
+                              [&key_str, &m_remediationsDatabase](
+                                  const ::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>>* vector)
+                              {
+                                  flatbuffers::FlatBufferBuilder builder;
 
-                    std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
+                                  std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
 
-                    for (auto update = 0; update < vector->size();update++)
-                    {
-                        updates_vec.emplace_back(vector->Get(update));
-                    }
+                                  for (auto update = 0; update < vector->size(); update++)
+                                  {
+                                      updates_vec.emplace_back(vector->Get(update));
+                                  }
 
-                    auto updates = builder.CreateVector(updates_vec);
-                    auto remediation = CreateRemediationInfo(builder, updates);
-                    builder.Finish(remediation);
+                                  auto updates = builder.CreateVector(updates_vec);
+                                  auto remediation = CreateRemediationInfo(builder, updates);
+                                  builder.Finish(remediation);
 
-                    rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()), builder.GetSize());
-                    m_remediationsDatabase->put(key_str, value);
-                });
-            } else {
-                std::cerr<<"Empty remediations. SKipping.\n";
+                                  rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()),
+                                                       builder.GetSize());
+                                  m_remediationsDatabase.put(key_str, value);
+                              });
+            }
+            else
+            {
+                std::cerr << "Empty remediations. Skipping.\n";
             }
         }
-        catch(...)
+        catch (...)
         {
-            std::cerr<<"Unable to store remediation in database.\n";
+            std::cerr << "Unable to store remediation in database.\n";
         }
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -1,0 +1,91 @@
+/*
+ * Wazuh Vulnerability scanner - Database Feed Manager
+ * Copyright (C) 2015, Wazuh Inc.
+ * May 1, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _STORE_REMEDIATIONS_MODEL_HPP
+#define _STORE_REMEDIATIONS_MODEL_HPP
+
+#include "vulnerabilityRemediations_generated.h"
+#include "cve5_generated.h"
+#include "databaseFeedManager.hpp"
+
+using namespace NSVulnerabilityScanner;
+using namespace cve_v5;
+
+/**
+ * @brief StoreRemediationsModel class.
+ *
+ */
+class StoreRemediationsModel final
+{
+public:
+
+    explicit StoreRemediationsModel(std::shared_ptr<Utils::RocksDBWrapper> remediationsDatabase)
+    {
+        m_remediations = remediationsDatabase;
+    }
+
+    void updateRemediation(const Entry* data)
+    {
+        try
+        {
+            auto remediations = data->containers()->cna()->x_remediations();
+
+            std::string key_str {data->cveMetadata()->cveId()->str()};
+
+            if (remediations->alpine()->size())
+            {
+                std::for_each(remediations->alpine()->begin(), remediations->alpine()->end(),
+                [&key_str](const ::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>> *vector)
+                {
+                    flatbuffers::FlatBufferBuilder builder;
+
+                    std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
+
+                    FlatbufferDataPair<RemediationInfo> query_result;
+
+
+
+                    for (auto update = 0; update < vector->size();update++)
+                    {
+                        updates_vec.emplace_back(vector->Get(update));
+                    }
+
+                    auto updates = builder.CreateVector(updates_vec);
+                    auto remediation = CreateRemediationInfo(builder, updates);
+                    builder.Finish(remediation);
+
+                    rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()), builder.GetSize());
+                    rocksdb::Slice c
+                });
+            }
+
+            for (int update = 0; update < remediations->GetField)
+
+            for(auto& update: data.at("updates"))
+            {
+                updates_vec.push_back(builder.CreateString(update));
+            }
+
+
+            m_remediationsDatabase->put(key_str, value);
+        }
+        catch(...)
+        {
+            std::cerr<<"Unable to store remediation in database.\n";
+        }
+    }
+private:
+    Utils::RocksDBWrapper& database_ref;
+    std::shared_ptr<Utils::RocksDBWrapper> m_remediations;
+
+};
+
+#endif // _STORE_REMEDIATIONS_MODEL_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -26,13 +26,7 @@ using namespace cve_v5;
 class StoreRemediationsModel final
 {
 public:
-
-    explicit StoreRemediationsModel(std::shared_ptr<Utils::RocksDBWrapper> remediationsDatabase)
-    {
-        m_remediations = remediationsDatabase;
-    }
-
-    void updateRemediation(const Entry* data)
+    static void updateRemediation(const Entry* data, std::shared_ptr<Utils::RocksDBWrapper> m_remediationsDatabase)
     {
         try
         {
@@ -40,18 +34,14 @@ public:
 
             std::string key_str {data->cveMetadata()->cveId()->str()};
 
-            if (remediations->alpine()->size())
+            if (remediations->windows()->size())
             {
-                std::for_each(remediations->alpine()->begin(), remediations->alpine()->end(),
-                [&key_str](const ::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>> *vector)
+                std::for_each(remediations->windows()->begin(), remediations->windows()->end(),
+                [&key_str, &m_remediationsDatabase](const ::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>> *vector)
                 {
                     flatbuffers::FlatBufferBuilder builder;
 
                     std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
-
-                    FlatbufferDataPair<RemediationInfo> query_result;
-
-
 
                     for (auto update = 0; update < vector->size();update++)
                     {
@@ -63,29 +53,17 @@ public:
                     builder.Finish(remediation);
 
                     rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()), builder.GetSize());
-                    rocksdb::Slice c
+                    m_remediationsDatabase->put(key_str, value);
                 });
+            } else {
+                std::cerr<<"Empty remediations. SKipping.\n";
             }
-
-            for (int update = 0; update < remediations->GetField)
-
-            for(auto& update: data.at("updates"))
-            {
-                updates_vec.push_back(builder.CreateString(update));
-            }
-
-
-            m_remediationsDatabase->put(key_str, value);
         }
         catch(...)
         {
             std::cerr<<"Unable to store remediation in database.\n";
         }
     }
-private:
-    Utils::RocksDBWrapper& database_ref;
-    std::shared_ptr<Utils::RocksDBWrapper> m_remediations;
-
 };
 
 #endif // _STORE_REMEDIATIONS_MODEL_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
@@ -13,6 +13,8 @@
 #include "factoryOrchestrator.hpp"
 #include <iostream>
 
+// TODO: Remove LCOV flags once the implementation of 'ScanOrchestrator' is completed
+// LCOV_EXCL_START
 void ScanOrchestrator::run(const std::string& agentId,
                            const std::vector<char>& message,
                            std::shared_ptr<IndexerConnector> /*indexerConnector*/)
@@ -28,3 +30,5 @@ void ScanOrchestrator::run(const std::string& agentId,
     {
     }
 }
+// LCOV_EXCL_START
+

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
@@ -31,4 +31,3 @@ void ScanOrchestrator::run(const std::string& agentId,
     }
 }
 // LCOV_EXCL_START
-

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -453,7 +453,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_ValidData)
                                               TrampolineRouterSubscriber>>(spIndexerConnectorTramp)};
 
     // Variables setup
-    std::string_view cveId {"CVE-2023-2609"};
+    std::string cveId {"CVE-2023-2609"};
     FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
 
     // Asserts
@@ -488,7 +488,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_DataNotFound)
                                               TrampolineRouterSubscriber>>(spIndexerConnectorTramp)};
 
     // Variables setup
-    std::string_view cveId {"CVE-2023-5678"};
+    std::string cveId {"CVE-2023-5678"};
     FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
 
     // Assert
@@ -531,7 +531,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_InvalidData)
                                               TrampolineRouterSubscriber>>(spIndexerConnectorTramp)};
 
     // Variables setup
-    std::string_view cveId {"CVE-2023-2609"};
+    std::string cveId {"CVE-2023-2609"};
     FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
 
     // Assert

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
@@ -1,0 +1,320 @@
+/*
+ * Wazuh storeRemediationsModel
+ * Copyright (C) 2015, Wazuh Inc.
+ * October 05, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "storeRemediationsModel_test.h"
+#include "flatbuffers/flatbuffers.h"
+#include "flatbuffers/idl.h"
+#include "flatbuffers/util.h"
+
+constexpr auto COMMON_DATABASE_DIR {"queue/vd"}; //<<Used for all databases
+const std::string flatbufferSchema {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
+const char* INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
+
+auto jsonCve5Valid = R"(
+    {
+        "dataType": "CVE_RECORD",
+        "dataVersion": "5.0",
+        "cveMetadata": {
+            "cveId": "CVE-1337-1234",
+            "assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+            "state": "PUBLISHED"
+        },
+        "containers": {
+            "cna": {
+                "providerMetadata": {
+                    "orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6"
+                },
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "lang": "en",
+                                "description": "CWE-78 OS Command Injection"
+                            }
+                        ]
+                    }
+                ],
+                "affected": [
+                    {
+                        "vendor": "Example.org",
+                        "product": "Example Enterprise",
+                        "versions": [
+                            {
+                                "version": "1.0.0",
+                                "status": "affected",
+                                "lessThan": "1.0.6",
+                                "versionType": "semver"
+                            }
+                        ],
+                        "defaultStatus": "unaffected"
+                    }
+                ],
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "OS Command Injection vulnerability parseFilename function of example.php in the Web Management Interface of Example.org Example Enterprise on Windows, MacOS and XT-4500 allows remote unauthenticated attackers to escalate privileges.\n\nThis issue affects:\n  *  1.0 versions before 1.0.6\n  *  2.1 versions from 2.16 until 2.1.9."
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://example.org/ESA-22-11-CVE-1337-1234"
+                    }
+                ],
+                "x_remediations": {
+                    "windows": [
+                        {
+                            "anyOf":["KBT-800","KBT-1000","KBT-3000"],
+                            "products": ["Windows 10 - HastaLaVistaBaby", "Windows 11 - RiseOfTheMachines", "Windows 12 - Genisys"],
+                            "type": "update"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+)";
+
+auto jsonCve5EmptyWindows = R"(
+    {
+        "dataType": "CVE_RECORD",
+        "dataVersion": "5.0",
+        "cveMetadata": {
+            "cveId": "CVE-1337-1234",
+            "assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+            "state": "PUBLISHED"
+        },
+        "containers": {
+            "cna": {
+                "providerMetadata": {
+                    "orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6"
+                },
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "lang": "en",
+                                "description": "CWE-78 OS Command Injection"
+                            }
+                        ]
+                    }
+                ],
+                "affected": [
+                    {
+                        "vendor": "Example.org",
+                        "product": "Example Enterprise",
+                        "versions": [
+                            {
+                                "version": "1.0.0",
+                                "status": "affected",
+                                "lessThan": "1.0.6",
+                                "versionType": "semver"
+                            }
+                        ],
+                        "defaultStatus": "unaffected"
+                    }
+                ],
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "OS Command Injection vulnerability parseFilename function of example.php in the Web Management Interface of Example.org Example Enterprise on Windows, MacOS and XT-4500 allows remote unauthenticated attackers to escalate privileges.\n\nThis issue affects:\n  *  1.0 versions before 1.0.6\n  *  2.1 versions from 2.16 until 2.1.9."
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://example.org/ESA-22-11-CVE-1337-1234"
+                    }
+                ],
+                "x_remediations": {
+                    "alpine": [
+                        {
+                            "anyOf":["KBT-800","KBT-1000","KBT-3000"],
+                            "products": ["Windows 10 - HastaLaVistaBaby", "Windows 11 - RiseOfTheMachines", "Windows 12 - Genisys"],
+                            "type": "update"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+)";
+
+auto jsonCve5EmptyUpdates = R"(
+    {
+        "dataType": "CVE_RECORD",
+        "dataVersion": "5.0",
+        "cveMetadata": {
+            "cveId": "CVE-1337-1234",
+            "assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+            "state": "PUBLISHED"
+        },
+        "containers": {
+            "cna": {
+                "providerMetadata": {
+                    "orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6"
+                },
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "lang": "en",
+                                "description": "CWE-78 OS Command Injection"
+                            }
+                        ]
+                    }
+                ],
+                "affected": [
+                    {
+                        "vendor": "Example.org",
+                        "product": "Example Enterprise",
+                        "versions": [
+                            {
+                                "version": "1.0.0",
+                                "status": "affected",
+                                "lessThan": "1.0.6",
+                                "versionType": "semver"
+                            }
+                        ],
+                        "defaultStatus": "unaffected"
+                    }
+                ],
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "OS Command Injection vulnerability parseFilename function of example.php in the Web Management Interface of Example.org Example Enterprise on Windows, MacOS and XT-4500 allows remote unauthenticated attackers to escalate privileges.\n\nThis issue affects:\n  *  1.0 versions before 1.0.6\n  *  2.1 versions from 2.16 until 2.1.9."
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://example.org/ESA-22-11-CVE-1337-1234"
+                    }
+                ],
+                "x_remediations": {
+                    "windows": [
+                        {
+                            "products": ["Windows 10 - HastaLaVistaBaby", "Windows 11 - RiseOfTheMachines", "Windows 12 - Genisys"],
+                            "type": "update"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+)";
+
+void StoreRemediationsModelTest::SetUp()
+{
+    std::filesystem::create_directories(COMMON_DATABASE_DIR);
+};
+
+void StoreRemediationsModelTest::TearDown()
+{
+    std::filesystem::remove_all(COMMON_DATABASE_DIR);
+};
+
+TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediation)
+{
+    // Define schema variable and parse JSON object.
+    std::string schemaStr;
+
+    // Load file with schema.
+    bool valid = flatbuffers::LoadFile(flatbufferSchema.c_str(), false, &schemaStr);
+    EXPECT_TRUE(valid);
+
+    // Parse schema.
+    flatbuffers::Parser parser;
+    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonCve5Valid);
+    EXPECT_TRUE(valid);
+
+    // Create a test Entry object with Windows remediations
+    auto jbuf = parser.builder_.GetBufferPointer();
+    flatbuffers::Verifier jverifier(jbuf, parser.builder_.GetSize());
+    EXPECT_TRUE(VerifyEntryBuffer(jverifier));
+    auto entry = GetEntry(jbuf);
+
+    // Create a mock RocksDBWrapper object
+    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+
+    // Call the updateRemediation function with the test data
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+
+    // Assert result.
+    std::string cveId {"CVE-1337-1234"};
+    FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
+
+    // Asserts
+    EXPECT_NO_THROW(rocksDBWrapper.get(cveId, dtoVulnRemediation.slice));
+    dtoVulnRemediation.data = const_cast<NSVulnerabilityScanner::RemediationInfo*>(
+        NSVulnerabilityScanner::GetRemediationInfo(dtoVulnRemediation.slice.data()));
+
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(0)->str().c_str(), "KBT-800");
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(1)->str().c_str(), "KBT-1000");
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(2)->str().c_str(), "KBT-3000");
+}
+
+TEST_F(StoreRemediationsModelTest, SkipsEmptyRemediations)
+{
+    // Define schema variable and parse JSON object.
+    std::string schemaStr;
+
+    // Load file with schema.
+    bool valid = flatbuffers::LoadFile(flatbufferSchema.c_str(), false, &schemaStr);
+    EXPECT_TRUE(valid);
+
+    // Parse schema.
+    flatbuffers::Parser parser;
+    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonCve5EmptyWindows);
+    EXPECT_TRUE(valid);
+
+    // Create a test Entry object with Windows remediations
+    auto jbuf = parser.builder_.GetBufferPointer();
+    flatbuffers::Verifier jverifier(jbuf, parser.builder_.GetSize());
+    EXPECT_TRUE(VerifyEntryBuffer(jverifier));
+    auto entry = GetEntry(jbuf);
+
+    // Create a mock RocksDBWrapper object
+    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+
+    // Assert result.
+    ::testing::internal::CaptureStderr();
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+    std::string capturedSterr = ::testing::internal::GetCapturedStderr().c_str();
+    EXPECT_STREQ("Empty remediations.\n", capturedSterr.c_str());
+}
+
+TEST_F(StoreRemediationsModelTest, SkipsEmptyUpdates)
+{
+    // Define schema variable and parse JSON object.
+    std::string schemaStr;
+
+    // Load file with schema.
+    bool valid = flatbuffers::LoadFile(flatbufferSchema.c_str(), false, &schemaStr);
+    EXPECT_TRUE(valid);
+
+    // Parse schema.
+    flatbuffers::Parser parser;
+    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonCve5EmptyUpdates);
+    EXPECT_TRUE(valid);
+
+    // Create a test Entry object with Windows remediations
+    auto jbuf = parser.builder_.GetBufferPointer();
+    flatbuffers::Verifier jverifier(jbuf, parser.builder_.GetSize());
+    EXPECT_TRUE(VerifyEntryBuffer(jverifier));
+    auto entry = GetEntry(jbuf);
+
+    // Create a mock RocksDBWrapper object
+    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+
+    // Assert result.
+    ::testing::internal::CaptureStderr();
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+    std::string capturedSterr = ::testing::internal::GetCapturedStderr().c_str();
+    EXPECT_STREQ("No updates available.\n", capturedSterr.c_str());
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
@@ -16,7 +16,7 @@
 
 constexpr auto COMMON_DATABASE_DIR {"queue/vd"}; //<<Used for all databases
 const std::string FLATBUFFER_SCHEMA {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
-const char* INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
+const char* FB_INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
 
 auto JSON_CVE5_VALID = R"(
     {
@@ -285,7 +285,7 @@ TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediation)
 
     // Parse schema.
     flatbuffers::Parser parser;
-    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_VALID);
+    valid = parser.Parse(schemaStr.c_str(), FB_INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_VALID);
     EXPECT_TRUE(valid);
 
     // Create a test Entry object with Windows remediations
@@ -325,7 +325,7 @@ TEST_F(StoreRemediationsModelTest, SkipsEmptyRemediations)
 
     // Parse schema.
     flatbuffers::Parser parser;
-    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_EMPTY_WINDOWS);
+    valid = parser.Parse(schemaStr.c_str(), FB_INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_EMPTY_WINDOWS);
     EXPECT_TRUE(valid);
 
     // Create a test Entry object with Windows remediations
@@ -355,7 +355,7 @@ TEST_F(StoreRemediationsModelTest, SkipsEmptyUpdates)
 
     // Parse schema.
     flatbuffers::Parser parser;
-    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_EMPTY_UPDATES);
+    valid = parser.Parse(schemaStr.c_str(), FB_INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_EMPTY_UPDATES);
     EXPECT_TRUE(valid);
 
     // Create a test Entry object with Windows remediations
@@ -385,7 +385,7 @@ TEST_F(StoreRemediationsModelTest, x_remediationsNotPresent)
 
     // Parse schema.
     flatbuffers::Parser parser;
-    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_NO_REMEDIATIONS);
+    valid = parser.Parse(schemaStr.c_str(), FB_INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_NO_REMEDIATIONS);
     EXPECT_TRUE(valid);
 
     // Create a test Entry object with Windows remediations

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
@@ -209,6 +209,61 @@ auto jsonCve5EmptyUpdates = R"(
     }
 )";
 
+auto jsonCve5NoRemediations = R"(
+    {
+        "dataType": "CVE_RECORD",
+        "dataVersion": "5.0",
+        "cveMetadata": {
+            "cveId": "CVE-1337-1234",
+            "assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+            "state": "PUBLISHED"
+        },
+        "containers": {
+            "cna": {
+                "providerMetadata": {
+                    "orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6"
+                },
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "lang": "en",
+                                "description": "CWE-78 OS Command Injection"
+                            }
+                        ]
+                    }
+                ],
+                "affected": [
+                    {
+                        "vendor": "Example.org",
+                        "product": "Example Enterprise",
+                        "versions": [
+                            {
+                                "version": "1.0.0",
+                                "status": "affected",
+                                "lessThan": "1.0.6",
+                                "versionType": "semver"
+                            }
+                        ],
+                        "defaultStatus": "unaffected"
+                    }
+                ],
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "OS Command Injection vulnerability parseFilename function of example.php in the Web Management Interface of Example.org Example Enterprise on Windows, MacOS and XT-4500 allows remote unauthenticated attackers to escalate privileges.\n\nThis issue affects:\n  *  1.0 versions before 1.0.6\n  *  2.1 versions from 2.16 until 2.1.9."
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://example.org/ESA-22-11-CVE-1337-1234"
+                    }
+                ],
+            }
+        }
+    }
+)";
+
 void StoreRemediationsModelTest::SetUp()
 {
     std::filesystem::create_directories(COMMON_DATABASE_DIR);
@@ -317,4 +372,34 @@ TEST_F(StoreRemediationsModelTest, SkipsEmptyUpdates)
     EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
     std::string capturedSterr = ::testing::internal::GetCapturedStderr().c_str();
     EXPECT_STREQ("No updates available.\n", capturedSterr.c_str());
+}
+
+TEST_F(StoreRemediationsModelTest, x_remediationsNotPresent)
+{
+    // Define schema variable and parse JSON object.
+    std::string schemaStr;
+
+    // Load file with schema.
+    bool valid = flatbuffers::LoadFile(flatbufferSchema.c_str(), false, &schemaStr);
+    EXPECT_TRUE(valid);
+
+    // Parse schema.
+    flatbuffers::Parser parser;
+    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonCve5NoRemediations);
+    EXPECT_TRUE(valid);
+
+    // Create a test Entry object with Windows remediations
+    auto jbuf = parser.builder_.GetBufferPointer();
+    flatbuffers::Verifier jverifier(jbuf, parser.builder_.GetSize());
+    EXPECT_TRUE(VerifyEntryBuffer(jverifier));
+    auto entry = GetEntry(jbuf);
+
+    // Create a mock RocksDBWrapper object
+    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+
+    // Assert result.
+    ::testing::internal::CaptureStderr();
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+    std::string capturedSterr = ::testing::internal::GetCapturedStderr().c_str();
+    EXPECT_STREQ("Fiel x_remediations not present.\n", capturedSterr.c_str());
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
@@ -15,10 +15,10 @@
 #include "flatbuffers/util.h"
 
 constexpr auto COMMON_DATABASE_DIR {"queue/vd"}; //<<Used for all databases
-const std::string flatbufferSchema {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
+const std::string FLATBUFFER_SCHEMA {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
 const char* INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
 
-auto jsonCve5Valid = R"(
+auto JSON_CVE5_VALID = R"(
     {
         "dataType": "CVE_RECORD",
         "dataVersion": "5.0",
@@ -82,7 +82,7 @@ auto jsonCve5Valid = R"(
     }
 )";
 
-auto jsonCve5EmptyWindows = R"(
+auto JSON_CVE5_EMPTY_WINDOWS = R"(
     {
         "dataType": "CVE_RECORD",
         "dataVersion": "5.0",
@@ -146,7 +146,7 @@ auto jsonCve5EmptyWindows = R"(
     }
 )";
 
-auto jsonCve5EmptyUpdates = R"(
+auto JSON_CVE5_EMPTY_UPDATES = R"(
     {
         "dataType": "CVE_RECORD",
         "dataVersion": "5.0",
@@ -209,7 +209,7 @@ auto jsonCve5EmptyUpdates = R"(
     }
 )";
 
-auto jsonCve5NoRemediations = R"(
+auto JSON_CVE5_NO_REMEDIATIONS = R"(
     {
         "dataType": "CVE_RECORD",
         "dataVersion": "5.0",
@@ -280,19 +280,19 @@ TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediation)
     std::string schemaStr;
 
     // Load file with schema.
-    bool valid = flatbuffers::LoadFile(flatbufferSchema.c_str(), false, &schemaStr);
+    bool valid = flatbuffers::LoadFile(FLATBUFFER_SCHEMA.c_str(), false, &schemaStr);
     EXPECT_TRUE(valid);
 
     // Parse schema.
     flatbuffers::Parser parser;
-    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonCve5Valid);
+    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_VALID);
     EXPECT_TRUE(valid);
 
     // Create a test Entry object with Windows remediations
     auto jbuf = parser.builder_.GetBufferPointer();
     flatbuffers::Verifier jverifier(jbuf, parser.builder_.GetSize());
-    EXPECT_TRUE(VerifyEntryBuffer(jverifier));
-    auto entry = GetEntry(jbuf);
+    EXPECT_TRUE(cve_v5::VerifyEntryBuffer(jverifier));
+    auto entry = cve_v5::GetEntry(jbuf);
 
     // Create a mock RocksDBWrapper object
     Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
@@ -320,19 +320,19 @@ TEST_F(StoreRemediationsModelTest, SkipsEmptyRemediations)
     std::string schemaStr;
 
     // Load file with schema.
-    bool valid = flatbuffers::LoadFile(flatbufferSchema.c_str(), false, &schemaStr);
+    bool valid = flatbuffers::LoadFile(FLATBUFFER_SCHEMA.c_str(), false, &schemaStr);
     EXPECT_TRUE(valid);
 
     // Parse schema.
     flatbuffers::Parser parser;
-    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonCve5EmptyWindows);
+    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_EMPTY_WINDOWS);
     EXPECT_TRUE(valid);
 
     // Create a test Entry object with Windows remediations
     auto jbuf = parser.builder_.GetBufferPointer();
     flatbuffers::Verifier jverifier(jbuf, parser.builder_.GetSize());
-    EXPECT_TRUE(VerifyEntryBuffer(jverifier));
-    auto entry = GetEntry(jbuf);
+    EXPECT_TRUE(cve_v5::VerifyEntryBuffer(jverifier));
+    auto entry = cve_v5::GetEntry(jbuf);
 
     // Create a mock RocksDBWrapper object
     Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
@@ -340,7 +340,7 @@ TEST_F(StoreRemediationsModelTest, SkipsEmptyRemediations)
     // Assert result.
     ::testing::internal::CaptureStderr();
     EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
-    std::string capturedSterr = ::testing::internal::GetCapturedStderr().c_str();
+    std::string capturedSterr = ::testing::internal::GetCapturedStderr();
     EXPECT_STREQ("Empty remediations.\n", capturedSterr.c_str());
 }
 
@@ -350,19 +350,19 @@ TEST_F(StoreRemediationsModelTest, SkipsEmptyUpdates)
     std::string schemaStr;
 
     // Load file with schema.
-    bool valid = flatbuffers::LoadFile(flatbufferSchema.c_str(), false, &schemaStr);
+    bool valid = flatbuffers::LoadFile(FLATBUFFER_SCHEMA.c_str(), false, &schemaStr);
     EXPECT_TRUE(valid);
 
     // Parse schema.
     flatbuffers::Parser parser;
-    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonCve5EmptyUpdates);
+    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_EMPTY_UPDATES);
     EXPECT_TRUE(valid);
 
     // Create a test Entry object with Windows remediations
     auto jbuf = parser.builder_.GetBufferPointer();
     flatbuffers::Verifier jverifier(jbuf, parser.builder_.GetSize());
-    EXPECT_TRUE(VerifyEntryBuffer(jverifier));
-    auto entry = GetEntry(jbuf);
+    EXPECT_TRUE(cve_v5::VerifyEntryBuffer(jverifier));
+    auto entry = cve_v5::GetEntry(jbuf);
 
     // Create a mock RocksDBWrapper object
     Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
@@ -370,7 +370,7 @@ TEST_F(StoreRemediationsModelTest, SkipsEmptyUpdates)
     // Assert result.
     ::testing::internal::CaptureStderr();
     EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
-    std::string capturedSterr = ::testing::internal::GetCapturedStderr().c_str();
+    std::string capturedSterr = ::testing::internal::GetCapturedStderr();
     EXPECT_STREQ("No updates available.\n", capturedSterr.c_str());
 }
 
@@ -380,19 +380,19 @@ TEST_F(StoreRemediationsModelTest, x_remediationsNotPresent)
     std::string schemaStr;
 
     // Load file with schema.
-    bool valid = flatbuffers::LoadFile(flatbufferSchema.c_str(), false, &schemaStr);
+    bool valid = flatbuffers::LoadFile(FLATBUFFER_SCHEMA.c_str(), false, &schemaStr);
     EXPECT_TRUE(valid);
 
     // Parse schema.
     flatbuffers::Parser parser;
-    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonCve5NoRemediations);
+    valid = parser.Parse(schemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_NO_REMEDIATIONS);
     EXPECT_TRUE(valid);
 
     // Create a test Entry object with Windows remediations
     auto jbuf = parser.builder_.GetBufferPointer();
     flatbuffers::Verifier jverifier(jbuf, parser.builder_.GetSize());
-    EXPECT_TRUE(VerifyEntryBuffer(jverifier));
-    auto entry = GetEntry(jbuf);
+    EXPECT_TRUE(cve_v5::VerifyEntryBuffer(jverifier));
+    auto entry = cve_v5::GetEntry(jbuf);
 
     // Create a mock RocksDBWrapper object
     Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
@@ -400,6 +400,6 @@ TEST_F(StoreRemediationsModelTest, x_remediationsNotPresent)
     // Assert result.
     ::testing::internal::CaptureStderr();
     EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
-    std::string capturedSterr = ::testing::internal::GetCapturedStderr().c_str();
+    std::string capturedSterr = ::testing::internal::GetCapturedStderr();
     EXPECT_STREQ("Fiel x_remediations not present.\n", capturedSterr.c_str());
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.h
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.h
@@ -1,0 +1,51 @@
+/*
+ * Wazuh storeRemediationsModel
+ * Copyright (C) 2015, Wazuh Inc.
+ * October 05, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _STORE_REMEDIATIONS_MODEL_TEST_H
+#define _STORE_REMEDIATIONS_MODEL_TEST_H
+#include "../../src/databaseFeedManager/storeRemediationsModel.hpp"
+#include "../../src/databaseFeedManager/databaseFeedManager.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+/**
+ * @brief This test class contains unit tests for the databaseFeedManager module.
+ */
+class StoreRemediationsModelTest : public ::testing::Test
+{
+protected:
+    /**
+     * @brief Construct a new Database Feed Manager Tests object
+     *
+     */
+    StoreRemediationsModelTest() = default;
+
+    /**
+     * @brief Destroy the Database Feed Manager Tests object
+     *
+     */
+    virtual ~StoreRemediationsModelTest() = default;
+
+    /**
+     * @brief SetUp.
+     *
+     */
+    void SetUp() override;
+
+    /**
+     * @brief TearDown.
+     *
+     */
+    void TearDown() override;
+};
+
+
+#endif //_STORE_REMEDIATIONS_MODEL_TEST_H

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.h
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.h
@@ -23,13 +23,13 @@ class StoreRemediationsModelTest : public ::testing::Test
 {
 protected:
     /**
-     * @brief Construct a new Database Feed Manager Tests object
+     * @brief Construct a new storeRemediationsModel Tests object
      *
      */
     StoreRemediationsModelTest() = default;
 
     /**
-     * @brief Destroy the Database Feed Manager Tests object
+     * @brief Destroy the storeRemediationsModel Tests object
      *
      */
     virtual ~StoreRemediationsModelTest() = default;


### PR DESCRIPTION
|Related issue|
|---|
|#19046|

## Objective

This pull request introduces a write interface that enables the storage of `Vulnerability Remediation` data from a CVE5 schema to the RocksDB database. With this enhancement, the vulnerability scanner can update and query data related to security vulnerabilities and their remediation efforts more efficiently and reliably. Adding this write interface significantly improves the system's capabilities, allowing for seamless integration of RocksDB as a data source, enhancing data storage speed, and providing a more robust foundation for managing security vulnerabilities within the application. This enhancement represents a critical step towards optimizing the performance and reliability of the Vulnerability Remediation feature.


## Description
- Implemented validation logic to verify the content of the CVE5 object.
- Added error-handling mechanisms to handle invalid or incomplete configurations.
- Included unit tests to verify the accuracy of the validation process.

For a better compression of the detailed work, please check this top-level sequence diagram

<details><summary>Sequence Diagram</summary>

</details>

## Quality Assurance
A new test has been included to verify the correct behavior and backward compatibility of this solution proposal.

<details><summary>Output testing 🟢 </summary>

```bash
[----------] 4 tests from StoreRemediationsModelTest
[ RUN      ] StoreRemediationsModelTest.UpdatesWindowsRemediation
[       OK ] StoreRemediationsModelTest.UpdatesWindowsRemediation (36 ms)
[ RUN      ] StoreRemediationsModelTest.SkipsEmptyRemediations
[       OK ] StoreRemediationsModelTest.SkipsEmptyRemediations (34 ms)
[ RUN      ] StoreRemediationsModelTest.SkipsEmptyUpdates
[       OK ] StoreRemediationsModelTest.SkipsEmptyUpdates (36 ms)
[ RUN      ] StoreRemediationsModelTest.x_remediationsNotPresent
[       OK ] StoreRemediationsModelTest.x_remediationsNotPresent (36 ms)
[----------] 4 tests from StoreRemediationsModelTest (145 ms total)
```

</details>

Regarding memory, no new memory allocations were introduced in this PR using `raw_pointers`.

<details><summary>ScanBuild report</summary>

Command:

```bash
scan-build-15 -enable-checker alpha.core.CastSize -enable-checker alpha.core.CastToStruct -enable-checker alpha.core.Conversion -enable-checker alpha.core.IdenticalExpr -enable-checker alpha.core.SizeofPtr -enable-checker alpha.core.TestAfterDivZero --exclude external make TARGET=server DEBUG=1 -j$(nproc)
```

```bash

Done building server

scan-build: No bugs found.

```

</details>

<details><summary>Clang-Format</summary>

```bash
---------------------------------
PASSED: Clang-format check passed
---------------------------------
```
</details>


## Exploratory tests
Not apply


### Check summary
- [x] Style and quality of SCA.
- [x] Documentation clear.
- [x] Functionality optimizated.