### PR TITLE
Add status_code field to agent model

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1445,6 +1445,14 @@ components:
             minor:
               type: string
           description: "Agent OS information"
+        status_code:
+          type: integer
+          description: "Agent connection status"
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+          maximum: 5
 
     Agent:
       allOf:
@@ -7278,6 +7286,7 @@ paths:
                       version: Wazuh v4.3.0
                       node_name: worker2
                       group_config_status: "synced"
+                      status_code: 0
                     - os:
                         arch: x86_64
                         codename: Focal Fossa
@@ -7302,6 +7311,7 @@ paths:
                       version: Wazuh v4.3.0
                       node_name: worker2
                       group_config_status: "synced"
+                      status_code: 0
                     - os:
                         arch: x86_64
                         codename: Focal Fossa
@@ -7326,6 +7336,7 @@ paths:
                       version: Wazuh v4.3.0
                       node_name: worker1
                       group_config_status: "not synced"
+                      status_code: 0
                   total_affected_items: 3
                   total_failed_items: 0
                   failed_items: []

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1447,7 +1447,7 @@ components:
           description: "Agent OS information"
         status_code:
           type: integer
-          description: "Agent connection status"
+          description: "Agent connection status code"
           type: integer
           format: int32
           default: 0

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -72,6 +72,19 @@ stages:
           extra_kwargs:
             key: "status"
       status_code: 200
+  
+  - name: Get all agents sorted by status_code
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        sort: status_code
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "status_code"
+      status_code: 200
 
   - name: Pagination with offset 0 and limit 2
     request:
@@ -1187,6 +1200,7 @@ stages:
               registerIP: !anystr
               status: !anystr
               version: !anystr
+              status_code: !anyint
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -3260,6 +3274,7 @@ marks:
         - registerIP
         - status
         - version
+        - status_code
 
 stages:
 
@@ -4155,6 +4170,7 @@ marks:
         - node_name
         - registerIP
         - status
+        - status_code
 
 stages:
 
@@ -4679,6 +4695,7 @@ marks:
         - registerIP
         - status
         - version
+        - status_code
 
 stages:
 

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -474,7 +474,7 @@ class Agent:
               'os.uname': 'os_uname', 'os.arch': 'os_arch', 'os.build': 'os_build',
               'node_name': 'node_name', 'lastKeepAlive': 'last_keepalive', 'internal_key': 'internal_key',
               'registerIP': 'register_ip', 'disconnection_time': 'disconnection_time',
-              'group_config_status': 'group_config_status'}
+              'group_config_status': 'group_config_status', 'status_code': 'status_code'}
 
     def __init__(self, id: str = None, name: str = None, ip: str = None, key: str = None, force: dict = None):
         """Initialize an agent.
@@ -517,6 +517,7 @@ class Agent:
         self.registerIP = ip
         self.disconnection_time = None
         self.group_config_status = None
+        self.status_code = None
 
         # If the method has only been called with an ID parameter, no new agent should be added.
         # Otherwise, a new agent must be added
@@ -531,7 +532,8 @@ class Agent:
                       'version': self.version, 'dateAdd': self.dateAdd, 'lastKeepAlive': self.lastKeepAlive,
                       'status': self.status, 'key': self.key, 'configSum': self.configSum, 'mergedSum': self.mergedSum,
                       'group': self.group, 'manager': self.manager, 'node_name': self.node_name,
-                      'disconnection_time': self.disconnection_time, 'group_config_status': self.group_config_status}
+                      'disconnection_time': self.disconnection_time, 'group_config_status': self.group_config_status,
+                      'status_code': self.status_code}
 
         return dictionary
 

--- a/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
+++ b/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
@@ -34,7 +34,8 @@ CREATE TABLE IF NOT EXISTS agent (
     reg_offset INTEGER NOT NULL DEFAULT 0,
     `group` TEXT DEFAULT 'default',
     disconnection_time INTEGER DEFAULT 0,
-    group_config_status TEXT NOT NULL CHECK (group_config_status IN ('synced', 'not synced')) DEFAULT 'not synced'
+    group_config_status TEXT NOT NULL CHECK (group_config_status IN ('synced', 'not synced')) DEFAULT 'not synced',
+    status_code INTEGER DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);

--- a/framework/wazuh/core/tests/data/test_database/schema_global_test.sql
+++ b/framework/wazuh/core/tests/data/test_database/schema_global_test.sql
@@ -32,7 +32,10 @@ CREATE TABLE IF NOT EXISTS agent (
     connection_status TEXT NOT NULL CHECK (connection_status IN ('active', 'pending', 'disconnected', 'never_connected')) DEFAULT 'never_connected',
     fim_offset INTEGER NOT NULL DEFAULT 0,
     reg_offset INTEGER NOT NULL DEFAULT 0,
-    `group` TEXT DEFAULT 'default'
+    `group` TEXT DEFAULT 'default',
+    disconnection_time INTEGER DEFAULT 0,
+    group_config_status TEXT NOT NULL CHECK (group_config_status IN ('synced', 'not synced')) DEFAULT 'not synced',
+    status_code INTEGER DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -77,7 +77,7 @@ class InitAgent:
             self.cur.executescript(f.read())
 
         self.never_connected_fields = {'status', 'name', 'ip', 'registerIP', 'node_name', 'dateAdd', 'id',
-                                       'group_config_status'}
+                                       'group_config_status', 'status_code'}
         self.pending_fields = self.never_connected_fields | {'manager', 'lastKeepAlive'}
         self.manager_fields = self.pending_fields | {'version', 'os', 'group'}
         self.active_fields = self.manager_fields | {'group', 'mergedSum', 'configSum'}

--- a/framework/wazuh/tests/data/schema_global_test.sql
+++ b/framework/wazuh/tests/data/schema_global_test.sql
@@ -34,7 +34,8 @@ CREATE TABLE IF NOT EXISTS agent (
     reg_offset INTEGER NOT NULL DEFAULT 0,
     `group` TEXT DEFAULT 'default',
     disconnection_time INTEGER DEFAULT 0,
-    group_config_status TEXT NOT NULL CHECK (group_config_status IN ('synced', 'not synced')) DEFAULT 'not synced'
+    group_config_status TEXT NOT NULL CHECK (group_config_status IN ('synced', 'not synced')) DEFAULT 'not synced',
+    status_code INTEGER DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/19721 |

## Description

Adds the `status_code` field to the agent model to be returned in the requests to `GET /agents`.

It does not add it as a request parameter to query results, but it can be used in fields such as `sort`, `select`, etc.

## Tests

<details><summary>test_agent_GET_endpoints.tavern.yaml</summary>

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_agent_GET_endpoints.tavern.yaml
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 96 items                                                                                                                                                         

test_agent_GET_endpoints.tavern.yaml::GET /agents PASSED                                                                                                             [  1%]
test_agent_GET_endpoints.tavern.yaml::GET /agents with single agent id PASSED                                                                                        [  2%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                               [  3%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} (only cluster configuration) PASSED                                  [  4%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                    [  5%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                              [  6%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                                                                    [  7%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                                                [  8%]
test_agent_GET_endpoints.tavern.yaml::GET /groups PASSED                                                                                                             [  9%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED                                                                                            [ 10%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED                                                                                           [ 11%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED                                                                                         [ 12%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED                                                                                         [ 13%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED                                                                                         [ 14%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED                                                                                         [ 15%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED                                                                                        [ 16%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED                                                                                        [ 17%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED                                                                                       [ 18%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED                                                                                       [ 19%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED                                                                                       [ 20%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED                                                                                       [ 21%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                           [ 22%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED                                                                  [ 23%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED                                                                    [ 25%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED                                                                      [ 26%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED                                                                         [ 27%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED                                                                         [ 28%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED                                                              [ 29%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED                                                                    [ 30%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED                                                                  [ 31%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED                                                                       [ 32%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED                                                                  [ 33%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED                                                                    [ 34%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED                                                                   [ 35%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED                                                                [ 36%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED                                                                   [ 37%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED                                                                   [ 38%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED                                                                    [ 39%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED                                                                [ 40%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED                                                                   [ 41%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED                                                                 [ 42%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED                                                                 [ 43%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED                                                                     [ 44%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED                                                                    [ 45%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status_code] PASSED                                                                [ 46%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                    [ 47%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                            [ 48%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED                                                                           [ 50%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED                                                                          [ 51%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED                                                                        [ 52%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED                                                                        [ 53%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED                                                                        [ 54%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED                                                                        [ 55%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED                                                                       [ 56%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED                                                                       [ 57%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED                                                                      [ 58%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED                                                                      [ 59%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED                                                                      [ 60%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED                                                                      [ 61%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                            [ 62%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                             [ 63%]
test_agent_GET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                             [ 64%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                    [ 65%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED                                                                             [ 66%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED                                                                                  [ 67%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED                                                                                  [ 68%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED                                                                                [ 69%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED                                                                           [ 70%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED                                                                          [ 71%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED                                                                              [ 72%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status_code] PASSED                                                                         [ 73%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                    [ 75%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                              [ 76%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED                                                                            [ 77%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED                                                                                 [ 78%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED                                                                                 [ 79%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED                                                                      [ 80%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED                                                                            [ 81%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED                                                                               [ 82%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED                                                                          [ 83%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED                                                                            [ 84%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED                                                                           [ 85%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED                                                                        [ 86%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED                                                                           [ 87%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED                                                                           [ 88%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED                                                                            [ 89%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED                                                                        [ 90%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED                                                                           [ 91%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED                                                                         [ 92%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED                                                                         [ 93%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED                                                                             [ 94%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED                                                                            [ 95%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status_code] PASSED                                                                        [ 96%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                              [ 97%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                  [ 98%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                              [100%]

============================================================================= warnings summary =============================================================================
../../../venv/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28
  /home/gasti/work/wazuh/venv/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

../../../venv/lib/python3.9/site-packages/_pytest/nodes.py:642
  /home/gasti/work/wazuh/venv/lib/python3.9/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ 96 passed, 2 warnings in 226.43s (0:03:46) ================================================================
```

</details>

<details><summary>test_rbac_black_agent_endpoints.tavern.yaml</summary>

> The other test should be enough, but just in case I ran this one too

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_rbac_black_agent_endpoints.tavern.yaml
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 42 items                                                                                                                                                         

test_rbac_black_agent_endpoints.tavern.yaml::GET /agents PASSED                                                                                                      [  2%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?agents_list=agent_id PASSED                                                                                 [  4%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                        [  7%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                             [  9%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                       [ 11%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                                                             [ 14%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                                         [ 16%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups PASSED                                                                                                      [ 19%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                    [ 21%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                             [ 23%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                     [ 26%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                     [ 28%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                      [ 30%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                      [ 33%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                             [ 35%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                             [ 38%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                       [ 40%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                       [ 42%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                           [ 45%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                       [ 47%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                       [ 50%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                  [ 52%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/group?group_id=group_id PASSED                                                                           [ 54%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE groups?groups_list=group_id PASSED                                                                               [ 57%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                   [ 59%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents?agents_list=agent_id PASSED                                                                              [ 61%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                   [ 64%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents PASSED                                                                                                     [ 66%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                              [ 69%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                        [ 71%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /groups PASSED                                                                                                     [ 73%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group?group_id={group_id} PASSED                                                                            [ 76%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                             [ 78%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                             [ 80%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/reconnect PASSED                                                                                            [ 83%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                              [ 85%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                          [ 88%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                   [ 90%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                              [ 92%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                                                                       [ 95%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents (allow cluster:read) PASSED                                                                                 [ 97%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                               [100%]

============================================================================= warnings summary =============================================================================
../../../venv/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28
  /home/gasti/work/wazuh/venv/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

../../../venv/lib/python3.9/site-packages/_pytest/nodes.py:642
  /home/gasti/work/wazuh/venv/lib/python3.9/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ 42 passed, 2 warnings in 702.17s (0:11:42) ===============================================================
```


</details>