### PR TITLE
Fix AWS Security Lake memory leak when setting the wrong configuration

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -577,6 +577,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     } else {
                          // If the value is empty, raise error
                          merror("Invalid content for tag '%s': It cannot be empty", XML_SUBSCRIBER_QUEUE);
+                         OS_ClearNode(children);
                          return OS_INVALID;
                     }
                 } else if (!strcmp(children[j]->element, XML_AWS_EXTERNAL_ID)) {
@@ -586,6 +587,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     } else {
                          // If the value is empty, raise error
                          merror("Invalid content for tag '%s': It cannot be empty", XML_AWS_EXTERNAL_ID);
+                         OS_ClearNode(children);
                          return OS_INVALID;
                     }
                 } else if (!strcmp(children[j]->element, XML_IAM_ROLE_ARN)) {
@@ -595,6 +597,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     } else {
                          // If the value is empty, raise error
                          merror("Invalid content for tag '%s': It cannot be empty", XML_IAM_ROLE_ARN);
+                         OS_ClearNode(children);
                          return OS_INVALID;
                     }
                 } else if (!strcmp(children[j]->element, XML_IAM_ROLE_DURATION)){


### PR DESCRIPTION
|Related issue|
|---|
| #19518 |

## Description

<!--
Add a clear description of how the problem has been solved.
-->

Closes #19518. It fixes the memory leak produced when having empty values for the `sqs_name`, `external_id`, or `iam_role_arn` parameters of the `ossec.conf` file.


