### PR TITLE
Fix typo in in stat commands

### DIFF
--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -5146,7 +5146,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells- -> r:0 root 0 root && r:644|640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 6.1.10 Ensure permissions on /etc/opasswd are configured. (Automated)
   - id: 2712

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -5003,7 +5003,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells- -> r:0 root 0 root && r:644|640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 6.1.10 Ensure permissions on /etc/opasswd are configured. (Automated)
   - id: 19205


### PR DESCRIPTION
## Description

I found some typos in CIS rules for Ubuntu and Debian. There was a stray dash preventing the rule from passing.