### PR TITLE
Giving DBSync the capability of DB persistance

### DIFF
--- a/src/shared_modules/common/commonDefs.h
+++ b/src/shared_modules/common/commonDefs.h
@@ -33,6 +33,16 @@ typedef enum
 } DbEngineType;
 
 /**
+ * @brief Configures how the engine manages the database at startup.
+ */
+typedef enum
+{
+    VOLATILE   = 0,  /*< Removes the DB every time .                          */
+    PERSISTENT = 1,  /*< The DB is kept and the correct version is checked.   */
+} DbManagement;
+
+
+/**
  * @brief Represents the database operation events.
  */
 typedef enum

--- a/src/shared_modules/dbsync/include/db_exception.h
+++ b/src/shared_modules/dbsync/include/db_exception.h
@@ -38,6 +38,7 @@ DBSyncExceptionType STEP_ERROR_DELETE_STATUS_FIELD { std::make_pair(19, "Error d
 DBSyncExceptionType DELETE_OLD_DB_ERROR            { std::make_pair(20, "Error deleting old db.")                               };
 DBSyncExceptionType MIN_ROW_LIMIT_BELOW_ZERO       { std::make_pair(21, "Invalid row limit, values below 0 not allowed.")       };
 DBSyncExceptionType ERROR_COUNT_MAX_ROWS           { std::make_pair(22, "Count is less than 0.")                                };
+DBSyncExceptionType STEP_ERROR_UPDATE_STMT         { std::make_pair(23, "Error upgrading DB.")                                  };
 
 namespace DbSync
 {

--- a/src/shared_modules/dbsync/include/dbsync.h
+++ b/src/shared_modules/dbsync/include/dbsync.h
@@ -41,25 +41,6 @@ extern "C" {
 EXPORTED void dbsync_initialize(log_fnc_t log_function);
 
 /**
- * @brief Creates a new DBSync instance.
- *
- * @param host_type          Dynamic library host type to be used.
- * @param db_type            Database type to be used (currently only supported SQLITE3)
- * @param path               Path where the local database will be created.
- * @param sql_statement      SQL sentence to create tables in a SQL engine.
- * @param db_management      Database management type to be used at startup.
- * @param upgrade_statements SQL sentences to be executed when upgrading the database (NULL terminated).
- *
- * @return Handle instance to be used for common sql operations (cannot be used by more than 1 thread).
- */
-DBSYNC_HANDLE dbsync_create_(const HostType      host_type,
-                             const DbEngineType  db_type,
-                             const char*         path,
-                             const char*         sql_statement,
-                             const DbManagement  db_management,
-                             const char**        upgrade_statements);
-
-/**
  * @brief Creates a new DBSync instance (wrapper)
  *
  * @param host_type          Dynamic library host type to be used.

--- a/src/shared_modules/dbsync/include/dbsync.h
+++ b/src/shared_modules/dbsync/include/dbsync.h
@@ -43,10 +43,31 @@ EXPORTED void dbsync_initialize(log_fnc_t log_function);
 /**
  * @brief Creates a new DBSync instance.
  *
- * @param host_type     Dynamic library host type to be used.
- * @param db_type       Database type to be used (currently only supported SQLITE3)
- * @param path          Path where the local database will be created.
- * @param sql_statement SQL sentence to create tables in a SQL engine.
+ * @param host_type          Dynamic library host type to be used.
+ * @param db_type            Database type to be used (currently only supported SQLITE3)
+ * @param path               Path where the local database will be created.
+ * @param sql_statement      SQL sentence to create tables in a SQL engine.
+ * @param db_management      Database management type to be used at startup.
+ * @param upgrade_statements SQL sentences to be executed when upgrading the database (NULL terminated).
+ *
+ * @return Handle instance to be used for common sql operations (cannot be used by more than 1 thread).
+ */
+EXPORTED DBSYNC_HANDLE dbsync_create_(const HostType      host_type,
+                                      const DbEngineType  db_type,
+                                      const char*         path,
+                                      const char*         sql_statement,
+                                      const DbManagement  db_management,
+                                      const char**        upgrade_statements);
+
+/**
+ * @brief Creates a new DBSync instance (wrapper)
+ *
+ * @param host_type          Dynamic library host type to be used.
+ * @param db_type            Database type to be used (currently only supported SQLITE3)
+ * @param path               Path where the local database will be created.
+ * @param sql_statement      SQL sentence to create tables in a SQL engine.
+ *
+ * @note db_management will be DbManagement::VOLATILE as default and upgrade_statements will be NULL.
  *
  * @return Handle instance to be used for common sql operations (cannot be used by more than 1 thread).
  */
@@ -54,6 +75,24 @@ EXPORTED DBSYNC_HANDLE dbsync_create(const HostType      host_type,
                                      const DbEngineType  db_type,
                                      const char*         path,
                                      const char*         sql_statement);
+
+/**
+ * @brief Creates a new DBSync instance (wrapper)
+ *
+ * @param host_type          Dynamic library host type to be used.
+ * @param db_type            Database type to be used (currently only supported SQLITE3)
+ * @param path               Path where the local database will be created.
+ * @param sql_statement      SQL sentence to create tables in a SQL engine.
+ *
+ * @note db_management will be DbManagement::PERSISTENT as default.
+ *
+ * @return Handle instance to be used for common sql operations (cannot be used by more than 1 thread).
+ */
+EXPORTED DBSYNC_HANDLE dbsync_create_persistent(const HostType      host_type,
+                                                const DbEngineType  db_type,
+                                                const char*         path,
+                                                const char*         sql_statement,
+                                                const char**        upgrade_statements);
 
 /**
  * @brief Turns off the services provided by the shared library.

--- a/src/shared_modules/dbsync/include/dbsync.h
+++ b/src/shared_modules/dbsync/include/dbsync.h
@@ -64,6 +64,7 @@ EXPORTED DBSYNC_HANDLE dbsync_create(const HostType      host_type,
  * @param db_type            Database type to be used (currently only supported SQLITE3)
  * @param path               Path where the local database will be created.
  * @param sql_statement      SQL sentence to create tables in a SQL engine.
+ * @param upgrade_statements SQL sentences to upgrade tables in a SQL engine.
  *
  * @note db_management will be DbManagement::PERSISTENT as default.
  *

--- a/src/shared_modules/dbsync/include/dbsync.h
+++ b/src/shared_modules/dbsync/include/dbsync.h
@@ -52,12 +52,12 @@ EXPORTED void dbsync_initialize(log_fnc_t log_function);
  *
  * @return Handle instance to be used for common sql operations (cannot be used by more than 1 thread).
  */
-EXPORTED DBSYNC_HANDLE dbsync_create_(const HostType      host_type,
-                                      const DbEngineType  db_type,
-                                      const char*         path,
-                                      const char*         sql_statement,
-                                      const DbManagement  db_management,
-                                      const char**        upgrade_statements);
+DBSYNC_HANDLE dbsync_create_(const HostType      host_type,
+                             const DbEngineType  db_type,
+                             const char*         path,
+                             const char*         sql_statement,
+                             const DbManagement  db_management,
+                             const char**        upgrade_statements);
 
 /**
  * @brief Creates a new DBSync instance (wrapper)

--- a/src/shared_modules/dbsync/include/dbsync.hpp
+++ b/src/shared_modules/dbsync/include/dbsync.hpp
@@ -46,16 +46,20 @@ class EXPORTED DBSync
         /**
          * @brief Explicit DBSync Constructor.
          *
-         * @param hostType     Dynamic library host type to be used.
-         * @param dbType       Database type to be used (currently only supported SQLITE3)
-         * @param path         Path where the local database will be created.
-         * @param sqlStatement SQL sentence to create tables in a SQL engine.
+         * @param hostType          Dynamic library host type to be used.
+         * @param dbType            Database type to be used (currently only supported SQLITE3)
+         * @param path              Path where the local database will be created.
+         * @param sqlStatement      SQL sentence to create tables in a SQL engine.
+         * @param dbManagement      Database management type to be used at startup.
+         * @param upgradeStatements SQL sentences to be executed when upgrading the database.
          *
          */
-        explicit DBSync(const HostType     hostType,
-                        const DbEngineType dbType,
-                        const std::string& path,
-                        const std::string& sqlStatement);
+        explicit DBSync(const HostType                  hostType,
+                        const DbEngineType              dbType,
+                        const std::string&              path,
+                        const std::string&              sqlStatement,
+                        const DbManagement              dbManagement = DbManagement::VOLATILE,
+                        const std::vector<std::string>& upgradeStatements = {});
 
         /**
          * @brief DBSync Constructor.

--- a/src/shared_modules/dbsync/src/dbengine_factory.h
+++ b/src/shared_modules/dbsync/src/dbengine_factory.h
@@ -23,13 +23,15 @@ namespace DbSync
     class FactoryDbEngine
     {
         public:
-            static std::unique_ptr<IDbEngine> create(const DbEngineType dbType,
-                                                     const std::string& path,
-                                                     const std::string& sqlStatement)
+            static std::unique_ptr<IDbEngine> create(const DbEngineType              dbType,
+                                                     const std::string&              path,
+                                                     const std::string&              sqlStatement,
+                                                     const DbManagement              dbManagement,
+                                                     const std::vector<std::string>& upgradeStatements)
             {
                 if (SQLITE3 == dbType)
                 {
-                    return std::make_unique<SQLiteDBEngine>(std::make_shared<SQLiteFactory>(), path, sqlStatement);
+                    return std::make_unique<SQLiteDBEngine>(std::make_shared<SQLiteFactory>(), path, sqlStatement, dbManagement, upgradeStatements);
                 }
 
                 throw dbsync_error

--- a/src/shared_modules/dbsync/src/dbsync.cpp
+++ b/src/shared_modules/dbsync/src/dbsync.cpp
@@ -41,23 +41,6 @@ void dbsync_initialize(log_fnc_t log_function)
     });
 }
 
-DBSYNC_HANDLE dbsync_create(const HostType     host_type,
-                            const DbEngineType db_type,
-                            const char*        path,
-                            const char*        sql_statement)
-{
-    return dbsync_create_(host_type, db_type, path, sql_statement, DbManagement::VOLATILE, nullptr);
-}
-
-DBSYNC_HANDLE dbsync_create_persistent(const HostType     host_type,
-                                       const DbEngineType db_type,
-                                       const char*        path,
-                                       const char*        sql_statement,
-                                       const char**       upgrade_statements)
-{
-    return dbsync_create_(host_type, db_type, path, sql_statement, DbManagement::PERSISTENT, upgrade_statements);
-}
-
 DBSYNC_HANDLE dbsync_create_(const HostType     host_type,
                              const DbEngineType db_type,
                              const char*        path,
@@ -80,7 +63,7 @@ DBSYNC_HANDLE dbsync_create_(const HostType     host_type,
 
             while (upgrade_statements && *upgrade_statements)
             {
-                upgradeStatements.emplace_back(std::string(*upgrade_statements));
+                upgradeStatements.emplace_back(*upgrade_statements);
                 upgrade_statements++;
             }
 
@@ -101,6 +84,23 @@ DBSYNC_HANDLE dbsync_create_(const HostType     host_type,
 
     log_message(errorMessage);
     return retVal;
+}
+
+DBSYNC_HANDLE dbsync_create(const HostType     host_type,
+                            const DbEngineType db_type,
+                            const char*        path,
+                            const char*        sql_statement)
+{
+    return dbsync_create_(host_type, db_type, path, sql_statement, DbManagement::VOLATILE, nullptr);
+}
+
+DBSYNC_HANDLE dbsync_create_persistent(const HostType     host_type,
+                                       const DbEngineType db_type,
+                                       const char*        path,
+                                       const char*        sql_statement,
+                                       const char**       upgrade_statements)
+{
+    return dbsync_create_(host_type, db_type, path, sql_statement, DbManagement::PERSISTENT, upgrade_statements);
 }
 
 void dbsync_teardown(void)

--- a/src/shared_modules/dbsync/src/dbsync.cpp
+++ b/src/shared_modules/dbsync/src/dbsync.cpp
@@ -46,6 +46,25 @@ DBSYNC_HANDLE dbsync_create(const HostType     host_type,
                             const char*        path,
                             const char*        sql_statement)
 {
+    return dbsync_create_(host_type, db_type, path, sql_statement, DbManagement::VOLATILE, nullptr);
+}
+
+DBSYNC_HANDLE dbsync_create_persistent(const HostType     host_type,
+                                       const DbEngineType db_type,
+                                       const char*        path,
+                                       const char*        sql_statement,
+                                       const char**       upgrade_statements)
+{
+    return dbsync_create_(host_type, db_type, path, sql_statement, DbManagement::PERSISTENT, upgrade_statements);
+}
+
+DBSYNC_HANDLE dbsync_create_(const HostType     host_type,
+                             const DbEngineType db_type,
+                             const char*        path,
+                             const char*        sql_statement,
+                             const DbManagement db_management,
+                             const char**       upgrade_statements)
+{
     DBSYNC_HANDLE retVal{ nullptr };
     std::string errorMessage;
 
@@ -57,7 +76,15 @@ DBSYNC_HANDLE dbsync_create(const HostType     host_type,
     {
         try
         {
-            retVal = DBSyncImplementation::instance().initialize(host_type, db_type, path, sql_statement);
+            auto upgradeStatements = std::vector<std::string>();
+
+            while (upgrade_statements && *upgrade_statements)
+            {
+                upgradeStatements.emplace_back(std::move(std::string(*upgrade_statements)));
+                upgrade_statements++;
+            }
+
+            retVal = DBSyncImplementation::instance().initialize(host_type, db_type, path, sql_statement, db_management, upgradeStatements);
         }
         catch (const DbSync::dbsync_error& ex)
         {
@@ -640,11 +667,13 @@ void DBSync::initialize(std::function<void(const std::string&)> logFunction)
     }
 }
 
-DBSync::DBSync(const HostType     hostType,
-               const DbEngineType dbType,
-               const std::string& path,
-               const std::string& sqlStatement)
-    : m_dbsyncHandle { DBSyncImplementation::instance().initialize(hostType, dbType, path, sqlStatement) }
+DBSync::DBSync(const HostType                  hostType,
+               const DbEngineType              dbType,
+               const std::string&              path,
+               const std::string&              sqlStatement,
+               const DbManagement              dbManagement,
+               const std::vector<std::string>& upgradeStatements)
+    : m_dbsyncHandle { DBSyncImplementation::instance().initialize(hostType, dbType, path, sqlStatement, dbManagement, upgradeStatements) }
     , m_shouldBeRemoved{ true }
 { }
 

--- a/src/shared_modules/dbsync/src/dbsync.cpp
+++ b/src/shared_modules/dbsync/src/dbsync.cpp
@@ -80,7 +80,7 @@ DBSYNC_HANDLE dbsync_create_(const HostType     host_type,
 
             while (upgrade_statements && *upgrade_statements)
             {
-                upgradeStatements.emplace_back(std::move(std::string(*upgrade_statements)));
+                upgradeStatements.emplace_back(std::string(*upgrade_statements));
                 upgrade_statements++;
             }
 

--- a/src/shared_modules/dbsync/src/dbsync_implementation.cpp
+++ b/src/shared_modules/dbsync/src/dbsync_implementation.cpp
@@ -15,12 +15,14 @@
 
 using namespace DbSync;
 
-DBSYNC_HANDLE DBSyncImplementation::initialize(const HostType     hostType,
-                                               const DbEngineType dbType,
-                                               const std::string& path,
-                                               const std::string& sqlStatement)
+DBSYNC_HANDLE DBSyncImplementation::initialize(const HostType                  hostType,
+                                               const DbEngineType              dbType,
+                                               const std::string&              path,
+                                               const std::string&              sqlStatement,
+                                               const DbManagement              dbManagement,
+                                               const std::vector<std::string>& upgradeStatements)
 {
-    auto db{ FactoryDbEngine::create(dbType, path, sqlStatement) };
+    auto db{ FactoryDbEngine::create(dbType, path, sqlStatement, dbManagement, upgradeStatements) };
     const auto spDbEngineContext
     {
         std::make_shared<DbEngineContext>(db, hostType, dbType)

--- a/src/shared_modules/dbsync/src/dbsync_implementation.h
+++ b/src/shared_modules/dbsync/src/dbsync_implementation.h
@@ -50,10 +50,12 @@ namespace DbSync
                                     const nlohmann::json&   json,
                                     const ResultCallback    callback);
 
-            DBSYNC_HANDLE initialize(const HostType     hostType,
-                                     const DbEngineType dbType,
-                                     const std::string& path,
-                                     const std::string& sqlStatement);
+            DBSYNC_HANDLE initialize(const HostType                  hostType,
+                                     const DbEngineType              dbType,
+                                     const std::string&              path,
+                                     const std::string&              sqlStatement,
+                                     const DbManagement              dbManagement,
+                                     const std::vector<std::string>& upgradeStatements);
 
             void setMaxRows(const DBSYNC_HANDLE handle,
                             const std::string& table,

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -19,11 +19,13 @@
 #include "commonDefs.h"
 
 SQLiteDBEngine::SQLiteDBEngine(const std::shared_ptr<ISQLiteFactory>& sqliteFactory,
-                               const std::string& path,
-                               const std::string& tableStmtCreation)
+                               const std::string&                     path,
+                               const std::string&                     tableStmtCreation,
+                               const DbManagement                     dbManagement,
+                               const std::vector<std::string>&        upgradeStatements)
     : m_sqliteFactory(sqliteFactory)
 {
-    initialize(path, tableStmtCreation);
+    initialize(path, tableStmtCreation, dbManagement, upgradeStatements);
 }
 
 SQLiteDBEngine::~SQLiteDBEngine()
@@ -527,36 +529,81 @@ void SQLiteDBEngine::addTableRelationship(const nlohmann::json& data)
 /// Private functions section
 ///
 
-void SQLiteDBEngine::initialize(const std::string& path,
-                                const std::string& tableStmtCreation)
+void SQLiteDBEngine::initialize(const std::string&              path,
+                                const std::string&              tableStmtCreation,
+                                const DbManagement              dbManagement,
+                                const std::vector<std::string>& upgradeStatements)
 {
     if (path.empty())
     {
-        throw dbengine_error { EMPTY_DATABASE_PATH };
+        throw dbengine_error {EMPTY_DATABASE_PATH};
     }
 
-    if (!cleanDB(path))
+    auto currentDbsyncVersion = upgradeStatements.size() + 1;
+
+    auto reCreateDbLambda = [&]()
     {
-        throw dbengine_error { DELETE_OLD_DB_ERROR };
-    }
 
-    m_sqliteConnection = m_sqliteFactory->createConnection(path);
-    const auto createDBQueryList { Utils::split(tableStmtCreation, ';') };
-    m_sqliteConnection->execute("PRAGMA temp_store = memory;");
-    m_sqliteConnection->execute("PRAGMA journal_mode = truncate;");
-    m_sqliteConnection->execute("PRAGMA synchronous = OFF;");
-
-    for (const auto& query : createDBQueryList)
-    {
-        const auto stmt { getStatement(query) };
-
-        if (SQLITE_DONE != stmt->step())
+        if (!cleanDB(path))
         {
-            throw dbengine_error { STEP_ERROR_CREATE_STMT };
+            throw dbengine_error {DELETE_OLD_DB_ERROR};
+        }
+
+        m_sqliteConnection = m_sqliteFactory->createConnection(path);
+        const auto createDBQueryList {Utils::split(tableStmtCreation, ';')};
+        m_sqliteConnection->execute("PRAGMA temp_store = memory;");
+        m_sqliteConnection->execute("PRAGMA journal_mode = truncate;");
+        m_sqliteConnection->execute("PRAGMA synchronous = OFF;");
+        m_sqliteConnection->execute("PRAGMA user_version = " + std::to_string(currentDbsyncVersion) + ";");
+
+        for (const auto& query : createDBQueryList)
+        {
+            const auto stmt {getStatement(query)};
+
+            if (SQLITE_DONE != stmt->step())
+            {
+                throw dbengine_error {STEP_ERROR_CREATE_STMT};
+            }
+        }
+
+        m_transaction = m_sqliteFactory->createTransaction(m_sqliteConnection);
+    };
+
+    size_t dbVersion = 0;
+
+    if (DbManagement::PERSISTENT == dbManagement)
+    {
+        m_sqliteConnection = m_sqliteFactory->createConnection(path);
+        dbVersion = getDbVersion();
+
+        if (0 == dbVersion)
+        {
+            reCreateDbLambda();
+        }
+
+        else if (dbVersion < currentDbsyncVersion)
+        {
+            for (size_t i = dbVersion - 1; i < upgradeStatements.size(); ++i)
+            {
+                auto transaction = m_sqliteFactory->createTransaction(m_sqliteConnection);
+                const auto stmt {m_sqliteFactory->createStatement(m_sqliteConnection, upgradeStatements[i])};
+
+                if (SQLITE_DONE != stmt->step())
+                {
+                    throw dbengine_error {STEP_ERROR_UPDATE_STMT};
+                }
+
+                transaction->commit();
+                m_sqliteConnection->execute("PRAGMA user_version = " + std::to_string(i + 2) + ";");
+            }
+
+            m_transaction = m_sqliteFactory->createTransaction(m_sqliteConnection);
         }
     }
-
-    m_transaction = m_sqliteFactory->createTransaction(m_sqliteConnection);
+    else if (DbManagement::VOLATILE == dbManagement)
+    {
+        reCreateDbLambda();
+    }
 }
 
 bool SQLiteDBEngine::cleanDB(const std::string& path)
@@ -575,6 +622,20 @@ bool SQLiteDBEngine::cleanDB(const std::string& path)
     }
 
     return ret;
+}
+
+size_t SQLiteDBEngine::getDbVersion()
+{
+    const auto stmt {m_sqliteFactory->createStatement(m_sqliteConnection, "PRAGMA user_version;")};
+
+    size_t version {0};
+
+    if (SQLITE_ROW == stmt->step())
+    {
+        version = stmt->column(0)->value(int32_t {});
+    }
+
+    return version;
 }
 
 void SQLiteDBEngine::insertElement(const std::string& table,

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -32,6 +32,11 @@ SQLiteDBEngine::~SQLiteDBEngine()
 {
     std::lock_guard<std::mutex> lock(m_stmtMutex);
     m_statementsCache.clear();
+
+    if (m_transaction)
+    {
+        m_transaction->commit();
+    }
 }
 
 void SQLiteDBEngine::setMaxRows(const std::string& table,
@@ -543,7 +548,6 @@ void SQLiteDBEngine::initialize(const std::string&              path,
 
     auto reCreateDbLambda = [&]()
     {
-
         if (!cleanDB(path))
         {
             throw dbengine_error {DELETE_OLD_DB_ERROR};
@@ -578,6 +582,7 @@ void SQLiteDBEngine::initialize(const std::string&              path,
 
         if (0 == dbVersion)
         {
+            m_sqliteConnection.reset();
             reCreateDbLambda();
         }
 

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
@@ -117,8 +117,10 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
 {
     public:
         SQLiteDBEngine(const std::shared_ptr<ISQLiteFactory>& sqliteFactory,
-                       const std::string& path,
-                       const std::string& tableStmtCreation);
+                       const std::string&                     path,
+                       const std::string&                     tableStmtCreation,
+                       const DbManagement                     dbManagement = DbManagement::VOLATILE,
+                       const std::vector<std::string>&        upgradeStatements = {});
         ~SQLiteDBEngine();
 
         void bulkInsert(const std::string& table,
@@ -155,10 +157,14 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         void addTableRelationship(const nlohmann::json& data) override;
 
     private:
-        void initialize(const std::string& path,
-                        const std::string& tableStmtCreation);
+        void initialize(const std::string&              path,
+                        const std::string&              tableStmtCreation,
+                        const DbManagement              dbManagement,
+                        const std::vector<std::string>& upgradeStatements);
 
         bool cleanDB(const std::string& path);
+
+        size_t getDbVersion();
 
         size_t loadTableData(const std::string& table);
 

--- a/src/shared_modules/dbsync/tests/dbengine/dbengine_test.cpp
+++ b/src/shared_modules/dbsync/tests/dbengine/dbengine_test.cpp
@@ -43,6 +43,7 @@ static void initNoMetaDataMocks(std::unique_ptr<SQLiteDBEngine>& spEngine)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
                                    mockFactory,
@@ -75,6 +76,7 @@ TEST_F(DBEngineTest, Initialization)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     EXPECT_NO_THROW(std::make_unique<SQLiteDBEngine>(
                         mockFactory,
@@ -97,6 +99,7 @@ TEST_F(DBEngineTest, InitializationSQLError)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     EXPECT_THROW(std::make_unique<SQLiteDBEngine>(
                      mockFactory,
@@ -117,6 +120,7 @@ TEST_F(DBEngineTest, InitializationEmptyQuery)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     EXPECT_NO_THROW(std::make_unique<SQLiteDBEngine>(
                         mockFactory,
@@ -154,6 +158,7 @@ TEST_F(DBEngineTest, InitializeStatusField)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
@@ -234,6 +239,7 @@ TEST_F(DBEngineTest, InitializeStatusFieldNoMetadata)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
@@ -274,6 +280,7 @@ TEST_F(DBEngineTest, InitializeStatusFieldPreExistent)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
@@ -362,6 +369,8 @@ TEST_F(DBEngineTest, DeleteRowsByStatusField)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
+
     EXPECT_CALL(*mockConnection, changes()).Times(1)
     .WillOnce(Return(1));
 
@@ -451,6 +460,7 @@ TEST_F(DBEngineTest, DeleteRowsByStatusFieldNoMetadata)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
@@ -490,6 +500,7 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusFieldNoMetadata)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
@@ -535,6 +546,7 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
@@ -696,6 +708,7 @@ TEST_F(DBEngineTest, AddTableRelationship)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
@@ -826,6 +839,7 @@ TEST_F(DBEngineTest, AddTableRelationshipNoMetadata)
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA user_version = 1;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(

--- a/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
@@ -2310,3 +2310,129 @@ TEST_F(DBSyncTest, InitializationCPP)
     EXPECT_EQ(DATABASE_PERMISSIONS, stStat.st_mode & 0777);
 #endif
 }
+
+TEST_F(DBSyncTest, TestVolatileMode)
+{
+    const auto sql{"CREATE TABLE simple_test(`name` TEXT, `value` BIGINT, PRIMARY KEY (`name`));"};
+    std::vector<std::string> updates;
+
+    auto dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql, DbManagement::VOLATILE, updates);
+    dbSync->insertData(nlohmann::json::parse(R"({"table":"simple_test","data":[{"name":"test1","value":1}]})"));
+
+    auto selectQuery
+    {
+        SelectQuery::builder()
+        .table("simple_test")
+        .columnList({"name", "value"})
+        .rowFilter("WHERE name = 'test1'")
+        .orderByOpt("name")
+        .distinctOpt(false)
+        .countOpt(1)
+        .build()
+    };
+
+    CallbackMock wrapper;
+    EXPECT_CALL(wrapper, callbackMock(SELECTED, nlohmann::json::parse(R"({"name":"test1","value":1})"))).Times(1);
+
+    ResultCallbackData selectCallbackData
+    {
+        [&wrapper](ReturnTypeCallback type, const nlohmann::json & jsonResult)
+        {
+            wrapper.callbackMock(type, jsonResult);
+        }
+    };
+
+    EXPECT_NO_THROW(dbSync->selectRows(selectQuery.query(), selectCallbackData));
+
+    // We expect no data after re-initializing the DB in VOLATILE mode
+    dbSync.reset();
+    dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql, DbManagement::VOLATILE, updates);
+    EXPECT_CALL(wrapper, callbackMock(SELECTED, nlohmann::json::parse("{}"))).Times(0);
+
+    EXPECT_NO_THROW(dbSync->selectRows(selectQuery.query(), selectCallbackData));
+}
+
+TEST_F(DBSyncTest, TestPersistentMode)
+{
+    const auto sql{"CREATE TABLE simple_test(`name` TEXT, `value` BIGINT, PRIMARY KEY (`name`));"};
+    std::vector<std::string> updates;
+
+    auto dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql, DbManagement::PERSISTENT, updates);
+    dbSync->insertData(nlohmann::json::parse(R"({"table":"simple_test","data":[{"name":"test1","value":1}]})"));
+
+    auto selectQuery
+    {
+        SelectQuery::builder()
+        .table("simple_test")
+        .columnList({"name", "value"})
+        .rowFilter("WHERE name = 'test1'")
+        .orderByOpt("name")
+        .distinctOpt(false)
+        .countOpt(1)
+        .build()
+    };
+
+    CallbackMock wrapper;
+    EXPECT_CALL(wrapper, callbackMock(SELECTED, nlohmann::json::parse(R"({"name":"test1","value":1})"))).Times(1);
+
+    ResultCallbackData selectCallbackData
+    {
+        [&wrapper](ReturnTypeCallback type, const nlohmann::json & jsonResult)
+        {
+            wrapper.callbackMock(type, jsonResult);
+        }
+    };
+
+    EXPECT_NO_THROW(dbSync->selectRows(selectQuery.query(), selectCallbackData));
+
+    // We expect the same data after re-initializing the DB in PERSISTENT mode
+    dbSync.reset();
+    dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql, DbManagement::PERSISTENT, updates);
+    EXPECT_CALL(wrapper, callbackMock(SELECTED, nlohmann::json::parse(R"({"name":"test1","value":1})"))).Times(1);
+
+    EXPECT_NO_THROW(dbSync->selectRows(selectQuery.query(), selectCallbackData));
+    std::remove(DATABASE_TEMP);
+}
+
+TEST_F(DBSyncTest, TestUpgrade)
+{
+    const auto sql{"CREATE TABLE simple_test(`name` TEXT, `value` BIGINT, PRIMARY KEY (`name`));"};
+    std::vector<std::string> updates;
+
+    auto dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql, DbManagement::PERSISTENT, updates);
+
+    // After the re-initialization, we expect the upgrades to run
+    const auto update1{"ALTER TABLE simple_test ADD COLUMN `new_column` TEXT;"};
+    updates.push_back(update1);
+
+    dbSync.reset();
+    dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql, DbManagement::PERSISTENT, updates);
+
+    dbSync->insertData(nlohmann::json::parse(R"({"table":"simple_test","data":[{"name":"test1","value":1,"new_column":"new_value"}]})"));
+
+    auto selectQuery
+    {
+        SelectQuery::builder()
+        .table("simple_test")
+        .columnList({"name", "value", "new_column"})
+        .rowFilter("WHERE name = 'test1'")
+        .orderByOpt("name")
+        .distinctOpt(false)
+        .countOpt(1)
+        .build()
+    };
+
+    CallbackMock wrapper;
+    EXPECT_CALL(wrapper, callbackMock(SELECTED, nlohmann::json::parse(R"({"name":"test1","value":1,"new_column":"new_value"})"))).Times(1);
+
+    ResultCallbackData selectCallbackData
+    {
+        [&wrapper](ReturnTypeCallback type, const nlohmann::json & jsonResult)
+        {
+            wrapper.callbackMock(type, jsonResult);
+        }
+    };
+
+    EXPECT_NO_THROW(dbSync->selectRows(selectQuery.query(), selectCallbackData));
+    std::remove(DATABASE_TEMP);
+}

--- a/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
@@ -59,6 +59,7 @@ void DBSyncTest::SetUp()
 void DBSyncTest::TearDown()
 {
     EXPECT_NO_THROW(dbsync_teardown());
+    std::remove(DATABASE_TEMP);
 };
 
 TEST_F(DBSyncTest, Initialization)
@@ -2391,7 +2392,6 @@ TEST_F(DBSyncTest, TestPersistentMode)
     EXPECT_CALL(wrapper, callbackMock(SELECTED, nlohmann::json::parse(R"({"name":"test1","value":1})"))).Times(1);
 
     EXPECT_NO_THROW(dbSync->selectRows(selectQuery.query(), selectCallbackData));
-    std::remove(DATABASE_TEMP);
 }
 
 TEST_F(DBSyncTest, TestUpgrade)
@@ -2434,5 +2434,4 @@ TEST_F(DBSyncTest, TestUpgrade)
     };
 
     EXPECT_NO_THROW(dbSync->selectRows(selectQuery.query(), selectCallbackData));
-    std::remove(DATABASE_TEMP);
 }

--- a/src/shared_modules/dbsync/tests/pipelineFactory/dbsyncPipelineFactory_test.cpp
+++ b/src/shared_modules/dbsync/tests/pipelineFactory/dbsyncPipelineFactory_test.cpp
@@ -24,7 +24,7 @@ using namespace DbSync;
 void DBSyncPipelineFactoryTest::SetUp()
 {
     const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `tid` BIGINT, PRIMARY KEY (`pid`)) WITHOUT ROWID;"};
-    m_dbHandle = DBSyncImplementation::instance().initialize(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql);
+    m_dbHandle = DBSyncImplementation::instance().initialize(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql, DbManagement::VOLATILE, {});
 };
 
 void DBSyncPipelineFactoryTest::TearDown()

--- a/src/shared_modules/dbsync/testtool/Readme.md
+++ b/src/shared_modules/dbsync/testtool/Readme.md
@@ -34,7 +34,7 @@ Where:
   - db_name: Database name to be used.
   - db_type: Database type to be used. Only SQLITE3 is currently supported.
   - host_type: Agent or Manager.
-  - persistance: Database type of persistance being used. Not implemented yet.
+  - persistance: Database type of persistance being used.
   - sql_statement: Database sql structure to be created. This structure will be associated with the other files needed to use the tool.
 
 2) Create the needed amount of json files representing the different actions information. These ones need to follow the sql_statement structure created in the step 1.
@@ -44,4 +44,3 @@ Where:
 ./dbsync_test_tool -c config.json -a input1.json,input2.json,input3.json -o ./output
 ```
 5) Considering the example above all diff snapshots will be located in ./output folder in the following format: action_1.json, action_2.json ... action_n.json where 'n' will be the number of json files passed as part of the argument "-a".
-

--- a/src/shared_modules/dbsync/testtool/main.cpp
+++ b/src/shared_modules/dbsync/testtool/main.cpp
@@ -44,16 +44,24 @@ int main(int argc, const char* argv[])
 
         dbsync_initialize(loggerFunction);
 
-        auto handle
-        {
-            dbsync_create_((hostType.compare("0") == 0) ? HostType::MANAGER : HostType::AGENT,
-                           (dbType.compare("1") == 0) ? DbEngineType::SQLITE3 : DbEngineType::UNDEFINED,
-                           dbName.c_str(),
-                           sqlStmt.c_str(),
-                           (persistance.compare("1") == 0) ? DbManagement::PERSISTENT : DbManagement::VOLATILE,
-                           nullptr)
-        };
+        DBSYNC_HANDLE handle {0};
 
+        if (persistance.compare("1") == 0)
+        {
+            handle = dbsync_create_persistent((hostType.compare("0") == 0) ? HostType::MANAGER : HostType::AGENT,
+                                              (dbType.compare("1") == 0) ? DbEngineType::SQLITE3 : DbEngineType::UNDEFINED,
+                                              dbName.c_str(),
+                                              sqlStmt.c_str(),
+                                              nullptr);
+
+        }
+        else
+        {
+            handle = dbsync_create((hostType.compare("0") == 0) ? HostType::MANAGER : HostType::AGENT,
+                                   (dbType.compare("1") == 0) ? DbEngineType::SQLITE3 : DbEngineType::UNDEFINED,
+                                   dbName.c_str(),
+                                   sqlStmt.c_str());
+        }
 
         if (0 != handle)
         {

--- a/src/shared_modules/dbsync/testtool/main.cpp
+++ b/src/shared_modules/dbsync/testtool/main.cpp
@@ -46,10 +46,12 @@ int main(int argc, const char* argv[])
 
         auto handle
         {
-            dbsync_create((hostType.compare("0") == 0) ? HostType::MANAGER : HostType::AGENT,
-                          (dbType.compare("1") == 0) ? DbEngineType::SQLITE3 : DbEngineType::UNDEFINED,
-                          dbName.c_str(),
-                          sqlStmt.c_str())
+            dbsync_create_((hostType.compare("0") == 0) ? HostType::MANAGER : HostType::AGENT,
+                           (dbType.compare("1") == 0) ? DbEngineType::SQLITE3 : DbEngineType::UNDEFINED,
+                           dbName.c_str(),
+                           sqlStmt.c_str(),
+                           (persistance.compare("1") == 0) ? DbManagement::PERSISTENT : DbManagement::VOLATILE,
+                           nullptr)
         };
 
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17917 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR introduces the capability of creating a DBSync instance in "persistent" mode, to avoid recreating the DB every time it starts.
UTs were also added.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

- [x] Added unit tests (for new features)

