### PR TITLE
Fix to generate the CPE for Windows systems without the os_release field

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -3063,6 +3063,30 @@ void test_wm_vuldet_generate_win_cpe_w10_no_os_release(void **state) {
     assert_int_equal(ret, 1);
 }
 
+void test_wm_vuldet_generate_win_cpe_known_no_os_release(void **state) {
+    scan_agent *agent = *state;
+
+    int known_win_sys_without_os_release[] = {
+        FEED_WS2012, FEED_WS2012R2,
+        FEED_W8, FEED_W81
+    };
+
+    agent->dist = FEED_WIN;
+    agent->os_release = NULL;
+    agent->os_display_version = NULL;
+    agent->arch = strdup("x86_64");
+
+    for (int i = 0; i < array_size(known_win_sys_without_os_release); i++) {
+        agent->dist_ver = known_win_sys_without_os_release[i];
+        int ret = wm_vuldet_generate_win_cpe(agent);
+        assert_int_equal(ret, 0);
+        for (int i = 0; agent->agent_os_cpe && agent->agent_os_cpe[i]; i++) {
+            wm_vuldet_free_cpe(&agent->agent_os_cpe[i]);
+        }
+        os_free(agent->agent_os_cpe);
+    }
+}
+
 void test_wm_vuldet_generate_win_cpe_no_dist(void **state) {
     scan_agent *agent = *state;
 
@@ -23238,6 +23262,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_win_cpe_w11, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_win_cpe_w10_no_display_version, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_win_cpe_w10_no_os_release, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_win_cpe_known_no_os_release, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_win_cpe_no_dist, setup_scan_agent, teardown_scan_agent),
         // Tests wm_vuldet_compare_vendors
         cmocka_unit_test(test_wm_vuldet_compare_vendors_external_vendor),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6687,8 +6687,9 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     char *ver_aux = NULL;
     char *pr_name = NULL;
 
-    if (!agent->os_release && agent->dist_ver != FEED_WS2012 && agent->dist_ver != FEED_WS2012R2 &&
-        agent->dist_ver != FEED_W8 && agent->dist_ver != FEED_W81) {
+    // Note: There are versions of Windows that do not have the os_release field,
+    // such as Windows Server 2012 or Windows 8
+    if (!agent->os_release && !wm_vuldet_without_os_release(agent->dist_ver)) {
         mtwarn(WM_VULNDETECTOR_LOGTAG, VU_OSINFO_DISABLED, atoi(agent->agent_id));
     }
 
@@ -6698,7 +6699,7 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
         agent->os_display_version = ver_aux;
     } else if (agent->os_release != NULL) {
         ver_aux = agent->os_release;
-    } else {
+    } else if (!wm_vuldet_without_os_release(agent->dist_ver)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_WIN_CPE_GEN_ERROR, atoi(agent->agent_id));
         return 1;
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -916,6 +916,7 @@ typedef struct scan_ctx_t {
 #define wm_vuldet_is_cpe_wc(x) (!strcmp(x, "*") || !strcmp(x, "-"))
 #define wm_vulndet_undefined_cond(x) (!x || !strcmp(x, "-"))
 #define wm_vulndet_without_r2(x) (x == FEED_WS2008 || x == FEED_WS2012)
+#define wm_vuldet_without_os_release(x) (x == FEED_WS2012 || x == FEED_WS2012R2 || x == FEED_W8 || x == FEED_W81)
 
 
 // Function headers


### PR DESCRIPTION
|Related issue|
|---|
|#19345|

## Description

With this PR, we fix the generation of system CPEs for Windows versions that cannot get the os_release field by default.

This fix allows Vulnerability Detector to re-detect all system vulnerabilities for Windows Server 2012 and Windows 8 (which are the ones we know of with this problem), and indicate the hotfixes that fix it, verifying it through the MSU.

## Configuration options

```xml
    <provider name="msu">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
    </provider>

    <provider name="nvd">
      <enabled>yes</enabled>
      <update_interval>1m</update_interval>
    </provider>
```

## Logs/Alerts example

- Without the fix:
  - Windows Server 2012 R2:
```
2023/10/10 11:47:11 wazuh-modulesd:vulnerability-detector[36463] wm_vuln_detector.c:6702 at wm_vuldet_generate_win_cpe(): ERROR: (5594): Could not generate the OS CPE for the agent '003'
2023/10/10 11:47:11 wazuh-modulesd:vulnerability-detector[36463] wm_vuln_detector_nvd.c:3313 at wm_vuldet_add_dic_cpe(): DEBUG: (5446): The CPE 'a:wazuh:wazuh:4.6.0::::::x86:' from the agent '003' was indexed.
2023/10/10 11:47:11 wazuh-modulesd:vulnerability-detector[36463] wm_vuln_detector_nvd.c:3313 at wm_vuldet_add_dic_cpe(): DEBUG: (5446): The CPE 'a:mozilla:firefox:32.0::::::x86:' from the agent '003' was indexed.
```
- With the fix:
  - Windows Server 2012 R2:
```
wm_vuln_detector.c:2784 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5438): A full scan will be run on agent '005'
wm_vuln_detector.c:5670 at wm_vuldet_collect_agent_software(): DEBUG: (5437): Collecting agent '005' software.
wm_vuln_detector.c:6960 at wm_vuldet_insert_agent_data(): DEBUG: (5446): The CPE 'o:microsoft:windows_server_2012:r2::::::x64:' from the agent '005' was indexed.
```
----------
  - Windows Server 2016:
```
2023/10/10 23:22:56 wazuh-modulesd:vulnerability-detector[50963] wm_vuln_detector.c:2816 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5491): A baseline scan will be run on agent '003'
2023/10/10 23:22:56 wazuh-modulesd:vulnerability-detector[50963] wm_vuln_detector.c:5817 at wm_vuldet_collect_agent_software(): DEBUG: (5437): Collecting agent '003' software.
2023/10/10 23:22:56 wazuh-modulesd:vulnerability-detector[50963] wm_vuln_detector.c:7132 at wm_vuldet_insert_agent_data(): DEBUG: (5446): The CPE 'o:microsoft:windows_server_2016:1607::::::x64:' from the agent '003' was indexed.
```
------------
  - Windows 10:
```
2023/10/10 17:37:25 wazuh-modulesd:vulnerability-detector[42525] wm_vuln_detector.c:5817 at wm_vuldet_collect_agent_software(): DEBUG: (5437): Collecting agent '002' software.
2023/10/10 17:37:25 wazuh-modulesd:vulnerability-detector[42525] wm_vuln_detector.c:7132 at wm_vuldet_insert_agent_data(): DEBUG: (5446): The CPE 'o:microsoft:windows_10_21h2:10.0.19044.2846::::::x64:' from the agent '002' was indexed.
```

- Force `os_release` and `display_version` to `NULL`:
```
2023/10/10 18:02:41 wazuh-modulesd:vulnerability-detector[50963] wm_vuln_detector.c:2816 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5491): A baseline scan will be run on agent '002'
2023/10/10 18:02:41 wazuh-modulesd:vulnerability-detector[50963] wm_vuln_detector.c:5817 at wm_vuldet_collect_agent_software(): DEBUG: (5437): Collecting agent '002' software.
2023/10/10 18:02:41 wazuh-modulesd:vulnerability-detector[50963] wm_vuln_detector.c:6693 at wm_vuldet_generate_win_cpe(): WARNING: (5443): Unable to get the OS release for agent '002'. It may not have the OS inventory enabled.
2023/10/10 18:02:41 wazuh-modulesd:vulnerability-detector[50963] wm_vuln_detector.c:6703 at wm_vuldet_generate_win_cpe(): ERROR: (5594): Could not generate the OS CPE for the agent '002'
```
---------
  - Windows 11:
```
2023/10/10 13:52:50 wazuh-modulesd:vulnerability-detector[18948] wm_vuln_detector.c:2816 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5491): A baseline scan will be run on agent '001'
2023/10/10 13:52:50 wazuh-modulesd:vulnerability-detector[18948] wm_vuln_detector.c:5817 at wm_vuldet_collect_agent_software(): DEBUG: (5437): Collecting agent '001' software.
2023/10/10 13:52:50 wazuh-modulesd:vulnerability-detector[18948] wm_vuln_detector.c:7132 at wm_vuldet_insert_agent_data(): DEBUG: (5446): The CPE 'o:microsoft:windows_11_22h2:10.0.22621::::::x64:' from the agent '001' was indexed.
```

   - Force `os_release` and `display_version` to `NULL`:
```
wazuh-modulesd:vulnerability-detector[23089] wm_vuln_detector.c:6562 at wm_vuldet_generate_win_cpe(): ERROR: (5593): Could not generate the OS CPE for the agent '001'
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
![Screenshot from 2023-10-11 11-59-15](https://github.com/wazuh/wazuh/assets/37207742/0bfa5c2b-d0c7-4c3d-a259-557ad9ff6cbc)
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer


<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components
