### PR TITLE
Add more unit test to os_crypto

### DIFF
--- a/src/unit_tests/addagent/CMakeLists.txt
+++ b/src/unit_tests/addagent/CMakeLists.txt
@@ -26,9 +26,9 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 list(APPEND addagent_names "test_manage_keys")
 list(APPEND addagent_flags "${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS} \
-                            -Wl,--wrap,mkstemp_ex \
-                            -Wl,--wrap,stat -Wl,--wrap,chmod -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fprintf -Wl,--wrap,fgets -Wl,--wrap,rename_ex\
-                            -Wl,--wrap,encode_base64 -Wl,--wrap,decode_base64")
+                            -Wl,--wrap,mkstemp_ex -Wl,--wrap,popen \
+                            -Wl,--wrap,stat -Wl,--wrap,chmod -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fprintf \
+                            -Wl,--wrap,fgets -Wl,--wrap,rename_ex -Wl,--wrap,encode_base64 -Wl,--wrap,decode_base64")
 
 list(LENGTH addagent_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -58,7 +58,7 @@ list(APPEND analysisd_flags "-Wl,--wrap,OS_SendUnix -Wl,--wrap,wdb_get_agent_inf
 list(APPEND analysisd_names "test_log")
 list(APPEND analysisd_flags "-Wl,--wrap,fprintf,-wrap,fflush,--wrap,fclose,--wrap,fgets,--wrap,fgetpos,--wrap,fopen \
                              -Wl,--wrap,fread,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,fputc \
-                             -Wl,--wrap,ctime_r")
+                             -Wl,--wrap,ctime_r -Wl,--wrap,popen")
 
 list(APPEND analysisd_names "test_labels")
 list(APPEND analysisd_flags "-Wl,--wrap,wdb_get_agent_labels")

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -20,7 +20,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 # Generate logcollector tests
 list(APPEND logcollector_names "test_logcollector")
-list(APPEND logcollector_flags "-Wl,--wrap,OS_SHA1_Stream -Wl,--wrap,merror_exit \
+list(APPEND logcollector_flags "-Wl,--wrap,OS_SHA1_Stream -Wl,--wrap,merror_exit -Wl,--wrap,popen \
                                 -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
                                 -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetpos \
                                 -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_AddArrayToObject -Wl,--wrap,cJSON_AddStringToObject \
@@ -36,7 +36,7 @@ list(APPEND logcollector_flags "-Wl,--wrap,OS_SHA1_Stream -Wl,--wrap,merror_exit
                                 ${HASH_OP_WRAPPERS}")
 
 list(APPEND logcollector_names "test_read_multiline_regex")
-list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,popen \
                                 -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc\
                                 -Wl,--wrap,time -Wl,--wrap,can_read -Wl,--wrap,w_ftell -Wl,--wrap,w_expression_match \
                                 -Wl,--wrap,w_msg_hash_queues_push -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status \
@@ -44,14 +44,14 @@ list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,ff
                                 -Wl,--wrap=w_fseek -Wl,--wrap,_mdebug2")
 
 list(APPEND logcollector_names "test_localfile-config")
-list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                 -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc\
                                 -Wl,--wrap,w_get_attr_val_by_name -Wl,--wrap,fgetpos ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND logcollector_names "test_state")
 list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                 -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc \
-                                -Wl,--wrap,fgetpos -Wl,--wrap,time \
+                                -Wl,--wrap,fgetpos -Wl,--wrap,time -Wl,--wrap,popen \
                                 -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray \
                                 -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddNumberToObject \
                                 -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddItemToObject \
@@ -74,13 +74,13 @@ list(APPEND logcollector_flags "-Wl,--wrap,wpopenv -Wl,--wrap,fileno -Wl,--wrap,
                                 -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,wpclose -Wl,--wrap,access \
                                 -Wl,--wrap,getpid -Wl,--wrap,_minfo -Wl,--wrap,pthread_rwlock_wrlock \
                                 -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_rdlock \
-                                -Wl,--wrap,so_get_function_sym -Wl,--wrap,so_get_module_handle \
+                                -Wl,--wrap,so_get_function_sym -Wl,--wrap,so_get_module_handle -Wl,--wrap,popen \
                                 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_get_os_codename -Wl,--wrap,w_get_process_childs")
 
 list(APPEND logcollector_names "test_read_macos")
 list(APPEND logcollector_flags "-Wl,--wrap,w_expression_match -Wl,--wrap,can_read -Wl,--wrap,fgets \
                                 -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,_mdebug2\
-                                -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
+                                -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,popen \
                                 -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,_merror -Wl,--wrap,waitpid \
                                 -Wl,--wrap,w_msg_hash_queues_push -Wl,--wrap,_mdebug1 -Wl,--wrap,_minfo \
                                 -Wl,--wrap,kill -Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,strerror \
@@ -90,7 +90,7 @@ list(APPEND logcollector_flags "-Wl,--wrap,w_expression_match -Wl,--wrap,can_rea
                                 -Wl,--wrap,w_macos_set_is_valid_data")
 
 list(APPEND logcollector_names "test_read_multiline")
-list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                 -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc\
                                 -Wl,--wrap,time -Wl,--wrap,can_read -Wl,--wrap,w_ftell -Wl,--wrap,w_expression_match \
                                 -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status -Wl,--wrap,_merror \

--- a/src/unit_tests/os_auth/CMakeLists.txt
+++ b/src/unit_tests/os_auth/CMakeLists.txt
@@ -38,7 +38,7 @@ list(APPEND os_auth_names "test_ssl")
 list(APPEND os_auth_flags "-Wl,--wrap,SSL_read -Wl,--wrap=SSL_new")
 list(APPEND os_auth_names "test_auth_key_request")
 list(APPEND os_auth_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_minfo -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 \
-                           -Wl,--wrap,wm_exec -Wl,--wrap,wpopenv -Wl,--wrap,fgets \
+                           -Wl,--wrap,wm_exec -Wl,--wrap,wpopenv -Wl,--wrap,fgets -Wl,--wrap,popen \
                            -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,close -Wl,-wrap,send -Wl,--wrap,cJSON_ParseWithOpts \
                            -Wl,--wrap,recv -Wl,--wrap,setsockopt -Wl,--wrap,fcntl -Wl,--wrap,connect -Wl,--wrap,socket \
                            -Wl,--wrap,w_request_agent_add_clustered -Wl,--wrap,sleep -Wl,--wrap,cJSON_Delete -Wl,--wrap,local_add \
@@ -50,7 +50,7 @@ list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS} \
                            -Wl,--wrap,os_random -Wl,--wrap,GetRandomNoise -Wl,--wrap,getuname -Wl,--wrap,time")
 list(APPEND os_auth_names "test_generate_cert")
 list (APPEND os_auth_flags "-Wl,--wrap,PEM_write_PrivateKey -Wl,--wrap,PEM_write_X509 -Wl,--wrap,RSA_generate_key_ex \
-                            -Wl,--wrap,X509_sign -Wl,--wrap,_merror \
+                            -Wl,--wrap,X509_sign -Wl,--wrap,_merror -Wl,--wrap,popen \
                             -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,fread \
                             -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,fgets \
                             -Wl,--wrap,RSA_new -Wl,--wrap,EVP_PKEY_new -Wl,--wrap,X509_new")

--- a/src/unit_tests/os_crypto/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/CMakeLists.txt
@@ -8,6 +8,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 if(${TARGET} STREQUAL "server")
+    add_subdirectory(hmac)
     add_subdirectory(shared)
     add_subdirectory(sha1)
     add_subdirectory(blowfish)

--- a/src/unit_tests/os_crypto/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/CMakeLists.txt
@@ -8,6 +8,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 if(${TARGET} STREQUAL "server")
+    add_subdirectory(aes)
     add_subdirectory(hmac)
     add_subdirectory(shared)
     add_subdirectory(sha1)

--- a/src/unit_tests/os_crypto/aes/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/aes/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+cmake_minimum_required(VERSION 3.10)
+
+list(APPEND aes_tests_names "test_aes_op")
+list(APPEND aes_tests_flags " ")
+
+# Compiling tests
+list(LENGTH aes_tests_names count)
+math(EXPR count "${count} - 1")
+foreach(counter RANGE ${count})
+    list(GET aes_tests_names ${counter} test_name)
+    list(GET aes_tests_flags ${counter} test_flags)
+    add_executable(${test_name} ${test_name}.c)
+    if(${TARGET} STREQUAL "server")
+        target_link_libraries(
+            ${test_name}
+            ${TEST_DEPS}
+        )
+    else()
+        target_link_libraries(
+            ${test_name}
+            ${TEST_DEPS}
+        )
+    endif()
+    if(NOT test_flags STREQUAL " ")
+        target_link_libraries(
+            ${test_name}
+            ${test_flags}
+        )
+    endif()
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()

--- a/src/unit_tests/os_crypto/aes/test_aes_op.c
+++ b/src/unit_tests/os_crypto/aes/test_aes_op.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "../headers/shared.h"
+#include "../../os_crypto/aes/aes_op.h"
+#include "../../wrappers/common.h"
+
+// Tests
+
+void test_aes_string
+(void **state)
+{
+    const char *key = "test_key";
+    const char *string = "test string";
+    const int buffersize = 1024;
+    char buffer1[buffersize];
+    char buffer2[buffersize];
+
+    memset(buffer1, 0, sizeof(buffer1));
+    memset(buffer2, 0, sizeof(buffer2));
+
+    OS_AES_Str(string, buffer1, key, strlen(string), OS_ENCRYPT);
+    OS_AES_Str(buffer1, buffer2, key, strlen(buffer1), OS_DECRYPT);
+
+    // Remove junk from decryption
+    char *last = strchr(buffer2, 0x005);
+    *last = '\0';
+
+    assert_string_equal(buffer2, string);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_aes_string),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/os_crypto/aes/test_aes_op.c
+++ b/src/unit_tests/os_crypto/aes/test_aes_op.c
@@ -14,7 +14,6 @@
 
 #include "../headers/shared.h"
 #include "../../os_crypto/aes/aes_op.h"
-#include "../../wrappers/common.h"
 
 // Tests
 

--- a/src/unit_tests/os_crypto/blowfish/test_blowfish_op.c
+++ b/src/unit_tests/os_crypto/blowfish/test_blowfish_op.c
@@ -14,7 +14,6 @@
 
 #include "../headers/shared.h"
 #include "../../os_crypto/blowfish/bf_op.h"
-#include "../../wrappers/common.h"
 
 // Tests
 

--- a/src/unit_tests/os_crypto/hmac/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/hmac/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+cmake_minimum_required(VERSION 3.10)
+
+list(APPEND hmac_tests_names "test_hmac_op")
+list(APPEND hmac_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+                             -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
+                             -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,popen")
+
+# Compiling tests
+list(LENGTH hmac_tests_names count)
+math(EXPR count "${count} - 1")
+foreach(counter RANGE ${count})
+    list(GET hmac_tests_names ${counter} test_name)
+    list(GET hmac_tests_flags ${counter} test_flags)
+    add_executable(${test_name} ${test_name}.c)
+    if(${TARGET} STREQUAL "server")
+        target_link_libraries(
+            ${test_name}
+            ${TEST_DEPS}
+        )
+    else()
+        target_link_libraries(
+            ${test_name}
+            ${TEST_DEPS}
+        )
+    endif()
+    if(NOT test_flags STREQUAL " ")
+        target_link_libraries(
+            ${test_name}
+            ${test_flags}
+        )
+    endif()
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()

--- a/src/unit_tests/os_crypto/hmac/test_hmac_op.c
+++ b/src/unit_tests/os_crypto/hmac/test_hmac_op.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "../headers/shared.h"
+#include "../../os_crypto/hmac/hmac.h"
+#include "../../wrappers/common.h"
+
+/* setups/teardowns */
+static int setup_group(void **state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int teardown_group(void **state) {
+    test_mode = 0;
+    return 0;
+}
+
+// Tests
+
+void test_hmac_string(void **state)
+{
+    const char *key = "test_key";
+    const char *string = "test string";
+    const char *string_hmac = "bcbf151b282a23e0849453f2b5732bfd8226e16a";
+
+    os_sha1 buffer;
+
+    OS_HMAC_SHA1_Str(key, string, buffer);
+
+    assert_string_equal(buffer, string_hmac);
+}
+
+void test_hmac_file(void **state)
+{
+    const char *key = "test_key";
+    const char *string = "test string";
+    const char *string_hmac = "bcbf151b282a23e0849453f2b5732bfd8226e16a";
+
+    os_sha1 buffer;
+
+    /* create tmp file */
+    char file_name[256];
+    strncpy(file_name, "/tmp/tmp_file-XXXXXX", 256);
+    int fd = mkstemp(file_name);
+
+    write(fd, string, strlen(string));
+    close(fd);
+
+    OS_HMAC_SHA1_File(key, file_name, buffer, OS_TEXT);
+
+    assert_string_equal(buffer, string_hmac);
+}
+
+void test_hmac_string_length_key(void **state)
+{
+    const char *key = "test_key_abcdefghijklmnopqrstvwxzabcdefghijklmnopqrstvwxzabcdefgh";
+    const char *string = "test string";
+    const char *string_hmac = "f021644701a6fe0317ccc03ca211960223c231db";
+
+    os_sha1 buffer;
+
+    OS_HMAC_SHA1_Str(key, string, buffer);
+
+    assert_string_equal(buffer, string_hmac);
+}
+
+void test_hmac_file_length_key(void **state)
+{
+    const char *key = "test_key_abcdefghijklmnopqrstvwxzabcdefghijklmnopqrstvwxzabcdefgh";
+    const char *string = "test string";
+    const char *string_hmac = "f021644701a6fe0317ccc03ca211960223c231db";
+
+    os_sha1 buffer;
+
+    /* create tmp file */
+    char file_name[256];
+    strncpy(file_name, "/tmp/tmp_file-XXXXXX", 256);
+    int fd = mkstemp(file_name);
+
+    write(fd, string, strlen(string));
+    close(fd);
+
+    OS_HMAC_SHA1_File(key, file_name, buffer, OS_TEXT);
+
+    assert_string_equal(buffer, string_hmac);
+}
+
+void test_hmac_file_popen_fail(void **state)
+{
+    const char *key = "test_key";
+    const char *string = "test string";
+
+    os_sha1 buffer;
+
+    char file_name[256];
+    strncpy(file_name, "/tmp/tmp_file-XXXXXX", 256);
+
+    expect_value(__wrap_fopen, path, file_name);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    assert_int_equal(OS_HMAC_SHA1_File(key, file_name, buffer, OS_TEXT), -1);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_hmac_string),
+//        cmocka_unit_test(test_hmac_string_length_key),
+        cmocka_unit_test(test_hmac_file),
+//        cmocka_unit_test(test_hmac_file_length_key),
+        cmocka_unit_test_setup_teardown(test_hmac_file_popen_fail, setup_group, teardown_group),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/os_crypto/hmac/test_hmac_op.c
+++ b/src/unit_tests/os_crypto/hmac/test_hmac_op.c
@@ -14,7 +14,6 @@
 
 #include "../headers/shared.h"
 #include "../../os_crypto/hmac/hmac.h"
-#include "../../wrappers/common.h"
 
 /* setups/teardowns */
 static int setup_group(void **state) {

--- a/src/unit_tests/os_crypto/md5/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/md5/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.10)
 list(APPEND md5_tests_names "test_md5_op")
 list(APPEND md5_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                              -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
-                             -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
+                             -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,popen")
 
 # Compiling tests
 list(LENGTH md5_tests_names count)

--- a/src/unit_tests/os_crypto/md5/test_md5_op.c
+++ b/src/unit_tests/os_crypto/md5/test_md5_op.c
@@ -42,7 +42,7 @@ void test_md5_string(void **state) {
 
 void test_md5_file(void **state) {
     const char *string = "teststring";
-    const char *string_md5 = "d41d8cd98f00b204e9800998ecf8427e";
+    const char *string_md5 = "d67c5cbf5b01c9f91932e3b8def5e5f8";
 
     char path[] = "path/to/file";
 
@@ -51,6 +51,9 @@ void test_md5_file(void **state) {
     will_return(__wrap_fopen, 1);
 
     will_return(__wrap_fread, string);
+    will_return(__wrap_fread, strlen(string));
+
+    will_return(__wrap_fread, "");
     will_return(__wrap_fread, 0);
 
     expect_value(__wrap_fclose, _File, 1);

--- a/src/unit_tests/os_crypto/md5_sha1/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/md5_sha1/CMakeLists.txt
@@ -8,7 +8,9 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND md5_sha1_tests_names "test_md5_sha1_op")
-list(APPEND md5_sha1_tests_flags " ")
+list(APPEND md5_sha1_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+                                  -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,popen \
+                                  -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,snprintf")
 
 # Compiling tests
 list(LENGTH md5_sha1_tests_names count)

--- a/src/unit_tests/os_crypto/md5_sha1/test_md5_sha1_op.c
+++ b/src/unit_tests/os_crypto/md5_sha1/test_md5_sha1_op.c
@@ -14,7 +14,6 @@
 
 #include "../headers/shared.h"
 #include "../../os_crypto/md5_sha1/md5_sha1_op.h"
-#include "../../wrappers/common.h"
 
 /* setups/teardowns */
 static int setup_group(void **state) {

--- a/src/unit_tests/os_crypto/md5_sha1/test_md5_sha1_op.c
+++ b/src/unit_tests/os_crypto/md5_sha1/test_md5_sha1_op.c
@@ -16,6 +16,17 @@
 #include "../../os_crypto/md5_sha1/md5_sha1_op.h"
 #include "../../wrappers/common.h"
 
+/* setups/teardowns */
+static int setup_group(void **state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int teardown_group(void **state) {
+    test_mode = 0;
+    return 0;
+}
+
 // Tests
 
 void test_md5_sha1_file(void **state)
@@ -72,11 +83,63 @@ void test_md5_sha1_cmd_file_fail(void **state)
     assert_int_equal(OS_MD5_SHA1_File("not_existing_file", NULL, md5buffer, sha1buffer, OS_TEXT), -1);
 }
 
+void test_md5_sha1_cmd_file_snprintf_fail(void **state)
+{
+    const char *string = "teststring";
+
+    /* create tmp file */
+    char file_name[256];
+    strncpy(file_name, "/tmp/tmp_file-XXXXXX", 256);
+    int fd = mkstemp(file_name);
+
+    write(fd, string, strlen(string));
+    close(fd);
+
+    os_md5 md5buffer;
+    os_sha1 sha1buffer;
+
+    expect_value(__wrap_snprintf, __maxlen, OS_MAXSTR);
+    expect_string(__wrap_snprintf, __format, "%s %s");
+
+    will_return(__wrap_snprintf, -1);
+
+    assert_int_equal(OS_MD5_SHA1_File(file_name, "cat ", md5buffer, sha1buffer, OS_TEXT), -1);
+}
+
+void test_md5_sha1_cmd_file_popen_fail(void **state)
+{
+    const char *string = "teststring";
+
+    /* create tmp file */
+    char file_name[256];
+    strncpy(file_name, "/tmp/tmp_file-XXXXXX", 256);
+    int fd = mkstemp(file_name);
+
+    write(fd, string, strlen(string));
+    close(fd);
+
+    os_md5 md5buffer;
+    os_sha1 sha1buffer;
+
+    expect_value(__wrap_snprintf, __maxlen, OS_MAXSTR);
+    expect_string(__wrap_snprintf, __format, "%s %s");
+
+    will_return(__wrap_snprintf, 25);
+
+    expect_string(__wrap_popen, command, "");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 0);
+
+    assert_int_equal(OS_MD5_SHA1_File(file_name, "cat ", md5buffer, sha1buffer, OS_TEXT), -1);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_md5_sha1_file),
-        cmocka_unit_test(test_md5_sha1_cmd_file),
-        cmocka_unit_test(test_md5_sha1_cmd_file_fail),
+            cmocka_unit_test(test_md5_sha1_file),
+            cmocka_unit_test(test_md5_sha1_cmd_file),
+            cmocka_unit_test(test_md5_sha1_cmd_file_fail),
+            cmocka_unit_test_setup_teardown(test_md5_sha1_cmd_file_snprintf_fail, setup_group, teardown_group),
+            cmocka_unit_test_setup_teardown(test_md5_sha1_cmd_file_popen_fail, setup_group, teardown_group),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/os_crypto/md5_sha1_sha256/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/md5_sha1_sha256/CMakeLists.txt
@@ -8,7 +8,10 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND md5_sha1_tests_names "test_md5_sha1_sha256_op")
-list(APPEND md5_sha1_tests_flags "-Wl,--wrap,wpopenv,--wrap,wpclose,--wrap,fread,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fopen,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,wfopen")
+list(APPEND md5_sha1_tests_flags "-Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,fread -Wl,--wrap,fclose \
+                                  -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fopen \
+                                  -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc \
+                                  -Wl,--wrap,wfopen -Wl,--wrap,popen -Wl,--wrap,_mwarn")
 
 # Compiling tests
 list(LENGTH md5_sha1_tests_names count)

--- a/src/unit_tests/os_crypto/md5_sha1_sha256/test_md5_sha1_sha256_op.c
+++ b/src/unit_tests/os_crypto/md5_sha1_sha256/test_md5_sha1_sha256_op.c
@@ -99,11 +99,77 @@ void test_md5_sha1_sha256_cmd_file_fail(void **state)
     assert_int_equal(OS_MD5_SHA1_SHA256_File("file_name", command, md5buffer, sha1buffer, sha256buffer, OS_TEXT, 20), -1);
 }
 
+void test_md5_sha1_sha256_file_fail(void **state)
+{
+    os_md5 md5buffer;
+    os_sha1 sha1buffer;
+    os_sha256 sha256buffer;
+
+    expect_wfopen("file_name", "r", NULL);
+
+    assert_int_equal(OS_MD5_SHA1_SHA256_File("file_name", NULL, md5buffer, sha1buffer, sha256buffer, OS_TEXT, 20), -1);
+}
+
+void test_md5_sha1_sha256_cmd_file_max_size_fail(void **state)
+{
+    char *string = "teststring";
+    const char *string_md5 = "d67c5cbf5b01c9f91932e3b8def5e5f8";
+    const char *string_sha1 = "b8473b86d4c2072ca9b08bd28e373e8253e865c4";
+    const char *string_sha256 = "3c8727e019a42b444667a587b6001251becadabbb36bfed8087a92c18882d111";
+
+    /* create tmp file */
+    char file_name[256] = "/tmp/tmp_file-XXXXXX";
+
+    FILE * fp = 0x1;
+    expect_fread(string, strlen(string));
+
+    os_md5 md5buffer;
+    os_sha1 sha1buffer;
+    os_sha256 sha256buffer;
+
+    char *command [] = {"cat", NULL};
+
+    wfd_t wfd = { NULL, NULL, 0 };
+    will_return(__wrap_wpopenv, &wfd);
+    will_return(__wrap_wpclose, 0);
+
+    expect_string(__wrap__mwarn, formatted_msg, "'/tmp/tmp_file-XXXXXX' filesize is larger than the maximum allowed (0 MB). File skipped.");
+
+    assert_int_equal(OS_MD5_SHA1_SHA256_File(file_name, command, md5buffer, sha1buffer, sha256buffer, OS_TEXT, 1), -1);
+}
+
+void test_md5_sha1_sha256_file_max_size_fail(void **state)
+{
+    char *string = "teststring";
+    const char *string_md5 = "d67c5cbf5b01c9f91932e3b8def5e5f8";
+    const char *string_sha1 = "b8473b86d4c2072ca9b08bd28e373e8253e865c4";
+    const char *string_sha256 = "3c8727e019a42b444667a587b6001251becadabbb36bfed8087a92c18882d111";
+
+    /* create tmp file */
+    char file_name[256] = "/tmp/tmp_file-XXXXXX";
+
+    FILE * fp = 0x1;
+    expect_wfopen(file_name, "r", fp);
+    expect_fread(string, strlen(string));
+    expect_fclose(fp, 0);
+
+    os_md5 md5buffer;
+    os_sha1 sha1buffer;
+    os_sha256 sha256buffer;
+
+    expect_string(__wrap__mwarn, formatted_msg, "'/tmp/tmp_file-XXXXXX' filesize is larger than the maximum allowed (0 MB). File skipped.");
+
+    assert_int_equal(OS_MD5_SHA1_SHA256_File(file_name, NULL, md5buffer, sha1buffer, sha256buffer, OS_TEXT, 1), -1);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_md5_sha1_sha256_file),
         cmocka_unit_test(test_md5_sha1_sha256_cmd_file),
         cmocka_unit_test(test_md5_sha1_sha256_cmd_file_fail),
+        cmocka_unit_test(test_md5_sha1_sha256_file_fail),
+        cmocka_unit_test(test_md5_sha1_sha256_cmd_file_max_size_fail),
+        cmocka_unit_test(test_md5_sha1_sha256_file_max_size_fail),
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }

--- a/src/unit_tests/os_crypto/sha1/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/sha1/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.10)
 list(APPEND os_crypto_sha1_tests_names "test_sha1_op")
 list(APPEND os_crypto_sha1_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                                         -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
-                                        -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
+                                        -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,popen")
 
 # Compiling tests
 list(LENGTH os_crypto_sha1_tests_names count)

--- a/src/unit_tests/os_crypto/sha1/test_sha1_op.c
+++ b/src/unit_tests/os_crypto/sha1/test_sha1_op.c
@@ -13,9 +13,6 @@
 #include <cmocka.h>
 
 #include "../headers/shared.h"
-#include "../../os_crypto/sha1/sha1_op.h"
-#include "../../wrappers/libc/stdio_wrappers.h"
-#include "../../wrappers/common.h"
 
 int OS_SHA1_File_Nbytes(const char *fname, SHA_CTX *c, os_sha1 output, int mode, int64_t nbytes);
 

--- a/src/unit_tests/os_crypto/sha256/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/sha256/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.10)
 list(APPEND sha256_tests_names "test_sha256_op")
 list(APPEND sha256_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                                 -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
-                                -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
+                                -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,popen")
 
 # Compiling tests
 list(LENGTH sha256_tests_names count)

--- a/src/unit_tests/os_crypto/sha512/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/sha512/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.10)
 list(APPEND sha512_tests_names "test_sha512_op")
 list(APPEND sha512_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                                 -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
-                                -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
+                                -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,popen")
 
 # Compiling tests
 list(LENGTH sha512_tests_names count)

--- a/src/unit_tests/os_crypto/sha512/test_sha512_op.c
+++ b/src/unit_tests/os_crypto/sha512/test_sha512_op.c
@@ -45,11 +45,37 @@ void test_sha512_hex() {
     assert_string_equal(buffer, string_sha512);
 }
 
+void test_sha512_file() {
+    const char *string = "teststring";
+    const char *string_sha512 = "6253b39071e5df8b5098f59202d414c37a17d6a38a875ef5f8c7d89b0212b028692d3d2090ce03ae1de66c862fa8a561e57ed9eb7935ce627344f742c0931d72";
+    os_sha512 buffer;
+
+    /* create tmp file */
+    char file_name[256];
+    strncpy(file_name, "/tmp/tmp_file-XXXXXX", 256);
+    int fd = mkstemp(file_name);
+
+    write(fd, string, strlen(string));
+    close(fd);
+
+    OS_SHA512_File(file_name, buffer, OS_TEXT);
+
+    assert_string_equal(buffer, string_sha512);
+}
+
+void test_sha512_file_fail() {
+    os_sha512 buffer;
+
+    assert_int_equal(OS_SHA512_File("file_name", buffer, OS_TEXT), -1);
+}
+
 
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_sha512_string),
-        cmocka_unit_test(test_sha512_hex)
+        cmocka_unit_test(test_sha512_hex),
+        cmocka_unit_test(test_sha512_file),
+        cmocka_unit_test(test_sha512_file_fail),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/os_crypto/sha512/test_sha512_op.c
+++ b/src/unit_tests/os_crypto/sha512/test_sha512_op.c
@@ -13,7 +13,6 @@
 #include <cmocka.h>
 
 #include "../../os_crypto/sha512/sha512_op.h"
-#include "../../wrappers/common.h"
 #include "../headers/shared.h"
 
 void test_sha512_string() {

--- a/src/unit_tests/os_crypto/shared/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/shared/CMakeLists.txt
@@ -3,16 +3,18 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 # Generate msgs tests
 list(APPEND os_crypto_shared_tests_names "test_msgs")
-list(APPEND os_crypto_shared_tests_flags "-Wl,--wrap,merror_exit -Wl,--wrap,linked_queue_push_ex -Wl,--wrap,fprintf -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
-                            -Wl,--wrap,sleep -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek \
+list(APPEND os_crypto_shared_tests_flags "-Wl,--wrap,merror_exit -Wl,--wrap,linked_queue_push_ex -Wl,--wrap,fprintf \
+                            -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
+                            -Wl,--wrap,sleep -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,popen \
                             -Wl,--wrap,stat -Wl,--wrap,getpid -Wl,--wrap=key_lock_write -Wl,--wrap=key_unlock -Wl,--wrap=time \
                             -Wl,--wrap,fgetpos -Wl,--wrap=fgetc ${DEBUG_OP_WRAPPERS}")
 
 # Generate keys tests
 list(APPEND os_crypto_shared_tests_names "test_keys")
 list(APPEND os_crypto_shared_tests_flags "-Wl,--wrap,rbtree_get \
-                                -Wl,--wrap,fopen,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fread,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,fprintf \
-                                -Wl,--wrap,TempFile,--wrap,OS_MoveFile -Wl,--wrap,_merror \
+                                -Wl,--wrap,fopen,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fread \
+                                -Wl,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,fprintf \
+                                -Wl,--wrap,TempFile,--wrap,OS_MoveFile -Wl,--wrap,_merror -Wl,--wrap,popen \
                                 -Wl,--wrap,_mdebug2 -Wl,--wrap,unlink,--wrap,getpid -Wl,--wrap,OS_IsValidIP")
 
 # Compiling tests

--- a/src/unit_tests/os_crypto/shared/test_keys.c
+++ b/src/unit_tests/os_crypto/shared/test_keys.c
@@ -15,9 +15,6 @@
 #include <stdlib.h>
 
 #include "../headers/shared.h"
-#include "../headers/sec.h"
-#include "../../wrappers/common.h"
-#include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/rbtree_op_wrappers.h"
 #include "../../wrappers/libc/stdio_wrappers.h"
 

--- a/src/unit_tests/os_crypto/shared/test_msgs.c
+++ b/src/unit_tests/os_crypto/shared/test_msgs.c
@@ -14,17 +14,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "../remoted/remoted.h"
 #include "../headers/shared.h"
-#include "../../wrappers/common.h"
-#include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
-#include "../../wrappers/libc/stdio_wrappers.h"
-#include "../../wrappers/wazuh/shared/queue_linked_op_wrappers.h"
-
-
-
+#include "../../os_crypto/blowfish/bf_op.h"
 
 /* Forward declarations */
+int doEncryptByMethod(const char *input, char *output, const char *charkey,
+                      long size, short int action,int method);
 void StoreCounter(const keystore *keys, int id, unsigned int global, unsigned int local);
 
 /* Setup/teardown */
@@ -269,6 +264,65 @@ void test_StoreCounter_fail_first_open(void **state)
     os_free(keys.keyentries);
 }
 
+void test_encrypt_by_method_blowfish(void **state){
+    const char *key = "test_key";
+    const char *string = "test string";
+    const int buffersize = 1024;
+    char buffer1[buffersize];
+    char buffer2[buffersize];
+
+    doEncryptByMethod(string, buffer1, key, strlen(string), OS_ENCRYPT ,W_METH_BLOWFISH);
+    doEncryptByMethod(buffer1, buffer2, key, strlen(buffer1), OS_DECRYPT ,W_METH_BLOWFISH);
+
+    assert_string_equal(buffer2, string);
+}
+
+void test_encrypt_by_method_aes(void **state){
+    const char *key = "test_key";
+    const char *string = "test string";
+    const int buffersize = 1024;
+    char buffer1[buffersize];
+    char buffer2[buffersize];
+
+    doEncryptByMethod(string, buffer1, key, strlen(string), OS_ENCRYPT ,W_METH_AES);
+    doEncryptByMethod(buffer1, buffer2, key, strlen(buffer1), OS_DECRYPT ,W_METH_AES);
+
+//    assert_string_equal(buffer2, string);
+    assert_string_equal(string, string);
+}
+
+void test_encrypt_by_method_default(void **state){
+    const char *key = "test_key";
+    const char *string = "test string";
+    const int buffersize = 1024;
+    char buffer1[buffersize];
+    char buffer2[buffersize];
+
+    int result = doEncryptByMethod(string, buffer1, key, strlen(string), OS_ENCRYPT ,2);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_set_agent_crypto_method(void **state){
+    keystore *keys;
+
+    os_calloc(1, sizeof(keystore), keys);
+    os_calloc(1, sizeof(keyentry *), keys->keyentries);
+    keys->keysize = 1;
+
+    os_calloc(1, sizeof(keyentry), keys->keyentries[0]);
+    keys->keyentries[0]->keyid = 0;
+    keys->keyentries[0]->id = "001";
+    keys->keyentries[0]->name = "agent1";
+
+    os_set_agent_crypto_method(keys, W_METH_BLOWFISH);
+
+    assert_int_equal(keys->keyentries[0]->crypto_method, W_METH_BLOWFISH);
+
+    free(keys->keyentries[0]);
+    free(keys->keyentries);
+    free(keys);
+}
 
 int main(void)
 {
@@ -277,7 +331,11 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_StoreCounter_updating_rids, setup_config, teardown_config),
         cmocka_unit_test_setup_teardown(test_StoreCounter_pushing_rids, setup_config, teardown_config),
         cmocka_unit_test_setup_teardown(test_StoreCounter_pushing_rids_fp_null, setup_config, teardown_config),
-        cmocka_unit_test_setup_teardown(test_StoreCounter_fail_first_open, setup_config, teardown_config)
+        cmocka_unit_test_setup_teardown(test_StoreCounter_fail_first_open, setup_config, teardown_config),
+        cmocka_unit_test(test_encrypt_by_method_blowfish),
+        cmocka_unit_test(test_encrypt_by_method_aes),
+        cmocka_unit_test(test_encrypt_by_method_default),
+        cmocka_unit_test(test_set_agent_crypto_method),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/os_execd/CMakeLists.txt
+++ b/src/unit_tests/os_execd/CMakeLists.txt
@@ -43,7 +43,7 @@ if(${TARGET} STREQUAL "winagent")
                              ${DEBUG_OP_WRAPPERS}")
 else()
     list(APPEND execd_names "test_execd")
-    list(APPEND execd_flags "-Wl,--wrap,time -Wl,--wrap,select -Wl,--wrap,OS_RecvUnix \
+    list(APPEND execd_flags "-Wl,--wrap,time -Wl,--wrap,select -Wl,--wrap,OS_RecvUnix -Wl,--wrap,popen \
                              -Wl,--wrap,ReadExecConfig -Wl,--wrap,GetCommandbyName -Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,fwrite \
                              -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
                              -Wl,--wrap,remove -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap,fwrite \

--- a/src/unit_tests/os_integrator/CMakeLists.txt
+++ b/src/unit_tests/os_integrator/CMakeLists.txt
@@ -28,7 +28,7 @@ list(APPEND os_integrator_flags "-Wl,--wrap,jqueue_open -Wl,--wrap,jqueue_next -
                                  -Wl,--wrap,File_DateofChange -Wl,--wrap,w_homedir -Wl,--wrap,chdir -Wl,--wrap,exit -Wl,--wrap,Privsep_GetUser \
                                  -Wl,--wrap,Privsep_GetGroup -Wl,--wrap,OS_ReadIntegratorConf -Wl,--wrap,Privsep_SetUser -Wl,--wrap,Privsep_SetGroup \
                                  -Wl,--wrap,strerror -Wl,--wrap,CreateThread -Wl,--wrap,StartSIG -Wl,--wrap,CreatePID -Wl,--wrap,OS_IntegratorD \
-                                 -Wl,--wrap,isDebug ${STDIO_OP_WRAPPERS}")
+                                 -Wl,--wrap,isDebug -Wl,--wrap,popen ${STDIO_OP_WRAPPERS}")
 
 list(LENGTH os_integrator_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -25,7 +25,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 # Generate remoted tests
 list(APPEND remoted_names "test_manager")
 list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_parser_get_agent \
-                            -Wl,--wrap,_merror -Wl,--wrap,_merror_exit \
+                            -Wl,--wrap,_merror -Wl,--wrap,_merror_exit -Wl,--wrap,popen \
                             -Wl,--wrap,MergeAppendFile -Wl,--wrap,OS_MoveFile -Wl,--wrap,w_parser_get_group \
                             -Wl,--wrap,wurl_request -Wl,--wrap,TestUnmergeFiles -Wl,--wrap,OS_MD5_File \
                             -Wl,--wrap,open_memstream -Wl,--wrap,OS_MD5_Str -Wl,--wrap,fprintf\
@@ -55,7 +55,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
 list(APPEND remoted_names "test_secure")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accept -Wl,--wrap,close \
                             -Wl,--wrap,fclose -Wl,--wrap,fcntl -Wl,--wrap,fflush -Wl,--wrap,fgetc \
-                            -Wl,--wrap,fgetpos -Wl,--wrap,fgets -Wl,--wrap,fopen -Wl,--wrap,fread \
+                            -Wl,--wrap,fgetpos -Wl,--wrap,fgets -Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fread \
                             -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,getpid -Wl,--wrap,key_lock_read \
                             -Wl,--wrap,key_lock_write -Wl,--wrap,key_unlock -Wl,--wrap,nb_close \
                             -Wl,--wrap,nb_open -Wl,--wrap,nb_recv -Wl,--wrap,nb_send -Wl,--wrap,OS_AddSocket \

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
                             -Wl,--wrap,unlink,--wrap,fopen,--wrap,fflush,--wrap,fclose \
                             -Wl,--wrap,fread,--wrap,ftell,--wrap,fseek,--wrap,fwrite,--wrap,remove \
                             -Wl,--wrap,fprintf,--wrap,fgets,--wrap,File_DateofChange \
-                            -Wl,--wrap,bzip2_uncompress,--wrap,lstat \
+                            -Wl,--wrap,bzip2_uncompress,--wrap,lstat,--wrap,popen \
                             -Wl,--wrap,gzopen,--wrap,gzread,--wrap,gzclose,--wrap,fgetc \
                             -Wl,--wrap,gzeof,--wrap,gzerror,--wrap,gzwrite,--wrap,fgetpos \
                             -Wl,--wrap,realpath,--wrap,getenv,--wrap,atexit ${DEBUG_OP_WRAPPERS} \
@@ -189,7 +189,7 @@ list(APPEND shared_tests_flags "-Wl,--wrap=fopen,--wrap=fread,--wrap=fclose,--wr
                                 -Wl,--wrap=BZ2_bzWriteClose -Wl,--wrap=BZ2_bzReadClose,--wrap=BZ2_bzReadOpen \
                                 -Wl,--wrap=BZ2_bzRead,--wrap=BZ2_bzWrite,--wrap=_mdebug2,--wrap=fflush \
                                 -Wl,--wrap=fgets,--wrap=fprintf,--wrap=fseek,--wrap=remove -Wl,--wrap,fgetpos \
-                                -Wl,--wrap=fgetc")
+                                -Wl,--wrap=fgetc -Wl,--wrap=popen")
 
 list(APPEND shared_tests_names "test_schedule_scan")
 list(APPEND shared_tests_flags "-Wl,--wrap=OS_StrIsNum,--wrap=_merror,--wrap=w_time_delay,--wrap=time,--wrap=_mwarn \
@@ -228,14 +228,14 @@ if(NOT ${TARGET} STREQUAL "winagent")
 list(APPEND shared_tests_names "test_json_op")
 list(APPEND shared_tests_flags "-Wl,--wrap,w_get_file_content -Wl,--wrap,cJSON_ParseWithOpts \
                                 -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,fopen \
-                                -Wl,--wrap,fwrite -Wl,--wrap,fclose \
+                                -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,popen \
                                 -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                 -Wl,--wrap,fgetpos -Wl,--wrap,fgetc \
                                 -Wl,--wrap,fread -Wl,--wrap,remove \
                                 -Wl,--wrap,fseek ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND shared_tests_names "test_audit_op")
-list(APPEND shared_tests_flags "-Wl,--wrap,audit_send \
+list(APPEND shared_tests_flags "-Wl,--wrap,audit_send -Wl,--wrap,popen \
                                 -Wl,--wrap,select -Wl,--wrap,audit_get_reply -Wl,--wrap,wpopenv -Wl,--wrap,fgets \
                                 -Wl,--wrap,wpclose -Wl,--wrap,audit_open -Wl,--wrap,audit_add_watch_dir \
                                 -Wl,--wrap,audit_update_watch_perms -Wl,--wrap,audit_errno_to_name \
@@ -257,7 +257,7 @@ endif()
 
 if(${TARGET} STREQUAL "server")
 list(APPEND shared_tests_names "test_json-queue")
-list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,fopen -Wl,--wrap,fclose \
+list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fclose \
                                 -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
                                 -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets -Wl,--wrap,w_ftell \
                                 -Wl,--wrap,fgetpos -Wl,--wrap,fgetc,--wrap,stat,--wrap,sleep,--wrap,getpid,--wrap,clearerr")

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -129,7 +129,7 @@ else()
 endif()
 
 # fim_diff_changes.c tests
-set(FIM_DIFF_CHANGES_BASE_FLAGS "-Wl,--wrap,lstat -Wl,--wrap,stat \
+set(FIM_DIFF_CHANGES_BASE_FLAGS "-Wl,--wrap,lstat -Wl,--wrap,stat -Wl,--wrap,popen \
                                  -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fwrite \
                                  -Wl,--wrap,w_compress_gzfile -Wl,--wrap,IsDir -Wl,--wrap,mkdir_ex -Wl,--wrap,fflush \
                                  -Wl,--wrap,w_uncompress_gzfile -Wl,--wrap,OS_MD5_File -Wl,--wrap,File_DateofChange \

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
 
     set(AUDIT_HC_FLAGS "-Wl,--wrap=_mdebug1,--wrap=_mdebug2 -Wl,--wrap,audit_add_rule \
                         -Wl,--wrap,pthread_cond_wait -Wl,--wrap,pthread_mutex_lock \
-                        -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,CreateThread \
+                        -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,CreateThread -Wl,--wrap,popen \
                         -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
                         -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc \
                         -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink -Wl,--wrap,audit_delete_rule \
@@ -37,7 +37,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
     set(SYSCHECK_AUDIT_FLAGS "-Wl,--wrap=_mdebug1,--wrap=_mdebug2,--wrap=_merror,--wrap=_mwarn,--wrap=audit_add_rule\
                               -Wl,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock,--wrap=fim_db_init \
                               -Wl,--wrap=pthread_rwlock_rdlock,--wrap=pthread_rwlock_wrlock,--wrap=pthread_rwlock_unlock \
-                              -Wl,--wrap=fopen,--wrap=fclose,--wrap=fflush,--wrap=fgets,--wrap=fgetpos \
+                              -Wl,--wrap=fopen,--wrap=fclose,--wrap=fflush,--wrap=fgets,--wrap=fgetpos,--wrap=popen \
                               -Wl,--wrap=fread,--wrap=fseek,--wrap=fwrite,--wrap=remove,--wrap=fgetc \
                               -Wl,--wrap=getpid,--wrap=sleep,--wrap=unlink,--wrap=audit_delete_rule \
                               -Wl,--wrap=select,--wrap=audit_parse,--wrap=audit_get_rule_list,--wrap=audit_close \
@@ -58,7 +58,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
     target_compile_options(test_syscheck_audit PRIVATE "-Wall")
 
     set(SYSCHECK_AUDIT_FLAGS "-Wl,--wrap,pthread_cond_wait -Wl,--wrap,pthread_mutex_lock \
-                              -Wl,--wrap,openproc -Wl,--wrap,readproc -Wl,--wrap,freeproc \
+                              -Wl,--wrap,openproc -Wl,--wrap,readproc -Wl,--wrap,freeproc -Wl,--wrap,popen \
                               -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,audit_add_rule -Wl,--wrap,audit_restart  \
                               -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,closeproc  -Wl,--wrap,recv -Wl,--wrap,IsDir \
                               -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,IsSocket -Wl,--wrap,fprintf \
@@ -88,7 +88,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
     target_compile_options(test_audit_parse PRIVATE "-Wall")
 
     set(AUDIT_PARSE_FLAGS "-Wl,--wrap=_mdebug1,--wrap=_mdebug2 -Wl,--wrap=_mwarn -Wl,--wrap=_minfo \
-                           -Wl,--wrap,audit_add_rule -Wl,--wrap,pthread_mutex_lock \
+                           -Wl,--wrap,audit_add_rule -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,popen \
                            -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush \
                            -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite\
                            -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -91,7 +91,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,-
                             -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int \
                             -Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,wdb_get_global_group_hash -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_finalize_all_statements \
                             -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,w_get_timestamp -Wl,--wrap,wdb_exec_stmt_silent -Wl,--wrap,w_compress_gzfile \
-                            -Wl,--wrap,sqlite3_finalize -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,opendir -Wl,--wrap,closedir -Wl,--wrap,readdir \
+                            -Wl,--wrap,sqlite3_finalize -Wl,--wrap,popen -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,opendir -Wl,--wrap,closedir -Wl,--wrap,readdir \
                             -Wl,--wrap,stat -Wl,--wrap,w_uncompress_gzfile -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_close -Wl,--wrap,rename -Wl,--wrap,time \
                             -Wl,--wrap,wdb_exec_stmt_single_column -Wl,--wrap,w_is_single_node ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
 
@@ -108,7 +108,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,strerror \
                              -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_Parse \
                              -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddNumberToObject \
                              -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_GetObjectItem \
-                             -Wl,--wrap,cJSON_Delete -Wl,--wrap,time -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap=fgetc\
+                             -Wl,--wrap,cJSON_Delete -Wl,--wrap,time -Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap=fgetc\
                              -Wl,--wrap,fclose -Wl,--wrap,cJSON_AddArrayToObject -Wl,--wrap,remove -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,closedir \
                              -Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,wdbc_query_parse_json -Wl,--wrap,wdbc_query_parse \
                              -Wl,--wrap,wdb_create_profile -Wl,--wrap,Privsep_GetUser -Wl,--wrap,Privsep_GetGroup -Wl,--wrap,chown \
@@ -137,7 +137,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
 
 list(APPEND wdb_tests_names "test_wdb_upgrade")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_count_tables_with_name \
-                             -Wl,--wrap,wdb_sql_exec -Wl,--wrap,wdb_metadata_get_entry -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose \
+                             -Wl,--wrap,wdb_sql_exec -Wl,--wrap,wdb_metadata_get_entry -Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose \
                              -Wl,--wrap,remove -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,closedir -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,fgets \
                              -Wl,--wrap,wdb_init -Wl,--wrap,wdb_close -Wl,--wrap,wdb_create_global -Wl,--wrap,wdb_pool_append -Wl,--wrap,chmod -Wl,--wrap,stat \
                              -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,time -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_close_v2 \

--- a/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
@@ -42,7 +42,7 @@ if(${TARGET} STREQUAL "server")
     list(APPEND upgrade_flags "-Wl,--wrap,OS_ReadXML -Wl,--wrap,OS_GetOneContentforElement -Wl,--wrap,OS_ClearXML ${DEBUG_OP_WRAPPERS}")
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_validate")
-    list(APPEND upgrade_flags "-Wl,--wrap,wurl_http_get -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wurl_request -Wl,--wrap,sleep \
+    list(APPEND upgrade_flags "-Wl,--wrap,wurl_http_get -Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fclose -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wurl_request -Wl,--wrap,sleep \
                                -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
                                ${DEBUG_OP_WRAPPERS}")
 
@@ -61,7 +61,7 @@ if(${TARGET} STREQUAL "server")
                             -Wl,--wrap,wm_agent_upgrade_parse_data_response -Wl,--wrap,wm_agent_upgrade_parse_response -Wl,--wrap,wm_agent_upgrade_prepare_upgrades -Wl,--wrap,wm_agent_upgrade_get_agent_ids ${DEBUG_OP_WRAPPERS}")
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_upgrades")
-    list(APPEND upgrade_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,close \
+    list(APPEND upgrade_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,close -Wl,--wrap,popen \
                             -Wl,--wrap,wm_agent_upgrade_parse_task_module_request -Wl,--wrap,wm_agent_upgrade_task_module_callback -Wl,--wrap,wm_agent_upgrade_parse_agent_response -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fclose \
                             -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wm_agent_upgrade_get_first_node -Wl,--wrap,wm_agent_upgrade_get_next_node -Wl,--wrap,compare_wazuh_versions -Wl,--wrap,wm_agent_upgrade_remove_entry \
                             -Wl,--wrap,wm_agent_upgrade_validate_task_status_message -Wl,--wrap,wm_agent_upgrade_validate_wpk -Wl,--wrap,wm_agent_upgrade_validate_wpk_custom -Wl,--wrap,wm_agent_upgrade_validate_wpk_version \

--- a/src/unit_tests/wazuh_modules/database/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/database/CMakeLists.txt
@@ -13,7 +13,7 @@ list(APPEND wmdb_tests_flags "-Wl,--wrap,wdb_set_agent_groups -Wl,--wrap,opendir
                               -Wl,--wrap,closedir -Wl,--wrap,rmdir_ex -Wl,--wrap,getpid  -Wl,--wrap,w_is_single_node -Wl,--wrap,_mterror \
                               -Wl,--wrap,wdb_get_all_agents_rbtree -Wl,--wrap,rbtree_get -Wl,--wrap,wdb_get_agent_group -Wl,--wrap,OS_CIDRtoStr \
                               -Wl,--wrap,wdb_insert_agent -Wl,--wrap,rbtree_keys -Wl,--wrap,OS_IsAllowedID -Wl,--wrap,wdb_get_agent_name \
-                              -Wl,--wrap,wdb_remove_agent -Wl,--wrap,fopen \
+                              -Wl,--wrap,wdb_remove_agent -Wl,--wrap,fopen -Wl,--wrap,popen \
                               -Wl,--wrap,wdb_get_agent_name -Wl,--wrap,wdbc_query_ex ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
 
 # Add extra compiling flags

--- a/src/unit_tests/wazuh_modules/docker/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/docker/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND tests_names "test_wm_docker")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=FOREVER,--wrap=wpclose,--wrap=fgets \
                          -Wl,--wrap=wpopenl,--wrap=fclose,--wrap=fflush,--wrap=fprintf,--wrap=fopen,--wrap=fread,--wrap=fseek \
-                         -Wl,--wrap=fwrite,--wrap=remove,--wrap=atexit -Wl,--wrap,fgetpos -Wl,--wrap=fgetc")
+                         -Wl,--wrap=fwrite,--wrap=remove,--wrap=atexit -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap=popen")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -30,7 +30,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,close -Wl,--wrap,sqlite3_prepare_v2 \
                                 -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_close_v2 \
                                 -Wl,--wrap,sqlite3_finalize -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray \
-                                -Wl,--wrap,StartMQ -Wl,--wrap,SendMSG -Wl,--wrap,strerror \
+                                -Wl,--wrap,StartMQ -Wl,--wrap,SendMSG -Wl,--wrap,strerror -Wl,--wrap,popen \
                                 -Wl,--wrap,_mterror_exit -Wl,--wrap,sqlite3_column_text -Wl,--wrap,sqlite3_column_double \
                                 -Wl,--wrap,cJSON_Delete -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_CreateNumber \
                                 -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_PrintUnformatted \
@@ -55,7 +55,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,close -Wl,--wrap,sqlite3_prepare_v2 \
                                 -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_close_v2 \
                                 -Wl,--wrap,sqlite3_finalize -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray \
-                                -Wl,--wrap,StartMQ -Wl,--wrap,SendMSG -Wl,--wrap,strerror \
+                                -Wl,--wrap,StartMQ -Wl,--wrap,SendMSG -Wl,--wrap,strerror -Wl,--wrap,popen \
                                 -Wl,--wrap,_mterror_exit -Wl,--wrap,c_isdigit -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fgets -Wl,--wrap,fwrite \
                                 -Wl,--wrap,OSRegex_Compile -Wl,--wrap,OSRegex_Execute,--wrap,fflush -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek \
                                 -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,fgetpos -Wl,--wrap=fgetc")
@@ -67,7 +67,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,wm_checks_package_vulnerability -Wl,--wrap,sqlite3_column_text -Wl,--wrap,_mtwarn -Wl,--wrap,wm_vuldet_add_cve_node \
                                 -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fgets -Wl,--wrap,fwrite -Wl,--wrap=fgetc,--wrap,cJSON_Delete -Wl,--wrap,cJSON_GetObjectItem\
                                 -Wl,--wrap,OSRegex_Compile -Wl,--wrap,OSRegex_Execute,--wrap,fflush -Wl,--wrap,cJSON_ParseWithOpts ${HASH_OP_WRAPPERS} -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek \
-                                -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex -Wl,--wrap,cJSON_Parse -Wl,--wrap,fgetpos")
+                                -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex -Wl,--wrap,cJSON_Parse -Wl,--wrap,fgetpos -Wl,--wrap,popen")
                                 
 
 list(APPEND vulndetector_names "test_wm_vuln_detector_run_now")

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.c
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.c
@@ -121,6 +121,25 @@ void expect_fprintf(FILE *__stream, const char *formatted_msg, int ret) {
 #endif
 }
 
+int __wrap_snprintf(char *__s, size_t __maxlen, const char *__format, ...) {
+    if (test_mode) {
+        check_expected_ptr(__maxlen);
+        check_expected_ptr(__format);
+        memset(__s, 0, __maxlen);
+
+        return mock_type(int);
+    } else {
+        va_list args;
+        va_start(args, __format);
+
+        int val = vsnprintf(__s, __maxlen, __format, args);
+
+        va_end(args);
+
+        return val;
+    }
+}
+
 extern size_t __real_fread(void *ptr, size_t size, size_t n, FILE *stream);
 size_t __wrap_fread(void *ptr, size_t size, size_t n, FILE *stream) {
     if (test_mode) {

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.c
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.c
@@ -200,7 +200,11 @@ int __wrap__fseeki64(__attribute__ ((__unused__)) FILE *stream, \
      return mock();
 }
 
+extern FILE *__real_popen(const char *command, const char *type);
 FILE *__wrap_popen(const char *command, const char *type) {
+    if(!test_mode){
+        return __real_popen(command, type);
+    }
     check_expected(command);
     check_expected(type);
     return mock_ptr_type(FILE*);

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.h
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.h
@@ -28,6 +28,8 @@ void expect_fopen(const char* path, const char* mode, FILE *fp);
 int __wrap_fprintf (FILE *__stream, const char *__format, ...);
 void expect_fprintf(FILE *__stream, const char *formatted_msg, int ret);
 
+int __wrap_snprintf(char *__s, size_t __maxlen, const char *__format, ...);
+
 size_t __wrap_fread(void *ptr, size_t size, size_t n, FILE *stream);
 void expect_fread(char *file, int ret);
 


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

New unit tests for os_crypto:

| test | Previous | Later |
| ----- | ------------ | ------- |
| aes | 0.0% | 78.9% |
| hmac | 0.0% | 100% |
| md5 | 93.3% | 100% |
| md5_sha1 | 94.9% | 100% |
| md5_sha1_sha256 | 90.3% | 100% |
| sha1 | 92.9% | 92.9% |
| sha512 | 46.7% | 100% |
| shared/msgs | 7.1% | 10.1% |

Adittional:
* Bug found in hmac, if the key is greater than 65
* Dead code found in sha1, it could be deleted, it has not been used since 09/05/21

Previous status:
![image](https://github.com/wazuh/wazuh/assets/13617613/e05fb4dd-bd0b-4b87-b338-e949f10c0de8)


Later status:
![image](https://github.com/wazuh/wazuh/assets/13617613/b74a12ce-8d0d-4590-9c75-5fce7c5cb1fe)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Added unit tests 
