### PR TITLE
Reject non ASCII characters in names

### DIFF
--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -32,7 +32,7 @@ _iso8601_date = re.compile(r'^([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9]
 _iso8601_date_time = re.compile(
     r'^([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])[tT](2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.['
     r'0-9]+)?([zZ]|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])$')
-_names = re.compile(r'^[\w\-.%]+$')
+_names = re.compile(r'^[\w\-.%]+$', re.ASCII)
 _numbers = re.compile(r'^\d+$')
 _numbers_or_all = re.compile(r'^(\d+|all)$')
 _wazuh_key = re.compile(r'[a-zA-Z0-9]+$')

--- a/api/test/integration/test_security_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_POST_endpoints.tavern.yaml
@@ -913,13 +913,23 @@ stages:
     response:
       status_code: 400
 
-  - name: Create a new user (invalid username parameter)
+  - name: Create a new user (invalid username parameter, integer)
     request:
       verify: False
       <<: *post_users_request
       json:
         password: "new_user11A"
         username: 1
+    response:
+      status_code: 400
+  
+  - name: Create a new user (invalid username parameter, non-ASCII)
+    request:
+      verify: False
+      <<: *post_users_request
+      json:
+        username: "new_user_啊"
+        password: "new_user"
     response:
       status_code: 400
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/19279 |

## Description

Added the `re.ASCII` flag to the `_names` regular expression to match ASCII characters only.

## Logs/Alerts example

<details><summary>POST /security/users</summary>

Request
```json
{
  "username": "test_啊",
  "password": "My_password01"
}
```

Response

`Status: 400 Bad Request`
```json
{
    "title": "Bad Request",
    "detail": "'test_啊' is not a 'names' - 'username'"
}
```

</details>
