### PR TITLE
Reduce the EPS limit default value for FIM

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10327,7 +10327,7 @@ paths:
                         skip_proc: yes
                         skip_sys: yes
                         process_priority: 10
-                        max_eps: 100
+                        max_eps: 50
                         synchronization:
                           enabled: yes
                           interval: "5m"

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -107,7 +107,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -124,7 +124,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -124,7 +124,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -137,7 +137,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -40,7 +40,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -48,7 +48,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -40,7 +40,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -46,7 +46,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/templates/config/windows/2003/syscheck.template
+++ b/etc/templates/config/windows/2003/syscheck.template
@@ -61,7 +61,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/etc/templates/config/windows/xp/syscheck.template
+++ b/etc/templates/config/windows/xp/syscheck.template
@@ -61,7 +61,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -120,7 +120,7 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->sync_thread_pool                = 1;
     syscheck->sync_max_eps                    = 10;
     syscheck->sync_queue_size                 = 16384;
-    syscheck->max_eps                         = 100;
+    syscheck->max_eps                         = 50;
     syscheck->max_files_per_second            = 0;
     syscheck->allow_remote_prefilter_cmd      = false;
     syscheck->disk_quota_enabled              = true;

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -265,7 +265,7 @@ void test_Read_Syscheck_Config_unparsed(void **state)
     assert_int_equal(syscheck.sync_interval, 300);
     assert_int_equal(syscheck.sync_queue_size, 16384);
     assert_int_equal(syscheck.sync_thread_pool, 1);
-    assert_int_equal(syscheck.max_eps, 100);
+    assert_int_equal(syscheck.max_eps, 50);
     assert_int_equal(syscheck.disk_quota_enabled, true);
     assert_int_equal(syscheck.disk_quota_limit, 1024 * 1024);
     assert_int_equal(syscheck.file_size_enabled, true);
@@ -611,7 +611,7 @@ void test_getSyscheckConfig_no_directories(void **state)
     cJSON *allow_remote_prefilter_cmd = cJSON_GetObjectItem(sys_items, "allow_remote_prefilter_cmd");
     assert_string_equal(cJSON_GetStringValue(allow_remote_prefilter_cmd), "no");
     cJSON *max_eps = cJSON_GetObjectItem(sys_items, "max_eps");
-    assert_int_equal(max_eps->valueint, 100);
+    assert_int_equal(max_eps->valueint, 50);
     cJSON *process_priority = cJSON_GetObjectItem(sys_items, "process_priority");
     assert_int_equal(process_priority->valueint, 10);
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -144,7 +144,7 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>


### PR DESCRIPTION
|Related issue|
|---|
|#19752|

## Description

Max EPS was increased to 100 to improve FIM processing performance, which was achieved, but since it might impact manager's capacity it was decided to decrease it to 50.


## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors