### PR TITLE
Extend FreeBSD support

### DIFF
--- a/ruleset/sca/freebsd/cis_freebsd12.yml
+++ b/ruleset/sca/freebsd/cis_freebsd12.yml
@@ -1,0 +1,4194 @@
+# Security Configuration Assessment
+# CIS Checks for FreeBSD 12.x based on Wazuh SCA files 
+# Copyright (C) 2023, Wazuh Inc.
+# Copyright (C) 2023, Alonso Cárdenas Márquez <acm@FreeBSD.org>.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+#
+# Based on:
+# Center for Internet Security Benchmarks - 16-10-2023
+
+policy:
+  id: "cis_freebsd12"
+  file: "cis_freebsd12.yml"
+  name: "SCA policy for FreeBSD 12.x"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for FreeBSD 12.x."
+  references:
+    - https://www.cisecurity.org/cis-benchmarks/
+
+requirements:
+  title: "Check FreeBSD version."
+  description: "Requirements for running the SCA scan against FreeBSD 12.x"
+  condition: all
+  rules:
+    - "f:/etc/os-release -> r:^NAME=FreeBSD"
+    - "c:sysctl -n kern.ostype -> r:^FreeBSD"
+    - "c:sysctl -n kern.osrelease -> r:^12."
+
+checks:
+  ###############################################
+  # 1 Initial setup
+  ###############################################
+  ###############################################
+  # 1.1 Filesystem Configuration
+  ###############################################
+  ###############################################
+  # 1.1.1 Disable unused filesystems
+  ###############################################
+  # 1.1.1.1 Ensure mounting of fusefs filesystems is disabled
+  - id: 40000
+    title: Ensure mounting of fusefs filesystems is disabled.
+    description: >
+      FUSE makes it possible to implement a filesystem in a userspace program.
+      Features include: simple yet comprehensive API, secure mounting by non-root
+      users, support for FreeBSD kernels, multi-threaded operation.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="fusefs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload fusefs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m fusefs -> r:fusefs && !r:fusefs$"    
+      
+  # 1.1.1.2 Ensure mounting of fdescfs filesystems is disabled (Automated)
+  - id: 40001
+    title: Ensure mounting of fdescfs filesystems is disabled.
+    description: >
+      The file-descriptor file system, or fdescfs, provides access to the per-
+      process file descriptor namespace in the global file system namespace.
+      The conventional mount point is /dev/fd
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="fdescfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload fdescfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m fdescfs -> r:fdescfs && !r:fdescfs$"    
+
+  # 1.1.1.3 Ensure mounting of smbfs filesystems is disabled (Automated)
+  - id: 40002
+    title: Ensure mounting of smbfs filesystems is disabled.
+    description: >
+      The SMB driver is an implementation of the CIFS (Common Internet
+      Filesystem) network protocol.
+
+      The smbfs filesystem driver supports only the obsolete SMBv1 protocol.
+      smbfs has known bugs and likely has security vulnerabilities.  smbfs and
+      userspace counterparts smbutil(1) and mount_smbfs(8) may be removed from
+      a future version of FreeBSD.  Users are advised to evaluate the
+      sysutils/fusefs-smbnetfs port instead.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="smbfsfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload smbfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.3"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m smbfs -> r:smbfs && !r:smbfs$"    
+      
+  # 1.1.1.4 Ensure mounting of nfscl filesystems is disabled (Automated)
+  - id: 40003
+    title: Ensure mounting of nfscl filesystems is disabled.
+    description: >
+      FUSE makes it possible to implement a filesystem in a userspace program.
+      Features include: simple yet comprehensive API, secure mounting by non-root
+      users, support for FreeBSD kernels, multi-threaded operation.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="nfscl"
+
+      Run the following command to unload the fusefs module:
+      # kldunload nfscl
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.4"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m nfscl -> r:nfscl && !r:nfscl$"    
+  
+  # 1.1.1.5 Ensure mounting of nfsd filesystems is disabled (Automated)
+  - id: 40004
+    title: Ensure mounting of nfsd filesystems is disabled.
+    description: >
+     The nfsd utility runs on a server machine to service NFS requests from
+     client machines.  At least one nfsd must be running for a machine to
+     operate as a server.
+
+     Unless otherwise specified, eight servers per CPU for UDP transport are
+     started.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="nfsd"
+
+      Run the following command to unload the fusefs module:
+      # kldunload nfsd
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m nfsd -> r:nfsd && !r:nfsd$"    
+  
+  # 1.1.1.6 Ensure mounting of msdosfs filesystems is disabled (Automated)
+  - id: 40005
+    title: Ensure mounting of msdosfs filesystems is disabled.
+    description: >
+      The msdosfs driver will permit the FreeBSD kernel to read and write MS-
+      DOS based file systems.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="msdosfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload msdosfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.6"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m msdosfs -> r:msdosfs && !r:msdosfs$"    
+        
+  # 1.1.1.7 Ensure mounting of cd9660 filesystems is disabled (Automated)
+  - id: 40006
+    title: Ensure mounting of cd9660 filesystems is disabled.
+    description: >
+      The cd9660 driver will permit the FreeBSD kernel to access the cd9660
+      file system.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="cd9660"
+
+      Run the following command to unload the fusefs module:
+      # kldunload cd9660
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.7"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m cd9660 -> r:cd9660 && !r:cd9660$"    
+  
+  # 1.1.1.8 Ensure mounting of procfs is disabled (Automated)
+  - id: 40007
+    title: Ensure mounting of procfs filesystems is disabled.
+    description: >
+      The procfs provides a two-level view of process space, unlike the
+      previous FreeBSD 1.1 procfs implementation.  At the highest level,
+      processes themselves are named, according to their process ids in
+      decimal, with no leading zeros.  There is also a special node called
+      curproc which always refers to the process making the lookup request.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="procfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload procfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.8"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m procfs -> r:procfs && !r:procfs$"    
+            
+  # 1.1.1.9 Ensure mounting of pseudofs is disabled (Automated)
+  - id: 40008
+    title: Ensure mounting of pseudofs filesystems is disabled.
+    description: >
+      The pseudofs module offers an abstract API for pseudo-file systems such
+      as procfs(5) and linprocfs(5).  It takes care of all the hairy bits like
+      interfacing with the VFS system, enforcing access control, keeping track
+      of file numbers, and cloning files and directories that are process-
+      specific.  The consumer module, i.e., the module that implements the
+      actual guts of the file system, needs only provide the directory
+      structure (represented by a collection of structures declared and
+      initialized by macros provided by pseudofs) and callbacks that report
+      file attributes or write the actual file contents into sbufs.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="pseudofs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload pseudofs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.9"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m pseudofs -> r:pseudofs && !r:pseudofs$"    
+
+  ###############################################
+  # 1.1.2 Configure /tmp
+  ###############################################
+  # 1.1.2.1 Ensure /tmp is a separate partition. (Automated)
+  - id: 40009
+    title: "Ensure /tmp is a separate partition."
+    description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
+    rationale: "Making /tmp its own file system allows an administrator to set additional mount options such as the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hard link to a system setuid program and wait for it to be updated. Once the program was updated, the hard link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp."
+    impact: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. Running out of /tmp space is a problem regardless of what kind of filesystem lies under it, but in a configuration where /tmp is not a separate file system it will essentially have the whole disk available, as the default installation only creates a single / partition. On the other hand, a RAM-based /tmp (as with tmpfs) will almost certainly be much smaller, which can lead to applications filling up the filesystem much more easily. Another alternative is to create a dedicated partition for /tmp from a separate volume or disk. One of the downsides of a disk-based dedicated partition is that it will be slower than tmpfs which is RAM-based. /tmp utilizing tmpfs can be resized using the size={size} parameter in the relevant entry in /etc/fstab."
+    remediation: "For specific configuration requirements of the /tmp mount for your environment, modify /etc/fstab: Configure /etc/fstab as appropriate: Example: tmpfs /tmp tmpfs rw,nosuid,noexec 0 0"
+    references:
+      - "https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/"
+      - "https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html"
+    compliance:
+      - cis: ["1.1.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s'
+
+  # 1.1.2.2 Ensure nodev option set on /tmp partition. (No apply)
+  - id: 40010
+    title: "Ensure nodev option set on /tmp partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s && r:nodev'
+      - 'c: zfs get -H -o value devices /tmp -> r:off'
+
+  # 1.1.2.3 Ensure noexec option set on /tmp partition. (Automated)
+  - id: 40011
+    title: "Ensure noexec option set on /tmp partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s && r:noexec'
+      - 'c: zfs get -H -o value exec /tmp -> r:off'   
+
+  # 1.1.2.4 Ensure nosuid option set on /tmp partition. (Automated)
+  - id: 40012
+    title: "Ensure nosuid option set on /tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s\s*/tmp\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /tmp -> r:off'      
+
+  ###############################################
+  # 1.1.3 Configure /var
+  ###############################################
+  # 1.1.3.1 Ensure separate partition exists for /var.
+  - id: 40013
+    title: "Ensure separate partition exists for /var."
+    description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
+    rationale: "The default installation only creates a single / partition. Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var and cause unintended behavior across the system as the disk is full. Fine grained control over the mount Configuring /var as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behaviour."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.3.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:/var\s'   
+
+  # 1.1.3.2 Ensure nodev option set on /var partition.
+  - id: 40014
+    title: "Ensure nodev option set on /var partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /var with the configured options: # mount -u -o /var. On ZFS filesystem do the following: zfs set devices=off mypool/var"
+    compliance:
+      - cis: ["1.1.3.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:/var\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var -> r:off'      
+
+  # 1.1.3.3 Ensure nosuid option set on /var partition.
+  - id: 40015
+    title: "Ensure nosuid option set on /var partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /var with the configured options: # mount -u -o /var. On ZFS filesystem do the following: zfs set setuid=off mypool/var"
+    compliance:
+      - cis: ["1.1.3.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:/var\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var -> r:off'      
+
+  ###############################################
+  # 1.1.4 Configure /var/tmp
+  ###############################################
+  # 1.1.4.1 Ensure separate partition exists for /var/tmp. (Automated)
+  - id: 40016
+    title: "Ensure separate partition exists for /var/tmp."
+    description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications. Temporary files residing in /var/tmp are to be preserved between reboots."
+    rationale: "The default installation only creates a single / partition. Since the /var/tmp directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var/tmp and cause the potential disruption to daemons as the disk is full. Configuring /var/tmp as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/tmp. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate. "
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.4.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s'
+
+  # 1.1.4.2 Ensure nodev option set on /var/tmp partition. (No apply)
+  - id: 40017
+    title: "Ensure nodev option set on /var/tmp partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set devices=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/tmp -> r:off'      
+
+  # 1.1.4.3 Ensure noexec option set on /var/tmp partition. (Automated)
+  - id: 40018
+    title: "Ensure noexec option set on /var/tmp partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set exec=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/tmp -> r:off'      
+
+  # 1.1.4.4 Ensure nosuid option set on /var/tmp partition. (Automated)
+  - id: 40019
+    title: "Ensure nosuid option set on /var/tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set setuid=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -u /var/tmp -> r:\s/var/tmp\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/tmp -> r:off'      
+
+  ###############################################
+  # 1.1.5 Configure /var/log
+  ###############################################
+  # 1.1.5.1 Ensure separate partition exists for /var/log. (Automated)
+  - id: 40020
+    title: "Ensure separate partition exists for /var/log."
+    description: "The /var/log directory is used by system services to store log data."
+    rationale: "The default installation only creates a single / partition. Since the /var/log directory contains log files which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. Fine grained control over the mount Configuring /var/log as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. As /var/log contains log files, care should be taken to ensure the security and integrity of the data and mount point."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.5.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s'    
+
+  # 1.1.5.2 Ensure nodev option set on /var/log partition. (Automated)
+  - id: 40021
+    title: "Ensure nodev option set on /var/log partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/log filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set devices=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/log -> r:off'      
+
+  # 1.1.5.3 Ensure noexec option set on /var/log partition. (Automated)
+  - id: 40022
+    title: "Ensure noexec option set on /var/log partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot run executable binaries from /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set exec=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/log -> r:off'      
+
+  # 1.1.5.4 Ensure nosuid option set on /var/log partition. (Automated)
+  - id: 40023
+    title: "Ensure nosuid option set on /var/log partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot create setuid files in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set setuid=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/log -> r:off'      
+
+  ###############################################
+  # 1.1.6 Configure /var/audit
+  ###############################################
+  # 1.1.6.1 Ensure separate partition exists for /var/audit. (Automated)
+  - id: 40024
+    title: "Ensure separate partition exists for /var/audit."
+    description: "The auditing daemon, auditd, stores log data in the /var/audit directory."
+    rationale: "The default installation only creates a single / partition. Since the /var/audit directory contains the audit log files which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. Configuring /var/audit as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. As /var/audit contains audit logs, care should be taken to ensure the security and integrity of the data and mount point."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/audit. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.6.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s'
+
+  # 1.1.6.2 Ensure nodev option set on /var/log/audit partition. (Automated)
+  - id: 40025
+    title: "Ensure nodev option set on /var/audit partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/audit filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/audit partition. Example: <device> /var/log/audit <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/log/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set devices=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/audit -> r:off'      
+
+  # 1.1.6.3 Ensure noexec option set on /var/log/audit partition. (Automated)
+  - id: 40026
+    title: "Ensure noexec option set on /var/audit partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/audit filesystem is only intended for audit logs, set this option to ensure that users cannot run executable binaries from /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var partition. Example: <device> /var/audit <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set exec=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/audit -> r:off'      
+
+  # 1.1.6.4 Ensure nosuid option set on /var/log/audit partition. (Automated)
+  - id: 40027
+    title: "Ensure nosuid option set on /var/audit partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/audit filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/audit partition. Example: <device> /var/audit <fstype> rw,nosuid,noexec,relatime 0 0 Run the following command to remount /var/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set setuid=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/audit -> r:off'      
+
+  ###############################################
+  # 1.1.7 Configure /usr/home
+  ###############################################
+  # 1.1.7.1 Ensure separate partition exists for /usr/home. (Automated)
+  - id: 40028
+    title: "Ensure separate partition exists for /usr/home."
+    description: "The /usr/home directory is used to support disk storage needs of local users."
+    rationale: "The default installation only creates a single / partition. Since the /usr/home directory contains user generated data, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /usr/home and impact all local users. Configuring /usr/home as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. In the case of /usr/home options such as quota may be considered to limit the impact that users can have on each other with regards to disk resource exhaustion."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /usr/home. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.7.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s'
+
+  # 1.1.7.2 Ensure nodev option set on /usr/home partition. (Automated)
+  - id: 40029
+    title: "Ensure nodev option set on /usr/home partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /usr/home filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /home."
+    remediation: "IF the /usr/home partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /usr/home partition. Example: <device> /usr/home <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /usr/home with the configured options: # mount -u -o /usr/home. On ZFS filesystem do the following: zfs set devices=off mypool/usr/home"
+    compliance:
+      - cis: ["1.1.7.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s && r:nodev'
+      - 'c: zfs get -H -o value devices /usr/home -> r:off'      
+
+  # 1.1.7.3 Ensure nosuid option set on /usr/home partition. (Automated)
+  - id: 40030
+    title: "Ensure nosuid option set on /usr/home partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /usr/home filesystem is only intended for user file storage, set this option to ensure that users cannot create setuid files in /usr/home."
+    remediation: "IF the /usr/home partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /usr/home partition. Example: <device> /usr/home <fstype> rw,nosuid 0 0 Run the following command to remount /usr/home with the configured options: # mount -u -o /usr/home. On ZFS filesystem do the following: zfs set setuid=off mypool/usr/home"
+    compliance:
+      - cis: ["1.1.7.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /usr/home -> r:off'      
+
+  ###############################################
+  # 1.1.8 Configure /dev/shm (No apply. It could be a tmpfs)
+  ###############################################
+
+  # 1.1.9 Disable Automounting. (Automated)
+  - id: 40031
+    title: "Disable Automounting."
+    description: "autofs or automount allows automatic mounting of devices, typically including CD/DVDs and USB drives."
+    rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in the filesystem even if they lacked permissions to mount it themselves."
+    impact: "The use of portable hard drives is very common for workstation users. If your organization allows the use of portable storage or media on workstations and physical access controls to workstations are considered adequate there is little value add in turning off automounting."
+    remediation: "If there are no other packages that depends on autofs or automount,  disable it with: # pkg remove automount; kldunload autofs; sysrc autofs_enable=NO"
+    compliance:
+      - cis: ["1.1.9"]
+      - cis_csc_v8: ["10.3"]
+      - cis_csc_v7: ["8.5"]
+      - cmmc_v2.0: ["MP.L2-3.8.7"]
+      - hipaa: ["164.310(d)(1)"]
+      - iso_27001-2013: ["A.12.2.1"]
+      - mitre_techniques: ["T1068", "T1203", "T1211", "T1212"]
+    condition: all
+    rules:
+      - "not c: sysctl -n vfs.usermount -> r:1"
+      - "c: kldstat -m autofs -> r:autofs && !r:autofs$"
+      - "not c: sysrc -n autofs_enable -> r:YES"
+      - "not c: pkg query %n-%v automount -> r:automount"   
+
+  # 1.1.10 Disable USB Storage. (Automated)   
+
+  ###############################################
+  # 1.2 Configure Software Updates
+  ###############################################
+  # 1.2.1 Ensure package manager repositories are configured. (Manual) - Not Implemented
+  # 1.2.2 Ensure updates, patches, and additional security software are installed. (Manual)
+  - id: 40032
+    title: "Ensure updates, patches, and additional security software are installed."
+    description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
+    rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
+    remediation: "Run the following command to update all packages following local site policy guidance on applying updates and patches: # pkg upgrade."
+    compliance:
+      - cis: ["1.2.1"]
+      - cis_csc_v8: ["7.3"]
+      - cis_csc_v7: ["3.4", "3.5"]
+      - cmmc_v2.0: ["SI.L1-3.14.1"]
+      - mitre_mitigations: ["M1051"]
+      - mitre_tactics: ["TA0004", "TA0008"]
+      - mitre_techniques: ["T1211"]
+      - nist_sp_800-53: ["SI-2(2)"]
+      - pci_dss_v3.2.1: ["6.2"]
+      - soc_2: ["CC7.1"]
+    condition: all
+    rules:
+      - "c:pkg upgrade -n -> r:^Your packages are up to date"
+        
+  ###############################################
+  # 1.3 Filesystem Integrity Checking
+  ###############################################
+  # 1.3.1 Ensure AIDE is installed. (Automated)
+  - id: 40033
+    title: "Ensure AIDE is installed."
+    description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
+    rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
+    remediation: "Install AIDE using the appropriate package manager or manual installation: # apt install aide aide-common Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options. Run the following commands to initialize AIDE: # aideinit # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db."
+    compliance:
+      - cis: ["1.3.1"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_techniques: ["T1036", "T1036.002", "T1036.003", "T1036.004", "T1036.005", "T1565", "T1565.001"]
+      - nist_sp_800-53: ["AC-6(9)"]
+      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "not c: pkg query %n-%v aide -> r:aide"
+       
+  # 1.3.2 Ensure filesystem integrity is regularly checked. (Automated)
+  - id: 40034
+    title: "Ensure filesystem integrity is regularly checked."
+    description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
+    rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
+    remediation: "If cron will be used to schedule and run aide check Run the following command: # crontab -u root -e Add the following line to the crontab: 0 5 * * * /usr/local/bin/aide --check."
+    references:
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.service"
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.timer"
+    compliance:
+      - cis: ["1.3.2"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - nist_sp_800-53: ["AU-2"]
+      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "c:crontab -l -> r:aide --check"
+
+  ###############################################
+  # 1.4 Secure Boot Settings
+  ###############################################
+  # 1.4.1 Ensure bootloader password is set. (Automated)
+  - id: 40035
+    title: "Ensure bootloader password is set."
+    description: "Setting the bootloader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
+    rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering bootloader menu. This prevents users from weakening security."
+    impact: 'If password protection is enabled, only the designated superuser can select any option of boot menu item.'
+    remediation: 'Add password="your_password_here" to /boot/loader.conf .'
+    compliance:
+      - cis: ["1.4.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1046"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1542"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/boot/loader.conf -> r:^password'
+
+  # 1.4.2 Ensure permissions on bootloader config are configured. (Automated)
+  - id: 40036
+    title: "Ensure permissions on bootloader config are configured."
+    description: "The bootloader configuration file contains information on boot settings and passwords for unlocking boot options."
+    rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
+    remediation: "Run the following commands to set permissions on your grub configuration: # chown root:wheel /boot/loader.conf # chmod 640 /boot/loader.conf."
+    compliance:
+      - cis: ["1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005", "TA0007"]
+      - mitre_techniques: ["T1542"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /boot/loader.conf -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /boot/loader.conf -> r:^root:wheel"
+
+  # 1.4.3 Ensure authentication required for single user mode. (Automated)
+  - id: 40037
+    title: "Ensure authentication required for single user mode."
+    description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
+    rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
+    remediation: "Run the following command and follow the prompts to set a password for the root user: # passwd root and change console line into /etc/ttys from secure to insecure."
+    compliance:
+      - cis: ["1.4.3"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/ttys -> r:^console && r:insecure'
+
+  ###############################################
+  # 1.5 Additional Process Hardening
+  ###############################################
+  # 1.5.1 Ensure address space layout randomization (ASLR) is enabled
+  - id: 40038
+    title: Ensure address space layout randomization (ASLR) is enabled.
+    description: >
+      Address space layout randomization (ASLR) is an exploit mitigation technique which
+      randomly arranges the address space of key data areas of a process.
+    rationale: >
+      Randomly placing virtual memory regions will make it difficult to write memory page
+      exploits as the memory placement will be consistently shifting.
+    remediation: >
+      Set the following parameter in /etc/sysctl.conf file:
+      kern.elf64.aslr.enable=1
+      kern.elf64.aslr.stack=1
+      kern.elf64.aslr.shared_page=1
+      kern.elf64.aslr.pie_enable=1
+      kern.elf32.aslr.stack=1 
+
+      Run the following command to set the active kernel parameter:
+      # sysctl kern.elf64.aslr.enable=1
+      # sysctl kern.elf64.aslr.stack=1
+      # sysctl kern.elf64.aslr.shared_page=1
+      # sysctl kern.elf64.aslr.pie_enable=1
+      # sysctl kern.elf32.aslr.stack=1 
+    compliance:
+      - cis: ["1.5.1"]
+      - cis_csc: ["8.3"]
+    condition: all
+    rules:
+      - "c:sysctl -n kern.elf64.aslr.enable -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.stack -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.shared_page -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.pie_enable -> r:1"
+      - "c:sysctl -n kern.elf32.aslr.stack -> r:1"      
+      
+  # 1.5.2 Ensure core dumps are restricted (Automated)
+  - id: 40039
+    title: "Ensure core dumps are restricted."
+    description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
+    rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). ."
+    remediation: > 
+      Set the following parameter in /etc/sysctl.conf file:
+      kern.coredump=0
+      kern.corefile=/dev/null
+      or            
+      # sysrc dumpdev="NO"     
+      Run the following command to set the active kernel parameter:
+      # sysctl kern.coredump=0
+      # sysctl kern.corefile=/dev/null      
+    compliance:
+      - cis: ["1.5.2"]
+      - mitre_techniques: ["T1005"]
+      - mitre_tactics: ["TA0007"]
+    condition: all
+    rules:
+      - "c:sysctl -n kern.coredump -> r:0"
+      - "c:sysctl -n kern.corefile -> r:/dev/null"      
+      - "c:sysrc -n dumpdev -> r:NO"
+
+  ###############################################
+  # 1.6 Mandatory Access Control
+  ###############################################
+  ###############################################
+  # 1.6.1 Configure TrustedBSD Mandatory Access Control
+  ###############################################  
+  # 1.6.1.1 Ensure TrustedBSD Mandatory Access Control is installed. (Automated)
+  - id: 40040
+    title: "Ensure TrustedBSD Mandatory Access Control is installed."
+    description: "TrustedBSD provides Mandatory Access Controls."
+    rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
+    remediation: "Enable TrustedBSD Mandatory Access Control. # sysctl kern.features.security_mac=1"
+    compliance:
+      - cis: ["1.6.1.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1068", "T1565", "T1565.001", "T1565.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n kern.features.security_mac -> r:1'
+
+  # 1.6.1.2 Ensure TrustedBSD MAC is not disabled in bootloader configuration. (Automated)
+  - id: 40041
+    title: "Ensure TrustedBSD MAC is not disabled in loader configuration."
+    description: "Configure TrustedBSD MAC to be enabled at boot time and verify that it has not been overwritten by the loader parameters."
+    rationale: "TrustedBSD MAC is enabled into kernel by default but it can be disabled from loader.conf."
+    impact: "Files created while TrustedBSD MAC is disabled are not labeled at all. This behavior causes problems when changing to enforcing mode because files are labeled incorrectly or are not labeled at all. To prevent incorrectly labeled and unlabeled files from causing problems, file systems are automatically relabeled when changing from the disabled state to permissive or enforcing mode. This can be a long running process that should be accounted for as it may extend downtime during initial re-boot."
+    remediation: "Remove instance of kern.features.security_mac=0 from /boot/loader.conf."
+    compliance:
+      - cis: ["1.6.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: none
+    rules:
+      - 'not f:/boot/loader.conf -> r:kern.features.security_mac=0'
+
+  ###############################################
+  # 1.7 Command Line Warning Banners
+  ###############################################
+  # 1.7.1 Ensure message of the day is configured properly. (Automated)
+  - id: 40042
+    title: "Ensure message of the day is configured properly."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform."
+    rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
+    remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy. Add or update the message text to follow local site policy. Example Text: # echo \"Authorized use only. All activity may be monitored and reported.\" > /etc/motd.template -- OR -- If the motd is not used, you can remove content inside of /etc/motd.template file and run # service motd restart."
+    compliance:
+      - cis: ["1.7.1"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1082", "T1592", "T1592.004"]
+    condition: all
+    rules:
+      - "f:/var/run/motd"
+      - "not f:/etc/motd"      
+
+  # 1.7.2 Ensure permissions on /etc/motd.template are configured. (Automated)
+  - id: 40043
+    title: "Ensure permissions on /etc/motd.template are configured."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
+    rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/motd, /etc/motd.template and /var/run/motd : # chown root:wheel /etc/motd /etc/motd.template /var/run/motd # chmod 644 /etc/motd /etc/motd.template /var/run/motd -- OR -- Run the following command to remove the /etc/motd file: # rm /etc/motd."
+    compliance:
+      - cis: ["1.7.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - "c:stat -f %Sp /etc/motd.template -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/motd.template -> r:^root:wheel"    
+      - "c:stat -f %Sp /etc/motd -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/motd -> r:^root:wheel"
+      - "c:stat -f %Sp /var/run/motd -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /var/run/motd -> r:^root:wheel"            
+
+  ###############################################
+  # 1.8 GNOME Display Manager
+  ###############################################
+  # 1.8.1 Ensure GNOME Display Manager is removed. (Automated)
+  - id: 40044
+    title: "Ensure GNOME Display Manager is removed."
+    description: "The GNOME Display Manager (GDM) is a program that manages graphical display servers and handles graphical user logins."
+    rationale: "If a Graphical User Interface (GUI) is not required, it should be removed to reduce the attack surface of the system."
+    impact: "Removing the GNOME Display manager will remove the Graphical User Interface (GUI) from the system."
+    remediation: "Run the following command to uninstall gdm3: # apt purge gdm3."
+    compliance:
+      - cis: ["1.8.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v gdm -> !r:gdm"    
+
+  # 1.8.2 Ensure GDM login banner is configured. (Automated) - Not Implemented
+  # 1.8.3 Ensure GDM disable-user-list option is enabled. (Automated) - Not Implemented
+  # 1.8.4 Ensure GDM screen locks when the user is idle. (Automated) - Not Implemented
+  # 1.8.5 Ensure GDM screen locks cannot be overridden. (Automated) - Not Implemented
+  # 1.8.6 Ensure GDM automatic mounting of removable media is disabled. (Automated) - Not Implemented
+  # 1.8.7 Ensure GDM disabling automatic mounting of removable media is not overridden. (Automated) - Not Implemented
+  # 1.8.8 Ensure GDM autorun-never is enabled. (Automated) - Not Implemented
+  # 1.8.9 Ensure GDM autorun-never is not overridden. (Automated) - Not Implemented
+
+  # 1.8.10 Ensure XDCMP is not enabled. (Automated)
+  - id: 40045
+    title: "Ensure XDCMP is not enabled."
+    description: "X Display Manager Control Protocol (XDMCP) is designed to provide authenticated access to display management services for remote displays."
+    rationale: "XDMCP is inherently insecure. - XDMCP is not a ciphered protocol. This may allow an attacker to capture keystrokes entered by a user - XDMCP is vulnerable to man-in-the-middle attacks. This may allow an attacker to steal the credentials of legitimate users by impersonating the XDMCP server."
+    remediation: "Edit the file /usr/local/etc/gdm/custom.conf and remove the line: Enable=true."
+    compliance:
+      - cis: ["1.8.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1050"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1040", "T1056", "T1056.001", "T1557"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - 'not f:/usr/local/etc/gdm/custom.conf -> r:^\s*Enable\s*=\s*true'
+      
+  ############################################################
+  # 2 Services
+  ############################################################
+  # 2.1 Configure Time Synchronization
+  # 2.1.1 Ensure time synchronization is in use
+  # 2.1.1.1 Ensure a single time synchronization daemon is in use. (Automated)
+  - id: 40046
+    title: "Ensure a single time synchronization daemon is in use."
+    description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them. Note: - On virtual systems where host based time synchronization is available consult your virtualization software documentation and verify that host based synchronization is in use and follows local site policy. Only one time synchronization method should be in use on the system. Configuring multiple time synchronization methods could lead to unexpected or unreliable results."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
+    remediation: "On physical systems, and virtual systems where host based time synchronization is not available. Select one of the three time synchronization daemons; ntpdate (1), ntpd (2) or chrony (3), and following the remediation procedure for the selected daemon. Note: enabling more than one synchronization daemon could lead to unexpected or unreliable results: 1. # sysrc ntpdate_enable=YES 2. # sysrc ntpd_enable=YES; # service ntpd start 3. # sysrc chronyd_enable=YES"
+    compliance:
+      - cis: ["2.1.1.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: any
+    rules:
+      - "c:sysrc -n ntpdate_enable -> r:YES"
+      - "c:sysrc -n ntpd_enable -> r:YES"    
+      - "c:sysrc -n chronyd_enable -> r:YES"               
+
+  # 2.1.2 Configure chrony
+  # 2.1.2.1 Ensure chrony is configured with authorized timeserver. (Manual)
+  - id: 40047
+    title: "Ensure chrony is configured with authorized timeserver."
+    description: "The server directive specifies an NTP server which can be used as a time source. The client-server relationship is strictly hierarchical: a client might synchronize its system time to that of the server, but the server's system time will never be influenced by that of a client. The syntax of pool directive is similar to that for the server directive, except that it is used to specify a pool of NTP servers rather than a single NTP server. The pool name is expected to resolve to multiple addresses which might change over time."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /use/local/etc/chrony/chrony.conf file and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]>. Run one of the following commands to load the updated time sources into chronyd running config: # service chronyd restart OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:pgrep -l chrony -> r:chronyd"
+      - 'f:/usr/local/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
+
+  # 2.1.2.2 Ensure chrony is running as user chrony. (Automated)
+  - id: 40048
+    title: "Ensure chrony is running as user chrony or ntpd."
+    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
+    rationale: "The chronyd service should run with only the required privileges."
+    remediation: "Add or edit the user line to /usr/local/etc/chrony/chrony.conf : user chrony|ntpd OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: any
+    rules:
+      - "c:pgrep -U chrony -l chronyd"    
+      - "c:pgrep -U ntpd -l chronyd"
+
+  # 2.1.2.3 Ensure chrony is enabled and running. (Automated)
+  - id: 40049
+    title: "Ensure chrony is enabled and running."
+    description: "chrony is a daemon for synchronizing the system clock across the network."
+    rationale: "chrony needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF chrony is in use on the system, run the following commands: Run the following command to enable and start chronyd service: # service chronyd enable; # service chronyd start OR If another time synchronization service is in use on the system, run the following command to remove chrony: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n chronyd_enable -> r:^YES"
+      - "c:service chronyd status -> r:^chronyd is running as pid"
+
+  # 2.1.3.1 Ensure ntp access control is configured. (Automated)
+  - id: 40050
+    title: "Ensure ntp access control is configured."
+    description: 'NTP access control is a security measure used to prevent fraudulent or inadvertent manipulation of a time server'
+    rationale: "If ntp is in use on the system, proper configuration is vital to ensuring time synchronization is accurate."
+    remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery OR If another time synchronization service is in use on the system, run the following command to stop ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+    compliance:
+      - cis: ["2.1.3.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1498", "T1498.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - 'f:/etc/ntp.conf -> r:^restrict\s*\t*-4\s*\t*default|^restrict\s*\t*default && r:\s*kod && r:\s*nomodify && r:\s*notrap && r:\s*nopeer && r:\s*noquery'
+      - 'f:/etc/ntp.conf -> r:^restrict\s*\t*-6\s*\t*default && r:\s*kod && r:\s*nomodify && r:\s*notrap && r:\s*nopeer && r:\s*noquery'
+
+  # 2.1.3.2 Ensure ntp is configured with authorized timeserver. (Manual)
+  - id: 40051
+    title: "Ensure ntp is configured with authorized timeserver."
+    description: '- pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. - server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses.'
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]>. Run the following command to load the updated time sources into ntp running config: # service ntp restart OR If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+      - "https://tf.nist.gov/tf-cgi/servers.cgi"
+    compliance:
+      - cis: ["2.1.3.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1498", "T1498.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "f:/etc/ntp.conf -> r:^pool"
+      - "f:/etc/ntp.conf -> r:^server"
+
+  # 2.1.3.3 Ensure ntp is running as user ntpd. (Automated)
+  - id: 40052
+    title: "Ensure ntp is running as user ntp."
+    description: "The ntpd application is part of FreeBD base system and it has a dedicated user account ntpd. This account is granted the access required by the ntpd daemon Note: - If chrony is used, ntpd should be removed and this section skipped - This recommendation only applies if ntpd is in use on the system - Only one time synchronization method should be in use on the system."
+    rationale: "The ntpd daemon should run with only the required privilege."
+    remediation: "The ntpd run by default using ntpd user. It can not changed. If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+    compliance:
+      - cis: ["2.1.3.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:pgrep -U ntpd -l ntpd -> r:ntpd"    
+
+  # 2.1.3.4 Ensure ntp is enabled and running. (Automated)
+  - id: 40053
+    title: "Ensure ntpd is enabled and running."
+    description: "ntpd is a daemon for synchronizing the system clock across the network."
+    rationale: "ntpd needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF ntpd is in use on the system, run the following commands: Run the following command to enable and start ntp service: # service ntpd enable; # service ntpd start OR If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    compliance:
+      - cis: ["2.1.3.4"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n ntpd_enable -> r:^YES"
+      - "c:service ntpd status -> r:^ntpd is running as pid"
+
+  ###############################################
+  # 2.2 Special Purpose Services
+  ###############################################
+  # 2.2.1 Ensure xinetd is not installed. (Automated)
+  - id: 40054
+    title: "Ensure xinetd is not installed."
+    description: "The eXtended InterNET Daemon (xinetd) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
+    rationale: "If there are no xinetd services required, it is recommended that the package be removed to reduce the attack surface are of the system. Note: If an xinetd service or services are required, ensure that any xinetd service not required is stopped and disabled."
+    remediation: "Run the following command to remove xinetd: # pkg remove xinetd -y."
+    compliance:
+      - cis: ["2.2.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v xinetd -> r:^xinetd"    
+
+  # 2.2.2 Ensure X Window System is not installed. (Automated)
+  - id: 40055
+    title: "Ensure X Window System is not installed."
+    description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
+    rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
+    impact: 'Many Unix-Like systems run applications which require a Java runtime. Some Java packages have a dependency on specific X Windows xorg-fonts. One workaround to avoid this dependency is to use the "headless" Java packages for your specific Java runtime, if provided by your distribution.'
+    remediation: "Remove the X Windows System packages: pkg remove 'xorg*'."
+    compliance:
+      - cis: ["2.2.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v xorg-server -> r:^xorg-server"      
+
+  # 2.2.3 Ensure Avahi Server is not installed. (Automated)
+  - id: 40056
+    title: "Ensure Avahi Server is not installed."
+    description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
+    rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
+    remediation: "Run the following commands to remove avahi-daemon: # service avahi_daaemon stop # sysrc -x avahi_daemon_enable  # pkg remove 'avahi*'."
+    compliance:
+      - cis: ["2.2.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v avahi-app -> r:^avahi-app"
+
+  # 2.2.4 Ensure CUPS is not installed. (Automated)
+  - id: 40057
+    title: "Ensure CUPS is not installed."
+    description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
+    rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface."
+    impact: "Removing CUPS will prevent printing from the system, a common task for workstation systems."
+    remediation: "Run one of the following commands to remove cups : # pkg remove cups."
+    references:
+      - "http://www.cups.org."
+    compliance:
+      - cis: ["2.2.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v cups -> r:^cups"
+
+  # 2.2.5 Ensure DHCP Server is not installed. (Automated)
+  - id: 40058
+    title: "Ensure DHCP Server is not installed."
+    description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
+    rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove isc-dhcp-server or dhcpd: # pkg remove 'isc-dhcp*' or pkg remove dhcpd."
+    references:
+      - "http://www.isc.org/software/dhcp."
+    compliance:
+      - cis: ["2.2.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dhcpd|isc-dhcp.*-server' -> r:dhcp"    
+
+  # 2.2.6 Ensure LDAP server is not installed. (Automated)
+  - id: 40059
+    title: "Ensure LDAP server is not installed."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove slapd: # pkg remove 'openldap*-server'."
+    references:
+      - "http://www.openldap.org."
+    compliance:
+      - cis: ["2.2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'openldap.*server' -> r:^openldap"    
+
+  # 2.2.7 Ensure NFS is not installed. (Automated)
+  - id: 40060
+    title: "Ensure NFS is not installed."
+    description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
+    rationale: "If the system does not export NFS shares, it is recommended that the nfs-kernel-server package be removed to reduce the remote attack surface."
+    remediation: "Run the following command to disable nfs: # sysctl kern.features.nfsd=0; # sysctl kern.features.nfscl=0 and add those entries to /etc/sysctl.conf"
+    compliance:
+      - cis: ["2.2.7"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:sysctl -n kern.features.nfsd -> r:0"
+      - "c:sysctl -n kern.features.nfscl -> r:0"      
+
+  # 2.2.8 Ensure DNS Server is not installed. (Automated)
+  - id: 40061
+    title: "Ensure DNS Server is not installed."
+    description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
+    rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following commands to disable DNS server: # pkg remove 'bind9*' or # pkg remove unbound."
+    compliance:
+      - cis: ["2.2.8"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v bind9 -> r:^bind9"    
+      - "not c:pkg query -x %n-%v unbound -> r:^unbound"      
+
+  # 2.2.9 Ensure FTP Server is not installed. (Automated)
+  - id: 40062
+    title: "Ensure FTP Server is not installed."
+    description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
+    rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended SFTP be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove ftp daemon: # pkg remove -x 'bbftp-server|ftpd|uftp'."
+    compliance:
+      - cis: ["2.2.9"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'bbftp-server|ftpd|uftp' -> r:ftp"
+
+  # 2.2.10 Ensure TFTP Server is not installed. (Automated)
+  - id: 40063
+    title: "Ensure TFTP Server is not installed."
+    description: "Trivial File Transfer Protocol (TFTP) is a simple protocol for exchanging files between two TCP/IP machines. TFTP servers allow connections from a TFTP Client for sending and receiving files."
+    rationale: "TFTP does not have built-in encryption, access control or authentication. This makes it very easy for an attacker to exploit TFTP to gain access to files."
+    remediation: "Run the following command to remove tftp servers: # pkg remove -x 'utftpd|tftp-'."
+    compliance:
+      - cis: ["2.2.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'utftpd|tftp-' -> r:tftp"
+
+  # 2.2.11 Ensure HTTP server is not installed. (Automated)
+  - id: 40064
+    title: "Ensure HTTP server is not installed."
+    description: "HTTP or web servers provide the ability to host web site content."
+    rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove httpd server: # pkg remove -x '^apache|^nginx|httpd'."
+    compliance:
+      - cis: ["2.2.11"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'nginx' -> r:^nginx"    
+      - "not c:pkg query -x %n-%v 'apache' -> r:^apache"
+      - "not c:pkg query -x %n-%v 'httpd' -> r:httpd"
+
+  # 2.2.12 Ensure IMAP and POP3 server are not installed. (Automated)
+  - id: 40065
+    title: "Ensure IMAP and POP3 server are not installed."
+    description: "dovecot-imapd, dovecot-pop3d, cyrus-imapd and pop3d are an open source IMAP and POP3 server for Unix based systems."
+    rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove imapd and pop3d servers: # pkg remove -x '^dovecot|^cyrus-imapd|^pop3d'."
+    compliance:
+      - cis: ["2.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dovecot' -> r:dovecot"    
+      - "not c:pkg query -x %n-%v 'cyrus-imapd' -> r:cyrus-imapd"      
+      - "not c:pkg query -x %n-%v 'pop3d' -> r:pop3d"
+
+  # 2.2.13 Ensure Samba is not installed. (Automated)
+  - id: 40066
+    title: "Ensure Samba is not installed."
+    description: "The Samba daemon allows system administrators to configure their FreeBSD systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Server Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
+    rationale: "If there is no need to mount directories and file systems to Windows systems, then this service should be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove samba: # pkg remove -x '^samba'."
+    compliance:
+      - cis: ["2.2.13"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1005", "T1039", "T1083", "T1135", "T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'samba' -> r:samba"
+
+  # 2.2.14 Ensure HTTP Proxy Server is not installed. (Automated)
+  - id: 40067
+    title: "Ensure HTTP Proxy Server is not installed."
+    description: "Squid, privoxy, tinyproxy, 3proxy are standard proxy servers used in many distributions and environments."
+    rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove squid: # pkg remove -x 'squid|privoxy|tinyproxy|3proxy'."
+    compliance:
+      - cis: ["2.2.14"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'squid' -> r:squid"    
+      - "not c:pkg query -x %n-%v 'privoxy' -> r:privoxy"      
+      - "not c:pkg query -x %n-%v 'tinyproxy' -> r:tinyproxy"      
+      - "not c:pkg query -x %n-%v '3proxy' -> r:3proxy"      
+
+  # 2.2.15 Ensure SNMP Server is not installed. (Automated)
+  - id: 40068
+    title: "Ensure SNMP Server is not installed."
+    description: 'Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system.'
+    rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the snmpd package should be removed to reduce the attack surface of the system. Note: If SNMP is required: - The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values. -."
+    remediation: "Run the following command to remove snmpd: # pkg remove net-snmp."
+    compliance:
+      - cis: ["2.2.15"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'net-snmp' -> r:net-snmp"    
+
+  # 2.2.16 Ensure NIS Server is not installed. (Automated)
+  - id: 40069
+    title: "Ensure NIS Server is not installed."
+    description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed and other, more secure services be used."
+    remediation: "Run the following command to disable nis: # service nis_server stop; # sysrc -x nis_server_enable OR # service nis_server disable."
+    compliance:
+      - cis: ["2.2.16"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c: sysrc -n nis_server_enable -> r:NO"
+
+  # 2.2.17 Ensure dnsmasq is not installed. (Automated)
+  - id: 40070
+    title: "Ensure dnsmasq is not installed."
+    description: "dnsmasq is a lightweight tool that provides DNS caching, DNS forwarding and DHCP (Dynamic Host Configuration Protocol) services."
+    rationale: "Unless a system is specifically designated to act as a DNS caching, DNS forwarding and/or DHCP server, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove dnsmasq: # pkg remove dnsmasq."
+    compliance:
+      - cis: ["2.2.17"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dnsmasq' -> r:dnsmasq"    
+
+  # 2.2.18 Ensure telnet-server is not installed. (Automated)
+  - id: 40071
+    title: "Ensure telnetd is not installed."
+    description: "The telnetd package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
+    remediation: "Run the following command to remove the telnetd package: # pkg remove freebsd-telnetd."
+    compliance:
+      - cis: ["2.2.18"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'freebsd-telnetd' -> r:^freebsd-telnetd"
+
+  # 2.2.19 Ensure sendmail transfer agent is configured for local-only mode. (Automated)
+  - id: 40072
+    title: "Ensure sendmail transfer agent is configured for local-only mode."
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: - This recommendation is designed around the postfix mail server. - Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /etc/rc.conf and add the following line: sendmail_enable=NO or sendmail_enable=NONE."
+    compliance:
+      - cis: ["2.2.19"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1018", "T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:sysrc -n sendmail_enable -> r:YES"
+      - "c:sysrc -n sendmail_enable -> r:NO|NONE"      
+      
+  # 2.2.20 Ensure postfix mail transfer agent is configured for local-only mode. (Automated)
+  - id: 40073
+    title: "Ensure postfix mail transfer agent is configured for local-only mode."
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: - This recommendation is designed around the postfix mail server. - Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /usr/local/etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only Run the following command to restart postfix: # service postfix restart."
+    compliance:
+      - cis: ["2.2.20"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1018", "T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "f:/usr/local/etc/postfix/main.cf -> r:^inet_interfaces = loopback-only"
+
+  # 2.2.21 Ensure rsync service is either not installed or is masked. (Automated)
+  - id: 40074
+    title: "Ensure rsync service is either not installed or is masked."
+    description: "The rsync service can be used to synchronize files between systems over network links."
+    rationale: "The rsync service presents a security risk as the rsync protocol is unencrypted. The rsync package should be removed or if required for dependencies, the rsync service should be stopped and masked to reduce the attack area of the system."
+    remediation: "Run the following command to remove rsync: # pkg remove rsync"
+    compliance:
+      - cis: ["2.2.21"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1105", "T1203", "T1210", "T1543", "T1543.002", "T1570"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'rsync' -> r:rsync"
+
+  # 2.3.1 Ensure NIS Client is not installed. (Automated)
+  - id: 40075
+    title: "Ensure NIS Client is not installed."
+    description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client was used to bind a machine to an NIS server and receive the distributed configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Disable nis client: # service nis_client stop; # service nis_client disable."
+    compliance:
+      - cis: ["2.3.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:sysrc -n nis_client_enable -> r:YES"
+
+  # 2.3.2 Ensure rsh client is not installed. (Automated)
+  - id: 40076
+    title: "Ensure rsh client is not installed."
+    description: "The bsdrcmds package contains the client commands for the rsh services."
+    rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Uninstall rsh: # pkg remove bsdrcmds."
+    compliance:
+      - cis: ["2.3.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1040", "T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c:pkg query -x %n-%v 'bsdrcmds' -> r:bsdrcmds"
+
+  # 2.3.3 Ensure talk client is not installed. (Automated)
+  - id: 40077
+    title: "Ensure talk client is not installed."
+    description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
+    rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Remove talk: # rm /usr/bin/talk."
+    compliance:
+      - cis: ["2.3.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0006", "TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/bin/talk"
+
+  # 2.3.4 Ensure telnet client is not installed. (Automated)
+  - id: 40078
+    title: "Ensure telnet client is not installed."
+    description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Remove talk: # rm /usr/bin/telnet."
+    compliance:
+      - cis: ["2.3.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0006", "TA0008"]
+      - mitre_techniques: ["T1040", "T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/bin/telnet"    
+
+  # 2.3.5 Ensure LDAP client is not installed. (Automated)
+  - id: 40079
+    title: "Ensure LDAP client is not installed."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
+    impact: "Removing the LDAP client will prevent or inhibit using LDAP for authentication in your environment."
+    remediation: "Uninstall ldap client: # pkg remove -x 'openldap.*-client'."
+    compliance:
+      - cis: ["2.3.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'openldap.*client' -> r:openldap"    
+
+  # 2.3.6 Ensure RPC is not installed. (Automated)
+  - id: 40080
+    title: "Ensure RPC is not installed."
+    description: 'Remote Procedure Call (RPC) is a method for creating low level client server applications across different system architectures. It requires an RPC compliant client listening on a network port. The supporting package is rpcbind.".'
+    rationale: "If RPC is not required, it is recommended that this services be removed to reduce the remote attack surface."
+    remediation: "Run the following command to remove rpcbind: # rm /usr/sbin/rpcbind."
+    compliance:
+      - cis: ["2.3.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/sbin/rpcbind"
+
+  # 2.4 Ensure nonessential services are removed or masked. (Manual) - Not Implemented
+
+  ###############################################
+  # 3 Network Configuration
+  ###############################################
+  ###############################################
+  # 3.1 Disable unused network protocols and devices
+  ###############################################
+  # 3.1.1 Ensure IPv6 status is identified. (Manual)
+  - id: 40081
+    title: "Ensure IPv6 status is identified."
+    description: "Internet Protocol Version 6 (IPv6) is the most recent version of Internet Protocol (IP). It's designed to supply IP addressing and additional security to support the predicted growth of connected devices. IPv6 is based on 128-bit addressing and can support 340 undecillion addresses, which is 340 followed by 36 zeroes. Features of IPv6 - Hierarchical addressing and routing infrastructure - Stateful and Stateless configuration - Support for quality of service (QoS) - An ideal protocol for neighboring node interaction."
+    rationale: "IETF RFC 4038 recommends that applications are built with an assumption of dual stack. It is recommended that IPv6 be enabled and configured in accordance with Benchmark recommendations. If dual stack and IPv6 are not used in your environment, IPv6 may be disabled to reduce the attack surface of the system, and recommendations pertaining to IPv6 can be skipped. Note: It is recommended that IPv6 be enabled and configured unless this is against local site policy."
+    impact: "IETF RFC 4038 recommends that applications are built with an assumption of dual stack. When enabled, IPv6 will require additional configuration to reduce risk to the system."
+    remediation: "Enable or disable IPv6 in accordance with system requirements and local site policy."
+    compliance:
+      - cis: ["3.1.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1557", "T1595", "T1595.001", "T1595.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n ipv6_activate_all_interfaces -> r:NO"
+      - "c:sysrc -n ip6addrctl_enable -> r:NO"
+
+  # 3.1.2 Ensure wireless interfaces are disabled. (Automated) - Not Implemented
+
+  # 3.1.3 Ensure bluetooth is disabled. (Automated)
+  - id: 40082
+    title: "Ensure bluetooth is disabled."
+    description: "Bluetooth is a short-range wireless technology standard that is used for exchanging data between devices over short distances. It employs UHF radio waves in the ISM bands, from 2.402 GHz to 2.48 GHz. It is mainly used as an alternative to wire connections."
+    rationale: "An attacker may be able to find a way to access or corrupt your data. One example of this type of activity is bluesnarfing, which refers to attackers using a Bluetooth connection to steal information off of your Bluetooth device. Also, viruses or other malicious code can take advantage of Bluetooth technology to infect other devices. If you are infected, your data may be corrupted, compromised, stolen, or lost."
+    impact: "Many personal electronic devices (PEDs) use Bluetooth technology. For example, you may be able to operate your computer with a wireless keyboard. Disabling Bluetooth will prevent these devices from connecting to the system."
+    remediation: "Run the following commands to stop and disable the Bluetooth service # kldunload ng_ubt and add ng_ubt to module_blacklist variable into /boot/loader.conf #  Note: A reboot may be required."
+    references:
+      - "https://www.cisa.gov/tips/st05-015"
+    compliance:
+      - cis: ["3.1.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:kldstat -n ng_ubt -> r:ng_ubt && !r:ng_ubt.ko$"
+      - 'not f:/boot/loader.conf -> r:ng_ubt_load && r:YES'            
+        
+  # 3.1.4 Ensure SCTP is disabled. (Automated) - Not Implemented
+  - id: 40083
+    title: "Ensure SCTP is disabled."
+    description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
+    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
+    remediation: 'Edit /boot/loader.conf and add sctp to module_blacklist variable. Note: A reboot may be required.'
+    compliance:
+      - cis: ["3.1.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:kldstat -n sctp -> r:sctp && !r:sctp.ko$"
+      - 'not f:/boot/loader.conf -> r:sctp_load && r:YES'      
+        
+  # 3.1.5 Ensure RDS is disabled. (Automated) Not Implemented
+  # 3.1.6 Ensure TIPC is disabled. (Automated) - Not Implemented
+
+  ###############################################
+  # 3.2 Network Parameters (Host Only)
+  ###############################################
+  # 3.2.1 Ensure packet redirect sending is disabled
+  - id: 40084
+    title: Ensure packet redirect sending is disabled
+    description: >
+      ICMP Redirects are used to send routing information to other hosts. As a host itself does
+      not act as a router (in a host only configuration), there is no need to send redirects.
+    rationale: >
+      An attacker could use a compromised host to send invalid ICMP redirects to other router
+      devices in an attempt to corrupt routing and have users access a system set up by the
+      attacker as opposed to a valid system.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.icmp.drop_redirect = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.icmp.drop_redirect=1
+    compliance:
+      - cis: ["3.2.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.icmp.drop_redirect -> r:1'
+
+  # 3.2.2 Ensure IP forwarding is disabled. (Automated) - Not Implemented
+  - id: 40085
+    title: Ensure IP forwarding is disabled.
+    description: >
+      IP forwarding allows the system to move traffic between interfaces that belong to the same 
+      machine (router) and forward the packets to the appropriate interface according to the 
+      machine's routing table
+    rationale: >
+      Keep this parameter disabled to prevent denial of service attacks through spoofed packets.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.ip.forwarding = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.ip.forwarding=1
+    compliance:
+      - cis: ["3.2.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.ip.forwarding -> r:0'
+
+  ###############################################
+  # 3.3 Network Parameters (Host and Router)
+  ###############################################
+  # 3.3.1 Ensure source routed packets are not accepted. (Automated) - Not Implemented
+  # 3.3.2 Ensure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.3 Ensure secure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.4 Ensure suspicious packets are logged. (Automated) - Not Implemented
+  # 3.3.5 Ensure broadcast ICMP requests are ignored
+  - id: 40086
+    title: Ensure broadcast ICMP requests are ignored
+    description: >
+      Setting net.inet.icmp.bmcastecho to 0 will cause the system to ignore all
+      ICMP echo and timestamp requests to broadcast and multicast addresses.
+    rationale: >
+      Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for
+      your network could be used to trick your host into starting (or participating) in a Smurf
+      attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast
+      messages with a spoofed source address. All hosts receiving this message and responding
+      would send echo-reply messages back to the spoofed address, which is probably not
+      routable. If many hosts respond to the packets, the amount of traffic on the network could
+      be significantly multiplied.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.icmp.bmcastecho = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.icmp.bmcastecho=0
+    compliance:
+      - cis: ["3.3.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.icmp.bmcastecho -> r:0'
+
+  # 3.3.6 Ensure bogus ICMP responses are ignored. (Automated) - Not Implemented
+  # 3.3.7 Ensure Reverse Path Filtering is enabled. (Automated) - Not Implemented
+  # 3.3.8 Ensure TCP SYN Cookies is enabled
+  - id: 40087
+    title: Ensure TCP SYN Cookies is enabled
+    description: >
+      When net.inet.tcp.syncookies is set, the kernel will handle TCP SYN packets normally until the
+      half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN
+      cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the
+      SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that
+      encodes the source and destination IP address and port number and the time the packet
+      was sent. A legitimate connection would send the ACK packet of the three way handshake
+      with the specially crafted sequence number. This allows the system to verify that it has
+      received a valid response to a SYN cookie and allow the connection, even though there is no
+      corresponding SYN in the queue.
+    rationale: >
+      Attackers use SYN flood attacks to perform a denial of service attacked on a system by
+      sending many SYN packets without completing the three way handshake. This will quickly
+      use up slots in the kernel's half-open connection queue and prevent legitimate connections
+      from succeeding. SYN cookies allow the system to keep accepting valid connections, even if
+      under a denial of service attack.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.tcp.syncookies = 1
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.tcp.syncookies=1
+    compliance:
+      - cis: ["3.3.8"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.tcp.syncookies -> r:1'
+      
+  # 3.3.9 Ensure IPv6 router advertisements are not accepted
+  - id: 40088
+    title: Ensure IPv6 router advertisements are not accepted
+    description: This setting disables the system's ability to accept IPv6 router advertisements.
+    rationale: >
+      It is recommended that systems do not accept router advertisements as they could be
+      tricked into routing traffic to compromised machines. Setting hard routes within the
+      system (usually a single default route to a trusted router) protects the system from bad
+      routes.
+    remediation: >
+      IF IPv6 is enabled:
+
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet6.ip6.accept_rtadv = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet6.ip6.accept_rtadv=0
+    compliance:
+      - cis: ["3.3.9"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet6.ip6.accept_rtadv -> r:0'      
+
+  ###############################################
+  # 3.4 Firewall Configuration
+  ###############################################
+  ###############################################
+  # 3.4.1 Configure Packet Filter firewall
+  ###############################################
+  # 3.4.1.1 Ensure packet filter is installed. (Automated)
+  - id: 40089
+    title: "Ensure Packet Filter is installed."
+    description: "FreeBSD has three firewalls built into the base system: PF, IPFW, and IPFILTER, also known as IPF. FreeBSD also provides two traffic shapers for controlling bandwidth usage: altq(4) and dummynet(4). ALTQ has traditionally been closely tied with PF and dummynet with IPFW. Each firewall uses rules to control the access of packets to and from a FreeBSD system, although they go about it in different ways and each has a different rule syntax."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "Packet Filter is part of FreeBSD base system."
+    compliance:
+      - cis: ["3.4.1.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/pfctl"           
+
+  # 3.4.1.2 Ensure Packet Filter is enabled and running. (Automated)
+  - id: 40090
+    title: "Ensure Packet Filter is enabled."
+    description: "Since FreeBSD 5.3, a ported version of OpenBSD’s PF firewall has been included as an integrated part of the base system. PF is a complete, full-featured firewall that has optional support for ALTQ (Alternate Queuing), which provides Quality of Service (QoS)."
+    rationale: "The service must be enabled and running in order for pf to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable pf: # service pf enable Run the following command to start the pf: # service pf start"
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-pf"
+    compliance:
+      - cis: ["3.4.1.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:YES"
+      - "c:kldstat -m pf -> r:pf && r:pf$"
+      - "c:service pf status -> r:^Status && r:Enabled"
+      - "c:sysrc -n ipfw_enable -> r:NO"  
+      - "c:kldstat -m ipfw -> r:ipfw && !r:ipfw$"          
+      - "c:sysrc -n ipfilter_enable -> r:NO"
+      - "c:kldstat -m ipfilter -> r:ipfilter && r:!ipfilter$"            
+
+  # 3.4.1.3 Ensure Packet Filter outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.1.4 Ensure Packet Filter firewall rules exist for all open ports. (Automated) - Not Implemented
+
+  # 3.4.1.5 Ensure Packet Filter default deny firewall policy. (Automated)
+  - id: 40091
+    title: "Ensure Packet Filter default deny firewall policy."
+    description: "A default deny policy on connections ensures that any unconfigured network usage will be rejected. Note: Any port or protocol without a explicit allow before the default deny will be blocked."
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
+    impact: "Any port and protocol not explicitly allowed will be blocked. The following rules should be considered before applying the default deny. ufw allow git ufw allow in http ufw allow out http <- required for apt to connect to repository ufw allow in https ufw allow out https ufw allow out 53 ufw logging on."
+    remediation: "Run the following commands to implement a default deny policy: # ufw default deny incoming # ufw default deny outgoing # ufw default deny routed."
+    compliance:
+      - cis: ["3.4.1.5"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - 'f:/etc/pf.conf -> r:^set block-policy'
+
+  ###############################################
+  # 3.4.2 Configure IPFW firewall
+  ###############################################
+  # 3.4.2.1 Ensure IPFW is installed. (Automated)
+  - id: 40092
+    title: "Ensure Packet Filter is installed."
+    description: "FreeBSD has three firewalls built into the base system: PF, IPFW, and IPFILTER, also known as IPF. FreeBSD also provides two traffic shapers for controlling bandwidth usage: altq(4) and dummynet(4). ALTQ has traditionally been closely tied with PF and dummynet with IPFW. Each firewall uses rules to control the access of packets to and from a FreeBSD system, although they go about it in different ways and each has a different rule syntax."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "IPFW is part of FreeBSD base system."
+    compliance:
+      - cis: ["3.4.2.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/ipfw"           
+
+  # 3.4.2.2 Ensure IPFW is enabled and running. (Automated)
+  - id: 40093
+    title: "Ensure IPFW is enabled and running."
+    description: "IPFW is a stateful firewall written for FreeBSD which supports both IPv4 and IPv6. It is comprised of several components: the kernel firewall filter rule processor and its integrated packet accounting facility, the logging facility, NAT, the dummynet(4) traffic shaper, a forward facility, a bridge facility, and an ipstealth facility."
+    rationale: "The service must be enabled and running in order for pf to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable ipfw: # service firewall enable. # sysrc firewall_type='open'. Run the following command to start the ipfw: # service ipfw start. Take on mind firewall_type='open' means passes all traffic. Look at ipfw documentation for more options."
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-ipfw"
+    compliance:
+      - cis: ["3.4.2.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:NO"
+      - "c:kldstat -m pf -> r:pf && !r:pf$"
+      - "c:sysrc -n ipfw_enable -> r:YES"
+      - "c:kldstat -m ipfw -> r:ipfw && r:ipfw$"
+      - "c:sysctl -n net.inet.ip.fw.enable -> r:1"                
+      - "c:sysrc -n ipfilter_enable -> r:NO"
+      - "c:kldstat -m ipfilter -> r:ipfilter && !r:ipfilter$"            
+
+  # 3.4.2.3 Ensure IPFW outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.2.4 Ensure IPFW firewall rules exist for all open ports. (Automated) - Not Implemented
+  # 3.4.2.5 Ensure IPFW default deny firewall policy. (Automated)
+      
+  ###############################################
+  # 3.4.3 Configure IPFilter firewall
+  ###############################################
+  # 3.4.3.1 Ensure IPFilter is installed. (Automated)
+  - id: 40094
+    title: "Ensure IPFilter is installed."
+    description: "IPFILTER is a kernel-side firewall and NAT mechanism that can be controlled and monitored by userland programs. Firewall rules can be set or deleted using ipf, NAT rules can be set or deleted using ipnat, run-time statistics for the kernel parts of IPFILTER can be printed using ipfstat, and ipmon can be used to log IPFILTER actions to the system log files."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "IPFilter is part of FreeBSD base system. If /sbin/ipfc is not found"
+    compliance:
+      - cis: ["3.4.3.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/ipf"
+
+  # 3.4.3.2 Ensure IPFilter is enabled. (Automated)
+  - id: 40095
+    title: "Ensure IPFilter is enabled and running."
+    description: "IPFILTER is a kernel-side firewall and NAT mechanism that can be controlled and monitored by userland programs. Firewall rules can be set or deleted using ipf, NAT rules can be set or deleted using ipnat, run-time statistics for the kernel parts of IPFILTER can be printed using ipfstat, and ipmon can be used to log IPFILTER actions to the system log files."
+    rationale: "The service must be enabled and running in order for IPFilter to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable IPFilter: # service ipfilter enable Run the following command to start the IPFilter: # service ipfilter start"
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-ipf"
+    compliance:
+      - cis: ["3.4.3.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:NO"
+      - "c:kldstat -m pf -> r:pf && !r:pf$"
+      - "c:sysrc -n ipfw_enable -> r:NO"  
+      - "c:kldstat -m ipfw -> r:ipfw && !r:ipfw$"          
+      - "c:sysrc -n ipfilter_enable -> r:YES"
+      - "c:kldstat -m ipfilter -> r:ipfilter && r:ipfilter$"
+      - "c:/sbin/ipf -V -> r:'^Running: yes'"                  
+
+  # 3.4.3.3 Ensure IPFilter outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.3.4 Ensure IPFilter firewall rules exist for all open ports. (Automated) - Not Implemented
+  # 3.4.3.5 Ensure IPFilter default deny firewall policy. (Not implemented)      
+  
+ ###############################################
+  # 4 Access, Authentication and Authorization
+  ###############################################
+  ###############################################
+  # 4.1 Configure time-based job schedulers
+  ###############################################  
+  # 4.1.1 Ensure cron daemon is enabled and active. (Automated)
+  - id: 40096
+    title: "Ensure cron daemon is enabled and active."
+    description: "The cron daemon is used to execute batch jobs on the system. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
+    remediation: "Run the following command to enable and start cron: # service cron enable # service cron start."
+    compliance:
+      - cis: ["4.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+    condition: all
+    rules:
+      - "c:sysrc -n cron_enable -> r:^YES"
+      - "c:service cron status -> r:^cron is running as pid"
+
+  # 4.1.2 Ensure permissions on /etc/crontab are configured. (Automated)
+  - id: 40097
+    title: "Ensure permissions on /etc/crontab are configured."
+    description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
+    remediation: "Run the following commands to set ownership and permissions on /etc/crontab : # chown root:wheel /etc/crontab # chmod 740 /etc/crontab."
+    compliance:
+      - cis: ["4.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/crontab -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/crontab -> r:^root:wheel"
+
+  # 4.1.3 Ensure permissions on /etc/cron.d are configured. (Automated)
+  - id: 40098
+    title: "Ensure permissions on /etc/cron.d are configured."
+    description: "The /etc/cron.d directory contains system cron jobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab, but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.d directory: # chown root:wheel /etc/cron.d/ # chmod 750 /etc/cron.d/."
+    compliance:
+      - cis: ["4.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/cron.d -> r:^-rwxr-x---"
+      - "c:stat -f %Su:%Sg /etc/cron.d -> r:^root:wheel"
+
+  # 4.1.4 Ensure cron is restricted to authorized users. (Automated)
+  - id: 40099
+    title: "Ensure cron is restricted to authorized users."
+    description: "Configure /var/cron/allow to allow specific users to use this service. If /var/cron/allow does not exist, then /var/cron/deny is checked. Any user not specifically defined in this file is allowed to use cron. By removing the file, only users in /var/etc/cron/allow are allowed to use cron."
+    rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list."
+    remediation: "Remove /var/cron/deny if it exists - Create /var/cron/allow if it doesn't exist - Change ownership of /var/cron/allow to the root user and wheel group. Add only authorized users to /var/cron/allow file. Restart cron daemon # service cron restart."
+    compliance:
+      - cis: ["4.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/var/run/cron/allow"
+      - "c:stat -f %Sp /var/cron/allow -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /var/cron/allow -> r:^root:wheel"
+
+  # 4.1.5 Ensure at is restricted to authorized users. (Automated)
+  - id: 40100
+    title: "Ensure at is restricted to authorized users."
+    description: "Configure /var/at/at.allow to allow specific users to use this service. If /var/at/at.allow does not exist, then /var/at/at.deny is checked. Any user not specifically defined in this file is allowed to use at. By removing the file, only users in /etc/at.allow are allowed to use at. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, at should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "On many systems, only the system administrator is authorized to schedule at jobs. Using the at.allow file to control who can run at jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
+    remediation: "Remove /var/at/at.deny if it exists - Create /var/at/at.allow if it doesn't exist - Change ownership of /var/at/at.allow to the root user - Change group ownership of /var/at/at.allow to the group wheel. Add only authorized users to /var/at/at.allow file. Restart cron daemon # service cron restart."
+    compliance:
+      - cis: ["4.1.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/var/at/at.allow"
+      - "c:stat -f %Sp /var/at/at.allow -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /var/at/at.allow -> r:^root:wheel"      
+
+  ###############################################
+  # 4.2 Configure SSH Server
+  ###############################################
+  # 4.2.1 Ensure permissions on /etc/ssh/sshd_config are configured. (Automated)
+  - id: 40101
+    title: "Ensure permissions on /etc/ssh/sshd_config are configured."
+    description: "The file /etc/ssh/sshd_config contain configuration specifications for sshd."
+    rationale: "configuration specifications for sshd need to be protected from unauthorized changes by non-privileged users."
+    remediation: "Change ownership and permissions on /etc/ssh/sshd_config file. # chown root:wheel /etc/ssh/sshd_config; # chmod 640 /etc/ssh/sshd_config."
+    compliance:
+      - cis: ["4.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1098", "T1098.004", "T1543", "T1543.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/etc/ssh/sshd_config"
+      - "c:stat -f %Sp /etc/ssh/sshd_config -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/ssh/sshd_config -> r:^root:wheel"
+
+   # 4.2.2 Ensure permissions on SSH private host key files are configured. (Automated) - Not Implemented
+  - id: 40102
+    title: "Ensure permissions on SSH private host key files are configured."
+    description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a private host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Change mode, ownership, and group on the public SSH host key files: # chown root:wheel /etc/ssh/ssh_host*_key; # chmod 600 /etc/ssh/ssh_host*_key."
+    compliance:
+      - cis: ["4.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0003", "TA0006"]
+      - mitre_techniques: ["T1557"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key" -exec stat -f %Sp  {} \; -> r:^-rw-------'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel' 
+
+  # 4.2.3 Ensure permissions on SSH public host key files are configured. (Automated)
+  - id: 40103
+    title: "Ensure permissions on SSH public host key files are configured."
+    description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Change mode, ownership, and group on the public SSH host key files: # chown root:wheel /etc/ssh/ssh_host*.pub; # chmod 644 /etc/ssh/ssh_host*.pub."
+    compliance:
+      - cis: ["4.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0003", "TA0006"]
+      - mitre_techniques: ["T1557"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key.pub" -exec stat -f %Sp  {} \; -> r:^-rw-r--r--'
+      - 'c:find /etc/ssh -xdev -type f -name 2ssh_host_*_key.pub" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel'      
+
+  # 4.2.4 Ensure SSH access is limited. (Automated)
+  - id: 40104
+    title: "Ensure SSH access is limited."
+    description: "There are several options available to limit which users and group can access the system via SSH. AllowUsers: o The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. AllowGroups: o The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. DenyUsers: o The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. DenyGroups: o The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
+    rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set one or more of the parameter above any Include entries as follows: AllowUsers <userlist> OR AllowGroups <grouplist> OR DenyUsers <userlist> OR DenyGroups <grouplist>."
+    compliance:
+      - cis: ["4.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021", "T1021.004"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^allowusers\s+\w+|^allowgroups\s+\w+|^denyusers\s+\w+|^*denygroups\s+\w+'
+      - 'f:/etc/ssh/sshd_config -> r:^AllowUsers\s+\w+|^AllowGroups\s+\w+|^DenyUsers\s+\w+|^DenyGroups\s+\w+'
+
+  # 4.2.5 Ensure SSH LogLevel is appropriate. (Automated)
+  - id: 40105
+    title: "Ensure SSH LogLevel is appropriate."
+    description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
+    rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: LogLevel VERBOSE OR LogLevel INFO Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "https://www.ssh.com/ssh/sshd_config/"
+    compliance:
+      - cis: ["4.2.5"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^loglevel\s+INFO|^loglevel\s+VERBOSE'
+      - 'not f:/etc/ssh/sshd_config -> !r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
+
+  # 4.2.6 Ensure SSH PAM is enabled. (Automated)
+  - id: 40106
+    title: "Ensure SSH PAM is enabled."
+    description: "The UsePAM directive enables the Pluggable Authentication Module (PAM) interface. If set to yes this will enable PAM authentication using ChallengeResponseAuthentication and PasswordAuthentication directives in addition to PAM account and session module processing for all authentication types."
+    rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: UsePAM yes Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.6"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1035"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1021", "T1021.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*usepam\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*UsePAM\s+no'
+
+  # 4.2.7 Ensure SSH root login is disabled. (Automated)
+  - id: 40107
+    title: "Ensure SSH root login is disabled."
+    description: "The PermitRootLogin parameter specifies if the root user can log in using SSH. The default is prohibit-password."
+    rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root. This limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitRootLogin no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.7"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permitrootlogin\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitRootLogin\s+yes'
+
+  # 4.2.8 Ensure SSH HostbasedAuthentication is disabled. (Automated)
+  - id: 40108
+    title: "Ensure SSH HostbasedAuthentication is disabled."
+    description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication."
+    rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: HostbasedAuthentication no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.8"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*hostbasedauthentication\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*HostbasedAuthentication\s+yes'
+
+  # 4.2.9 Ensure SSH PermitEmptyPasswords is disabled. (Automated)
+  - id: 40109
+    title: "Ensure SSH PermitEmptyPasswords is disabled."
+    description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
+    rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitEmptyPasswords no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.9"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permitemptypasswords\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitEmptyPasswords\s+yes'
+
+  # 4.2.10 Ensure SSH PermitUserEnvironment is disabled. (Automated)
+  - id: 40110
+    title: "Ensure SSH PermitUserEnvironment is disabled."
+    description: "The PermitUserEnvironment option allows users to present environment options to the SSH daemon."
+    rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has SSH executing trojan'd programs)."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitUserEnvironment no Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.10"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permituserenvironment\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitUserEnvironment\s+yes'
+
+  # 4.2.11 Ensure SSH IgnoreRhosts is enabled. (Automated)
+  - id: 40111
+    title: "Ensure SSH IgnoreRhosts is enabled."
+    description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
+    rationale: "Setting this parameter forces users to enter a password when authenticating with SSH."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: IgnoreRhosts yes Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.11"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*ignorerhosts\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*IgnoreRhosts\s+no'
+
+  # 4.2.12 Ensure SSH X11 forwarding is disabled. (Automated)
+  - id: 40112
+    title: "Ensure SSH X11 forwarding is disabled."
+    description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
+    rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: X11Forwarding no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*x11forwarding\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s+yes'
+
+  # 4.2.13 Ensure only strong Ciphers are used. (Automated)
+  - id: 40113
+    title: "Ensure only strong Ciphers are used."
+    description: 'This variable limits the ciphers that SSH can use during communication. Note: - Some organizations may have stricter requirements for approved ciphers. - Ensure that ciphers used are in compliance with site policy. - The only "strong" ciphers currently FIPS 140-2 compliant are: o aes256-ctr o aes192-ctr o aes128-ctr.'
+    rationale: 'Weak ciphers like 3DES that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised.'
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma separated list of the site approved ciphers. Example: Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128- gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr."
+    references:
+      - "https://nvd.nist.gov/vuln/detail/CVE-2016-2183"
+      - "https://www.openssh.com/txt/cbc.adv"
+      - "https://nvd.nist.gov/vuln/detail/CVE-2008-5161"
+    compliance:
+      - cis: ["4.2.13"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|rijndael-cbc@lysator.liu.se"
+
+  # 4.2.14 Ensure only strong MAC algorithms are used. (Automated)
+  - id: 40114
+    title: "Ensure only strong MAC algorithms are used."
+    description: 'This variable limits the types of MAC algorithms that SSH can use during communication. The only "strong" MACs currently FIPS 140-2 approved are: o hmac-sha2-256 o hmac-sha2-512.'
+    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information."
+    remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs above any Include entries: Example: MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2- 512,hmac-sha2-256,umac-128-etm@openssh.com,umac-128@openssh.com."
+    references:
+      - "http://www.mitls.org/pages/attacks/SLOTH"
+    compliance:
+      - cis: ["4.2.14"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4", "16.5"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:macs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com"
+
+  # 4.2.15 Ensure only strong Key Exchange algorithms are used. (Automated)
+  - id: 40115
+    title: "Ensure only strong Key Exchange algorithms are used."
+    description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties. The only Key Exchange Algorithms currently FIPS 140-2 approved are: o ecdh-sha2-nistp256 o ecdh-sha2-nistp384 o ecdh-sha2-nistp521 o diffie-hellman-group-exchange-sha256 o diffie-hellman-group16-sha512 o diffie-hellman-group18-sha512 o diffie-hellman-group14-sha256."
+    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks."
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to list of the site approved key exchange algorithms. Example: KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256."
+    compliance:
+      - cis: ["4.2.15"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1"
+
+  # 4.2.16 Ensure SSH AllowTcpForwarding is disabled. (Automated)
+  - id: 40116
+    title: "Ensure SSH AllowTcpForwarding is disabled."
+    description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines."
+    rationale: "Leaving port forwarding enabled can expose the organization to security risks and backdoors. SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network."
+    impact: "SSH tunnels are widely used in many corporate environments. In some environments the applications themselves may have very limited native support for security. By utilizing tunneling, compliance with SOX, HIPAA, PCI-DSS, and other standards can be achieved without having to modify the applications."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: AllowTcpForwarding no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "https://www.ssh.com/ssh/tunneling/example"
+    compliance:
+      - cis: ["4.2.16"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1048", "T1048.002", "T1572"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*allowtcpforwarding\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*AllowTcpForwarding\s+yes'
+
+  # 4.2.17 Ensure SSH warning banner is configured. (Automated)
+  - id: 40117
+    title: "Ensure SSH warning banner is configured."
+    description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
+    rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: Banner /path/ro/banner Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.17"]
+      - mitre_mitigations: ["M1035"]
+      - mitre_tactics: ["TA0001", "TA0007"]
+    condition: all
+    rules:
+      - 'not c:sshd -T -> r:^\s*banner\s+none'
+
+  # 4.2.18 Ensure SSH MaxAuthTries is set to 4 or less. (Automated)
+  - id: 40118
+    title: "Ensure SSH MaxAuthTries is set to 4 or less."
+    description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
+    rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxAuthTries 4 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.18"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - mitre_mitigations: ["M1036"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1110", "T1110.001", "T1110.003"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^maxauthtries\s*\t*(\d+) compare <= 4'
+      - 'not f:/etc/ssh/sshd_config -> n:^MaxAuthTries\s*\t*(\d+) compare > 4'
+
+  # 4.2.19 Ensure SSH MaxStartups is configured. (Automated)
+  - id: 40119
+    title: "Ensure SSH MaxStartups is configured."
+    description: "The MaxStartups parameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon."
+    rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxStartups 10:30:60 Note: First occurrence of an option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.19"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1499", "T1499.002"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*maxstartups\s+10:30:60'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxStartups\s+(((1[1-9]|[1-9][0-9][0-9]+):([0-9]+):([0-9]+))|(([0-9]+):(3[1-9]|[4-9][0-9]|[1-9][0-9][0-9]+):([0-9]+))|(([0-9]+):([0-9]+):(6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+)))'
+
+  # 4.2.20 Ensure SSH LoginGraceTime is set to one minute or less. (Automated)
+  - id: 40120
+    title: "Ensure SSH LoginGraceTime is set to one minute or less."
+    description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
+    rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: LoginGraceTime 60 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.20"]
+      - mitre_mitigations: ["M1036"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1110", "T1110.001", "T1110.003", "T1110.004"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:logingracetime\s*\t*(\d+) compare <= 60 && n:LoginGraceTime\s*\t*(\d+) compare != 0'
+      - 'not f:/etc/ssh/sshd_config -> r:\s*LoginGraceTime\s+(0|6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+|[^1]m)'
+
+  # 4.2.21 Ensure SSH MaxSessions is set to 10 or less. (Automated)
+  - id: 40121
+    title: "Ensure SSH MaxSessions is set to 10 or less."
+    description: "The MaxSessions parameter specifies the maximum number of open sessions permitted from a given connection."
+    rationale: "To protect a system from denial of service due to a large number of concurrent sessions, use the rate limiting function of MaxSessions to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxSessions 10 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.21"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1499", "T1499.002"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^\s*maxsessions\s+(\d+) compare <= 10'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxSessions\s+(1[1-9]|[2-9][0-9]|[1-9][0-9][0-9]+)'
+
+  # 4.2.22 Ensure SSH Idle Timeout Interval is configured. (Automated)
+  - id: 40122
+    title: "Ensure SSH Idle Timeout Interval is configured."
+    description: "ClientAliveInterval sets a timeout interval in seconds after which if no data has been received from the client. ClientAliveCountMax sets the number of client alive messages which may be sent without sshd(8) receiving any messages back from the client. It is important to note that the use of client alive messages is very different from TCPKeepAlive. The client alive messages are sent through the encrypted channel and therefore will not be spoofable. The TCP keepalive option enabled by TCPKeepAlive is spoofable."
+    rationale: "In order to prevent resource exhaustion, appropriate values should be set for both ClientAliveInterval and ClientAliveCountMax. Specifically, looking at the source code, ClientAliveCountMax must be greater than zero in order to utilize the ability of SSH to drop idle connections. If connections are allowed to stay open indefinately, this can potentially be used as a DDOS attack or simple resource exhaustion could occur over unreliable networks. The example set here is a 45 second timeout. Consult your site policy for network timeouts and apply as appropriate."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameters above any Include entries according to site policy. Example: ClientAliveInterval 15 ClientAliveCountMax 3."
+    references:
+      - "https://man.openbsd.org/sshd_config"
+    compliance:
+      - cis: ["4.2.22"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:clientaliveinterval\s*\t*(\d+) compare > 0'
+      - 'c:sshd -T -> n:clientalivecountmax\s*\t*(\d+) compare > 0'
+
+  ############################################################
+  # 4.3 Configure privilege escalation
+  ############################################################
+  # 4.3.1 Ensure sudo is installed. (Automated)
+  - id: 40123
+    title: "Ensure sudo is installed."
+    description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
+    rationale: "sudo supports a plug-in architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plug-ins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers and any entries in /etc/sudoers.d. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
+    remediation: "Install sudo. Example: # pkg install sudo."
+    compliance:
+      - cis: ["4.3.1"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v sudo -> r:^sudo"    
+
+  # 4.3.2 Ensure sudo commands use pty. (Automated)
+  - id: 40124
+    title: "Ensure sudo commands use pty."
+    description: "sudo can be configured to run only from a pseudo terminal (pseudo-pty)."
+    rationale: "Attackers can run a malicious program using sudo which would fork a background process that remains even when the main program has finished executing."
+    impact: "WARNING: Editing the sudo configuration incorrectly can cause sudo to stop functioning. Always use visudo to modify sudo configuration files."
+    remediation: "Edit the file /usr/local/etc/sudoers with ee or a file in /usr/local//etc/sudoers.d/ with ee <PATH TO FILE> and add the following line: Defaults use_pty Note: - sudo will read each file in /usr/local/etc/sudoers.d, skipping file names that end in ~ or contain a . character to avoid causing problems with package manager or editor temporary/backup files. - Files are parsed in sorted lexical order. That is, /etc/sudoers.d/01_first will be parsed before /etc/sudoers.d/10_second. - Be aware that because the sorting is lexical, not numeric, /usr/local/etc/sudoers.d/1_whoops would be loaded after /usr/local/etc/sudoers.d/10_second. - Using a consistent number of leading zeroes in the file names can be used to avoid such problems."
+    compliance:
+      - cis: ["4.3.2"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1026", "M1038"]
+      - mitre_tactics: ["TA0001", "TA0003"]
+      - mitre_techniques: ["T1078", "T1078.003", "T1548", "T1548.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: any
+    rules:
+      - 'not f:/usr/local/etc/sudoers -> r:^Defaults\s*!use_pty'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> r:^Defaults\s*!use_pty'
+
+  # 4.3.3 Ensure sudo log file exists. (Automated)
+  - id: 40125
+    title: "Ensure sudo log file exists."
+    description: "sudo can use a custom log file."
+    rationale: "A sudo log file simplifies auditing of sudo commands."
+    impact: "WARNING: Editing the sudo configuration incorrectly can cause sudo to stop functioning. Always use visudo to modify sudo configuration files."
+    remediation: 'Edit the file /usr/local/etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH TO FILE> and add the following line: Example: Defaults logfile="/var/log/sudo.log" Note: - sudo will read each file in /etc/sudoers.d, skipping file names that end in ~ or contain a . character to avoid causing problems with package manager or editor temporary/backup files. - Files are parsed in sorted lexical order. That is, /etc/sudoers.d/01_first will be parsed before /etc/sudoers.d/10_second. - Be aware that because the sorting is lexical, not numeric, /etc/sudoers.d/1_whoops would be loaded after /etc/sudoers.d/10_second. - Using a consistent number of leading zeroes in the file names can be used to avoid such problems.'
+    compliance:
+      - cis: ["4.3.3"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: any
+    rules:
+      - 'f:/usr/local/etc/sudoers -> r:^\s*\t*Defaults\s*\t*logfile='
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile='
+
+  # 4.3.4 Ensure users must provide password for privilege escalation. (Automated)
+  - id: 40126
+    title: "Ensure users must provide password for privilege escalation."
+    description: "The operating system must be configured so that users must provide a password for privilege escalation."
+    rationale: "Without (re-)authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user (re-)authenticate."
+    impact: "This will prevent automated processes from being able to elevate privileges."
+    remediation: "Based on the outcome of the audit procedure, use ee <PATH TO FILE> to edit the relevant sudoers file. Remove any line with occurrences of NOPASSWD tags in the file."
+    compliance:
+      - cis: ["4.3.4"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1548"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - "f:/usr/local/etc/sudoers -> !r:^# && r:*NOPASSWD"
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:*NOPASSWD'
+
+  # 4.3.5 Ensure re-authentication for privilege escalation is not disabled globally. (Automated)
+  - id: 40127
+    title: "Ensure re-authentication for privilege escalation is not disabled globally."
+    description: "The operating system must be configured so that users must re-authenticate for privilege escalation."
+    rationale: "Without re-authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate."
+    remediation: "Configure the operating system to require users to reauthenticate for privilege escalation. Based on the outcome of the audit procedure, use ee <PATH TO FILE> to edit the relevant sudoers file. Remove any occurrences of !authenticate tags in the file(s)."
+    compliance:
+      - cis: ["4.3.5"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - 'f:/usr/local/etc/sudoers -> !r:^# && r:*\!authenticate'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:*\!authenticate'
+
+  # 4.3.6 Ensure sudo authentication timeout is configured correctly. (Automated)
+  - id: 40128
+    title: "Ensure sudo authentication timeout is configured correctly."
+    description: "sudo caches used credentials for a default of 5 minutes. This is for ease of use when there are multiple administrative tasks to perform. The timeout can be modified to suit local security policies. This default is distribution specific. See audit section for further information."
+    rationale: "Setting a timeout value reduces the window of opportunity for unauthorized privileged access to another user."
+    remediation: "If the currently configured timeout is larger than 5 minutes, edit the file listed in the audit section with ee <PATH TO FILE> and modify the entry timestamp_timeout= to 5 minutes or less as per your site policy. The value is in minutes. This particular entry may appear on it's own, or on the same line as env_reset. See the following two examples: Defaults env_reset, timestamp_timeout=5 Defaults timestamp_timeout=5 Defaults env_reset."
+    references:
+      - "https://www.sudo.ws/man/1.9.14/sudoers.man.html"
+    compliance:
+      - cis: ["4.3.6"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - 'c:sudo -V -> r:Authentication timestamp timeout:\s*\t*5.0 minutes'
+      - 'f:/usr/local/etc/sudoers -> n:timestamp_timeout=(\d+) compare <=5'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> n:timestamp_timeout=(\d+) compare <=5'
+
+  # 4.3.7 Ensure access to the su command is restricted. (Automated)
+  - id: 40129
+    title: "Ensure access to the su command is restricted."
+    description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in a specific groups to execute su. This group should be empty to reinforce the use of sudo for privileged access."
+    rationale: "Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program."
+    remediation: "Check wheel group into /etc/pam.d/su for use of the su command. the line could look like the following: auth requisite pam_group.so no_warn group=wheel root_only fail_safe ruser."
+    compliance:
+      - cis: ["4.3.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/su -> !r:^# && r:auth\s*requisite\s*pam_group.so && r:\sgroup=wheel\s'
+      
+  # 4.3.8 Ensure doas is installed. (Automated)
+  - id: 40130
+    title: "Ensure doas is installed."
+    description: "doas allows a permitted user to execute a command as the superuser or another user, as specified by the security policy."
+    rationale: "The default security policy is configured via /usr/local/etc/doas.conf. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism."
+    remediation: "Install doas. Example: # pkg install doas."
+    compliance:
+      - cis: ["4.3.1"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v doas -> r:^doas"   
+      
+  # 4.3.9 Ensure users must provide password for privilege escalation. (Automated)
+  - id: 40131
+    title: "Ensure doas users must provide password for privilege escalation."
+    description: "The operating system must be configured so that users must provide a password for privilege escalation."
+    rationale: "Without authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user (re-)authenticate."
+    impact: "This will prevent automated processes from being able to elevate privileges."
+    remediation: "Based on the outcome of the audit procedure, use ee /usr/local/etc/doas.conf file. Remove any line with occurrences of nopass tags in the file."
+    compliance:
+      - cis: ["4.3.4"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1548"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - "f:/usr/local/etc/doas.conf -> !r:^# && r:*nopass"          
+
+  ###############################################
+  # 4.4 Configure PAM and login.conf
+  ###############################################
+  # 4.4.1 Ensure password creation requirements are configured. (Automated)
+  # 4.4.2 Ensure lockout for failed password attempts is configured. (Automated)
+  # 4.4.3 Ensure password reuse is limited. (Automated)
+  # 4.4.4 Ensure strong password hashing algorithm is configured. (Automated)
+  - id: 40132
+    title: "Ensure strong password hashing algorithm is configured."
+    description: "Hash functions behave as one-way functions by using mathematical operations that are extremely difficult and cumbersome to revert When a user is created, the password is run through a one-way hashing algorithm before being stored. When the user logs in, the password sent is run through the same one-way hashing algorithm and compared to the hash connected with the provided username. If the hashed password and the stored hash match, the login is valid."
+    rationale: "The SHA512 hashing algorithm provides stronger hashing than previous available algorithms like MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords."
+    remediation: "Note: - Pay special attention to the configuration. Incorrect configuration can cause system lock outs. - This is an example configuration. Your configuration may differ based on previous changes to the files."
+    compliance:
+      - cis: ["4.4.4"]
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["16.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1110", "T1110.002"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "f:/etc/login.conf -> r:passwd_format && r:sha512|blf"
+
+  # 4.4.5 Ensure all current passwords uses the configured hashing algorithm. (Manual) - Not Implemented
+
+  ###############################################
+  # 4.5 User Accounts and Environment
+  ###############################################
+  ###############################################
+  # 4.5.1 Set Shadow Password Suite Parameters
+  ###############################################
+  # 4.5.1.1 Ensure password expiration is 365 days or less. (Automated)
+  - id: 40133
+    title: "Ensure password expiration is 365 days or less."
+    description: "The passwordtime parameter in /etc/login.conf allows an administrator to force passwords to expire once they reach a defined age."
+    rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity. It is recommended that the passwordtime parameter does not exceed 365 days and is greater than the value of 1."
+    remediation: "Set the passwordtime parameter to conform to site policy in /etc/login.conf : passwordtime=365d. Modify user parameters for all users with a password set to match: # pw usermod <user> -p +365d."
+    references:
+      - "https://www.cisecurity.org/white-papers/cis-password-policy-guide/"
+    compliance:
+      - cis: ["4.5.1.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.conf -> n:^\t:passwordtime=(\d+)\w: compare <= 365'
+      - 'f:/etc/login.conf -> n:^\t:passwordtime=(\d+)\w: compare > 0'
+
+  # 4.5.1.2 Ensure password expiration warning days is 7 or more. (Automated)
+  - id: 40134
+    title: "Ensure password expiration warning days is 7 or more."
+    description: "The warnpassword parameter in /etc/login.conf allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
+    rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
+    remediation: "Set the warnpassword parameter to 7 in /etc/login.conf: warnpassword=7d."
+    compliance:
+      - cis: ["4.5.1.2"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.conf -> n:^\t:warnpassword=(\d+)\w: compare >= 7'
+
+  # 4.5.1.3 Ensure inactive password lock is 30 days or less. (Automated)
+  # 4.5.1.4 Ensure all users last password change date is in the past. (Automated) - Not Implemented
+  # 4.5.1.5 Ensure the number of changed characters in a new password is configured. (Automated)
+  # 4.5.1.6 Ensure preventing the use of dictionary words for passwords is configured. (Automated)
+  # 4.5.2 Ensure system accounts are secured. (Automated) - Not Implemented
+
+  # 4.5.3 Ensure default group for the root account is GID 0. (Automated)
+  - id: 40135
+    title: "Ensure default group for the root account is GID 0."
+    description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
+    rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
+    remediation: "Run the following command to set the root user default group to GID 0 : # usermod -g 0 root."
+    compliance:
+      - cis: ["4.5.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/passwd -> !r:^# && r:root:\w+:\w+:0:'
+
+  # 4.5.4 Ensure default user umask is 027 or more restrictive. (Automated) - Not Implemented
+  # 4.5.5 Ensure default user shell timeout is configured. (Automated) - Not Implemented
+
+  # 4.5.6 Ensure nologin is not listed in /etc/shells. (Automated)
+  - id: 40136
+    title: "Ensure nologin is not listed in /etc/shells."
+    description: "/etc/shells is a text file which contains the full pathnames of valid login shells. This file is consulted by chsh and available to be queried by other programs. Be aware that there are programs which consult this file to find out if a user is a normal user; for example, FTP daemons traditionally disallow access to users with shells not included in this file."
+    rationale: "A user can use chsh to change their configured shell. If a user has a shell configured that isn't in in /etc/shells, then the system assumes that they're somehow restricted. In the case of chsh it means that the user cannot change that value. Other programs might query that list and apply similar restrictions. By putting nologin in /etc/shells, any user that has nologin as its shell is considered a full, unrestricted user. This is not the expected behavior for nologin."
+    remediation: "Edit /etc/shells and remove any lines that include nologin."
+    compliance:
+      - cis: ["4.5.6"]
+    condition: all
+    rules:
+      - "not f:/etc/shells -> !r:^# && r:nologin"
+
+  # 4.5.7 Ensure maximum number of same consecutive characters in a password is configured. (Automated)
+
+   ###############################################
+  # 5.1 Logging and auditing
+  ###############################################
+  # 5.1.1 Configure syslog
+  ###############################################
+  # 5.1.1.1 Ensure syslog is installed. (Automated)
+  - id: 40137
+    title: "Ensure syslog is installed."
+    description: "FreeBSD provides a system logger, syslogd(8), to manage logging. By default, syslogd is enabled and started when the system boots."
+    rationale: "The security enhancements of syslog such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
+    remediation: "The syslog is installed by default on FreeBSD. If it is not available an incomplete or modified version of FreeBSD is running."
+    compliance:
+      - cis: ["5.1.1.1"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1005", "T1070", "T1070.002"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "f:/usr/sbin/syslogd"
+
+  # 5.1.1.2 Ensure syslog service is enabled. (Automated)
+  - id: 40138
+    title: "Ensure syslog service is enabled."
+    description: "Once the syslog package is installed, ensure that the service is enabled."
+    rationale: "If the syslog service is not enabled to start on boot, the system will not capture logging events."
+    remediation: "Run the following command to enable syslog: # service syslogd enable; # service syslogd start."
+    compliance:
+      - cis: ["5.1.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:service syslogd status -> r:^syslogd is running as pid"
+
+  # 5.1.1.3 Ensure syslog is not configured to receive logs from a remote client. (Automated)
+  - id: 40139
+    title: "Ensure syslog is not configured to receive logs from a remote client."
+    description: "Syslog supports the ability to receive messages from remote hosts, thus acting as a log server. Clients should not receive data from other hosts."
+    rationale: "If a client is configured to also receive data, thus turning it into a server, the client system is acting outside it's operational boundary."
+    remediation: 'Disable syslog for not log messages from remote machines: # sysrc syslogd_flags="-ss".If -s is specified twice, no network socket will be opened at all, which also disables logging to remote machines'
+    compliance:
+      - cis: ["5.1.1.3"]
+      - cis_csc_v8: ["4.8", "8.2"]
+      - cis_csc_v7: ["6.2", "6.3", "9.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1", "A.13.1.3"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "10.2", "10.3", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "2.2.4", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - 'c: sysrc -n syslogd_flags -> r:^-ss'
+
+  # 5.1.1.8 Ensure all logfiles have appropriate access configured. (Automated) - Not Implemented
+
+  ############################################################
+  # 5.2 Configure System Accounting (auditd).
+  ############################################################
+  ############################################################
+  # 5.2.1 Ensure auditing is enabled.
+  ############################################################
+  # 5.2.1.1 Ensure auditd is installed. (Automated)
+  - id: 40140
+    title: "Ensure auditd is installed."
+    description: "The FreeBSD operating system includes support for security event auditing. Event auditing supports reliable, fine-grained, and configurable logging of a variety of security-relevant system events, including logins, configuration changes, and file and network access."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "The auditd is installed by default on FreeBSD. If it is not available an incomplete or modified version of FreeBSD is running."
+    compliance:
+      - cis: ["5.2.1.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f: /usr/sbin/auditd"
+
+  # 5.2.1.2 Ensure auditd service is enabled and active. (Automated)
+  - id: 40141
+    title: "Ensure auditd service is enabled and active."
+    description: "Turn on the auditd daemon to record system events."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "Run the following command to enable and start auditd: # service auditd enable; # service auditd start."
+    compliance:
+      - cis: ["5.2.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n auditd_enable -> r:^YES"
+      - "c:service auditd status -> r:^auditd is running as pid"
+
+  # 5.2.1.3 Ensure audit log storage size is configured. (Automated)
+  - id: 40142
+    title: "Ensure audit log storage size is configured."
+    description: "Configure the filesz of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
+    rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
+    remediation: "Set the following parameter in /etc/security/audit_control in accordance with site policy: filesz:2M B(Bytes), K(Kilobytes), M(Megabytes), or G(Gigabytes)."
+    compliance:
+      - cis: ["5.2.1.3"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^filesz:(\d+)M'
+
+  # 5.2.1.4 Ensure audit logs are not automatically deleted. (Automated)
+  - id: 40143
+    title: "Ensure audit logs are not automatically deleted."
+    description: "The expire-after setting determines how to handle the audit log file reaching the max file size. No expire-after value never delete old logs."
+    rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
+    remediation: "Remove the following parameter in /etc/audit/audit_control: expire-after."
+    compliance:
+      - cis: ["5.2.1.4"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'not f:/etc/security/audit_control -> r:^expire-after'
+
+  # 5.2.1.5 Ensure system is disabled when audit logs are full. (Automated)
+
+  # 5.2.3.1 Ensure changes to system administration events are collected. (Automated)
+  - id: 40144
+    title: "Ensure changes to system administration events are collected."
+    description: 'Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope..'
+    rationale: "Administration system changes can indicate that an unauthorized change has been made to the scope of system administrator activity."
+    remediation: "Edit /etc/security/audit_control file and add or check if exist the following flags: ad,ex,fw. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ad' 
+      - 'f:/etc/security/audit_control -> r:^flags: && r:+ex|ex'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:+fw|fw'      
+
+  # 5.2.3.2 Ensure actions as another user are always logged. (Automated)
+  - id: 40145
+    title: "Ensure actions as another user are always logged."
+    description: "sudo provides users with temporary elevated privileges to perform operations, either as the superuser or another user."
+    rationale: "Creating an audit log of users with temporary elevated privileges and the operation(s) they performed is essential to reporting. Administrators will want to correlate the events written to the audit trail with the records written to sudo's logfile to verify if unauthorized commands have been executed."
+    remediation: "Create audit rules editing /etc/security/audit_user file. Add an user with sudo privileges entry like the following: sudouser:lo,aa,ad:no. If you want apply flags globally the following must be added to flags: lo,aa,ad into /etc/security/audit_control. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.2"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.9.4.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:lo'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:aa'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ad'      
+
+  # 5.2.3.3 Ensure events that modify the sudo log file are collected. (Automated) - Not Implemented
+  # 5.2.3.4 Ensure events that modify date and time information are collected. (Automated)  
+
+  # 5.2.3.5 Ensure events that modify the system's network environment are collected. (Automated)
+  - id: 40146
+    title: "Ensure events that modify the system's network environment are collected."
+    description: "Record changes to network environment files or system calls. The below parameters monitors the following system calls, and write an audit event on system call exit: - sethostname - set the systems host name - setdomainname - set the systems domain name The files being monitored are: - /etc/issue and /etc/issue.net - messages displayed pre-login - /etc/hosts - file containing host names and associated IP addresses - /etc/networks - symbolic names for networks - /etc/network/ - directory containing network interface scripts and configurations files."
+    rationale: "Monitoring network events will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. All audit records should have a relevant tag associated with them."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events that modify the system's network environment. flags: +nt,+fm,+exe. Restart auditd service: # service auditd restart or restart OS: # reboot."
+    compliance:
+      - cis: ["5.2.3.5"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:nt|+nt'
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fm|+fm'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:exe|+exe'      
+
+  # 5.2.3.6 Ensure use of privileged commands are collected. (Automated) - Not Implemented
+  
+  # 5.2.3.7 Ensure unsuccessful file access attempts are collected. (Automated) - Not Implemented
+  - id: 40147
+    title: "Ensure unsuccessful file access attempts are collected."
+    description: "Record events of unsuccessful file access attempts."
+    rationale: "Monitoring unsucessful file access attempts could be an indication that the system has been compromised and that an unauthorized user is attempting to modify configuration system files."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events of unsuccessful file access attempts. flags: -fr. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.7"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fr|-fr'
+
+  # 5.2.3.8 Ensure events that modify user/group information are collected. (Automated)
+  - id: 40148
+    title: "Ensure events that modify files are collected."
+    description: 'Record events affecting the files modification.'
+    rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events of modify files. flags: +fr,+fw,+fm. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.8"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fm|+fm'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fr|+fr'
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fw|+fw'      
+
+  # 5.2.3.9 Ensure discretionary access control permission modification events are collected. (Automated) - Not Implemented
+
+  # 5.2.3.10 Ensure login and logout events are collected. (Automated)
+  - id: 40149
+    title: "Ensure login and logout events are collected."
+    description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events."
+    rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor login and logout events. flags: lo. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.10"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9", "16.11", "16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.9.4.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3", "AU-3(1)"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:lo'
+
+  # 5.2.3.11 Ensure file deletion events by users are collected. (Automated)
+  - id: 40150
+    title: "Ensure file deletion events by users are collected."
+    description: 'Monitor the use of system calls associated with the deletion or renaming of files and file attributes.'
+    rationale: "Monitoring these calls from users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor delete files events. flags: +fd. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.11"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fd|+fd'
+
+   # 5.2.3.12 Ensure successful and unsuccessful attempts to use commands are recorded. (Automated)
+  - id: 40151
+    title: "Ensure successful and unsuccessful attempts to use commands are recorded."
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the commands."
+    rationale: "The system commands can be used to change file security context. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor delete files events. flags: ex. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.12"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ex'
+
+  # 5.2.3.13 Ensure the audit configuration is immutable. (Automated)
+  # 5.2.3.14 Ensure the running and on disk configuration is the same. (Manual)
+  
+  # 5.2.4.1 Ensure audit log files are mode 0640 or less permissive. (Automated)
+  - id: 40152
+    title: "Ensure audit log files are mode 0640 or less permissive."
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: 'Run the following command to configure the audit log files to fix the permissions: # find /var/audit/ -type f -exec chmod 440 {} \\;'
+    compliance:
+      - cis: ["5.2.4.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /var/audit -xdev -type f -exec stat -f %Sp {} \; -> r:^-r--r-----'
+
+  # 5.2.4.2 Ensure only authorized users and groups are assigned ownership of audit log files. (Automated)
+  - id: 40153
+    title: "Ensure only authorized groups are assigned ownership of audit log files."
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: "Run the following command to configure the audit log files to be group owned by audit: # find /var/audit/ -type f -exec chown root:audit {} \\;"
+    compliance:
+      - cis: ["5.2.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /var/audit -xdev -type f -exec stat -f %Su:%Sg {} \; -> r:^root:audit'
+
+  # 5.2.4.4 Ensure the audit log directory is 0750 or more restrictive. (Automated)  
+
+  # 5.2.4.5 Ensure audit configuration files are 640 or more restrictive. (Automated)
+  - id: 40154
+    title: "Ensure audit configuration files are 640 or more restrictive."
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to fix permissive mode from the audit configuration files: # chmod 440 /etc/security/audit_class /etc/security/audit_event # chmod 600 /etc/security/audit_control /etc/security/audit_user # chmod 500 /etc/security/audit_warn."
+    compliance:
+      - cis: ["5.2.4.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:stat -f %Sp /etc/security/audit_class -> r:^-r--r-----'      
+      - 'c:stat -f %Sp /etc/security/audit_control -> r:^-rw-------'
+      - 'c:stat -f %Sp /etc/security/audit_event -> r:^-r--r-----'
+      - 'c:stat -f %Sp /etc/security/audit_user -> r:^-rw-------'
+      - 'c:stat -f %Sp /etc/security/audit_warn -> r:^-r-x------' 
+
+  # 5.2.4.6 Ensure audit configuration files are owned by root. (Automated)
+  - id: 40155
+    title: "Ensure audit configuration files are owned by root and wheel group."
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to change ownership to root user: # find /etc/security -xdev -type f -name 'audit_*' -exec chown root:wheel {} \\;"
+    compliance:
+      - cis: ["5.2.4.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:  
+      - 'c:find /etc/security -xdev -type f -name "audit_*" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel'                       
+          
+  # 5.2.4.7 Ensure audit tools are 755 or more restrictive. (Automated)
+  - id: 40156
+    title: "Ensure audit tools are 755 or more restrictive."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to remove more permissive mode from the audit tools: # chmod 555 /usr/sbin/audit /usr/sbin/auditd /usr/sbin/auditdistd /usr/sbin/auditreduce /usr/sbin/paudit."
+    compliance:
+      - cis: ["5.2.4.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /usr/sbin/audit -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditd -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditdistd -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditreduce -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/praudit -> r:^-r-xr-xr-x"
+
+  # 5.2.4.8 Ensure audit tools are owned by root. (Automated)
+  - id: 40157
+    title: "Ensure audit tools are owned by root and group wheel."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to change the owner of the audit tools to the root user and group wheel: # chown root:wheel /usr/sbin/audit /usr/sbin/auditd /usr/sbin/auditdistd /usr/sbin/auditreduce /usr/sbin/paudit."
+    compliance:
+      - cis: ["5.2.4.8"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Su:%Sg /usr/sbin/audit -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditd -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditdistd -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditreduce -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/praudit -> r:^root:wheel"                        
+
+   # 5.2.4.9 Ensure cryptographic mechanisms are used to protect the integrity of audit tools. (Automated)
+  - id: 40158
+    title: "Ensure cryptographic mechanisms are used to protect the integrity of audit tools."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records."
+    rationale: "Protecting the integrity of the tools used for auditing purposes is a critical step toward ensuring the integrity of audit information. Attackers may replace the audit tools or inject code into the existing tools with the purpose of providing the capability to hide or erase system activity from the audit logs. Audit tools should be cryptographically signed in order to provide the capability to identify when the audit tools have been modified, manipulated, or replaced. An example is a checksum hash of the file or files."
+    remediation: "Add/Update the following selection lines to /usr/local/etc/aide.conf to protect the integrity of the audit tools: # Audit Tools /usr/sbin/audit p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditdistd p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditreduce p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/paudit p+i+n+u+g+s+b+acl+xattrs+sha512."
+    compliance:
+      - cis: ["5.2.4.9"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+    condition: all
+    rules:
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/audit p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditdistd p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditreduce p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/paudit p+i+n+u+g+s+b+acl+xattrs+sha512"
+
+  ###############################################
+  # 6 System Maintenance
+  ###############################################
+  ###############################################
+  # 6.1 System File Permissions
+  ###############################################
+  # 6.1.1 Ensure permissions on /etc/passwd are configured. (Automated)
+  - id: 40159
+    title: "Ensure permissions on /etc/passwd are configured."
+    description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
+    rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/passwd: # chmod 640 /etc/passwd # chown root:wheel /etc/passwd."
+    compliance:
+      - cis: ["6.1.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/passwd -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/passwd -> r:^root:wheel"    
+
+  # 6.1.2 Ensure permissions on /etc/group are configured. (Automated)
+  - id: 40160
+    title: "Ensure permissions on /etc/group are configured."
+    description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
+    rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/group: # chmod 640 /etc/group # chown root:wheel /etc/group."
+    compliance:
+      - cis: ["6.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/group -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/group -> r:^root:wheel"
+
+  # 6.1.3 Ensure permissions on /etc/master.passwd are configured. (Automated)
+  - id: 40161
+    title: "Ensure permissions on /etc/master.passwd are configured."
+    description: "The /etc/master.passwd file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
+    rationale: "If attackers can gain read access to the /etc/master.passwd file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/master.passwd file (such as expiration) could also be useful to subvert the user accounts."
+    remediation: "Run one of the following commands to set ownership of /etc/master.passwd to root and group to either root and wheel: # chown root:wheel /etc/master.passwd. Run the following command to remove excess permissions form /etc/master.passwd: # chmod 600 /etc/master.passwd."
+    compliance:
+      - cis: ["6.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/master.passwd -> r:^-rw-------"
+      - "c:stat -f %Su:%Sg /etc/master.passwd -> r:^root:wheel"
+
+   # 6.1.4 Ensure permissions on /etc/shells are configured. (Automated)
+  - id: 40162
+    title: "Ensure permissions on /etc/shells are configured."
+    description: "/etc/shells is a text file which contains the full pathnames of valid login shells. This file is consulted by chsh and available to be queried by other programs."
+    rationale: "It is critical to ensure that the /etc/shells file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/shells: # chmod 644 /etc/shells # chown root:wheel /etc/shells."
+    compliance:
+      - cis: ["6.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/shells -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/shells -> r:^root:wheel"    
+
+  # 6.1.5 Ensure world writable files and directories are secured. (Automated) - Not Implemented
+  # 6.1.6 Ensure no unowned or ungrouped files or directories exist. (Automated) - Not Implemented
+  # 6.1.7 Ensure SUID and SGID files are reviewed. (Manual) - - Not Implemented
+
+  ################################################
+  # 6.2 User and Group Settings
+  ################################################
+  # 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords. (Automated)
+  - id: 40163
+    title: "Ensure accounts in /etc/passwd use encrypted passwords."
+    description: "Local accounts can uses encrypted passwords. With encrypted passwords, The passwords are saved in /etc/master.passwd file encrypted by crypt. Accounts with a encrypted password have an * in the second field in /etc/passwd."
+    rationale: "The /etc/passwd file also contains information like user ID's and group ID's that are used by many system programs. Therefore, the /etc/passwd file must remain world readable. In spite of encoding the password with a randomly-generated one-way hash function, an attacker could still break the system if they got access to the /etc/passwd file. This can be mitigated by using encrypted passwords. The /etc/master.passwd file is set so only root will be able to read and write. This helps mitigate the risk of an attacker gaining access to the encoded passwords with which to perform a dictionary attack."
+    remediation: "Run the following command to set accounts to use encrypted passwords: # sed -e 's/^\\([a-zA-Z0-9_]*\\):[^:]*:/\\1:*:/' -i /etc/passwd Investigate to determine if the account is logged in and what it is being used for, to determine if it needs to be forced off."
+    compliance:
+      - cis: ["6.2.1"]
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["16.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1003", "T1003.008"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'not f:/etc/passwd -> !r:^\w+:*:'
+
+  # 6.2.2 Ensure /etc/shadow password fields are not empty. (Automated)
+  - id: 40164
+    title: "Ensure /etc/master.passwd password fields are not empty."
+    description: "An account with an empty password field means that anybody may log in as that user without providing a password."
+    rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
+    remediation: "If any accounts in the /etc/master.passwd file do not have a password, run the following command to lock the account until it can be determined why it does not have a password: # pw lock <username> Also, check to see if the account is logged in and investigate what it is being used for to determine if it needs to be forced off."
+    compliance:
+      - cis: ["6.2.2"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'not f:/etc/master.passwd -> r:^\w+::'
+
+  # 6.2.3 Ensure all groups in /etc/passwd exist in /etc/group. (Automated) - Not Implemented
+  # 6.2.4 Ensure no duplicate UIDs exist. (Automated) - Not Implemented
+  # 6.2.5 Ensure no duplicate GIDs exist. (Automated) - Not Implemented
+  # 6.2.6 Ensure no duplicate user names exist. (Automated) - Not Implemented
+  # 6.2.7 Ensure no duplicate group names exist. (Automated) - Not Implemented
+  # 6.2.8 Ensure root PATH Integrity. (Automated) - Not Implemented
+
+  # 6.2.9 Ensure root is the only UID 0 account. (Automated)
+  - id: 40165
+    title: "Ensure root is the only UID 0 account."
+    description: "Any account with UID 0 has superuser privileges on the system."
+    rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
+    remediation: "Remove any users other than root with UID 0 or assign them a new UID if appropriate."
+    compliance:
+      - cis: ["6.2.9"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1548"]
+    condition: all
+    rules:
+      - 'not f:/etc/passwd -> !r:^\s*\t*# && !r:^root: && r:^\w+:\w+:0:'
+
+  # 6.2.10 Ensure local interactive user home directories are configured. (Automated) - Not Implemented
+  # 6.2.11 Ensure local interactive user dot files access is configured. (Automated) - Not Implemented

--- a/ruleset/sca/freebsd/cis_freebsd13.yml
+++ b/ruleset/sca/freebsd/cis_freebsd13.yml
@@ -3091,7 +3091,7 @@ checks:
     condition: all
     rules:
       - 'c:sshd -T -> n:^\s*maxsessions\s+(\d+) compare <= 10'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxSessions\s+(1[1-9]|[2-9][0-9]|[1-9][0-9][0-9]+)'
+      - 'not f:/etc/ssh/sshd_config -> n:^MaxSessions\s+(\d+) compare > 10'
 
   # 4.2.22 Ensure SSH Idle Timeout Interval is configured. (Automated)
   - id: 40322
@@ -3225,8 +3225,8 @@ checks:
       - soc_2: ["CC6.1", "CC6.3"]
     condition: none
     rules:
-      - 'f:/usr/local/etc/sudoers -> !r:^# && r:*\!authenticate'
-      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:*\!authenticate'
+      - 'f:/usr/local/etc/sudoers -> !r:^# && r:!authenticate'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:!authenticate'
 
   # 4.3.6 Ensure sudo authentication timeout is configured correctly. (Automated)
   - id: 40328

--- a/ruleset/sca/freebsd/cis_freebsd13.yml
+++ b/ruleset/sca/freebsd/cis_freebsd13.yml
@@ -1,0 +1,4194 @@
+# Security Configuration Assessment
+# CIS Checks for FreeBSD 13.x based on Wazuh SCA files 
+# Copyright (C) 2023, Wazuh Inc.
+# Copyright (C) 2023, Alonso Cárdenas Márquez <acm@FreeBSD.org>.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+#
+# Based on:
+# Center for Internet Security Benchmarks - 16-10-2023
+
+policy:
+  id: "cis_freebsd13"
+  file: "cis_freebsd13.yml"
+  name: "SCA policy for FreeBSD 13.x"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for FreeBSD 13.x."
+  references:
+    - https://www.cisecurity.org/cis-benchmarks/
+
+requirements:
+  title: "Check FreeBSD version."
+  description: "Requirements for running the SCA scan against FreeBSD 13.x"
+  condition: all
+  rules:
+    - "f:/etc/os-release -> r:^NAME=FreeBSD"
+    - "c:sysctl -n kern.ostype -> r:^FreeBSD"
+    - "c:sysctl -n kern.osrelease -> r:^13."
+
+checks:
+  ###############################################
+  # 1 Initial setup
+  ###############################################
+  ###############################################
+  # 1.1 Filesystem Configuration
+  ###############################################
+  ###############################################
+  # 1.1.1 Disable unused filesystems
+  ###############################################
+  # 1.1.1.1 Ensure mounting of fusefs filesystems is disabled
+  - id: 40200
+    title: Ensure mounting of fusefs filesystems is disabled.
+    description: >
+      FUSE makes it possible to implement a filesystem in a userspace program.
+      Features include: simple yet comprehensive API, secure mounting by non-root
+      users, support for FreeBSD kernels, multi-threaded operation.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="fusefs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload fusefs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m fusefs -> r:fusefs && !r:fusefs$"    
+      
+  # 1.1.1.2 Ensure mounting of fdescfs filesystems is disabled (Automated)
+  - id: 40201
+    title: Ensure mounting of fdescfs filesystems is disabled.
+    description: >
+      The file-descriptor file system, or fdescfs, provides access to the per-
+      process file descriptor namespace in the global file system namespace.
+      The conventional mount point is /dev/fd
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="fdescfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload fdescfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m fdescfs -> r:fdescfs && !r:fdescfs$"    
+
+  # 1.1.1.3 Ensure mounting of smbfs filesystems is disabled (Automated)
+  - id: 40202
+    title: Ensure mounting of smbfs filesystems is disabled.
+    description: >
+      The SMB driver is an implementation of the CIFS (Common Internet
+      Filesystem) network protocol.
+
+      The smbfs filesystem driver supports only the obsolete SMBv1 protocol.
+      smbfs has known bugs and likely has security vulnerabilities.  smbfs and
+      userspace counterparts smbutil(1) and mount_smbfs(8) may be removed from
+      a future version of FreeBSD.  Users are advised to evaluate the
+      sysutils/fusefs-smbnetfs port instead.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="smbfsfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload smbfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.3"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m smbfs -> r:smbfs && !r:smbfs$"    
+      
+  # 1.1.1.4 Ensure mounting of nfscl filesystems is disabled (Automated)
+  - id: 40203
+    title: Ensure mounting of nfscl filesystems is disabled.
+    description: >
+      FUSE makes it possible to implement a filesystem in a userspace program.
+      Features include: simple yet comprehensive API, secure mounting by non-root
+      users, support for FreeBSD kernels, multi-threaded operation.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="nfscl"
+
+      Run the following command to unload the fusefs module:
+      # kldunload nfscl
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.4"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m nfscl -> r:nfscl && !r:nfscl$"    
+  
+  # 1.1.1.5 Ensure mounting of nfsd filesystems is disabled (Automated)
+  - id: 40204
+    title: Ensure mounting of nfsd filesystems is disabled.
+    description: >
+     The nfsd utility runs on a server machine to service NFS requests from
+     client machines.  At least one nfsd must be running for a machine to
+     operate as a server.
+
+     Unless otherwise specified, eight servers per CPU for UDP transport are
+     started.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="nfsd"
+
+      Run the following command to unload the fusefs module:
+      # kldunload nfsd
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m nfsd -> r:nfsd && !r:nfsd$"    
+  
+  # 1.1.1.6 Ensure mounting of msdosfs filesystems is disabled (Automated)
+  - id: 40205
+    title: Ensure mounting of msdosfs filesystems is disabled.
+    description: >
+      The msdosfs driver will permit the FreeBSD kernel to read and write MS-
+      DOS based file systems.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="msdosfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload msdosfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.6"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m msdosfs -> r:msdosfs && !r:msdosfs$"    
+        
+  # 1.1.1.7 Ensure mounting of cd9660 filesystems is disabled (Automated)
+  - id: 40206
+    title: Ensure mounting of cd9660 filesystems is disabled.
+    description: >
+      The cd9660 driver will permit the FreeBSD kernel to access the cd9660
+      file system.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="cd9660"
+
+      Run the following command to unload the fusefs module:
+      # kldunload cd9660
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.7"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m cd9660 -> r:cd9660 && !r:cd9660$"    
+  
+  # 1.1.1.8 Ensure mounting of procfs is disabled (Automated)
+  - id: 40207
+    title: Ensure mounting of procfs filesystems is disabled.
+    description: >
+      The procfs provides a two-level view of process space, unlike the
+      previous FreeBSD 1.1 procfs implementation.  At the highest level,
+      processes themselves are named, according to their process ids in
+      decimal, with no leading zeros.  There is also a special node called
+      curproc which always refers to the process making the lookup request.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="procfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload procfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.8"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m procfs -> r:procfs && !r:procfs$"    
+            
+  # 1.1.1.9 Ensure mounting of pseudofs is disabled (Automated)
+  - id: 40208
+    title: Ensure mounting of pseudofs filesystems is disabled.
+    description: >
+      The pseudofs module offers an abstract API for pseudo-file systems such
+      as procfs(5) and linprocfs(5).  It takes care of all the hairy bits like
+      interfacing with the VFS system, enforcing access control, keeping track
+      of file numbers, and cloning files and directories that are process-
+      specific.  The consumer module, i.e., the module that implements the
+      actual guts of the file system, needs only provide the directory
+      structure (represented by a collection of structures declared and
+      initialized by macros provided by pseudofs) and callbacks that report
+      file attributes or write the actual file contents into sbufs.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="pseudofs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload pseudofs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.9"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m pseudofs -> r:pseudofs && !r:pseudofs$"    
+
+  ###############################################
+  # 1.1.2 Configure /tmp
+  ###############################################
+  # 1.1.2.1 Ensure /tmp is a separate partition. (Automated)
+  - id: 40209
+    title: "Ensure /tmp is a separate partition."
+    description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
+    rationale: "Making /tmp its own file system allows an administrator to set additional mount options such as the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hard link to a system setuid program and wait for it to be updated. Once the program was updated, the hard link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp."
+    impact: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. Running out of /tmp space is a problem regardless of what kind of filesystem lies under it, but in a configuration where /tmp is not a separate file system it will essentially have the whole disk available, as the default installation only creates a single / partition. On the other hand, a RAM-based /tmp (as with tmpfs) will almost certainly be much smaller, which can lead to applications filling up the filesystem much more easily. Another alternative is to create a dedicated partition for /tmp from a separate volume or disk. One of the downsides of a disk-based dedicated partition is that it will be slower than tmpfs which is RAM-based. /tmp utilizing tmpfs can be resized using the size={size} parameter in the relevant entry in /etc/fstab."
+    remediation: "For specific configuration requirements of the /tmp mount for your environment, modify /etc/fstab: Configure /etc/fstab as appropriate: Example: tmpfs /tmp tmpfs rw,nosuid,noexec 0 0"
+    references:
+      - "https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/"
+      - "https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html"
+    compliance:
+      - cis: ["1.1.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s'
+
+  # 1.1.2.2 Ensure nodev option set on /tmp partition. (No apply)
+  - id: 40210
+    title: "Ensure nodev option set on /tmp partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s && r:nodev'
+      - 'c: zfs get -H -o value devices /tmp -> r:off'
+
+  # 1.1.2.3 Ensure noexec option set on /tmp partition. (Automated)
+  - id: 40211
+    title: "Ensure noexec option set on /tmp partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s && r:noexec'
+      - 'c: zfs get -H -o value exec /tmp -> r:off'   
+
+  # 1.1.2.4 Ensure nosuid option set on /tmp partition. (Automated)
+  - id: 40212
+    title: "Ensure nosuid option set on /tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s\s*/tmp\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /tmp -> r:off'      
+
+  ###############################################
+  # 1.1.3 Configure /var
+  ###############################################
+  # 1.1.3.1 Ensure separate partition exists for /var.
+  - id: 40213
+    title: "Ensure separate partition exists for /var."
+    description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
+    rationale: "The default installation only creates a single / partition. Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var and cause unintended behavior across the system as the disk is full. Fine grained control over the mount Configuring /var as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behaviour."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.3.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:/var\s'   
+
+  # 1.1.3.2 Ensure nodev option set on /var partition.
+  - id: 40214
+    title: "Ensure nodev option set on /var partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /var with the configured options: # mount -u -o /var. On ZFS filesystem do the following: zfs set devices=off mypool/var"
+    compliance:
+      - cis: ["1.1.3.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:/var\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var -> r:off'      
+
+  # 1.1.3.3 Ensure nosuid option set on /var partition.
+  - id: 40215
+    title: "Ensure nosuid option set on /var partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /var with the configured options: # mount -u -o /var. On ZFS filesystem do the following: zfs set setuid=off mypool/var"
+    compliance:
+      - cis: ["1.1.3.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:/var\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var -> r:off'      
+
+  ###############################################
+  # 1.1.4 Configure /var/tmp
+  ###############################################
+  # 1.1.4.1 Ensure separate partition exists for /var/tmp. (Automated)
+  - id: 40216
+    title: "Ensure separate partition exists for /var/tmp."
+    description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications. Temporary files residing in /var/tmp are to be preserved between reboots."
+    rationale: "The default installation only creates a single / partition. Since the /var/tmp directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var/tmp and cause the potential disruption to daemons as the disk is full. Configuring /var/tmp as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/tmp. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate. "
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.4.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s'
+
+  # 1.1.4.2 Ensure nodev option set on /var/tmp partition. (No apply)
+  - id: 40217
+    title: "Ensure nodev option set on /var/tmp partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set devices=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/tmp -> r:off'      
+
+  # 1.1.4.3 Ensure noexec option set on /var/tmp partition. (Automated)
+  - id: 40218
+    title: "Ensure noexec option set on /var/tmp partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set exec=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/tmp -> r:off'      
+
+  # 1.1.4.4 Ensure nosuid option set on /var/tmp partition. (Automated)
+  - id: 40219
+    title: "Ensure nosuid option set on /var/tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set setuid=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -u /var/tmp -> r:\s/var/tmp\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/tmp -> r:off'      
+
+  ###############################################
+  # 1.1.5 Configure /var/log
+  ###############################################
+  # 1.1.5.1 Ensure separate partition exists for /var/log. (Automated)
+  - id: 40220
+    title: "Ensure separate partition exists for /var/log."
+    description: "The /var/log directory is used by system services to store log data."
+    rationale: "The default installation only creates a single / partition. Since the /var/log directory contains log files which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. Fine grained control over the mount Configuring /var/log as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. As /var/log contains log files, care should be taken to ensure the security and integrity of the data and mount point."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.5.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s'    
+
+  # 1.1.5.2 Ensure nodev option set on /var/log partition. (Automated)
+  - id: 40221
+    title: "Ensure nodev option set on /var/log partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/log filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set devices=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/log -> r:off'      
+
+  # 1.1.5.3 Ensure noexec option set on /var/log partition. (Automated)
+  - id: 40222
+    title: "Ensure noexec option set on /var/log partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot run executable binaries from /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set exec=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/log -> r:off'      
+
+  # 1.1.5.4 Ensure nosuid option set on /var/log partition. (Automated)
+  - id: 40223
+    title: "Ensure nosuid option set on /var/log partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot create setuid files in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set setuid=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/log -> r:off'      
+
+  ###############################################
+  # 1.1.6 Configure /var/audit
+  ###############################################
+  # 1.1.6.1 Ensure separate partition exists for /var/audit. (Automated)
+  - id: 40224
+    title: "Ensure separate partition exists for /var/audit."
+    description: "The auditing daemon, auditd, stores log data in the /var/audit directory."
+    rationale: "The default installation only creates a single / partition. Since the /var/audit directory contains the audit log files which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. Configuring /var/audit as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. As /var/audit contains audit logs, care should be taken to ensure the security and integrity of the data and mount point."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/audit. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.6.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s'
+
+  # 1.1.6.2 Ensure nodev option set on /var/log/audit partition. (Automated)
+  - id: 40225
+    title: "Ensure nodev option set on /var/audit partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/audit filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/audit partition. Example: <device> /var/log/audit <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/log/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set devices=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/audit -> r:off'      
+
+  # 1.1.6.3 Ensure noexec option set on /var/log/audit partition. (Automated)
+  - id: 40226
+    title: "Ensure noexec option set on /var/audit partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/audit filesystem is only intended for audit logs, set this option to ensure that users cannot run executable binaries from /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var partition. Example: <device> /var/audit <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set exec=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/audit -> r:off'      
+
+  # 1.1.6.4 Ensure nosuid option set on /var/log/audit partition. (Automated)
+  - id: 40227
+    title: "Ensure nosuid option set on /var/audit partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/audit filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/audit partition. Example: <device> /var/audit <fstype> rw,nosuid,noexec,relatime 0 0 Run the following command to remount /var/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set setuid=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/audit -> r:off'      
+
+  ###############################################
+  # 1.1.7 Configure /usr/home
+  ###############################################
+  # 1.1.7.1 Ensure separate partition exists for /usr/home. (Automated)
+  - id: 40228
+    title: "Ensure separate partition exists for /usr/home."
+    description: "The /usr/home directory is used to support disk storage needs of local users."
+    rationale: "The default installation only creates a single / partition. Since the /usr/home directory contains user generated data, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /usr/home and impact all local users. Configuring /usr/home as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. In the case of /usr/home options such as quota may be considered to limit the impact that users can have on each other with regards to disk resource exhaustion."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /usr/home. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.7.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s'
+
+  # 1.1.7.2 Ensure nodev option set on /usr/home partition. (Automated)
+  - id: 40229
+    title: "Ensure nodev option set on /usr/home partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /usr/home filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /home."
+    remediation: "IF the /usr/home partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /usr/home partition. Example: <device> /usr/home <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /usr/home with the configured options: # mount -u -o /usr/home. On ZFS filesystem do the following: zfs set devices=off mypool/usr/home"
+    compliance:
+      - cis: ["1.1.7.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s && r:nodev'
+      - 'c: zfs get -H -o value devices /usr/home -> r:off'      
+
+  # 1.1.7.3 Ensure nosuid option set on /usr/home partition. (Automated)
+  - id: 40230
+    title: "Ensure nosuid option set on /usr/home partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /usr/home filesystem is only intended for user file storage, set this option to ensure that users cannot create setuid files in /usr/home."
+    remediation: "IF the /usr/home partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /usr/home partition. Example: <device> /usr/home <fstype> rw,nosuid 0 0 Run the following command to remount /usr/home with the configured options: # mount -u -o /usr/home. On ZFS filesystem do the following: zfs set setuid=off mypool/usr/home"
+    compliance:
+      - cis: ["1.1.7.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /usr/home -> r:off'      
+
+  ###############################################
+  # 1.1.8 Configure /dev/shm (No apply. It could be a tmpfs)
+  ###############################################
+
+  # 1.1.9 Disable Automounting. (Automated)
+  - id: 40231
+    title: "Disable Automounting."
+    description: "autofs or automount allows automatic mounting of devices, typically including CD/DVDs and USB drives."
+    rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in the filesystem even if they lacked permissions to mount it themselves."
+    impact: "The use of portable hard drives is very common for workstation users. If your organization allows the use of portable storage or media on workstations and physical access controls to workstations are considered adequate there is little value add in turning off automounting."
+    remediation: "If there are no other packages that depends on autofs or automount,  disable it with: # pkg remove automount; kldunload autofs; sysrc autofs_enable=NO"
+    compliance:
+      - cis: ["1.1.9"]
+      - cis_csc_v8: ["10.3"]
+      - cis_csc_v7: ["8.5"]
+      - cmmc_v2.0: ["MP.L2-3.8.7"]
+      - hipaa: ["164.310(d)(1)"]
+      - iso_27001-2013: ["A.12.2.1"]
+      - mitre_techniques: ["T1068", "T1203", "T1211", "T1212"]
+    condition: all
+    rules:
+      - "not c: sysctl -n vfs.usermount -> r:1"
+      - "c: kldstat -m autofs -> r:autofs && !r:autofs$"
+      - "not c: sysrc -n autofs_enable -> r:YES"
+      - "not c: pkg query %n-%v automount -> r:automount"   
+
+  # 1.1.10 Disable USB Storage. (Automated)   
+
+  ###############################################
+  # 1.2 Configure Software Updates
+  ###############################################
+  # 1.2.1 Ensure package manager repositories are configured. (Manual) - Not Implemented
+  # 1.2.2 Ensure updates, patches, and additional security software are installed. (Manual)
+  - id: 40232
+    title: "Ensure updates, patches, and additional security software are installed."
+    description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
+    rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
+    remediation: "Run the following command to update all packages following local site policy guidance on applying updates and patches: # pkg upgrade."
+    compliance:
+      - cis: ["1.2.1"]
+      - cis_csc_v8: ["7.3"]
+      - cis_csc_v7: ["3.4", "3.5"]
+      - cmmc_v2.0: ["SI.L1-3.14.1"]
+      - mitre_mitigations: ["M1051"]
+      - mitre_tactics: ["TA0004", "TA0008"]
+      - mitre_techniques: ["T1211"]
+      - nist_sp_800-53: ["SI-2(2)"]
+      - pci_dss_v3.2.1: ["6.2"]
+      - soc_2: ["CC7.1"]
+    condition: all
+    rules:
+      - "c:pkg upgrade -n -> r:^Your packages are up to date"
+        
+  ###############################################
+  # 1.3 Filesystem Integrity Checking
+  ###############################################
+  # 1.3.1 Ensure AIDE is installed. (Automated)
+  - id: 40233
+    title: "Ensure AIDE is installed."
+    description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
+    rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
+    remediation: "Install AIDE using the appropriate package manager or manual installation: # apt install aide aide-common Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options. Run the following commands to initialize AIDE: # aideinit # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db."
+    compliance:
+      - cis: ["1.3.1"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_techniques: ["T1036", "T1036.002", "T1036.003", "T1036.004", "T1036.005", "T1565", "T1565.001"]
+      - nist_sp_800-53: ["AC-6(9)"]
+      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "not c: pkg query %n-%v aide -> r:aide"
+       
+  # 1.3.2 Ensure filesystem integrity is regularly checked. (Automated)
+  - id: 40234
+    title: "Ensure filesystem integrity is regularly checked."
+    description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
+    rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
+    remediation: "If cron will be used to schedule and run aide check Run the following command: # crontab -u root -e Add the following line to the crontab: 0 5 * * * /usr/local/bin/aide --check."
+    references:
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.service"
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.timer"
+    compliance:
+      - cis: ["1.3.2"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - nist_sp_800-53: ["AU-2"]
+      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "c:crontab -l -> r:aide --check"
+
+  ###############################################
+  # 1.4 Secure Boot Settings
+  ###############################################
+  # 1.4.1 Ensure bootloader password is set. (Automated)
+  - id: 40235
+    title: "Ensure bootloader password is set."
+    description: "Setting the bootloader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
+    rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering bootloader menu. This prevents users from weakening security."
+    impact: 'If password protection is enabled, only the designated superuser can select any option of boot menu item.'
+    remediation: 'Add password="your_password_here" to /boot/loader.conf .'
+    compliance:
+      - cis: ["1.4.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1046"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1542"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/boot/loader.conf -> r:^password'
+
+  # 1.4.2 Ensure permissions on bootloader config are configured. (Automated)
+  - id: 40236
+    title: "Ensure permissions on bootloader config are configured."
+    description: "The bootloader configuration file contains information on boot settings and passwords for unlocking boot options."
+    rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
+    remediation: "Run the following commands to set permissions on your grub configuration: # chown root:wheel /boot/loader.conf # chmod 640 /boot/loader.conf."
+    compliance:
+      - cis: ["1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005", "TA0007"]
+      - mitre_techniques: ["T1542"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /boot/loader.conf -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /boot/loader.conf -> r:^root:wheel"
+
+  # 1.4.3 Ensure authentication required for single user mode. (Automated)
+  - id: 40237
+    title: "Ensure authentication required for single user mode."
+    description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
+    rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
+    remediation: "Run the following command and follow the prompts to set a password for the root user: # passwd root and change console line into /etc/ttys from secure to insecure."
+    compliance:
+      - cis: ["1.4.3"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/ttys -> r:^console && r:insecure'
+
+  ###############################################
+  # 1.5 Additional Process Hardening
+  ###############################################
+  # 1.5.1 Ensure address space layout randomization (ASLR) is enabled
+  - id: 40238
+    title: Ensure address space layout randomization (ASLR) is enabled.
+    description: >
+      Address space layout randomization (ASLR) is an exploit mitigation technique which
+      randomly arranges the address space of key data areas of a process.
+    rationale: >
+      Randomly placing virtual memory regions will make it difficult to write memory page
+      exploits as the memory placement will be consistently shifting.
+    remediation: >
+      Set the following parameter in /etc/sysctl.conf file:
+      kern.elf64.aslr.enable=1
+      kern.elf64.aslr.stack=1
+      kern.elf64.aslr.shared_page=1
+      kern.elf64.aslr.pie_enable=1
+      kern.elf32.aslr.stack=1 
+
+      Run the following command to set the active kernel parameter:
+      # sysctl kern.elf64.aslr.enable=1
+      # sysctl kern.elf64.aslr.stack=1
+      # sysctl kern.elf64.aslr.shared_page=1
+      # sysctl kern.elf64.aslr.pie_enable=1
+      # sysctl kern.elf32.aslr.stack=1 
+    compliance:
+      - cis: ["1.5.1"]
+      - cis_csc: ["8.3"]
+    condition: all
+    rules:
+      - "c:sysctl -n kern.elf64.aslr.enable -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.stack -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.shared_page -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.pie_enable -> r:1"
+      - "c:sysctl -n kern.elf32.aslr.stack -> r:1"      
+      
+  # 1.5.2 Ensure core dumps are restricted (Automated)
+  - id: 40239
+    title: "Ensure core dumps are restricted."
+    description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
+    rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). ."
+    remediation: > 
+      Set the following parameter in /etc/sysctl.conf file:
+      kern.coredump=0
+      kern.corefile=/dev/null
+      or            
+      # sysrc dumpdev="NO"     
+      Run the following command to set the active kernel parameter:
+      # sysctl kern.coredump=0
+      # sysctl kern.corefile=/dev/null      
+    compliance:
+      - cis: ["1.5.2"]
+      - mitre_techniques: ["T1005"]
+      - mitre_tactics: ["TA0007"]
+    condition: all
+    rules:
+      - "c:sysctl -n kern.coredump -> r:0"
+      - "c:sysctl -n kern.corefile -> r:/dev/null"      
+      - "c:sysrc -n dumpdev -> r:NO"
+
+  ###############################################
+  # 1.6 Mandatory Access Control
+  ###############################################
+  ###############################################
+  # 1.6.1 Configure TrustedBSD Mandatory Access Control
+  ###############################################  
+  # 1.6.1.1 Ensure TrustedBSD Mandatory Access Control is installed. (Automated)
+  - id: 40240
+    title: "Ensure TrustedBSD Mandatory Access Control is installed."
+    description: "TrustedBSD provides Mandatory Access Controls."
+    rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
+    remediation: "Enable TrustedBSD Mandatory Access Control. # sysctl kern.features.security_mac=1"
+    compliance:
+      - cis: ["1.6.1.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1068", "T1565", "T1565.001", "T1565.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n kern.features.security_mac -> r:1'
+
+  # 1.6.1.2 Ensure TrustedBSD MAC is not disabled in bootloader configuration. (Automated)
+  - id: 40241
+    title: "Ensure TrustedBSD MAC is not disabled in loader configuration."
+    description: "Configure TrustedBSD MAC to be enabled at boot time and verify that it has not been overwritten by the loader parameters."
+    rationale: "TrustedBSD MAC is enabled into kernel by default but it can be disabled from loader.conf."
+    impact: "Files created while TrustedBSD MAC is disabled are not labeled at all. This behavior causes problems when changing to enforcing mode because files are labeled incorrectly or are not labeled at all. To prevent incorrectly labeled and unlabeled files from causing problems, file systems are automatically relabeled when changing from the disabled state to permissive or enforcing mode. This can be a long running process that should be accounted for as it may extend downtime during initial re-boot."
+    remediation: "Remove instance of kern.features.security_mac=0 from /boot/loader.conf."
+    compliance:
+      - cis: ["1.6.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: none
+    rules:
+      - 'not f:/boot/loader.conf -> r:kern.features.security_mac=0'
+
+  ###############################################
+  # 1.7 Command Line Warning Banners
+  ###############################################
+  # 1.7.1 Ensure message of the day is configured properly. (Automated)
+  - id: 40242
+    title: "Ensure message of the day is configured properly."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform."
+    rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
+    remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy. Add or update the message text to follow local site policy. Example Text: # echo \"Authorized use only. All activity may be monitored and reported.\" > /etc/motd.template -- OR -- If the motd is not used, you can remove content inside of /etc/motd.template file and run # service motd restart."
+    compliance:
+      - cis: ["1.7.1"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1082", "T1592", "T1592.004"]
+    condition: all
+    rules:
+      - "f:/var/run/motd"
+      - "not f:/etc/motd"      
+
+  # 1.7.2 Ensure permissions on /etc/motd.template are configured. (Automated)
+  - id: 40243
+    title: "Ensure permissions on /etc/motd.template are configured."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
+    rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/motd, /etc/motd.template and /var/run/motd : # chown root:wheel /etc/motd /etc/motd.template /var/run/motd # chmod 644 /etc/motd /etc/motd.template /var/run/motd -- OR -- Run the following command to remove the /etc/motd file: # rm /etc/motd."
+    compliance:
+      - cis: ["1.7.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - "c:stat -f %Sp /etc/motd.template -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/motd.template -> r:^root:wheel"    
+      - "c:stat -f %Sp /etc/motd -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/motd -> r:^root:wheel"
+      - "c:stat -f %Sp /var/run/motd -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /var/run/motd -> r:^root:wheel"            
+
+  ###############################################
+  # 1.8 GNOME Display Manager
+  ###############################################
+  # 1.8.1 Ensure GNOME Display Manager is removed. (Automated)
+  - id: 40244
+    title: "Ensure GNOME Display Manager is removed."
+    description: "The GNOME Display Manager (GDM) is a program that manages graphical display servers and handles graphical user logins."
+    rationale: "If a Graphical User Interface (GUI) is not required, it should be removed to reduce the attack surface of the system."
+    impact: "Removing the GNOME Display manager will remove the Graphical User Interface (GUI) from the system."
+    remediation: "Run the following command to uninstall gdm3: # apt purge gdm3."
+    compliance:
+      - cis: ["1.8.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v gdm -> !r:gdm"    
+
+  # 1.8.2 Ensure GDM login banner is configured. (Automated) - Not Implemented
+  # 1.8.3 Ensure GDM disable-user-list option is enabled. (Automated) - Not Implemented
+  # 1.8.4 Ensure GDM screen locks when the user is idle. (Automated) - Not Implemented
+  # 1.8.5 Ensure GDM screen locks cannot be overridden. (Automated) - Not Implemented
+  # 1.8.6 Ensure GDM automatic mounting of removable media is disabled. (Automated) - Not Implemented
+  # 1.8.7 Ensure GDM disabling automatic mounting of removable media is not overridden. (Automated) - Not Implemented
+  # 1.8.8 Ensure GDM autorun-never is enabled. (Automated) - Not Implemented
+  # 1.8.9 Ensure GDM autorun-never is not overridden. (Automated) - Not Implemented
+
+  # 1.8.10 Ensure XDCMP is not enabled. (Automated)
+  - id: 40245
+    title: "Ensure XDCMP is not enabled."
+    description: "X Display Manager Control Protocol (XDMCP) is designed to provide authenticated access to display management services for remote displays."
+    rationale: "XDMCP is inherently insecure. - XDMCP is not a ciphered protocol. This may allow an attacker to capture keystrokes entered by a user - XDMCP is vulnerable to man-in-the-middle attacks. This may allow an attacker to steal the credentials of legitimate users by impersonating the XDMCP server."
+    remediation: "Edit the file /usr/local/etc/gdm/custom.conf and remove the line: Enable=true."
+    compliance:
+      - cis: ["1.8.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1050"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1040", "T1056", "T1056.001", "T1557"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - 'not f:/usr/local/etc/gdm/custom.conf -> r:^\s*Enable\s*=\s*true'
+      
+  ############################################################
+  # 2 Services
+  ############################################################
+  # 2.1 Configure Time Synchronization
+  # 2.1.1 Ensure time synchronization is in use
+  # 2.1.1.1 Ensure a single time synchronization daemon is in use. (Automated)
+  - id: 40246
+    title: "Ensure a single time synchronization daemon is in use."
+    description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them. Note: - On virtual systems where host based time synchronization is available consult your virtualization software documentation and verify that host based synchronization is in use and follows local site policy. Only one time synchronization method should be in use on the system. Configuring multiple time synchronization methods could lead to unexpected or unreliable results."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
+    remediation: "On physical systems, and virtual systems where host based time synchronization is not available. Select one of the three time synchronization daemons; ntpdate (1), ntpd (2) or chrony (3), and following the remediation procedure for the selected daemon. Note: enabling more than one synchronization daemon could lead to unexpected or unreliable results: 1. # sysrc ntpdate_enable=YES 2. # sysrc ntpd_enable=YES; # service ntpd start 3. # sysrc chronyd_enable=YES"
+    compliance:
+      - cis: ["2.1.1.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: any
+    rules:
+      - "c:sysrc -n ntpdate_enable -> r:YES"
+      - "c:sysrc -n ntpd_enable -> r:YES"    
+      - "c:sysrc -n chronyd_enable -> r:YES"               
+
+  # 2.1.2 Configure chrony
+  # 2.1.2.1 Ensure chrony is configured with authorized timeserver. (Manual)
+  - id: 40247
+    title: "Ensure chrony is configured with authorized timeserver."
+    description: "The server directive specifies an NTP server which can be used as a time source. The client-server relationship is strictly hierarchical: a client might synchronize its system time to that of the server, but the server's system time will never be influenced by that of a client. The syntax of pool directive is similar to that for the server directive, except that it is used to specify a pool of NTP servers rather than a single NTP server. The pool name is expected to resolve to multiple addresses which might change over time."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /use/local/etc/chrony/chrony.conf file and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]>. Run one of the following commands to load the updated time sources into chronyd running config: # service chronyd restart OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:pgrep -l chrony -> r:chronyd"
+      - 'f:/usr/local/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
+
+  # 2.1.2.2 Ensure chrony is running as user chrony. (Automated)
+  - id: 40248
+    title: "Ensure chrony is running as user chrony or ntpd."
+    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
+    rationale: "The chronyd service should run with only the required privileges."
+    remediation: "Add or edit the user line to /usr/local/etc/chrony/chrony.conf : user chrony|ntpd OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: any
+    rules:
+      - "c:pgrep -U chrony -l chronyd"    
+      - "c:pgrep -U ntpd -l chronyd"
+
+  # 2.1.2.3 Ensure chrony is enabled and running. (Automated)
+  - id: 40249
+    title: "Ensure chrony is enabled and running."
+    description: "chrony is a daemon for synchronizing the system clock across the network."
+    rationale: "chrony needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF chrony is in use on the system, run the following commands: Run the following command to enable and start chronyd service: # service chronyd enable; # service chronyd start OR If another time synchronization service is in use on the system, run the following command to remove chrony: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n chronyd_enable -> r:^YES"
+      - "c:service chronyd status -> r:^chronyd is running as pid"
+
+  # 2.1.3.1 Ensure ntp access control is configured. (Automated)
+  - id: 40250
+    title: "Ensure ntp access control is configured."
+    description: 'NTP access control is a security measure used to prevent fraudulent or inadvertent manipulation of a time server'
+    rationale: "If ntp is in use on the system, proper configuration is vital to ensuring time synchronization is accurate."
+    remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery OR If another time synchronization service is in use on the system, run the following command to stop ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+    compliance:
+      - cis: ["2.1.3.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1498", "T1498.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - 'f:/etc/ntp.conf -> r:^restrict\s*\t*-4\s*\t*default|^restrict\s*\t*default && r:\s*kod && r:\s*nomodify && r:\s*notrap && r:\s*nopeer && r:\s*noquery'
+      - 'f:/etc/ntp.conf -> r:^restrict\s*\t*-6\s*\t*default && r:\s*kod && r:\s*nomodify && r:\s*notrap && r:\s*nopeer && r:\s*noquery'
+
+  # 2.1.3.2 Ensure ntp is configured with authorized timeserver. (Manual)
+  - id: 40251
+    title: "Ensure ntp is configured with authorized timeserver."
+    description: '- pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. - server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses.'
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]>. Run the following command to load the updated time sources into ntp running config: # service ntp restart OR If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+      - "https://tf.nist.gov/tf-cgi/servers.cgi"
+    compliance:
+      - cis: ["2.1.3.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1498", "T1498.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "f:/etc/ntp.conf -> r:^pool"
+      - "f:/etc/ntp.conf -> r:^server"
+
+  # 2.1.3.3 Ensure ntp is running as user ntpd. (Automated)
+  - id: 40252
+    title: "Ensure ntp is running as user ntp."
+    description: "The ntpd application is part of FreeBD base system and it has a dedicated user account ntpd. This account is granted the access required by the ntpd daemon Note: - If chrony is used, ntpd should be removed and this section skipped - This recommendation only applies if ntpd is in use on the system - Only one time synchronization method should be in use on the system."
+    rationale: "The ntpd daemon should run with only the required privilege."
+    remediation: "The ntpd run by default using ntpd user. It can not changed. If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+    compliance:
+      - cis: ["2.1.3.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:pgrep -U ntpd -l ntpd -> r:ntpd"    
+
+  # 2.1.3.4 Ensure ntp is enabled and running. (Automated)
+  - id: 40253
+    title: "Ensure ntpd is enabled and running."
+    description: "ntpd is a daemon for synchronizing the system clock across the network."
+    rationale: "ntpd needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF ntpd is in use on the system, run the following commands: Run the following command to enable and start ntp service: # service ntpd enable; # service ntpd start OR If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    compliance:
+      - cis: ["2.1.3.4"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n ntpd_enable -> r:^YES"
+      - "c:service ntpd status -> r:^ntpd is running as pid"
+
+  ###############################################
+  # 2.2 Special Purpose Services
+  ###############################################
+  # 2.2.1 Ensure xinetd is not installed. (Automated)
+  - id: 40254
+    title: "Ensure xinetd is not installed."
+    description: "The eXtended InterNET Daemon (xinetd) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
+    rationale: "If there are no xinetd services required, it is recommended that the package be removed to reduce the attack surface are of the system. Note: If an xinetd service or services are required, ensure that any xinetd service not required is stopped and disabled."
+    remediation: "Run the following command to remove xinetd: # pkg remove xinetd -y."
+    compliance:
+      - cis: ["2.2.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v xinetd -> r:^xinetd"    
+
+  # 2.2.2 Ensure X Window System is not installed. (Automated)
+  - id: 40255
+    title: "Ensure X Window System is not installed."
+    description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
+    rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
+    impact: 'Many Unix-Like systems run applications which require a Java runtime. Some Java packages have a dependency on specific X Windows xorg-fonts. One workaround to avoid this dependency is to use the "headless" Java packages for your specific Java runtime, if provided by your distribution.'
+    remediation: "Remove the X Windows System packages: pkg remove 'xorg*'."
+    compliance:
+      - cis: ["2.2.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v xorg-server -> r:^xorg-server"      
+
+  # 2.2.3 Ensure Avahi Server is not installed. (Automated)
+  - id: 40256
+    title: "Ensure Avahi Server is not installed."
+    description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
+    rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
+    remediation: "Run the following commands to remove avahi-daemon: # service avahi_daaemon stop # sysrc -x avahi_daemon_enable  # pkg remove 'avahi*'."
+    compliance:
+      - cis: ["2.2.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v avahi-app -> r:^avahi-app"
+
+  # 2.2.4 Ensure CUPS is not installed. (Automated)
+  - id: 40257
+    title: "Ensure CUPS is not installed."
+    description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
+    rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface."
+    impact: "Removing CUPS will prevent printing from the system, a common task for workstation systems."
+    remediation: "Run one of the following commands to remove cups : # pkg remove cups."
+    references:
+      - "http://www.cups.org."
+    compliance:
+      - cis: ["2.2.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v cups -> r:^cups"
+
+  # 2.2.5 Ensure DHCP Server is not installed. (Automated)
+  - id: 40258
+    title: "Ensure DHCP Server is not installed."
+    description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
+    rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove isc-dhcp-server or dhcpd: # pkg remove 'isc-dhcp*' or pkg remove dhcpd."
+    references:
+      - "http://www.isc.org/software/dhcp."
+    compliance:
+      - cis: ["2.2.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dhcpd|isc-dhcp.*-server' -> r:dhcp"    
+
+  # 2.2.6 Ensure LDAP server is not installed. (Automated)
+  - id: 40259
+    title: "Ensure LDAP server is not installed."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove slapd: # pkg remove 'openldap*-server'."
+    references:
+      - "http://www.openldap.org."
+    compliance:
+      - cis: ["2.2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'openldap.*server' -> r:^openldap"    
+
+  # 2.2.7 Ensure NFS is not installed. (Automated)
+  - id: 40260
+    title: "Ensure NFS is not installed."
+    description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
+    rationale: "If the system does not export NFS shares, it is recommended that the nfs-kernel-server package be removed to reduce the remote attack surface."
+    remediation: "Run the following command to disable nfs: # sysctl kern.features.nfsd=0; # sysctl kern.features.nfscl=0 and add those entries to /etc/sysctl.conf"
+    compliance:
+      - cis: ["2.2.7"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:sysctl -n kern.features.nfsd -> r:0"
+      - "c:sysctl -n kern.features.nfscl -> r:0"      
+
+  # 2.2.8 Ensure DNS Server is not installed. (Automated)
+  - id: 40261
+    title: "Ensure DNS Server is not installed."
+    description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
+    rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following commands to disable DNS server: # pkg remove 'bind9*' or # pkg remove unbound."
+    compliance:
+      - cis: ["2.2.8"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v bind9 -> r:^bind9"    
+      - "not c:pkg query -x %n-%v unbound -> r:^unbound"      
+
+  # 2.2.9 Ensure FTP Server is not installed. (Automated)
+  - id: 40262
+    title: "Ensure FTP Server is not installed."
+    description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
+    rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended SFTP be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove ftp daemon: # pkg remove -x 'bbftp-server|ftpd|uftp'."
+    compliance:
+      - cis: ["2.2.9"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'bbftp-server|ftpd|uftp' -> r:ftp"
+
+  # 2.2.10 Ensure TFTP Server is not installed. (Automated)
+  - id: 40263
+    title: "Ensure TFTP Server is not installed."
+    description: "Trivial File Transfer Protocol (TFTP) is a simple protocol for exchanging files between two TCP/IP machines. TFTP servers allow connections from a TFTP Client for sending and receiving files."
+    rationale: "TFTP does not have built-in encryption, access control or authentication. This makes it very easy for an attacker to exploit TFTP to gain access to files."
+    remediation: "Run the following command to remove tftp servers: # pkg remove -x 'utftpd|tftp-'."
+    compliance:
+      - cis: ["2.2.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'utftpd|tftp-' -> r:tftp"
+
+  # 2.2.11 Ensure HTTP server is not installed. (Automated)
+  - id: 40264
+    title: "Ensure HTTP server is not installed."
+    description: "HTTP or web servers provide the ability to host web site content."
+    rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove httpd server: # pkg remove -x '^apache|^nginx|httpd'."
+    compliance:
+      - cis: ["2.2.11"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'nginx' -> r:^nginx"    
+      - "not c:pkg query -x %n-%v 'apache' -> r:^apache"
+      - "not c:pkg query -x %n-%v 'httpd' -> r:httpd"
+
+  # 2.2.12 Ensure IMAP and POP3 server are not installed. (Automated)
+  - id: 40265
+    title: "Ensure IMAP and POP3 server are not installed."
+    description: "dovecot-imapd, dovecot-pop3d, cyrus-imapd and pop3d are an open source IMAP and POP3 server for Unix based systems."
+    rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove imapd and pop3d servers: # pkg remove -x '^dovecot|^cyrus-imapd|^pop3d'."
+    compliance:
+      - cis: ["2.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dovecot' -> r:dovecot"    
+      - "not c:pkg query -x %n-%v 'cyrus-imapd' -> r:cyrus-imapd"      
+      - "not c:pkg query -x %n-%v 'pop3d' -> r:pop3d"
+
+  # 2.2.13 Ensure Samba is not installed. (Automated)
+  - id: 40266
+    title: "Ensure Samba is not installed."
+    description: "The Samba daemon allows system administrators to configure their FreeBSD systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Server Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
+    rationale: "If there is no need to mount directories and file systems to Windows systems, then this service should be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove samba: # pkg remove -x '^samba'."
+    compliance:
+      - cis: ["2.2.13"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1005", "T1039", "T1083", "T1135", "T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'samba' -> r:samba"
+
+  # 2.2.14 Ensure HTTP Proxy Server is not installed. (Automated)
+  - id: 40267
+    title: "Ensure HTTP Proxy Server is not installed."
+    description: "Squid, privoxy, tinyproxy, 3proxy are standard proxy servers used in many distributions and environments."
+    rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove squid: # pkg remove -x 'squid|privoxy|tinyproxy|3proxy'."
+    compliance:
+      - cis: ["2.2.14"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'squid' -> r:squid"    
+      - "not c:pkg query -x %n-%v 'privoxy' -> r:privoxy"      
+      - "not c:pkg query -x %n-%v 'tinyproxy' -> r:tinyproxy"      
+      - "not c:pkg query -x %n-%v '3proxy' -> r:3proxy"      
+
+  # 2.2.15 Ensure SNMP Server is not installed. (Automated)
+  - id: 40268
+    title: "Ensure SNMP Server is not installed."
+    description: 'Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system.'
+    rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the snmpd package should be removed to reduce the attack surface of the system. Note: If SNMP is required: - The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values. -."
+    remediation: "Run the following command to remove snmpd: # pkg remove net-snmp."
+    compliance:
+      - cis: ["2.2.15"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'net-snmp' -> r:net-snmp"    
+
+  # 2.2.16 Ensure NIS Server is not installed. (Automated)
+  - id: 40269
+    title: "Ensure NIS Server is not installed."
+    description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed and other, more secure services be used."
+    remediation: "Run the following command to disable nis: # service nis_server stop; # sysrc -x nis_server_enable OR # service nis_server disable."
+    compliance:
+      - cis: ["2.2.16"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c: sysrc -n nis_server_enable -> r:NO"
+
+  # 2.2.17 Ensure dnsmasq is not installed. (Automated)
+  - id: 40270
+    title: "Ensure dnsmasq is not installed."
+    description: "dnsmasq is a lightweight tool that provides DNS caching, DNS forwarding and DHCP (Dynamic Host Configuration Protocol) services."
+    rationale: "Unless a system is specifically designated to act as a DNS caching, DNS forwarding and/or DHCP server, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove dnsmasq: # pkg remove dnsmasq."
+    compliance:
+      - cis: ["2.2.17"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dnsmasq' -> r:dnsmasq"    
+
+  # 2.2.18 Ensure telnet-server is not installed. (Automated)
+  - id: 40271
+    title: "Ensure telnetd is not installed."
+    description: "The telnetd package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
+    remediation: "Run the following command to remove the telnetd package: # pkg remove freebsd-telnetd."
+    compliance:
+      - cis: ["2.2.18"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'freebsd-telnetd' -> r:^freebsd-telnetd"
+
+  # 2.2.19 Ensure sendmail transfer agent is configured for local-only mode. (Automated)
+  - id: 40272
+    title: "Ensure sendmail transfer agent is configured for local-only mode."
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: - This recommendation is designed around the postfix mail server. - Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /etc/rc.conf and add the following line: sendmail_enable=NO or sendmail_enable=NONE."
+    compliance:
+      - cis: ["2.2.19"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1018", "T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:sysrc -n sendmail_enable -> r:YES"
+      - "c:sysrc -n sendmail_enable -> r:NO|NONE"      
+      
+  # 2.2.20 Ensure postfix mail transfer agent is configured for local-only mode. (Automated)
+  - id: 40273
+    title: "Ensure postfix mail transfer agent is configured for local-only mode."
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: - This recommendation is designed around the postfix mail server. - Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /usr/local/etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only Run the following command to restart postfix: # service postfix restart."
+    compliance:
+      - cis: ["2.2.20"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1018", "T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "f:/usr/local/etc/postfix/main.cf -> r:^inet_interfaces = loopback-only"
+
+  # 2.2.21 Ensure rsync service is either not installed or is masked. (Automated)
+  - id: 40274
+    title: "Ensure rsync service is either not installed or is masked."
+    description: "The rsync service can be used to synchronize files between systems over network links."
+    rationale: "The rsync service presents a security risk as the rsync protocol is unencrypted. The rsync package should be removed or if required for dependencies, the rsync service should be stopped and masked to reduce the attack area of the system."
+    remediation: "Run the following command to remove rsync: # pkg remove rsync"
+    compliance:
+      - cis: ["2.2.21"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1105", "T1203", "T1210", "T1543", "T1543.002", "T1570"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'rsync' -> r:rsync"
+
+  # 2.3.1 Ensure NIS Client is not installed. (Automated)
+  - id: 40275
+    title: "Ensure NIS Client is not installed."
+    description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client was used to bind a machine to an NIS server and receive the distributed configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Disable nis client: # service nis_client stop; # service nis_client disable."
+    compliance:
+      - cis: ["2.3.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:sysrc -n nis_client_enable -> r:YES"
+
+  # 2.3.2 Ensure rsh client is not installed. (Automated)
+  - id: 40276
+    title: "Ensure rsh client is not installed."
+    description: "The bsdrcmds package contains the client commands for the rsh services."
+    rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Uninstall rsh: # pkg remove bsdrcmds."
+    compliance:
+      - cis: ["2.3.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1040", "T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c:pkg query -x %n-%v 'bsdrcmds' -> r:bsdrcmds"
+
+  # 2.3.3 Ensure talk client is not installed. (Automated)
+  - id: 40277
+    title: "Ensure talk client is not installed."
+    description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
+    rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Remove talk: # rm /usr/bin/talk."
+    compliance:
+      - cis: ["2.3.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0006", "TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/bin/talk"
+
+  # 2.3.4 Ensure telnet client is not installed. (Automated)
+  - id: 40278
+    title: "Ensure telnet client is not installed."
+    description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Remove talk: # rm /usr/bin/telnet."
+    compliance:
+      - cis: ["2.3.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0006", "TA0008"]
+      - mitre_techniques: ["T1040", "T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/bin/telnet"    
+
+  # 2.3.5 Ensure LDAP client is not installed. (Automated)
+  - id: 40279
+    title: "Ensure LDAP client is not installed."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
+    impact: "Removing the LDAP client will prevent or inhibit using LDAP for authentication in your environment."
+    remediation: "Uninstall ldap client: # pkg remove -x 'openldap.*-client'."
+    compliance:
+      - cis: ["2.3.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'openldap.*client' -> r:openldap"    
+
+  # 2.3.6 Ensure RPC is not installed. (Automated)
+  - id: 40280
+    title: "Ensure RPC is not installed."
+    description: 'Remote Procedure Call (RPC) is a method for creating low level client server applications across different system architectures. It requires an RPC compliant client listening on a network port. The supporting package is rpcbind.".'
+    rationale: "If RPC is not required, it is recommended that this services be removed to reduce the remote attack surface."
+    remediation: "Run the following command to remove rpcbind: # rm /usr/sbin/rpcbind."
+    compliance:
+      - cis: ["2.3.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/sbin/rpcbind"
+
+  # 2.4 Ensure nonessential services are removed or masked. (Manual) - Not Implemented
+
+  ###############################################
+  # 3 Network Configuration
+  ###############################################
+  ###############################################
+  # 3.1 Disable unused network protocols and devices
+  ###############################################
+  # 3.1.1 Ensure IPv6 status is identified. (Manual)
+  - id: 40281
+    title: "Ensure IPv6 status is identified."
+    description: "Internet Protocol Version 6 (IPv6) is the most recent version of Internet Protocol (IP). It's designed to supply IP addressing and additional security to support the predicted growth of connected devices. IPv6 is based on 128-bit addressing and can support 340 undecillion addresses, which is 340 followed by 36 zeroes. Features of IPv6 - Hierarchical addressing and routing infrastructure - Stateful and Stateless configuration - Support for quality of service (QoS) - An ideal protocol for neighboring node interaction."
+    rationale: "IETF RFC 4038 recommends that applications are built with an assumption of dual stack. It is recommended that IPv6 be enabled and configured in accordance with Benchmark recommendations. If dual stack and IPv6 are not used in your environment, IPv6 may be disabled to reduce the attack surface of the system, and recommendations pertaining to IPv6 can be skipped. Note: It is recommended that IPv6 be enabled and configured unless this is against local site policy."
+    impact: "IETF RFC 4038 recommends that applications are built with an assumption of dual stack. When enabled, IPv6 will require additional configuration to reduce risk to the system."
+    remediation: "Enable or disable IPv6 in accordance with system requirements and local site policy."
+    compliance:
+      - cis: ["3.1.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1557", "T1595", "T1595.001", "T1595.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n ipv6_activate_all_interfaces -> r:NO"
+      - "c:sysrc -n ip6addrctl_enable -> r:NO"
+
+  # 3.1.2 Ensure wireless interfaces are disabled. (Automated) - Not Implemented
+
+  # 3.1.3 Ensure bluetooth is disabled. (Automated)
+  - id: 40282
+    title: "Ensure bluetooth is disabled."
+    description: "Bluetooth is a short-range wireless technology standard that is used for exchanging data between devices over short distances. It employs UHF radio waves in the ISM bands, from 2.402 GHz to 2.48 GHz. It is mainly used as an alternative to wire connections."
+    rationale: "An attacker may be able to find a way to access or corrupt your data. One example of this type of activity is bluesnarfing, which refers to attackers using a Bluetooth connection to steal information off of your Bluetooth device. Also, viruses or other malicious code can take advantage of Bluetooth technology to infect other devices. If you are infected, your data may be corrupted, compromised, stolen, or lost."
+    impact: "Many personal electronic devices (PEDs) use Bluetooth technology. For example, you may be able to operate your computer with a wireless keyboard. Disabling Bluetooth will prevent these devices from connecting to the system."
+    remediation: "Run the following commands to stop and disable the Bluetooth service # kldunload ng_ubt and add ng_ubt to module_blacklist variable into /boot/loader.conf #  Note: A reboot may be required."
+    references:
+      - "https://www.cisa.gov/tips/st05-015"
+    compliance:
+      - cis: ["3.1.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:kldstat -n ng_ubt -> r:ng_ubt && !r:ng_ubt.ko$"
+      - 'not f:/boot/loader.conf -> r:ng_ubt_load && r:YES'            
+        
+  # 3.1.4 Ensure SCTP is disabled. (Automated) - Not Implemented
+  - id: 40283
+    title: "Ensure SCTP is disabled."
+    description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
+    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
+    remediation: 'Edit /boot/loader.conf and add sctp to module_blacklist variable. Note: A reboot may be required.'
+    compliance:
+      - cis: ["3.1.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:kldstat -n sctp -> r:sctp && !r:sctp.ko$"
+      - 'not f:/boot/loader.conf -> r:sctp_load && r:YES'      
+        
+  # 3.1.5 Ensure RDS is disabled. (Automated) Not Implemented
+  # 3.1.6 Ensure TIPC is disabled. (Automated) - Not Implemented
+
+  ###############################################
+  # 3.2 Network Parameters (Host Only)
+  ###############################################
+  # 3.2.1 Ensure packet redirect sending is disabled
+  - id: 40284
+    title: Ensure packet redirect sending is disabled
+    description: >
+      ICMP Redirects are used to send routing information to other hosts. As a host itself does
+      not act as a router (in a host only configuration), there is no need to send redirects.
+    rationale: >
+      An attacker could use a compromised host to send invalid ICMP redirects to other router
+      devices in an attempt to corrupt routing and have users access a system set up by the
+      attacker as opposed to a valid system.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.icmp.drop_redirect = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.icmp.drop_redirect=1
+    compliance:
+      - cis: ["3.2.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.icmp.drop_redirect -> r:1'
+
+  # 3.2.2 Ensure IP forwarding is disabled. (Automated) - Not Implemented
+  - id: 40285
+    title: Ensure IP forwarding is disabled.
+    description: >
+      IP forwarding allows the system to move traffic between interfaces that belong to the same 
+      machine (router) and forward the packets to the appropriate interface according to the 
+      machine's routing table
+    rationale: >
+      Keep this parameter disabled to prevent denial of service attacks through spoofed packets.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.ip.forwarding = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.ip.forwarding=1
+    compliance:
+      - cis: ["3.2.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.ip.forwarding -> r:0'
+
+  ###############################################
+  # 3.3 Network Parameters (Host and Router)
+  ###############################################
+  # 3.3.1 Ensure source routed packets are not accepted. (Automated) - Not Implemented
+  # 3.3.2 Ensure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.3 Ensure secure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.4 Ensure suspicious packets are logged. (Automated) - Not Implemented
+  # 3.3.5 Ensure broadcast ICMP requests are ignored
+  - id: 40286
+    title: Ensure broadcast ICMP requests are ignored
+    description: >
+      Setting net.inet.icmp.bmcastecho to 0 will cause the system to ignore all
+      ICMP echo and timestamp requests to broadcast and multicast addresses.
+    rationale: >
+      Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for
+      your network could be used to trick your host into starting (or participating) in a Smurf
+      attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast
+      messages with a spoofed source address. All hosts receiving this message and responding
+      would send echo-reply messages back to the spoofed address, which is probably not
+      routable. If many hosts respond to the packets, the amount of traffic on the network could
+      be significantly multiplied.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.icmp.bmcastecho = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.icmp.bmcastecho=0
+    compliance:
+      - cis: ["3.3.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.icmp.bmcastecho -> r:0'
+
+  # 3.3.6 Ensure bogus ICMP responses are ignored. (Automated) - Not Implemented
+  # 3.3.7 Ensure Reverse Path Filtering is enabled. (Automated) - Not Implemented
+  # 3.3.8 Ensure TCP SYN Cookies is enabled
+  - id: 40287
+    title: Ensure TCP SYN Cookies is enabled
+    description: >
+      When net.inet.tcp.syncookies is set, the kernel will handle TCP SYN packets normally until the
+      half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN
+      cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the
+      SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that
+      encodes the source and destination IP address and port number and the time the packet
+      was sent. A legitimate connection would send the ACK packet of the three way handshake
+      with the specially crafted sequence number. This allows the system to verify that it has
+      received a valid response to a SYN cookie and allow the connection, even though there is no
+      corresponding SYN in the queue.
+    rationale: >
+      Attackers use SYN flood attacks to perform a denial of service attacked on a system by
+      sending many SYN packets without completing the three way handshake. This will quickly
+      use up slots in the kernel's half-open connection queue and prevent legitimate connections
+      from succeeding. SYN cookies allow the system to keep accepting valid connections, even if
+      under a denial of service attack.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.tcp.syncookies = 1
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.tcp.syncookies=1
+    compliance:
+      - cis: ["3.3.8"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.tcp.syncookies -> r:1'
+      
+  # 3.3.9 Ensure IPv6 router advertisements are not accepted
+  - id: 40288
+    title: Ensure IPv6 router advertisements are not accepted
+    description: This setting disables the system's ability to accept IPv6 router advertisements.
+    rationale: >
+      It is recommended that systems do not accept router advertisements as they could be
+      tricked into routing traffic to compromised machines. Setting hard routes within the
+      system (usually a single default route to a trusted router) protects the system from bad
+      routes.
+    remediation: >
+      IF IPv6 is enabled:
+
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet6.ip6.accept_rtadv = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet6.ip6.accept_rtadv=0
+    compliance:
+      - cis: ["3.3.9"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet6.ip6.accept_rtadv -> r:0'      
+
+  ###############################################
+  # 3.4 Firewall Configuration
+  ###############################################
+  ###############################################
+  # 3.4.1 Configure Packet Filter firewall
+  ###############################################
+  # 3.4.1.1 Ensure packet filter is installed. (Automated)
+  - id: 40289
+    title: "Ensure Packet Filter is installed."
+    description: "FreeBSD has three firewalls built into the base system: PF, IPFW, and IPFILTER, also known as IPF. FreeBSD also provides two traffic shapers for controlling bandwidth usage: altq(4) and dummynet(4). ALTQ has traditionally been closely tied with PF and dummynet with IPFW. Each firewall uses rules to control the access of packets to and from a FreeBSD system, although they go about it in different ways and each has a different rule syntax."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "Packet Filter is part of FreeBSD base system."
+    compliance:
+      - cis: ["3.4.1.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/pfctl"           
+
+  # 3.4.1.2 Ensure Packet Filter is enabled and running. (Automated)
+  - id: 40290
+    title: "Ensure Packet Filter is enabled."
+    description: "Since FreeBSD 5.3, a ported version of OpenBSD’s PF firewall has been included as an integrated part of the base system. PF is a complete, full-featured firewall that has optional support for ALTQ (Alternate Queuing), which provides Quality of Service (QoS)."
+    rationale: "The service must be enabled and running in order for pf to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable pf: # service pf enable Run the following command to start the pf: # service pf start"
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-pf"
+    compliance:
+      - cis: ["3.4.1.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:YES"
+      - "c:kldstat -m pf -> r:pf && r:pf$"
+      - "c:service pf status -> r:^Status && r:Enabled"
+      - "c:sysrc -n ipfw_enable -> r:NO"  
+      - "c:kldstat -m ipfw -> r:ipfw && !r:ipfw$"          
+      - "c:sysrc -n ipfilter_enable -> r:NO"
+      - "c:kldstat -m ipfilter -> r:ipfilter && r:!ipfilter$"            
+
+  # 3.4.1.3 Ensure Packet Filter outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.1.4 Ensure Packet Filter firewall rules exist for all open ports. (Automated) - Not Implemented
+
+  # 3.4.1.5 Ensure Packet Filter default deny firewall policy. (Automated)
+  - id: 40291
+    title: "Ensure Packet Filter default deny firewall policy."
+    description: "A default deny policy on connections ensures that any unconfigured network usage will be rejected. Note: Any port or protocol without a explicit allow before the default deny will be blocked."
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
+    impact: "Any port and protocol not explicitly allowed will be blocked. The following rules should be considered before applying the default deny. ufw allow git ufw allow in http ufw allow out http <- required for apt to connect to repository ufw allow in https ufw allow out https ufw allow out 53 ufw logging on."
+    remediation: "Run the following commands to implement a default deny policy: # ufw default deny incoming # ufw default deny outgoing # ufw default deny routed."
+    compliance:
+      - cis: ["3.4.1.5"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - 'f:/etc/pf.conf -> r:^set block-policy'
+
+  ###############################################
+  # 3.4.2 Configure IPFW firewall
+  ###############################################
+  # 3.4.2.1 Ensure IPFW is installed. (Automated)
+  - id: 40292
+    title: "Ensure Packet Filter is installed."
+    description: "FreeBSD has three firewalls built into the base system: PF, IPFW, and IPFILTER, also known as IPF. FreeBSD also provides two traffic shapers for controlling bandwidth usage: altq(4) and dummynet(4). ALTQ has traditionally been closely tied with PF and dummynet with IPFW. Each firewall uses rules to control the access of packets to and from a FreeBSD system, although they go about it in different ways and each has a different rule syntax."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "IPFW is part of FreeBSD base system."
+    compliance:
+      - cis: ["3.4.2.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/ipfw"           
+
+  # 3.4.2.2 Ensure IPFW is enabled and running. (Automated)
+  - id: 40293
+    title: "Ensure IPFW is enabled and running."
+    description: "IPFW is a stateful firewall written for FreeBSD which supports both IPv4 and IPv6. It is comprised of several components: the kernel firewall filter rule processor and its integrated packet accounting facility, the logging facility, NAT, the dummynet(4) traffic shaper, a forward facility, a bridge facility, and an ipstealth facility."
+    rationale: "The service must be enabled and running in order for pf to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable ipfw: # service firewall enable. # sysrc firewall_type='open'. Run the following command to start the ipfw: # service ipfw start. Take on mind firewall_type='open' means passes all traffic. Look at ipfw documentation for more options."
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-ipfw"
+    compliance:
+      - cis: ["3.4.2.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:NO"
+      - "c:kldstat -m pf -> r:pf && !r:pf$"
+      - "c:sysrc -n ipfw_enable -> r:YES"
+      - "c:kldstat -m ipfw -> r:ipfw && r:ipfw$"
+      - "c:sysctl -n net.inet.ip.fw.enable -> r:1"                
+      - "c:sysrc -n ipfilter_enable -> r:NO"
+      - "c:kldstat -m ipfilter -> r:ipfilter && !r:ipfilter$"            
+
+  # 3.4.2.3 Ensure IPFW outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.2.4 Ensure IPFW firewall rules exist for all open ports. (Automated) - Not Implemented
+  # 3.4.2.5 Ensure IPFW default deny firewall policy. (Automated)
+      
+  ###############################################
+  # 3.4.3 Configure IPFilter firewall
+  ###############################################
+  # 3.4.3.1 Ensure IPFilter is installed. (Automated)
+  - id: 40294
+    title: "Ensure IPFilter is installed."
+    description: "IPFILTER is a kernel-side firewall and NAT mechanism that can be controlled and monitored by userland programs. Firewall rules can be set or deleted using ipf, NAT rules can be set or deleted using ipnat, run-time statistics for the kernel parts of IPFILTER can be printed using ipfstat, and ipmon can be used to log IPFILTER actions to the system log files."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "IPFilter is part of FreeBSD base system. If /sbin/ipfc is not found"
+    compliance:
+      - cis: ["3.4.3.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/ipf"
+
+  # 3.4.3.2 Ensure IPFilter is enabled. (Automated)
+  - id: 40295
+    title: "Ensure IPFilter is enabled and running."
+    description: "IPFILTER is a kernel-side firewall and NAT mechanism that can be controlled and monitored by userland programs. Firewall rules can be set or deleted using ipf, NAT rules can be set or deleted using ipnat, run-time statistics for the kernel parts of IPFILTER can be printed using ipfstat, and ipmon can be used to log IPFILTER actions to the system log files."
+    rationale: "The service must be enabled and running in order for IPFilter to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable IPFilter: # service ipfilter enable Run the following command to start the IPFilter: # service ipfilter start"
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-ipf"
+    compliance:
+      - cis: ["3.4.3.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:NO"
+      - "c:kldstat -m pf -> r:pf && !r:pf$"
+      - "c:sysrc -n ipfw_enable -> r:NO"  
+      - "c:kldstat -m ipfw -> r:ipfw && !r:ipfw$"          
+      - "c:sysrc -n ipfilter_enable -> r:YES"
+      - "c:kldstat -m ipfilter -> r:ipfilter && r:ipfilter$"
+      - "c:/sbin/ipf -V -> r:'^Running: yes'"                  
+
+  # 3.4.3.3 Ensure IPFilter outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.3.4 Ensure IPFilter firewall rules exist for all open ports. (Automated) - Not Implemented
+  # 3.4.3.5 Ensure IPFilter default deny firewall policy. (Not implemented)      
+  
+ ###############################################
+  # 4 Access, Authentication and Authorization
+  ###############################################
+  ###############################################
+  # 4.1 Configure time-based job schedulers
+  ###############################################  
+  # 4.1.1 Ensure cron daemon is enabled and active. (Automated)
+  - id: 40296
+    title: "Ensure cron daemon is enabled and active."
+    description: "The cron daemon is used to execute batch jobs on the system. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
+    remediation: "Run the following command to enable and start cron: # service cron enable # service cron start."
+    compliance:
+      - cis: ["4.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+    condition: all
+    rules:
+      - "c:sysrc -n cron_enable -> r:^YES"
+      - "c:service cron status -> r:^cron is running as pid"
+
+  # 4.1.2 Ensure permissions on /etc/crontab are configured. (Automated)
+  - id: 40297
+    title: "Ensure permissions on /etc/crontab are configured."
+    description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
+    remediation: "Run the following commands to set ownership and permissions on /etc/crontab : # chown root:wheel /etc/crontab # chmod 740 /etc/crontab."
+    compliance:
+      - cis: ["4.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/crontab -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/crontab -> r:^root:wheel"
+
+  # 4.1.3 Ensure permissions on /etc/cron.d are configured. (Automated)
+  - id: 40298
+    title: "Ensure permissions on /etc/cron.d are configured."
+    description: "The /etc/cron.d directory contains system cron jobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab, but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.d directory: # chown root:wheel /etc/cron.d/ # chmod 750 /etc/cron.d/."
+    compliance:
+      - cis: ["4.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/cron.d -> r:^-rwxr-x---"
+      - "c:stat -f %Su:%Sg /etc/cron.d -> r:^root:wheel"
+
+  # 4.1.4 Ensure cron is restricted to authorized users. (Automated)
+  - id: 40299
+    title: "Ensure cron is restricted to authorized users."
+    description: "Configure /var/cron/allow to allow specific users to use this service. If /var/cron/allow does not exist, then /var/cron/deny is checked. Any user not specifically defined in this file is allowed to use cron. By removing the file, only users in /var/etc/cron/allow are allowed to use cron."
+    rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list."
+    remediation: "Remove /var/cron/deny if it exists - Create /var/cron/allow if it doesn't exist - Change ownership of /var/cron/allow to the root user and wheel group. Add only authorized users to /var/cron/allow file. Restart cron daemon # service cron restart."
+    compliance:
+      - cis: ["4.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/var/run/cron/allow"
+      - "c:stat -f %Sp /var/cron/allow -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /var/cron/allow -> r:^root:wheel"
+
+  # 4.1.5 Ensure at is restricted to authorized users. (Automated)
+  - id: 40300
+    title: "Ensure at is restricted to authorized users."
+    description: "Configure /var/at/at.allow to allow specific users to use this service. If /var/at/at.allow does not exist, then /var/at/at.deny is checked. Any user not specifically defined in this file is allowed to use at. By removing the file, only users in /etc/at.allow are allowed to use at. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, at should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "On many systems, only the system administrator is authorized to schedule at jobs. Using the at.allow file to control who can run at jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
+    remediation: "Remove /var/at/at.deny if it exists - Create /var/at/at.allow if it doesn't exist - Change ownership of /var/at/at.allow to the root user - Change group ownership of /var/at/at.allow to the group wheel. Add only authorized users to /var/at/at.allow file. Restart cron daemon # service cron restart."
+    compliance:
+      - cis: ["4.1.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/var/at/at.allow"
+      - "c:stat -f %Sp /var/at/at.allow -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /var/at/at.allow -> r:^root:wheel"      
+
+  ###############################################
+  # 4.2 Configure SSH Server
+  ###############################################
+  # 4.2.1 Ensure permissions on /etc/ssh/sshd_config are configured. (Automated)
+  - id: 40301
+    title: "Ensure permissions on /etc/ssh/sshd_config are configured."
+    description: "The file /etc/ssh/sshd_config contain configuration specifications for sshd."
+    rationale: "configuration specifications for sshd need to be protected from unauthorized changes by non-privileged users."
+    remediation: "Change ownership and permissions on /etc/ssh/sshd_config file. # chown root:wheel /etc/ssh/sshd_config; # chmod 640 /etc/ssh/sshd_config."
+    compliance:
+      - cis: ["4.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1098", "T1098.004", "T1543", "T1543.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/etc/ssh/sshd_config"
+      - "c:stat -f %Sp /etc/ssh/sshd_config -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/ssh/sshd_config -> r:^root:wheel"
+
+   # 4.2.2 Ensure permissions on SSH private host key files are configured. (Automated) - Not Implemented
+  - id: 40302
+    title: "Ensure permissions on SSH private host key files are configured."
+    description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a private host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Change mode, ownership, and group on the public SSH host key files: # chown root:wheel /etc/ssh/ssh_host*_key; # chmod 600 /etc/ssh/ssh_host*_key."
+    compliance:
+      - cis: ["4.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0003", "TA0006"]
+      - mitre_techniques: ["T1557"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key" -exec stat -f %Sp  {} \; -> r:^-rw-------'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel' 
+
+  # 4.2.3 Ensure permissions on SSH public host key files are configured. (Automated)
+  - id: 40303
+    title: "Ensure permissions on SSH public host key files are configured."
+    description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Change mode, ownership, and group on the public SSH host key files: # chown root:wheel /etc/ssh/ssh_host*.pub; # chmod 644 /etc/ssh/ssh_host*.pub."
+    compliance:
+      - cis: ["4.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0003", "TA0006"]
+      - mitre_techniques: ["T1557"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key.pub" -exec stat -f %Sp  {} \; -> r:^-rw-r--r--'
+      - 'c:find /etc/ssh -xdev -type f -name 2ssh_host_*_key.pub" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel'      
+
+  # 4.2.4 Ensure SSH access is limited. (Automated)
+  - id: 40304
+    title: "Ensure SSH access is limited."
+    description: "There are several options available to limit which users and group can access the system via SSH. AllowUsers: o The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. AllowGroups: o The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. DenyUsers: o The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. DenyGroups: o The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
+    rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set one or more of the parameter above any Include entries as follows: AllowUsers <userlist> OR AllowGroups <grouplist> OR DenyUsers <userlist> OR DenyGroups <grouplist>."
+    compliance:
+      - cis: ["4.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021", "T1021.004"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^allowusers\s+\w+|^allowgroups\s+\w+|^denyusers\s+\w+|^*denygroups\s+\w+'
+      - 'f:/etc/ssh/sshd_config -> r:^AllowUsers\s+\w+|^AllowGroups\s+\w+|^DenyUsers\s+\w+|^DenyGroups\s+\w+'
+
+  # 4.2.5 Ensure SSH LogLevel is appropriate. (Automated)
+  - id: 40305
+    title: "Ensure SSH LogLevel is appropriate."
+    description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
+    rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: LogLevel VERBOSE OR LogLevel INFO Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "https://www.ssh.com/ssh/sshd_config/"
+    compliance:
+      - cis: ["4.2.5"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^loglevel\s+INFO|^loglevel\s+VERBOSE'
+      - 'not f:/etc/ssh/sshd_config -> !r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
+
+  # 4.2.6 Ensure SSH PAM is enabled. (Automated)
+  - id: 40306
+    title: "Ensure SSH PAM is enabled."
+    description: "The UsePAM directive enables the Pluggable Authentication Module (PAM) interface. If set to yes this will enable PAM authentication using ChallengeResponseAuthentication and PasswordAuthentication directives in addition to PAM account and session module processing for all authentication types."
+    rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: UsePAM yes Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.6"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1035"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1021", "T1021.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*usepam\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*UsePAM\s+no'
+
+  # 4.2.7 Ensure SSH root login is disabled. (Automated)
+  - id: 40307
+    title: "Ensure SSH root login is disabled."
+    description: "The PermitRootLogin parameter specifies if the root user can log in using SSH. The default is prohibit-password."
+    rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root. This limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitRootLogin no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.7"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permitrootlogin\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitRootLogin\s+yes'
+
+  # 4.2.8 Ensure SSH HostbasedAuthentication is disabled. (Automated)
+  - id: 40308
+    title: "Ensure SSH HostbasedAuthentication is disabled."
+    description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication."
+    rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: HostbasedAuthentication no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.8"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*hostbasedauthentication\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*HostbasedAuthentication\s+yes'
+
+  # 4.2.9 Ensure SSH PermitEmptyPasswords is disabled. (Automated)
+  - id: 40309
+    title: "Ensure SSH PermitEmptyPasswords is disabled."
+    description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
+    rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitEmptyPasswords no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.9"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permitemptypasswords\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitEmptyPasswords\s+yes'
+
+  # 4.2.10 Ensure SSH PermitUserEnvironment is disabled. (Automated)
+  - id: 40310
+    title: "Ensure SSH PermitUserEnvironment is disabled."
+    description: "The PermitUserEnvironment option allows users to present environment options to the SSH daemon."
+    rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has SSH executing trojan'd programs)."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitUserEnvironment no Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.10"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permituserenvironment\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitUserEnvironment\s+yes'
+
+  # 4.2.11 Ensure SSH IgnoreRhosts is enabled. (Automated)
+  - id: 40311
+    title: "Ensure SSH IgnoreRhosts is enabled."
+    description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
+    rationale: "Setting this parameter forces users to enter a password when authenticating with SSH."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: IgnoreRhosts yes Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.11"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*ignorerhosts\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*IgnoreRhosts\s+no'
+
+  # 4.2.12 Ensure SSH X11 forwarding is disabled. (Automated)
+  - id: 40312
+    title: "Ensure SSH X11 forwarding is disabled."
+    description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
+    rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: X11Forwarding no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*x11forwarding\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s+yes'
+
+  # 4.2.13 Ensure only strong Ciphers are used. (Automated)
+  - id: 40313
+    title: "Ensure only strong Ciphers are used."
+    description: 'This variable limits the ciphers that SSH can use during communication. Note: - Some organizations may have stricter requirements for approved ciphers. - Ensure that ciphers used are in compliance with site policy. - The only "strong" ciphers currently FIPS 140-2 compliant are: o aes256-ctr o aes192-ctr o aes128-ctr.'
+    rationale: 'Weak ciphers like 3DES that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised.'
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma separated list of the site approved ciphers. Example: Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128- gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr."
+    references:
+      - "https://nvd.nist.gov/vuln/detail/CVE-2016-2183"
+      - "https://www.openssh.com/txt/cbc.adv"
+      - "https://nvd.nist.gov/vuln/detail/CVE-2008-5161"
+    compliance:
+      - cis: ["4.2.13"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|rijndael-cbc@lysator.liu.se"
+
+  # 4.2.14 Ensure only strong MAC algorithms are used. (Automated)
+  - id: 40314
+    title: "Ensure only strong MAC algorithms are used."
+    description: 'This variable limits the types of MAC algorithms that SSH can use during communication. The only "strong" MACs currently FIPS 140-2 approved are: o hmac-sha2-256 o hmac-sha2-512.'
+    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information."
+    remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs above any Include entries: Example: MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2- 512,hmac-sha2-256,umac-128-etm@openssh.com,umac-128@openssh.com."
+    references:
+      - "http://www.mitls.org/pages/attacks/SLOTH"
+    compliance:
+      - cis: ["4.2.14"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4", "16.5"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:macs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com"
+
+  # 4.2.15 Ensure only strong Key Exchange algorithms are used. (Automated)
+  - id: 40315
+    title: "Ensure only strong Key Exchange algorithms are used."
+    description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties. The only Key Exchange Algorithms currently FIPS 140-2 approved are: o ecdh-sha2-nistp256 o ecdh-sha2-nistp384 o ecdh-sha2-nistp521 o diffie-hellman-group-exchange-sha256 o diffie-hellman-group16-sha512 o diffie-hellman-group18-sha512 o diffie-hellman-group14-sha256."
+    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks."
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to list of the site approved key exchange algorithms. Example: KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256."
+    compliance:
+      - cis: ["4.2.15"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1"
+
+  # 4.2.16 Ensure SSH AllowTcpForwarding is disabled. (Automated)
+  - id: 40316
+    title: "Ensure SSH AllowTcpForwarding is disabled."
+    description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines."
+    rationale: "Leaving port forwarding enabled can expose the organization to security risks and backdoors. SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network."
+    impact: "SSH tunnels are widely used in many corporate environments. In some environments the applications themselves may have very limited native support for security. By utilizing tunneling, compliance with SOX, HIPAA, PCI-DSS, and other standards can be achieved without having to modify the applications."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: AllowTcpForwarding no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "https://www.ssh.com/ssh/tunneling/example"
+    compliance:
+      - cis: ["4.2.16"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1048", "T1048.002", "T1572"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*allowtcpforwarding\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*AllowTcpForwarding\s+yes'
+
+  # 4.2.17 Ensure SSH warning banner is configured. (Automated)
+  - id: 40317
+    title: "Ensure SSH warning banner is configured."
+    description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
+    rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: Banner /path/ro/banner Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.17"]
+      - mitre_mitigations: ["M1035"]
+      - mitre_tactics: ["TA0001", "TA0007"]
+    condition: all
+    rules:
+      - 'not c:sshd -T -> r:^\s*banner\s+none'
+
+  # 4.2.18 Ensure SSH MaxAuthTries is set to 4 or less. (Automated)
+  - id: 40318
+    title: "Ensure SSH MaxAuthTries is set to 4 or less."
+    description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
+    rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxAuthTries 4 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.18"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - mitre_mitigations: ["M1036"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1110", "T1110.001", "T1110.003"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^maxauthtries\s*\t*(\d+) compare <= 4'
+      - 'not f:/etc/ssh/sshd_config -> n:^MaxAuthTries\s*\t*(\d+) compare > 4'
+
+  # 4.2.19 Ensure SSH MaxStartups is configured. (Automated)
+  - id: 40319
+    title: "Ensure SSH MaxStartups is configured."
+    description: "The MaxStartups parameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon."
+    rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxStartups 10:30:60 Note: First occurrence of an option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.19"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1499", "T1499.002"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*maxstartups\s+10:30:60'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxStartups\s+(((1[1-9]|[1-9][0-9][0-9]+):([0-9]+):([0-9]+))|(([0-9]+):(3[1-9]|[4-9][0-9]|[1-9][0-9][0-9]+):([0-9]+))|(([0-9]+):([0-9]+):(6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+)))'
+
+  # 4.2.20 Ensure SSH LoginGraceTime is set to one minute or less. (Automated)
+  - id: 40320
+    title: "Ensure SSH LoginGraceTime is set to one minute or less."
+    description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
+    rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: LoginGraceTime 60 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.20"]
+      - mitre_mitigations: ["M1036"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1110", "T1110.001", "T1110.003", "T1110.004"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:logingracetime\s*\t*(\d+) compare <= 60 && n:LoginGraceTime\s*\t*(\d+) compare != 0'
+      - 'not f:/etc/ssh/sshd_config -> r:\s*LoginGraceTime\s+(0|6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+|[^1]m)'
+
+  # 4.2.21 Ensure SSH MaxSessions is set to 10 or less. (Automated)
+  - id: 40321
+    title: "Ensure SSH MaxSessions is set to 10 or less."
+    description: "The MaxSessions parameter specifies the maximum number of open sessions permitted from a given connection."
+    rationale: "To protect a system from denial of service due to a large number of concurrent sessions, use the rate limiting function of MaxSessions to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxSessions 10 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.21"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1499", "T1499.002"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^\s*maxsessions\s+(\d+) compare <= 10'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxSessions\s+(1[1-9]|[2-9][0-9]|[1-9][0-9][0-9]+)'
+
+  # 4.2.22 Ensure SSH Idle Timeout Interval is configured. (Automated)
+  - id: 40322
+    title: "Ensure SSH Idle Timeout Interval is configured."
+    description: "ClientAliveInterval sets a timeout interval in seconds after which if no data has been received from the client. ClientAliveCountMax sets the number of client alive messages which may be sent without sshd(8) receiving any messages back from the client. It is important to note that the use of client alive messages is very different from TCPKeepAlive. The client alive messages are sent through the encrypted channel and therefore will not be spoofable. The TCP keepalive option enabled by TCPKeepAlive is spoofable."
+    rationale: "In order to prevent resource exhaustion, appropriate values should be set for both ClientAliveInterval and ClientAliveCountMax. Specifically, looking at the source code, ClientAliveCountMax must be greater than zero in order to utilize the ability of SSH to drop idle connections. If connections are allowed to stay open indefinately, this can potentially be used as a DDOS attack or simple resource exhaustion could occur over unreliable networks. The example set here is a 45 second timeout. Consult your site policy for network timeouts and apply as appropriate."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameters above any Include entries according to site policy. Example: ClientAliveInterval 15 ClientAliveCountMax 3."
+    references:
+      - "https://man.openbsd.org/sshd_config"
+    compliance:
+      - cis: ["4.2.22"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:clientaliveinterval\s*\t*(\d+) compare > 0'
+      - 'c:sshd -T -> n:clientalivecountmax\s*\t*(\d+) compare > 0'
+
+  ############################################################
+  # 4.3 Configure privilege escalation
+  ############################################################
+  # 4.3.1 Ensure sudo is installed. (Automated)
+  - id: 40323
+    title: "Ensure sudo is installed."
+    description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
+    rationale: "sudo supports a plug-in architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plug-ins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers and any entries in /etc/sudoers.d. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
+    remediation: "Install sudo. Example: # pkg install sudo."
+    compliance:
+      - cis: ["4.3.1"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v sudo -> r:^sudo"    
+
+  # 4.3.2 Ensure sudo commands use pty. (Automated)
+  - id: 40324
+    title: "Ensure sudo commands use pty."
+    description: "sudo can be configured to run only from a pseudo terminal (pseudo-pty)."
+    rationale: "Attackers can run a malicious program using sudo which would fork a background process that remains even when the main program has finished executing."
+    impact: "WARNING: Editing the sudo configuration incorrectly can cause sudo to stop functioning. Always use visudo to modify sudo configuration files."
+    remediation: "Edit the file /usr/local/etc/sudoers with ee or a file in /usr/local//etc/sudoers.d/ with ee <PATH TO FILE> and add the following line: Defaults use_pty Note: - sudo will read each file in /usr/local/etc/sudoers.d, skipping file names that end in ~ or contain a . character to avoid causing problems with package manager or editor temporary/backup files. - Files are parsed in sorted lexical order. That is, /etc/sudoers.d/01_first will be parsed before /etc/sudoers.d/10_second. - Be aware that because the sorting is lexical, not numeric, /usr/local/etc/sudoers.d/1_whoops would be loaded after /usr/local/etc/sudoers.d/10_second. - Using a consistent number of leading zeroes in the file names can be used to avoid such problems."
+    compliance:
+      - cis: ["4.3.2"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1026", "M1038"]
+      - mitre_tactics: ["TA0001", "TA0003"]
+      - mitre_techniques: ["T1078", "T1078.003", "T1548", "T1548.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: any
+    rules:
+      - 'not f:/usr/local/etc/sudoers -> r:^Defaults\s*!use_pty'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> r:^Defaults\s*!use_pty'
+
+  # 4.3.3 Ensure sudo log file exists. (Automated)
+  - id: 40325
+    title: "Ensure sudo log file exists."
+    description: "sudo can use a custom log file."
+    rationale: "A sudo log file simplifies auditing of sudo commands."
+    impact: "WARNING: Editing the sudo configuration incorrectly can cause sudo to stop functioning. Always use visudo to modify sudo configuration files."
+    remediation: 'Edit the file /usr/local/etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH TO FILE> and add the following line: Example: Defaults logfile="/var/log/sudo.log" Note: - sudo will read each file in /etc/sudoers.d, skipping file names that end in ~ or contain a . character to avoid causing problems with package manager or editor temporary/backup files. - Files are parsed in sorted lexical order. That is, /etc/sudoers.d/01_first will be parsed before /etc/sudoers.d/10_second. - Be aware that because the sorting is lexical, not numeric, /etc/sudoers.d/1_whoops would be loaded after /etc/sudoers.d/10_second. - Using a consistent number of leading zeroes in the file names can be used to avoid such problems.'
+    compliance:
+      - cis: ["4.3.3"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: any
+    rules:
+      - 'f:/usr/local/etc/sudoers -> r:^\s*\t*Defaults\s*\t*logfile='
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile='
+
+  # 4.3.4 Ensure users must provide password for privilege escalation. (Automated)
+  - id: 40326
+    title: "Ensure users must provide password for privilege escalation."
+    description: "The operating system must be configured so that users must provide a password for privilege escalation."
+    rationale: "Without (re-)authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user (re-)authenticate."
+    impact: "This will prevent automated processes from being able to elevate privileges."
+    remediation: "Based on the outcome of the audit procedure, use ee <PATH TO FILE> to edit the relevant sudoers file. Remove any line with occurrences of NOPASSWD tags in the file."
+    compliance:
+      - cis: ["4.3.4"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1548"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - "f:/usr/local/etc/sudoers -> !r:^# && r:*NOPASSWD"
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:*NOPASSWD'
+
+  # 4.3.5 Ensure re-authentication for privilege escalation is not disabled globally. (Automated)
+  - id: 40327
+    title: "Ensure re-authentication for privilege escalation is not disabled globally."
+    description: "The operating system must be configured so that users must re-authenticate for privilege escalation."
+    rationale: "Without re-authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate."
+    remediation: "Configure the operating system to require users to reauthenticate for privilege escalation. Based on the outcome of the audit procedure, use ee <PATH TO FILE> to edit the relevant sudoers file. Remove any occurrences of !authenticate tags in the file(s)."
+    compliance:
+      - cis: ["4.3.5"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - 'f:/usr/local/etc/sudoers -> !r:^# && r:*\!authenticate'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:*\!authenticate'
+
+  # 4.3.6 Ensure sudo authentication timeout is configured correctly. (Automated)
+  - id: 40328
+    title: "Ensure sudo authentication timeout is configured correctly."
+    description: "sudo caches used credentials for a default of 5 minutes. This is for ease of use when there are multiple administrative tasks to perform. The timeout can be modified to suit local security policies. This default is distribution specific. See audit section for further information."
+    rationale: "Setting a timeout value reduces the window of opportunity for unauthorized privileged access to another user."
+    remediation: "If the currently configured timeout is larger than 5 minutes, edit the file listed in the audit section with ee <PATH TO FILE> and modify the entry timestamp_timeout= to 5 minutes or less as per your site policy. The value is in minutes. This particular entry may appear on it's own, or on the same line as env_reset. See the following two examples: Defaults env_reset, timestamp_timeout=5 Defaults timestamp_timeout=5 Defaults env_reset."
+    references:
+      - "https://www.sudo.ws/man/1.9.14/sudoers.man.html"
+    compliance:
+      - cis: ["4.3.6"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - 'c:sudo -V -> r:Authentication timestamp timeout:\s*\t*5.0 minutes'
+      - 'f:/usr/local/etc/sudoers -> n:timestamp_timeout=(\d+) compare <=5'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> n:timestamp_timeout=(\d+) compare <=5'
+
+  # 4.3.7 Ensure access to the su command is restricted. (Automated)
+  - id: 40329
+    title: "Ensure access to the su command is restricted."
+    description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in a specific groups to execute su. This group should be empty to reinforce the use of sudo for privileged access."
+    rationale: "Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program."
+    remediation: "Check wheel group into /etc/pam.d/su for use of the su command. the line could look like the following: auth requisite pam_group.so no_warn group=wheel root_only fail_safe ruser."
+    compliance:
+      - cis: ["4.3.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/su -> !r:^# && r:auth\s*requisite\s*pam_group.so && r:\sgroup=wheel\s'
+      
+  # 4.3.8 Ensure doas is installed. (Automated)
+  - id: 40330
+    title: "Ensure doas is installed."
+    description: "doas allows a permitted user to execute a command as the superuser or another user, as specified by the security policy."
+    rationale: "The default security policy is configured via /usr/local/etc/doas.conf. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism."
+    remediation: "Install doas. Example: # pkg install doas."
+    compliance:
+      - cis: ["4.3.1"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v doas -> r:^doas"   
+      
+  # 4.3.9 Ensure users must provide password for privilege escalation. (Automated)
+  - id: 40331
+    title: "Ensure doas users must provide password for privilege escalation."
+    description: "The operating system must be configured so that users must provide a password for privilege escalation."
+    rationale: "Without authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user (re-)authenticate."
+    impact: "This will prevent automated processes from being able to elevate privileges."
+    remediation: "Based on the outcome of the audit procedure, use ee /usr/local/etc/doas.conf file. Remove any line with occurrences of nopass tags in the file."
+    compliance:
+      - cis: ["4.3.4"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1548"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - "f:/usr/local/etc/doas.conf -> !r:^# && r:*nopass"          
+
+  ###############################################
+  # 4.4 Configure PAM and login.conf
+  ###############################################
+  # 4.4.1 Ensure password creation requirements are configured. (Automated)
+  # 4.4.2 Ensure lockout for failed password attempts is configured. (Automated)
+  # 4.4.3 Ensure password reuse is limited. (Automated)
+  # 4.4.4 Ensure strong password hashing algorithm is configured. (Automated)
+  - id: 40332
+    title: "Ensure strong password hashing algorithm is configured."
+    description: "Hash functions behave as one-way functions by using mathematical operations that are extremely difficult and cumbersome to revert When a user is created, the password is run through a one-way hashing algorithm before being stored. When the user logs in, the password sent is run through the same one-way hashing algorithm and compared to the hash connected with the provided username. If the hashed password and the stored hash match, the login is valid."
+    rationale: "The SHA512 hashing algorithm provides stronger hashing than previous available algorithms like MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords."
+    remediation: "Note: - Pay special attention to the configuration. Incorrect configuration can cause system lock outs. - This is an example configuration. Your configuration may differ based on previous changes to the files."
+    compliance:
+      - cis: ["4.4.4"]
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["16.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1110", "T1110.002"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "f:/etc/login.conf -> r:passwd_format && r:sha512|blf"
+
+  # 4.4.5 Ensure all current passwords uses the configured hashing algorithm. (Manual) - Not Implemented
+
+  ###############################################
+  # 4.5 User Accounts and Environment
+  ###############################################
+  ###############################################
+  # 4.5.1 Set Shadow Password Suite Parameters
+  ###############################################
+  # 4.5.1.1 Ensure password expiration is 365 days or less. (Automated)
+  - id: 40333
+    title: "Ensure password expiration is 365 days or less."
+    description: "The passwordtime parameter in /etc/login.conf allows an administrator to force passwords to expire once they reach a defined age."
+    rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity. It is recommended that the passwordtime parameter does not exceed 365 days and is greater than the value of 1."
+    remediation: "Set the passwordtime parameter to conform to site policy in /etc/login.conf : passwordtime=365d. Modify user parameters for all users with a password set to match: # pw usermod <user> -p +365d."
+    references:
+      - "https://www.cisecurity.org/white-papers/cis-password-policy-guide/"
+    compliance:
+      - cis: ["4.5.1.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.conf -> n:^\t:passwordtime=(\d+)\w: compare <= 365'
+      - 'f:/etc/login.conf -> n:^\t:passwordtime=(\d+)\w: compare > 0'
+
+  # 4.5.1.2 Ensure password expiration warning days is 7 or more. (Automated)
+  - id: 40334
+    title: "Ensure password expiration warning days is 7 or more."
+    description: "The warnpassword parameter in /etc/login.conf allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
+    rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
+    remediation: "Set the warnpassword parameter to 7 in /etc/login.conf: warnpassword=7d."
+    compliance:
+      - cis: ["4.5.1.2"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.conf -> n:^\t:warnpassword=(\d+)\w: compare >= 7'
+
+  # 4.5.1.3 Ensure inactive password lock is 30 days or less. (Automated)
+  # 4.5.1.4 Ensure all users last password change date is in the past. (Automated) - Not Implemented
+  # 4.5.1.5 Ensure the number of changed characters in a new password is configured. (Automated)
+  # 4.5.1.6 Ensure preventing the use of dictionary words for passwords is configured. (Automated)
+  # 4.5.2 Ensure system accounts are secured. (Automated) - Not Implemented
+
+  # 4.5.3 Ensure default group for the root account is GID 0. (Automated)
+  - id: 40335
+    title: "Ensure default group for the root account is GID 0."
+    description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
+    rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
+    remediation: "Run the following command to set the root user default group to GID 0 : # usermod -g 0 root."
+    compliance:
+      - cis: ["4.5.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/passwd -> !r:^# && r:root:\w+:\w+:0:'
+
+  # 4.5.4 Ensure default user umask is 027 or more restrictive. (Automated) - Not Implemented
+  # 4.5.5 Ensure default user shell timeout is configured. (Automated) - Not Implemented
+
+  # 4.5.6 Ensure nologin is not listed in /etc/shells. (Automated)
+  - id: 40336
+    title: "Ensure nologin is not listed in /etc/shells."
+    description: "/etc/shells is a text file which contains the full pathnames of valid login shells. This file is consulted by chsh and available to be queried by other programs. Be aware that there are programs which consult this file to find out if a user is a normal user; for example, FTP daemons traditionally disallow access to users with shells not included in this file."
+    rationale: "A user can use chsh to change their configured shell. If a user has a shell configured that isn't in in /etc/shells, then the system assumes that they're somehow restricted. In the case of chsh it means that the user cannot change that value. Other programs might query that list and apply similar restrictions. By putting nologin in /etc/shells, any user that has nologin as its shell is considered a full, unrestricted user. This is not the expected behavior for nologin."
+    remediation: "Edit /etc/shells and remove any lines that include nologin."
+    compliance:
+      - cis: ["4.5.6"]
+    condition: all
+    rules:
+      - "not f:/etc/shells -> !r:^# && r:nologin"
+
+  # 4.5.7 Ensure maximum number of same consecutive characters in a password is configured. (Automated)
+
+   ###############################################
+  # 5.1 Logging and auditing
+  ###############################################
+  # 5.1.1 Configure syslog
+  ###############################################
+  # 5.1.1.1 Ensure syslog is installed. (Automated)
+  - id: 40337
+    title: "Ensure syslog is installed."
+    description: "FreeBSD provides a system logger, syslogd(8), to manage logging. By default, syslogd is enabled and started when the system boots."
+    rationale: "The security enhancements of syslog such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
+    remediation: "The syslog is installed by default on FreeBSD. If it is not available an incomplete or modified version of FreeBSD is running."
+    compliance:
+      - cis: ["5.1.1.1"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1005", "T1070", "T1070.002"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "f:/usr/sbin/syslogd"
+
+  # 5.1.1.2 Ensure syslog service is enabled. (Automated)
+  - id: 40338
+    title: "Ensure syslog service is enabled."
+    description: "Once the syslog package is installed, ensure that the service is enabled."
+    rationale: "If the syslog service is not enabled to start on boot, the system will not capture logging events."
+    remediation: "Run the following command to enable syslog: # service syslogd enable; # service syslogd start."
+    compliance:
+      - cis: ["5.1.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:service syslogd status -> r:^syslogd is running as pid"
+
+  # 5.1.1.3 Ensure syslog is not configured to receive logs from a remote client. (Automated)
+  - id: 40339
+    title: "Ensure syslog is not configured to receive logs from a remote client."
+    description: "Syslog supports the ability to receive messages from remote hosts, thus acting as a log server. Clients should not receive data from other hosts."
+    rationale: "If a client is configured to also receive data, thus turning it into a server, the client system is acting outside it's operational boundary."
+    remediation: 'Disable syslog for not log messages from remote machines: # sysrc syslogd_flags="-ss".If -s is specified twice, no network socket will be opened at all, which also disables logging to remote machines'
+    compliance:
+      - cis: ["5.1.1.3"]
+      - cis_csc_v8: ["4.8", "8.2"]
+      - cis_csc_v7: ["6.2", "6.3", "9.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1", "A.13.1.3"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "10.2", "10.3", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "2.2.4", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - 'c: sysrc -n syslogd_flags -> r:^-ss'
+
+  # 5.1.1.8 Ensure all logfiles have appropriate access configured. (Automated) - Not Implemented
+
+  ############################################################
+  # 5.2 Configure System Accounting (auditd).
+  ############################################################
+  ############################################################
+  # 5.2.1 Ensure auditing is enabled.
+  ############################################################
+  # 5.2.1.1 Ensure auditd is installed. (Automated)
+  - id: 40340
+    title: "Ensure auditd is installed."
+    description: "The FreeBSD operating system includes support for security event auditing. Event auditing supports reliable, fine-grained, and configurable logging of a variety of security-relevant system events, including logins, configuration changes, and file and network access."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "The auditd is installed by default on FreeBSD. If it is not available an incomplete or modified version of FreeBSD is running."
+    compliance:
+      - cis: ["5.2.1.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f: /usr/sbin/auditd"
+
+  # 5.2.1.2 Ensure auditd service is enabled and active. (Automated)
+  - id: 40341
+    title: "Ensure auditd service is enabled and active."
+    description: "Turn on the auditd daemon to record system events."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "Run the following command to enable and start auditd: # service auditd enable; # service auditd start."
+    compliance:
+      - cis: ["5.2.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n auditd_enable -> r:^YES"
+      - "c:service auditd status -> r:^auditd is running as pid"
+
+  # 5.2.1.3 Ensure audit log storage size is configured. (Automated)
+  - id: 40342
+    title: "Ensure audit log storage size is configured."
+    description: "Configure the filesz of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
+    rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
+    remediation: "Set the following parameter in /etc/security/audit_control in accordance with site policy: filesz:2M B(Bytes), K(Kilobytes), M(Megabytes), or G(Gigabytes)."
+    compliance:
+      - cis: ["5.2.1.3"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^filesz:(\d+)M'
+
+  # 5.2.1.4 Ensure audit logs are not automatically deleted. (Automated)
+  - id: 40343
+    title: "Ensure audit logs are not automatically deleted."
+    description: "The expire-after setting determines how to handle the audit log file reaching the max file size. No expire-after value never delete old logs."
+    rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
+    remediation: "Remove the following parameter in /etc/audit/audit_control: expire-after."
+    compliance:
+      - cis: ["5.2.1.4"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'not f:/etc/security/audit_control -> r:^expire-after'
+
+  # 5.2.1.5 Ensure system is disabled when audit logs are full. (Automated)
+
+  # 5.2.3.1 Ensure changes to system administration events are collected. (Automated)
+  - id: 40344
+    title: "Ensure changes to system administration events are collected."
+    description: 'Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope..'
+    rationale: "Administration system changes can indicate that an unauthorized change has been made to the scope of system administrator activity."
+    remediation: "Edit /etc/security/audit_control file and add or check if exist the following flags: ad,ex,fw. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ad' 
+      - 'f:/etc/security/audit_control -> r:^flags: && r:+ex|ex'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:+fw|fw'      
+
+  # 5.2.3.2 Ensure actions as another user are always logged. (Automated)
+  - id: 40345
+    title: "Ensure actions as another user are always logged."
+    description: "sudo provides users with temporary elevated privileges to perform operations, either as the superuser or another user."
+    rationale: "Creating an audit log of users with temporary elevated privileges and the operation(s) they performed is essential to reporting. Administrators will want to correlate the events written to the audit trail with the records written to sudo's logfile to verify if unauthorized commands have been executed."
+    remediation: "Create audit rules editing /etc/security/audit_user file. Add an user with sudo privileges entry like the following: sudouser:lo,aa,ad:no. If you want apply flags globally the following must be added to flags: lo,aa,ad into /etc/security/audit_control. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.2"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.9.4.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:lo'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:aa'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ad'      
+
+  # 5.2.3.3 Ensure events that modify the sudo log file are collected. (Automated) - Not Implemented
+  # 5.2.3.4 Ensure events that modify date and time information are collected. (Automated)  
+
+  # 5.2.3.5 Ensure events that modify the system's network environment are collected. (Automated)
+  - id: 40346
+    title: "Ensure events that modify the system's network environment are collected."
+    description: "Record changes to network environment files or system calls. The below parameters monitors the following system calls, and write an audit event on system call exit: - sethostname - set the systems host name - setdomainname - set the systems domain name The files being monitored are: - /etc/issue and /etc/issue.net - messages displayed pre-login - /etc/hosts - file containing host names and associated IP addresses - /etc/networks - symbolic names for networks - /etc/network/ - directory containing network interface scripts and configurations files."
+    rationale: "Monitoring network events will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. All audit records should have a relevant tag associated with them."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events that modify the system's network environment. flags: +nt,+fm,+exe. Restart auditd service: # service auditd restart or restart OS: # reboot."
+    compliance:
+      - cis: ["5.2.3.5"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:nt|+nt'
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fm|+fm'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:exe|+exe'      
+
+  # 5.2.3.6 Ensure use of privileged commands are collected. (Automated) - Not Implemented
+  
+  # 5.2.3.7 Ensure unsuccessful file access attempts are collected. (Automated) - Not Implemented
+  - id: 40347
+    title: "Ensure unsuccessful file access attempts are collected."
+    description: "Record events of unsuccessful file access attempts."
+    rationale: "Monitoring unsucessful file access attempts could be an indication that the system has been compromised and that an unauthorized user is attempting to modify configuration system files."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events of unsuccessful file access attempts. flags: -fr. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.7"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fr|-fr'
+
+  # 5.2.3.8 Ensure events that modify user/group information are collected. (Automated)
+  - id: 40348
+    title: "Ensure events that modify files are collected."
+    description: 'Record events affecting the files modification.'
+    rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events of modify files. flags: +fr,+fw,+fm. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.8"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fm|+fm'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fr|+fr'
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fw|+fw'      
+
+  # 5.2.3.9 Ensure discretionary access control permission modification events are collected. (Automated) - Not Implemented
+
+  # 5.2.3.10 Ensure login and logout events are collected. (Automated)
+  - id: 40349
+    title: "Ensure login and logout events are collected."
+    description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events."
+    rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor login and logout events. flags: lo. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.10"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9", "16.11", "16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.9.4.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3", "AU-3(1)"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:lo'
+
+  # 5.2.3.11 Ensure file deletion events by users are collected. (Automated)
+  - id: 40350
+    title: "Ensure file deletion events by users are collected."
+    description: 'Monitor the use of system calls associated with the deletion or renaming of files and file attributes.'
+    rationale: "Monitoring these calls from users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor delete files events. flags: +fd. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.11"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fd|+fd'
+
+   # 5.2.3.12 Ensure successful and unsuccessful attempts to use commands are recorded. (Automated)
+  - id: 40351
+    title: "Ensure successful and unsuccessful attempts to use commands are recorded."
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the commands."
+    rationale: "The system commands can be used to change file security context. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor delete files events. flags: ex. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.12"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ex'
+
+  # 5.2.3.13 Ensure the audit configuration is immutable. (Automated)
+  # 5.2.3.14 Ensure the running and on disk configuration is the same. (Manual)
+  
+  # 5.2.4.1 Ensure audit log files are mode 0640 or less permissive. (Automated)
+  - id: 40352
+    title: "Ensure audit log files are mode 0640 or less permissive."
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: 'Run the following command to configure the audit log files to fix the permissions: # find /var/audit/ -type f -exec chmod 440 {} \\;'
+    compliance:
+      - cis: ["5.2.4.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /var/audit -xdev -type f -exec stat -f %Sp {} \; -> r:^-r--r-----'
+
+  # 5.2.4.2 Ensure only authorized users and groups are assigned ownership of audit log files. (Automated)
+  - id: 40353
+    title: "Ensure only authorized groups are assigned ownership of audit log files."
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: "Run the following command to configure the audit log files to be group owned by audit: # find /var/audit/ -type f -exec chown root:audit {} \\;"
+    compliance:
+      - cis: ["5.2.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /var/audit -xdev -type f -exec stat -f %Su:%Sg {} \; -> r:^root:audit'
+
+  # 5.2.4.4 Ensure the audit log directory is 0750 or more restrictive. (Automated)  
+
+  # 5.2.4.5 Ensure audit configuration files are 640 or more restrictive. (Automated)
+  - id: 40354
+    title: "Ensure audit configuration files are 640 or more restrictive."
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to fix permissive mode from the audit configuration files: # chmod 440 /etc/security/audit_class /etc/security/audit_event # chmod 600 /etc/security/audit_control /etc/security/audit_user # chmod 500 /etc/security/audit_warn."
+    compliance:
+      - cis: ["5.2.4.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:stat -f %Sp /etc/security/audit_class -> r:^-r--r-----'      
+      - 'c:stat -f %Sp /etc/security/audit_control -> r:^-rw-------'
+      - 'c:stat -f %Sp /etc/security/audit_event -> r:^-r--r-----'
+      - 'c:stat -f %Sp /etc/security/audit_user -> r:^-rw-------'
+      - 'c:stat -f %Sp /etc/security/audit_warn -> r:^-r-x------' 
+
+  # 5.2.4.6 Ensure audit configuration files are owned by root. (Automated)
+  - id: 40355
+    title: "Ensure audit configuration files are owned by root and wheel group."
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to change ownership to root user: # find /etc/security -xdev -type f -name 'audit_*' -exec chown root:wheel {} \\;"
+    compliance:
+      - cis: ["5.2.4.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:  
+      - 'c:find /etc/security -xdev -type f -name "audit_*" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel'                       
+          
+  # 5.2.4.7 Ensure audit tools are 755 or more restrictive. (Automated)
+  - id: 40356
+    title: "Ensure audit tools are 755 or more restrictive."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to remove more permissive mode from the audit tools: # chmod 555 /usr/sbin/audit /usr/sbin/auditd /usr/sbin/auditdistd /usr/sbin/auditreduce /usr/sbin/paudit."
+    compliance:
+      - cis: ["5.2.4.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /usr/sbin/audit -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditd -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditdistd -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditreduce -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/praudit -> r:^-r-xr-xr-x"
+
+  # 5.2.4.8 Ensure audit tools are owned by root. (Automated)
+  - id: 40357
+    title: "Ensure audit tools are owned by root and group wheel."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to change the owner of the audit tools to the root user and group wheel: # chown root:wheel /usr/sbin/audit /usr/sbin/auditd /usr/sbin/auditdistd /usr/sbin/auditreduce /usr/sbin/paudit."
+    compliance:
+      - cis: ["5.2.4.8"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Su:%Sg /usr/sbin/audit -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditd -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditdistd -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditreduce -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/praudit -> r:^root:wheel"                        
+
+   # 5.2.4.9 Ensure cryptographic mechanisms are used to protect the integrity of audit tools. (Automated)
+  - id: 40358
+    title: "Ensure cryptographic mechanisms are used to protect the integrity of audit tools."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records."
+    rationale: "Protecting the integrity of the tools used for auditing purposes is a critical step toward ensuring the integrity of audit information. Attackers may replace the audit tools or inject code into the existing tools with the purpose of providing the capability to hide or erase system activity from the audit logs. Audit tools should be cryptographically signed in order to provide the capability to identify when the audit tools have been modified, manipulated, or replaced. An example is a checksum hash of the file or files."
+    remediation: "Add/Update the following selection lines to /usr/local/etc/aide.conf to protect the integrity of the audit tools: # Audit Tools /usr/sbin/audit p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditdistd p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditreduce p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/paudit p+i+n+u+g+s+b+acl+xattrs+sha512."
+    compliance:
+      - cis: ["5.2.4.9"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+    condition: all
+    rules:
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/audit p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditdistd p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditreduce p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/paudit p+i+n+u+g+s+b+acl+xattrs+sha512"
+
+  ###############################################
+  # 6 System Maintenance
+  ###############################################
+  ###############################################
+  # 6.1 System File Permissions
+  ###############################################
+  # 6.1.1 Ensure permissions on /etc/passwd are configured. (Automated)
+  - id: 40359
+    title: "Ensure permissions on /etc/passwd are configured."
+    description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
+    rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/passwd: # chmod 640 /etc/passwd # chown root:wheel /etc/passwd."
+    compliance:
+      - cis: ["6.1.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/passwd -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/passwd -> r:^root:wheel"    
+
+  # 6.1.2 Ensure permissions on /etc/group are configured. (Automated)
+  - id: 40360
+    title: "Ensure permissions on /etc/group are configured."
+    description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
+    rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/group: # chmod 640 /etc/group # chown root:wheel /etc/group."
+    compliance:
+      - cis: ["6.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/group -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/group -> r:^root:wheel"
+
+  # 6.1.3 Ensure permissions on /etc/master.passwd are configured. (Automated)
+  - id: 40361
+    title: "Ensure permissions on /etc/master.passwd are configured."
+    description: "The /etc/master.passwd file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
+    rationale: "If attackers can gain read access to the /etc/master.passwd file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/master.passwd file (such as expiration) could also be useful to subvert the user accounts."
+    remediation: "Run one of the following commands to set ownership of /etc/master.passwd to root and group to either root and wheel: # chown root:wheel /etc/master.passwd. Run the following command to remove excess permissions form /etc/master.passwd: # chmod 600 /etc/master.passwd."
+    compliance:
+      - cis: ["6.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/master.passwd -> r:^-rw-------"
+      - "c:stat -f %Su:%Sg /etc/master.passwd -> r:^root:wheel"
+
+   # 6.1.4 Ensure permissions on /etc/shells are configured. (Automated)
+  - id: 40362
+    title: "Ensure permissions on /etc/shells are configured."
+    description: "/etc/shells is a text file which contains the full pathnames of valid login shells. This file is consulted by chsh and available to be queried by other programs."
+    rationale: "It is critical to ensure that the /etc/shells file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/shells: # chmod 644 /etc/shells # chown root:wheel /etc/shells."
+    compliance:
+      - cis: ["6.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/shells -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/shells -> r:^root:wheel"    
+
+  # 6.1.5 Ensure world writable files and directories are secured. (Automated) - Not Implemented
+  # 6.1.6 Ensure no unowned or ungrouped files or directories exist. (Automated) - Not Implemented
+  # 6.1.7 Ensure SUID and SGID files are reviewed. (Manual) - - Not Implemented
+
+  ################################################
+  # 6.2 User and Group Settings
+  ################################################
+  # 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords. (Automated)
+  - id: 40363
+    title: "Ensure accounts in /etc/passwd use encrypted passwords."
+    description: "Local accounts can uses encrypted passwords. With encrypted passwords, The passwords are saved in /etc/master.passwd file encrypted by crypt. Accounts with a encrypted password have an * in the second field in /etc/passwd."
+    rationale: "The /etc/passwd file also contains information like user ID's and group ID's that are used by many system programs. Therefore, the /etc/passwd file must remain world readable. In spite of encoding the password with a randomly-generated one-way hash function, an attacker could still break the system if they got access to the /etc/passwd file. This can be mitigated by using encrypted passwords. The /etc/master.passwd file is set so only root will be able to read and write. This helps mitigate the risk of an attacker gaining access to the encoded passwords with which to perform a dictionary attack."
+    remediation: "Run the following command to set accounts to use encrypted passwords: # sed -e 's/^\\([a-zA-Z0-9_]*\\):[^:]*:/\\1:*:/' -i /etc/passwd Investigate to determine if the account is logged in and what it is being used for, to determine if it needs to be forced off."
+    compliance:
+      - cis: ["6.2.1"]
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["16.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1003", "T1003.008"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'not f:/etc/passwd -> !r:^\w+:*:'
+
+  # 6.2.2 Ensure /etc/shadow password fields are not empty. (Automated)
+  - id: 40364
+    title: "Ensure /etc/master.passwd password fields are not empty."
+    description: "An account with an empty password field means that anybody may log in as that user without providing a password."
+    rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
+    remediation: "If any accounts in the /etc/master.passwd file do not have a password, run the following command to lock the account until it can be determined why it does not have a password: # pw lock <username> Also, check to see if the account is logged in and investigate what it is being used for to determine if it needs to be forced off."
+    compliance:
+      - cis: ["6.2.2"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'not f:/etc/master.passwd -> r:^\w+::'
+
+  # 6.2.3 Ensure all groups in /etc/passwd exist in /etc/group. (Automated) - Not Implemented
+  # 6.2.4 Ensure no duplicate UIDs exist. (Automated) - Not Implemented
+  # 6.2.5 Ensure no duplicate GIDs exist. (Automated) - Not Implemented
+  # 6.2.6 Ensure no duplicate user names exist. (Automated) - Not Implemented
+  # 6.2.7 Ensure no duplicate group names exist. (Automated) - Not Implemented
+  # 6.2.8 Ensure root PATH Integrity. (Automated) - Not Implemented
+
+  # 6.2.9 Ensure root is the only UID 0 account. (Automated)
+  - id: 40365
+    title: "Ensure root is the only UID 0 account."
+    description: "Any account with UID 0 has superuser privileges on the system."
+    rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
+    remediation: "Remove any users other than root with UID 0 or assign them a new UID if appropriate."
+    compliance:
+      - cis: ["6.2.9"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1548"]
+    condition: all
+    rules:
+      - 'not f:/etc/passwd -> !r:^\s*\t*# && !r:^root: && r:^\w+:\w+:0:'
+
+  # 6.2.10 Ensure local interactive user home directories are configured. (Automated) - Not Implemented
+  # 6.2.11 Ensure local interactive user dot files access is configured. (Automated) - Not Implemented

--- a/ruleset/sca/freebsd/cis_freebsd14.yml
+++ b/ruleset/sca/freebsd/cis_freebsd14.yml
@@ -1,0 +1,4194 @@
+# Security Configuration Assessment
+# CIS Checks for FreeBSD 14.x based on Wazuh SCA files 
+# Copyright (C) 2023, Wazuh Inc.
+# Copyright (C) 2023, Alonso Cárdenas Márquez <acm@FreeBSD.org>.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+#
+# Based on:
+# Center for Internet Security Benchmarks - 16-10-2023
+
+policy:
+  id: "cis_freebsd14"
+  file: "cis_freebsd14.yml"
+  name: "SCA policy for FreeBSD 14.x"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for FreeBSD 14.x."
+  references:
+    - https://www.cisecurity.org/cis-benchmarks/
+
+requirements:
+  title: "Check FreeBSD version."
+  description: "Requirements for running the SCA scan against FreeBSD 14.x"
+  condition: all
+  rules:
+    - "f:/etc/os-release -> r:^NAME=FreeBSD"
+    - "c:sysctl -n kern.ostype -> r:^FreeBSD"
+    - "c:sysctl -n kern.osrelease -> r:^14."
+
+checks:
+  ###############################################
+  # 1 Initial setup
+  ###############################################
+  ###############################################
+  # 1.1 Filesystem Configuration
+  ###############################################
+  ###############################################
+  # 1.1.1 Disable unused filesystems
+  ###############################################
+  # 1.1.1.1 Ensure mounting of fusefs filesystems is disabled
+  - id: 40400
+    title: Ensure mounting of fusefs filesystems is disabled.
+    description: >
+      FUSE makes it possible to implement a filesystem in a userspace program.
+      Features include: simple yet comprehensive API, secure mounting by non-root
+      users, support for FreeBSD kernels, multi-threaded operation.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="fusefs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload fusefs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m fusefs -> r:fusefs && !r:fusefs$"    
+      
+  # 1.1.1.2 Ensure mounting of fdescfs filesystems is disabled (Automated)
+  - id: 40401
+    title: Ensure mounting of fdescfs filesystems is disabled.
+    description: >
+      The file-descriptor file system, or fdescfs, provides access to the per-
+      process file descriptor namespace in the global file system namespace.
+      The conventional mount point is /dev/fd
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="fdescfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload fdescfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m fdescfs -> r:fdescfs && !r:fdescfs$"    
+
+  # 1.1.1.3 Ensure mounting of smbfs filesystems is disabled (Automated)
+  - id: 40402
+    title: Ensure mounting of smbfs filesystems is disabled.
+    description: >
+      The SMB driver is an implementation of the CIFS (Common Internet
+      Filesystem) network protocol.
+
+      The smbfs filesystem driver supports only the obsolete SMBv1 protocol.
+      smbfs has known bugs and likely has security vulnerabilities.  smbfs and
+      userspace counterparts smbutil(1) and mount_smbfs(8) may be removed from
+      a future version of FreeBSD.  Users are advised to evaluate the
+      sysutils/fusefs-smbnetfs port instead.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="smbfsfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload smbfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.3"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m smbfs -> r:smbfs && !r:smbfs$"    
+      
+  # 1.1.1.4 Ensure mounting of nfscl filesystems is disabled (Automated)
+  - id: 40403
+    title: Ensure mounting of nfscl filesystems is disabled.
+    description: >
+      FUSE makes it possible to implement a filesystem in a userspace program.
+      Features include: simple yet comprehensive API, secure mounting by non-root
+      users, support for FreeBSD kernels, multi-threaded operation.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="nfscl"
+
+      Run the following command to unload the fusefs module:
+      # kldunload nfscl
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.4"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m nfscl -> r:nfscl && !r:nfscl$"    
+  
+  # 1.1.1.5 Ensure mounting of nfsd filesystems is disabled (Automated)
+  - id: 40404
+    title: Ensure mounting of nfsd filesystems is disabled.
+    description: >
+     The nfsd utility runs on a server machine to service NFS requests from
+     client machines.  At least one nfsd must be running for a machine to
+     operate as a server.
+
+     Unless otherwise specified, eight servers per CPU for UDP transport are
+     started.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="nfsd"
+
+      Run the following command to unload the fusefs module:
+      # kldunload nfsd
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m nfsd -> r:nfsd && !r:nfsd$"    
+  
+  # 1.1.1.6 Ensure mounting of msdosfs filesystems is disabled (Automated)
+  - id: 40405
+    title: Ensure mounting of msdosfs filesystems is disabled.
+    description: >
+      The msdosfs driver will permit the FreeBSD kernel to read and write MS-
+      DOS based file systems.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="msdosfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload msdosfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.6"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m msdosfs -> r:msdosfs && !r:msdosfs$"    
+        
+  # 1.1.1.7 Ensure mounting of cd9660 filesystems is disabled (Automated)
+  - id: 40406
+    title: Ensure mounting of cd9660 filesystems is disabled.
+    description: >
+      The cd9660 driver will permit the FreeBSD kernel to access the cd9660
+      file system.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="cd9660"
+
+      Run the following command to unload the fusefs module:
+      # kldunload cd9660
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.7"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m cd9660 -> r:cd9660 && !r:cd9660$"    
+  
+  # 1.1.1.8 Ensure mounting of procfs is disabled (Automated)
+  - id: 40407
+    title: Ensure mounting of procfs filesystems is disabled.
+    description: >
+      The procfs provides a two-level view of process space, unlike the
+      previous FreeBSD 1.1 procfs implementation.  At the highest level,
+      processes themselves are named, according to their process ids in
+      decimal, with no leading zeros.  There is also a special node called
+      curproc which always refers to the process making the lookup request.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="procfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload procfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.8"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m procfs -> r:procfs && !r:procfs$"    
+            
+  # 1.1.1.9 Ensure mounting of pseudofs is disabled (Automated)
+  - id: 40408
+    title: Ensure mounting of pseudofs filesystems is disabled.
+    description: >
+      The pseudofs module offers an abstract API for pseudo-file systems such
+      as procfs(5) and linprocfs(5).  It takes care of all the hairy bits like
+      interfacing with the VFS system, enforcing access control, keeping track
+      of file numbers, and cloning files and directories that are process-
+      specific.  The consumer module, i.e., the module that implements the
+      actual guts of the file system, needs only provide the directory
+      structure (represented by a collection of structures declared and
+      initialized by macros provided by pseudofs) and callbacks that report
+      file attributes or write the actual file contents into sbufs.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="pseudofs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload pseudofs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.9"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m pseudofs -> r:pseudofs && !r:pseudofs$"    
+
+  ###############################################
+  # 1.1.2 Configure /tmp
+  ###############################################
+  # 1.1.2.1 Ensure /tmp is a separate partition. (Automated)
+  - id: 40409
+    title: "Ensure /tmp is a separate partition."
+    description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
+    rationale: "Making /tmp its own file system allows an administrator to set additional mount options such as the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hard link to a system setuid program and wait for it to be updated. Once the program was updated, the hard link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp."
+    impact: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. Running out of /tmp space is a problem regardless of what kind of filesystem lies under it, but in a configuration where /tmp is not a separate file system it will essentially have the whole disk available, as the default installation only creates a single / partition. On the other hand, a RAM-based /tmp (as with tmpfs) will almost certainly be much smaller, which can lead to applications filling up the filesystem much more easily. Another alternative is to create a dedicated partition for /tmp from a separate volume or disk. One of the downsides of a disk-based dedicated partition is that it will be slower than tmpfs which is RAM-based. /tmp utilizing tmpfs can be resized using the size={size} parameter in the relevant entry in /etc/fstab."
+    remediation: "For specific configuration requirements of the /tmp mount for your environment, modify /etc/fstab: Configure /etc/fstab as appropriate: Example: tmpfs /tmp tmpfs rw,nosuid,noexec 0 0"
+    references:
+      - "https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/"
+      - "https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html"
+    compliance:
+      - cis: ["1.1.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s'
+
+  # 1.1.2.2 Ensure nodev option set on /tmp partition. (No apply)
+  - id: 40410
+    title: "Ensure nodev option set on /tmp partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s && r:nodev'
+      - 'c: zfs get -H -o value devices /tmp -> r:off'
+
+  # 1.1.2.3 Ensure noexec option set on /tmp partition. (Automated)
+  - id: 40411
+    title: "Ensure noexec option set on /tmp partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s && r:noexec'
+      - 'c: zfs get -H -o value exec /tmp -> r:off'   
+
+  # 1.1.2.4 Ensure nosuid option set on /tmp partition. (Automated)
+  - id: 40412
+    title: "Ensure nosuid option set on /tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s\s*/tmp\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /tmp -> r:off'      
+
+  ###############################################
+  # 1.1.3 Configure /var
+  ###############################################
+  # 1.1.3.1 Ensure separate partition exists for /var.
+  - id: 40413
+    title: "Ensure separate partition exists for /var."
+    description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
+    rationale: "The default installation only creates a single / partition. Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var and cause unintended behavior across the system as the disk is full. Fine grained control over the mount Configuring /var as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behaviour."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.3.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:/var\s'   
+
+  # 1.1.3.2 Ensure nodev option set on /var partition.
+  - id: 40414
+    title: "Ensure nodev option set on /var partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /var with the configured options: # mount -u -o /var. On ZFS filesystem do the following: zfs set devices=off mypool/var"
+    compliance:
+      - cis: ["1.1.3.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:/var\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var -> r:off'      
+
+  # 1.1.3.3 Ensure nosuid option set on /var partition.
+  - id: 40415
+    title: "Ensure nosuid option set on /var partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /var with the configured options: # mount -u -o /var. On ZFS filesystem do the following: zfs set setuid=off mypool/var"
+    compliance:
+      - cis: ["1.1.3.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:/var\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var -> r:off'      
+
+  ###############################################
+  # 1.1.4 Configure /var/tmp
+  ###############################################
+  # 1.1.4.1 Ensure separate partition exists for /var/tmp. (Automated)
+  - id: 40416
+    title: "Ensure separate partition exists for /var/tmp."
+    description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications. Temporary files residing in /var/tmp are to be preserved between reboots."
+    rationale: "The default installation only creates a single / partition. Since the /var/tmp directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var/tmp and cause the potential disruption to daemons as the disk is full. Configuring /var/tmp as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/tmp. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate. "
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.4.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s'
+
+  # 1.1.4.2 Ensure nodev option set on /var/tmp partition. (No apply)
+  - id: 40417
+    title: "Ensure nodev option set on /var/tmp partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set devices=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/tmp -> r:off'      
+
+  # 1.1.4.3 Ensure noexec option set on /var/tmp partition. (Automated)
+  - id: 40418
+    title: "Ensure noexec option set on /var/tmp partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set exec=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/tmp -> r:off'      
+
+  # 1.1.4.4 Ensure nosuid option set on /var/tmp partition. (Automated)
+  - id: 40419
+    title: "Ensure nosuid option set on /var/tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set setuid=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -u /var/tmp -> r:\s/var/tmp\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/tmp -> r:off'      
+
+  ###############################################
+  # 1.1.5 Configure /var/log
+  ###############################################
+  # 1.1.5.1 Ensure separate partition exists for /var/log. (Automated)
+  - id: 40420
+    title: "Ensure separate partition exists for /var/log."
+    description: "The /var/log directory is used by system services to store log data."
+    rationale: "The default installation only creates a single / partition. Since the /var/log directory contains log files which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. Fine grained control over the mount Configuring /var/log as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. As /var/log contains log files, care should be taken to ensure the security and integrity of the data and mount point."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.5.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s'    
+
+  # 1.1.5.2 Ensure nodev option set on /var/log partition. (Automated)
+  - id: 40421
+    title: "Ensure nodev option set on /var/log partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/log filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set devices=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/log -> r:off'      
+
+  # 1.1.5.3 Ensure noexec option set on /var/log partition. (Automated)
+  - id: 40422
+    title: "Ensure noexec option set on /var/log partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot run executable binaries from /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set exec=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/log -> r:off'      
+
+  # 1.1.5.4 Ensure nosuid option set on /var/log partition. (Automated)
+  - id: 40423
+    title: "Ensure nosuid option set on /var/log partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot create setuid files in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set setuid=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/log -> r:off'      
+
+  ###############################################
+  # 1.1.6 Configure /var/audit
+  ###############################################
+  # 1.1.6.1 Ensure separate partition exists for /var/audit. (Automated)
+  - id: 40424
+    title: "Ensure separate partition exists for /var/audit."
+    description: "The auditing daemon, auditd, stores log data in the /var/audit directory."
+    rationale: "The default installation only creates a single / partition. Since the /var/audit directory contains the audit log files which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. Configuring /var/audit as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. As /var/audit contains audit logs, care should be taken to ensure the security and integrity of the data and mount point."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/audit. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.6.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s'
+
+  # 1.1.6.2 Ensure nodev option set on /var/log/audit partition. (Automated)
+  - id: 40425
+    title: "Ensure nodev option set on /var/audit partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/audit filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/audit partition. Example: <device> /var/log/audit <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/log/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set devices=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/audit -> r:off'      
+
+  # 1.1.6.3 Ensure noexec option set on /var/log/audit partition. (Automated)
+  - id: 40426
+    title: "Ensure noexec option set on /var/audit partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/audit filesystem is only intended for audit logs, set this option to ensure that users cannot run executable binaries from /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var partition. Example: <device> /var/audit <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set exec=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/audit -> r:off'      
+
+  # 1.1.6.4 Ensure nosuid option set on /var/log/audit partition. (Automated)
+  - id: 40427
+    title: "Ensure nosuid option set on /var/audit partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/audit filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/audit partition. Example: <device> /var/audit <fstype> rw,nosuid,noexec,relatime 0 0 Run the following command to remount /var/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set setuid=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/audit -> r:off'      
+
+  ###############################################
+  # 1.1.7 Configure /usr/home
+  ###############################################
+  # 1.1.7.1 Ensure separate partition exists for /usr/home. (Automated)
+  - id: 40428
+    title: "Ensure separate partition exists for /usr/home."
+    description: "The /usr/home directory is used to support disk storage needs of local users."
+    rationale: "The default installation only creates a single / partition. Since the /usr/home directory contains user generated data, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /usr/home and impact all local users. Configuring /usr/home as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. In the case of /usr/home options such as quota may be considered to limit the impact that users can have on each other with regards to disk resource exhaustion."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /usr/home. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.7.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s'
+
+  # 1.1.7.2 Ensure nodev option set on /usr/home partition. (Automated)
+  - id: 40429
+    title: "Ensure nodev option set on /usr/home partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /usr/home filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /home."
+    remediation: "IF the /usr/home partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /usr/home partition. Example: <device> /usr/home <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /usr/home with the configured options: # mount -u -o /usr/home. On ZFS filesystem do the following: zfs set devices=off mypool/usr/home"
+    compliance:
+      - cis: ["1.1.7.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s && r:nodev'
+      - 'c: zfs get -H -o value devices /usr/home -> r:off'      
+
+  # 1.1.7.3 Ensure nosuid option set on /usr/home partition. (Automated)
+  - id: 40430
+    title: "Ensure nosuid option set on /usr/home partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /usr/home filesystem is only intended for user file storage, set this option to ensure that users cannot create setuid files in /usr/home."
+    remediation: "IF the /usr/home partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /usr/home partition. Example: <device> /usr/home <fstype> rw,nosuid 0 0 Run the following command to remount /usr/home with the configured options: # mount -u -o /usr/home. On ZFS filesystem do the following: zfs set setuid=off mypool/usr/home"
+    compliance:
+      - cis: ["1.1.7.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /usr/home -> r:off'      
+
+  ###############################################
+  # 1.1.8 Configure /dev/shm (No apply. It could be a tmpfs)
+  ###############################################
+
+  # 1.1.9 Disable Automounting. (Automated)
+  - id: 40431
+    title: "Disable Automounting."
+    description: "autofs or automount allows automatic mounting of devices, typically including CD/DVDs and USB drives."
+    rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in the filesystem even if they lacked permissions to mount it themselves."
+    impact: "The use of portable hard drives is very common for workstation users. If your organization allows the use of portable storage or media on workstations and physical access controls to workstations are considered adequate there is little value add in turning off automounting."
+    remediation: "If there are no other packages that depends on autofs or automount,  disable it with: # pkg remove automount; kldunload autofs; sysrc autofs_enable=NO"
+    compliance:
+      - cis: ["1.1.9"]
+      - cis_csc_v8: ["10.3"]
+      - cis_csc_v7: ["8.5"]
+      - cmmc_v2.0: ["MP.L2-3.8.7"]
+      - hipaa: ["164.310(d)(1)"]
+      - iso_27001-2013: ["A.12.2.1"]
+      - mitre_techniques: ["T1068", "T1203", "T1211", "T1212"]
+    condition: all
+    rules:
+      - "not c: sysctl -n vfs.usermount -> r:1"
+      - "c: kldstat -m autofs -> r:autofs && !r:autofs$"
+      - "not c: sysrc -n autofs_enable -> r:YES"
+      - "not c: pkg query %n-%v automount -> r:automount"   
+
+  # 1.1.10 Disable USB Storage. (Automated)   
+
+  ###############################################
+  # 1.2 Configure Software Updates
+  ###############################################
+  # 1.2.1 Ensure package manager repositories are configured. (Manual) - Not Implemented
+  # 1.2.2 Ensure updates, patches, and additional security software are installed. (Manual)
+  - id: 40432
+    title: "Ensure updates, patches, and additional security software are installed."
+    description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
+    rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
+    remediation: "Run the following command to update all packages following local site policy guidance on applying updates and patches: # pkg upgrade."
+    compliance:
+      - cis: ["1.2.1"]
+      - cis_csc_v8: ["7.3"]
+      - cis_csc_v7: ["3.4", "3.5"]
+      - cmmc_v2.0: ["SI.L1-3.14.1"]
+      - mitre_mitigations: ["M1051"]
+      - mitre_tactics: ["TA0004", "TA0008"]
+      - mitre_techniques: ["T1211"]
+      - nist_sp_800-53: ["SI-2(2)"]
+      - pci_dss_v3.2.1: ["6.2"]
+      - soc_2: ["CC7.1"]
+    condition: all
+    rules:
+      - "c:pkg upgrade -n -> r:^Your packages are up to date"
+        
+  ###############################################
+  # 1.3 Filesystem Integrity Checking
+  ###############################################
+  # 1.3.1 Ensure AIDE is installed. (Automated)
+  - id: 40433
+    title: "Ensure AIDE is installed."
+    description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
+    rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
+    remediation: "Install AIDE using the appropriate package manager or manual installation: # apt install aide aide-common Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options. Run the following commands to initialize AIDE: # aideinit # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db."
+    compliance:
+      - cis: ["1.3.1"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_techniques: ["T1036", "T1036.002", "T1036.003", "T1036.004", "T1036.005", "T1565", "T1565.001"]
+      - nist_sp_800-53: ["AC-6(9)"]
+      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "not c: pkg query %n-%v aide -> r:aide"
+       
+  # 1.3.2 Ensure filesystem integrity is regularly checked. (Automated)
+  - id: 40434
+    title: "Ensure filesystem integrity is regularly checked."
+    description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
+    rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
+    remediation: "If cron will be used to schedule and run aide check Run the following command: # crontab -u root -e Add the following line to the crontab: 0 5 * * * /usr/local/bin/aide --check."
+    references:
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.service"
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.timer"
+    compliance:
+      - cis: ["1.3.2"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - nist_sp_800-53: ["AU-2"]
+      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "c:crontab -l -> r:aide --check"
+
+  ###############################################
+  # 1.4 Secure Boot Settings
+  ###############################################
+  # 1.4.1 Ensure bootloader password is set. (Automated)
+  - id: 40435
+    title: "Ensure bootloader password is set."
+    description: "Setting the bootloader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
+    rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering bootloader menu. This prevents users from weakening security."
+    impact: 'If password protection is enabled, only the designated superuser can select any option of boot menu item.'
+    remediation: 'Add password="your_password_here" to /boot/loader.conf .'
+    compliance:
+      - cis: ["1.4.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1046"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1542"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/boot/loader.conf -> r:^password'
+
+  # 1.4.2 Ensure permissions on bootloader config are configured. (Automated)
+  - id: 40436
+    title: "Ensure permissions on bootloader config are configured."
+    description: "The bootloader configuration file contains information on boot settings and passwords for unlocking boot options."
+    rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
+    remediation: "Run the following commands to set permissions on your grub configuration: # chown root:wheel /boot/loader.conf # chmod 640 /boot/loader.conf."
+    compliance:
+      - cis: ["1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005", "TA0007"]
+      - mitre_techniques: ["T1542"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /boot/loader.conf -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /boot/loader.conf -> r:^root:wheel"
+
+  # 1.4.3 Ensure authentication required for single user mode. (Automated)
+  - id: 40437
+    title: "Ensure authentication required for single user mode."
+    description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
+    rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
+    remediation: "Run the following command and follow the prompts to set a password for the root user: # passwd root and change console line into /etc/ttys from secure to insecure."
+    compliance:
+      - cis: ["1.4.3"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/ttys -> r:^console && r:insecure'
+
+  ###############################################
+  # 1.5 Additional Process Hardening
+  ###############################################
+  # 1.5.1 Ensure address space layout randomization (ASLR) is enabled
+  - id: 40438
+    title: Ensure address space layout randomization (ASLR) is enabled.
+    description: >
+      Address space layout randomization (ASLR) is an exploit mitigation technique which
+      randomly arranges the address space of key data areas of a process.
+    rationale: >
+      Randomly placing virtual memory regions will make it difficult to write memory page
+      exploits as the memory placement will be consistently shifting.
+    remediation: >
+      Set the following parameter in /etc/sysctl.conf file:
+      kern.elf64.aslr.enable=1
+      kern.elf64.aslr.stack=1
+      kern.elf64.aslr.shared_page=1
+      kern.elf64.aslr.pie_enable=1
+      kern.elf32.aslr.stack=1 
+
+      Run the following command to set the active kernel parameter:
+      # sysctl kern.elf64.aslr.enable=1
+      # sysctl kern.elf64.aslr.stack=1
+      # sysctl kern.elf64.aslr.shared_page=1
+      # sysctl kern.elf64.aslr.pie_enable=1
+      # sysctl kern.elf32.aslr.stack=1 
+    compliance:
+      - cis: ["1.5.1"]
+      - cis_csc: ["8.3"]
+    condition: all
+    rules:
+      - "c:sysctl -n kern.elf64.aslr.enable -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.stack -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.shared_page -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.pie_enable -> r:1"
+      - "c:sysctl -n kern.elf32.aslr.stack -> r:1"      
+      
+  # 1.5.2 Ensure core dumps are restricted (Automated)
+  - id: 40439
+    title: "Ensure core dumps are restricted."
+    description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
+    rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). ."
+    remediation: > 
+      Set the following parameter in /etc/sysctl.conf file:
+      kern.coredump=0
+      kern.corefile=/dev/null
+      or            
+      # sysrc dumpdev="NO"     
+      Run the following command to set the active kernel parameter:
+      # sysctl kern.coredump=0
+      # sysctl kern.corefile=/dev/null      
+    compliance:
+      - cis: ["1.5.2"]
+      - mitre_techniques: ["T1005"]
+      - mitre_tactics: ["TA0007"]
+    condition: all
+    rules:
+      - "c:sysctl -n kern.coredump -> r:0"
+      - "c:sysctl -n kern.corefile -> r:/dev/null"      
+      - "c:sysrc -n dumpdev -> r:NO"
+
+  ###############################################
+  # 1.6 Mandatory Access Control
+  ###############################################
+  ###############################################
+  # 1.6.1 Configure TrustedBSD Mandatory Access Control
+  ###############################################  
+  # 1.6.1.1 Ensure TrustedBSD Mandatory Access Control is installed. (Automated)
+  - id: 40440
+    title: "Ensure TrustedBSD Mandatory Access Control is installed."
+    description: "TrustedBSD provides Mandatory Access Controls."
+    rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
+    remediation: "Enable TrustedBSD Mandatory Access Control. # sysctl kern.features.security_mac=1"
+    compliance:
+      - cis: ["1.6.1.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1068", "T1565", "T1565.001", "T1565.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n kern.features.security_mac -> r:1'
+
+  # 1.6.1.2 Ensure TrustedBSD MAC is not disabled in bootloader configuration. (Automated)
+  - id: 40441
+    title: "Ensure TrustedBSD MAC is not disabled in loader configuration."
+    description: "Configure TrustedBSD MAC to be enabled at boot time and verify that it has not been overwritten by the loader parameters."
+    rationale: "TrustedBSD MAC is enabled into kernel by default but it can be disabled from loader.conf."
+    impact: "Files created while TrustedBSD MAC is disabled are not labeled at all. This behavior causes problems when changing to enforcing mode because files are labeled incorrectly or are not labeled at all. To prevent incorrectly labeled and unlabeled files from causing problems, file systems are automatically relabeled when changing from the disabled state to permissive or enforcing mode. This can be a long running process that should be accounted for as it may extend downtime during initial re-boot."
+    remediation: "Remove instance of kern.features.security_mac=0 from /boot/loader.conf."
+    compliance:
+      - cis: ["1.6.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: none
+    rules:
+      - 'not f:/boot/loader.conf -> r:kern.features.security_mac=0'
+
+  ###############################################
+  # 1.7 Command Line Warning Banners
+  ###############################################
+  # 1.7.1 Ensure message of the day is configured properly. (Automated)
+  - id: 40442
+    title: "Ensure message of the day is configured properly."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform."
+    rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
+    remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy. Add or update the message text to follow local site policy. Example Text: # echo \"Authorized use only. All activity may be monitored and reported.\" > /etc/motd.template -- OR -- If the motd is not used, you can remove content inside of /etc/motd.template file and run # service motd restart."
+    compliance:
+      - cis: ["1.7.1"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1082", "T1592", "T1592.004"]
+    condition: all
+    rules:
+      - "f:/var/run/motd"
+      - "not f:/etc/motd"      
+
+  # 1.7.2 Ensure permissions on /etc/motd.template are configured. (Automated)
+  - id: 40443
+    title: "Ensure permissions on /etc/motd.template are configured."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
+    rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/motd, /etc/motd.template and /var/run/motd : # chown root:wheel /etc/motd /etc/motd.template /var/run/motd # chmod 644 /etc/motd /etc/motd.template /var/run/motd -- OR -- Run the following command to remove the /etc/motd file: # rm /etc/motd."
+    compliance:
+      - cis: ["1.7.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - "c:stat -f %Sp /etc/motd.template -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/motd.template -> r:^root:wheel"    
+      - "c:stat -f %Sp /etc/motd -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/motd -> r:^root:wheel"
+      - "c:stat -f %Sp /var/run/motd -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /var/run/motd -> r:^root:wheel"            
+
+  ###############################################
+  # 1.8 GNOME Display Manager
+  ###############################################
+  # 1.8.1 Ensure GNOME Display Manager is removed. (Automated)
+  - id: 40444
+    title: "Ensure GNOME Display Manager is removed."
+    description: "The GNOME Display Manager (GDM) is a program that manages graphical display servers and handles graphical user logins."
+    rationale: "If a Graphical User Interface (GUI) is not required, it should be removed to reduce the attack surface of the system."
+    impact: "Removing the GNOME Display manager will remove the Graphical User Interface (GUI) from the system."
+    remediation: "Run the following command to uninstall gdm3: # apt purge gdm3."
+    compliance:
+      - cis: ["1.8.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v gdm -> !r:gdm"    
+
+  # 1.8.2 Ensure GDM login banner is configured. (Automated) - Not Implemented
+  # 1.8.3 Ensure GDM disable-user-list option is enabled. (Automated) - Not Implemented
+  # 1.8.4 Ensure GDM screen locks when the user is idle. (Automated) - Not Implemented
+  # 1.8.5 Ensure GDM screen locks cannot be overridden. (Automated) - Not Implemented
+  # 1.8.6 Ensure GDM automatic mounting of removable media is disabled. (Automated) - Not Implemented
+  # 1.8.7 Ensure GDM disabling automatic mounting of removable media is not overridden. (Automated) - Not Implemented
+  # 1.8.8 Ensure GDM autorun-never is enabled. (Automated) - Not Implemented
+  # 1.8.9 Ensure GDM autorun-never is not overridden. (Automated) - Not Implemented
+
+  # 1.8.10 Ensure XDCMP is not enabled. (Automated)
+  - id: 40445
+    title: "Ensure XDCMP is not enabled."
+    description: "X Display Manager Control Protocol (XDMCP) is designed to provide authenticated access to display management services for remote displays."
+    rationale: "XDMCP is inherently insecure. - XDMCP is not a ciphered protocol. This may allow an attacker to capture keystrokes entered by a user - XDMCP is vulnerable to man-in-the-middle attacks. This may allow an attacker to steal the credentials of legitimate users by impersonating the XDMCP server."
+    remediation: "Edit the file /usr/local/etc/gdm/custom.conf and remove the line: Enable=true."
+    compliance:
+      - cis: ["1.8.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1050"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1040", "T1056", "T1056.001", "T1557"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - 'not f:/usr/local/etc/gdm/custom.conf -> r:^\s*Enable\s*=\s*true'
+      
+  ############################################################
+  # 2 Services
+  ############################################################
+  # 2.1 Configure Time Synchronization
+  # 2.1.1 Ensure time synchronization is in use
+  # 2.1.1.1 Ensure a single time synchronization daemon is in use. (Automated)
+  - id: 40446
+    title: "Ensure a single time synchronization daemon is in use."
+    description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them. Note: - On virtual systems where host based time synchronization is available consult your virtualization software documentation and verify that host based synchronization is in use and follows local site policy. Only one time synchronization method should be in use on the system. Configuring multiple time synchronization methods could lead to unexpected or unreliable results."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
+    remediation: "On physical systems, and virtual systems where host based time synchronization is not available. Select one of the three time synchronization daemons; ntpdate (1), ntpd (2) or chrony (3), and following the remediation procedure for the selected daemon. Note: enabling more than one synchronization daemon could lead to unexpected or unreliable results: 1. # sysrc ntpdate_enable=YES 2. # sysrc ntpd_enable=YES; # service ntpd start 3. # sysrc chronyd_enable=YES"
+    compliance:
+      - cis: ["2.1.1.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: any
+    rules:
+      - "c:sysrc -n ntpdate_enable -> r:YES"
+      - "c:sysrc -n ntpd_enable -> r:YES"    
+      - "c:sysrc -n chronyd_enable -> r:YES"               
+
+  # 2.1.2 Configure chrony
+  # 2.1.2.1 Ensure chrony is configured with authorized timeserver. (Manual)
+  - id: 40447
+    title: "Ensure chrony is configured with authorized timeserver."
+    description: "The server directive specifies an NTP server which can be used as a time source. The client-server relationship is strictly hierarchical: a client might synchronize its system time to that of the server, but the server's system time will never be influenced by that of a client. The syntax of pool directive is similar to that for the server directive, except that it is used to specify a pool of NTP servers rather than a single NTP server. The pool name is expected to resolve to multiple addresses which might change over time."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /use/local/etc/chrony/chrony.conf file and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]>. Run one of the following commands to load the updated time sources into chronyd running config: # service chronyd restart OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:pgrep -l chrony -> r:chronyd"
+      - 'f:/usr/local/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
+
+  # 2.1.2.2 Ensure chrony is running as user chrony. (Automated)
+  - id: 40448
+    title: "Ensure chrony is running as user chrony or ntpd."
+    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
+    rationale: "The chronyd service should run with only the required privileges."
+    remediation: "Add or edit the user line to /usr/local/etc/chrony/chrony.conf : user chrony|ntpd OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: any
+    rules:
+      - "c:pgrep -U chrony -l chronyd"    
+      - "c:pgrep -U ntpd -l chronyd"
+
+  # 2.1.2.3 Ensure chrony is enabled and running. (Automated)
+  - id: 40449
+    title: "Ensure chrony is enabled and running."
+    description: "chrony is a daemon for synchronizing the system clock across the network."
+    rationale: "chrony needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF chrony is in use on the system, run the following commands: Run the following command to enable and start chronyd service: # service chronyd enable; # service chronyd start OR If another time synchronization service is in use on the system, run the following command to remove chrony: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n chronyd_enable -> r:^YES"
+      - "c:service chronyd status -> r:^chronyd is running as pid"
+
+  # 2.1.3.1 Ensure ntp access control is configured. (Automated)
+  - id: 40450
+    title: "Ensure ntp access control is configured."
+    description: 'NTP access control is a security measure used to prevent fraudulent or inadvertent manipulation of a time server'
+    rationale: "If ntp is in use on the system, proper configuration is vital to ensuring time synchronization is accurate."
+    remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery OR If another time synchronization service is in use on the system, run the following command to stop ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+    compliance:
+      - cis: ["2.1.3.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1498", "T1498.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - 'f:/etc/ntp.conf -> r:^restrict\s*\t*-4\s*\t*default|^restrict\s*\t*default && r:\s*kod && r:\s*nomodify && r:\s*notrap && r:\s*nopeer && r:\s*noquery'
+      - 'f:/etc/ntp.conf -> r:^restrict\s*\t*-6\s*\t*default && r:\s*kod && r:\s*nomodify && r:\s*notrap && r:\s*nopeer && r:\s*noquery'
+
+  # 2.1.3.2 Ensure ntp is configured with authorized timeserver. (Manual)
+  - id: 40451
+    title: "Ensure ntp is configured with authorized timeserver."
+    description: '- pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. - server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses.'
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]>. Run the following command to load the updated time sources into ntp running config: # service ntp restart OR If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+      - "https://tf.nist.gov/tf-cgi/servers.cgi"
+    compliance:
+      - cis: ["2.1.3.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1498", "T1498.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "f:/etc/ntp.conf -> r:^pool"
+      - "f:/etc/ntp.conf -> r:^server"
+
+  # 2.1.3.3 Ensure ntp is running as user ntpd. (Automated)
+  - id: 40452
+    title: "Ensure ntp is running as user ntp."
+    description: "The ntpd application is part of FreeBD base system and it has a dedicated user account ntpd. This account is granted the access required by the ntpd daemon Note: - If chrony is used, ntpd should be removed and this section skipped - This recommendation only applies if ntpd is in use on the system - Only one time synchronization method should be in use on the system."
+    rationale: "The ntpd daemon should run with only the required privilege."
+    remediation: "The ntpd run by default using ntpd user. It can not changed. If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+    compliance:
+      - cis: ["2.1.3.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:pgrep -U ntpd -l ntpd -> r:ntpd"    
+
+  # 2.1.3.4 Ensure ntp is enabled and running. (Automated)
+  - id: 40453
+    title: "Ensure ntpd is enabled and running."
+    description: "ntpd is a daemon for synchronizing the system clock across the network."
+    rationale: "ntpd needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF ntpd is in use on the system, run the following commands: Run the following command to enable and start ntp service: # service ntpd enable; # service ntpd start OR If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    compliance:
+      - cis: ["2.1.3.4"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n ntpd_enable -> r:^YES"
+      - "c:service ntpd status -> r:^ntpd is running as pid"
+
+  ###############################################
+  # 2.2 Special Purpose Services
+  ###############################################
+  # 2.2.1 Ensure xinetd is not installed. (Automated)
+  - id: 40454
+    title: "Ensure xinetd is not installed."
+    description: "The eXtended InterNET Daemon (xinetd) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
+    rationale: "If there are no xinetd services required, it is recommended that the package be removed to reduce the attack surface are of the system. Note: If an xinetd service or services are required, ensure that any xinetd service not required is stopped and disabled."
+    remediation: "Run the following command to remove xinetd: # pkg remove xinetd -y."
+    compliance:
+      - cis: ["2.2.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v xinetd -> r:^xinetd"    
+
+  # 2.2.2 Ensure X Window System is not installed. (Automated)
+  - id: 40455
+    title: "Ensure X Window System is not installed."
+    description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
+    rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
+    impact: 'Many Unix-Like systems run applications which require a Java runtime. Some Java packages have a dependency on specific X Windows xorg-fonts. One workaround to avoid this dependency is to use the "headless" Java packages for your specific Java runtime, if provided by your distribution.'
+    remediation: "Remove the X Windows System packages: pkg remove 'xorg*'."
+    compliance:
+      - cis: ["2.2.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v xorg-server -> r:^xorg-server"      
+
+  # 2.2.3 Ensure Avahi Server is not installed. (Automated)
+  - id: 40456
+    title: "Ensure Avahi Server is not installed."
+    description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
+    rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
+    remediation: "Run the following commands to remove avahi-daemon: # service avahi_daaemon stop # sysrc -x avahi_daemon_enable  # pkg remove 'avahi*'."
+    compliance:
+      - cis: ["2.2.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v avahi-app -> r:^avahi-app"
+
+  # 2.2.4 Ensure CUPS is not installed. (Automated)
+  - id: 40457
+    title: "Ensure CUPS is not installed."
+    description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
+    rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface."
+    impact: "Removing CUPS will prevent printing from the system, a common task for workstation systems."
+    remediation: "Run one of the following commands to remove cups : # pkg remove cups."
+    references:
+      - "http://www.cups.org."
+    compliance:
+      - cis: ["2.2.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v cups -> r:^cups"
+
+  # 2.2.5 Ensure DHCP Server is not installed. (Automated)
+  - id: 40458
+    title: "Ensure DHCP Server is not installed."
+    description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
+    rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove isc-dhcp-server or dhcpd: # pkg remove 'isc-dhcp*' or pkg remove dhcpd."
+    references:
+      - "http://www.isc.org/software/dhcp."
+    compliance:
+      - cis: ["2.2.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dhcpd|isc-dhcp.*-server' -> r:dhcp"    
+
+  # 2.2.6 Ensure LDAP server is not installed. (Automated)
+  - id: 40459
+    title: "Ensure LDAP server is not installed."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove slapd: # pkg remove 'openldap*-server'."
+    references:
+      - "http://www.openldap.org."
+    compliance:
+      - cis: ["2.2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'openldap.*server' -> r:^openldap"    
+
+  # 2.2.7 Ensure NFS is not installed. (Automated)
+  - id: 40460
+    title: "Ensure NFS is not installed."
+    description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
+    rationale: "If the system does not export NFS shares, it is recommended that the nfs-kernel-server package be removed to reduce the remote attack surface."
+    remediation: "Run the following command to disable nfs: # sysctl kern.features.nfsd=0; # sysctl kern.features.nfscl=0 and add those entries to /etc/sysctl.conf"
+    compliance:
+      - cis: ["2.2.7"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:sysctl -n kern.features.nfsd -> r:0"
+      - "c:sysctl -n kern.features.nfscl -> r:0"      
+
+  # 2.2.8 Ensure DNS Server is not installed. (Automated)
+  - id: 40461
+    title: "Ensure DNS Server is not installed."
+    description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
+    rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following commands to disable DNS server: # pkg remove 'bind9*' or # pkg remove unbound."
+    compliance:
+      - cis: ["2.2.8"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v bind9 -> r:^bind9"    
+      - "not c:pkg query -x %n-%v unbound -> r:^unbound"      
+
+  # 2.2.9 Ensure FTP Server is not installed. (Automated)
+  - id: 40462
+    title: "Ensure FTP Server is not installed."
+    description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
+    rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended SFTP be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove ftp daemon: # pkg remove -x 'bbftp-server|ftpd|uftp'."
+    compliance:
+      - cis: ["2.2.9"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'bbftp-server|ftpd|uftp' -> r:ftp"
+
+  # 2.2.10 Ensure TFTP Server is not installed. (Automated)
+  - id: 40463
+    title: "Ensure TFTP Server is not installed."
+    description: "Trivial File Transfer Protocol (TFTP) is a simple protocol for exchanging files between two TCP/IP machines. TFTP servers allow connections from a TFTP Client for sending and receiving files."
+    rationale: "TFTP does not have built-in encryption, access control or authentication. This makes it very easy for an attacker to exploit TFTP to gain access to files."
+    remediation: "Run the following command to remove tftp servers: # pkg remove -x 'utftpd|tftp-'."
+    compliance:
+      - cis: ["2.2.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'utftpd|tftp-' -> r:tftp"
+
+  # 2.2.11 Ensure HTTP server is not installed. (Automated)
+  - id: 40464
+    title: "Ensure HTTP server is not installed."
+    description: "HTTP or web servers provide the ability to host web site content."
+    rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove httpd server: # pkg remove -x '^apache|^nginx|httpd'."
+    compliance:
+      - cis: ["2.2.11"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'nginx' -> r:^nginx"    
+      - "not c:pkg query -x %n-%v 'apache' -> r:^apache"
+      - "not c:pkg query -x %n-%v 'httpd' -> r:httpd"
+
+  # 2.2.12 Ensure IMAP and POP3 server are not installed. (Automated)
+  - id: 40465
+    title: "Ensure IMAP and POP3 server are not installed."
+    description: "dovecot-imapd, dovecot-pop3d, cyrus-imapd and pop3d are an open source IMAP and POP3 server for Unix based systems."
+    rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove imapd and pop3d servers: # pkg remove -x '^dovecot|^cyrus-imapd|^pop3d'."
+    compliance:
+      - cis: ["2.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dovecot' -> r:dovecot"    
+      - "not c:pkg query -x %n-%v 'cyrus-imapd' -> r:cyrus-imapd"      
+      - "not c:pkg query -x %n-%v 'pop3d' -> r:pop3d"
+
+  # 2.2.13 Ensure Samba is not installed. (Automated)
+  - id: 40466
+    title: "Ensure Samba is not installed."
+    description: "The Samba daemon allows system administrators to configure their FreeBSD systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Server Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
+    rationale: "If there is no need to mount directories and file systems to Windows systems, then this service should be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove samba: # pkg remove -x '^samba'."
+    compliance:
+      - cis: ["2.2.13"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1005", "T1039", "T1083", "T1135", "T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'samba' -> r:samba"
+
+  # 2.2.14 Ensure HTTP Proxy Server is not installed. (Automated)
+  - id: 40467
+    title: "Ensure HTTP Proxy Server is not installed."
+    description: "Squid, privoxy, tinyproxy, 3proxy are standard proxy servers used in many distributions and environments."
+    rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove squid: # pkg remove -x 'squid|privoxy|tinyproxy|3proxy'."
+    compliance:
+      - cis: ["2.2.14"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'squid' -> r:squid"    
+      - "not c:pkg query -x %n-%v 'privoxy' -> r:privoxy"      
+      - "not c:pkg query -x %n-%v 'tinyproxy' -> r:tinyproxy"      
+      - "not c:pkg query -x %n-%v '3proxy' -> r:3proxy"      
+
+  # 2.2.15 Ensure SNMP Server is not installed. (Automated)
+  - id: 40468
+    title: "Ensure SNMP Server is not installed."
+    description: 'Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system.'
+    rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the snmpd package should be removed to reduce the attack surface of the system. Note: If SNMP is required: - The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values. -."
+    remediation: "Run the following command to remove snmpd: # pkg remove net-snmp."
+    compliance:
+      - cis: ["2.2.15"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'net-snmp' -> r:net-snmp"    
+
+  # 2.2.16 Ensure NIS Server is not installed. (Automated)
+  - id: 40469
+    title: "Ensure NIS Server is not installed."
+    description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed and other, more secure services be used."
+    remediation: "Run the following command to disable nis: # service nis_server stop; # sysrc -x nis_server_enable OR # service nis_server disable."
+    compliance:
+      - cis: ["2.2.16"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c: sysrc -n nis_server_enable -> r:NO"
+
+  # 2.2.17 Ensure dnsmasq is not installed. (Automated)
+  - id: 40470
+    title: "Ensure dnsmasq is not installed."
+    description: "dnsmasq is a lightweight tool that provides DNS caching, DNS forwarding and DHCP (Dynamic Host Configuration Protocol) services."
+    rationale: "Unless a system is specifically designated to act as a DNS caching, DNS forwarding and/or DHCP server, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove dnsmasq: # pkg remove dnsmasq."
+    compliance:
+      - cis: ["2.2.17"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dnsmasq' -> r:dnsmasq"    
+
+  # 2.2.18 Ensure telnet-server is not installed. (Automated)
+  - id: 40471
+    title: "Ensure telnetd is not installed."
+    description: "The telnetd package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
+    remediation: "Run the following command to remove the telnetd package: # pkg remove freebsd-telnetd."
+    compliance:
+      - cis: ["2.2.18"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'freebsd-telnetd' -> r:^freebsd-telnetd"
+
+  # 2.2.19 Ensure sendmail transfer agent is configured for local-only mode. (Automated)
+  - id: 40472
+    title: "Ensure sendmail transfer agent is configured for local-only mode."
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: - This recommendation is designed around the postfix mail server. - Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /etc/rc.conf and add the following line: sendmail_enable=NO or sendmail_enable=NONE."
+    compliance:
+      - cis: ["2.2.19"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1018", "T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:sysrc -n sendmail_enable -> r:YES"
+      - "c:sysrc -n sendmail_enable -> r:NO|NONE"      
+      
+  # 2.2.20 Ensure postfix mail transfer agent is configured for local-only mode. (Automated)
+  - id: 40473
+    title: "Ensure postfix mail transfer agent is configured for local-only mode."
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: - This recommendation is designed around the postfix mail server. - Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /usr/local/etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only Run the following command to restart postfix: # service postfix restart."
+    compliance:
+      - cis: ["2.2.20"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1018", "T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "f:/usr/local/etc/postfix/main.cf -> r:^inet_interfaces = loopback-only"
+
+  # 2.2.21 Ensure rsync service is either not installed or is masked. (Automated)
+  - id: 40474
+    title: "Ensure rsync service is either not installed or is masked."
+    description: "The rsync service can be used to synchronize files between systems over network links."
+    rationale: "The rsync service presents a security risk as the rsync protocol is unencrypted. The rsync package should be removed or if required for dependencies, the rsync service should be stopped and masked to reduce the attack area of the system."
+    remediation: "Run the following command to remove rsync: # pkg remove rsync"
+    compliance:
+      - cis: ["2.2.21"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1105", "T1203", "T1210", "T1543", "T1543.002", "T1570"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'rsync' -> r:rsync"
+
+  # 2.3.1 Ensure NIS Client is not installed. (Automated)
+  - id: 40475
+    title: "Ensure NIS Client is not installed."
+    description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client was used to bind a machine to an NIS server and receive the distributed configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Disable nis client: # service nis_client stop; # service nis_client disable."
+    compliance:
+      - cis: ["2.3.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:sysrc -n nis_client_enable -> r:YES"
+
+  # 2.3.2 Ensure rsh client is not installed. (Automated)
+  - id: 40476
+    title: "Ensure rsh client is not installed."
+    description: "The bsdrcmds package contains the client commands for the rsh services."
+    rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Uninstall rsh: # pkg remove bsdrcmds."
+    compliance:
+      - cis: ["2.3.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1040", "T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c:pkg query -x %n-%v 'bsdrcmds' -> r:bsdrcmds"
+
+  # 2.3.3 Ensure talk client is not installed. (Automated)
+  - id: 40477
+    title: "Ensure talk client is not installed."
+    description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
+    rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Remove talk: # rm /usr/bin/talk."
+    compliance:
+      - cis: ["2.3.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0006", "TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/bin/talk"
+
+  # 2.3.4 Ensure telnet client is not installed. (Automated)
+  - id: 40478
+    title: "Ensure telnet client is not installed."
+    description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Remove talk: # rm /usr/bin/telnet."
+    compliance:
+      - cis: ["2.3.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0006", "TA0008"]
+      - mitre_techniques: ["T1040", "T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/bin/telnet"    
+
+  # 2.3.5 Ensure LDAP client is not installed. (Automated)
+  - id: 40479
+    title: "Ensure LDAP client is not installed."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
+    impact: "Removing the LDAP client will prevent or inhibit using LDAP for authentication in your environment."
+    remediation: "Uninstall ldap client: # pkg remove -x 'openldap.*-client'."
+    compliance:
+      - cis: ["2.3.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'openldap.*client' -> r:openldap"    
+
+  # 2.3.6 Ensure RPC is not installed. (Automated)
+  - id: 40480
+    title: "Ensure RPC is not installed."
+    description: 'Remote Procedure Call (RPC) is a method for creating low level client server applications across different system architectures. It requires an RPC compliant client listening on a network port. The supporting package is rpcbind.".'
+    rationale: "If RPC is not required, it is recommended that this services be removed to reduce the remote attack surface."
+    remediation: "Run the following command to remove rpcbind: # rm /usr/sbin/rpcbind."
+    compliance:
+      - cis: ["2.3.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/sbin/rpcbind"
+
+  # 2.4 Ensure nonessential services are removed or masked. (Manual) - Not Implemented
+
+  ###############################################
+  # 3 Network Configuration
+  ###############################################
+  ###############################################
+  # 3.1 Disable unused network protocols and devices
+  ###############################################
+  # 3.1.1 Ensure IPv6 status is identified. (Manual)
+  - id: 40481
+    title: "Ensure IPv6 status is identified."
+    description: "Internet Protocol Version 6 (IPv6) is the most recent version of Internet Protocol (IP). It's designed to supply IP addressing and additional security to support the predicted growth of connected devices. IPv6 is based on 128-bit addressing and can support 340 undecillion addresses, which is 340 followed by 36 zeroes. Features of IPv6 - Hierarchical addressing and routing infrastructure - Stateful and Stateless configuration - Support for quality of service (QoS) - An ideal protocol for neighboring node interaction."
+    rationale: "IETF RFC 4038 recommends that applications are built with an assumption of dual stack. It is recommended that IPv6 be enabled and configured in accordance with Benchmark recommendations. If dual stack and IPv6 are not used in your environment, IPv6 may be disabled to reduce the attack surface of the system, and recommendations pertaining to IPv6 can be skipped. Note: It is recommended that IPv6 be enabled and configured unless this is against local site policy."
+    impact: "IETF RFC 4038 recommends that applications are built with an assumption of dual stack. When enabled, IPv6 will require additional configuration to reduce risk to the system."
+    remediation: "Enable or disable IPv6 in accordance with system requirements and local site policy."
+    compliance:
+      - cis: ["3.1.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1557", "T1595", "T1595.001", "T1595.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n ipv6_activate_all_interfaces -> r:NO"
+      - "c:sysrc -n ip6addrctl_enable -> r:NO"
+
+  # 3.1.2 Ensure wireless interfaces are disabled. (Automated) - Not Implemented
+
+  # 3.1.3 Ensure bluetooth is disabled. (Automated)
+  - id: 40482
+    title: "Ensure bluetooth is disabled."
+    description: "Bluetooth is a short-range wireless technology standard that is used for exchanging data between devices over short distances. It employs UHF radio waves in the ISM bands, from 2.402 GHz to 2.48 GHz. It is mainly used as an alternative to wire connections."
+    rationale: "An attacker may be able to find a way to access or corrupt your data. One example of this type of activity is bluesnarfing, which refers to attackers using a Bluetooth connection to steal information off of your Bluetooth device. Also, viruses or other malicious code can take advantage of Bluetooth technology to infect other devices. If you are infected, your data may be corrupted, compromised, stolen, or lost."
+    impact: "Many personal electronic devices (PEDs) use Bluetooth technology. For example, you may be able to operate your computer with a wireless keyboard. Disabling Bluetooth will prevent these devices from connecting to the system."
+    remediation: "Run the following commands to stop and disable the Bluetooth service # kldunload ng_ubt and add ng_ubt to module_blacklist variable into /boot/loader.conf #  Note: A reboot may be required."
+    references:
+      - "https://www.cisa.gov/tips/st05-015"
+    compliance:
+      - cis: ["3.1.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:kldstat -n ng_ubt -> r:ng_ubt && !r:ng_ubt.ko$"
+      - 'not f:/boot/loader.conf -> r:ng_ubt_load && r:YES'            
+        
+  # 3.1.4 Ensure SCTP is disabled. (Automated) - Not Implemented
+  - id: 40483
+    title: "Ensure SCTP is disabled."
+    description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
+    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
+    remediation: 'Edit /boot/loader.conf and add sctp to module_blacklist variable. Note: A reboot may be required.'
+    compliance:
+      - cis: ["3.1.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:kldstat -n sctp -> r:sctp && !r:sctp.ko$"
+      - 'not f:/boot/loader.conf -> r:sctp_load && r:YES'      
+        
+  # 3.1.5 Ensure RDS is disabled. (Automated) Not Implemented
+  # 3.1.6 Ensure TIPC is disabled. (Automated) - Not Implemented
+
+  ###############################################
+  # 3.2 Network Parameters (Host Only)
+  ###############################################
+  # 3.2.1 Ensure packet redirect sending is disabled
+  - id: 40484
+    title: Ensure packet redirect sending is disabled
+    description: >
+      ICMP Redirects are used to send routing information to other hosts. As a host itself does
+      not act as a router (in a host only configuration), there is no need to send redirects.
+    rationale: >
+      An attacker could use a compromised host to send invalid ICMP redirects to other router
+      devices in an attempt to corrupt routing and have users access a system set up by the
+      attacker as opposed to a valid system.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.icmp.drop_redirect = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.icmp.drop_redirect=1
+    compliance:
+      - cis: ["3.2.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.icmp.drop_redirect -> r:1'
+
+  # 3.2.2 Ensure IP forwarding is disabled. (Automated) - Not Implemented
+  - id: 40485
+    title: Ensure IP forwarding is disabled.
+    description: >
+      IP forwarding allows the system to move traffic between interfaces that belong to the same 
+      machine (router) and forward the packets to the appropriate interface according to the 
+      machine's routing table
+    rationale: >
+      Keep this parameter disabled to prevent denial of service attacks through spoofed packets.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.ip.forwarding = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.ip.forwarding=1
+    compliance:
+      - cis: ["3.2.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.ip.forwarding -> r:0'
+
+  ###############################################
+  # 3.3 Network Parameters (Host and Router)
+  ###############################################
+  # 3.3.1 Ensure source routed packets are not accepted. (Automated) - Not Implemented
+  # 3.3.2 Ensure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.3 Ensure secure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.4 Ensure suspicious packets are logged. (Automated) - Not Implemented
+  # 3.3.5 Ensure broadcast ICMP requests are ignored
+  - id: 40486
+    title: Ensure broadcast ICMP requests are ignored
+    description: >
+      Setting net.inet.icmp.bmcastecho to 0 will cause the system to ignore all
+      ICMP echo and timestamp requests to broadcast and multicast addresses.
+    rationale: >
+      Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for
+      your network could be used to trick your host into starting (or participating) in a Smurf
+      attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast
+      messages with a spoofed source address. All hosts receiving this message and responding
+      would send echo-reply messages back to the spoofed address, which is probably not
+      routable. If many hosts respond to the packets, the amount of traffic on the network could
+      be significantly multiplied.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.icmp.bmcastecho = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.icmp.bmcastecho=0
+    compliance:
+      - cis: ["3.3.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.icmp.bmcastecho -> r:0'
+
+  # 3.3.6 Ensure bogus ICMP responses are ignored. (Automated) - Not Implemented
+  # 3.3.7 Ensure Reverse Path Filtering is enabled. (Automated) - Not Implemented
+  # 3.3.8 Ensure TCP SYN Cookies is enabled
+  - id: 40487
+    title: Ensure TCP SYN Cookies is enabled
+    description: >
+      When net.inet.tcp.syncookies is set, the kernel will handle TCP SYN packets normally until the
+      half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN
+      cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the
+      SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that
+      encodes the source and destination IP address and port number and the time the packet
+      was sent. A legitimate connection would send the ACK packet of the three way handshake
+      with the specially crafted sequence number. This allows the system to verify that it has
+      received a valid response to a SYN cookie and allow the connection, even though there is no
+      corresponding SYN in the queue.
+    rationale: >
+      Attackers use SYN flood attacks to perform a denial of service attacked on a system by
+      sending many SYN packets without completing the three way handshake. This will quickly
+      use up slots in the kernel's half-open connection queue and prevent legitimate connections
+      from succeeding. SYN cookies allow the system to keep accepting valid connections, even if
+      under a denial of service attack.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.tcp.syncookies = 1
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.tcp.syncookies=1
+    compliance:
+      - cis: ["3.3.8"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.tcp.syncookies -> r:1'
+      
+  # 3.3.9 Ensure IPv6 router advertisements are not accepted
+  - id: 40488
+    title: Ensure IPv6 router advertisements are not accepted
+    description: This setting disables the system's ability to accept IPv6 router advertisements.
+    rationale: >
+      It is recommended that systems do not accept router advertisements as they could be
+      tricked into routing traffic to compromised machines. Setting hard routes within the
+      system (usually a single default route to a trusted router) protects the system from bad
+      routes.
+    remediation: >
+      IF IPv6 is enabled:
+
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet6.ip6.accept_rtadv = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet6.ip6.accept_rtadv=0
+    compliance:
+      - cis: ["3.3.9"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet6.ip6.accept_rtadv -> r:0'      
+
+  ###############################################
+  # 3.4 Firewall Configuration
+  ###############################################
+  ###############################################
+  # 3.4.1 Configure Packet Filter firewall
+  ###############################################
+  # 3.4.1.1 Ensure packet filter is installed. (Automated)
+  - id: 40489
+    title: "Ensure Packet Filter is installed."
+    description: "FreeBSD has three firewalls built into the base system: PF, IPFW, and IPFILTER, also known as IPF. FreeBSD also provides two traffic shapers for controlling bandwidth usage: altq(4) and dummynet(4). ALTQ has traditionally been closely tied with PF and dummynet with IPFW. Each firewall uses rules to control the access of packets to and from a FreeBSD system, although they go about it in different ways and each has a different rule syntax."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "Packet Filter is part of FreeBSD base system."
+    compliance:
+      - cis: ["3.4.1.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/pfctl"           
+
+  # 3.4.1.2 Ensure Packet Filter is enabled and running. (Automated)
+  - id: 40490
+    title: "Ensure Packet Filter is enabled."
+    description: "Since FreeBSD 5.3, a ported version of OpenBSD’s PF firewall has been included as an integrated part of the base system. PF is a complete, full-featured firewall that has optional support for ALTQ (Alternate Queuing), which provides Quality of Service (QoS)."
+    rationale: "The service must be enabled and running in order for pf to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable pf: # service pf enable Run the following command to start the pf: # service pf start"
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-pf"
+    compliance:
+      - cis: ["3.4.1.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:YES"
+      - "c:kldstat -m pf -> r:pf && r:pf$"
+      - "c:service pf status -> r:^Status && r:Enabled"
+      - "c:sysrc -n ipfw_enable -> r:NO"  
+      - "c:kldstat -m ipfw -> r:ipfw && !r:ipfw$"          
+      - "c:sysrc -n ipfilter_enable -> r:NO"
+      - "c:kldstat -m ipfilter -> r:ipfilter && r:!ipfilter$"            
+
+  # 3.4.1.3 Ensure Packet Filter outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.1.4 Ensure Packet Filter firewall rules exist for all open ports. (Automated) - Not Implemented
+
+  # 3.4.1.5 Ensure Packet Filter default deny firewall policy. (Automated)
+  - id: 40491
+    title: "Ensure Packet Filter default deny firewall policy."
+    description: "A default deny policy on connections ensures that any unconfigured network usage will be rejected. Note: Any port or protocol without a explicit allow before the default deny will be blocked."
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
+    impact: "Any port and protocol not explicitly allowed will be blocked. The following rules should be considered before applying the default deny. ufw allow git ufw allow in http ufw allow out http <- required for apt to connect to repository ufw allow in https ufw allow out https ufw allow out 53 ufw logging on."
+    remediation: "Run the following commands to implement a default deny policy: # ufw default deny incoming # ufw default deny outgoing # ufw default deny routed."
+    compliance:
+      - cis: ["3.4.1.5"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - 'f:/etc/pf.conf -> r:^set block-policy'
+
+  ###############################################
+  # 3.4.2 Configure IPFW firewall
+  ###############################################
+  # 3.4.2.1 Ensure IPFW is installed. (Automated)
+  - id: 40492
+    title: "Ensure Packet Filter is installed."
+    description: "FreeBSD has three firewalls built into the base system: PF, IPFW, and IPFILTER, also known as IPF. FreeBSD also provides two traffic shapers for controlling bandwidth usage: altq(4) and dummynet(4). ALTQ has traditionally been closely tied with PF and dummynet with IPFW. Each firewall uses rules to control the access of packets to and from a FreeBSD system, although they go about it in different ways and each has a different rule syntax."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "IPFW is part of FreeBSD base system."
+    compliance:
+      - cis: ["3.4.2.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/ipfw"           
+
+  # 3.4.2.2 Ensure IPFW is enabled and running. (Automated)
+  - id: 40493
+    title: "Ensure IPFW is enabled and running."
+    description: "IPFW is a stateful firewall written for FreeBSD which supports both IPv4 and IPv6. It is comprised of several components: the kernel firewall filter rule processor and its integrated packet accounting facility, the logging facility, NAT, the dummynet(4) traffic shaper, a forward facility, a bridge facility, and an ipstealth facility."
+    rationale: "The service must be enabled and running in order for pf to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable ipfw: # service firewall enable. # sysrc firewall_type='open'. Run the following command to start the ipfw: # service ipfw start. Take on mind firewall_type='open' means passes all traffic. Look at ipfw documentation for more options."
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-ipfw"
+    compliance:
+      - cis: ["3.4.2.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:NO"
+      - "c:kldstat -m pf -> r:pf && !r:pf$"
+      - "c:sysrc -n ipfw_enable -> r:YES"
+      - "c:kldstat -m ipfw -> r:ipfw && r:ipfw$"
+      - "c:sysctl -n net.inet.ip.fw.enable -> r:1"                
+      - "c:sysrc -n ipfilter_enable -> r:NO"
+      - "c:kldstat -m ipfilter -> r:ipfilter && !r:ipfilter$"            
+
+  # 3.4.2.3 Ensure IPFW outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.2.4 Ensure IPFW firewall rules exist for all open ports. (Automated) - Not Implemented
+  # 3.4.2.5 Ensure IPFW default deny firewall policy. (Automated)
+      
+  ###############################################
+  # 3.4.3 Configure IPFilter firewall
+  ###############################################
+  # 3.4.3.1 Ensure IPFilter is installed. (Automated)
+  - id: 40494
+    title: "Ensure IPFilter is installed."
+    description: "IPFILTER is a kernel-side firewall and NAT mechanism that can be controlled and monitored by userland programs. Firewall rules can be set or deleted using ipf, NAT rules can be set or deleted using ipnat, run-time statistics for the kernel parts of IPFILTER can be printed using ipfstat, and ipmon can be used to log IPFILTER actions to the system log files."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "IPFilter is part of FreeBSD base system. If /sbin/ipfc is not found"
+    compliance:
+      - cis: ["3.4.3.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/ipf"
+
+  # 3.4.3.2 Ensure IPFilter is enabled. (Automated)
+  - id: 40495
+    title: "Ensure IPFilter is enabled and running."
+    description: "IPFILTER is a kernel-side firewall and NAT mechanism that can be controlled and monitored by userland programs. Firewall rules can be set or deleted using ipf, NAT rules can be set or deleted using ipnat, run-time statistics for the kernel parts of IPFILTER can be printed using ipfstat, and ipmon can be used to log IPFILTER actions to the system log files."
+    rationale: "The service must be enabled and running in order for IPFilter to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable IPFilter: # service ipfilter enable Run the following command to start the IPFilter: # service ipfilter start"
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-ipf"
+    compliance:
+      - cis: ["3.4.3.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:NO"
+      - "c:kldstat -m pf -> r:pf && !r:pf$"
+      - "c:sysrc -n ipfw_enable -> r:NO"  
+      - "c:kldstat -m ipfw -> r:ipfw && !r:ipfw$"          
+      - "c:sysrc -n ipfilter_enable -> r:YES"
+      - "c:kldstat -m ipfilter -> r:ipfilter && r:ipfilter$"
+      - "c:/sbin/ipf -V -> r:'^Running: yes'"                  
+
+  # 3.4.3.3 Ensure IPFilter outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.3.4 Ensure IPFilter firewall rules exist for all open ports. (Automated) - Not Implemented
+  # 3.4.3.5 Ensure IPFilter default deny firewall policy. (Not implemented)      
+  
+ ###############################################
+  # 4 Access, Authentication and Authorization
+  ###############################################
+  ###############################################
+  # 4.1 Configure time-based job schedulers
+  ###############################################  
+  # 4.1.1 Ensure cron daemon is enabled and active. (Automated)
+  - id: 40496
+    title: "Ensure cron daemon is enabled and active."
+    description: "The cron daemon is used to execute batch jobs on the system. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
+    remediation: "Run the following command to enable and start cron: # service cron enable # service cron start."
+    compliance:
+      - cis: ["4.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+    condition: all
+    rules:
+      - "c:sysrc -n cron_enable -> r:^YES"
+      - "c:service cron status -> r:^cron is running as pid"
+
+  # 4.1.2 Ensure permissions on /etc/crontab are configured. (Automated)
+  - id: 40497
+    title: "Ensure permissions on /etc/crontab are configured."
+    description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
+    remediation: "Run the following commands to set ownership and permissions on /etc/crontab : # chown root:wheel /etc/crontab # chmod 740 /etc/crontab."
+    compliance:
+      - cis: ["4.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/crontab -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/crontab -> r:^root:wheel"
+
+  # 4.1.3 Ensure permissions on /etc/cron.d are configured. (Automated)
+  - id: 40498
+    title: "Ensure permissions on /etc/cron.d are configured."
+    description: "The /etc/cron.d directory contains system cron jobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab, but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.d directory: # chown root:wheel /etc/cron.d/ # chmod 750 /etc/cron.d/."
+    compliance:
+      - cis: ["4.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/cron.d -> r:^-rwxr-x---"
+      - "c:stat -f %Su:%Sg /etc/cron.d -> r:^root:wheel"
+
+  # 4.1.4 Ensure cron is restricted to authorized users. (Automated)
+  - id: 40499
+    title: "Ensure cron is restricted to authorized users."
+    description: "Configure /var/cron/allow to allow specific users to use this service. If /var/cron/allow does not exist, then /var/cron/deny is checked. Any user not specifically defined in this file is allowed to use cron. By removing the file, only users in /var/etc/cron/allow are allowed to use cron."
+    rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list."
+    remediation: "Remove /var/cron/deny if it exists - Create /var/cron/allow if it doesn't exist - Change ownership of /var/cron/allow to the root user and wheel group. Add only authorized users to /var/cron/allow file. Restart cron daemon # service cron restart."
+    compliance:
+      - cis: ["4.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/var/run/cron/allow"
+      - "c:stat -f %Sp /var/cron/allow -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /var/cron/allow -> r:^root:wheel"
+
+  # 4.1.5 Ensure at is restricted to authorized users. (Automated)
+  - id: 40500
+    title: "Ensure at is restricted to authorized users."
+    description: "Configure /var/at/at.allow to allow specific users to use this service. If /var/at/at.allow does not exist, then /var/at/at.deny is checked. Any user not specifically defined in this file is allowed to use at. By removing the file, only users in /etc/at.allow are allowed to use at. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, at should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "On many systems, only the system administrator is authorized to schedule at jobs. Using the at.allow file to control who can run at jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
+    remediation: "Remove /var/at/at.deny if it exists - Create /var/at/at.allow if it doesn't exist - Change ownership of /var/at/at.allow to the root user - Change group ownership of /var/at/at.allow to the group wheel. Add only authorized users to /var/at/at.allow file. Restart cron daemon # service cron restart."
+    compliance:
+      - cis: ["4.1.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/var/at/at.allow"
+      - "c:stat -f %Sp /var/at/at.allow -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /var/at/at.allow -> r:^root:wheel"      
+
+  ###############################################
+  # 4.2 Configure SSH Server
+  ###############################################
+  # 4.2.1 Ensure permissions on /etc/ssh/sshd_config are configured. (Automated)
+  - id: 40501
+    title: "Ensure permissions on /etc/ssh/sshd_config are configured."
+    description: "The file /etc/ssh/sshd_config contain configuration specifications for sshd."
+    rationale: "configuration specifications for sshd need to be protected from unauthorized changes by non-privileged users."
+    remediation: "Change ownership and permissions on /etc/ssh/sshd_config file. # chown root:wheel /etc/ssh/sshd_config; # chmod 640 /etc/ssh/sshd_config."
+    compliance:
+      - cis: ["4.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1098", "T1098.004", "T1543", "T1543.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/etc/ssh/sshd_config"
+      - "c:stat -f %Sp /etc/ssh/sshd_config -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/ssh/sshd_config -> r:^root:wheel"
+
+   # 4.2.2 Ensure permissions on SSH private host key files are configured. (Automated) - Not Implemented
+  - id: 40502
+    title: "Ensure permissions on SSH private host key files are configured."
+    description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a private host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Change mode, ownership, and group on the public SSH host key files: # chown root:wheel /etc/ssh/ssh_host*_key; # chmod 600 /etc/ssh/ssh_host*_key."
+    compliance:
+      - cis: ["4.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0003", "TA0006"]
+      - mitre_techniques: ["T1557"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key" -exec stat -f %Sp  {} \; -> r:^-rw-------'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel' 
+
+  # 4.2.3 Ensure permissions on SSH public host key files are configured. (Automated)
+  - id: 40503
+    title: "Ensure permissions on SSH public host key files are configured."
+    description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Change mode, ownership, and group on the public SSH host key files: # chown root:wheel /etc/ssh/ssh_host*.pub; # chmod 644 /etc/ssh/ssh_host*.pub."
+    compliance:
+      - cis: ["4.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0003", "TA0006"]
+      - mitre_techniques: ["T1557"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key.pub" -exec stat -f %Sp  {} \; -> r:^-rw-r--r--'
+      - 'c:find /etc/ssh -xdev -type f -name 2ssh_host_*_key.pub" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel'      
+
+  # 4.2.4 Ensure SSH access is limited. (Automated)
+  - id: 40504
+    title: "Ensure SSH access is limited."
+    description: "There are several options available to limit which users and group can access the system via SSH. AllowUsers: o The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. AllowGroups: o The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. DenyUsers: o The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. DenyGroups: o The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
+    rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set one or more of the parameter above any Include entries as follows: AllowUsers <userlist> OR AllowGroups <grouplist> OR DenyUsers <userlist> OR DenyGroups <grouplist>."
+    compliance:
+      - cis: ["4.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021", "T1021.004"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^allowusers\s+\w+|^allowgroups\s+\w+|^denyusers\s+\w+|^*denygroups\s+\w+'
+      - 'f:/etc/ssh/sshd_config -> r:^AllowUsers\s+\w+|^AllowGroups\s+\w+|^DenyUsers\s+\w+|^DenyGroups\s+\w+'
+
+  # 4.2.5 Ensure SSH LogLevel is appropriate. (Automated)
+  - id: 40505
+    title: "Ensure SSH LogLevel is appropriate."
+    description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
+    rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: LogLevel VERBOSE OR LogLevel INFO Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "https://www.ssh.com/ssh/sshd_config/"
+    compliance:
+      - cis: ["4.2.5"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^loglevel\s+INFO|^loglevel\s+VERBOSE'
+      - 'not f:/etc/ssh/sshd_config -> !r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
+
+  # 4.2.6 Ensure SSH PAM is enabled. (Automated)
+  - id: 40506
+    title: "Ensure SSH PAM is enabled."
+    description: "The UsePAM directive enables the Pluggable Authentication Module (PAM) interface. If set to yes this will enable PAM authentication using ChallengeResponseAuthentication and PasswordAuthentication directives in addition to PAM account and session module processing for all authentication types."
+    rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: UsePAM yes Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.6"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1035"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1021", "T1021.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*usepam\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*UsePAM\s+no'
+
+  # 4.2.7 Ensure SSH root login is disabled. (Automated)
+  - id: 40507
+    title: "Ensure SSH root login is disabled."
+    description: "The PermitRootLogin parameter specifies if the root user can log in using SSH. The default is prohibit-password."
+    rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root. This limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitRootLogin no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.7"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permitrootlogin\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitRootLogin\s+yes'
+
+  # 4.2.8 Ensure SSH HostbasedAuthentication is disabled. (Automated)
+  - id: 40508
+    title: "Ensure SSH HostbasedAuthentication is disabled."
+    description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication."
+    rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: HostbasedAuthentication no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.8"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*hostbasedauthentication\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*HostbasedAuthentication\s+yes'
+
+  # 4.2.9 Ensure SSH PermitEmptyPasswords is disabled. (Automated)
+  - id: 40509
+    title: "Ensure SSH PermitEmptyPasswords is disabled."
+    description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
+    rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitEmptyPasswords no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.9"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permitemptypasswords\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitEmptyPasswords\s+yes'
+
+  # 4.2.10 Ensure SSH PermitUserEnvironment is disabled. (Automated)
+  - id: 40510
+    title: "Ensure SSH PermitUserEnvironment is disabled."
+    description: "The PermitUserEnvironment option allows users to present environment options to the SSH daemon."
+    rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has SSH executing trojan'd programs)."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitUserEnvironment no Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.10"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permituserenvironment\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitUserEnvironment\s+yes'
+
+  # 4.2.11 Ensure SSH IgnoreRhosts is enabled. (Automated)
+  - id: 40511
+    title: "Ensure SSH IgnoreRhosts is enabled."
+    description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
+    rationale: "Setting this parameter forces users to enter a password when authenticating with SSH."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: IgnoreRhosts yes Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.11"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*ignorerhosts\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*IgnoreRhosts\s+no'
+
+  # 4.2.12 Ensure SSH X11 forwarding is disabled. (Automated)
+  - id: 40512
+    title: "Ensure SSH X11 forwarding is disabled."
+    description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
+    rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: X11Forwarding no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*x11forwarding\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s+yes'
+
+  # 4.2.13 Ensure only strong Ciphers are used. (Automated)
+  - id: 40513
+    title: "Ensure only strong Ciphers are used."
+    description: 'This variable limits the ciphers that SSH can use during communication. Note: - Some organizations may have stricter requirements for approved ciphers. - Ensure that ciphers used are in compliance with site policy. - The only "strong" ciphers currently FIPS 140-2 compliant are: o aes256-ctr o aes192-ctr o aes128-ctr.'
+    rationale: 'Weak ciphers like 3DES that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised.'
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma separated list of the site approved ciphers. Example: Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128- gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr."
+    references:
+      - "https://nvd.nist.gov/vuln/detail/CVE-2016-2183"
+      - "https://www.openssh.com/txt/cbc.adv"
+      - "https://nvd.nist.gov/vuln/detail/CVE-2008-5161"
+    compliance:
+      - cis: ["4.2.13"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|rijndael-cbc@lysator.liu.se"
+
+  # 4.2.14 Ensure only strong MAC algorithms are used. (Automated)
+  - id: 40514
+    title: "Ensure only strong MAC algorithms are used."
+    description: 'This variable limits the types of MAC algorithms that SSH can use during communication. The only "strong" MACs currently FIPS 140-2 approved are: o hmac-sha2-256 o hmac-sha2-512.'
+    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information."
+    remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs above any Include entries: Example: MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2- 512,hmac-sha2-256,umac-128-etm@openssh.com,umac-128@openssh.com."
+    references:
+      - "http://www.mitls.org/pages/attacks/SLOTH"
+    compliance:
+      - cis: ["4.2.14"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4", "16.5"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:macs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com"
+
+  # 4.2.15 Ensure only strong Key Exchange algorithms are used. (Automated)
+  - id: 40515
+    title: "Ensure only strong Key Exchange algorithms are used."
+    description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties. The only Key Exchange Algorithms currently FIPS 140-2 approved are: o ecdh-sha2-nistp256 o ecdh-sha2-nistp384 o ecdh-sha2-nistp521 o diffie-hellman-group-exchange-sha256 o diffie-hellman-group16-sha512 o diffie-hellman-group18-sha512 o diffie-hellman-group14-sha256."
+    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks."
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to list of the site approved key exchange algorithms. Example: KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256."
+    compliance:
+      - cis: ["4.2.15"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1"
+
+  # 4.2.16 Ensure SSH AllowTcpForwarding is disabled. (Automated)
+  - id: 40516
+    title: "Ensure SSH AllowTcpForwarding is disabled."
+    description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines."
+    rationale: "Leaving port forwarding enabled can expose the organization to security risks and backdoors. SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network."
+    impact: "SSH tunnels are widely used in many corporate environments. In some environments the applications themselves may have very limited native support for security. By utilizing tunneling, compliance with SOX, HIPAA, PCI-DSS, and other standards can be achieved without having to modify the applications."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: AllowTcpForwarding no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "https://www.ssh.com/ssh/tunneling/example"
+    compliance:
+      - cis: ["4.2.16"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1048", "T1048.002", "T1572"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*allowtcpforwarding\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*AllowTcpForwarding\s+yes'
+
+  # 4.2.17 Ensure SSH warning banner is configured. (Automated)
+  - id: 40517
+    title: "Ensure SSH warning banner is configured."
+    description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
+    rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: Banner /path/ro/banner Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.17"]
+      - mitre_mitigations: ["M1035"]
+      - mitre_tactics: ["TA0001", "TA0007"]
+    condition: all
+    rules:
+      - 'not c:sshd -T -> r:^\s*banner\s+none'
+
+  # 4.2.18 Ensure SSH MaxAuthTries is set to 4 or less. (Automated)
+  - id: 40518
+    title: "Ensure SSH MaxAuthTries is set to 4 or less."
+    description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
+    rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxAuthTries 4 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.18"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - mitre_mitigations: ["M1036"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1110", "T1110.001", "T1110.003"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^maxauthtries\s*\t*(\d+) compare <= 4'
+      - 'not f:/etc/ssh/sshd_config -> n:^MaxAuthTries\s*\t*(\d+) compare > 4'
+
+  # 4.2.19 Ensure SSH MaxStartups is configured. (Automated)
+  - id: 40519
+    title: "Ensure SSH MaxStartups is configured."
+    description: "The MaxStartups parameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon."
+    rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxStartups 10:30:60 Note: First occurrence of an option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.19"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1499", "T1499.002"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*maxstartups\s+10:30:60'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxStartups\s+(((1[1-9]|[1-9][0-9][0-9]+):([0-9]+):([0-9]+))|(([0-9]+):(3[1-9]|[4-9][0-9]|[1-9][0-9][0-9]+):([0-9]+))|(([0-9]+):([0-9]+):(6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+)))'
+
+  # 4.2.20 Ensure SSH LoginGraceTime is set to one minute or less. (Automated)
+  - id: 40520
+    title: "Ensure SSH LoginGraceTime is set to one minute or less."
+    description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
+    rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: LoginGraceTime 60 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.20"]
+      - mitre_mitigations: ["M1036"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1110", "T1110.001", "T1110.003", "T1110.004"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:logingracetime\s*\t*(\d+) compare <= 60 && n:LoginGraceTime\s*\t*(\d+) compare != 0'
+      - 'not f:/etc/ssh/sshd_config -> r:\s*LoginGraceTime\s+(0|6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+|[^1]m)'
+
+  # 4.2.21 Ensure SSH MaxSessions is set to 10 or less. (Automated)
+  - id: 40521
+    title: "Ensure SSH MaxSessions is set to 10 or less."
+    description: "The MaxSessions parameter specifies the maximum number of open sessions permitted from a given connection."
+    rationale: "To protect a system from denial of service due to a large number of concurrent sessions, use the rate limiting function of MaxSessions to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxSessions 10 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.21"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1499", "T1499.002"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^\s*maxsessions\s+(\d+) compare <= 10'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxSessions\s+(1[1-9]|[2-9][0-9]|[1-9][0-9][0-9]+)'
+
+  # 4.2.22 Ensure SSH Idle Timeout Interval is configured. (Automated)
+  - id: 40522
+    title: "Ensure SSH Idle Timeout Interval is configured."
+    description: "ClientAliveInterval sets a timeout interval in seconds after which if no data has been received from the client. ClientAliveCountMax sets the number of client alive messages which may be sent without sshd(8) receiving any messages back from the client. It is important to note that the use of client alive messages is very different from TCPKeepAlive. The client alive messages are sent through the encrypted channel and therefore will not be spoofable. The TCP keepalive option enabled by TCPKeepAlive is spoofable."
+    rationale: "In order to prevent resource exhaustion, appropriate values should be set for both ClientAliveInterval and ClientAliveCountMax. Specifically, looking at the source code, ClientAliveCountMax must be greater than zero in order to utilize the ability of SSH to drop idle connections. If connections are allowed to stay open indefinately, this can potentially be used as a DDOS attack or simple resource exhaustion could occur over unreliable networks. The example set here is a 45 second timeout. Consult your site policy for network timeouts and apply as appropriate."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameters above any Include entries according to site policy. Example: ClientAliveInterval 15 ClientAliveCountMax 3."
+    references:
+      - "https://man.openbsd.org/sshd_config"
+    compliance:
+      - cis: ["4.2.22"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:clientaliveinterval\s*\t*(\d+) compare > 0'
+      - 'c:sshd -T -> n:clientalivecountmax\s*\t*(\d+) compare > 0'
+
+  ############################################################
+  # 4.3 Configure privilege escalation
+  ############################################################
+  # 4.3.1 Ensure sudo is installed. (Automated)
+  - id: 40523
+    title: "Ensure sudo is installed."
+    description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
+    rationale: "sudo supports a plug-in architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plug-ins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers and any entries in /etc/sudoers.d. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
+    remediation: "Install sudo. Example: # pkg install sudo."
+    compliance:
+      - cis: ["4.3.1"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v sudo -> r:^sudo"    
+
+  # 4.3.2 Ensure sudo commands use pty. (Automated)
+  - id: 40524
+    title: "Ensure sudo commands use pty."
+    description: "sudo can be configured to run only from a pseudo terminal (pseudo-pty)."
+    rationale: "Attackers can run a malicious program using sudo which would fork a background process that remains even when the main program has finished executing."
+    impact: "WARNING: Editing the sudo configuration incorrectly can cause sudo to stop functioning. Always use visudo to modify sudo configuration files."
+    remediation: "Edit the file /usr/local/etc/sudoers with ee or a file in /usr/local//etc/sudoers.d/ with ee <PATH TO FILE> and add the following line: Defaults use_pty Note: - sudo will read each file in /usr/local/etc/sudoers.d, skipping file names that end in ~ or contain a . character to avoid causing problems with package manager or editor temporary/backup files. - Files are parsed in sorted lexical order. That is, /etc/sudoers.d/01_first will be parsed before /etc/sudoers.d/10_second. - Be aware that because the sorting is lexical, not numeric, /usr/local/etc/sudoers.d/1_whoops would be loaded after /usr/local/etc/sudoers.d/10_second. - Using a consistent number of leading zeroes in the file names can be used to avoid such problems."
+    compliance:
+      - cis: ["4.3.2"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1026", "M1038"]
+      - mitre_tactics: ["TA0001", "TA0003"]
+      - mitre_techniques: ["T1078", "T1078.003", "T1548", "T1548.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: any
+    rules:
+      - 'not f:/usr/local/etc/sudoers -> r:^Defaults\s*!use_pty'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> r:^Defaults\s*!use_pty'
+
+  # 4.3.3 Ensure sudo log file exists. (Automated)
+  - id: 40525
+    title: "Ensure sudo log file exists."
+    description: "sudo can use a custom log file."
+    rationale: "A sudo log file simplifies auditing of sudo commands."
+    impact: "WARNING: Editing the sudo configuration incorrectly can cause sudo to stop functioning. Always use visudo to modify sudo configuration files."
+    remediation: 'Edit the file /usr/local/etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH TO FILE> and add the following line: Example: Defaults logfile="/var/log/sudo.log" Note: - sudo will read each file in /etc/sudoers.d, skipping file names that end in ~ or contain a . character to avoid causing problems with package manager or editor temporary/backup files. - Files are parsed in sorted lexical order. That is, /etc/sudoers.d/01_first will be parsed before /etc/sudoers.d/10_second. - Be aware that because the sorting is lexical, not numeric, /etc/sudoers.d/1_whoops would be loaded after /etc/sudoers.d/10_second. - Using a consistent number of leading zeroes in the file names can be used to avoid such problems.'
+    compliance:
+      - cis: ["4.3.3"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: any
+    rules:
+      - 'f:/usr/local/etc/sudoers -> r:^\s*\t*Defaults\s*\t*logfile='
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile='
+
+  # 4.3.4 Ensure users must provide password for privilege escalation. (Automated)
+  - id: 40526
+    title: "Ensure users must provide password for privilege escalation."
+    description: "The operating system must be configured so that users must provide a password for privilege escalation."
+    rationale: "Without (re-)authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user (re-)authenticate."
+    impact: "This will prevent automated processes from being able to elevate privileges."
+    remediation: "Based on the outcome of the audit procedure, use ee <PATH TO FILE> to edit the relevant sudoers file. Remove any line with occurrences of NOPASSWD tags in the file."
+    compliance:
+      - cis: ["4.3.4"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1548"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - "f:/usr/local/etc/sudoers -> !r:^# && r:*NOPASSWD"
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:*NOPASSWD'
+
+  # 4.3.5 Ensure re-authentication for privilege escalation is not disabled globally. (Automated)
+  - id: 40527
+    title: "Ensure re-authentication for privilege escalation is not disabled globally."
+    description: "The operating system must be configured so that users must re-authenticate for privilege escalation."
+    rationale: "Without re-authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate."
+    remediation: "Configure the operating system to require users to reauthenticate for privilege escalation. Based on the outcome of the audit procedure, use ee <PATH TO FILE> to edit the relevant sudoers file. Remove any occurrences of !authenticate tags in the file(s)."
+    compliance:
+      - cis: ["4.3.5"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - 'f:/usr/local/etc/sudoers -> !r:^# && r:*\!authenticate'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:*\!authenticate'
+
+  # 4.3.6 Ensure sudo authentication timeout is configured correctly. (Automated)
+  - id: 40528
+    title: "Ensure sudo authentication timeout is configured correctly."
+    description: "sudo caches used credentials for a default of 5 minutes. This is for ease of use when there are multiple administrative tasks to perform. The timeout can be modified to suit local security policies. This default is distribution specific. See audit section for further information."
+    rationale: "Setting a timeout value reduces the window of opportunity for unauthorized privileged access to another user."
+    remediation: "If the currently configured timeout is larger than 5 minutes, edit the file listed in the audit section with ee <PATH TO FILE> and modify the entry timestamp_timeout= to 5 minutes or less as per your site policy. The value is in minutes. This particular entry may appear on it's own, or on the same line as env_reset. See the following two examples: Defaults env_reset, timestamp_timeout=5 Defaults timestamp_timeout=5 Defaults env_reset."
+    references:
+      - "https://www.sudo.ws/man/1.9.14/sudoers.man.html"
+    compliance:
+      - cis: ["4.3.6"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - 'c:sudo -V -> r:Authentication timestamp timeout:\s*\t*5.0 minutes'
+      - 'f:/usr/local/etc/sudoers -> n:timestamp_timeout=(\d+) compare <=5'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> n:timestamp_timeout=(\d+) compare <=5'
+
+  # 4.3.7 Ensure access to the su command is restricted. (Automated)
+  - id: 40529
+    title: "Ensure access to the su command is restricted."
+    description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in a specific groups to execute su. This group should be empty to reinforce the use of sudo for privileged access."
+    rationale: "Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program."
+    remediation: "Check wheel group into /etc/pam.d/su for use of the su command. the line could look like the following: auth requisite pam_group.so no_warn group=wheel root_only fail_safe ruser."
+    compliance:
+      - cis: ["4.3.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/su -> !r:^# && r:auth\s*requisite\s*pam_group.so && r:\sgroup=wheel\s'
+      
+  # 4.3.8 Ensure doas is installed. (Automated)
+  - id: 40530
+    title: "Ensure doas is installed."
+    description: "doas allows a permitted user to execute a command as the superuser or another user, as specified by the security policy."
+    rationale: "The default security policy is configured via /usr/local/etc/doas.conf. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism."
+    remediation: "Install doas. Example: # pkg install doas."
+    compliance:
+      - cis: ["4.3.1"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v doas -> r:^doas"   
+      
+  # 4.3.9 Ensure users must provide password for privilege escalation. (Automated)
+  - id: 40531
+    title: "Ensure doas users must provide password for privilege escalation."
+    description: "The operating system must be configured so that users must provide a password for privilege escalation."
+    rationale: "Without authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user (re-)authenticate."
+    impact: "This will prevent automated processes from being able to elevate privileges."
+    remediation: "Based on the outcome of the audit procedure, use ee /usr/local/etc/doas.conf file. Remove any line with occurrences of nopass tags in the file."
+    compliance:
+      - cis: ["4.3.4"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1548"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - "f:/usr/local/etc/doas.conf -> !r:^# && r:*nopass"          
+
+  ###############################################
+  # 4.4 Configure PAM and login.conf
+  ###############################################
+  # 4.4.1 Ensure password creation requirements are configured. (Automated)
+  # 4.4.2 Ensure lockout for failed password attempts is configured. (Automated)
+  # 4.4.3 Ensure password reuse is limited. (Automated)
+  # 4.4.4 Ensure strong password hashing algorithm is configured. (Automated)
+  - id: 40532
+    title: "Ensure strong password hashing algorithm is configured."
+    description: "Hash functions behave as one-way functions by using mathematical operations that are extremely difficult and cumbersome to revert When a user is created, the password is run through a one-way hashing algorithm before being stored. When the user logs in, the password sent is run through the same one-way hashing algorithm and compared to the hash connected with the provided username. If the hashed password and the stored hash match, the login is valid."
+    rationale: "The SHA512 hashing algorithm provides stronger hashing than previous available algorithms like MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords."
+    remediation: "Note: - Pay special attention to the configuration. Incorrect configuration can cause system lock outs. - This is an example configuration. Your configuration may differ based on previous changes to the files."
+    compliance:
+      - cis: ["4.4.4"]
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["16.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1110", "T1110.002"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "f:/etc/login.conf -> r:passwd_format && r:sha512|blf"
+
+  # 4.4.5 Ensure all current passwords uses the configured hashing algorithm. (Manual) - Not Implemented
+
+  ###############################################
+  # 4.5 User Accounts and Environment
+  ###############################################
+  ###############################################
+  # 4.5.1 Set Shadow Password Suite Parameters
+  ###############################################
+  # 4.5.1.1 Ensure password expiration is 365 days or less. (Automated)
+  - id: 40533
+    title: "Ensure password expiration is 365 days or less."
+    description: "The passwordtime parameter in /etc/login.conf allows an administrator to force passwords to expire once they reach a defined age."
+    rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity. It is recommended that the passwordtime parameter does not exceed 365 days and is greater than the value of 1."
+    remediation: "Set the passwordtime parameter to conform to site policy in /etc/login.conf : passwordtime=365d. Modify user parameters for all users with a password set to match: # pw usermod <user> -p +365d."
+    references:
+      - "https://www.cisecurity.org/white-papers/cis-password-policy-guide/"
+    compliance:
+      - cis: ["4.5.1.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.conf -> n:^\t:passwordtime=(\d+)\w: compare <= 365'
+      - 'f:/etc/login.conf -> n:^\t:passwordtime=(\d+)\w: compare > 0'
+
+  # 4.5.1.2 Ensure password expiration warning days is 7 or more. (Automated)
+  - id: 40534
+    title: "Ensure password expiration warning days is 7 or more."
+    description: "The warnpassword parameter in /etc/login.conf allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
+    rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
+    remediation: "Set the warnpassword parameter to 7 in /etc/login.conf: warnpassword=7d."
+    compliance:
+      - cis: ["4.5.1.2"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.conf -> n:^\t:warnpassword=(\d+)\w: compare >= 7'
+
+  # 4.5.1.3 Ensure inactive password lock is 30 days or less. (Automated)
+  # 4.5.1.4 Ensure all users last password change date is in the past. (Automated) - Not Implemented
+  # 4.5.1.5 Ensure the number of changed characters in a new password is configured. (Automated)
+  # 4.5.1.6 Ensure preventing the use of dictionary words for passwords is configured. (Automated)
+  # 4.5.2 Ensure system accounts are secured. (Automated) - Not Implemented
+
+  # 4.5.3 Ensure default group for the root account is GID 0. (Automated)
+  - id: 40535
+    title: "Ensure default group for the root account is GID 0."
+    description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
+    rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
+    remediation: "Run the following command to set the root user default group to GID 0 : # usermod -g 0 root."
+    compliance:
+      - cis: ["4.5.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/passwd -> !r:^# && r:root:\w+:\w+:0:'
+
+  # 4.5.4 Ensure default user umask is 027 or more restrictive. (Automated) - Not Implemented
+  # 4.5.5 Ensure default user shell timeout is configured. (Automated) - Not Implemented
+
+  # 4.5.6 Ensure nologin is not listed in /etc/shells. (Automated)
+  - id: 40536
+    title: "Ensure nologin is not listed in /etc/shells."
+    description: "/etc/shells is a text file which contains the full pathnames of valid login shells. This file is consulted by chsh and available to be queried by other programs. Be aware that there are programs which consult this file to find out if a user is a normal user; for example, FTP daemons traditionally disallow access to users with shells not included in this file."
+    rationale: "A user can use chsh to change their configured shell. If a user has a shell configured that isn't in in /etc/shells, then the system assumes that they're somehow restricted. In the case of chsh it means that the user cannot change that value. Other programs might query that list and apply similar restrictions. By putting nologin in /etc/shells, any user that has nologin as its shell is considered a full, unrestricted user. This is not the expected behavior for nologin."
+    remediation: "Edit /etc/shells and remove any lines that include nologin."
+    compliance:
+      - cis: ["4.5.6"]
+    condition: all
+    rules:
+      - "not f:/etc/shells -> !r:^# && r:nologin"
+
+  # 4.5.7 Ensure maximum number of same consecutive characters in a password is configured. (Automated)
+
+   ###############################################
+  # 5.1 Logging and auditing
+  ###############################################
+  # 5.1.1 Configure syslog
+  ###############################################
+  # 5.1.1.1 Ensure syslog is installed. (Automated)
+  - id: 40537
+    title: "Ensure syslog is installed."
+    description: "FreeBSD provides a system logger, syslogd(8), to manage logging. By default, syslogd is enabled and started when the system boots."
+    rationale: "The security enhancements of syslog such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
+    remediation: "The syslog is installed by default on FreeBSD. If it is not available an incomplete or modified version of FreeBSD is running."
+    compliance:
+      - cis: ["5.1.1.1"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1005", "T1070", "T1070.002"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "f:/usr/sbin/syslogd"
+
+  # 5.1.1.2 Ensure syslog service is enabled. (Automated)
+  - id: 40538
+    title: "Ensure syslog service is enabled."
+    description: "Once the syslog package is installed, ensure that the service is enabled."
+    rationale: "If the syslog service is not enabled to start on boot, the system will not capture logging events."
+    remediation: "Run the following command to enable syslog: # service syslogd enable; # service syslogd start."
+    compliance:
+      - cis: ["5.1.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:service syslogd status -> r:^syslogd is running as pid"
+
+  # 5.1.1.3 Ensure syslog is not configured to receive logs from a remote client. (Automated)
+  - id: 40539
+    title: "Ensure syslog is not configured to receive logs from a remote client."
+    description: "Syslog supports the ability to receive messages from remote hosts, thus acting as a log server. Clients should not receive data from other hosts."
+    rationale: "If a client is configured to also receive data, thus turning it into a server, the client system is acting outside it's operational boundary."
+    remediation: 'Disable syslog for not log messages from remote machines: # sysrc syslogd_flags="-ss".If -s is specified twice, no network socket will be opened at all, which also disables logging to remote machines'
+    compliance:
+      - cis: ["5.1.1.3"]
+      - cis_csc_v8: ["4.8", "8.2"]
+      - cis_csc_v7: ["6.2", "6.3", "9.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1", "A.13.1.3"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "10.2", "10.3", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "2.2.4", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - 'c: sysrc -n syslogd_flags -> r:^-ss'
+
+  # 5.1.1.8 Ensure all logfiles have appropriate access configured. (Automated) - Not Implemented
+
+  ############################################################
+  # 5.2 Configure System Accounting (auditd).
+  ############################################################
+  ############################################################
+  # 5.2.1 Ensure auditing is enabled.
+  ############################################################
+  # 5.2.1.1 Ensure auditd is installed. (Automated)
+  - id: 40540
+    title: "Ensure auditd is installed."
+    description: "The FreeBSD operating system includes support for security event auditing. Event auditing supports reliable, fine-grained, and configurable logging of a variety of security-relevant system events, including logins, configuration changes, and file and network access."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "The auditd is installed by default on FreeBSD. If it is not available an incomplete or modified version of FreeBSD is running."
+    compliance:
+      - cis: ["5.2.1.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f: /usr/sbin/auditd"
+
+  # 5.2.1.2 Ensure auditd service is enabled and active. (Automated)
+  - id: 40541
+    title: "Ensure auditd service is enabled and active."
+    description: "Turn on the auditd daemon to record system events."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "Run the following command to enable and start auditd: # service auditd enable; # service auditd start."
+    compliance:
+      - cis: ["5.2.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n auditd_enable -> r:^YES"
+      - "c:service auditd status -> r:^auditd is running as pid"
+
+  # 5.2.1.3 Ensure audit log storage size is configured. (Automated)
+  - id: 40542
+    title: "Ensure audit log storage size is configured."
+    description: "Configure the filesz of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
+    rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
+    remediation: "Set the following parameter in /etc/security/audit_control in accordance with site policy: filesz:2M B(Bytes), K(Kilobytes), M(Megabytes), or G(Gigabytes)."
+    compliance:
+      - cis: ["5.2.1.3"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^filesz:(\d+)M'
+
+  # 5.2.1.4 Ensure audit logs are not automatically deleted. (Automated)
+  - id: 40543
+    title: "Ensure audit logs are not automatically deleted."
+    description: "The expire-after setting determines how to handle the audit log file reaching the max file size. No expire-after value never delete old logs."
+    rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
+    remediation: "Remove the following parameter in /etc/audit/audit_control: expire-after."
+    compliance:
+      - cis: ["5.2.1.4"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'not f:/etc/security/audit_control -> r:^expire-after'
+
+  # 5.2.1.5 Ensure system is disabled when audit logs are full. (Automated)
+
+  # 5.2.3.1 Ensure changes to system administration events are collected. (Automated)
+  - id: 40544
+    title: "Ensure changes to system administration events are collected."
+    description: 'Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope..'
+    rationale: "Administration system changes can indicate that an unauthorized change has been made to the scope of system administrator activity."
+    remediation: "Edit /etc/security/audit_control file and add or check if exist the following flags: ad,ex,fw. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ad' 
+      - 'f:/etc/security/audit_control -> r:^flags: && r:+ex|ex'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:+fw|fw'      
+
+  # 5.2.3.2 Ensure actions as another user are always logged. (Automated)
+  - id: 40545
+    title: "Ensure actions as another user are always logged."
+    description: "sudo provides users with temporary elevated privileges to perform operations, either as the superuser or another user."
+    rationale: "Creating an audit log of users with temporary elevated privileges and the operation(s) they performed is essential to reporting. Administrators will want to correlate the events written to the audit trail with the records written to sudo's logfile to verify if unauthorized commands have been executed."
+    remediation: "Create audit rules editing /etc/security/audit_user file. Add an user with sudo privileges entry like the following: sudouser:lo,aa,ad:no. If you want apply flags globally the following must be added to flags: lo,aa,ad into /etc/security/audit_control. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.2"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.9.4.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:lo'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:aa'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ad'      
+
+  # 5.2.3.3 Ensure events that modify the sudo log file are collected. (Automated) - Not Implemented
+  # 5.2.3.4 Ensure events that modify date and time information are collected. (Automated)  
+
+  # 5.2.3.5 Ensure events that modify the system's network environment are collected. (Automated)
+  - id: 40546
+    title: "Ensure events that modify the system's network environment are collected."
+    description: "Record changes to network environment files or system calls. The below parameters monitors the following system calls, and write an audit event on system call exit: - sethostname - set the systems host name - setdomainname - set the systems domain name The files being monitored are: - /etc/issue and /etc/issue.net - messages displayed pre-login - /etc/hosts - file containing host names and associated IP addresses - /etc/networks - symbolic names for networks - /etc/network/ - directory containing network interface scripts and configurations files."
+    rationale: "Monitoring network events will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. All audit records should have a relevant tag associated with them."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events that modify the system's network environment. flags: +nt,+fm,+exe. Restart auditd service: # service auditd restart or restart OS: # reboot."
+    compliance:
+      - cis: ["5.2.3.5"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:nt|+nt'
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fm|+fm'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:exe|+exe'      
+
+  # 5.2.3.6 Ensure use of privileged commands are collected. (Automated) - Not Implemented
+  
+  # 5.2.3.7 Ensure unsuccessful file access attempts are collected. (Automated) - Not Implemented
+  - id: 40547
+    title: "Ensure unsuccessful file access attempts are collected."
+    description: "Record events of unsuccessful file access attempts."
+    rationale: "Monitoring unsucessful file access attempts could be an indication that the system has been compromised and that an unauthorized user is attempting to modify configuration system files."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events of unsuccessful file access attempts. flags: -fr. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.7"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fr|-fr'
+
+  # 5.2.3.8 Ensure events that modify user/group information are collected. (Automated)
+  - id: 40548
+    title: "Ensure events that modify files are collected."
+    description: 'Record events affecting the files modification.'
+    rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events of modify files. flags: +fr,+fw,+fm. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.8"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fm|+fm'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fr|+fr'
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fw|+fw'      
+
+  # 5.2.3.9 Ensure discretionary access control permission modification events are collected. (Automated) - Not Implemented
+
+  # 5.2.3.10 Ensure login and logout events are collected. (Automated)
+  - id: 40549
+    title: "Ensure login and logout events are collected."
+    description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events."
+    rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor login and logout events. flags: lo. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.10"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9", "16.11", "16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.9.4.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3", "AU-3(1)"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:lo'
+
+  # 5.2.3.11 Ensure file deletion events by users are collected. (Automated)
+  - id: 40550
+    title: "Ensure file deletion events by users are collected."
+    description: 'Monitor the use of system calls associated with the deletion or renaming of files and file attributes.'
+    rationale: "Monitoring these calls from users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor delete files events. flags: +fd. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.11"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fd|+fd'
+
+   # 5.2.3.12 Ensure successful and unsuccessful attempts to use commands are recorded. (Automated)
+  - id: 40551
+    title: "Ensure successful and unsuccessful attempts to use commands are recorded."
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the commands."
+    rationale: "The system commands can be used to change file security context. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor delete files events. flags: ex. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.12"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ex'
+
+  # 5.2.3.13 Ensure the audit configuration is immutable. (Automated)
+  # 5.2.3.14 Ensure the running and on disk configuration is the same. (Manual)
+  
+  # 5.2.4.1 Ensure audit log files are mode 0640 or less permissive. (Automated)
+  - id: 40552
+    title: "Ensure audit log files are mode 0640 or less permissive."
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: 'Run the following command to configure the audit log files to fix the permissions: # find /var/audit/ -type f -exec chmod 440 {} \\;'
+    compliance:
+      - cis: ["5.2.4.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /var/audit -xdev -type f -exec stat -f %Sp {} \; -> r:^-r--r-----'
+
+  # 5.2.4.2 Ensure only authorized users and groups are assigned ownership of audit log files. (Automated)
+  - id: 40553
+    title: "Ensure only authorized groups are assigned ownership of audit log files."
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: "Run the following command to configure the audit log files to be group owned by audit: # find /var/audit/ -type f -exec chown root:audit {} \\;"
+    compliance:
+      - cis: ["5.2.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /var/audit -xdev -type f -exec stat -f %Su:%Sg {} \; -> r:^root:audit'
+
+  # 5.2.4.4 Ensure the audit log directory is 0750 or more restrictive. (Automated)  
+
+  # 5.2.4.5 Ensure audit configuration files are 640 or more restrictive. (Automated)
+  - id: 40554
+    title: "Ensure audit configuration files are 640 or more restrictive."
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to fix permissive mode from the audit configuration files: # chmod 440 /etc/security/audit_class /etc/security/audit_event # chmod 600 /etc/security/audit_control /etc/security/audit_user # chmod 500 /etc/security/audit_warn."
+    compliance:
+      - cis: ["5.2.4.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:stat -f %Sp /etc/security/audit_class -> r:^-r--r-----'      
+      - 'c:stat -f %Sp /etc/security/audit_control -> r:^-rw-------'
+      - 'c:stat -f %Sp /etc/security/audit_event -> r:^-r--r-----'
+      - 'c:stat -f %Sp /etc/security/audit_user -> r:^-rw-------'
+      - 'c:stat -f %Sp /etc/security/audit_warn -> r:^-r-x------' 
+
+  # 5.2.4.6 Ensure audit configuration files are owned by root. (Automated)
+  - id: 40555
+    title: "Ensure audit configuration files are owned by root and wheel group."
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to change ownership to root user: # find /etc/security -xdev -type f -name 'audit_*' -exec chown root:wheel {} \\;"
+    compliance:
+      - cis: ["5.2.4.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:  
+      - 'c:find /etc/security -xdev -type f -name "audit_*" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel'                       
+          
+  # 5.2.4.7 Ensure audit tools are 755 or more restrictive. (Automated)
+  - id: 40556
+    title: "Ensure audit tools are 755 or more restrictive."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to remove more permissive mode from the audit tools: # chmod 555 /usr/sbin/audit /usr/sbin/auditd /usr/sbin/auditdistd /usr/sbin/auditreduce /usr/sbin/paudit."
+    compliance:
+      - cis: ["5.2.4.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /usr/sbin/audit -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditd -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditdistd -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditreduce -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/praudit -> r:^-r-xr-xr-x"
+
+  # 5.2.4.8 Ensure audit tools are owned by root. (Automated)
+  - id: 40557
+    title: "Ensure audit tools are owned by root and group wheel."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to change the owner of the audit tools to the root user and group wheel: # chown root:wheel /usr/sbin/audit /usr/sbin/auditd /usr/sbin/auditdistd /usr/sbin/auditreduce /usr/sbin/paudit."
+    compliance:
+      - cis: ["5.2.4.8"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Su:%Sg /usr/sbin/audit -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditd -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditdistd -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditreduce -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/praudit -> r:^root:wheel"                        
+
+   # 5.2.4.9 Ensure cryptographic mechanisms are used to protect the integrity of audit tools. (Automated)
+  - id: 40558
+    title: "Ensure cryptographic mechanisms are used to protect the integrity of audit tools."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records."
+    rationale: "Protecting the integrity of the tools used for auditing purposes is a critical step toward ensuring the integrity of audit information. Attackers may replace the audit tools or inject code into the existing tools with the purpose of providing the capability to hide or erase system activity from the audit logs. Audit tools should be cryptographically signed in order to provide the capability to identify when the audit tools have been modified, manipulated, or replaced. An example is a checksum hash of the file or files."
+    remediation: "Add/Update the following selection lines to /usr/local/etc/aide.conf to protect the integrity of the audit tools: # Audit Tools /usr/sbin/audit p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditdistd p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditreduce p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/paudit p+i+n+u+g+s+b+acl+xattrs+sha512."
+    compliance:
+      - cis: ["5.2.4.9"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+    condition: all
+    rules:
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/audit p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditdistd p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditreduce p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/paudit p+i+n+u+g+s+b+acl+xattrs+sha512"
+
+  ###############################################
+  # 6 System Maintenance
+  ###############################################
+  ###############################################
+  # 6.1 System File Permissions
+  ###############################################
+  # 6.1.1 Ensure permissions on /etc/passwd are configured. (Automated)
+  - id: 40559
+    title: "Ensure permissions on /etc/passwd are configured."
+    description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
+    rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/passwd: # chmod 640 /etc/passwd # chown root:wheel /etc/passwd."
+    compliance:
+      - cis: ["6.1.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/passwd -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/passwd -> r:^root:wheel"    
+
+  # 6.1.2 Ensure permissions on /etc/group are configured. (Automated)
+  - id: 40560
+    title: "Ensure permissions on /etc/group are configured."
+    description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
+    rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/group: # chmod 640 /etc/group # chown root:wheel /etc/group."
+    compliance:
+      - cis: ["6.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/group -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/group -> r:^root:wheel"
+
+  # 6.1.3 Ensure permissions on /etc/master.passwd are configured. (Automated)
+  - id: 40561
+    title: "Ensure permissions on /etc/master.passwd are configured."
+    description: "The /etc/master.passwd file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
+    rationale: "If attackers can gain read access to the /etc/master.passwd file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/master.passwd file (such as expiration) could also be useful to subvert the user accounts."
+    remediation: "Run one of the following commands to set ownership of /etc/master.passwd to root and group to either root and wheel: # chown root:wheel /etc/master.passwd. Run the following command to remove excess permissions form /etc/master.passwd: # chmod 600 /etc/master.passwd."
+    compliance:
+      - cis: ["6.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/master.passwd -> r:^-rw-------"
+      - "c:stat -f %Su:%Sg /etc/master.passwd -> r:^root:wheel"
+
+   # 6.1.4 Ensure permissions on /etc/shells are configured. (Automated)
+  - id: 40562
+    title: "Ensure permissions on /etc/shells are configured."
+    description: "/etc/shells is a text file which contains the full pathnames of valid login shells. This file is consulted by chsh and available to be queried by other programs."
+    rationale: "It is critical to ensure that the /etc/shells file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/shells: # chmod 644 /etc/shells # chown root:wheel /etc/shells."
+    compliance:
+      - cis: ["6.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/shells -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/shells -> r:^root:wheel"    
+
+  # 6.1.5 Ensure world writable files and directories are secured. (Automated) - Not Implemented
+  # 6.1.6 Ensure no unowned or ungrouped files or directories exist. (Automated) - Not Implemented
+  # 6.1.7 Ensure SUID and SGID files are reviewed. (Manual) - - Not Implemented
+
+  ################################################
+  # 6.2 User and Group Settings
+  ################################################
+  # 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords. (Automated)
+  - id: 40563
+    title: "Ensure accounts in /etc/passwd use encrypted passwords."
+    description: "Local accounts can uses encrypted passwords. With encrypted passwords, The passwords are saved in /etc/master.passwd file encrypted by crypt. Accounts with a encrypted password have an * in the second field in /etc/passwd."
+    rationale: "The /etc/passwd file also contains information like user ID's and group ID's that are used by many system programs. Therefore, the /etc/passwd file must remain world readable. In spite of encoding the password with a randomly-generated one-way hash function, an attacker could still break the system if they got access to the /etc/passwd file. This can be mitigated by using encrypted passwords. The /etc/master.passwd file is set so only root will be able to read and write. This helps mitigate the risk of an attacker gaining access to the encoded passwords with which to perform a dictionary attack."
+    remediation: "Run the following command to set accounts to use encrypted passwords: # sed -e 's/^\\([a-zA-Z0-9_]*\\):[^:]*:/\\1:*:/' -i /etc/passwd Investigate to determine if the account is logged in and what it is being used for, to determine if it needs to be forced off."
+    compliance:
+      - cis: ["6.2.1"]
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["16.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1003", "T1003.008"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'not f:/etc/passwd -> !r:^\w+:*:'
+
+  # 6.2.2 Ensure /etc/shadow password fields are not empty. (Automated)
+  - id: 40564
+    title: "Ensure /etc/master.passwd password fields are not empty."
+    description: "An account with an empty password field means that anybody may log in as that user without providing a password."
+    rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
+    remediation: "If any accounts in the /etc/master.passwd file do not have a password, run the following command to lock the account until it can be determined why it does not have a password: # pw lock <username> Also, check to see if the account is logged in and investigate what it is being used for to determine if it needs to be forced off."
+    compliance:
+      - cis: ["6.2.2"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'not f:/etc/master.passwd -> r:^\w+::'
+
+  # 6.2.3 Ensure all groups in /etc/passwd exist in /etc/group. (Automated) - Not Implemented
+  # 6.2.4 Ensure no duplicate UIDs exist. (Automated) - Not Implemented
+  # 6.2.5 Ensure no duplicate GIDs exist. (Automated) - Not Implemented
+  # 6.2.6 Ensure no duplicate user names exist. (Automated) - Not Implemented
+  # 6.2.7 Ensure no duplicate group names exist. (Automated) - Not Implemented
+  # 6.2.8 Ensure root PATH Integrity. (Automated) - Not Implemented
+
+  # 6.2.9 Ensure root is the only UID 0 account. (Automated)
+  - id: 40565
+    title: "Ensure root is the only UID 0 account."
+    description: "Any account with UID 0 has superuser privileges on the system."
+    rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
+    remediation: "Remove any users other than root with UID 0 or assign them a new UID if appropriate."
+    compliance:
+      - cis: ["6.2.9"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1548"]
+    condition: all
+    rules:
+      - 'not f:/etc/passwd -> !r:^\s*\t*# && !r:^root: && r:^\w+:\w+:0:'
+
+  # 6.2.10 Ensure local interactive user home directories are configured. (Automated) - Not Implemented
+  # 6.2.11 Ensure local interactive user dot files access is configured. (Automated) - Not Implemented

--- a/ruleset/sca/freebsd/cis_freebsd14.yml
+++ b/ruleset/sca/freebsd/cis_freebsd14.yml
@@ -3091,7 +3091,7 @@ checks:
     condition: all
     rules:
       - 'c:sshd -T -> n:^\s*maxsessions\s+(\d+) compare <= 10'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxSessions\s+(1[1-9]|[2-9][0-9]|[1-9][0-9][0-9]+)'
+      - 'not f:/etc/ssh/sshd_config -> n:^MaxSessions\s+(\d+) compare > 10'
 
   # 4.2.22 Ensure SSH Idle Timeout Interval is configured. (Automated)
   - id: 40522
@@ -3225,8 +3225,8 @@ checks:
       - soc_2: ["CC6.1", "CC6.3"]
     condition: none
     rules:
-      - 'f:/usr/local/etc/sudoers -> !r:^# && r:*\!authenticate'
-      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:*\!authenticate'
+      - 'f:/usr/local/etc/sudoers -> !r:^# && r:!authenticate'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:!authenticate'
 
   # 4.3.6 Ensure sudo authentication timeout is configured correctly. (Automated)
   - id: 40528

--- a/ruleset/sca/freebsd/cis_freebsd15.yml
+++ b/ruleset/sca/freebsd/cis_freebsd15.yml
@@ -3091,7 +3091,7 @@ checks:
     condition: all
     rules:
       - 'c:sshd -T -> n:^\s*maxsessions\s+(\d+) compare <= 10'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxSessions\s+(1[1-9]|[2-9][0-9]|[1-9][0-9][0-9]+)'
+      - 'not f:/etc/ssh/sshd_config -> n:^MaxSessions\s+(\d+) compare > 10'
 
   # 4.2.22 Ensure SSH Idle Timeout Interval is configured. (Automated)
   - id: 40722
@@ -3225,8 +3225,8 @@ checks:
       - soc_2: ["CC6.1", "CC6.3"]
     condition: none
     rules:
-      - 'f:/usr/local/etc/sudoers -> !r:^# && r:*\!authenticate'
-      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:*\!authenticate'
+      - 'f:/usr/local/etc/sudoers -> !r:^# && r:!authenticate'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:!authenticate'
 
   # 4.3.6 Ensure sudo authentication timeout is configured correctly. (Automated)
   - id: 40728

--- a/ruleset/sca/freebsd/cis_freebsd15.yml
+++ b/ruleset/sca/freebsd/cis_freebsd15.yml
@@ -1,0 +1,4194 @@
+# Security Configuration Assessment
+# CIS Checks for FreeBSD 15.x based on Wazuh SCA files 
+# Copyright (C) 2023, Wazuh Inc.
+# Copyright (C) 2023, Alonso Cárdenas Márquez <acm@FreeBSD.org>.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+#
+# Based on:
+# Center for Internet Security Benchmarks - 16-10-2023
+
+policy:
+  id: "cis_freebsd15"
+  file: "cis_freebsd15.yml"
+  name: "SCA policy for FreeBSD 15.x"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for FreeBSD 15.x."
+  references:
+    - https://www.cisecurity.org/cis-benchmarks/
+
+requirements:
+  title: "Check FreeBSD version."
+  description: "Requirements for running the SCA scan against FreeBSD 14.x"
+  condition: all
+  rules:
+    - "f:/etc/os-release -> r:^NAME=FreeBSD"
+    - "c:sysctl -n kern.ostype -> r:^FreeBSD"
+    - "c:sysctl -n kern.osrelease -> r:^15."
+
+checks:
+  ###############################################
+  # 1 Initial setup
+  ###############################################
+  ###############################################
+  # 1.1 Filesystem Configuration
+  ###############################################
+  ###############################################
+  # 1.1.1 Disable unused filesystems
+  ###############################################
+  # 1.1.1.1 Ensure mounting of fusefs filesystems is disabled
+  - id: 40600
+    title: Ensure mounting of fusefs filesystems is disabled.
+    description: >
+      FUSE makes it possible to implement a filesystem in a userspace program.
+      Features include: simple yet comprehensive API, secure mounting by non-root
+      users, support for FreeBSD kernels, multi-threaded operation.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="fusefs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload fusefs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m fusefs -> r:fusefs && !r:fusefs$"    
+      
+  # 1.1.1.2 Ensure mounting of fdescfs filesystems is disabled (Automated)
+  - id: 40601
+    title: Ensure mounting of fdescfs filesystems is disabled.
+    description: >
+      The file-descriptor file system, or fdescfs, provides access to the per-
+      process file descriptor namespace in the global file system namespace.
+      The conventional mount point is /dev/fd
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="fdescfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload fdescfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m fdescfs -> r:fdescfs && !r:fdescfs$"    
+
+  # 1.1.1.3 Ensure mounting of smbfs filesystems is disabled (Automated)
+  - id: 40602
+    title: Ensure mounting of smbfs filesystems is disabled.
+    description: >
+      The SMB driver is an implementation of the CIFS (Common Internet
+      Filesystem) network protocol.
+
+      The smbfs filesystem driver supports only the obsolete SMBv1 protocol.
+      smbfs has known bugs and likely has security vulnerabilities.  smbfs and
+      userspace counterparts smbutil(1) and mount_smbfs(8) may be removed from
+      a future version of FreeBSD.  Users are advised to evaluate the
+      sysutils/fusefs-smbnetfs port instead.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="smbfsfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload smbfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.3"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m smbfs -> r:smbfs && !r:smbfs$"    
+      
+  # 1.1.1.4 Ensure mounting of nfscl filesystems is disabled (Automated)
+  - id: 40603
+    title: Ensure mounting of nfscl filesystems is disabled.
+    description: >
+      FUSE makes it possible to implement a filesystem in a userspace program.
+      Features include: simple yet comprehensive API, secure mounting by non-root
+      users, support for FreeBSD kernels, multi-threaded operation.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="nfscl"
+
+      Run the following command to unload the fusefs module:
+      # kldunload nfscl
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.4"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m nfscl -> r:nfscl && !r:nfscl$"    
+  
+  # 1.1.1.5 Ensure mounting of nfsd filesystems is disabled (Automated)
+  - id: 40604
+    title: Ensure mounting of nfsd filesystems is disabled.
+    description: >
+     The nfsd utility runs on a server machine to service NFS requests from
+     client machines.  At least one nfsd must be running for a machine to
+     operate as a server.
+
+     Unless otherwise specified, eight servers per CPU for UDP transport are
+     started.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="nfsd"
+
+      Run the following command to unload the fusefs module:
+      # kldunload nfsd
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m nfsd -> r:nfsd && !r:nfsd$"    
+  
+  # 1.1.1.6 Ensure mounting of msdosfs filesystems is disabled (Automated)
+  - id: 40605
+    title: Ensure mounting of msdosfs filesystems is disabled.
+    description: >
+      The msdosfs driver will permit the FreeBSD kernel to read and write MS-
+      DOS based file systems.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="msdosfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload msdosfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.6"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m msdosfs -> r:msdosfs && !r:msdosfs$"    
+        
+  # 1.1.1.7 Ensure mounting of cd9660 filesystems is disabled (Automated)
+  - id: 40606
+    title: Ensure mounting of cd9660 filesystems is disabled.
+    description: >
+      The cd9660 driver will permit the FreeBSD kernel to access the cd9660
+      file system.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="cd9660"
+
+      Run the following command to unload the fusefs module:
+      # kldunload cd9660
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.7"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m cd9660 -> r:cd9660 && !r:cd9660$"    
+  
+  # 1.1.1.8 Ensure mounting of procfs is disabled (Automated)
+  - id: 40607
+    title: Ensure mounting of procfs filesystems is disabled.
+    description: >
+      The procfs provides a two-level view of process space, unlike the
+      previous FreeBSD 1.1 procfs implementation.  At the highest level,
+      processes themselves are named, according to their process ids in
+      decimal, with no leading zeros.  There is also a special node called
+      curproc which always refers to the process making the lookup request.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="procfs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload procfs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.8"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m procfs -> r:procfs && !r:procfs$"    
+            
+  # 1.1.1.9 Ensure mounting of pseudofs is disabled (Automated)
+  - id: 40608
+    title: Ensure mounting of pseudofs filesystems is disabled.
+    description: >
+      The pseudofs module offers an abstract API for pseudo-file systems such
+      as procfs(5) and linprocfs(5).  It takes care of all the hairy bits like
+      interfacing with the VFS system, enforcing access control, keeping track
+      of file numbers, and cloning files and directories that are process-
+      specific.  The consumer module, i.e., the module that implements the
+      actual guts of the file system, needs only provide the directory
+      structure (represented by a collection of structures declared and
+      initialized by macros provided by pseudofs) and callbacks that report
+      file attributes or write the actual file contents into sbufs.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit /boot/loader.conf file and add or modify module_blacklist entry.
+      Example: ee /boot/loader.conf
+      and add the following line:
+
+      module_blacklist="pseudofs"
+
+      Run the following command to unload the fusefs module:
+      # kldunload pseudofs
+      
+      Take on mind if it is compiled inside kernel you must remove this options
+      from GENERIC file and recompile the kernel
+    compliance:
+      - cis: ["1.1.1.9"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - "c: kldstat -m pseudofs -> r:pseudofs && !r:pseudofs$"    
+
+  ###############################################
+  # 1.1.2 Configure /tmp
+  ###############################################
+  # 1.1.2.1 Ensure /tmp is a separate partition. (Automated)
+  - id: 40609
+    title: "Ensure /tmp is a separate partition."
+    description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
+    rationale: "Making /tmp its own file system allows an administrator to set additional mount options such as the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hard link to a system setuid program and wait for it to be updated. Once the program was updated, the hard link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp."
+    impact: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. Running out of /tmp space is a problem regardless of what kind of filesystem lies under it, but in a configuration where /tmp is not a separate file system it will essentially have the whole disk available, as the default installation only creates a single / partition. On the other hand, a RAM-based /tmp (as with tmpfs) will almost certainly be much smaller, which can lead to applications filling up the filesystem much more easily. Another alternative is to create a dedicated partition for /tmp from a separate volume or disk. One of the downsides of a disk-based dedicated partition is that it will be slower than tmpfs which is RAM-based. /tmp utilizing tmpfs can be resized using the size={size} parameter in the relevant entry in /etc/fstab."
+    remediation: "For specific configuration requirements of the /tmp mount for your environment, modify /etc/fstab: Configure /etc/fstab as appropriate: Example: tmpfs /tmp tmpfs rw,nosuid,noexec 0 0"
+    references:
+      - "https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/"
+      - "https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html"
+    compliance:
+      - cis: ["1.1.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s'
+
+  # 1.1.2.2 Ensure nodev option set on /tmp partition. (No apply)
+  - id: 40610
+    title: "Ensure nodev option set on /tmp partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s && r:nodev'
+      - 'c: zfs get -H -o value devices /tmp -> r:off'
+
+  # 1.1.2.3 Ensure noexec option set on /tmp partition. (Automated)
+  - id: 40611
+    title: "Ensure noexec option set on /tmp partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s*\s/tmp\s && r:noexec'
+      - 'c: zfs get -H -o value exec /tmp -> r:off'   
+
+  # 1.1.2.4 Ensure nosuid option set on /tmp partition. (Automated)
+  - id: 40612
+    title: "Ensure nosuid option set on /tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /tmp with the configured options: # mount -u -o rw,nosuid,noexec /tmp."
+    compliance:
+      - cis: ["1.1.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s\s*/tmp\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /tmp -> r:off'      
+
+  ###############################################
+  # 1.1.3 Configure /var
+  ###############################################
+  # 1.1.3.1 Ensure separate partition exists for /var.
+  - id: 40613
+    title: "Ensure separate partition exists for /var."
+    description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
+    rationale: "The default installation only creates a single / partition. Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var and cause unintended behavior across the system as the disk is full. Fine grained control over the mount Configuring /var as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behaviour."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.3.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:/var\s'   
+
+  # 1.1.3.2 Ensure nodev option set on /var partition.
+  - id: 40614
+    title: "Ensure nodev option set on /var partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /var with the configured options: # mount -u -o /var. On ZFS filesystem do the following: zfs set devices=off mypool/var"
+    compliance:
+      - cis: ["1.1.3.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:/var\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var -> r:off'      
+
+  # 1.1.3.3 Ensure nosuid option set on /var partition.
+  - id: 40615
+    title: "Ensure nosuid option set on /var partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /var with the configured options: # mount -u -o /var. On ZFS filesystem do the following: zfs set setuid=off mypool/var"
+    compliance:
+      - cis: ["1.1.3.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:/var\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var -> r:off'      
+
+  ###############################################
+  # 1.1.4 Configure /var/tmp
+  ###############################################
+  # 1.1.4.1 Ensure separate partition exists for /var/tmp. (Automated)
+  - id: 40616
+    title: "Ensure separate partition exists for /var/tmp."
+    description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications. Temporary files residing in /var/tmp are to be preserved between reboots."
+    rationale: "The default installation only creates a single / partition. Since the /var/tmp directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var/tmp and cause the potential disruption to daemons as the disk is full. Configuring /var/tmp as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/tmp. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate. "
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.4.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s'
+
+  # 1.1.4.2 Ensure nodev option set on /var/tmp partition. (No apply)
+  - id: 40617
+    title: "Ensure nodev option set on /var/tmp partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set devices=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/tmp -> r:off'      
+
+  # 1.1.4.3 Ensure noexec option set on /var/tmp partition. (Automated)
+  - id: 40618
+    title: "Ensure noexec option set on /var/tmp partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set exec=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/tmp\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/tmp -> r:off'      
+
+  # 1.1.4.4 Ensure nosuid option set on /var/tmp partition. (Automated)
+  - id: 40619
+    title: "Ensure nosuid option set on /var/tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/tmp with the configured options: # mount -u -o /var/tmp. On ZFS filesystem do the following: zfs set setuid=off mypool/var/tmp"
+    compliance:
+      - cis: ["1.1.4.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022", "M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -u /var/tmp -> r:\s/var/tmp\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/tmp -> r:off'      
+
+  ###############################################
+  # 1.1.5 Configure /var/log
+  ###############################################
+  # 1.1.5.1 Ensure separate partition exists for /var/log. (Automated)
+  - id: 40620
+    title: "Ensure separate partition exists for /var/log."
+    description: "The /var/log directory is used by system services to store log data."
+    rationale: "The default installation only creates a single / partition. Since the /var/log directory contains log files which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. Fine grained control over the mount Configuring /var/log as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. As /var/log contains log files, care should be taken to ensure the security and integrity of the data and mount point."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.5.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s'    
+
+  # 1.1.5.2 Ensure nodev option set on /var/log partition. (Automated)
+  - id: 40621
+    title: "Ensure nodev option set on /var/log partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/log filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set devices=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/log -> r:off'      
+
+  # 1.1.5.3 Ensure noexec option set on /var/log partition. (Automated)
+  - id: 40622
+    title: "Ensure noexec option set on /var/log partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot run executable binaries from /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set exec=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/log -> r:off'      
+
+  # 1.1.5.4 Ensure nosuid option set on /var/log partition. (Automated)
+  - id: 40623
+    title: "Ensure nosuid option set on /var/log partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot create setuid files in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/log with the configured options: # mount -u -o /var/log. On ZFS filesystem do the following: zfs set setuid=off mypool/var/log"
+    compliance:
+      - cis: ["1.1.5.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/log\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/log -> r:off'      
+
+  ###############################################
+  # 1.1.6 Configure /var/audit
+  ###############################################
+  # 1.1.6.1 Ensure separate partition exists for /var/audit. (Automated)
+  - id: 40624
+    title: "Ensure separate partition exists for /var/audit."
+    description: "The auditing daemon, auditd, stores log data in the /var/audit directory."
+    rationale: "The default installation only creates a single / partition. Since the /var/audit directory contains the audit log files which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. Configuring /var/audit as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. As /var/audit contains audit logs, care should be taken to ensure the security and integrity of the data and mount point."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/audit. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.6.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s'
+
+  # 1.1.6.2 Ensure nodev option set on /var/log/audit partition. (Automated)
+  - id: 40625
+    title: "Ensure nodev option set on /var/audit partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/audit filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/audit partition. Example: <device> /var/log/audit <fstype> rw,nosuid,nodev,noexec 0 0 Run the following command to remount /var/log/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set devices=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:nodev'
+      - 'c: zfs get -H -o value devices /var/audit -> r:off'      
+
+  # 1.1.6.3 Ensure noexec option set on /var/log/audit partition. (Automated)
+  - id: 40626
+    title: "Ensure noexec option set on /var/audit partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/audit filesystem is only intended for audit logs, set this option to ensure that users cannot run executable binaries from /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var partition. Example: <device> /var/audit <fstype> rw,nosuid,noexec 0 0 Run the following command to remount /var/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set exec=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1204", "T1204.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:noexec'
+      - 'c: zfs get -H -o value exec /var/audit -> r:off'      
+
+  # 1.1.6.4 Ensure nosuid option set on /var/log/audit partition. (Automated)
+  - id: 40627
+    title: "Ensure nosuid option set on /var/audit partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/audit filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var/audit."
+    remediation: "IF the /var/audit partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/audit partition. Example: <device> /var/audit <fstype> rw,nosuid,noexec,relatime 0 0 Run the following command to remount /var/audit with the configured options: # mount -u -o /var/audit. On ZFS filesystem do the following: zfs set setuid=off mypool/var/audit"
+    compliance:
+      - cis: ["1.1.6.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/var/audit\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /var/audit -> r:off'      
+
+  ###############################################
+  # 1.1.7 Configure /usr/home
+  ###############################################
+  # 1.1.7.1 Ensure separate partition exists for /usr/home. (Automated)
+  - id: 40628
+    title: "Ensure separate partition exists for /usr/home."
+    description: "The /usr/home directory is used to support disk storage needs of local users."
+    rationale: "The default installation only creates a single / partition. Since the /usr/home directory contains user generated data, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /usr/home and impact all local users. Configuring /usr/home as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. In the case of /usr/home options such as quota may be considered to limit the impact that users can have on each other with regards to disk resource exhaustion."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /usr/home. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+    compliance:
+      - cis: ["1.1.7.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1038"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1499", "T1499.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s'
+
+  # 1.1.7.2 Ensure nodev option set on /usr/home partition. (Automated)
+  - id: 40629
+    title: "Ensure nodev option set on /usr/home partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /usr/home filesystem is not intended to support devices, set this option to ensure that users cannot create block or character special devices in /home."
+    remediation: "IF the /usr/home partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /usr/home partition. Example: <device> /usr/home <fstype> rw,nosuid,nodev 0 0 Run the following command to remount /usr/home with the configured options: # mount -u -o /usr/home. On ZFS filesystem do the following: zfs set devices=off mypool/usr/home"
+    compliance:
+      - cis: ["1.1.7.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1200"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s && r:nodev'
+      - 'c: zfs get -H -o value devices /usr/home -> r:off'      
+
+  # 1.1.7.3 Ensure nosuid option set on /usr/home partition. (Automated)
+  - id: 40630
+    title: "Ensure nosuid option set on /usr/home partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /usr/home filesystem is only intended for user file storage, set this option to ensure that users cannot create setuid files in /usr/home."
+    remediation: "IF the /usr/home partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /usr/home partition. Example: <device> /usr/home <fstype> rw,nosuid 0 0 Run the following command to remount /usr/home with the configured options: # mount -u -o /usr/home. On ZFS filesystem do the following: zfs set setuid=off mypool/usr/home"
+    compliance:
+      - cis: ["1.1.7.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548", "T1548.001"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - 'c: mount -p -> r:\s/usr/home\s && r:nosuid'
+      - 'c: zfs get -H -o value setuid /usr/home -> r:off'      
+
+  ###############################################
+  # 1.1.8 Configure /dev/shm (No apply. It could be a tmpfs)
+  ###############################################
+
+  # 1.1.9 Disable Automounting. (Automated)
+  - id: 40631
+    title: "Disable Automounting."
+    description: "autofs or automount allows automatic mounting of devices, typically including CD/DVDs and USB drives."
+    rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in the filesystem even if they lacked permissions to mount it themselves."
+    impact: "The use of portable hard drives is very common for workstation users. If your organization allows the use of portable storage or media on workstations and physical access controls to workstations are considered adequate there is little value add in turning off automounting."
+    remediation: "If there are no other packages that depends on autofs or automount,  disable it with: # pkg remove automount; kldunload autofs; sysrc autofs_enable=NO"
+    compliance:
+      - cis: ["1.1.9"]
+      - cis_csc_v8: ["10.3"]
+      - cis_csc_v7: ["8.5"]
+      - cmmc_v2.0: ["MP.L2-3.8.7"]
+      - hipaa: ["164.310(d)(1)"]
+      - iso_27001-2013: ["A.12.2.1"]
+      - mitre_techniques: ["T1068", "T1203", "T1211", "T1212"]
+    condition: all
+    rules:
+      - "not c: sysctl -n vfs.usermount -> r:1"
+      - "c: kldstat -m autofs -> r:autofs && !r:autofs$"
+      - "not c: sysrc -n autofs_enable -> r:YES"
+      - "not c: pkg query %n-%v automount -> r:automount"   
+
+  # 1.1.10 Disable USB Storage. (Automated)   
+
+  ###############################################
+  # 1.2 Configure Software Updates
+  ###############################################
+  # 1.2.1 Ensure package manager repositories are configured. (Manual) - Not Implemented
+  # 1.2.2 Ensure updates, patches, and additional security software are installed. (Manual)
+  - id: 40632
+    title: "Ensure updates, patches, and additional security software are installed."
+    description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
+    rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
+    remediation: "Run the following command to update all packages following local site policy guidance on applying updates and patches: # pkg upgrade."
+    compliance:
+      - cis: ["1.2.1"]
+      - cis_csc_v8: ["7.3"]
+      - cis_csc_v7: ["3.4", "3.5"]
+      - cmmc_v2.0: ["SI.L1-3.14.1"]
+      - mitre_mitigations: ["M1051"]
+      - mitre_tactics: ["TA0004", "TA0008"]
+      - mitre_techniques: ["T1211"]
+      - nist_sp_800-53: ["SI-2(2)"]
+      - pci_dss_v3.2.1: ["6.2"]
+      - soc_2: ["CC7.1"]
+    condition: all
+    rules:
+      - "c:pkg upgrade -n -> r:^Your packages are up to date"
+        
+  ###############################################
+  # 1.3 Filesystem Integrity Checking
+  ###############################################
+  # 1.3.1 Ensure AIDE is installed. (Automated)
+  - id: 40633
+    title: "Ensure AIDE is installed."
+    description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
+    rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
+    remediation: "Install AIDE using the appropriate package manager or manual installation: # apt install aide aide-common Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options. Run the following commands to initialize AIDE: # aideinit # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db."
+    compliance:
+      - cis: ["1.3.1"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_techniques: ["T1036", "T1036.002", "T1036.003", "T1036.004", "T1036.005", "T1565", "T1565.001"]
+      - nist_sp_800-53: ["AC-6(9)"]
+      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "not c: pkg query %n-%v aide -> r:aide"
+       
+  # 1.3.2 Ensure filesystem integrity is regularly checked. (Automated)
+  - id: 40634
+    title: "Ensure filesystem integrity is regularly checked."
+    description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
+    rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
+    remediation: "If cron will be used to schedule and run aide check Run the following command: # crontab -u root -e Add the following line to the crontab: 0 5 * * * /usr/local/bin/aide --check."
+    references:
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.service"
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.timer"
+    compliance:
+      - cis: ["1.3.2"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - nist_sp_800-53: ["AU-2"]
+      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "c:crontab -l -> r:aide --check"
+
+  ###############################################
+  # 1.4 Secure Boot Settings
+  ###############################################
+  # 1.4.1 Ensure bootloader password is set. (Automated)
+  - id: 40635
+    title: "Ensure bootloader password is set."
+    description: "Setting the bootloader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
+    rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering bootloader menu. This prevents users from weakening security."
+    impact: 'If password protection is enabled, only the designated superuser can select any option of boot menu item.'
+    remediation: 'Add password="your_password_here" to /boot/loader.conf .'
+    compliance:
+      - cis: ["1.4.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1046"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1542"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/boot/loader.conf -> r:^password'
+
+  # 1.4.2 Ensure permissions on bootloader config are configured. (Automated)
+  - id: 40636
+    title: "Ensure permissions on bootloader config are configured."
+    description: "The bootloader configuration file contains information on boot settings and passwords for unlocking boot options."
+    rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
+    remediation: "Run the following commands to set permissions on your grub configuration: # chown root:wheel /boot/loader.conf # chmod 640 /boot/loader.conf."
+    compliance:
+      - cis: ["1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005", "TA0007"]
+      - mitre_techniques: ["T1542"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /boot/loader.conf -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /boot/loader.conf -> r:^root:wheel"
+
+  # 1.4.3 Ensure authentication required for single user mode. (Automated)
+  - id: 40637
+    title: "Ensure authentication required for single user mode."
+    description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
+    rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
+    remediation: "Run the following command and follow the prompts to set a password for the root user: # passwd root and change console line into /etc/ttys from secure to insecure."
+    compliance:
+      - cis: ["1.4.3"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/ttys -> r:^console && r:insecure'
+
+  ###############################################
+  # 1.5 Additional Process Hardening
+  ###############################################
+  # 1.5.1 Ensure address space layout randomization (ASLR) is enabled
+  - id: 40638
+    title: Ensure address space layout randomization (ASLR) is enabled.
+    description: >
+      Address space layout randomization (ASLR) is an exploit mitigation technique which
+      randomly arranges the address space of key data areas of a process.
+    rationale: >
+      Randomly placing virtual memory regions will make it difficult to write memory page
+      exploits as the memory placement will be consistently shifting.
+    remediation: >
+      Set the following parameter in /etc/sysctl.conf file:
+      kern.elf64.aslr.enable=1
+      kern.elf64.aslr.stack=1
+      kern.elf64.aslr.shared_page=1
+      kern.elf64.aslr.pie_enable=1
+      kern.elf32.aslr.stack=1 
+
+      Run the following command to set the active kernel parameter:
+      # sysctl kern.elf64.aslr.enable=1
+      # sysctl kern.elf64.aslr.stack=1
+      # sysctl kern.elf64.aslr.shared_page=1
+      # sysctl kern.elf64.aslr.pie_enable=1
+      # sysctl kern.elf32.aslr.stack=1 
+    compliance:
+      - cis: ["1.5.1"]
+      - cis_csc: ["8.3"]
+    condition: all
+    rules:
+      - "c:sysctl -n kern.elf64.aslr.enable -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.stack -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.shared_page -> r:1"
+      - "c:sysctl -n kern.elf64.aslr.pie_enable -> r:1"
+      - "c:sysctl -n kern.elf32.aslr.stack -> r:1"      
+      
+  # 1.5.2 Ensure core dumps are restricted (Automated)
+  - id: 40639
+    title: "Ensure core dumps are restricted."
+    description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
+    rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). ."
+    remediation: > 
+      Set the following parameter in /etc/sysctl.conf file:
+      kern.coredump=0
+      kern.corefile=/dev/null
+      or            
+      # sysrc dumpdev="NO"     
+      Run the following command to set the active kernel parameter:
+      # sysctl kern.coredump=0
+      # sysctl kern.corefile=/dev/null      
+    compliance:
+      - cis: ["1.5.2"]
+      - mitre_techniques: ["T1005"]
+      - mitre_tactics: ["TA0007"]
+    condition: all
+    rules:
+      - "c:sysctl -n kern.coredump -> r:0"
+      - "c:sysctl -n kern.corefile -> r:/dev/null"      
+      - "c:sysrc -n dumpdev -> r:NO"
+
+  ###############################################
+  # 1.6 Mandatory Access Control
+  ###############################################
+  ###############################################
+  # 1.6.1 Configure TrustedBSD Mandatory Access Control
+  ###############################################  
+  # 1.6.1.1 Ensure TrustedBSD Mandatory Access Control is installed. (Automated)
+  - id: 40640
+    title: "Ensure TrustedBSD Mandatory Access Control is installed."
+    description: "TrustedBSD provides Mandatory Access Controls."
+    rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
+    remediation: "Enable TrustedBSD Mandatory Access Control. # sysctl kern.features.security_mac=1"
+    compliance:
+      - cis: ["1.6.1.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1068", "T1565", "T1565.001", "T1565.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n kern.features.security_mac -> r:1'
+
+  # 1.6.1.2 Ensure TrustedBSD MAC is not disabled in bootloader configuration. (Automated)
+  - id: 40641
+    title: "Ensure TrustedBSD MAC is not disabled in loader configuration."
+    description: "Configure TrustedBSD MAC to be enabled at boot time and verify that it has not been overwritten by the loader parameters."
+    rationale: "TrustedBSD MAC is enabled into kernel by default but it can be disabled from loader.conf."
+    impact: "Files created while TrustedBSD MAC is disabled are not labeled at all. This behavior causes problems when changing to enforcing mode because files are labeled incorrectly or are not labeled at all. To prevent incorrectly labeled and unlabeled files from causing problems, file systems are automatically relabeled when changing from the disabled state to permissive or enforcing mode. This can be a long running process that should be accounted for as it may extend downtime during initial re-boot."
+    remediation: "Remove instance of kern.features.security_mac=0 from /boot/loader.conf."
+    compliance:
+      - cis: ["1.6.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: none
+    rules:
+      - 'not f:/boot/loader.conf -> r:kern.features.security_mac=0'
+
+  ###############################################
+  # 1.7 Command Line Warning Banners
+  ###############################################
+  # 1.7.1 Ensure message of the day is configured properly. (Automated)
+  - id: 40642
+    title: "Ensure message of the day is configured properly."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform."
+    rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
+    remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy. Add or update the message text to follow local site policy. Example Text: # echo \"Authorized use only. All activity may be monitored and reported.\" > /etc/motd.template -- OR -- If the motd is not used, you can remove content inside of /etc/motd.template file and run # service motd restart."
+    compliance:
+      - cis: ["1.7.1"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1082", "T1592", "T1592.004"]
+    condition: all
+    rules:
+      - "f:/var/run/motd"
+      - "not f:/etc/motd"      
+
+  # 1.7.2 Ensure permissions on /etc/motd.template are configured. (Automated)
+  - id: 40643
+    title: "Ensure permissions on /etc/motd.template are configured."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
+    rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/motd, /etc/motd.template and /var/run/motd : # chown root:wheel /etc/motd /etc/motd.template /var/run/motd # chmod 644 /etc/motd /etc/motd.template /var/run/motd -- OR -- Run the following command to remove the /etc/motd file: # rm /etc/motd."
+    compliance:
+      - cis: ["1.7.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
+    rules:
+      - "c:stat -f %Sp /etc/motd.template -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/motd.template -> r:^root:wheel"    
+      - "c:stat -f %Sp /etc/motd -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/motd -> r:^root:wheel"
+      - "c:stat -f %Sp /var/run/motd -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /var/run/motd -> r:^root:wheel"            
+
+  ###############################################
+  # 1.8 GNOME Display Manager
+  ###############################################
+  # 1.8.1 Ensure GNOME Display Manager is removed. (Automated)
+  - id: 40644
+    title: "Ensure GNOME Display Manager is removed."
+    description: "The GNOME Display Manager (GDM) is a program that manages graphical display servers and handles graphical user logins."
+    rationale: "If a Graphical User Interface (GUI) is not required, it should be removed to reduce the attack surface of the system."
+    impact: "Removing the GNOME Display manager will remove the Graphical User Interface (GUI) from the system."
+    remediation: "Run the following command to uninstall gdm3: # apt purge gdm3."
+    compliance:
+      - cis: ["1.8.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v gdm -> !r:gdm"    
+
+  # 1.8.2 Ensure GDM login banner is configured. (Automated) - Not Implemented
+  # 1.8.3 Ensure GDM disable-user-list option is enabled. (Automated) - Not Implemented
+  # 1.8.4 Ensure GDM screen locks when the user is idle. (Automated) - Not Implemented
+  # 1.8.5 Ensure GDM screen locks cannot be overridden. (Automated) - Not Implemented
+  # 1.8.6 Ensure GDM automatic mounting of removable media is disabled. (Automated) - Not Implemented
+  # 1.8.7 Ensure GDM disabling automatic mounting of removable media is not overridden. (Automated) - Not Implemented
+  # 1.8.8 Ensure GDM autorun-never is enabled. (Automated) - Not Implemented
+  # 1.8.9 Ensure GDM autorun-never is not overridden. (Automated) - Not Implemented
+
+  # 1.8.10 Ensure XDCMP is not enabled. (Automated)
+  - id: 40645
+    title: "Ensure XDCMP is not enabled."
+    description: "X Display Manager Control Protocol (XDMCP) is designed to provide authenticated access to display management services for remote displays."
+    rationale: "XDMCP is inherently insecure. - XDMCP is not a ciphered protocol. This may allow an attacker to capture keystrokes entered by a user - XDMCP is vulnerable to man-in-the-middle attacks. This may allow an attacker to steal the credentials of legitimate users by impersonating the XDMCP server."
+    remediation: "Edit the file /usr/local/etc/gdm/custom.conf and remove the line: Enable=true."
+    compliance:
+      - cis: ["1.8.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1050"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1040", "T1056", "T1056.001", "T1557"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - 'not f:/usr/local/etc/gdm/custom.conf -> r:^\s*Enable\s*=\s*true'
+      
+  ############################################################
+  # 2 Services
+  ############################################################
+  # 2.1 Configure Time Synchronization
+  # 2.1.1 Ensure time synchronization is in use
+  # 2.1.1.1 Ensure a single time synchronization daemon is in use. (Automated)
+  - id: 40646
+    title: "Ensure a single time synchronization daemon is in use."
+    description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them. Note: - On virtual systems where host based time synchronization is available consult your virtualization software documentation and verify that host based synchronization is in use and follows local site policy. Only one time synchronization method should be in use on the system. Configuring multiple time synchronization methods could lead to unexpected or unreliable results."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
+    remediation: "On physical systems, and virtual systems where host based time synchronization is not available. Select one of the three time synchronization daemons; ntpdate (1), ntpd (2) or chrony (3), and following the remediation procedure for the selected daemon. Note: enabling more than one synchronization daemon could lead to unexpected or unreliable results: 1. # sysrc ntpdate_enable=YES 2. # sysrc ntpd_enable=YES; # service ntpd start 3. # sysrc chronyd_enable=YES"
+    compliance:
+      - cis: ["2.1.1.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: any
+    rules:
+      - "c:sysrc -n ntpdate_enable -> r:YES"
+      - "c:sysrc -n ntpd_enable -> r:YES"    
+      - "c:sysrc -n chronyd_enable -> r:YES"               
+
+  # 2.1.2 Configure chrony
+  # 2.1.2.1 Ensure chrony is configured with authorized timeserver. (Manual)
+  - id: 40647
+    title: "Ensure chrony is configured with authorized timeserver."
+    description: "The server directive specifies an NTP server which can be used as a time source. The client-server relationship is strictly hierarchical: a client might synchronize its system time to that of the server, but the server's system time will never be influenced by that of a client. The syntax of pool directive is similar to that for the server directive, except that it is used to specify a pool of NTP servers rather than a single NTP server. The pool name is expected to resolve to multiple addresses which might change over time."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /use/local/etc/chrony/chrony.conf file and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]>. Run one of the following commands to load the updated time sources into chronyd running config: # service chronyd restart OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:pgrep -l chrony -> r:chronyd"
+      - 'f:/usr/local/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
+
+  # 2.1.2.2 Ensure chrony is running as user chrony. (Automated)
+  - id: 40648
+    title: "Ensure chrony is running as user chrony or ntpd."
+    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
+    rationale: "The chronyd service should run with only the required privileges."
+    remediation: "Add or edit the user line to /usr/local/etc/chrony/chrony.conf : user chrony|ntpd OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: any
+    rules:
+      - "c:pgrep -U chrony -l chronyd"    
+      - "c:pgrep -U ntpd -l chronyd"
+
+  # 2.1.2.3 Ensure chrony is enabled and running. (Automated)
+  - id: 40649
+    title: "Ensure chrony is enabled and running."
+    description: "chrony is a daemon for synchronizing the system clock across the network."
+    rationale: "chrony needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF chrony is in use on the system, run the following commands: Run the following command to enable and start chronyd service: # service chronyd enable; # service chronyd start OR If another time synchronization service is in use on the system, run the following command to remove chrony: # pkg remove chrony -y."
+    compliance:
+      - cis: ["2.1.2.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n chronyd_enable -> r:^YES"
+      - "c:service chronyd status -> r:^chronyd is running as pid"
+
+  # 2.1.3.1 Ensure ntp access control is configured. (Automated)
+  - id: 40650
+    title: "Ensure ntp access control is configured."
+    description: 'NTP access control is a security measure used to prevent fraudulent or inadvertent manipulation of a time server'
+    rationale: "If ntp is in use on the system, proper configuration is vital to ensuring time synchronization is accurate."
+    remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery OR If another time synchronization service is in use on the system, run the following command to stop ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+    compliance:
+      - cis: ["2.1.3.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1498", "T1498.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - 'f:/etc/ntp.conf -> r:^restrict\s*\t*-4\s*\t*default|^restrict\s*\t*default && r:\s*kod && r:\s*nomodify && r:\s*notrap && r:\s*nopeer && r:\s*noquery'
+      - 'f:/etc/ntp.conf -> r:^restrict\s*\t*-6\s*\t*default && r:\s*kod && r:\s*nomodify && r:\s*notrap && r:\s*nopeer && r:\s*noquery'
+
+  # 2.1.3.2 Ensure ntp is configured with authorized timeserver. (Manual)
+  - id: 40651
+    title: "Ensure ntp is configured with authorized timeserver."
+    description: '- pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. - server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses.'
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]>. Run the following command to load the updated time sources into ntp running config: # service ntp restart OR If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+      - "https://tf.nist.gov/tf-cgi/servers.cgi"
+    compliance:
+      - cis: ["2.1.3.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1498", "T1498.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "f:/etc/ntp.conf -> r:^pool"
+      - "f:/etc/ntp.conf -> r:^server"
+
+  # 2.1.3.3 Ensure ntp is running as user ntpd. (Automated)
+  - id: 40652
+    title: "Ensure ntp is running as user ntp."
+    description: "The ntpd application is part of FreeBD base system and it has a dedicated user account ntpd. This account is granted the access required by the ntpd daemon Note: - If chrony is used, ntpd should be removed and this section skipped - This recommendation only applies if ntpd is in use on the system - Only one time synchronization method should be in use on the system."
+    rationale: "The ntpd daemon should run with only the required privilege."
+    remediation: "The ntpd run by default using ntpd user. It can not changed. If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    references:
+      - "http://www.ntp.org/"
+    compliance:
+      - cis: ["2.1.3.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:pgrep -U ntpd -l ntpd -> r:ntpd"    
+
+  # 2.1.3.4 Ensure ntp is enabled and running. (Automated)
+  - id: 40653
+    title: "Ensure ntpd is enabled and running."
+    description: "ntpd is a daemon for synchronizing the system clock across the network."
+    rationale: "ntpd needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF ntpd is in use on the system, run the following commands: Run the following command to enable and start ntp service: # service ntpd enable; # service ntpd start OR If another time synchronization service is in use on the system, run the following command to disable ntp from the system: # service ntpd stop; # sysrc ntpd_enable=NO."
+    compliance:
+      - cis: ["2.1.3.4"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n ntpd_enable -> r:^YES"
+      - "c:service ntpd status -> r:^ntpd is running as pid"
+
+  ###############################################
+  # 2.2 Special Purpose Services
+  ###############################################
+  # 2.2.1 Ensure xinetd is not installed. (Automated)
+  - id: 40654
+    title: "Ensure xinetd is not installed."
+    description: "The eXtended InterNET Daemon (xinetd) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
+    rationale: "If there are no xinetd services required, it is recommended that the package be removed to reduce the attack surface are of the system. Note: If an xinetd service or services are required, ensure that any xinetd service not required is stopped and disabled."
+    remediation: "Run the following command to remove xinetd: # pkg remove xinetd -y."
+    compliance:
+      - cis: ["2.2.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v xinetd -> r:^xinetd"    
+
+  # 2.2.2 Ensure X Window System is not installed. (Automated)
+  - id: 40655
+    title: "Ensure X Window System is not installed."
+    description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
+    rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
+    impact: 'Many Unix-Like systems run applications which require a Java runtime. Some Java packages have a dependency on specific X Windows xorg-fonts. One workaround to avoid this dependency is to use the "headless" Java packages for your specific Java runtime, if provided by your distribution.'
+    remediation: "Remove the X Windows System packages: pkg remove 'xorg*'."
+    compliance:
+      - cis: ["2.2.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v xorg-server -> r:^xorg-server"      
+
+  # 2.2.3 Ensure Avahi Server is not installed. (Automated)
+  - id: 40656
+    title: "Ensure Avahi Server is not installed."
+    description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
+    rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
+    remediation: "Run the following commands to remove avahi-daemon: # service avahi_daaemon stop # sysrc -x avahi_daemon_enable  # pkg remove 'avahi*'."
+    compliance:
+      - cis: ["2.2.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v avahi-app -> r:^avahi-app"
+
+  # 2.2.4 Ensure CUPS is not installed. (Automated)
+  - id: 40657
+    title: "Ensure CUPS is not installed."
+    description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
+    rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface."
+    impact: "Removing CUPS will prevent printing from the system, a common task for workstation systems."
+    remediation: "Run one of the following commands to remove cups : # pkg remove cups."
+    references:
+      - "http://www.cups.org."
+    compliance:
+      - cis: ["2.2.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c: pkg query -x %n-%v cups -> r:^cups"
+
+  # 2.2.5 Ensure DHCP Server is not installed. (Automated)
+  - id: 40658
+    title: "Ensure DHCP Server is not installed."
+    description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
+    rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove isc-dhcp-server or dhcpd: # pkg remove 'isc-dhcp*' or pkg remove dhcpd."
+    references:
+      - "http://www.isc.org/software/dhcp."
+    compliance:
+      - cis: ["2.2.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dhcpd|isc-dhcp.*-server' -> r:dhcp"    
+
+  # 2.2.6 Ensure LDAP server is not installed. (Automated)
+  - id: 40659
+    title: "Ensure LDAP server is not installed."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove slapd: # pkg remove 'openldap*-server'."
+    references:
+      - "http://www.openldap.org."
+    compliance:
+      - cis: ["2.2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'openldap.*server' -> r:^openldap"    
+
+  # 2.2.7 Ensure NFS is not installed. (Automated)
+  - id: 40660
+    title: "Ensure NFS is not installed."
+    description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
+    rationale: "If the system does not export NFS shares, it is recommended that the nfs-kernel-server package be removed to reduce the remote attack surface."
+    remediation: "Run the following command to disable nfs: # sysctl kern.features.nfsd=0; # sysctl kern.features.nfscl=0 and add those entries to /etc/sysctl.conf"
+    compliance:
+      - cis: ["2.2.7"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:sysctl -n kern.features.nfsd -> r:0"
+      - "c:sysctl -n kern.features.nfscl -> r:0"      
+
+  # 2.2.8 Ensure DNS Server is not installed. (Automated)
+  - id: 40661
+    title: "Ensure DNS Server is not installed."
+    description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
+    rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following commands to disable DNS server: # pkg remove 'bind9*' or # pkg remove unbound."
+    compliance:
+      - cis: ["2.2.8"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v bind9 -> r:^bind9"    
+      - "not c:pkg query -x %n-%v unbound -> r:^unbound"      
+
+  # 2.2.9 Ensure FTP Server is not installed. (Automated)
+  - id: 40662
+    title: "Ensure FTP Server is not installed."
+    description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
+    rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended SFTP be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove ftp daemon: # pkg remove -x 'bbftp-server|ftpd|uftp'."
+    compliance:
+      - cis: ["2.2.9"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'bbftp-server|ftpd|uftp' -> r:ftp"
+
+  # 2.2.10 Ensure TFTP Server is not installed. (Automated)
+  - id: 40663
+    title: "Ensure TFTP Server is not installed."
+    description: "Trivial File Transfer Protocol (TFTP) is a simple protocol for exchanging files between two TCP/IP machines. TFTP servers allow connections from a TFTP Client for sending and receiving files."
+    rationale: "TFTP does not have built-in encryption, access control or authentication. This makes it very easy for an attacker to exploit TFTP to gain access to files."
+    remediation: "Run the following command to remove tftp servers: # pkg remove -x 'utftpd|tftp-'."
+    compliance:
+      - cis: ["2.2.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'utftpd|tftp-' -> r:tftp"
+
+  # 2.2.11 Ensure HTTP server is not installed. (Automated)
+  - id: 40664
+    title: "Ensure HTTP server is not installed."
+    description: "HTTP or web servers provide the ability to host web site content."
+    rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove httpd server: # pkg remove -x '^apache|^nginx|httpd'."
+    compliance:
+      - cis: ["2.2.11"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'nginx' -> r:^nginx"    
+      - "not c:pkg query -x %n-%v 'apache' -> r:^apache"
+      - "not c:pkg query -x %n-%v 'httpd' -> r:httpd"
+
+  # 2.2.12 Ensure IMAP and POP3 server are not installed. (Automated)
+  - id: 40665
+    title: "Ensure IMAP and POP3 server are not installed."
+    description: "dovecot-imapd, dovecot-pop3d, cyrus-imapd and pop3d are an open source IMAP and POP3 server for Unix based systems."
+    rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove imapd and pop3d servers: # pkg remove -x '^dovecot|^cyrus-imapd|^pop3d'."
+    compliance:
+      - cis: ["2.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dovecot' -> r:dovecot"    
+      - "not c:pkg query -x %n-%v 'cyrus-imapd' -> r:cyrus-imapd"      
+      - "not c:pkg query -x %n-%v 'pop3d' -> r:pop3d"
+
+  # 2.2.13 Ensure Samba is not installed. (Automated)
+  - id: 40666
+    title: "Ensure Samba is not installed."
+    description: "The Samba daemon allows system administrators to configure their FreeBSD systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Server Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
+    rationale: "If there is no need to mount directories and file systems to Windows systems, then this service should be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove samba: # pkg remove -x '^samba'."
+    compliance:
+      - cis: ["2.2.13"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1005", "T1039", "T1083", "T1135", "T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'samba' -> r:samba"
+
+  # 2.2.14 Ensure HTTP Proxy Server is not installed. (Automated)
+  - id: 40667
+    title: "Ensure HTTP Proxy Server is not installed."
+    description: "Squid, privoxy, tinyproxy, 3proxy are standard proxy servers used in many distributions and environments."
+    rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove squid: # pkg remove -x 'squid|privoxy|tinyproxy|3proxy'."
+    compliance:
+      - cis: ["2.2.14"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'squid' -> r:squid"    
+      - "not c:pkg query -x %n-%v 'privoxy' -> r:privoxy"      
+      - "not c:pkg query -x %n-%v 'tinyproxy' -> r:tinyproxy"      
+      - "not c:pkg query -x %n-%v '3proxy' -> r:3proxy"      
+
+  # 2.2.15 Ensure SNMP Server is not installed. (Automated)
+  - id: 40668
+    title: "Ensure SNMP Server is not installed."
+    description: 'Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system.'
+    rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the snmpd package should be removed to reduce the attack surface of the system. Note: If SNMP is required: - The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values. -."
+    remediation: "Run the following command to remove snmpd: # pkg remove net-snmp."
+    compliance:
+      - cis: ["2.2.15"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'net-snmp' -> r:net-snmp"    
+
+  # 2.2.16 Ensure NIS Server is not installed. (Automated)
+  - id: 40669
+    title: "Ensure NIS Server is not installed."
+    description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed and other, more secure services be used."
+    remediation: "Run the following command to disable nis: # service nis_server stop; # sysrc -x nis_server_enable OR # service nis_server disable."
+    compliance:
+      - cis: ["2.2.16"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c: sysrc -n nis_server_enable -> r:NO"
+
+  # 2.2.17 Ensure dnsmasq is not installed. (Automated)
+  - id: 40670
+    title: "Ensure dnsmasq is not installed."
+    description: "dnsmasq is a lightweight tool that provides DNS caching, DNS forwarding and DHCP (Dynamic Host Configuration Protocol) services."
+    rationale: "Unless a system is specifically designated to act as a DNS caching, DNS forwarding and/or DHCP server, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove dnsmasq: # pkg remove dnsmasq."
+    compliance:
+      - cis: ["2.2.17"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1210", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'dnsmasq' -> r:dnsmasq"    
+
+  # 2.2.18 Ensure telnet-server is not installed. (Automated)
+  - id: 40671
+    title: "Ensure telnetd is not installed."
+    description: "The telnetd package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
+    remediation: "Run the following command to remove the telnetd package: # pkg remove freebsd-telnetd."
+    compliance:
+      - cis: ["2.2.18"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - nist_sp_800-53: ["CM-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'freebsd-telnetd' -> r:^freebsd-telnetd"
+
+  # 2.2.19 Ensure sendmail transfer agent is configured for local-only mode. (Automated)
+  - id: 40672
+    title: "Ensure sendmail transfer agent is configured for local-only mode."
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: - This recommendation is designed around the postfix mail server. - Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /etc/rc.conf and add the following line: sendmail_enable=NO or sendmail_enable=NONE."
+    compliance:
+      - cis: ["2.2.19"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1018", "T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:sysrc -n sendmail_enable -> r:YES"
+      - "c:sysrc -n sendmail_enable -> r:NO|NONE"      
+      
+  # 2.2.20 Ensure postfix mail transfer agent is configured for local-only mode. (Automated)
+  - id: 40673
+    title: "Ensure postfix mail transfer agent is configured for local-only mode."
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: - This recommendation is designed around the postfix mail server. - Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /usr/local/etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only Run the following command to restart postfix: # service postfix restart."
+    compliance:
+      - cis: ["2.2.20"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1018", "T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "f:/usr/local/etc/postfix/main.cf -> r:^inet_interfaces = loopback-only"
+
+  # 2.2.21 Ensure rsync service is either not installed or is masked. (Automated)
+  - id: 40674
+    title: "Ensure rsync service is either not installed or is masked."
+    description: "The rsync service can be used to synchronize files between systems over network links."
+    rationale: "The rsync service presents a security risk as the rsync protocol is unencrypted. The rsync package should be removed or if required for dependencies, the rsync service should be stopped and masked to reduce the attack area of the system."
+    remediation: "Run the following command to remove rsync: # pkg remove rsync"
+    compliance:
+      - cis: ["2.2.21"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1105", "T1203", "T1210", "T1543", "T1543.002", "T1570"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'rsync' -> r:rsync"
+
+  # 2.3.1 Ensure NIS Client is not installed. (Automated)
+  - id: 40675
+    title: "Ensure NIS Client is not installed."
+    description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client was used to bind a machine to an NIS server and receive the distributed configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Disable nis client: # service nis_client stop; # service nis_client disable."
+    compliance:
+      - cis: ["2.3.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:sysrc -n nis_client_enable -> r:YES"
+
+  # 2.3.2 Ensure rsh client is not installed. (Automated)
+  - id: 40676
+    title: "Ensure rsh client is not installed."
+    description: "The bsdrcmds package contains the client commands for the rsh services."
+    rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Uninstall rsh: # pkg remove bsdrcmds."
+    compliance:
+      - cis: ["2.3.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1040", "T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:   
+      - "not c:pkg query -x %n-%v 'bsdrcmds' -> r:bsdrcmds"
+
+  # 2.3.3 Ensure talk client is not installed. (Automated)
+  - id: 40677
+    title: "Ensure talk client is not installed."
+    description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
+    rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Remove talk: # rm /usr/bin/talk."
+    compliance:
+      - cis: ["2.3.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0006", "TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/bin/talk"
+
+  # 2.3.4 Ensure telnet client is not installed. (Automated)
+  - id: 40678
+    title: "Ensure telnet client is not installed."
+    description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Remove talk: # rm /usr/bin/telnet."
+    compliance:
+      - cis: ["2.3.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1041", "M1042"]
+      - mitre_tactics: ["TA0006", "TA0008"]
+      - mitre_techniques: ["T1040", "T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/bin/telnet"    
+
+  # 2.3.5 Ensure LDAP client is not installed. (Automated)
+  - id: 40679
+    title: "Ensure LDAP client is not installed."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
+    impact: "Removing the LDAP client will prevent or inhibit using LDAP for authentication in your environment."
+    remediation: "Uninstall ldap client: # pkg remove -x 'openldap.*-client'."
+    compliance:
+      - cis: ["2.3.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:pkg query -x %n-%v 'openldap.*client' -> r:openldap"    
+
+  # 2.3.6 Ensure RPC is not installed. (Automated)
+  - id: 40680
+    title: "Ensure RPC is not installed."
+    description: 'Remote Procedure Call (RPC) is a method for creating low level client server applications across different system architectures. It requires an RPC compliant client listening on a network port. The supporting package is rpcbind.".'
+    rationale: "If RPC is not required, it is recommended that this services be removed to reduce the remote attack surface."
+    remediation: "Run the following command to remove rpcbind: # rm /usr/sbin/rpcbind."
+    compliance:
+      - cis: ["2.3.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1203", "T1543", "T1543.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not f:/usr/sbin/rpcbind"
+
+  # 2.4 Ensure nonessential services are removed or masked. (Manual) - Not Implemented
+
+  ###############################################
+  # 3 Network Configuration
+  ###############################################
+  ###############################################
+  # 3.1 Disable unused network protocols and devices
+  ###############################################
+  # 3.1.1 Ensure IPv6 status is identified. (Manual)
+  - id: 40681
+    title: "Ensure IPv6 status is identified."
+    description: "Internet Protocol Version 6 (IPv6) is the most recent version of Internet Protocol (IP). It's designed to supply IP addressing and additional security to support the predicted growth of connected devices. IPv6 is based on 128-bit addressing and can support 340 undecillion addresses, which is 340 followed by 36 zeroes. Features of IPv6 - Hierarchical addressing and routing infrastructure - Stateful and Stateless configuration - Support for quality of service (QoS) - An ideal protocol for neighboring node interaction."
+    rationale: "IETF RFC 4038 recommends that applications are built with an assumption of dual stack. It is recommended that IPv6 be enabled and configured in accordance with Benchmark recommendations. If dual stack and IPv6 are not used in your environment, IPv6 may be disabled to reduce the attack surface of the system, and recommendations pertaining to IPv6 can be skipped. Note: It is recommended that IPv6 be enabled and configured unless this is against local site policy."
+    impact: "IETF RFC 4038 recommends that applications are built with an assumption of dual stack. When enabled, IPv6 will require additional configuration to reduce risk to the system."
+    remediation: "Enable or disable IPv6 in accordance with system requirements and local site policy."
+    compliance:
+      - cis: ["3.1.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1557", "T1595", "T1595.001", "T1595.002"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n ipv6_activate_all_interfaces -> r:NO"
+      - "c:sysrc -n ip6addrctl_enable -> r:NO"
+
+  # 3.1.2 Ensure wireless interfaces are disabled. (Automated) - Not Implemented
+
+  # 3.1.3 Ensure bluetooth is disabled. (Automated)
+  - id: 40682
+    title: "Ensure bluetooth is disabled."
+    description: "Bluetooth is a short-range wireless technology standard that is used for exchanging data between devices over short distances. It employs UHF radio waves in the ISM bands, from 2.402 GHz to 2.48 GHz. It is mainly used as an alternative to wire connections."
+    rationale: "An attacker may be able to find a way to access or corrupt your data. One example of this type of activity is bluesnarfing, which refers to attackers using a Bluetooth connection to steal information off of your Bluetooth device. Also, viruses or other malicious code can take advantage of Bluetooth technology to infect other devices. If you are infected, your data may be corrupted, compromised, stolen, or lost."
+    impact: "Many personal electronic devices (PEDs) use Bluetooth technology. For example, you may be able to operate your computer with a wireless keyboard. Disabling Bluetooth will prevent these devices from connecting to the system."
+    remediation: "Run the following commands to stop and disable the Bluetooth service # kldunload ng_ubt and add ng_ubt to module_blacklist variable into /boot/loader.conf #  Note: A reboot may be required."
+    references:
+      - "https://www.cisa.gov/tips/st05-015"
+    compliance:
+      - cis: ["3.1.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:kldstat -n ng_ubt -> r:ng_ubt && !r:ng_ubt.ko$"
+      - 'not f:/boot/loader.conf -> r:ng_ubt_load && r:YES'            
+        
+  # 3.1.4 Ensure SCTP is disabled. (Automated) - Not Implemented
+  - id: 40683
+    title: "Ensure SCTP is disabled."
+    description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
+    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
+    remediation: 'Edit /boot/loader.conf and add sctp to module_blacklist variable. Note: A reboot may be required.'
+    compliance:
+      - cis: ["3.1.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:kldstat -n sctp -> r:sctp && !r:sctp.ko$"
+      - 'not f:/boot/loader.conf -> r:sctp_load && r:YES'      
+        
+  # 3.1.5 Ensure RDS is disabled. (Automated) Not Implemented
+  # 3.1.6 Ensure TIPC is disabled. (Automated) - Not Implemented
+
+  ###############################################
+  # 3.2 Network Parameters (Host Only)
+  ###############################################
+  # 3.2.1 Ensure packet redirect sending is disabled
+  - id: 40684
+    title: Ensure packet redirect sending is disabled
+    description: >
+      ICMP Redirects are used to send routing information to other hosts. As a host itself does
+      not act as a router (in a host only configuration), there is no need to send redirects.
+    rationale: >
+      An attacker could use a compromised host to send invalid ICMP redirects to other router
+      devices in an attempt to corrupt routing and have users access a system set up by the
+      attacker as opposed to a valid system.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.icmp.drop_redirect = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.icmp.drop_redirect=1
+    compliance:
+      - cis: ["3.2.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.icmp.drop_redirect -> r:1'
+
+  # 3.2.2 Ensure IP forwarding is disabled. (Automated) - Not Implemented
+  - id: 40685
+    title: Ensure IP forwarding is disabled.
+    description: >
+      IP forwarding allows the system to move traffic between interfaces that belong to the same 
+      machine (router) and forward the packets to the appropriate interface according to the 
+      machine's routing table
+    rationale: >
+      Keep this parameter disabled to prevent denial of service attacks through spoofed packets.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.ip.forwarding = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.ip.forwarding=1
+    compliance:
+      - cis: ["3.2.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.ip.forwarding -> r:0'
+
+  ###############################################
+  # 3.3 Network Parameters (Host and Router)
+  ###############################################
+  # 3.3.1 Ensure source routed packets are not accepted. (Automated) - Not Implemented
+  # 3.3.2 Ensure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.3 Ensure secure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.4 Ensure suspicious packets are logged. (Automated) - Not Implemented
+  # 3.3.5 Ensure broadcast ICMP requests are ignored
+  - id: 40686
+    title: Ensure broadcast ICMP requests are ignored
+    description: >
+      Setting net.inet.icmp.bmcastecho to 0 will cause the system to ignore all
+      ICMP echo and timestamp requests to broadcast and multicast addresses.
+    rationale: >
+      Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for
+      your network could be used to trick your host into starting (or participating) in a Smurf
+      attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast
+      messages with a spoofed source address. All hosts receiving this message and responding
+      would send echo-reply messages back to the spoofed address, which is probably not
+      routable. If many hosts respond to the packets, the amount of traffic on the network could
+      be significantly multiplied.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.icmp.bmcastecho = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.icmp.bmcastecho=0
+    compliance:
+      - cis: ["3.3.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.icmp.bmcastecho -> r:0'
+
+  # 3.3.6 Ensure bogus ICMP responses are ignored. (Automated) - Not Implemented
+  # 3.3.7 Ensure Reverse Path Filtering is enabled. (Automated) - Not Implemented
+  # 3.3.8 Ensure TCP SYN Cookies is enabled
+  - id: 40687
+    title: Ensure TCP SYN Cookies is enabled
+    description: >
+      When net.inet.tcp.syncookies is set, the kernel will handle TCP SYN packets normally until the
+      half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN
+      cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the
+      SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that
+      encodes the source and destination IP address and port number and the time the packet
+      was sent. A legitimate connection would send the ACK packet of the three way handshake
+      with the specially crafted sequence number. This allows the system to verify that it has
+      received a valid response to a SYN cookie and allow the connection, even though there is no
+      corresponding SYN in the queue.
+    rationale: >
+      Attackers use SYN flood attacks to perform a denial of service attacked on a system by
+      sending many SYN packets without completing the three way handshake. This will quickly
+      use up slots in the kernel's half-open connection queue and prevent legitimate connections
+      from succeeding. SYN cookies allow the system to keep accepting valid connections, even if
+      under a denial of service attack.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet.tcp.syncookies = 1
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet.tcp.syncookies=1
+    compliance:
+      - cis: ["3.3.8"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet.tcp.syncookies -> r:1'
+      
+  # 3.3.9 Ensure IPv6 router advertisements are not accepted
+  - id: 40688
+    title: Ensure IPv6 router advertisements are not accepted
+    description: This setting disables the system's ability to accept IPv6 router advertisements.
+    rationale: >
+      It is recommended that systems do not accept router advertisements as they could be
+      tricked into routing traffic to compromised machines. Setting hard routes within the
+      system (usually a single default route to a trusted router) protects the system from bad
+      routes.
+    remediation: >
+      IF IPv6 is enabled:
+
+      Set the following parameters in /etc/sysctl.conf file:
+      net.inet6.ip6.accept_rtadv = 0
+
+      Run the following commands to set the active kernel parameters:
+      # sysctl net.inet6.ip6.accept_rtadv=0
+    compliance:
+      - cis: ["3.3.9"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl -n net.inet6.ip6.accept_rtadv -> r:0'      
+
+  ###############################################
+  # 3.4 Firewall Configuration
+  ###############################################
+  ###############################################
+  # 3.4.1 Configure Packet Filter firewall
+  ###############################################
+  # 3.4.1.1 Ensure packet filter is installed. (Automated)
+  - id: 40689
+    title: "Ensure Packet Filter is installed."
+    description: "FreeBSD has three firewalls built into the base system: PF, IPFW, and IPFILTER, also known as IPF. FreeBSD also provides two traffic shapers for controlling bandwidth usage: altq(4) and dummynet(4). ALTQ has traditionally been closely tied with PF and dummynet with IPFW. Each firewall uses rules to control the access of packets to and from a FreeBSD system, although they go about it in different ways and each has a different rule syntax."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "Packet Filter is part of FreeBSD base system."
+    compliance:
+      - cis: ["3.4.1.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/pfctl"           
+
+  # 3.4.1.2 Ensure Packet Filter is enabled and running. (Automated)
+  - id: 40690
+    title: "Ensure Packet Filter is enabled."
+    description: "Since FreeBSD 5.3, a ported version of OpenBSD’s PF firewall has been included as an integrated part of the base system. PF is a complete, full-featured firewall that has optional support for ALTQ (Alternate Queuing), which provides Quality of Service (QoS)."
+    rationale: "The service must be enabled and running in order for pf to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable pf: # service pf enable Run the following command to start the pf: # service pf start"
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-pf"
+    compliance:
+      - cis: ["3.4.1.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:YES"
+      - "c:kldstat -m pf -> r:pf && r:pf$"
+      - "c:service pf status -> r:^Status && r:Enabled"
+      - "c:sysrc -n ipfw_enable -> r:NO"  
+      - "c:kldstat -m ipfw -> r:ipfw && !r:ipfw$"          
+      - "c:sysrc -n ipfilter_enable -> r:NO"
+      - "c:kldstat -m ipfilter -> r:ipfilter && r:!ipfilter$"            
+
+  # 3.4.1.3 Ensure Packet Filter outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.1.4 Ensure Packet Filter firewall rules exist for all open ports. (Automated) - Not Implemented
+
+  # 3.4.1.5 Ensure Packet Filter default deny firewall policy. (Automated)
+  - id: 40691
+    title: "Ensure Packet Filter default deny firewall policy."
+    description: "A default deny policy on connections ensures that any unconfigured network usage will be rejected. Note: Any port or protocol without a explicit allow before the default deny will be blocked."
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
+    impact: "Any port and protocol not explicitly allowed will be blocked. The following rules should be considered before applying the default deny. ufw allow git ufw allow in http ufw allow out http <- required for apt to connect to repository ufw allow in https ufw allow out https ufw allow out 53 ufw logging on."
+    remediation: "Run the following commands to implement a default deny policy: # ufw default deny incoming # ufw default deny outgoing # ufw default deny routed."
+    compliance:
+      - cis: ["3.4.1.5"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - 'f:/etc/pf.conf -> r:^set block-policy'
+
+  ###############################################
+  # 3.4.2 Configure IPFW firewall
+  ###############################################
+  # 3.4.2.1 Ensure IPFW is installed. (Automated)
+  - id: 40692
+    title: "Ensure Packet Filter is installed."
+    description: "FreeBSD has three firewalls built into the base system: PF, IPFW, and IPFILTER, also known as IPF. FreeBSD also provides two traffic shapers for controlling bandwidth usage: altq(4) and dummynet(4). ALTQ has traditionally been closely tied with PF and dummynet with IPFW. Each firewall uses rules to control the access of packets to and from a FreeBSD system, although they go about it in different ways and each has a different rule syntax."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "IPFW is part of FreeBSD base system."
+    compliance:
+      - cis: ["3.4.2.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/ipfw"           
+
+  # 3.4.2.2 Ensure IPFW is enabled and running. (Automated)
+  - id: 40693
+    title: "Ensure IPFW is enabled and running."
+    description: "IPFW is a stateful firewall written for FreeBSD which supports both IPv4 and IPv6. It is comprised of several components: the kernel firewall filter rule processor and its integrated packet accounting facility, the logging facility, NAT, the dummynet(4) traffic shaper, a forward facility, a bridge facility, and an ipstealth facility."
+    rationale: "The service must be enabled and running in order for pf to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable ipfw: # service firewall enable. # sysrc firewall_type='open'. Run the following command to start the ipfw: # service ipfw start. Take on mind firewall_type='open' means passes all traffic. Look at ipfw documentation for more options."
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-ipfw"
+    compliance:
+      - cis: ["3.4.2.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:NO"
+      - "c:kldstat -m pf -> r:pf && !r:pf$"
+      - "c:sysrc -n ipfw_enable -> r:YES"
+      - "c:kldstat -m ipfw -> r:ipfw && r:ipfw$"
+      - "c:sysctl -n net.inet.ip.fw.enable -> r:1"                
+      - "c:sysrc -n ipfilter_enable -> r:NO"
+      - "c:kldstat -m ipfilter -> r:ipfilter && !r:ipfilter$"            
+
+  # 3.4.2.3 Ensure IPFW outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.2.4 Ensure IPFW firewall rules exist for all open ports. (Automated) - Not Implemented
+  # 3.4.2.5 Ensure IPFW default deny firewall policy. (Automated)
+      
+  ###############################################
+  # 3.4.3 Configure IPFilter firewall
+  ###############################################
+  # 3.4.3.1 Ensure IPFilter is installed. (Automated)
+  - id: 40694
+    title: "Ensure IPFilter is installed."
+    description: "IPFILTER is a kernel-side firewall and NAT mechanism that can be controlled and monitored by userland programs. Firewall rules can be set or deleted using ipf, NAT rules can be set or deleted using ipnat, run-time statistics for the kernel parts of IPFILTER can be printed using ipfstat, and ipmon can be used to log IPFILTER actions to the system log files."
+    rationale: "A firewall utility is required to configure the FreeBSD kernel's filter framework. The host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured."
+    remediation: "IPFilter is part of FreeBSD base system. If /sbin/ipfc is not found"
+    compliance:
+      - cis: ["3.4.3.1"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_mitigations: ["M1031", "M1037"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: any
+    rules:
+      - "f:/sbin/ipf"
+
+  # 3.4.3.2 Ensure IPFilter is enabled. (Automated)
+  - id: 40695
+    title: "Ensure IPFilter is enabled and running."
+    description: "IPFILTER is a kernel-side firewall and NAT mechanism that can be controlled and monitored by userland programs. Firewall rules can be set or deleted using ipf, NAT rules can be set or deleted using ipnat, run-time statistics for the kernel parts of IPFILTER can be printed using ipfstat, and ipmon can be used to log IPFILTER actions to the system log files."
+    rationale: "The service must be enabled and running in order for IPFilter to protect the system."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to enable IPFilter: # service ipfilter enable Run the following command to start the IPFilter: # service ipfilter start"
+    references:
+      - "https://docs.freebsd.org/en/books/handbook/firewalls/#firewalls-ipf"
+    compliance:
+      - cis: ["3.4.3.2"]
+      - cis_csc_v8: ["4.4", "4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.004"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1", "1.4"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:sysrc -n pf_enable -> r:NO"
+      - "c:kldstat -m pf -> r:pf && !r:pf$"
+      - "c:sysrc -n ipfw_enable -> r:NO"  
+      - "c:kldstat -m ipfw -> r:ipfw && !r:ipfw$"          
+      - "c:sysrc -n ipfilter_enable -> r:YES"
+      - "c:kldstat -m ipfilter -> r:ipfilter && r:ipfilter$"
+      - "c:/sbin/ipf -V -> r:'^Running: yes'"                  
+
+  # 3.4.3.3 Ensure IPFilter outbound connections are configured. (Manual) - Not Implemented
+  # 3.4.3.4 Ensure IPFilter firewall rules exist for all open ports. (Automated) - Not Implemented
+  # 3.4.3.5 Ensure IPFilter default deny firewall policy. (Not implemented)      
+  
+ ###############################################
+  # 4 Access, Authentication and Authorization
+  ###############################################
+  ###############################################
+  # 4.1 Configure time-based job schedulers
+  ###############################################  
+  # 4.1.1 Ensure cron daemon is enabled and active. (Automated)
+  - id: 40696
+    title: "Ensure cron daemon is enabled and active."
+    description: "The cron daemon is used to execute batch jobs on the system. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
+    remediation: "Run the following command to enable and start cron: # service cron enable # service cron start."
+    compliance:
+      - cis: ["4.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+    condition: all
+    rules:
+      - "c:sysrc -n cron_enable -> r:^YES"
+      - "c:service cron status -> r:^cron is running as pid"
+
+  # 4.1.2 Ensure permissions on /etc/crontab are configured. (Automated)
+  - id: 40697
+    title: "Ensure permissions on /etc/crontab are configured."
+    description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
+    remediation: "Run the following commands to set ownership and permissions on /etc/crontab : # chown root:wheel /etc/crontab # chmod 740 /etc/crontab."
+    compliance:
+      - cis: ["4.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/crontab -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/crontab -> r:^root:wheel"
+
+  # 4.1.3 Ensure permissions on /etc/cron.d are configured. (Automated)
+  - id: 40698
+    title: "Ensure permissions on /etc/cron.d are configured."
+    description: "The /etc/cron.d directory contains system cron jobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab, but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.d directory: # chown root:wheel /etc/cron.d/ # chmod 750 /etc/cron.d/."
+    compliance:
+      - cis: ["4.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002", "TA0007"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/cron.d -> r:^-rwxr-x---"
+      - "c:stat -f %Su:%Sg /etc/cron.d -> r:^root:wheel"
+
+  # 4.1.4 Ensure cron is restricted to authorized users. (Automated)
+  - id: 40699
+    title: "Ensure cron is restricted to authorized users."
+    description: "Configure /var/cron/allow to allow specific users to use this service. If /var/cron/allow does not exist, then /var/cron/deny is checked. Any user not specifically defined in this file is allowed to use cron. By removing the file, only users in /var/etc/cron/allow are allowed to use cron."
+    rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list."
+    remediation: "Remove /var/cron/deny if it exists - Create /var/cron/allow if it doesn't exist - Change ownership of /var/cron/allow to the root user and wheel group. Add only authorized users to /var/cron/allow file. Restart cron daemon # service cron restart."
+    compliance:
+      - cis: ["4.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/var/run/cron/allow"
+      - "c:stat -f %Sp /var/cron/allow -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /var/cron/allow -> r:^root:wheel"
+
+  # 4.1.5 Ensure at is restricted to authorized users. (Automated)
+  - id: 40700
+    title: "Ensure at is restricted to authorized users."
+    description: "Configure /var/at/at.allow to allow specific users to use this service. If /var/at/at.allow does not exist, then /var/at/at.deny is checked. Any user not specifically defined in this file is allowed to use at. By removing the file, only users in /etc/at.allow are allowed to use at. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, at should be removed, and the alternate method should be secured in accordance with local site policy."
+    rationale: "On many systems, only the system administrator is authorized to schedule at jobs. Using the at.allow file to control who can run at jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
+    remediation: "Remove /var/at/at.deny if it exists - Create /var/at/at.allow if it doesn't exist - Change ownership of /var/at/at.allow to the root user - Change group ownership of /var/at/at.allow to the group wheel. Add only authorized users to /var/at/at.allow file. Restart cron daemon # service cron restart."
+    compliance:
+      - cis: ["4.1.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_techniques: ["T1053", "T1053.003"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/var/at/at.allow"
+      - "c:stat -f %Sp /var/at/at.allow -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /var/at/at.allow -> r:^root:wheel"      
+
+  ###############################################
+  # 4.2 Configure SSH Server
+  ###############################################
+  # 4.2.1 Ensure permissions on /etc/ssh/sshd_config are configured. (Automated)
+  - id: 40701
+    title: "Ensure permissions on /etc/ssh/sshd_config are configured."
+    description: "The file /etc/ssh/sshd_config contain configuration specifications for sshd."
+    rationale: "configuration specifications for sshd need to be protected from unauthorized changes by non-privileged users."
+    remediation: "Change ownership and permissions on /etc/ssh/sshd_config file. # chown root:wheel /etc/ssh/sshd_config; # chmod 640 /etc/ssh/sshd_config."
+    compliance:
+      - cis: ["4.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1098", "T1098.004", "T1543", "T1543.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "f:/etc/ssh/sshd_config"
+      - "c:stat -f %Sp /etc/ssh/sshd_config -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/ssh/sshd_config -> r:^root:wheel"
+
+   # 4.2.2 Ensure permissions on SSH private host key files are configured. (Automated) - Not Implemented
+  - id: 40702
+    title: "Ensure permissions on SSH private host key files are configured."
+    description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a private host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Change mode, ownership, and group on the public SSH host key files: # chown root:wheel /etc/ssh/ssh_host*_key; # chmod 600 /etc/ssh/ssh_host*_key."
+    compliance:
+      - cis: ["4.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0003", "TA0006"]
+      - mitre_techniques: ["T1557"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key" -exec stat -f %Sp  {} \; -> r:^-rw-------'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel' 
+
+  # 4.2.3 Ensure permissions on SSH public host key files are configured. (Automated)
+  - id: 40703
+    title: "Ensure permissions on SSH public host key files are configured."
+    description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Change mode, ownership, and group on the public SSH host key files: # chown root:wheel /etc/ssh/ssh_host*.pub; # chmod 644 /etc/ssh/ssh_host*.pub."
+    compliance:
+      - cis: ["4.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0003", "TA0006"]
+      - mitre_techniques: ["T1557"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_*_key.pub" -exec stat -f %Sp  {} \; -> r:^-rw-r--r--'
+      - 'c:find /etc/ssh -xdev -type f -name 2ssh_host_*_key.pub" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel'      
+
+  # 4.2.4 Ensure SSH access is limited. (Automated)
+  - id: 40704
+    title: "Ensure SSH access is limited."
+    description: "There are several options available to limit which users and group can access the system via SSH. AllowUsers: o The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. AllowGroups: o The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. DenyUsers: o The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. DenyGroups: o The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
+    rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set one or more of the parameter above any Include entries as follows: AllowUsers <userlist> OR AllowGroups <grouplist> OR DenyUsers <userlist> OR DenyGroups <grouplist>."
+    compliance:
+      - cis: ["4.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1018"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021", "T1021.004"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^allowusers\s+\w+|^allowgroups\s+\w+|^denyusers\s+\w+|^*denygroups\s+\w+'
+      - 'f:/etc/ssh/sshd_config -> r:^AllowUsers\s+\w+|^AllowGroups\s+\w+|^DenyUsers\s+\w+|^DenyGroups\s+\w+'
+
+  # 4.2.5 Ensure SSH LogLevel is appropriate. (Automated)
+  - id: 40705
+    title: "Ensure SSH LogLevel is appropriate."
+    description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
+    rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: LogLevel VERBOSE OR LogLevel INFO Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "https://www.ssh.com/ssh/sshd_config/"
+    compliance:
+      - cis: ["4.2.5"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^loglevel\s+INFO|^loglevel\s+VERBOSE'
+      - 'not f:/etc/ssh/sshd_config -> !r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
+
+  # 4.2.6 Ensure SSH PAM is enabled. (Automated)
+  - id: 40706
+    title: "Ensure SSH PAM is enabled."
+    description: "The UsePAM directive enables the Pluggable Authentication Module (PAM) interface. If set to yes this will enable PAM authentication using ChallengeResponseAuthentication and PasswordAuthentication directives in addition to PAM account and session module processing for all authentication types."
+    rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: UsePAM yes Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.6"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1035"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1021", "T1021.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*usepam\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*UsePAM\s+no'
+
+  # 4.2.7 Ensure SSH root login is disabled. (Automated)
+  - id: 40707
+    title: "Ensure SSH root login is disabled."
+    description: "The PermitRootLogin parameter specifies if the root user can log in using SSH. The default is prohibit-password."
+    rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root. This limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitRootLogin no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.7"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permitrootlogin\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitRootLogin\s+yes'
+
+  # 4.2.8 Ensure SSH HostbasedAuthentication is disabled. (Automated)
+  - id: 40708
+    title: "Ensure SSH HostbasedAuthentication is disabled."
+    description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication."
+    rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: HostbasedAuthentication no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.8"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*hostbasedauthentication\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*HostbasedAuthentication\s+yes'
+
+  # 4.2.9 Ensure SSH PermitEmptyPasswords is disabled. (Automated)
+  - id: 40709
+    title: "Ensure SSH PermitEmptyPasswords is disabled."
+    description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
+    rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitEmptyPasswords no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.9"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permitemptypasswords\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitEmptyPasswords\s+yes'
+
+  # 4.2.10 Ensure SSH PermitUserEnvironment is disabled. (Automated)
+  - id: 40710
+    title: "Ensure SSH PermitUserEnvironment is disabled."
+    description: "The PermitUserEnvironment option allows users to present environment options to the SSH daemon."
+    rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has SSH executing trojan'd programs)."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: PermitUserEnvironment no Note: First occurrence of a option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.10"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1021"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permituserenvironment\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitUserEnvironment\s+yes'
+
+  # 4.2.11 Ensure SSH IgnoreRhosts is enabled. (Automated)
+  - id: 40711
+    title: "Ensure SSH IgnoreRhosts is enabled."
+    description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
+    rationale: "Setting this parameter forces users to enter a password when authenticating with SSH."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: IgnoreRhosts yes Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.11"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*ignorerhosts\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*IgnoreRhosts\s+no'
+
+  # 4.2.12 Ensure SSH X11 forwarding is disabled. (Automated)
+  - id: 40712
+    title: "Ensure SSH X11 forwarding is disabled."
+    description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
+    rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: X11Forwarding no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1210"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*x11forwarding\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s+yes'
+
+  # 4.2.13 Ensure only strong Ciphers are used. (Automated)
+  - id: 40713
+    title: "Ensure only strong Ciphers are used."
+    description: 'This variable limits the ciphers that SSH can use during communication. Note: - Some organizations may have stricter requirements for approved ciphers. - Ensure that ciphers used are in compliance with site policy. - The only "strong" ciphers currently FIPS 140-2 compliant are: o aes256-ctr o aes192-ctr o aes128-ctr.'
+    rationale: 'Weak ciphers like 3DES that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised.'
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma separated list of the site approved ciphers. Example: Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128- gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr."
+    references:
+      - "https://nvd.nist.gov/vuln/detail/CVE-2016-2183"
+      - "https://www.openssh.com/txt/cbc.adv"
+      - "https://nvd.nist.gov/vuln/detail/CVE-2008-5161"
+    compliance:
+      - cis: ["4.2.13"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|rijndael-cbc@lysator.liu.se"
+
+  # 4.2.14 Ensure only strong MAC algorithms are used. (Automated)
+  - id: 40714
+    title: "Ensure only strong MAC algorithms are used."
+    description: 'This variable limits the types of MAC algorithms that SSH can use during communication. The only "strong" MACs currently FIPS 140-2 approved are: o hmac-sha2-256 o hmac-sha2-512.'
+    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information."
+    remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs above any Include entries: Example: MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2- 512,hmac-sha2-256,umac-128-etm@openssh.com,umac-128@openssh.com."
+    references:
+      - "http://www.mitls.org/pages/attacks/SLOTH"
+    compliance:
+      - cis: ["4.2.14"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4", "16.5"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:macs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com"
+
+  # 4.2.15 Ensure only strong Key Exchange algorithms are used. (Automated)
+  - id: 40715
+    title: "Ensure only strong Key Exchange algorithms are used."
+    description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties. The only Key Exchange Algorithms currently FIPS 140-2 approved are: o ecdh-sha2-nistp256 o ecdh-sha2-nistp384 o ecdh-sha2-nistp521 o diffie-hellman-group-exchange-sha256 o diffie-hellman-group16-sha512 o diffie-hellman-group18-sha512 o diffie-hellman-group14-sha256."
+    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks."
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to list of the site approved key exchange algorithms. Example: KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256."
+    compliance:
+      - cis: ["4.2.15"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1040", "T1557"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
+    rules:
+      - "not c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1"
+
+  # 4.2.16 Ensure SSH AllowTcpForwarding is disabled. (Automated)
+  - id: 40716
+    title: "Ensure SSH AllowTcpForwarding is disabled."
+    description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines."
+    rationale: "Leaving port forwarding enabled can expose the organization to security risks and backdoors. SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network."
+    impact: "SSH tunnels are widely used in many corporate environments. In some environments the applications themselves may have very limited native support for security. By utilizing tunneling, compliance with SOX, HIPAA, PCI-DSS, and other standards can be achieved without having to modify the applications."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: AllowTcpForwarding no Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    references:
+      - "https://www.ssh.com/ssh/tunneling/example"
+    compliance:
+      - cis: ["4.2.16"]
+      - mitre_mitigations: ["M1042"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_techniques: ["T1048", "T1048.002", "T1572"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*allowtcpforwarding\s+no'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*AllowTcpForwarding\s+yes'
+
+  # 4.2.17 Ensure SSH warning banner is configured. (Automated)
+  - id: 40717
+    title: "Ensure SSH warning banner is configured."
+    description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
+    rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: Banner /path/ro/banner Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.17"]
+      - mitre_mitigations: ["M1035"]
+      - mitre_tactics: ["TA0001", "TA0007"]
+    condition: all
+    rules:
+      - 'not c:sshd -T -> r:^\s*banner\s+none'
+
+  # 4.2.18 Ensure SSH MaxAuthTries is set to 4 or less. (Automated)
+  - id: 40718
+    title: "Ensure SSH MaxAuthTries is set to 4 or less."
+    description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
+    rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxAuthTries 4 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.18"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - mitre_mitigations: ["M1036"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1110", "T1110.001", "T1110.003"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^maxauthtries\s*\t*(\d+) compare <= 4'
+      - 'not f:/etc/ssh/sshd_config -> n:^MaxAuthTries\s*\t*(\d+) compare > 4'
+
+  # 4.2.19 Ensure SSH MaxStartups is configured. (Automated)
+  - id: 40719
+    title: "Ensure SSH MaxStartups is configured."
+    description: "The MaxStartups parameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon."
+    rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxStartups 10:30:60 Note: First occurrence of an option takes precedence. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.19"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1499", "T1499.002"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*maxstartups\s+10:30:60'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxStartups\s+(((1[1-9]|[1-9][0-9][0-9]+):([0-9]+):([0-9]+))|(([0-9]+):(3[1-9]|[4-9][0-9]|[1-9][0-9][0-9]+):([0-9]+))|(([0-9]+):([0-9]+):(6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+)))'
+
+  # 4.2.20 Ensure SSH LoginGraceTime is set to one minute or less. (Automated)
+  - id: 40720
+    title: "Ensure SSH LoginGraceTime is set to one minute or less."
+    description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
+    rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: LoginGraceTime 60 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.20"]
+      - mitre_mitigations: ["M1036"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1110", "T1110.001", "T1110.003", "T1110.004"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:logingracetime\s*\t*(\d+) compare <= 60 && n:LoginGraceTime\s*\t*(\d+) compare != 0'
+      - 'not f:/etc/ssh/sshd_config -> r:\s*LoginGraceTime\s+(0|6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+|[^1]m)'
+
+  # 4.2.21 Ensure SSH MaxSessions is set to 10 or less. (Automated)
+  - id: 40721
+    title: "Ensure SSH MaxSessions is set to 10 or less."
+    description: "The MaxSessions parameter specifies the maximum number of open sessions permitted from a given connection."
+    rationale: "To protect a system from denial of service due to a large number of concurrent sessions, use the rate limiting function of MaxSessions to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter above any Include entries as follows: MaxSessions 10 Note: First occurrence of a option takes precedence, Match set statements withstanding. If Include locations are enabled, used, and order of precedence is understood in your environment, the entry may be created in a file in Include location."
+    compliance:
+      - cis: ["4.2.21"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1499", "T1499.002"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^\s*maxsessions\s+(\d+) compare <= 10'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxSessions\s+(1[1-9]|[2-9][0-9]|[1-9][0-9][0-9]+)'
+
+  # 4.2.22 Ensure SSH Idle Timeout Interval is configured. (Automated)
+  - id: 40722
+    title: "Ensure SSH Idle Timeout Interval is configured."
+    description: "ClientAliveInterval sets a timeout interval in seconds after which if no data has been received from the client. ClientAliveCountMax sets the number of client alive messages which may be sent without sshd(8) receiving any messages back from the client. It is important to note that the use of client alive messages is very different from TCPKeepAlive. The client alive messages are sent through the encrypted channel and therefore will not be spoofable. The TCP keepalive option enabled by TCPKeepAlive is spoofable."
+    rationale: "In order to prevent resource exhaustion, appropriate values should be set for both ClientAliveInterval and ClientAliveCountMax. Specifically, looking at the source code, ClientAliveCountMax must be greater than zero in order to utilize the ability of SSH to drop idle connections. If connections are allowed to stay open indefinately, this can potentially be used as a DDOS attack or simple resource exhaustion could occur over unreliable networks. The example set here is a 45 second timeout. Consult your site policy for network timeouts and apply as appropriate."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameters above any Include entries according to site policy. Example: ClientAliveInterval 15 ClientAliveCountMax 3."
+    references:
+      - "https://man.openbsd.org/sshd_config"
+    compliance:
+      - cis: ["4.2.22"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:clientaliveinterval\s*\t*(\d+) compare > 0'
+      - 'c:sshd -T -> n:clientalivecountmax\s*\t*(\d+) compare > 0'
+
+  ############################################################
+  # 4.3 Configure privilege escalation
+  ############################################################
+  # 4.3.1 Ensure sudo is installed. (Automated)
+  - id: 40723
+    title: "Ensure sudo is installed."
+    description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
+    rationale: "sudo supports a plug-in architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plug-ins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers and any entries in /etc/sudoers.d. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
+    remediation: "Install sudo. Example: # pkg install sudo."
+    compliance:
+      - cis: ["4.3.1"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v sudo -> r:^sudo"    
+
+  # 4.3.2 Ensure sudo commands use pty. (Automated)
+  - id: 40724
+    title: "Ensure sudo commands use pty."
+    description: "sudo can be configured to run only from a pseudo terminal (pseudo-pty)."
+    rationale: "Attackers can run a malicious program using sudo which would fork a background process that remains even when the main program has finished executing."
+    impact: "WARNING: Editing the sudo configuration incorrectly can cause sudo to stop functioning. Always use visudo to modify sudo configuration files."
+    remediation: "Edit the file /usr/local/etc/sudoers with ee or a file in /usr/local//etc/sudoers.d/ with ee <PATH TO FILE> and add the following line: Defaults use_pty Note: - sudo will read each file in /usr/local/etc/sudoers.d, skipping file names that end in ~ or contain a . character to avoid causing problems with package manager or editor temporary/backup files. - Files are parsed in sorted lexical order. That is, /etc/sudoers.d/01_first will be parsed before /etc/sudoers.d/10_second. - Be aware that because the sorting is lexical, not numeric, /usr/local/etc/sudoers.d/1_whoops would be loaded after /usr/local/etc/sudoers.d/10_second. - Using a consistent number of leading zeroes in the file names can be used to avoid such problems."
+    compliance:
+      - cis: ["4.3.2"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - mitre_mitigations: ["M1026", "M1038"]
+      - mitre_tactics: ["TA0001", "TA0003"]
+      - mitre_techniques: ["T1078", "T1078.003", "T1548", "T1548.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: any
+    rules:
+      - 'not f:/usr/local/etc/sudoers -> r:^Defaults\s*!use_pty'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> r:^Defaults\s*!use_pty'
+
+  # 4.3.3 Ensure sudo log file exists. (Automated)
+  - id: 40725
+    title: "Ensure sudo log file exists."
+    description: "sudo can use a custom log file."
+    rationale: "A sudo log file simplifies auditing of sudo commands."
+    impact: "WARNING: Editing the sudo configuration incorrectly can cause sudo to stop functioning. Always use visudo to modify sudo configuration files."
+    remediation: 'Edit the file /usr/local/etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH TO FILE> and add the following line: Example: Defaults logfile="/var/log/sudo.log" Note: - sudo will read each file in /etc/sudoers.d, skipping file names that end in ~ or contain a . character to avoid causing problems with package manager or editor temporary/backup files. - Files are parsed in sorted lexical order. That is, /etc/sudoers.d/01_first will be parsed before /etc/sudoers.d/10_second. - Be aware that because the sorting is lexical, not numeric, /etc/sudoers.d/1_whoops would be loaded after /etc/sudoers.d/10_second. - Using a consistent number of leading zeroes in the file names can be used to avoid such problems.'
+    compliance:
+      - cis: ["4.3.3"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: any
+    rules:
+      - 'f:/usr/local/etc/sudoers -> r:^\s*\t*Defaults\s*\t*logfile='
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile='
+
+  # 4.3.4 Ensure users must provide password for privilege escalation. (Automated)
+  - id: 40726
+    title: "Ensure users must provide password for privilege escalation."
+    description: "The operating system must be configured so that users must provide a password for privilege escalation."
+    rationale: "Without (re-)authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user (re-)authenticate."
+    impact: "This will prevent automated processes from being able to elevate privileges."
+    remediation: "Based on the outcome of the audit procedure, use ee <PATH TO FILE> to edit the relevant sudoers file. Remove any line with occurrences of NOPASSWD tags in the file."
+    compliance:
+      - cis: ["4.3.4"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1548"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - "f:/usr/local/etc/sudoers -> !r:^# && r:*NOPASSWD"
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:*NOPASSWD'
+
+  # 4.3.5 Ensure re-authentication for privilege escalation is not disabled globally. (Automated)
+  - id: 40727
+    title: "Ensure re-authentication for privilege escalation is not disabled globally."
+    description: "The operating system must be configured so that users must re-authenticate for privilege escalation."
+    rationale: "Without re-authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate."
+    remediation: "Configure the operating system to require users to reauthenticate for privilege escalation. Based on the outcome of the audit procedure, use ee <PATH TO FILE> to edit the relevant sudoers file. Remove any occurrences of !authenticate tags in the file(s)."
+    compliance:
+      - cis: ["4.3.5"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - 'f:/usr/local/etc/sudoers -> !r:^# && r:*\!authenticate'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> !r:^# && r:*\!authenticate'
+
+  # 4.3.6 Ensure sudo authentication timeout is configured correctly. (Automated)
+  - id: 40728
+    title: "Ensure sudo authentication timeout is configured correctly."
+    description: "sudo caches used credentials for a default of 5 minutes. This is for ease of use when there are multiple administrative tasks to perform. The timeout can be modified to suit local security policies. This default is distribution specific. See audit section for further information."
+    rationale: "Setting a timeout value reduces the window of opportunity for unauthorized privileged access to another user."
+    remediation: "If the currently configured timeout is larger than 5 minutes, edit the file listed in the audit section with ee <PATH TO FILE> and modify the entry timestamp_timeout= to 5 minutes or less as per your site policy. The value is in minutes. This particular entry may appear on it's own, or on the same line as env_reset. See the following two examples: Defaults env_reset, timestamp_timeout=5 Defaults timestamp_timeout=5 Defaults env_reset."
+    references:
+      - "https://www.sudo.ws/man/1.9.14/sudoers.man.html"
+    compliance:
+      - cis: ["4.3.6"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - 'c:sudo -V -> r:Authentication timestamp timeout:\s*\t*5.0 minutes'
+      - 'f:/usr/local/etc/sudoers -> n:timestamp_timeout=(\d+) compare <=5'
+      - 'd:/usr/local/etc/sudoers.d -> r:\.* -> n:timestamp_timeout=(\d+) compare <=5'
+
+  # 4.3.7 Ensure access to the su command is restricted. (Automated)
+  - id: 40729
+    title: "Ensure access to the su command is restricted."
+    description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in a specific groups to execute su. This group should be empty to reinforce the use of sudo for privileged access."
+    rationale: "Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program."
+    remediation: "Check wheel group into /etc/pam.d/su for use of the su command. the line could look like the following: auth requisite pam_group.so no_warn group=wheel root_only fail_safe ruser."
+    compliance:
+      - cis: ["4.3.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/su -> !r:^# && r:auth\s*requisite\s*pam_group.so && r:\sgroup=wheel\s'
+      
+  # 4.3.8 Ensure doas is installed. (Automated)
+  - id: 40730
+    title: "Ensure doas is installed."
+    description: "doas allows a permitted user to execute a command as the superuser or another user, as specified by the security policy."
+    rationale: "The default security policy is configured via /usr/local/etc/doas.conf. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism."
+    remediation: "Install doas. Example: # pkg install doas."
+    compliance:
+      - cis: ["4.3.1"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1078", "T1078.003"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: all
+    rules:
+      - "c:pkg query %n-%v doas -> r:^doas"   
+      
+  # 4.3.9 Ensure users must provide password for privilege escalation. (Automated)
+  - id: 40731
+    title: "Ensure doas users must provide password for privilege escalation."
+    description: "The operating system must be configured so that users must provide a password for privilege escalation."
+    rationale: "Without authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user (re-)authenticate."
+    impact: "This will prevent automated processes from being able to elevate privileges."
+    remediation: "Based on the outcome of the audit procedure, use ee /usr/local/etc/doas.conf file. Remove any line with occurrences of nopass tags in the file."
+    compliance:
+      - cis: ["4.3.4"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1078", "T1548"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
+    condition: none
+    rules:
+      - "f:/usr/local/etc/doas.conf -> !r:^# && r:*nopass"          
+
+  ###############################################
+  # 4.4 Configure PAM and login.conf
+  ###############################################
+  # 4.4.1 Ensure password creation requirements are configured. (Automated)
+  # 4.4.2 Ensure lockout for failed password attempts is configured. (Automated)
+  # 4.4.3 Ensure password reuse is limited. (Automated)
+  # 4.4.4 Ensure strong password hashing algorithm is configured. (Automated)
+  - id: 40732
+    title: "Ensure strong password hashing algorithm is configured."
+    description: "Hash functions behave as one-way functions by using mathematical operations that are extremely difficult and cumbersome to revert When a user is created, the password is run through a one-way hashing algorithm before being stored. When the user logs in, the password sent is run through the same one-way hashing algorithm and compared to the hash connected with the provided username. If the hashed password and the stored hash match, the login is valid."
+    rationale: "The SHA512 hashing algorithm provides stronger hashing than previous available algorithms like MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords."
+    remediation: "Note: - Pay special attention to the configuration. Incorrect configuration can cause system lock outs. - This is an example configuration. Your configuration may differ based on previous changes to the files."
+    compliance:
+      - cis: ["4.4.4"]
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["16.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1"]
+      - mitre_mitigations: ["M1041"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1110", "T1110.002"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "f:/etc/login.conf -> r:passwd_format && r:sha512|blf"
+
+  # 4.4.5 Ensure all current passwords uses the configured hashing algorithm. (Manual) - Not Implemented
+
+  ###############################################
+  # 4.5 User Accounts and Environment
+  ###############################################
+  ###############################################
+  # 4.5.1 Set Shadow Password Suite Parameters
+  ###############################################
+  # 4.5.1.1 Ensure password expiration is 365 days or less. (Automated)
+  - id: 40733
+    title: "Ensure password expiration is 365 days or less."
+    description: "The passwordtime parameter in /etc/login.conf allows an administrator to force passwords to expire once they reach a defined age."
+    rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity. It is recommended that the passwordtime parameter does not exceed 365 days and is greater than the value of 1."
+    remediation: "Set the passwordtime parameter to conform to site policy in /etc/login.conf : passwordtime=365d. Modify user parameters for all users with a password set to match: # pw usermod <user> -p +365d."
+    references:
+      - "https://www.cisecurity.org/white-papers/cis-password-policy-guide/"
+    compliance:
+      - cis: ["4.5.1.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.conf -> n:^\t:passwordtime=(\d+)\w: compare <= 365'
+      - 'f:/etc/login.conf -> n:^\t:passwordtime=(\d+)\w: compare > 0'
+
+  # 4.5.1.2 Ensure password expiration warning days is 7 or more. (Automated)
+  - id: 40734
+    title: "Ensure password expiration warning days is 7 or more."
+    description: "The warnpassword parameter in /etc/login.conf allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
+    rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
+    remediation: "Set the warnpassword parameter to 7 in /etc/login.conf: warnpassword=7d."
+    compliance:
+      - cis: ["4.5.1.2"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1078.004", "T1110", "T1110.001", "T1110.002", "T1110.003", "T1110.004"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.conf -> n:^\t:warnpassword=(\d+)\w: compare >= 7'
+
+  # 4.5.1.3 Ensure inactive password lock is 30 days or less. (Automated)
+  # 4.5.1.4 Ensure all users last password change date is in the past. (Automated) - Not Implemented
+  # 4.5.1.5 Ensure the number of changed characters in a new password is configured. (Automated)
+  # 4.5.1.6 Ensure preventing the use of dictionary words for passwords is configured. (Automated)
+  # 4.5.2 Ensure system accounts are secured. (Automated) - Not Implemented
+
+  # 4.5.3 Ensure default group for the root account is GID 0. (Automated)
+  - id: 40735
+    title: "Ensure default group for the root account is GID 0."
+    description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
+    rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
+    remediation: "Run the following command to set the root user default group to GID 0 : # usermod -g 0 root."
+    compliance:
+      - cis: ["4.5.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1548"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/passwd -> !r:^# && r:root:\w+:\w+:0:'
+
+  # 4.5.4 Ensure default user umask is 027 or more restrictive. (Automated) - Not Implemented
+  # 4.5.5 Ensure default user shell timeout is configured. (Automated) - Not Implemented
+
+  # 4.5.6 Ensure nologin is not listed in /etc/shells. (Automated)
+  - id: 40736
+    title: "Ensure nologin is not listed in /etc/shells."
+    description: "/etc/shells is a text file which contains the full pathnames of valid login shells. This file is consulted by chsh and available to be queried by other programs. Be aware that there are programs which consult this file to find out if a user is a normal user; for example, FTP daemons traditionally disallow access to users with shells not included in this file."
+    rationale: "A user can use chsh to change their configured shell. If a user has a shell configured that isn't in in /etc/shells, then the system assumes that they're somehow restricted. In the case of chsh it means that the user cannot change that value. Other programs might query that list and apply similar restrictions. By putting nologin in /etc/shells, any user that has nologin as its shell is considered a full, unrestricted user. This is not the expected behavior for nologin."
+    remediation: "Edit /etc/shells and remove any lines that include nologin."
+    compliance:
+      - cis: ["4.5.6"]
+    condition: all
+    rules:
+      - "not f:/etc/shells -> !r:^# && r:nologin"
+
+  # 4.5.7 Ensure maximum number of same consecutive characters in a password is configured. (Automated)
+
+   ###############################################
+  # 5.1 Logging and auditing
+  ###############################################
+  # 5.1.1 Configure syslog
+  ###############################################
+  # 5.1.1.1 Ensure syslog is installed. (Automated)
+  - id: 40737
+    title: "Ensure syslog is installed."
+    description: "FreeBSD provides a system logger, syslogd(8), to manage logging. By default, syslogd is enabled and started when the system boots."
+    rationale: "The security enhancements of syslog such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
+    remediation: "The syslog is installed by default on FreeBSD. If it is not available an incomplete or modified version of FreeBSD is running."
+    compliance:
+      - cis: ["5.1.1.1"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1005", "T1070", "T1070.002"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "f:/usr/sbin/syslogd"
+
+  # 5.1.1.2 Ensure syslog service is enabled. (Automated)
+  - id: 40738
+    title: "Ensure syslog service is enabled."
+    description: "Once the syslog package is installed, ensure that the service is enabled."
+    rationale: "If the syslog service is not enabled to start on boot, the system will not capture logging events."
+    remediation: "Run the following command to enable syslog: # service syslogd enable; # service syslogd start."
+    compliance:
+      - cis: ["5.1.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:service syslogd status -> r:^syslogd is running as pid"
+
+  # 5.1.1.3 Ensure syslog is not configured to receive logs from a remote client. (Automated)
+  - id: 40739
+    title: "Ensure syslog is not configured to receive logs from a remote client."
+    description: "Syslog supports the ability to receive messages from remote hosts, thus acting as a log server. Clients should not receive data from other hosts."
+    rationale: "If a client is configured to also receive data, thus turning it into a server, the client system is acting outside it's operational boundary."
+    remediation: 'Disable syslog for not log messages from remote machines: # sysrc syslogd_flags="-ss".If -s is specified twice, no network socket will be opened at all, which also disables logging to remote machines'
+    compliance:
+      - cis: ["5.1.1.3"]
+      - cis_csc_v8: ["4.8", "8.2"]
+      - cis_csc_v7: ["6.2", "6.3", "9.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1", "A.13.1.3"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "10.2", "10.3", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "2.2.4", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - 'c: sysrc -n syslogd_flags -> r:^-ss'
+
+  # 5.1.1.8 Ensure all logfiles have appropriate access configured. (Automated) - Not Implemented
+
+  ############################################################
+  # 5.2 Configure System Accounting (auditd).
+  ############################################################
+  ############################################################
+  # 5.2.1 Ensure auditing is enabled.
+  ############################################################
+  # 5.2.1.1 Ensure auditd is installed. (Automated)
+  - id: 40740
+    title: "Ensure auditd is installed."
+    description: "The FreeBSD operating system includes support for security event auditing. Event auditing supports reliable, fine-grained, and configurable logging of a variety of security-relevant system events, including logins, configuration changes, and file and network access."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "The auditd is installed by default on FreeBSD. If it is not available an incomplete or modified version of FreeBSD is running."
+    compliance:
+      - cis: ["5.2.1.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f: /usr/sbin/auditd"
+
+  # 5.2.1.2 Ensure auditd service is enabled and active. (Automated)
+  - id: 40741
+    title: "Ensure auditd service is enabled and active."
+    description: "Turn on the auditd daemon to record system events."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "Run the following command to enable and start auditd: # service auditd enable; # service auditd start."
+    compliance:
+      - cis: ["5.2.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1028"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.001"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "c:sysrc -n auditd_enable -> r:^YES"
+      - "c:service auditd status -> r:^auditd is running as pid"
+
+  # 5.2.1.3 Ensure audit log storage size is configured. (Automated)
+  - id: 40742
+    title: "Ensure audit log storage size is configured."
+    description: "Configure the filesz of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
+    rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
+    remediation: "Set the following parameter in /etc/security/audit_control in accordance with site policy: filesz:2M B(Bytes), K(Kilobytes), M(Megabytes), or G(Gigabytes)."
+    compliance:
+      - cis: ["5.2.1.3"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^filesz:(\d+)M'
+
+  # 5.2.1.4 Ensure audit logs are not automatically deleted. (Automated)
+  - id: 40743
+    title: "Ensure audit logs are not automatically deleted."
+    description: "The expire-after setting determines how to handle the audit log file reaching the max file size. No expire-after value never delete old logs."
+    rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
+    remediation: "Remove the following parameter in /etc/audit/audit_control: expire-after."
+    compliance:
+      - cis: ["5.2.1.4"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'not f:/etc/security/audit_control -> r:^expire-after'
+
+  # 5.2.1.5 Ensure system is disabled when audit logs are full. (Automated)
+
+  # 5.2.3.1 Ensure changes to system administration events are collected. (Automated)
+  - id: 40744
+    title: "Ensure changes to system administration events are collected."
+    description: 'Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope..'
+    rationale: "Administration system changes can indicate that an unauthorized change has been made to the scope of system administrator activity."
+    remediation: "Edit /etc/security/audit_control file and add or check if exist the following flags: ad,ex,fw. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ad' 
+      - 'f:/etc/security/audit_control -> r:^flags: && r:+ex|ex'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:+fw|fw'      
+
+  # 5.2.3.2 Ensure actions as another user are always logged. (Automated)
+  - id: 40745
+    title: "Ensure actions as another user are always logged."
+    description: "sudo provides users with temporary elevated privileges to perform operations, either as the superuser or another user."
+    rationale: "Creating an audit log of users with temporary elevated privileges and the operation(s) they performed is essential to reporting. Administrators will want to correlate the events written to the audit trail with the records written to sudo's logfile to verify if unauthorized commands have been executed."
+    remediation: "Create audit rules editing /etc/security/audit_user file. Add an user with sudo privileges entry like the following: sudouser:lo,aa,ad:no. If you want apply flags globally the following must be added to flags: lo,aa,ad into /etc/security/audit_control. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.2"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.9.4.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:lo'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:aa'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ad'      
+
+  # 5.2.3.3 Ensure events that modify the sudo log file are collected. (Automated) - Not Implemented
+  # 5.2.3.4 Ensure events that modify date and time information are collected. (Automated)  
+
+  # 5.2.3.5 Ensure events that modify the system's network environment are collected. (Automated)
+  - id: 40746
+    title: "Ensure events that modify the system's network environment are collected."
+    description: "Record changes to network environment files or system calls. The below parameters monitors the following system calls, and write an audit event on system call exit: - sethostname - set the systems host name - setdomainname - set the systems domain name The files being monitored are: - /etc/issue and /etc/issue.net - messages displayed pre-login - /etc/hosts - file containing host names and associated IP addresses - /etc/networks - symbolic names for networks - /etc/network/ - directory containing network interface scripts and configurations files."
+    rationale: "Monitoring network events will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. All audit records should have a relevant tag associated with them."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events that modify the system's network environment. flags: +nt,+fm,+exe. Restart auditd service: # service auditd restart or restart OS: # reboot."
+    compliance:
+      - cis: ["5.2.3.5"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:nt|+nt'
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fm|+fm'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:exe|+exe'      
+
+  # 5.2.3.6 Ensure use of privileged commands are collected. (Automated) - Not Implemented
+  
+  # 5.2.3.7 Ensure unsuccessful file access attempts are collected. (Automated) - Not Implemented
+  - id: 40747
+    title: "Ensure unsuccessful file access attempts are collected."
+    description: "Record events of unsuccessful file access attempts."
+    rationale: "Monitoring unsucessful file access attempts could be an indication that the system has been compromised and that an unauthorized user is attempting to modify configuration system files."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events of unsuccessful file access attempts. flags: -fr. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.7"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fr|-fr'
+
+  # 5.2.3.8 Ensure events that modify user/group information are collected. (Automated)
+  - id: 40748
+    title: "Ensure events that modify files are collected."
+    description: 'Record events affecting the files modification.'
+    rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor events of modify files. flags: +fr,+fw,+fm. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.8"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fm|+fm'      
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fr|+fr'
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fw|+fw'      
+
+  # 5.2.3.9 Ensure discretionary access control permission modification events are collected. (Automated) - Not Implemented
+
+  # 5.2.3.10 Ensure login and logout events are collected. (Automated)
+  - id: 40749
+    title: "Ensure login and logout events are collected."
+    description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events."
+    rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor login and logout events. flags: lo. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.10"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9", "16.11", "16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.9.4.2"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3", "AU-3(1)"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:lo'
+
+  # 5.2.3.11 Ensure file deletion events by users are collected. (Automated)
+  - id: 40750
+    title: "Ensure file deletion events by users are collected."
+    description: 'Monitor the use of system calls associated with the deletion or renaming of files and file attributes.'
+    rationale: "Monitoring these calls from users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor delete files events. flags: +fd. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.11"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:fd|+fd'
+
+   # 5.2.3.12 Ensure successful and unsuccessful attempts to use commands are recorded. (Automated)
+  - id: 40751
+    title: "Ensure successful and unsuccessful attempts to use commands are recorded."
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the commands."
+    rationale: "The system commands can be used to change file security context. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system."
+    remediation: "Edit /etc/securty/audit_control file and add the relevant rules to monitor delete files events. flags: ex. Restart auditd service: # service auditd restart or restart OS: # reboot"
+    compliance:
+      - cis: ["5.2.3.12"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1562", "T1562.006"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "f:/etc/security/audit_control"
+      - 'f:/etc/security/audit_control -> r:^flags: && r:ex'
+
+  # 5.2.3.13 Ensure the audit configuration is immutable. (Automated)
+  # 5.2.3.14 Ensure the running and on disk configuration is the same. (Manual)
+  
+  # 5.2.4.1 Ensure audit log files are mode 0640 or less permissive. (Automated)
+  - id: 40752
+    title: "Ensure audit log files are mode 0640 or less permissive."
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: 'Run the following command to configure the audit log files to fix the permissions: # find /var/audit/ -type f -exec chmod 440 {} \\;'
+    compliance:
+      - cis: ["5.2.4.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /var/audit -xdev -type f -exec stat -f %Sp {} \; -> r:^-r--r-----'
+
+  # 5.2.4.2 Ensure only authorized users and groups are assigned ownership of audit log files. (Automated)
+  - id: 40753
+    title: "Ensure only authorized groups are assigned ownership of audit log files."
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: "Run the following command to configure the audit log files to be group owned by audit: # find /var/audit/ -type f -exec chown root:audit {} \\;"
+    compliance:
+      - cis: ["5.2.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:find /var/audit -xdev -type f -exec stat -f %Su:%Sg {} \; -> r:^root:audit'
+
+  # 5.2.4.4 Ensure the audit log directory is 0750 or more restrictive. (Automated)  
+
+  # 5.2.4.5 Ensure audit configuration files are 640 or more restrictive. (Automated)
+  - id: 40754
+    title: "Ensure audit configuration files are 640 or more restrictive."
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to fix permissive mode from the audit configuration files: # chmod 440 /etc/security/audit_class /etc/security/audit_event # chmod 600 /etc/security/audit_control /etc/security/audit_user # chmod 500 /etc/security/audit_warn."
+    compliance:
+      - cis: ["5.2.4.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:stat -f %Sp /etc/security/audit_class -> r:^-r--r-----'      
+      - 'c:stat -f %Sp /etc/security/audit_control -> r:^-rw-------'
+      - 'c:stat -f %Sp /etc/security/audit_event -> r:^-r--r-----'
+      - 'c:stat -f %Sp /etc/security/audit_user -> r:^-rw-------'
+      - 'c:stat -f %Sp /etc/security/audit_warn -> r:^-r-x------' 
+
+  # 5.2.4.6 Ensure audit configuration files are owned by root. (Automated)
+  - id: 40755
+    title: "Ensure audit configuration files are owned by root and wheel group."
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to change ownership to root user: # find /etc/security -xdev -type f -name 'audit_*' -exec chown root:wheel {} \\;"
+    compliance:
+      - cis: ["5.2.4.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:  
+      - 'c:find /etc/security -xdev -type f -name "audit_*" -exec stat -f %Su:%Sg  {} \; -> r:^root:wheel'                       
+          
+  # 5.2.4.7 Ensure audit tools are 755 or more restrictive. (Automated)
+  - id: 40756
+    title: "Ensure audit tools are 755 or more restrictive."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to remove more permissive mode from the audit tools: # chmod 555 /usr/sbin/audit /usr/sbin/auditd /usr/sbin/auditdistd /usr/sbin/auditreduce /usr/sbin/paudit."
+    compliance:
+      - cis: ["5.2.4.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /usr/sbin/audit -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditd -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditdistd -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/auditreduce -> r:^-r-xr-xr-x"
+      - "c:stat -f %Sp /usr/sbin/praudit -> r:^-r-xr-xr-x"
+
+  # 5.2.4.8 Ensure audit tools are owned by root. (Automated)
+  - id: 40757
+    title: "Ensure audit tools are owned by root and group wheel."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to change the owner of the audit tools to the root user and group wheel: # chown root:wheel /usr/sbin/audit /usr/sbin/auditd /usr/sbin/auditdistd /usr/sbin/auditreduce /usr/sbin/paudit."
+    compliance:
+      - cis: ["5.2.4.8"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Su:%Sg /usr/sbin/audit -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditd -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditdistd -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/auditreduce -> r:^root:wheel"
+      - "c:stat -f %Su:%Sg /usr/sbin/praudit -> r:^root:wheel"                        
+
+   # 5.2.4.9 Ensure cryptographic mechanisms are used to protect the integrity of audit tools. (Automated)
+  - id: 40758
+    title: "Ensure cryptographic mechanisms are used to protect the integrity of audit tools."
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records."
+    rationale: "Protecting the integrity of the tools used for auditing purposes is a critical step toward ensuring the integrity of audit information. Attackers may replace the audit tools or inject code into the existing tools with the purpose of providing the capability to hide or erase system activity from the audit logs. Audit tools should be cryptographically signed in order to provide the capability to identify when the audit tools have been modified, manipulated, or replaced. An example is a checksum hash of the file or files."
+    remediation: "Add/Update the following selection lines to /usr/local/etc/aide.conf to protect the integrity of the audit tools: # Audit Tools /usr/sbin/audit p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditdistd p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/auditreduce p+i+n+u+g+s+b+acl+xattrs+sha512 /usr/sbin/paudit p+i+n+u+g+s+b+acl+xattrs+sha512."
+    compliance:
+      - cis: ["5.2.4.9"]
+      - mitre_mitigations: ["M1047"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
+    condition: all
+    rules:
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/audit p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditdistd p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/auditreduce p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "f:/usr/local/etc/aide.conf -> r:/usr/sbin/paudit p+i+n+u+g+s+b+acl+xattrs+sha512"
+
+  ###############################################
+  # 6 System Maintenance
+  ###############################################
+  ###############################################
+  # 6.1 System File Permissions
+  ###############################################
+  # 6.1.1 Ensure permissions on /etc/passwd are configured. (Automated)
+  - id: 40759
+    title: "Ensure permissions on /etc/passwd are configured."
+    description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
+    rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/passwd: # chmod 640 /etc/passwd # chown root:wheel /etc/passwd."
+    compliance:
+      - cis: ["6.1.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/passwd -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/passwd -> r:^root:wheel"    
+
+  # 6.1.2 Ensure permissions on /etc/group are configured. (Automated)
+  - id: 40760
+    title: "Ensure permissions on /etc/group are configured."
+    description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
+    rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/group: # chmod 640 /etc/group # chown root:wheel /etc/group."
+    compliance:
+      - cis: ["6.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/group -> r:^-rw-r-----"
+      - "c:stat -f %Su:%Sg /etc/group -> r:^root:wheel"
+
+  # 6.1.3 Ensure permissions on /etc/master.passwd are configured. (Automated)
+  - id: 40761
+    title: "Ensure permissions on /etc/master.passwd are configured."
+    description: "The /etc/master.passwd file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
+    rationale: "If attackers can gain read access to the /etc/master.passwd file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/master.passwd file (such as expiration) could also be useful to subvert the user accounts."
+    remediation: "Run one of the following commands to set ownership of /etc/master.passwd to root and group to either root and wheel: # chown root:wheel /etc/master.passwd. Run the following command to remove excess permissions form /etc/master.passwd: # chmod 600 /etc/master.passwd."
+    compliance:
+      - cis: ["6.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/master.passwd -> r:^-rw-------"
+      - "c:stat -f %Su:%Sg /etc/master.passwd -> r:^root:wheel"
+
+   # 6.1.4 Ensure permissions on /etc/shells are configured. (Automated)
+  - id: 40762
+    title: "Ensure permissions on /etc/shells are configured."
+    description: "/etc/shells is a text file which contains the full pathnames of valid login shells. This file is consulted by chsh and available to be queried by other programs."
+    rationale: "It is critical to ensure that the /etc/shells file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/shells: # chmod 644 /etc/shells # chown root:wheel /etc/shells."
+    compliance:
+      - cis: ["6.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_mitigations: ["M1022"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1003", "T1003.008", "T1222", "T1222.002"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:stat -f %Sp /etc/shells -> r:^-rw-r--r--"
+      - "c:stat -f %Su:%Sg /etc/shells -> r:^root:wheel"    
+
+  # 6.1.5 Ensure world writable files and directories are secured. (Automated) - Not Implemented
+  # 6.1.6 Ensure no unowned or ungrouped files or directories exist. (Automated) - Not Implemented
+  # 6.1.7 Ensure SUID and SGID files are reviewed. (Manual) - - Not Implemented
+
+  ################################################
+  # 6.2 User and Group Settings
+  ################################################
+  # 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords. (Automated)
+  - id: 40763
+    title: "Ensure accounts in /etc/passwd use encrypted passwords."
+    description: "Local accounts can uses encrypted passwords. With encrypted passwords, The passwords are saved in /etc/master.passwd file encrypted by crypt. Accounts with a encrypted password have an * in the second field in /etc/passwd."
+    rationale: "The /etc/passwd file also contains information like user ID's and group ID's that are used by many system programs. Therefore, the /etc/passwd file must remain world readable. In spite of encoding the password with a randomly-generated one-way hash function, an attacker could still break the system if they got access to the /etc/passwd file. This can be mitigated by using encrypted passwords. The /etc/master.passwd file is set so only root will be able to read and write. This helps mitigate the risk of an attacker gaining access to the encoded passwords with which to perform a dictionary attack."
+    remediation: "Run the following command to set accounts to use encrypted passwords: # sed -e 's/^\\([a-zA-Z0-9_]*\\):[^:]*:/\\1:*:/' -i /etc/passwd Investigate to determine if the account is logged in and what it is being used for, to determine if it needs to be forced off."
+    compliance:
+      - cis: ["6.2.1"]
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["16.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1003", "T1003.008"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'not f:/etc/passwd -> !r:^\w+:*:'
+
+  # 6.2.2 Ensure /etc/shadow password fields are not empty. (Automated)
+  - id: 40764
+    title: "Ensure /etc/master.passwd password fields are not empty."
+    description: "An account with an empty password field means that anybody may log in as that user without providing a password."
+    rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
+    remediation: "If any accounts in the /etc/master.passwd file do not have a password, run the following command to lock the account until it can be determined why it does not have a password: # pw lock <username> Also, check to see if the account is logged in and investigate what it is being used for to determine if it needs to be forced off."
+    compliance:
+      - cis: ["6.2.2"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_mitigations: ["M1027"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'not f:/etc/master.passwd -> r:^\w+::'
+
+  # 6.2.3 Ensure all groups in /etc/passwd exist in /etc/group. (Automated) - Not Implemented
+  # 6.2.4 Ensure no duplicate UIDs exist. (Automated) - Not Implemented
+  # 6.2.5 Ensure no duplicate GIDs exist. (Automated) - Not Implemented
+  # 6.2.6 Ensure no duplicate user names exist. (Automated) - Not Implemented
+  # 6.2.7 Ensure no duplicate group names exist. (Automated) - Not Implemented
+  # 6.2.8 Ensure root PATH Integrity. (Automated) - Not Implemented
+
+  # 6.2.9 Ensure root is the only UID 0 account. (Automated)
+  - id: 40765
+    title: "Ensure root is the only UID 0 account."
+    description: "Any account with UID 0 has superuser privileges on the system."
+    rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
+    remediation: "Remove any users other than root with UID 0 or assign them a new UID if appropriate."
+    compliance:
+      - cis: ["6.2.9"]
+      - mitre_mitigations: ["M1026"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_techniques: ["T1548"]
+    condition: all
+    rules:
+      - 'not f:/etc/passwd -> !r:^\s*\t*# && !r:^root: && r:^\w+:\w+:0:'
+
+  # 6.2.10 Ensure local interactive user home directories are configured. (Automated) - Not Implemented
+  # 6.2.11 Ensure local interactive user dot files access is configured. (Automated) - Not Implemented

--- a/src/data_provider/src/sysInfoFreeBSD.cpp
+++ b/src/data_provider/src/sysInfoFreeBSD.cpp
@@ -11,6 +11,7 @@
 #include "sysInfo.hpp"
 #include "cmdHelper.h"
 #include "stringHelper.h"
+#include "timeHelper.h"
 #include "osinfo/sysOsParsers.h"
 #include <sys/sysctl.h>
 #include <sys/vmmeter.h>
@@ -19,12 +20,13 @@
 
 static void getMemory(nlohmann::json& info)
 {
+    constexpr auto vmFree{"vm.stats.vm.v_free_count"};
+    constexpr auto vmInactive{"vm.stats.vm.v_inactive_count"};
     constexpr auto vmPageSize{"vm.stats.vm.v_page_size"};
-    constexpr auto vmTotal{"vm.vmtotal"};
+    constexpr auto vmTotal{"hw.physmem"};
     uint64_t ram{0};
-    const std::vector<int> mib{CTL_HW, HW_PHYSMEM};
     size_t len{sizeof(ram)};
-    auto ret{sysctl(const_cast<int*>(mib.data()), mib.size(), &ram, &len, nullptr, 0)};
+    auto ret{sysctlbyname(vmTotal, &ram, &len, nullptr, 0)};
 
     if (ret)
     {
@@ -52,11 +54,9 @@ static void getMemory(nlohmann::json& info)
         };
     }
 
-    struct vmtotal vmt {};
-
-    len = sizeof(vmt);
-
-    ret = sysctlbyname(vmTotal, &vmt, &len, nullptr, 0);
+    uint64_t freeMem{0};
+    len = sizeof(freeMem);
+    ret = sysctlbyname(vmFree, &freeMem, &len, nullptr, 0);
 
     if (ret)
     {
@@ -64,11 +64,25 @@ static void getMemory(nlohmann::json& info)
         {
             ret,
             std::system_category(),
-            "Error reading total memory."
+            "Error reading free memory size."
         };
     }
 
-    const auto ramFree{(vmt.t_free * pageSize) / KByte};
+    uint64_t inactiveMem{0};
+    len = sizeof(inactiveMem);
+    ret = sysctlbyname(vmInactive, &inactiveMem, &len, nullptr, 0);
+
+    if (ret)
+    {
+        throw std::system_error
+        {
+            ret,
+            std::system_category(),
+            "Error reading inactive memory size."
+        };
+    }
+
+    const auto ramFree{(freeMem + inactiveMem) * pageSize / KByte};
     info["ram_free"] = ramFree;
     info["ram_usage"] = 100 - (100 * ramFree / ramTotal);
 }
@@ -184,8 +198,12 @@ nlohmann::json SysInfo::getPackages() const
 
 nlohmann::json SysInfo::getProcessesInfo() const
 {
-    // Currently not supported for this OS
-    return nlohmann::json {};
+    nlohmann::json ret;
+    getProcessesInfo([&ret](nlohmann::json & data)
+    {
+        ret.push_back(data);
+    });
+    return ret;
 }
 
 nlohmann::json SysInfo::getOsInfo() const
@@ -196,10 +214,11 @@ nlohmann::json SysInfo::getOsInfo() const
 
     if (!spParser->parseUname(Utils::exec("uname -r"), ret))
     {
-        ret["os_name"] = "BSD";
         ret["os_platform"] = "bsd";
         ret["os_version"] = UNKNOWN_VALUE;
     }
+
+    ret["os_name"] = "FreeBSD";
 
     if (uname(&uts) >= 0)
     {
@@ -215,18 +234,129 @@ nlohmann::json SysInfo::getOsInfo() const
 
 nlohmann::json SysInfo::getPorts() const
 {
-    // Currently not supported for this OS.
-    return nlohmann::json {};
+    const auto query{Utils::exec(R"(sockstat -46qs)")};
+    nlohmann::json ports {};
+
+    if (!query.empty())
+    {
+        const auto lines{Utils::split(Utils::trimToOneSpace(query), '\n')};
+
+        for (const auto& line : lines)
+        {
+            std::string localip = "";
+            std::string localport = "";
+            std::string remoteip = "";
+            std::string remoteport = "";
+            const auto data{Utils::split(line, ' ')};
+            auto localdata{Utils::split(data[5], ':')};
+            auto remotedata{Utils::split(data[6], ':')};
+            auto statedata{Utils::toLowerCase(data[7])};
+
+            localip = localdata[0];
+            localport = localdata[1];
+            remoteip = remotedata[0];
+            remoteport = remotedata[1];
+
+            if(statedata == "listen") {
+              statedata = "listening";
+            }
+
+            if(localdata.size() == 4) {
+              localip = localdata[0] + ":"+ localdata[1] + ":" + localdata[2];
+              localport = localdata[3];
+            } else if(localip == "*") {
+              if((data[4] == "tcp6") || (data[4] == "udp6")) {
+                localip = "0:0:0:0:0:0:0:0";
+              } else {
+                localip = "0.0.0.0";
+              }
+            }
+
+            if(remotedata.size() == 4) {
+              remoteip = remotedata[0] + ":"+ remotedata[1] + ":" + remotedata[2];
+              remoteport = remotedata[3];
+            } else if(remoteport == "*") {
+                remoteip = "";
+                remoteport = "";
+            }
+
+            if(data[0] != "?") {
+              nlohmann::json port {};
+              port["protocol"] = data[4];
+              port["local_ip"] = localip;
+              port["local_port"] = localport;
+              port["remote_ip"] = remoteip;
+              port["remote_port"] = remoteport;
+              port["tx_queue"] = 0;
+              port["rx_queue"] = 0;
+              port["inode"] = data[3];
+              port["state"] = statedata;
+              port["pid"] = data[2];
+              port["process"] = data[1];
+
+              ports.push_back(port);
+            }
+        }
+    }
+
+    return ports;
 }
 
-void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/) const
+void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) const
 {
-    // Currently not supported for this OS.
+    const auto query{Utils::exec(R"(ps -ax -w -o pid,comm,state,ppid,usertime,systime,user,ruser,svuid,group,rgroup,svgid,pri,nice,ssiz,vsz,rss,pmem,etimes,sid,pgid,tpgid,tty,cpu,nlwp,args --libxo json)")};
+
+    if (!query.empty())
+    {
+      nlohmann::json psjson;
+      psjson = nlohmann::json::parse(query);
+      auto &processes = psjson["process-information"]["process"];
+
+      for(auto &process : processes) {
+          std::string user_time{""};
+          std::string system_time{""};
+
+          user_time = process["user-time"].get<std::string>();
+          system_time = process["system-time"].get<std::string>();
+
+          nlohmann::json jsProcessInfo{};
+          jsProcessInfo["pid"]        = process["pid"].get<std::string>();
+          jsProcessInfo["name"]       = process["command"].get<std::string>();
+          jsProcessInfo["state"]      = process["state"].get<std::string>();
+          jsProcessInfo["ppid"]       = process["ppid"].get<std::string>();
+          jsProcessInfo["utime"]      = Utils::timeToSeconds(user_time);
+          jsProcessInfo["stime"]      = Utils::timeToSeconds(system_time);
+          jsProcessInfo["cmd"]        = process["command"].get<std::string>();
+          jsProcessInfo["argvs"]      = process["arguments"].get<std::string>();
+          jsProcessInfo["euser"]      = process["user"].get<std::string>();
+          jsProcessInfo["ruser"]      = process["real-user"].get<std::string>();
+          jsProcessInfo["suser"]      = process["saved-uid"].get<std::string>();
+          jsProcessInfo["egroup"]     = process["group"].get<std::string>();
+          jsProcessInfo["rgroup"]     = process["real-group"].get<std::string>();
+          jsProcessInfo["sgroup"]     = process["saved-gid"].get<std::string>();
+          jsProcessInfo["fgroup"]     = process["group"].get<std::string>();
+          jsProcessInfo["priority"]   = process["priority"].get<std::string>();
+          jsProcessInfo["nice"]       = process["nice"].get<std::string>();
+          jsProcessInfo["size"]       = process["stack-size"].get<std::string>();
+          jsProcessInfo["vm_size"]    = process["virtual-size"].get<std::string>();
+          jsProcessInfo["resident"]   = process["rss"].get<std::string>();
+          jsProcessInfo["share"]      = process["percent-memory"].get<std::string>();
+          jsProcessInfo["start_time"] = process["elapsed-times"].get<std::string>();
+          jsProcessInfo["pgrp"]       = process["process-group"].get<std::string>();
+          jsProcessInfo["session"]    = process["sid"].get<std::string>();
+          jsProcessInfo["tgid"]       = process["terminal-process-gid"].get<std::string>();
+          //jsProcessInfo["tty"]        = process["tty"].get<std::string>(); // this field should be TEXT into local.db
+          jsProcessInfo["processor"]  = process["on-cpu"].get<std::string>();
+          jsProcessInfo["nlwp"]       = process["threads"].get<std::string>();
+
+          callback(jsProcessInfo);
+      }
+    }
 }
 
 void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
 {
-    const auto query{Utils::exec(R"(pkg query -a "%n|%m|%v|%q|%c")")};
+    const auto query{Utils::exec(R"(pkg query -a "%n|%m|%v|%q|%c|%sb|%t|%R|%o")")};
 
     if (!query.empty())
     {
@@ -235,18 +365,22 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
         for (const auto& line : lines)
         {
             const auto data{Utils::split(line, '|')};
+            const auto archdata{Utils::split(data[3], ':')};
+            const auto sectiondata{Utils::split(data[8], '/')};
+
             nlohmann::json package;
             package["name"] = data[0];
             package["vendor"] = data[1];
             package["version"] = data[2];
-            package["install_time"] = UNKNOWN_VALUE;
+            package["install_time"] = data[6];
             package["location"] = UNKNOWN_VALUE;
-            package["architecture"] = data[3];
+            package["architecture"] = archdata[2];
             package["groups"] = UNKNOWN_VALUE;
             package["description"] = data[4];
-            package["size"] = 0;
+            package["size"] = data[5];
             package["priority"] = UNKNOWN_VALUE;
-            package["source"] = UNKNOWN_VALUE;
+            package["source"] = data[7];
+            package["section"] = sectiondata[0];
             package["format"] = "pkg";
             // The multiarch field won't have a default value
 

--- a/src/data_provider/src/sysInfoFreeBSD.cpp
+++ b/src/data_provider/src/sysInfoFreeBSD.cpp
@@ -247,15 +247,19 @@ nlohmann::json SysInfo::getPorts() const
             std::string localport = "";
             std::string remoteip = "";
             std::string remoteport = "";
+            std::string statedata = "";
             const auto data{Utils::split(line, ' ')};
             auto localdata{Utils::split(data[5], ':')};
             auto remotedata{Utils::split(data[6], ':')};
-            auto statedata{Utils::toLowerCase(data[7])};
 
             localip = localdata[0];
             localport = localdata[1];
             remoteip = remotedata[0];
             remoteport = remotedata[1];
+
+            if((data[4] != "udp4") && (data[4] != "udp6")) {
+              statedata=toLowerCase(data[7]);
+            }
 
             if(statedata == "listen") {
               statedata = "listening";
@@ -277,7 +281,7 @@ nlohmann::json SysInfo::getPorts() const
               remoteport = remotedata[3];
             } else if(remoteport == "*") {
                 remoteip = "";
-                remoteport = "";
+                remoteport = "0";
             }
 
             if(data[0] != "?") {

--- a/src/data_provider/src/sysInfoFreeBSD.cpp
+++ b/src/data_provider/src/sysInfoFreeBSD.cpp
@@ -258,7 +258,7 @@ nlohmann::json SysInfo::getPorts() const
             remoteport = remotedata[1];
 
             if((data[4] != "udp4") && (data[4] != "udp6")) {
-              statedata=toLowerCase(data[7]);
+              statedata = Utils::toLowerCase(data[7]);
             }
 
             if(statedata == "listen") {

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -234,6 +234,17 @@ namespace Utils
         return ret;
     }
 
+    static std::string trimToOneSpace(const std::string& str)
+    {
+        std::string str_output;
+
+        str_output.clear();
+        std::unique_copy (str.begin(), str.end(), std::back_insert_iterator<std::string>(str_output),
+                                     [](char a,char b){ return std::isspace(a) && std::isspace(b);});
+
+        return str_output;
+    }
+
     static std::string toUpperCase(const std::string& str)
     {
         std::string temp{ str };
@@ -243,6 +254,19 @@ namespace Utils
                        [](std::string::value_type character)
         {
             return std::toupper(character);
+        });
+        return temp;
+    }
+
+    static std::string toLowerCase(const std::string& str)
+    {
+        std::string temp{ str };
+        std::transform(std::begin(temp),
+                       std::end(temp),
+                       std::begin(temp),
+                       [](std::string::value_type character)
+        {
+            return std::tolower(character);
         });
         return temp;
     }

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -48,6 +48,17 @@ namespace Utils
     {
         return getTimestamp(std::time(nullptr));
     }
+
+    static std::string timeToSeconds(std::string& str) {
+        int seconds;
+        std::tm t;
+        std::istringstream ss(str);
+
+        ss >> std::get_time(&t, "%H:%M.%S");
+        seconds = t.tm_hour * 3600 + t.tm_min * 60 + t.tm_sec;
+
+        return std::to_string(seconds);
+    }
 };
 
 #pragma GCC diagnostic pop

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -16,6 +16,11 @@
 #include "addagent/manage_agents.h" // FILE_SIZE
 #include "external/cJSON/cJSON.h"
 
+#if defined(__FreeBSD__)
+#include <sys/param.h>
+#define HOST_NAME_MAX MAXHOSTNAMELEN
+#endif
+
 #ifndef CLIENT
 
 #ifdef INOTIFY_ENABLED


### PR DESCRIPTION
| Related issue |
|--------|
| https://github.com/wazuh/wazuh/issues/8792 |
|https://github.com/wazuh/wazuh/issues/10713|
|https://github.com/wazuh/wazuh/issues/17381|
|https://github.com/wazuh/wazuh/issues/21930|

## Description

- Add FreeBSD SCA for 12.x, 13.x, 14.x and 15.x. 
- Add support for get ports info
- Add support for get processes info
- Add a better way for get memory info
- Minor changes to SysInfo::getPackages function
- Define HOST_NAME_MAX
- Another minor modifications

I have created SCA files for FreeBSD based on another Wazuh SCA files. these could be more complete than policies included into FreeBSD benchmark 1.0.5 document because this document is based on FreeBSD 4.x

cis-freebsd files have the same content except header and requirements section. I prefer maintain each document for each freebsd branch. I need to do some second review for get off some policies that not apply to freebsd12 

https://github.com/alonsobsd/wazuh-freebsd

![image](https://github.com/wazuh/wazuh/assets/11150989/3c65c9ad-a2bf-4132-8f90-d8198363b025)

![image](https://github.com/wazuh/wazuh/assets/11150989/72fd1e43-f88b-4934-a081-5fb5f257fca9)

![image](https://github.com/wazuh/wazuh/assets/11150989/f1f574fd-70d2-4f8c-bb67-890016af6312)

![image](https://github.com/wazuh/wazuh/assets/11150989/9afbfce7-1998-4d3f-8e3e-f44b7efae48a)

![image](https://github.com/wazuh/wazuh/assets/11150989/6a3481d1-018b-428c-94eb-b0f8c4efd030)

