### PR TITLE
Modify API Integration Tests due to test dependencies update

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -539,7 +539,7 @@ def pytest_html_results_summary(prefix, summary, postfix):
         ) for k, v in results.items()])])
 
 
-@pytest.fixture
+@pytest.fixture(scope='function', autouse=True)
 def big_events_payload() -> list:
     """Return a payload with a number of events larger than the maximum allowed.
 
@@ -551,7 +551,7 @@ def big_events_payload() -> list:
     return [f"Event {i}" for i in range(101)]
 
 
-@pytest.fixture
+@pytest.fixture(scope='function', autouse=True)
 def max_size_event() -> str:
     """Return an event with the max size allowed.
 
@@ -563,7 +563,7 @@ def max_size_event() -> str:
     return " ".join(str(i) for i in range(12772))
 
 
-@pytest.fixture
+@pytest.fixture(scope='function', autouse=True)
 def large_event() -> str:
     """Return an event with the size larger than the maximum allowed.
 

--- a/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
@@ -235,7 +235,7 @@ test_name: GET /cluster/nodes/{node_id}
 
 stages:
 
-  - name: Get cluster {worker2} (Deny)
+  - name: Get cluster (worker2) (Deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
@@ -247,7 +247,7 @@ stages:
     response:
       <<: *permission_denied
 
-  - name: Get cluster {worker2} (Allow)
+  - name: Get cluster (worker1) (Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
@@ -268,7 +268,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Get cluster {master-node,worker1,worker2} (Allow, Deny, Allow)
+  - name: Get cluster (master-node,worker1,worker2) (Allow, Deny, Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
@@ -316,7 +316,7 @@ test_name: GET /cluster/{node_id}/configuration
 
 stages:
 
-  - name: Request {node_id}
+  - name: Request (worker1)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
@@ -348,7 +348,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Request (worker1) (Deny)
+  - name: Request (master-node) (Deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
@@ -439,7 +439,7 @@ test_name: GET /cluster/{node_id}/info
 
 stages:
 
-  - name: Request {node_id}
+  - name: Request (worker2)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/info"
@@ -449,7 +449,7 @@ stages:
     response:
       <<: *permission_denied
 
-  - name: Request {node_id}
+  - name: Request (worker1)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/info"
@@ -464,7 +464,7 @@ test_name: GET /cluster/{node_id}/logs
 
 stages:
 
-  - name: Request {worker1} (Allow)
+  - name: Request (worker1) (Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs"
@@ -474,7 +474,7 @@ stages:
     response:
       status_code: 200
 
-  - name: Request {worker2} (Deny)
+  - name: Request (worker2) (Deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs"
@@ -489,7 +489,7 @@ test_name: GET /cluster/{node_id}/logs/summary
 
 stages:
 
-  - name: Request {worker1} (Allow)
+  - name: Request (worker1) (Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs/summary"
@@ -499,7 +499,7 @@ stages:
     response:
       status_code: 200
 
-  - name: Request {worker2} (Deny)
+  - name: Request (worker2) (Deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs/summary"
@@ -539,7 +539,7 @@ test_name: GET /cluster/{node_id}/stats
 
 stages:
 
-  - name: Cluster stats {worker2} today (Deny)
+  - name: Cluster stats (worker2) today (Deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/stats"
@@ -549,7 +549,7 @@ stages:
     response:
       <<: *permission_denied
 
-  - name: Cluster stats {worker1} today (Allow)
+  - name: Cluster stats (worker1) today (Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/stats"
@@ -566,7 +566,7 @@ test_name: GET /cluster/{node_id}/status
 
 stages:
 
-  - name: Request {worker1} (Allow)
+  - name: Request (worker1) (Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/status"
@@ -576,7 +576,7 @@ stages:
     response:
       status_code: 200
 
-  - name: Request {worker2} (Deny)
+  - name: Request (worker2) (Deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/status"

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -233,7 +233,7 @@ test_name: GET /cluster/nodes/{node_id}
 
 stages:
 
-  - name: Get cluster {worker1} (Deny)
+  - name: Get cluster (worker1) (Deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
@@ -247,7 +247,7 @@ stages:
       json:
         error: 4000
 
-  - name: Get cluster {worker2} (Allow)
+  - name: Get cluster (worker2) (Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
@@ -268,7 +268,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
         
-  - name: Get cluster {master-node,worker1,worker2} (Allow, Deny, Allow)
+  - name: Get cluster (master-node,worker1,worker2) (Allow, Deny, Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
@@ -320,7 +320,7 @@ test_name: GET /cluster/{node_id}/configuration
 
 stages:
 
-  - name: Request {node_id}
+  - name: Request (master-node)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
@@ -465,7 +465,7 @@ test_name: GET /cluster/{node_id}/info
 
 stages:
 
-  - name: Request {node_id}
+  - name: Request (worker1)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/info"
@@ -475,7 +475,7 @@ stages:
     response:
       <<: *permission_denied
 
-  - name: Request {node_id}
+  - name: Request (master-node)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/info"
@@ -490,7 +490,7 @@ test_name: GET /cluster/{node_id}/logs
 
 stages:
 
-  - name: Request {worker2} (Allow)
+  - name: Request (worker2) (Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs"
@@ -500,7 +500,7 @@ stages:
     response:
       status_code: 200
 
-  - name: Request {worker1} (Deny)
+  - name: Request (worker1) (Deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs"
@@ -515,7 +515,7 @@ test_name: GET /cluster/{node_id}/logs/summary
 
 stages:
 
-  - name: Request {worker2} (Allow)
+  - name: Request (worker2) (Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs/summary"
@@ -525,7 +525,7 @@ stages:
     response:
       status_code: 200
 
-  - name: Request {worker1} (Deny)
+  - name: Request (worker1) (Deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs/summary"
@@ -565,7 +565,7 @@ test_name: GET /cluster/{node_id}/stats
 
 stages:
 
-  - name: Cluster stats {worker1} today (Deny)
+  - name: Cluster stats (worker1) today (Deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/stats"
@@ -575,7 +575,7 @@ stages:
     response:
       <<: *permission_denied
 
-  - name: Cluster stats {worker2} today (Allow)
+  - name: Cluster stats (worker2) today (Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/stats"
@@ -592,7 +592,7 @@ test_name: GET /cluster/{node_id}/status
 
 stages:
 
-  - name: Request {worker2} (Allow)
+  - name: Request (worker2) (Allow)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/status"
@@ -602,7 +602,7 @@ stages:
     response:
       status_code: 200
 
-  - name: Request {worker1} (Deny)
+  - name: Request (worker1) (Deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/status"

--- a/api/test/integration/test_webhook_endpoints.tavern.yaml
+++ b/api/test/integration/test_webhook_endpoints.tavern.yaml
@@ -80,12 +80,8 @@ stages:
         title: Bad Request
 
 ---
-
 test_name: POST /events with more than 100 events
 
-marks:
-  - usefixtures:
-      - big_events_payload
 
 stages:
   - name: Try to send events with an invalid size
@@ -101,13 +97,7 @@ stages:
         title: Events bulk size exceeded
 
 ---
-
 test_name: POST /events with big events
-
-marks:
-  - usefixtures:
-      - max_size_event
-      - large_event
 
 stages:
   - name: Try to send a too big event (65536B)
@@ -159,7 +149,6 @@ stages:
         error: 2
 
 ---
-
 test_name: Try to send more than 30 requests per minute
 
 stages:


### PR DESCRIPTION
|Related issue|
|---|
| #19612 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Closes #19612. Modifies the AITs that fail due to the new `requirements-dev.txt` dependencies.

## Tests

<details><summary>test_rbac_black_cluster_endpoints</summary>

```console
pytest test_rbac_black_cluster_endpoints.tavern.yaml
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 19 items                                                                                                                                              

test_rbac_black_cluster_endpoints.tavern.yaml ...................                                                                                         [100%]

======================================================================= warnings summary ========================================================================
../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/pytest_aiohttp/plugin.py:28
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_rbac_black_cluster_endpoints.tavern.yaml: 19 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 19 passed, 21 warnings in 184.31s (0:03:04) ==========================================================

```

</details>

<details><summary>pytest test_rbac_white_cluster_endpoints</summary>

```console
pytest test_rbac_white_cluster_endpoints.tavern.yaml
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 19 items                                                                                                                                              

test_rbac_white_cluster_endpoints.tavern.yaml ...................                                                                                         [100%]

======================================================================= warnings summary ========================================================================
../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/pytest_aiohttp/plugin.py:28
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_rbac_white_cluster_endpoints.tavern.yaml: 19 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 19 passed, 21 warnings in 439.84s (0:07:19) ==========================================================
```

</details>

<details><summary>test_webhook_endpoints</summary>

```console
pytest test_webhook_endpoints.tavern.yaml
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 5 items                                                                                                                                               

test_webhook_endpoints.tavern.yaml .....                                                                                                                  [100%]

======================================================================= warnings summary ========================================================================
../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/pytest_aiohttp/plugin.py:28
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_webhook_endpoints.tavern.yaml::POST /events
test_webhook_endpoints.tavern.yaml::POST /events with invalid formats
test_webhook_endpoints.tavern.yaml::POST /events with more than 100 events
test_webhook_endpoints.tavern.yaml::POST /events with big events
test_webhook_endpoints.tavern.yaml::Try to send more than 30 requests per minute
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 5 passed, 7 warnings in 148.84s (0:02:28) ===========================================================
```

</details>



