### PR TITLE
Fix typo: opasswds -> opasswd

### DIFF
--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -5170,7 +5170,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/security/opasswds -> r:0 root 0 root && r:644|640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/security/opasswd -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 6.1.11 Ensure world writable files and directories are secured. (Automated) - Not Implemented
   # 6.1.12 Ensure no unowned or ungrouped files or directories exist. (Automated) - Not Implemented

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -5027,7 +5027,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/security/opasswds -> r:0 root 0 root && r:644|640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/security/opasswd -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 6.1.11 Ensure world writable files and directories are secured. (Automated) - Not Implemented
   # 6.1.12 Ensure no unowned or ungrouped files or directories exist. (Automated) - Not Implemented


### PR DESCRIPTION
## Description

I found some typos in CIS rules for Ubuntu and Debian. `/etc/security/opasswd` was misspelled `/etc/security/opasswds`