### PR TITLE
Added debug and warning messages when AWS does not contain the discard field

### DIFF
--- a/wodles/aws/buckets_s3/aws_bucket.py
+++ b/wodles/aws/buckets_s3/aws_bucket.py
@@ -528,6 +528,10 @@ class AWSBucket(wazuh_integration.WazuhAWSDatabase):
                         f'+++ The "{self.discard_regex.pattern}" regex found a match in the "{self.discard_field}" '
                         f'field. The event will be skipped.', 2)
                     continue
+                else:
+                    aws_tools.debug(
+                        f'+++ The "{self.discard_regex.pattern}" regex did not match any value in the '
+                        f'"{self.discard_field}" field. The event will be processed.', 3)
                 # Parse out all the values of 'None'
                 event_msg = self.get_alert_msg(aws_account_id, log_key, event)
 

--- a/wodles/aws/services/cloudwatchlogs.py
+++ b/wodles/aws/services/cloudwatchlogs.py
@@ -306,6 +306,10 @@ class AWSCloudWatchLogs(aws_service.AWSService):
                                 f'+++ The "{self.discard_regex.pattern}" regex found a match in the "{self.discard_field}" '
                                 f'field. The event will be skipped.', 2)
                             continue
+                        else:
+                            aws_tools.debug(
+                                f'+++ The "{self.discard_regex.pattern}" regex did not match any value in the '
+                                f'"{self.discard_field}" field. The event will be processed.', 3)
                     except ValueError:
                         # event_msg is not a JSON object, check if discard_regex.pattern matches the given string
                         aws_tools.debug(f"+++ Retrieved log event is not a JSON object.", 3)
@@ -314,6 +318,9 @@ class AWSCloudWatchLogs(aws_service.AWSService):
                                 f'+++ The "{self.discard_regex.pattern}" regex found a match. The event will be skipped.',
                                 2)
                             continue
+                        else:
+                            print(f'WARNING: The "{self.discard_regex.pattern}" regex did not match any value in the '
+                                  f'field. The event will be processed.')
                     aws_tools.debug('The message is "{}"'.format(event_msg), 2)
                     aws_tools.debug('The message\'s timestamp is {}'.format(event["timestamp"]), 3)
                     self.send_msg(event_msg, dump_json=False)

--- a/wodles/aws/subscribers/s3_log_handler.py
+++ b/wodles/aws/subscribers/s3_log_handler.py
@@ -219,12 +219,19 @@ class AWSSubscriberBucket(wazuh_integration.WazuhIntegration, AWSS3LogHandler):
                 if re.match(self.discard_regex, log['full_log']):
                     aws_tools.debug(f'+++ The "{self.discard_regex.pattern}" regex found a match. '
                                     f'The event will be skipped.', 2)
+                else:
+                    print(f'WARNING: The "{self.discard_regex.pattern}" regex did not match any value in the '
+                          f'field. The event will be processed.')             
                     continue
             elif self.event_should_be_skipped(log):
                 aws_tools.debug(f'+++ The "{self.discard_regex.pattern}" regex found a match '
                                 f'in the "{self.discard_field}" '
                       f'field. The event will be skipped.', 2)
                 continue
+            else:
+                aws_tools.debug(
+                                f'+++ The "{self.discard_regex.pattern}" regex did not match any value in the '
+                                f'"{self.discard_field}" field. The event will be processed.', 3)
 
             msg['aws'].update(log)
             self.send_msg(msg)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18424|



## Description

A warning message was added when `discard_field` does not find a match in the logs, and a level 3 debug message when the declared regular expression does not match the value found for that field. This change was made because when the parameter was declared and the field was not present in the log or no match was found for the regular expression, no message was displayed, and all available logs were processed

## Logs/Alerts example

```
/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -g 4_5_test -d 3 -s 2021-JUN-20 -p dev -r us-east-1 --discard-field Test  --discard-regex Test
DEBUG: +++ Debug mode on - Level: 3
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'dev' configuration
DEBUG: only logs: 1624147200000
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: Getting data from DB for log stream "test_stream" in log group "4_5_test"
DEBUG: Token: "None", start_time: "None", end_time: "None"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_5_test" using token "None", start_time "1624147200000" and end_time "None"
DEBUG: +++ Sending events to Analysisd...
DEBUG: +++ The "Test" regex did not match any value in the "Test" field. The event will be processed.
```
`DEBUG: +++ The "Test" regex did not match any value in the "Test" field. The event will be processed.
`

```
root@wazuh-master:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -g 4_5_test -d 3 -s 2021-JUN-20 -p dev -r us-east-1 --discard-regex Testing
DEBUG: +++ Debug mode on - Level: 3
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'dev' configuration
DEBUG: only logs: 1624147200000
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: Getting data from DB for log stream "test_stream" in log group "4_5_test"
DEBUG: Token: "None", start_time: "None", end_time: "None"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_5_test" using token "None", start_time "1624147200000" and end_time "None"
DEBUG: +++ Sending events to Analysisd...
DEBUG: +++ Retrieved log event is not a JSON object.
WARNING: The "Testing" regex did not match any value in the field. The event will be processed.
WARNING: The "Testing" regex did not match any value in the field. The event will be processed.
```
`WARNING: The "Testing" regex did not match any value in the field. The event will be processed.
`





## Tests

## Test_cloudwathlogs
                                                                                                                 
```
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_initializes_properly[True-test_log_group-20220101] PASSED                                                                           [  1%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_initializes_properly[True-test_log_group-None] PASSED                                                                               [  3%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_initializes_properly[True-None-20220101] PASSED                                                                                     [  5%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_initializes_properly[True-None-None] PASSED                                                                                         [  7%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_initializes_properly[False-test_log_group-20220101] PASSED                                                                          [  9%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_initializes_properly[False-test_log_group-None] PASSED                                                                              [ 11%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_initializes_properly[False-None-20220101] PASSED                                                                                    [ 13%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_initializes_properly[False-None-None] PASSED                                                                                        [ 15%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts[True-20220101-True] PASSED                                                                                               [ 16%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts[True-20220101-False] PASSED                                                                                              [ 18%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts[True-None-True] PASSED                                                                                                   [ 20%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts[True-None-False] PASSED                                                                                                  [ 22%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts[False-20220101-True] PASSED                                                                                              [ 24%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts[False-20220101-False] PASSED                                                                                             [ 26%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts[False-None-True] PASSED                                                                                                  [ 28%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts[False-None-False] PASSED                                                                                                 [ 30%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_remove_aws_log_stream PASSED                                                                                                        [ 32%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_remove_aws_log_stream_handles_exceptions PASSED                                                                                     [ 33%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[None-1659355591835-None-None] PASSED                                                                        [ 35%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[None-1659355591835-None-1659355591834] PASSED                                                               [ 37%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[None-1659355591835-1640996200001-None] PASSED                                                               [ 39%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[None-1659355591835-1640996200001-1659355591834] PASSED                                                      [ 41%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[None-1640996200000-None-None] PASSED                                                                        [ 43%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[None-1640996200000-None-1659355591834] PASSED                                                               [ 45%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[None-1640996200000-1640996200001-None] PASSED                                                               [ 47%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[None-1640996200000-1640996200001-1659355591834] PASSED                                                      [ 49%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[f/12345678123456781234567812345678123456781234567812345678/s-1659355591835-None-None] PASSED                [ 50%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[f/12345678123456781234567812345678123456781234567812345678/s-1659355591835-None-1659355591834] PASSED       [ 52%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[f/12345678123456781234567812345678123456781234567812345678/s-1659355591835-1640996200001-None] PASSED       [ 54%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[f/12345678123456781234567812345678123456781234567812345678/s-1659355591835-1640996200001-1659355591834] PASSED [ 56%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[f/12345678123456781234567812345678123456781234567812345678/s-1640996200000-None-None] PASSED                [ 58%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[f/12345678123456781234567812345678123456781234567812345678/s-1640996200000-None-1659355591834] PASSED       [ 60%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[f/12345678123456781234567812345678123456781234567812345678/s-1640996200000-1640996200001-None] PASSED       [ 62%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range[f/12345678123456781234567812345678123456781234567812345678/s-1640996200000-1640996200001-1659355591834] PASSED [ 64%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_alerts_within_range_handles_exceptions_on_client_error PASSED                                                                   [ 66%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_data_from_db PASSED                                                                                                             [ 67%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[None-None-None] PASSED                                                                                                [ 69%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[None-None-values1] PASSED                                                                                             [ 71%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[None-None-values2] PASSED                                                                                             [ 73%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[None-result_after1-None] PASSED                                                                                       [ 75%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[None-result_after1-values1] PASSED                                                                                    [ 77%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[None-result_after1-values2] PASSED                                                                                    [ 79%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[result_before1-None-None] PASSED                                                                                      [ 81%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[result_before1-None-values1] PASSED                                                                                   [ 83%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[result_before1-None-values2] PASSED                                                                                   [ 84%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[result_before1-result_after1-None] PASSED                                                                             [ 86%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[result_before1-result_after1-values1] PASSED                                                                          [ 88%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_update_values[result_before1-result_after1-values2] PASSED                                                                          [ 90%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_save_data_db PASSED                                                                                                                 [ 92%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_log_streams[describe_log_streams_response0-expected_result_list0] PASSED                                                        [ 94%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_log_streams[describe_log_streams_response1-expected_result_list1] PASSED                                                        [ 96%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_get_log_streams_handles_exceptions PASSED                                                                                           [ 98%]
wodles/aws/tests/test_cloudwatchlogs.py::test_aws_cloudwatchlogs_purge_db PASSED                                                                                                                     [100%]
```


## Test_s3_log_handler

```
wodles/aws/tests/test_s3_log_handler.py::test_aws_sl_subscriber_bucket_initializes_properly PASSED                                                                                                   [ 25%]
wodles/aws/tests/test_s3_log_handler.py::test_aws_sl_subscriber_bucket_obtain_logs PASSED                                                                                                            [ 50%]
wodles/aws/tests/test_s3_log_handler.py::test_aws_sl_subscriber_bucket_obtain_logs_handles_exception PASSED                                                                                          [ 75%]
wodles/aws/tests/test_s3_log_handler.py::test_aws_sl_subscriber_bucket_process_file PASSED                                                                                                           [100%]
```

## Test_aws_bucket
[Test_aws_bucket.zip](https://github.com/wazuh/wazuh/files/13114163/Test_aws_bucket.zip)


