### PR TITLE
Add support for the Server Name Indication TLS extension during automatic enroll

### DIFF
--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -244,7 +244,6 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
     if (1 != SSL_set_tlsext_host_name(cfg->ssl, server_address)) {
         mwarn("Unable to set SNI hostname: %s", server_address);
     }
-
     
     ERR_clear_error();
     int ret = SSL_connect(cfg->ssl);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -241,13 +241,10 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
     SSL_set_bio(cfg->ssl, sbio, sbio);
 
     /* Do SNI */
-    if (!strcmp(ip_address, server_address)) {
-        if (1 != SSL_set_tlsext_host_name(cfg->ssl, server_address)) {
-            merror("Unable to set SNI hostname: %s", server_address);
-        } else {
-            minfo("SNI Hostname set to: %s", server_address);
-        }
+    if (1 != SSL_set_tlsext_host_name(cfg->ssl, server_address)) {
+        merror("Unable to set SNI hostname: %s", server_address);
     }
+
     
     ERR_clear_error();
     int ret = SSL_connect(cfg->ssl);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -198,7 +198,6 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
     assert(server_address != NULL);
 
     char *ip_address = NULL;
-
     char *tmp_str = strchr(server_address, '/');
     if (tmp_str) {
         // server_address comes in {hostname}/{ip} format

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -242,7 +242,7 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
 
     /* Do SNI */
     if (1 != SSL_set_tlsext_host_name(cfg->ssl, server_address)) {
-        merror("Unable to set SNI hostname: %s", server_address);
+        mwarn("Unable to set SNI hostname: %s", server_address);
     }
 
     


### PR DESCRIPTION
|Related issue|
|---|
|None|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR adds support for sending the SNI extension when doing automatic enroll. This allows the server side to use (for example) reverse proxies to route the request to the correct backend location
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
None
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
None
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer