### PR TITLE
Add `index.query.default_field`

### DIFF
--- a/src/shared_modules/indexer_connector/testtool/input/config.json
+++ b/src/shared_modules/indexer_connector/testtool/input/config.json
@@ -1,6 +1,6 @@
 {
   "indexer": {
-  "name": "vulnerability-state",
+  "name": "wazuh-states-vulnerabilities",
   "enabled": "yes",
   "hosts": ["http://192.168.1.7:9200"],
   "username": "user",

--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
@@ -1,9 +1,38 @@
 {
   "index_patterns": [
-    "vulnerability-state-*"
+    "wazuh-states-vulnerabilities"
   ],
   "priority": 1,
   "template": {
+    "settings": {
+      "index": {
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": 1000
+          }
+        },
+        "number_of_replicas": "0",
+        "number_of_shards": "1",
+        "query.default_field": [
+          "base.tags",
+          "agent.id",
+          "ecs.version",
+          "event.id",
+          "event.module",
+          "event.severity",
+          "host.os.family",
+          "host.os.full.text",
+          "host.os.version",
+          "package.name",
+          "package.version",
+          "vulnerability.id",
+          "vulnerability.description.text",
+          "vulnerability.severity"
+        ],
+        "refresh_interval": "2s"
+      }
+    },
     "mappings": {
       "date_detection": false,
       "dynamic_templates": [
@@ -337,17 +366,6 @@
             }
           }
         }
-      }
-    },
-    "settings": {
-      "index": {
-        "codec": "best_compression",
-        "mapping": {
-          "total_fields": {
-            "limit": 1000
-          }
-        },
-        "refresh_interval": "2s"
       }
     }
   }


### PR DESCRIPTION
|Related issue|
|---|
| #14153, https://github.com/wazuh/wazuh-indexer/issues/6|

## Description

This PR adds default query fields to the vulnerability detector index (`wazuh-states-vulnerability`).

Use this command to upload the template (change the name of the template as desired):

```bash
curl -u admin:admin -k -X PUT "https://localhost:9200/_index_template/wazuh-vulnerability-detector" -H "Content-Type: application/json" -d @legacy-template.json
```


![image](https://github.com/wazuh/wazuh/assets/15186973/8e1d66ba-598e-4282-82ec-2091e99e1ffd)
![image](https://github.com/wazuh/wazuh/assets/15186973/6f145afd-af40-40e4-9798-6a928707a4a7)
![image](https://github.com/wazuh/wazuh/assets/15186973/b5f50838-c928-4c50-8012-22295f99a30a)
