### PR TITLE
Break local server connections when connection with master is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.5.4]
 
+### Manager
+
+#### Fixed
+- Fixed a bug that might leave some worker's services hanging if the connection to the master was broken. ([#19702](https://github.com/wazuh/wazuh/pull/19702))
+
 
 ## [v4.5.3] - 2023-10-10
 

--- a/framework/wazuh/core/cluster/client.py
+++ b/framework/wazuh/core/cluster/client.py
@@ -212,11 +212,17 @@ class AbstractClient(common.Handler):
     def _cancel_all_tasks(self):
         """Cancel all asyncio tasks and clients."""
         for task in asyncio.all_tasks():
-            task.cancel()
+            try:
+                task.cancel()
+            except Exception as e:
+                self.logger.error(f"Error cancelling task {task}: {e}")
 
         for client in list(self.get_manager().local_server.clients.keys()):
-            self.get_manager().local_server.clients[client].close()
-            del self.get_manager().local_server.clients[client]
+            try:
+                self.get_manager().local_server.clients[client].close()
+                del self.get_manager().local_server.clients[client]
+            except Exception as e:
+                self.logger.error(f"Error closing client {client}: {e}")
 
     def process_response(self, command: bytes, payload: bytes) -> bytes:
         """Define response commands for clients.

--- a/framework/wazuh/core/cluster/client.py
+++ b/framework/wazuh/core/cluster/client.py
@@ -210,9 +210,13 @@ class AbstractClient(common.Handler):
         self._cancel_all_tasks()
 
     def _cancel_all_tasks(self):
-        """Iterate asyncio tasks and cancel each of them."""
+        """Cancel all asyncio tasks and clients."""
         for task in asyncio.all_tasks():
             task.cancel()
+
+        for client in list(self.get_manager().local_server.clients.keys()):
+            self.get_manager().local_server.clients[client].close()
+            del self.get_manager().local_server.clients[client]
 
     def process_response(self, command: bytes, payload: bytes) -> bytes:
         """Define response commands for clients.


### PR DESCRIPTION
|Related issue|
|---|
| Closes #19686 |

## Description

This PR adds a new step to the `connection_lost` method in cluster workers. Now, when the connection between the master and worker is broken, the worker will iterate all Local server clients and close their connection.  

By doing this, the client will stop waiting for a response and will therefore stop blocking other tasks. For example, if an agent tried to register pointing to a worker, the worker would forward the request to the master using `sendsync` command. Below it can be seen what was happening if the master was restarted before responding to the worker:

### Before

Cluster log of the worker node: a connection is received in the local server (`399860`), but the master closes the connection with the worker. The local server connection would remain opened:
```
2023/10/17 11:39:41 DEBUG: [Local 399860] [Main] Connection received in local server.
2023/10/17 11:39:43 INFO: [Worker worker1] [Main] The master closed the connection
2023/10/17 11:39:53 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2023/10/17 11:39:53 DEBUG: [Local Server] [Keep alive] Calculating.
2023/10/17 11:39:53 DEBUG: [Local Server] [Keep alive] Calculated.
2023/10/17 11:39:53 ERROR: [Local Server] [Main] Could not connect to master. Trying again in 10 seconds.
```

Ossec log of an agent: the agent remains stuck waiting for a response that never comes:
```
root@1dbcd954a4ce:/# /var/ossec/bin/agent-auth -m wazuh-worker1 -A test1
2023/10/17 11:39:41 agent-auth: INFO: Started (pid: 530).
2023/10/17 11:39:41 agent-auth: INFO: Requesting a key from server: wazuh-worker1
2023/10/17 11:39:41 agent-auth: INFO: No authentication password provided
2023/10/17 11:39:41 agent-auth: INFO: Using agent name as: test1
2023/10/17 11:39:41 agent-auth: INFO: Waiting for server reply
```

If the agent cancels the request and tries to register again, it wouldn't even receive a response from worker1 because authd is stuck waiting for a response from the cluster:
```
root@1dbcd954a4ce:/# /var/ossec/bin/agent-auth -m wazuh-worker1 -A test1
2023/10/17 11:39:51 agent-auth: INFO: Started (pid: 531).
2023/10/17 11:39:51 agent-auth: INFO: Requesting a key from server: wazuh-worker1
```

### Now
In this `cluster.log` of a worker, it can be seen that a new client (`561630`) connects to the worker's local server. However, after the connection with the master is broken, the client also disconnects:
```
2023/10/17 11:35:52 DEBUG: [Local 561630] [Main] Connection received in local server.
2023/10/17 11:35:54 INFO: [Worker worker1] [Main] The master closed the connection
2023/10/17 11:35:54 DEBUG: [Worker worker1] [Main] Disconnected 561630.
```

As a consequence, authd stops waiting and answers the agent and future agent requests, showing this error in the failed registration request:
```
root@1dbcd954a4ce:/# /var/ossec/bin/agent-auth -m wazuh-worker1 -A test1
2023/10/17 11:35:52 agent-auth: INFO: Started (pid: 519).
2023/10/17 11:35:52 agent-auth: INFO: Requesting a key from server: wazuh-worker1
2023/10/17 11:35:52 agent-auth: INFO: No authentication password provided
2023/10/17 11:35:52 agent-auth: INFO: Using agent name as: test1
2023/10/17 11:35:52 agent-auth: INFO: Waiting for server reply
2023/10/17 11:35:54 agent-auth: ERROR: Cannot comunicate with master (from manager)
2023/10/17 11:35:54 agent-auth: ERROR: Unable to add agent (from manager)
```


### Wazuh remoted
The same was tested with `remoted` and the service is freed when the connection with the master is broken, so all queued events are sent to analysisd. 

