### PR TITLE
Fix win32 compilation after incomplete bump

### DIFF
--- a/src/win32/version.rc
+++ b/src/win32/version.rc
@@ -16,7 +16,7 @@
 #define QUOTE(x) Q(x)
 
 #ifndef VER_PRODUCTVERSION
-#define VER_PRODUCTVERSION 
+#define VER_PRODUCTVERSION 4,5,4,0
 #endif
 
 #ifndef VER_PRODUCTVERSION_STR


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19713 |

This PR aims to solve a compilation error detected after the 4.5.4 bump.