### PR TITLE
Fix to generate the CPE for Windows systems without the os_release field (backport)

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2948,6 +2948,30 @@ void test_wm_vuldet_generate_win_cpe_w10_no_os_release(void **state) {
     assert_int_equal(ret, 1);
 }
 
+void test_wm_vuldet_generate_win_cpe_known_no_os_release(void **state) {
+    scan_agent *agent = *state;
+
+    int known_win_sys_without_os_release[] = {
+        FEED_WS2012, FEED_WS2012R2,
+        FEED_W8, FEED_W81
+    };
+
+    agent->dist = FEED_WIN;
+    agent->os_release = NULL;
+    agent->os_display_version = NULL;
+    agent->arch = strdup("x86_64");
+
+    for (int i = 0; i < array_size(known_win_sys_without_os_release); i++) {
+        agent->dist_ver = known_win_sys_without_os_release[i];
+        int ret = wm_vuldet_generate_win_cpe(agent);
+        assert_int_equal(ret, 0);
+        for (int i = 0; agent->agent_os_cpe && agent->agent_os_cpe[i]; i++) {
+            wm_vuldet_free_cpe(&agent->agent_os_cpe[i]);
+        }
+        os_free(agent->agent_os_cpe);
+    }
+}
+
 void test_wm_vuldet_generate_win_cpe_no_dist(void **state) {
     scan_agent *agent = *state;
 
@@ -22385,6 +22409,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_win_cpe_w11, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_win_cpe_w10_no_display_version, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_win_cpe_w10_no_os_release, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_win_cpe_known_no_os_release, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_win_cpe_no_dist, setup_scan_agent, teardown_scan_agent),
         // Tests wm_vuldet_compare_vendors
         cmocka_unit_test(test_wm_vuldet_compare_vendors_external_vendor),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6527,8 +6527,9 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     char *ver_aux = NULL;
     char *pr_name = NULL;
 
-    if (!agent->os_release && agent->dist_ver != FEED_WS2012 && agent->dist_ver != FEED_WS2012R2 &&
-        agent->dist_ver != FEED_W8 && agent->dist_ver != FEED_W81) {
+    // Note: There are versions of Windows that do not have the os_release field,
+    // such as Windows Server 2012 or Windows 8
+    if (!agent->os_release && !wm_vuldet_without_os_release(agent->dist_ver)) {
         mtwarn(WM_VULNDETECTOR_LOGTAG, VU_OSINFO_DISABLED, atoi(agent->agent_id));
     }
 
@@ -6538,7 +6539,7 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
         agent->os_display_version = ver_aux;
     } else if (agent->os_release != NULL) {
         ver_aux = agent->os_release;
-    } else {
+    } else if (!wm_vuldet_without_os_release(agent->dist_ver)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_WIN_CPE_GEN_ERROR, atoi(agent->agent_id));
         return 1;
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -901,6 +901,7 @@ typedef struct scan_ctx_t {
 #define wm_vuldet_is_cpe_wc(x) (!strcmp(x, "*") || !strcmp(x, "-"))
 #define wm_vulndet_undefined_cond(x) (!x || !strcmp(x, "-"))
 #define wm_vulndet_without_r2(x) (x == FEED_WS2008 || x == FEED_WS2012)
+#define wm_vuldet_without_os_release(x) (x == FEED_WS2012 || x == FEED_WS2012R2 || x == FEED_W8 || x == FEED_W81)
 
 
 // Function headers


### PR DESCRIPTION
|Related issue|
|---|
|#19345|

This PR aims to port the fix to generate the CPE for Windows systems without `os_release` reported at #19345 to version `4.5.4`.
- Issue: #19345
  - PR: https://github.com/wazuh/wazuh/pull/19595

## Tests

- [x] The CPEs are correctly generated for _`WS2012`_ and _`W8`_ on `4.5.4`.
- [x] Run `scan-build`.