### PR TITLE
Fix deleted validation block for update_check configuration

### DIFF
--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -374,6 +374,21 @@ int Read_Global(const OS_XML *xml, XML_NODE node, void *configp, void *mailp)
                 return (OS_INVALID);
             }
         }
+        /* update check system */
+        else if (strcmp(node[i]->element, xml_update_check) == 0) {
+            if (strcmp(node[i]->content, "yes") == 0) {
+                if (Config) {
+                    Config->update_check = 1;
+                }
+            } else if (strcmp(node[i]->content, "no") == 0) {
+                if (Config) {
+                    Config->update_check = 0;
+                }
+            } else {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
+        }
         /* Compress alerts */
         else if (strcmp(node[i]->element, xml_compress_alerts) == 0) {
             /* removed from here -- compatibility issues only */


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19256|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

Fixes [`ossec.conf` error](https://github.com/wazuh/wazuh/issues/19257#issuecomment-1779243311) introduced in #19616.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

```command
Starting Wazuh v4.8.0...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
Started wazuh-modulesd...
Started wazuh-clusterd...
Completed.

```

```xml 
  <global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>no</logall>
    <logall_json>no</logall_json>
    <email_notification>no</email_notification>
    <smtp_server>smtp.example.wazuh.com</smtp_server>
    <email_from>wazuh@example.wazuh.com</email_from>
    <email_to>recipient@example.wazuh.com</email_to>
    <email_maxperhour>12</email_maxperhour>
    <email_log_source>alerts.log</email_log_source>
    <agents_disconnection_time>10m</agents_disconnection_time>
    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
    <update_check>yes</update_check>
  </global>

```