### PR TITLE
Remove wazuh-salt from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,6 @@ Here you can find all the automation tools maintained by the Wazuh team.
 
 * [Wazuh Bosh](https://github.com/wazuh/wazuh-bosh)
 
-* [Wazuh Salt](https://github.com/wazuh/wazuh-salt)
-
 ## Branches
 
 * `master` branch contains the latest code, be aware of possible bugs on this branch.


### PR DESCRIPTION
|Related issue|
|---|
None|| 

## Description
Remove [Wazuh Salt](https://github.com/wazuh/wazuh-salt) -> https://github.com/wazuh/wazuh-salt link from README.md **Orchestration** section as the link is broken.

