### PR TITLE
Revert logging level changes in wazuh-integratord

### DIFF
--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -434,7 +434,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                 exec_tmp_file,
                 integrator_config[s]->apikey == NULL ? "" : integrator_config[s]->apikey,
                 integrator_config[s]->hookurl == NULL ? "" : integrator_config[s]->hookurl,
-                debugLevels[dbg_lvl],
+                dbg_lvl <= 0 ? "" : "debug",
                 opt_file_created == 0 ? "" : opt_tmp_file,
                 integrator_config[s]->timeout,
                 integrator_config[s]->retries);

--- a/src/os_integrator/integrator.h
+++ b/src/os_integrator/integrator.h
@@ -14,9 +14,6 @@
 
 #include "../config/integrator-config.h"
 
-#define MAX_DEBUG_LEVEL LOGLEVEL_CRITICAL + 1
-static const char* debugLevels[] = { "NOTSET", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" };
-
 /** Prototypes **/
 
 /* Read syslog config */

--- a/src/os_integrator/main.c
+++ b/src/os_integrator/main.c
@@ -12,6 +12,7 @@
 #include "integrator.h"
 #include "shared.h"
 
+
 void help(const char *prog)
 {
     print_out(" ");
@@ -32,10 +33,6 @@ void help(const char *prog)
     exit(1);
 }
 
-#ifdef WAZUH_UNIT_TESTING
-int test_main() __attribute__ ((weak, alias ("main")));
-__attribute((weak))
-#endif
 int main(int argc, char **argv)
 {
     int i = 0;
@@ -74,10 +71,8 @@ int main(int argc, char **argv)
                 help(ARGV0);
                 break;
             case 'd':
-                if (MAX_DEBUG_LEVEL > debug_level) {
-                    nowDebug();
-                    debug_level++;
-                }
+                nowDebug();
+                debug_level = 1;
                 break;
             case 'u':
                 if(!optarg)
@@ -103,7 +98,7 @@ int main(int argc, char **argv)
 
     if (debug_level == 0) {
         /* Get debug level */
-        debug_level = getDefine_Int("integrator", "debug", 0, MAX_DEBUG_LEVEL);
+        debug_level = getDefine_Int("integrator", "debug", 0, 2);
         while (debug_level != 0) {
             nowDebug();
             debug_level--;

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -38,12 +38,6 @@ static void _log(int level, const char *tag, const char * file, int line, const 
 }
 
 
-#ifdef WAZUH_UNIT_TESTING
-void resetDebug() {
-    dbg_flag = 0;
-}
-#endif
-
 #ifdef WIN32
 void WinSetError();
 #endif

--- a/src/unit_tests/os_integrator/CMakeLists.txt
+++ b/src/unit_tests/os_integrator/CMakeLists.txt
@@ -25,10 +25,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 list(APPEND os_integrator_names "test_integrator")
 list(APPEND os_integrator_flags "-Wl,--wrap,jqueue_open -Wl,--wrap,jqueue_next -Wl,--wrap,FOREVER -Wl,--wrap,time ${DEBUG_OP_WRAPPERS} \
                                  -Wl,--wrap,os_random -Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,fprintf -Wl,--wrap,unlink,--wrap,getpid \
-                                 -Wl,--wrap,File_DateofChange -Wl,--wrap,w_homedir -Wl,--wrap,chdir -Wl,--wrap,exit -Wl,--wrap,Privsep_GetUser \
-                                 -Wl,--wrap,Privsep_GetGroup -Wl,--wrap,OS_ReadIntegratorConf -Wl,--wrap,Privsep_SetUser -Wl,--wrap,Privsep_SetGroup \
-                                 -Wl,--wrap,strerror -Wl,--wrap,CreateThread -Wl,--wrap,StartSIG -Wl,--wrap,CreatePID -Wl,--wrap,OS_IntegratorD \
-                                 -Wl,--wrap,isDebug ${STDIO_OP_WRAPPERS}")
+                                 -Wl,--wrap,File_DateofChange ${STDIO_OP_WRAPPERS}")
 
 list(LENGTH os_integrator_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/os_integrator/test_integrator.c
+++ b/src/unit_tests/os_integrator/test_integrator.c
@@ -19,10 +19,6 @@
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/libc/stdio_wrappers.h"
 
-int test_main(int argc, char **argv);
-IntegratorConfig **local_integrator_config = NULL;
-static bool call_real = true;
-
 static int test_setup(void **state) {
     test_mode = 1;
 
@@ -45,11 +41,6 @@ static int test_setup(void **state) {
 
     state[0] = virustotal_config;
     state[1] = pagerduty_config;
-
-    optarg = NULL;
-    optind = opterr = optopt = 0;
-    resetDebug();
-    call_real = true;
 
     return OS_SUCCESS;
 }
@@ -138,12 +129,10 @@ void test_OS_IntegratorD(void **state) {
 
     expect_fclose((FILE *)1, 0);
 
-    will_return(__wrap_isDebug, __real_isDebug());
-
     will_return(__wrap_time, 1111);
     will_return(__wrap_os_random, 2222);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Running script with args: integrations /tmp/virustotal-1111-2222.alert 123456  NOTSET  0 0 > /dev/null 2>&1");
+    expect_string(__wrap__mdebug1, formatted_msg, "Running script with args: integrations /tmp/virustotal-1111-2222.alert 123456    0 0 > /dev/null 2>&1");
 
     will_return(__wrap_wpopenv, wfd);
 
@@ -161,8 +150,6 @@ void test_OS_IntegratorD(void **state) {
 
     expect_string(__wrap_unlink, file, virustotal_file);
     will_return(__wrap_unlink, 0);
-
-    will_return(__wrap_isDebug, LOGLEVEL_WARNING + 1);
 
     will_return(__wrap_time, 1111);
     will_return(__wrap_os_random, 2222);
@@ -187,7 +174,7 @@ void test_OS_IntegratorD(void **state) {
 
     expect_fclose((FILE *)1, 0);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Running script with args: integrations /tmp/pagerduty-1111-2222.alert 123456  WARNING /tmp/pagerduty-1111-2222.options 0 0");
+    expect_string(__wrap__mdebug1, formatted_msg, "Running script with args: integrations /tmp/pagerduty-1111-2222.alert 123456   /tmp/pagerduty-1111-2222.options 0 0 > /dev/null 2>&1");
 
     will_return(__wrap_wpopenv, wfd);
 
@@ -218,130 +205,9 @@ void test_OS_IntegratorD(void **state) {
     cJSON_Delete(op_json);
 }
 
-int __wrap_isDebug() {
-    return mock();
-}
-
-char *__wrap_w_homedir(void **state)
-{
-    check_expected(state);
-    return mock();
-}
-
-void **__wrap_OS_ReadIntegratorConf(char *cfgfile, IntegratorConfig ***integrator_config)
-{
-    check_expected_ptr(integrator_config);
-    *integrator_config = local_integrator_config;
-    return (void **)*integrator_config;
-}
-
-void __wrap_StartSIG(__attribute__((unused)) const char *process_name)
-{
-}
-
-int __wrap_CreatePID(__attribute__((unused)) const char *name, __attribute__((unused)) int pid) {
-    return OS_SUCCESS;
-}
-
-void __wrap_OS_IntegratorD(IntegratorConfig **integrator_config) {
-    if (call_real)
-        __real_OS_IntegratorD(integrator_config);
-}
-
-#define PATH_TO_TEST "/path/to/test"
-#define HOME_PATH_STRDUP()      char* _home_path = strdup(PATH_TO_TEST); \
-                                expect_string(__wrap_w_homedir, state, _home_path); \
-                                will_return(__wrap_w_homedir, _home_path); \
-                                expect_string(__wrap_chdir, __path, _home_path); \
-                                will_return(__wrap_chdir, 0)
-
-#define GET_USER_GROUP()        expect_string(__wrap_Privsep_GetUser, name, USER); \
-                                will_return(__wrap_Privsep_GetUser, OS_SUCCESS); \
-                                expect_string(__wrap_Privsep_GetGroup, name, GROUPGLOBAL); \
-                                will_return(__wrap_Privsep_GetGroup, OS_SUCCESS)
-
-#define SET_CONFIG_AND_TIME()   expect_value(__wrap_OS_ReadIntegratorConf, integrator_config, &integrator_config); \
-                                time_t now = 123456789; \
-                                will_return(__wrap_time, now); \
-                                will_return_always(__wrap_os_random, 12345)
-
-#define SET_USER_GROUP()        expect_value(__wrap_Privsep_SetGroup, gid, 0); \
-                                will_return(__wrap_Privsep_SetGroup, OS_SUCCESS);\
-                                expect_value(__wrap_Privsep_SetUser, uid, 0);\
-                                will_return(__wrap_Privsep_SetUser, OS_SUCCESS)
-
-void test_debug_option_default_level(void **state)
-{
-    IntegratorConfig *test_integrator_config[] = { state[0], state[1], NULL };
-    local_integrator_config = test_integrator_config;
-
-    HOME_PATH_STRDUP();
-    GET_USER_GROUP();
-    SET_CONFIG_AND_TIME();
-    SET_USER_GROUP();
-
-    expect_string(__wrap__mdebug1, formatted_msg, "Chrooted to directory: " PATH_TO_TEST ", using user: " USER);
-    expect_string(__wrap__minfo, formatted_msg, "Started (pid: 2345).");
-
-    expect_value(__wrap_exit, __status, 0);
-    char *argv[] = { PATH_TO_TEST, "-d", "-f" };
-
-    call_real = false;
-    expect_assert_failure(test_main(3, argv));
-    assert_int_equal(__real_isDebug(), 1);
-}
-
-void test_debug_option_custom_level(void **state)
-{
-    IntegratorConfig *test_integrator_config[] = { state[0], state[1], NULL };
-    local_integrator_config = test_integrator_config;
-
-    HOME_PATH_STRDUP();
-    GET_USER_GROUP();
-    SET_CONFIG_AND_TIME();
-    SET_USER_GROUP();
-
-    expect_string(__wrap__mdebug1, formatted_msg, "Chrooted to directory: " PATH_TO_TEST ", using user: " USER);
-    expect_string(__wrap__minfo, formatted_msg, "Started (pid: 2345).");
-
-    expect_value(__wrap_exit, __status, 0);
-    // get WARNING debug level constant
-    char *argv[] = { PATH_TO_TEST, "-ddd", "-f" };
-
-    call_real = false;
-    expect_assert_failure(test_main(3, argv));
-    assert_int_equal(__real_isDebug(), LOGLEVEL_WARNING + 1);
-}
-
-void test_debug_option_max_level(void **state)
-{
-    IntegratorConfig *test_integrator_config[] = { state[0], state[1], NULL };
-    local_integrator_config = test_integrator_config;
-
-    HOME_PATH_STRDUP();
-    GET_USER_GROUP();
-    SET_CONFIG_AND_TIME();
-    SET_USER_GROUP();
-
-    expect_string(__wrap__mdebug1, formatted_msg, "Chrooted to directory: " PATH_TO_TEST ", using user: " USER);
-    expect_string(__wrap__minfo, formatted_msg, "Started (pid: 2345).");
-
-    expect_value(__wrap_exit, __status, 0);
-    // can't reach more of MAX_DEBUG_LEVEL
-    char *argv[] = { PATH_TO_TEST, "-ddddddddd", "-f" };
-
-    call_real = false;
-    expect_assert_failure(test_main(3, argv));
-    assert_int_equal(__real_isDebug(), MAX_DEBUG_LEVEL);
-}
-
-int main(void)
-{
+int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_OS_IntegratorD, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_debug_option_default_level, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_debug_option_custom_level, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_debug_option_max_level, test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/posix/unistd_wrappers.c
+++ b/src/unit_tests/wrappers/posix/unistd_wrappers.c
@@ -102,15 +102,3 @@ int __wrap__access (const char *__name, int __type) {
     return mock();
 }
 #endif
-
-int __wrap_chdir(const char *__path)
-{
-    check_expected(__path);
-    return mock();
-}
-
-void __wrap_exit(int __status)
-{
-    check_expected(__status);
-    mock_assert(0, __FUNCTION__, __FILE__, __LINE__);
-}

--- a/src/unit_tests/wrappers/wazuh/shared/privsep_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/privsep_op_wrappers.c
@@ -51,15 +51,3 @@ int __wrap_Privsep_GetGroup(const char *name) {
 
     return mock();
 }
-
-int __wrap_Privsep_SetGroup(int gid)
-{
-    check_expected(gid);
-    return mock();
-}
-
-int __wrap_Privsep_SetUser(int uid)
-{
-    check_expected(uid);
-    return mock();
-}


### PR DESCRIPTION
## Description

This reverts the logging level changes made in wazuh-integratord (13efaa08ae3aad5877c55a745256b7b5ff637777), which is no longer planned for the `4.8.0` version.