### PR TITLE
Add timeout to clusterd requests

### DIFF
--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -212,7 +212,7 @@ cJSON *getClusterConfig(void) {
 
     strcpy(sockname, CLUSTER_SOCK);
 
-    if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock < 0) {
+    if (sock = external_socket_connect(sockname, WAZUH_IPC_TIMEOUT), sock < 0) {
         switch (errno) {
         case ECONNREFUSED:
             merror("At getClusterConfig(): Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -17,6 +17,8 @@
 
 #define IPV6_LINK_LOCAL_PREFIX "FE80:0000:0000:0000:"
 
+#define WAZUH_IPC_TIMEOUT 600    // seconds
+
 /* OS_Bindport*
  * Bind a specific port (protocol and a ip).
  * If the IP is not set, it is going to use ADDR_ANY

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -617,7 +617,7 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
 
     strcpy(sockname, CLUSTER_SOCK);
 
-    if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock >= 0) {
+    if (sock = external_socket_connect(sockname, WAZUH_IPC_TIMEOUT), sock >= 0) {
         if (OS_SendSecureTCPCluster(sock, command, payload, strlen(payload)) >= 0) {
             if (response_length = OS_RecvSecureClusterTCP(sock, response, OS_MAXSTR), response_length <= 0) {
                 switch (response_length) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/19684|

## Description

This PR adds a hardcoded timeout of 10 minutes to the communication with the cluster socket (Wazuh manager).

This is done to avoid deadlocks that can be caused when the cluster communication hangs for any reason.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)