### PR TITLE
Vulnerability scanner - cvev5 flatbuffer schema fails to convert some generated document - Fix

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
+++ b/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
@@ -87,7 +87,7 @@ table Metric {
     format: string;
     scenarios: [Scenario];
     cvssV3_1: cvss.V3_1;
-    cvssV3_0: cvss.V2_0;
+    cvssV3_0: cvss.V3_0;
     cvssV2_0: cvss.V2_0;
     other: Other;
 }


### PR DESCRIPTION
|Related issue|
|---|
| #19723 |


## Description
This PR aims to fix the [cve5 flatbuffer schema](https://github.com/wazuh/wazuh/tree/dev-14153-vulndet-refactor/src/wazuh_modules/vulnerability_scanner/schemas) noncompliance with the [metrics field from the CVEv5 schema](https://github.com/CVEProject/cve-schema/blob/6b11a1b3a7c3a9e504c5cba1b39129d279a7f147/schema/v5.0/docs/CVE_JSON_5.0_bundled.json#L932-L955).

The error was due to a typo:
https://github.com/wazuh/wazuh/blob/411dcfb2a2092404520fdfa9bd0b3efe27cbb561/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs#L90

## Results
I've converted all generated documents to flatbuffers and counted each instance of success and failure, before and after the fix:

### Before
```
Success:          107547
RejectedReasons:   12388
Description:       25438
AttackComplexity:  37281
Total:            182654
```

### After
```
Success:          142165
RejectedReasons:   12388
Description:       28101
attackComplexity:      0
Total:            182654
```

> **Note**: This PR aims to fix the `attackComplexity` noncompliance.

As expected, all documents that previously failed to convert the cvssV3_0 field, are now successfully converted