### PR TITLE
Content Manager - `OfflineDownloader` implementation

### DIFF
--- a/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
@@ -1,0 +1,26 @@
+# Offline Downloader stage
+
+## Details
+
+The `offline downloader` stage is part of the Content Manager orchestration and is in charge of copying an input file from the local filesystem to be processed by the following stages. The input file hash is calculated and stored in order to avoid processing the same file multiple times in the next orchestration executions.
+
+The copy can be made into any of the two following output directories:
+- Downloads folder: If the input file is compressed.
+- Content folder: If the input file is not compressed.
+
+If the copy is successful, this stage also updates the context [data paths](../../src/components/updaterContext.hpp) with the copy destination path.
+
+> Note: Despite the class name, there is no such download performed. The copy is made entirely locally.
+
+## Relation with the UpdaterContext
+
+The context fields related to this stage are:
+
+- `configData`
+  + `url`: Used as input file path.
+  + `compressionType`: Used to know whether the input file is compressed or not.
+- `downloadsFolder`: Used as output folder when the input file is compressed.
+- `contentsFolder`: Used as output folder when the input file is not compressed.
+- `data`: Used to read and update the paths under the `paths` key. The stage status is also updated on this member.
+- `outputFolder`: Used as the destination file path base.
+- `downloadedFileHash`: Used to store the last input file hash. A file will be copied only if its hash is different from this one.

--- a/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
@@ -2,13 +2,13 @@
 
 ## Details
 
-The `offline downloader` stage is part of the Content Manager orchestration and is in charge of copying an input file from the local filesystem to be processed by the following stages. The input file hash is calculated and stored in order to avoid processing the same file multiple times in the next orchestration executions.
+The [offline downloader](../../src/components/offlineDownloader.hpp) stage is part of the Content Manager orchestration and is in charge of copying an input file from the local filesystem to be processed by the following stages. The input file hash is calculated and stored in order to avoid processing the same file multiple times in the next orchestration executions.
 
-The copy can be made into any of the two following output directories:
+The copy will be made into any of the following output directories:
 - Downloads folder: If the input file is compressed.
 - Contents folder: If the input file is not compressed.
 
-If the copy is successful, this stage also updates the context [data paths](../../src/components/updaterContext.hpp) with the copy destination path.
+If the copy is successful, this stage also updates the context [data paths](../../src/components/updaterContext.hpp) field with the destination path of the copied file.
 
 > Note: Despite the class name, there is no such download performed. The copy is made entirely locally.
 

--- a/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
@@ -6,7 +6,7 @@ The `offline downloader` stage is part of the Content Manager orchestration and 
 
 The copy can be made into any of the two following output directories:
 - Downloads folder: If the input file is compressed.
-- Content folder: If the input file is not compressed.
+- Contents folder: If the input file is not compressed.
 
 If the copy is successful, this stage also updates the context [data paths](../../src/components/updaterContext.hpp) with the copy destination path.
 
@@ -17,7 +17,7 @@ If the copy is successful, this stage also updates the context [data paths](../.
 The context fields related to this stage are:
 
 - `configData`
-  + `url`: Used as input file path.
+  + `url`: Used as input file path. The prefix `file://` is allowed.
   + `compressionType`: Used to know whether the input file is compressed or not.
 - `downloadsFolder`: Used as output folder when the input file is compressed.
 - `contentsFolder`: Used as output folder when the input file is not compressed.

--- a/src/shared_modules/content_manager/src/components/factoryContentUpdater.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryContentUpdater.hpp
@@ -38,7 +38,7 @@ public:
      * @param config Configurations.
      * @return std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>>
      */
-    static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(const nlohmann::json& config)
+    static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(nlohmann::json& config)
     {
         std::cout << "FactoryContentUpdater - Starting process" << std::endl;
 

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -20,9 +20,7 @@
 #include "offlineDownloader.hpp"
 #include "updaterContext.hpp"
 #include "utils/chainOfResponsability.hpp"
-#include <filesystem>
 #include <iostream>
-#include <map>
 #include <memory>
 #include <string>
 
@@ -34,26 +32,6 @@
  */
 class FactoryDownloader final
 {
-private:
-    /**
-     * @brief Deduces and returns the compression type given an input file extension.
-     *
-     * @param inputFile Input file whose compression type will be deduced.
-     * @return std::string Compression type.
-     */
-    static std::string deduceCompressionType(const std::string& inputFile)
-    {
-        const std::map<std::string, std::string> COMPRESSED_EXTENSIONS {{".gz", "gzip"}, {".xz", "xz"}};
-        const auto& fileExtension {std::filesystem::path(inputFile).extension()};
-
-        if (const auto& it {COMPRESSED_EXTENSIONS.find(fileExtension)}; it != COMPRESSED_EXTENSIONS.end())
-        {
-            return it->second;
-        }
-
-        return "raw";
-    }
-
 public:
     /**
      * @brief Create the content downloader based on the contentSource value.
@@ -61,7 +39,7 @@ public:
      * @param config Configurations.
      * @return std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>>
      */
-    static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(nlohmann::json& config)
+    static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(const nlohmann::json& config)
     {
         auto const downloaderType {config.at("contentSource").get<std::string>()};
         std::cout << "Creating '" << downloaderType << "' downloader" << std::endl;
@@ -80,8 +58,6 @@ public:
         }
         if ("offline" == downloaderType)
         {
-            // When using an offline downloader, the compression type is automatically deduced.
-            config["compressionType"] = deduceCompressionType(config.at("url").get_ref<const std::string&>());
             return std::make_shared<OfflineDownloader>();
         }
         else

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -46,9 +46,9 @@ private:
         const std::map<std::string, std::string> COMPRESSED_EXTENSIONS {{".gz", "gzip"}, {".xz", "xz"}};
         const auto& fileExtension {std::filesystem::path(inputFile).extension()};
 
-        if (COMPRESSED_EXTENSIONS.find(fileExtension) != COMPRESSED_EXTENSIONS.end())
+        if (const auto& it {COMPRESSED_EXTENSIONS.find(fileExtension)}; it != COMPRESSED_EXTENSIONS.end())
         {
-            return COMPRESSED_EXTENSIONS.at(fileExtension);
+            return it->second;
         }
 
         return "raw";

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -78,7 +78,7 @@ public:
         {
             return std::make_shared<S3Downloader>();
         }
-        if (downloaderType.compare("offline") == 0)
+        if ("offline" == downloaderType)
         {
             // When using an offline downloader, the compression type is automatically deduced.
             config["compressionType"] = deduceCompressionType(config.at("url").get_ref<const std::string&>());

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -46,7 +46,7 @@ private:
         const std::map<std::string, std::string> COMPRESSED_EXTENSIONS {{".gz", "gzip"}, {".xz", "xz"}};
         const auto& fileExtension {std::filesystem::path(inputFile).extension()};
 
-        if (COMPRESSED_EXTENSIONS.count(fileExtension))
+        if (COMPRESSED_EXTENSIONS.find(fileExtension) != COMPRESSED_EXTENSIONS.end())
         {
             return COMPRESSED_EXTENSIONS.at(fileExtension);
         }

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -44,15 +44,15 @@ public:
         auto const downloaderType {config.at("contentSource").get<std::string>()};
         std::cout << "Creating '" << downloaderType << "' downloader" << std::endl;
 
-        if (downloaderType.compare("api") == 0)
+        if ("api" == downloaderType)
         {
             return std::make_shared<APIDownloader>(HTTPRequest::instance());
         }
-        if (downloaderType.compare("cti-api") == 0)
+        if ("cti-api" == downloaderType)
         {
             return std::make_shared<CtiApiDownloader>(HTTPRequest::instance());
         }
-        if (downloaderType.compare("s3") == 0)
+        if ("s3" == downloaderType)
         {
             return std::make_shared<S3Downloader>();
         }
@@ -60,10 +60,8 @@ public:
         {
             return std::make_shared<OfflineDownloader>();
         }
-        else
-        {
-            throw std::invalid_argument {"Invalid 'contentSource' type: " + downloaderType};
-        }
+
+        throw std::invalid_argument {"Invalid 'contentSource' type: " + downloaderType};
     }
 };
 

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -1,0 +1,158 @@
+/*
+ * Wazuh content manager
+ * Copyright (C) 2015, Wazuh Inc.
+ * October 24, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _OFFLINE_DOWNLOADER_HPP
+#define _OFFLINE_DOWNLOADER_HPP
+
+#include "hashHelper.h"
+#include "json.hpp"
+#include "stringHelper.h"
+#include "updaterContext.hpp"
+#include "utils/chainOfResponsability.hpp"
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+/**
+ * @class OfflineDownloader
+ *
+ * @brief Class in charge of copying a file from the filesystem and update the context accordingly, as a step of a chain
+ * of responsibility.
+ *
+ */
+class OfflineDownloader final : public AbstractHandler<std::shared_ptr<UpdaterContext>>
+{
+private:
+    /**
+     * @brief Pushes the state of the current stage into the data field of the context.
+     *
+     * @param contextData Reference to the context data.
+     * @param status Status to be pushed.
+     */
+    void pushStageStatus(nlohmann::json& contextData, std::string status) const
+    {
+        auto statusObject = nlohmann::json::object();
+        statusObject["stage"] = "OfflineDownloader";
+        statusObject["status"] = std::move(status);
+
+        contextData.at("stageStatus").push_back(std::move(statusObject));
+    }
+
+    /**
+     * @brief Function to calculate the hash of a file.
+     *
+     * @param filepath Path to the file.
+     * @return std::string Digest vector.
+     */
+    std::string hashFile(const std::filesystem::path& filepath) const
+    {
+        if (std::ifstream inputFile(filepath, std::fstream::in); inputFile)
+        {
+            constexpr int BUFFER_SIZE {4096};
+            std::array<char, BUFFER_SIZE> buffer;
+
+            Utils::HashData hash;
+            while (inputFile.read(buffer.data(), buffer.size()))
+            {
+                // LCOV_EXCL_START
+                hash.update(buffer.data(), inputFile.gcount());
+                // LCOV_EXCL_STOP
+            }
+            hash.update(buffer.data(), inputFile.gcount());
+
+            return Utils::asciiToHex(hash.hash());
+        }
+
+        throw std::runtime_error {"Unable to open '" + filepath.string() + "' for hashing."};
+    };
+
+    /**
+     * @brief Downloads the requested local file and update the context accordingly.
+     *
+     * @note Despite the method name, there is no such download since the file is present in the filesystem.
+     *
+     * @param context Updater context.
+     */
+    void download(UpdaterContext& context) const
+    {
+        // Take the 'url' as the input file path.
+        auto url {context.spUpdaterBaseContext->configData.at("url").get_ref<const std::string&>()};
+        constexpr auto filePrefix {"file://"};
+        if (Utils::startsWith(url, filePrefix))
+        {
+            Utils::replaceFirst(url, filePrefix, "");
+        }
+        const std::filesystem::path inputFilePath {url};
+
+        // Check if file is compressed.
+        const auto compressed {
+            "raw" != context.spUpdaterBaseContext->configData.at("compressionType").get_ref<const std::string&>()};
+
+        // Generate output file path. If the input file is compressed, the output file will be in the downloads folder
+        // and if it's not compressed, in the contents folder.
+        auto outputFilePath {compressed ? context.spUpdaterBaseContext->downloadsFolder
+                                        : context.spUpdaterBaseContext->contentsFolder};
+        outputFilePath = outputFilePath / inputFilePath.filename();
+
+        // Process input file hash.
+        auto inputFileHash {hashFile(inputFilePath)};
+
+        // Just process the new file if the hash is different from the last one.
+        if (context.spUpdaterBaseContext->downloadedFileHash != inputFileHash)
+        {
+            // Copy files.
+            std::filesystem::copy(inputFilePath, outputFilePath);
+
+            // Store new hash.
+            context.spUpdaterBaseContext->downloadedFileHash = std::move(inputFileHash);
+
+            // Download finished: Insert path into context.
+            context.data.at("paths").push_back(outputFilePath.string());
+        }
+    }
+
+public:
+    /**
+     * @brief Copies a file from the localsystem in order to be processed and passes the control to the next chain
+     * stage.
+     *
+     * @param context Updater context.
+     * @return std::shared_ptr<UpdaterContext> Next step of the chain.
+     */
+    std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
+    {
+        try
+        {
+            download(*context);
+        }
+        catch (const std::exception& e)
+        {
+            // Push error state.
+            pushStageStatus(context->data, "fail");
+
+            throw std::runtime_error("Download failed: " + std::string(e.what()));
+        }
+
+        // Push success state.
+        pushStageStatus(context->data, "ok");
+
+        std::cout << "OfflineDownloader - Download done successfully" << std::endl;
+
+        return AbstractHandler<std::shared_ptr<UpdaterContext>>::handleRequest(context);
+    }
+};
+
+#endif // _OFFLINE_DOWNLOADER_HPP

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -89,7 +89,7 @@ private:
     void download(UpdaterContext& context) const
     {
         // Take the 'url' as the input file path.
-        auto url {context.spUpdaterBaseContext->configData.at("url").get_ref<const std::string&>()};
+        auto url {context.spUpdaterBaseContext->configData.at("url").get<std::string>()};
         constexpr auto filePrefix {"file://"};
         if (Utils::startsWith(url, filePrefix))
         {
@@ -97,22 +97,22 @@ private:
         }
         const std::filesystem::path inputFilePath {url};
 
-        // Check if file is compressed.
-        const auto compressed {
-            "raw" != context.spUpdaterBaseContext->configData.at("compressionType").get_ref<const std::string&>()};
-
-        // Generate output file path. If the input file is compressed, the output file will be in the downloads folder
-        // and if it's not compressed, in the contents folder.
-        auto outputFilePath {compressed ? context.spUpdaterBaseContext->downloadsFolder
-                                        : context.spUpdaterBaseContext->contentsFolder};
-        outputFilePath = outputFilePath / inputFilePath.filename();
-
         // Process input file hash.
         auto inputFileHash {hashFile(inputFilePath)};
 
         // Just process the new file if the hash is different from the last one.
         if (context.spUpdaterBaseContext->downloadedFileHash != inputFileHash)
         {
+            // Check if file is compressed.
+            const auto compressed {
+                "raw" != context.spUpdaterBaseContext->configData.at("compressionType").get_ref<const std::string&>()};
+
+            // Generate output file path. If the input file is compressed, the output file will be in the downloads
+            // folder and if it's not compressed, in the contents folder.
+            auto outputFilePath {compressed ? context.spUpdaterBaseContext->downloadsFolder
+                                            : context.spUpdaterBaseContext->contentsFolder};
+            outputFilePath = outputFilePath / inputFilePath.filename();
+
             // Copy files.
             std::filesystem::copy(inputFilePath, outputFilePath);
 
@@ -126,7 +126,7 @@ private:
 
 public:
     /**
-     * @brief Copies a file from the localsystem in order to be processed and passes the control to the next chain
+     * @brief Copies a file from the local filesystem in order to be processed and passes the control to the next chain
      * stage.
      *
      * @param context Updater context.

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -62,7 +62,7 @@ private:
         if (std::ifstream inputFile(filepath, std::fstream::in); inputFile)
         {
             constexpr int BUFFER_SIZE {4096};
-            std::array<char, BUFFER_SIZE> buffer;
+            std::array<char, BUFFER_SIZE> buffer {};
 
             Utils::HashData hash;
             while (inputFile.read(buffer.data(), buffer.size()))

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -111,8 +111,8 @@ private:
                                             : context.spUpdaterBaseContext->contentsFolder};
             outputFilePath = outputFilePath / inputFilePath.filename();
 
-            // Copy files.
-            std::filesystem::copy(inputFilePath, outputFilePath);
+            // Copy file, overriding the output one if necessary.
+            std::filesystem::copy(inputFilePath, outputFilePath, std::filesystem::copy_options::overwrite_existing);
 
             // Store new hash.
             context.spUpdaterBaseContext->downloadedFileHash = std::move(inputFileHash);

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -67,9 +67,7 @@ private:
             Utils::HashData hash;
             while (inputFile.read(buffer.data(), buffer.size()))
             {
-                // LCOV_EXCL_START
                 hash.update(buffer.data(), inputFile.gcount());
-                // LCOV_EXCL_STOP
             }
             hash.update(buffer.data(), inputFile.gcount());
 

--- a/src/shared_modules/content_manager/src/components/updaterContext.hpp
+++ b/src/shared_modules/content_manager/src/components/updaterContext.hpp
@@ -16,6 +16,7 @@
 #include "utils/rocksDBWrapper.hpp"
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
+#include <string>
 
 constexpr auto DOWNLOAD_FOLDER = "downloads";
 constexpr auto CONTENTS_FOLDER = "contents";
@@ -67,6 +68,12 @@ struct UpdaterBaseContext
      *
      */
     std::filesystem::path contentsFolder;
+
+    /**
+     * @brief Hash of the downloaded file. Used to avoid redundant publications.
+     *
+     */
+    std::string downloadedFileHash;
 
     /**
      * @brief For testing purposes. Delete it.

--- a/src/shared_modules/content_manager/src/contentModule.cpp
+++ b/src/shared_modules/content_manager/src/contentModule.cpp
@@ -25,6 +25,7 @@ static void logFunction(const modules_log_level_t logLevel, const std::string& m
     }
 }
 
+// \cond
 void ContentModule::start(const std::function<void(const modules_log_level_t, const std::string&)>& logFunction)
 {
     if (!GS_LOG_FUNCTION)
@@ -34,6 +35,7 @@ void ContentModule::start(const std::function<void(const modules_log_level_t, co
 
     ContentModuleFacade::instance().start();
 }
+// \endcond
 
 void ContentModule::stop()
 {

--- a/src/shared_modules/content_manager/src/contentModule.cpp
+++ b/src/shared_modules/content_manager/src/contentModule.cpp
@@ -25,7 +25,6 @@ static void logFunction(const modules_log_level_t logLevel, const std::string& m
     }
 }
 
-// \cond
 void ContentModule::start(const std::function<void(const modules_log_level_t, const std::string&)>& logFunction)
 {
     if (!GS_LOG_FUNCTION)
@@ -35,7 +34,6 @@ void ContentModule::start(const std::function<void(const modules_log_level_t, co
 
     ContentModuleFacade::instance().start();
 }
-// \endcond
 
 void ContentModule::stop()
 {

--- a/src/shared_modules/content_manager/tests/unit/factoryDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/factoryDownloader_test.cpp
@@ -112,6 +112,36 @@ TEST_F(FactoryDownloaderTest, CreateOfflineDownloaderCompressedFile)
     EXPECT_EQ(config, expectedConfig);
 }
 
+/**
+ * @brief Check the creation of a OfflineDownloader for downloading a file with no extension.
+ *
+ */
+TEST_F(FactoryDownloaderTest, CreateOfflineDownloaderNoExtension)
+{
+    auto config = R"(
+        {
+            "contentSource": "offline",
+            "url": "file:///home/user/file_without_extension",
+            "compressionType": "ignored"
+        }
+    )"_json;
+
+    const auto expectedConfig = R"(
+        {
+            "contentSource": "offline",
+            "url": "file:///home/user/file_without_extension",
+            "compressionType": "raw"
+        }
+    )"_json;
+
+    // Create the downloader.
+    std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> spDownloader {};
+
+    EXPECT_NO_THROW(spDownloader = FactoryDownloader::create(config));
+    EXPECT_TRUE(std::dynamic_pointer_cast<OfflineDownloader>(spDownloader));
+    EXPECT_EQ(config, expectedConfig);
+}
+
 /*
  * @brief Check an invalid contentSource type.
  */

--- a/src/shared_modules/content_manager/tests/unit/factoryDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/factoryDownloader_test.cpp
@@ -12,8 +12,12 @@
 #include "factoryDownloader_test.hpp"
 #include "CtiApiDownloader.hpp"
 #include "S3Downloader.hpp"
+#include "chainOfResponsability.hpp"
 #include "factoryDownloader.hpp"
+#include "json.hpp"
+#include "offlineDownloader.hpp"
 #include "updaterContext.hpp"
+#include "gtest/gtest.h"
 #include <memory>
 
 /*
@@ -46,6 +50,66 @@ TEST_F(FactoryDownloaderTest, CreateS3Downloader)
 
     // Check if the downloader is a S3Downloader
     EXPECT_TRUE(std::dynamic_pointer_cast<S3Downloader>(spDownloader));
+}
+
+/**
+ * @brief Check the creation of a OfflineDownloader for downloading a raw file.
+ *
+ */
+TEST_F(FactoryDownloaderTest, CreateOfflineDownloaderRawFile)
+{
+    auto config = R"(
+        {
+            "contentSource": "offline",
+            "url": "file:///home/user/file.txt",
+            "compressionType": "ignored"
+        }
+    )"_json;
+
+    const auto expectedConfig = R"(
+        {
+            "contentSource": "offline",
+            "url": "file:///home/user/file.txt",
+            "compressionType": "raw"
+        }
+    )"_json;
+
+    // Create the downloader.
+    std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> spDownloader {};
+
+    EXPECT_NO_THROW(spDownloader = FactoryDownloader::create(config));
+    EXPECT_TRUE(std::dynamic_pointer_cast<OfflineDownloader>(spDownloader));
+    EXPECT_EQ(config, expectedConfig);
+}
+
+/**
+ * @brief Check the creation of a OfflineDownloader for downloading a compressed file.
+ *
+ */
+TEST_F(FactoryDownloaderTest, CreateOfflineDownloaderCompressedFile)
+{
+    auto config = R"(
+        {
+            "contentSource": "offline",
+            "url": "file:///home/user/file.txt.gz",
+            "compressionType": "ignored"
+        }
+    )"_json;
+
+    const auto expectedConfig = R"(
+        {
+            "contentSource": "offline",
+            "url": "file:///home/user/file.txt.gz",
+            "compressionType": "gzip"
+        }
+    )"_json;
+
+    // Create the downloader.
+    std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> spDownloader {};
+
+    EXPECT_NO_THROW(spDownloader = FactoryDownloader::create(config));
+    EXPECT_TRUE(std::dynamic_pointer_cast<OfflineDownloader>(spDownloader));
+    EXPECT_EQ(config, expectedConfig);
 }
 
 /*

--- a/src/shared_modules/content_manager/tests/unit/factoryDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/factoryDownloader_test.cpp
@@ -53,93 +53,18 @@ TEST_F(FactoryDownloaderTest, CreateS3Downloader)
 }
 
 /**
- * @brief Check the creation of a OfflineDownloader for downloading a raw file.
+ * @brief Check the creation of a OfflineDownloader.
  *
  */
-TEST_F(FactoryDownloaderTest, CreateOfflineDownloaderRawFile)
+TEST_F(FactoryDownloaderTest, CreateOfflineDownloader)
 {
-    auto config = R"(
-        {
-            "contentSource": "offline",
-            "url": "file:///home/user/file.txt",
-            "compressionType": "ignored"
-        }
-    )"_json;
-
-    const auto expectedConfig = R"(
-        {
-            "contentSource": "offline",
-            "url": "file:///home/user/file.txt",
-            "compressionType": "raw"
-        }
-    )"_json;
+    auto config = R"({"contentSource":"offline"})"_json;
 
     // Create the downloader.
     std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> spDownloader {};
-
     EXPECT_NO_THROW(spDownloader = FactoryDownloader::create(config));
+
     EXPECT_TRUE(std::dynamic_pointer_cast<OfflineDownloader>(spDownloader));
-    EXPECT_EQ(config, expectedConfig);
-}
-
-/**
- * @brief Check the creation of a OfflineDownloader for downloading a compressed file.
- *
- */
-TEST_F(FactoryDownloaderTest, CreateOfflineDownloaderCompressedFile)
-{
-    auto config = R"(
-        {
-            "contentSource": "offline",
-            "url": "file:///home/user/file.txt.gz",
-            "compressionType": "ignored"
-        }
-    )"_json;
-
-    const auto expectedConfig = R"(
-        {
-            "contentSource": "offline",
-            "url": "file:///home/user/file.txt.gz",
-            "compressionType": "gzip"
-        }
-    )"_json;
-
-    // Create the downloader.
-    std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> spDownloader {};
-
-    EXPECT_NO_THROW(spDownloader = FactoryDownloader::create(config));
-    EXPECT_TRUE(std::dynamic_pointer_cast<OfflineDownloader>(spDownloader));
-    EXPECT_EQ(config, expectedConfig);
-}
-
-/**
- * @brief Check the creation of a OfflineDownloader for downloading a file with no extension.
- *
- */
-TEST_F(FactoryDownloaderTest, CreateOfflineDownloaderNoExtension)
-{
-    auto config = R"(
-        {
-            "contentSource": "offline",
-            "url": "file:///home/user/file_without_extension",
-            "compressionType": "ignored"
-        }
-    )"_json;
-
-    const auto expectedConfig = R"(
-        {
-            "contentSource": "offline",
-            "url": "file:///home/user/file_without_extension",
-            "compressionType": "raw"
-        }
-    )"_json;
-
-    // Create the downloader.
-    std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> spDownloader {};
-
-    EXPECT_NO_THROW(spDownloader = FactoryDownloader::create(config));
-    EXPECT_TRUE(std::dynamic_pointer_cast<OfflineDownloader>(spDownloader));
-    EXPECT_EQ(config, expectedConfig);
 }
 
 /*

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
@@ -1,0 +1,120 @@
+/*
+ * Wazuh content manager - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * October 24, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "offlineDownloader_test.hpp"
+#include "json.hpp"
+#include "offlineDownloader.hpp"
+#include "gtest/gtest.h"
+#include <filesystem>
+#include <memory>
+
+const auto OK_STATUS = R"({"stage":"OfflineDownloader","status":"ok"})"_json;
+const auto FAIL_STATUS = R"({"stage":"OfflineDownloader","status":"fail"})"_json;
+
+/**
+ * @brief Tests the correct instantiation of the class.
+ *
+ */
+TEST_F(OfflineDownloaderTest, Instantiation)
+{
+    EXPECT_NO_THROW(OfflineDownloader());
+    EXPECT_NO_THROW(std::make_shared<OfflineDownloader>());
+}
+
+/**
+ * @brief Tests the download a raw file. The expected output folder is the contents one.
+ *
+ */
+TEST_F(OfflineDownloaderTest, RawFileDownload)
+{
+    m_spUpdaterBaseContext->configData["url"] = m_inputFilePathRaw.string();
+    m_spUpdaterBaseContext->configData["compressionType"] = "raw";
+
+    nlohmann::json expectedData;
+    expectedData["paths"].push_back(m_spUpdaterBaseContext->contentsFolder.string() + "/" +
+                                    m_inputFilePathRaw.filename().string());
+    expectedData["stageStatus"] = nlohmann::json::array();
+    expectedData["stageStatus"].push_back(OK_STATUS);
+
+    ASSERT_NO_THROW(OfflineDownloader().handleRequest(m_spUpdaterContext));
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+    EXPECT_TRUE(std::filesystem::exists(m_spUpdaterBaseContext->contentsFolder / m_inputFilePathRaw.filename()));
+}
+
+/**
+ * @brief Tests the download a compressed file. The expected output folder is the downloads one.
+ *
+ */
+TEST_F(OfflineDownloaderTest, CompressedFileDownload)
+{
+    m_spUpdaterBaseContext->configData["url"] = m_inputFilePathCompressed.string();
+    m_spUpdaterBaseContext->configData["compressionType"] = "gzip";
+
+    nlohmann::json expectedData;
+    expectedData["paths"].push_back(m_spUpdaterBaseContext->downloadsFolder.string() + "/" +
+                                    m_inputFilePathCompressed.filename().string());
+    expectedData["stageStatus"] = nlohmann::json::array();
+    expectedData["stageStatus"].push_back(OK_STATUS);
+
+    ASSERT_NO_THROW(OfflineDownloader().handleRequest(m_spUpdaterContext));
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+    EXPECT_TRUE(
+        std::filesystem::exists(m_spUpdaterBaseContext->downloadsFolder / m_inputFilePathCompressed.filename()));
+}
+
+/**
+ * @brief Tests the download of an inexistant file. Exception is excepted, as well as a fail stage status.
+ *
+ */
+TEST_F(OfflineDownloaderTest, InexistantFileDownload)
+{
+    m_spUpdaterBaseContext->configData["url"] = "file://" + m_tempPath.string() + "/inexistant.txt";
+    m_spUpdaterBaseContext->configData["compressionType"] = "raw";
+
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = nlohmann::json::array();
+    expectedData["stageStatus"].push_back(FAIL_STATUS);
+
+    ASSERT_THROW(OfflineDownloader().handleRequest(m_spUpdaterContext), std::runtime_error);
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}
+
+/**
+ * @brief Tests two downloads in a row of the same file. The second download should not add the filepath to the data
+ * paths.
+ *
+ */
+TEST_F(OfflineDownloaderTest, SkipFileProcessing)
+{
+    m_spUpdaterBaseContext->configData["url"] = m_inputFilePathRaw.string();
+    m_spUpdaterBaseContext->configData["compressionType"] = "raw";
+
+    nlohmann::json expectedData;
+    expectedData["paths"].push_back(m_spUpdaterBaseContext->contentsFolder.string() + "/" +
+                                    m_inputFilePathRaw.filename().string());
+    expectedData["stageStatus"] = nlohmann::json::array();
+    expectedData["stageStatus"].push_back(OK_STATUS);
+
+    ASSERT_NO_THROW(OfflineDownloader().handleRequest(m_spUpdaterContext));
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+    EXPECT_TRUE(std::filesystem::exists(m_spUpdaterBaseContext->contentsFolder / m_inputFilePathRaw.filename()));
+
+    // Reset context.
+    m_spUpdaterContext.reset(new UpdaterContext());
+    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
+
+    // No paths are expected.
+    expectedData.at("paths").clear();
+
+    ASSERT_NO_THROW(OfflineDownloader().handleRequest(m_spUpdaterContext));
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
@@ -71,7 +71,7 @@ TEST_F(OfflineDownloaderTest, CompressedFileDownload)
 }
 
 /**
- * @brief Tests the download of an inexistant file. Exception is excepted, as well as a fail stage status.
+ * @brief Tests the download of an inexistant file. Exception is expected, as well as a fail stage status.
  *
  */
 TEST_F(OfflineDownloaderTest, InexistantFileDownload)

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
@@ -44,12 +44,16 @@ protected:
      */
     static void SetUpTestSuite()
     {
+        // Create raw input file.
         std::ofstream testFileStream {m_inputFilePathRaw};
         testFileStream << "I'm a test file with a .txt extension." << std::endl;
         testFileStream.close();
 
+        // Create "compressed" input file with a greater size.
         testFileStream.open(m_inputFilePathCompressed);
-        testFileStream << "I'm a test file with a .gz extension." << std::endl;
+        testFileStream.fill(' ');
+        testFileStream.width(10000);
+        testFileStream << "I'm a larger test file with a .gz extension." << std::endl;
         testFileStream.close();
     }
 

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
@@ -29,20 +29,19 @@ protected:
     OfflineDownloaderTest() = default;
     ~OfflineDownloaderTest() override = default;
 
-    inline static const auto m_tempPath {std::filesystem::temp_directory_path()};          ///< Temporary path.
-    inline static const auto m_inputFilePathRaw {"file://" / m_tempPath / "testFile.txt"}; ///< Raw input test path.
-    inline static const auto m_inputFilePathCompressed {"file://" / m_tempPath /
-                                                        "testFile.txt.gz"}; ///< Compressed input test path.
-
+    const std::filesystem::path m_tempPath {std::filesystem::temp_directory_path()};          ///< Temporary path.
+    const std::filesystem::path m_inputFilePathRaw {"file://" / m_tempPath / "testFile.txt"}; ///< Raw input test path.
+    const std::filesystem::path m_inputFilePathCompressed {"file://" / m_tempPath /
+                                                           "testFile.txt.gz"}; ///< Compressed input test path.
+    const std::filesystem::path m_outputFolder {m_tempPath / "offline-downloader-tests"}; ///< Output test folder.
     std::shared_ptr<UpdaterContext> m_spUpdaterContext;         ///< UpdaterContext used on tests.
     std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on tests.
-    const std::filesystem::path m_outputFolder {m_tempPath / "offline-downloader-tests"}; ///< Output test folder.
 
     /**
-     * @brief Set up routine for the test suite.
+     * @brief Set up routine for each test fixture.
      *
      */
-    static void SetUpTestSuite()
+    void SetUp() override
     {
         // Create raw input file.
         std::ofstream testFileStream {m_inputFilePathRaw};
@@ -55,24 +54,7 @@ protected:
         testFileStream.width(10000);
         testFileStream << "I'm a larger test file with a .gz extension." << std::endl;
         testFileStream.close();
-    }
 
-    /**
-     * @brief Tear down routine for the test suite.
-     *
-     */
-    static void TearDownTestSuite()
-    {
-        std::filesystem::remove(m_inputFilePathRaw);
-        std::filesystem::remove(m_inputFilePathCompressed);
-    }
-
-    /**
-     * @brief Set up routine for each test fixture.
-     *
-     */
-    void SetUp() override
-    {
         // Updater base context.
         m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
         m_spUpdaterBaseContext->outputFolder = m_outputFolder;
@@ -93,6 +75,8 @@ protected:
      */
     void TearDown() override
     {
+        std::filesystem::remove(m_inputFilePathRaw);
+        std::filesystem::remove(m_inputFilePathCompressed);
         std::filesystem::remove_all(m_outputFolder);
     }
 };

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
@@ -1,0 +1,96 @@
+/*
+ * Wazuh content manager - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * October 24, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _OFFLINE_DOWNLOADER_TEST
+#define _OFFLINE_DOWNLOADER_TEST
+
+#include "offlineDownloader.hpp"
+#include "updaterContext.hpp"
+#include "gtest/gtest.h"
+#include <filesystem>
+#include <fstream>
+#include <memory>
+
+/**
+ * @brief Runs unit tests for OfflineDownloader
+ *
+ */
+class OfflineDownloaderTest : public ::testing::Test
+{
+protected:
+    OfflineDownloaderTest() = default;
+    ~OfflineDownloaderTest() override = default;
+
+    inline static const auto m_tempPath {std::filesystem::temp_directory_path()};          ///< Temporary path.
+    inline static const auto m_inputFilePathRaw {"file://" / m_tempPath / "testFile.txt"}; ///< Raw input test path.
+    inline static const auto m_inputFilePathCompressed {"file://" / m_tempPath /
+                                                        "testFile.txt.gz"}; ///< Compressed input test path.
+
+    std::shared_ptr<UpdaterContext> m_spUpdaterContext;         ///< UpdaterContext used on tests.
+    std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on tests.
+    const std::filesystem::path m_outputFolder {m_tempPath / "offline-downloader-tests"}; ///< Output test folder.
+
+    /**
+     * @brief Set up routine for the test suite.
+     *
+     */
+    static void SetUpTestSuite()
+    {
+        std::ofstream testFileStream {m_inputFilePathRaw};
+        testFileStream << "I'm a test file with a .txt extension." << std::endl;
+        testFileStream.close();
+
+        testFileStream.open(m_inputFilePathCompressed);
+        testFileStream << "I'm a test file with a .gz extension." << std::endl;
+        testFileStream.close();
+    }
+
+    /**
+     * @brief Tear down routine for the test suite.
+     *
+     */
+    static void TearDownTestSuite()
+    {
+        std::filesystem::remove(m_inputFilePathRaw);
+        std::filesystem::remove(m_inputFilePathCompressed);
+    }
+
+    /**
+     * @brief Set up routine for each test fixture.
+     *
+     */
+    void SetUp() override
+    {
+        // Updater base context.
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spUpdaterBaseContext->outputFolder = m_outputFolder;
+        m_spUpdaterBaseContext->downloadsFolder = m_outputFolder / DOWNLOAD_FOLDER;
+        m_spUpdaterBaseContext->contentsFolder = m_outputFolder / CONTENTS_FOLDER;
+
+        m_spUpdaterContext = std::make_shared<UpdaterContext>();
+        m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
+
+        std::filesystem::create_directory(m_spUpdaterBaseContext->outputFolder);
+        std::filesystem::create_directory(m_spUpdaterBaseContext->downloadsFolder);
+        std::filesystem::create_directory(m_spUpdaterBaseContext->contentsFolder);
+    }
+
+    /**
+     * @brief Tear down routine for each test fixture.
+     *
+     */
+    void TearDown() override
+    {
+        std::filesystem::remove_all(m_outputFolder);
+    }
+};
+
+#endif //_OFFLINE_DOWNLOADER_TEST

--- a/src/shared_modules/utils/hashHelper.h
+++ b/src/shared_modules/utils/hashHelper.h
@@ -12,8 +12,9 @@
 #ifndef _HASH_HELPER_H
 #define _HASH_HELPER_H
 
-#include <vector>
 #include <memory>
+#include <vector>
+#include <stdexcept>
 #include "openssl/evp.h"
 
 namespace Utils


### PR DESCRIPTION
|Related issue|
|---|
|#19525 |

## Description

This PR implements the `OfflineDownloader` class, in charge of copying an input local file to be processed by the Content Manager.

Change log:
- `OfflineDownloader` class implemented.
- `OfflineDownloader` UTs added.
- `FactoryDownloader` modified to allow this new downloader. 
- `FactoryDownloader` UTs added.
- Add a new member in the updater context to hold a hash.
- Add header on `hashHelper` to prevent a compilation error.
- Remove config constness in the `FactoryContentUploader` class.
- Documentation added.
- `FactoryDecompressor`  modified to deduce automatically the correct decompressor when the offline downloader is chosen.

## Results

### Test tool

#### Execution with a compressed file as input

Config (just important fields):
```json
{
    "contentSource": "offline",
    "compressionType": "ignored",
    "deleteDownloadedContent": false,
    "url": "file:///home/test_file.txt.gz",
    "outputFolder": "/tmp/testProvider"
}
```
![image](https://github.com/wazuh/wazuh/assets/42682247/e10be7aa-5c8e-4b38-9026-7885c8014321)
**1**: Offline decompressor instanziated. Gzip decompressor chosen.
**2**: Path published.
**3 and 4**: No data to publish since the file didn't change.
**5**: Output structure


#### Execution with a raw file as input

Config (just important fields):
```json
{
    "contentSource": "offline",
    "compressionType": "ignored",
    "deleteDownloadedContent": false,
    "url": "file:///home/test_file.txt",
    "outputFolder": "/tmp/testProvider"
}
```

![image](https://github.com/wazuh/wazuh/assets/42682247/59890322-e235-4608-9e28-4f7e7c510c15)
**1**: Offline decompressor instanziated. No decompressor was chosen.
**2**: Path published.
**3 and 4**: No data to publish since the file didn't change.
**5**: Output structure

### Coverage

100% of coverage.
![image](https://github.com/wazuh/wazuh/assets/42682247/e44cba39-1425-43f0-b121-b2ffa692cba5)

