### PR TITLE
Logcollector module memory leaks in Windows agents

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1530,6 +1530,9 @@ int check_pattern_expand(int do_seek) {
 
                     if (current_files >= maximum_files) {
                         mwarn(FILE_LIMIT, maximum_files);
+                        for (int f = file; result[f] != NULL; f++) {
+                            os_free(result[f]);
+                        }
                         break;
                     }
 
@@ -1619,7 +1622,6 @@ int check_pattern_expand(int do_seek) {
                     }
                     os_free(full_path);
                 }
-
                 os_free(result);
             }
         }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1520,7 +1520,7 @@ int check_pattern_expand(int do_seek) {
             }
 
             char** result = expand_win32_wildcards(globs[j].gpath);
-            
+
             if (result) {
 
                 int file;
@@ -1534,6 +1534,7 @@ int check_pattern_expand(int do_seek) {
                     }
 
                     os_strdup(result[file], full_path);
+                    os_free(result[file]);
 
                     found = 0;
                     for (i = 0; globs[j].gfiles[i].file; i++) {
@@ -1618,6 +1619,8 @@ int check_pattern_expand(int do_seek) {
                     }
                     os_free(full_path);
                 }
+
+                os_free(result);
             }
         }
     }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/19310|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Found some places in the `check_pattern_expand` function (`src/logcollector/logcollector.c` Windows only) where allocated memory was not freed in logcollector module.

Therefore, the increase in memory occurred when adding new files to the monitoring directories.
This **PR** contains the correct release of those memory blocks.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

A test has been launched stressing the `logcollector` module for 12 Hours, between a Linux Manager and a **Windows Agent** with positive results, here is the **[Footprint metrics information](https://github.com/wazuh/wazuh/issues/19310#issuecomment-1766146008)**



<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

