### PR TITLE
Fix key longer than 65 characters fails in HMAC

### DIFF
--- a/src/os_crypto/hmac/hmac.c
+++ b/src/os_crypto/hmac/hmac.c
@@ -23,6 +23,7 @@ int OS_HMAC_SHA1_Str(const char *key, const char *text, os_sha1 output)
     unsigned char result[SHA_DIGEST_LENGTH + 1];
     unsigned char o_key_pad[HMAC_SHA1_BLOCKSIZE + 1];
     unsigned char i_key_pad[HMAC_SHA1_BLOCKSIZE + 1];
+    unsigned char key_temp[HMAC_SHA1_BLOCKSIZE + 1];
 
     int i;
     size_t key_length;
@@ -32,17 +33,20 @@ int OS_HMAC_SHA1_Str(const char *key, const char *text, os_sha1 output)
     key_length = strlen(key);
     text_length = strlen(text);
 
-    os_sha1 sha_key;
     if (key_length > HMAC_SHA1_BLOCKSIZE){
+        os_sha1 sha_key;
         OS_SHA1_Str(key, key_length, sha_key);
-        key = sha_key;
-        key_length = SHA_DIGEST_LENGTH;
+        key_length = strlen(sha_key);
+        memcpy(key_temp, sha_key, key_length);
+    }
+    else {
+        memcpy(key_temp, key, key_length);
     }
 
     memset(o_key_pad, 0, sizeof(o_key_pad));
     memset(i_key_pad, 0, sizeof(i_key_pad));
-    memcpy(o_key_pad, key, key_length);
-    memcpy(i_key_pad, key, key_length);
+    memcpy(o_key_pad, key_temp, key_length);
+    memcpy(i_key_pad, key_temp, key_length);
 
     for (i = 0; i < HMAC_SHA1_BLOCKSIZE; i++){
         o_key_pad[i] ^= 0x5c;
@@ -75,8 +79,10 @@ int OS_HMAC_SHA1_File(const char *key, const char *file_path, os_sha1 output, in
 {
     unsigned char o_key_pad[HMAC_SHA1_BLOCKSIZE + 1];
     unsigned char i_key_pad[HMAC_SHA1_BLOCKSIZE + 1];
+    unsigned char key_temp[HMAC_SHA1_BLOCKSIZE + 1];
     unsigned char result[SHA_DIGEST_LENGTH + 1];
     unsigned char buffer[2048 + 2];
+
     int i;
     size_t key_length;
     SHA_CTX context;
@@ -84,17 +90,19 @@ int OS_HMAC_SHA1_File(const char *key, const char *file_path, os_sha1 output, in
 
     key_length = strlen(key);
 
-    os_sha1 sha_key;
     if (key_length > HMAC_SHA1_BLOCKSIZE){
+        os_sha1 sha_key;
         OS_SHA1_Str(key, key_length, sha_key);
-        key = sha_key;
-        key_length = SHA_DIGEST_LENGTH;
+        key_length = strlen(sha_key);
+        memcpy(key_temp, sha_key, key_length);
+    } else {
+      memcpy(key_temp, key, key_length);
     }
 
     memset(o_key_pad, 0, sizeof(o_key_pad));
     memset(i_key_pad, 0, sizeof(i_key_pad));
-    memcpy(o_key_pad, key, key_length);
-    memcpy(i_key_pad, key, key_length);
+    memcpy(o_key_pad, key_temp, key_length);
+    memcpy(i_key_pad, key_temp, key_length);
 
     for (i = 0; i < HMAC_SHA1_BLOCKSIZE; i++){
         o_key_pad[i] ^= 0x5c;

--- a/src/os_crypto/hmac/hmac.c
+++ b/src/os_crypto/hmac/hmac.c
@@ -32,8 +32,8 @@ int OS_HMAC_SHA1_Str(const char *key, const char *text, os_sha1 output)
     key_length = strlen(key);
     text_length = strlen(text);
 
+    os_sha1 sha_key;
     if (key_length > HMAC_SHA1_BLOCKSIZE){
-        os_sha1 sha_key;
         OS_SHA1_Str(key, key_length, sha_key);
         key = sha_key;
         key_length = SHA_DIGEST_LENGTH;
@@ -84,8 +84,8 @@ int OS_HMAC_SHA1_File(const char *key, const char *file_path, os_sha1 output, in
 
     key_length = strlen(key);
 
+    os_sha1 sha_key;
     if (key_length > HMAC_SHA1_BLOCKSIZE){
-        os_sha1 sha_key;
         OS_SHA1_Str(key, key_length, sha_key);
         key = sha_key;
         key_length = SHA_DIGEST_LENGTH;


### PR DESCRIPTION
os_sha1 was accessed out of scope.

|Related issue|
|---|
|#19793|

## Description

The variable `os_sha1` of the functions `OS_HMAC_SHA1_File(const char *key, const char *file_path, os_sha1 output, int mode)` and `OS_HMAC_SHA1_Str(const char *key, const char *text, os_sha1 output)` was accessed out of its scope, causing the error.

```
    if (key_length > HMAC_SHA1_BLOCKSIZE){
        os_sha1 sha_key;  <<<---
        OS_SHA1_Str(key, key_length, sha_key);
        key = sha_key;    <<<---
        key_length = SHA_DIGEST_LENGTH;
    }

    memset(o_key_pad, 0, sizeof(o_key_pad));
    memset(i_key_pad, 0, sizeof(i_key_pad));
    memcpy(o_key_pad, key, key_length);
    memcpy(i_key_pad, key, key_length);
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation