### PR TITLE
Add update check configuration parameter to global config and construct

### DIFF
--- a/etc/templates/config/generic/global.template
+++ b/etc/templates/config/generic/global.template
@@ -11,4 +11,5 @@
     <email_log_source>alerts.log</email_log_source>
     <agents_disconnection_time>10m</agents_disconnection_time>
     <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
+    <update_check>yes</update_check>
   </global>

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -158,6 +158,7 @@ int Read_Global(const OS_XML *xml, XML_NODE node, void *configp, void *mailp)
     const char *xml_agents_disconnection_time = "agents_disconnection_time";
     const char *xml_agents_disconnection_alert_time = "agents_disconnection_alert_time";
     const char *xml_limits = "limits";
+    const char *xml_update_check = "update_check";
 
 
     const char *xml_emailto = "email_to";
@@ -400,6 +401,21 @@ int Read_Global(const OS_XML *xml, XML_NODE node, void *configp, void *mailp)
             }
             if (Config) {
                 Config->hostinfo = (u_int8_t) atoi(node[i]->content);
+            }
+        }
+        /* update check system */
+        else if (strcmp(node[i]->element, xml_update_check) == 0) {
+            if (strcmp(node[i]->content, "yes") == 0) {
+                if (Config) {
+                    Config->update_check = 1;
+                }
+            } else if (strcmp(node[i]->content, "no") == 0) {
+                if (Config) {
+                    Config->update_check = 0;
+                }
+            } else {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
             }
         }
         /* stats */

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -213,11 +213,12 @@ int Read_Global(const OS_XML *xml, XML_NODE node, void *configp, void *mailp)
             ww++;
         }
     }
-    /* update check system */
-    * Default values */
+
+    /* Default values */
     if (Config) {
         Config->update_check = 1;
     }
+    
     while (node[i]) {
         if (!node[i]->element) {
             merror(XML_ELEMNULL);

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -213,7 +213,11 @@ int Read_Global(const OS_XML *xml, XML_NODE node, void *configp, void *mailp)
             ww++;
         }
     }
-
+    /* update check system */
+    * Default values */
+    if (Config) {
+        Config->update_check = 1;
+    }
     while (node[i]) {
         if (!node[i]->element) {
             merror(XML_ELEMNULL);
@@ -401,21 +405,6 @@ int Read_Global(const OS_XML *xml, XML_NODE node, void *configp, void *mailp)
             }
             if (Config) {
                 Config->hostinfo = (u_int8_t) atoi(node[i]->content);
-            }
-        }
-        /* update check system */
-        else if (strcmp(node[i]->element, xml_update_check) == 0) {
-            if (strcmp(node[i]->content, "yes") == 0) {
-                if (Config) {
-                    Config->update_check = 1;
-                }
-            } else if (strcmp(node[i]->content, "no") == 0) {
-                if (Config) {
-                    Config->update_check = 0;
-                }
-            } else {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
-                return (OS_INVALID);
             }
         }
         /* stats */

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -41,6 +41,7 @@ typedef struct __Config {
     u_int8_t mailbylevel;
     u_int8_t logbylevel;
     u_int8_t logfw;
+    u_int8_t update_check;
     int decoder_order_size;
 
     /* Agent's disconnection global parameters */


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19256 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

As described in #19256, this PR tends to add the `<update_check>` configuration into the global config of the `ossec.conf`.


## Tests

The test performed was to test whether the config was enabled or disabled accordingly in the manager and error raised in case of a wrong value. Results can be seen [here](https://github.com/wazuh/wazuh/issues/19256#issuecomment-1760262009).  