### PR TITLE
Content Manager - Improve API offset acquisition

### DIFF
--- a/src/shared_modules/content_manager/doc/components/EXECUTION_CONTEXT.md
+++ b/src/shared_modules/content_manager/doc/components/EXECUTION_CONTEXT.md
@@ -1,0 +1,24 @@
+# Execution Context stage
+
+## Details
+
+The `execution context` stage is part of the Content Manager orchestration initialization and is in charge of preparing the execution environment before any orchestration is started. This stage implementation can be seen in the [ExecutionContext](../../src/components/executionContext.hpp) class.
+
+The tasks that this stage performs are:
+- **Set up context**: Configure some of the fields present on the Updater Context.
+- **Database initialization**: Initializes the RocksDB database, retrieving the API offset stored in it. It also defines which offset will be considered as the current one between the offset in the database and the offset in the input configuration.
+- **Output folders creation**: It creates the folders needed to store the execution files, such as downloaded and uncompressed files. If the output folder already exists, it gets deleted and re-created.
+
+It is important to note that this stage is only called once for each Content Manager execution.
+
+## Relation with the UpdaterContext
+
+The context fields related to this stage are:
+
+- `configData`
+  + `outputFolder`: Used to set the output folder.
+  + `databasePath`: Used to set the database files location.
+  + `offset`: Used to override the offset from the database.
+- `topicName`: Used to compose the name of the database.
+- `spRocksDB`: Used to initialize the database connector.
+- `outputFolder`: Used to create the output files location.

--- a/src/shared_modules/content_manager/doc/components/EXECUTION_CONTEXT.md
+++ b/src/shared_modules/content_manager/doc/components/EXECUTION_CONTEXT.md
@@ -18,7 +18,7 @@ The context fields related to this stage are:
 - `configData`
   + `outputFolder`: Used to set the output folder.
   + `databasePath`: Used to set the database files location.
-  + `offset`: Used to override the offset from the database.
+  + `offset`: Used to override (if greater than) the offset from the database.
 - `topicName`: Used to compose the name of the database.
 - `spRocksDB`: Used to initialize the database connector.
 - `outputFolder`: Used to create the output files location.

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -76,8 +76,8 @@ public:
             // If the database exists, get the last offset
             if (m_spBaseContext->spRocksDB)
             {
-                const auto value = m_spBaseContext->spRocksDB->getLastKeyValue().second;
-                spUpdaterContext->currentOffset = value.empty() ? 0 : std::stoi(value.ToString());
+                spUpdaterContext->currentOffset =
+                    std::stoi(m_spBaseContext->spRocksDB->getLastKeyValue().second.ToString());
             }
 
             // Run the updater chain

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -62,14 +62,14 @@ private:
      * @brief Parses the offset from the input configuration.
      *
      * @param inputConfig Reference to the input config.
-     * @return unsigned int Non negative offset from the input config.
+     * @return unsigned int Non-negative offset from the input config.
      */
     unsigned int getConfigOffset(const nlohmann::json& inputConfig) const
     {
         const auto configOffset {inputConfig.at("offset").get<int>()};
         if (configOffset < 0)
         {
-            throw std::runtime_error {"Offset is not a non negative number: " + std::to_string(configOffset)};
+            throw std::runtime_error {"Offset is not a non-negative number: " + std::to_string(configOffset)};
         }
 
         return configOffset;

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -48,7 +48,7 @@ private:
         {
             databaseOffset = std::stoi(context.spRocksDB->getLastKeyValue().second.ToString());
         }
-        catch ([[maybe_unused]] const std::runtime_error& e)
+        catch (const std::runtime_error&)
         {
             // First execution. Set offset to zero.
             databaseOffset = 0;
@@ -69,7 +69,7 @@ private:
         const auto configOffset {inputConfig.at("offset").get<int>()};
         if (configOffset < 0)
         {
-            throw std::runtime_error {"Offset is not a non-negative number: " + std::to_string(configOffset)};
+            throw std::runtime_error {"Offset should be a non-negative number: " + std::to_string(configOffset)};
         }
 
         return configOffset;
@@ -86,14 +86,14 @@ private:
         const auto databaseName {"/updater_" + context.topicName + "_metadata"};
         const auto databasePath {context.configData.at("databasePath").get_ref<std::string&>()};
 
-        // check if the output folder exists.
+        // Check if the output folder exists.
         if (!std::filesystem::exists(databasePath))
         {
             // Create the folders.
             std::filesystem::create_directories(databasePath);
         }
 
-        // Inititalize RocksDB driver instance.
+        // Initialize RocksDB driver instance.
         context.spRocksDB = std::make_unique<Utils::RocksDBWrapper>(databasePath + databaseName);
 
         // Read input offsets.
@@ -103,7 +103,7 @@ private:
         // Choose the greatest between the DB and the config offset.
         const auto currentOffset {std::max(databaseOffset, configOffset)};
 
-        if (currentOffset != databaseOffset)
+        if (currentOffset > databaseOffset)
         {
             // Put the current offset in the database.
             context.spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)), std::to_string(currentOffset));

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -13,10 +13,16 @@
 #define _EXECUTION_CONTEXT_HPP
 
 #include "chainOfResponsability.hpp"
+#include "json.hpp"
+#include "stringHelper.h"
 #include "updaterContext.hpp"
 #include "utils/timeHelper.h"
+#include <algorithm>
+#include <cstdlib>
 #include <filesystem>
 #include <iostream>
+#include <memory>
+#include <string>
 
 const std::string GENERIC_OUTPUT_FOLDER_PATH {std::filesystem::temp_directory_path() / "output_folder"};
 
@@ -29,6 +35,46 @@ const std::string GENERIC_OUTPUT_FOLDER_PATH {std::filesystem::temp_directory_pa
 class ExecutionContext final : public AbstractHandler<std::shared_ptr<UpdaterBaseContext>>
 {
 private:
+    /**
+     * @brief Reads and returns the last offset from the database.
+     *
+     * @param context Updater context configured with the database driver.
+     * @return unsigned int Last offset from the database.
+     */
+    unsigned int getDatabaseOffset(const UpdaterBaseContext& context) const
+    {
+        unsigned int databaseOffset;
+        try
+        {
+            databaseOffset = std::stoi(context.spRocksDB->getLastKeyValue().second.ToString());
+        }
+        catch ([[maybe_unused]] const std::runtime_error& e)
+        {
+            // First execution. Set offset to zero.
+            databaseOffset = 0;
+            context.spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)), "0");
+        }
+
+        return databaseOffset;
+    }
+
+    /**
+     * @brief Parses the offset from the input configuration.
+     *
+     * @param inputConfig Reference to the input config.
+     * @return unsigned int Non negative offset from the input config.
+     */
+    unsigned int getConfigOffset(const nlohmann::json& inputConfig) const
+    {
+        const auto configOffset {inputConfig.at("offset").get<int>()};
+        if (configOffset < 0)
+        {
+            throw std::runtime_error {"Offset is not a non negative number: " + std::to_string(configOffset)};
+        }
+
+        return configOffset;
+    }
+
     /**
      * @brief Creates the RocksDB instance.
      *
@@ -47,9 +93,23 @@ private:
             std::filesystem::create_directories(databasePath);
         }
 
-        // Create a RocksDB instance
+        // Inititalize RocksDB driver instance.
         context.spRocksDB = std::make_unique<Utils::RocksDBWrapper>(databasePath + databaseName);
-        context.spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)), "0");
+
+        // Read input offsets.
+        const auto databaseOffset {getDatabaseOffset(context)};
+        const auto configOffset {getConfigOffset(context.configData)};
+
+        // Chose the greater between the DB and the config offset.
+        const auto currentOffset {std::max(databaseOffset, configOffset)};
+
+        if (currentOffset != databaseOffset)
+        {
+            // Put the current offset in the database.
+            context.spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)), std::to_string(currentOffset));
+        }
+
+        std::cout << "API offset to be used: " << currentOffset << std::endl;
     }
 
     /**

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -100,7 +100,7 @@ private:
         const auto databaseOffset {getDatabaseOffset(context)};
         const auto configOffset {getConfigOffset(context.configData)};
 
-        // Chose the greater between the DB and the config offset.
+        // Choose the greatest between the DB and the config offset.
         const auto currentOffset {std::max(databaseOffset, configOffset)};
 
         if (currentOffset != databaseOffset)

--- a/src/shared_modules/content_manager/tests/component/action_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.hpp
@@ -52,7 +52,8 @@ protected:
                     "outputFolder": "/tmp/action-tests",
                     "dataFormat": "json",
                     "contentFileName": "sample.json",
-                    "databasePath": "/tmp/action-tests/rocksdb"
+                    "databasePath": "/tmp/action-tests/rocksdb",
+                    "offset": 0
                 }
             }
         )"_json;

--- a/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
@@ -33,7 +33,8 @@ protected:
 
     std::shared_ptr<ExecutionContext> m_spExecutionContext; ///< ExecutionContext.
 
-    const std::filesystem::path m_databasePath {"/tmp/database"}; ///< Path used to store the database files.
+    const std::filesystem::path m_databasePath {"/tmp/database"};        ///< Path used to store the database files.
+    const std::filesystem::path m_outputFolder {"/tmp/content_manager"}; ///< Path used to store the output files.
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -46,11 +47,7 @@ protected:
         // Create a updater context
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
         m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
-        m_spUpdaterBaseContext->configData = R"(
-            {
-                "outputFolder": "/tmp/content_manager"
-            }
-        )"_json;
+        m_spUpdaterBaseContext->configData["outputFolder"] = m_outputFolder.string();
     }
 
     /**
@@ -59,7 +56,7 @@ protected:
      */
     void TearDown() override
     {
-        std::filesystem::remove_all("/tmp/content_manager");
+        std::filesystem::remove_all(m_outputFolder);
         std::filesystem::remove_all(m_databasePath);
     }
 };

--- a/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
@@ -15,6 +15,7 @@
 #include "executionContext.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <filesystem>
 #include <memory>
 
 /**
@@ -32,6 +33,8 @@ protected:
 
     std::shared_ptr<ExecutionContext> m_spExecutionContext; ///< ExecutionContext.
 
+    const std::filesystem::path m_databasePath {"/tmp/database"}; ///< Path used to store the database files.
+
     /**
      * @brief Sets initial conditions for each test case.
      *
@@ -48,6 +51,16 @@ protected:
                 "outputFolder": "/tmp/content_manager"
             }
         )"_json;
+    }
+
+    /**
+     * @brief Tear down routine for each test fixture.
+     *
+     */
+    void TearDown() override
+    {
+        std::filesystem::remove_all("/tmp/content_manager");
+        std::filesystem::remove_all(m_databasePath);
     }
 };
 

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -19,6 +19,7 @@
  * @outputFolder: if defined, the content will be downloaded to this folder.
  * @dataFormat: Format of the content downloaded or after decompression.
  * @fileName: Name of the file to download or file name in case of raw content.
+ * @offset (integer): Api offset used to override (if greater) the one set on the database.
  */
 static const nlohmann::json CONFIG_PARAMETERS =
     R"(
@@ -37,7 +38,8 @@ static const nlohmann::json CONFIG_PARAMETERS =
                 "dataFormat": "json",
                 "contentFileName": "example.json",
                 "s3FileName": "content.filtered_little.1.xz",
-                "databasePath": "/tmp/content_updater/rocksdb"
+                "databasePath": "/tmp/content_updater/rocksdb",
+                "offset": 0
             }
         }
         )"_json;


### PR DESCRIPTION
|Related issue|
|---|
|#19786 |

## Description

This PR modifies the `ExecutionContext` class in order to improve the way the API offset is handled. 

The offset is chosen following these directives:
- If the offset is not set on the database (first execution ever), the offset is acquired from the config file.
- If the offset is set on the database, the chosen offset is the greatest between the one in the database and the one in the input config.

Notes:
- There are no redundant insertions on the database. The new offset to be used is only inserted in the database if it has changed from the previous execution.

## Results

### Test tool

First execution: `offset = 0` (chosen offset 0)
```bash
# ./content_manager_test_tool 
ActionOrchestrator - Starting process
API offset to be used: 0
Output folders created.
FactoryContentUpdater - Starting process
Creating 'api' downloader
Content decompressor not needed
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
```

Second execution: `offset = 1000` (chosen offset 1000)
```bash
# ./content_manager_test_tool 
ActionOrchestrator - Starting process
API offset to be used: 1000
The previous output folder: "/tmp/testProvider" will be removed.
Output folders created.
FactoryContentUpdater - Starting process
Creating 'api' downloader
Content decompressor not needed
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
```

Third execution: `offset = 500` (chosen offset 1000)
```bash
# ./content_manager_test_tool 
ActionOrchestrator - Starting process
API offset to be used: 1000
The previous output folder: "/tmp/testProvider" will be removed.
Output folders created.
FactoryContentUpdater - Starting process
Creating 'api' downloader
Content decompressor not needed
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
```

Fourth execution: `offset = -10` (exception)
```bash
# ./content_manager_test_tool 
ActionOrchestrator - Starting process
terminate called after throwing an instance of 'std::invalid_argument'
  what():  Orchestration creation failed. Offset is not a non-negative number: -10
```

Fifth execution: `offset = 4000` (chosen offset 4000)
```bash
# ./content_manager_test_tool 
ActionOrchestrator - Starting process
API offset to be used: 4000
The previous output folder: "/tmp/testProvider" will be removed.
Output folders created.
FactoryContentUpdater - Starting process
Creating 'api' downloader
Content decompressor not needed
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
```

### Coverage

100% of coverage reached.

![image](https://github.com/wazuh/wazuh/assets/42682247/74ead684-c4f1-40bb-a165-1cb1ff3e6fd5)

