### PR TITLE
Windows eventchannel XML parsing fix

### DIFF
--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -131,7 +131,7 @@ int DecodeWinevt(Eventinfo *lf){
         goto cleanup;
     }
 
-    event = cJSON_PrintUnformatted(json_received_event);
+    w_strdup(json_received_event->valuestring, event);
 
     if(event){
         if (OS_ReadXMLString(event, &xml) < 0){

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -399,7 +399,7 @@ static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_
                 retval = 0;
                 goto end;
             }
-        } else if ((location == 1) && (c == _R_CONFS) && (prevv == 1)) {
+        } else if ((location == 1) && (c == _R_CONFS)) {
             if ((c = xml_getc_fun(_lxml->fp, _lxml)) == '/') {
                 cont[count] = '\0';
                 count = 0;

--- a/src/unit_tests/os_xml/test_os_xml.c
+++ b/src/unit_tests/os_xml/test_os_xml.c
@@ -406,9 +406,10 @@ void test_comments4(void **state) {
 void test_special_chars(void **state) {
 
     test_struct_t *data  = (test_struct_t *)*state;
-    char *parse_str =   "<var name=\"var1\">value1</var>"
-                        "<root1>\\</root1\\></root1>";
-    char *xml_str = "<root1>\\</root1\\></root1>";
+    char *parse_str =   "<var name=\"var1\">value1</var>";
+    char *xml_str = "<var name=\"var1\">value1</var>";
+    // TODO: this case is not compliant on any xml standard:
+    //              "<root1>\</root1\></root1>"
 
     assert_os_xml_eq(data, parse_str, xml_str);
 }

--- a/src/unit_tests/wazuh_modules/gcp/test_wmodules_gcp.c
+++ b/src/unit_tests/wazuh_modules/gcp/test_wmodules_gcp.c
@@ -1376,6 +1376,62 @@ static void test_wm_gcp_bucket_read_invalid_nodes(void **state) {
     assert_int_equal(ret, -1);
 }
 
+static void test_complete_xml(void **state) {
+    OS_XML *xml = NULL;
+    if(os_calloc(1, sizeof(OS_XML), xml), xml == NULL)
+        return;
+    char *base_config = R"(<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/><EventID>1</EventID><Version>5</Version><Level>4</Level><Task>1</Task><Opcode>0</Opcode><Keywords>0x800000/0000000000</Keywords><TimeCreated SystemTime='2023-10-26T18:23:55.367105700Z'/><EventRecordID>89875</EventRecordID><Execution ProcessID='2748' ThreadID='3832'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>EC2AMAZ-UTVJU8R</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>technique_id=T1202,technique_name=Indirect Command Execution</Data><Data Name='UtcTime'>2023-10-26 18:23:55.361</Data><Data Name='ProcessGuid'>{a24b1ed4-aebb-653a-e439-000000001202}</Data><Data Name='ProcessId'>6076</Data><Data Name='Image'>C:\Windows\SysWOW64\wscript.exe</Data><Data Name='FileVersion'>5.812.10240.16384</Data><Data Name='Description'>Microsoft ® Windows Based Script Host</Data><Data Name='Product'>Microsoft ® Windows Script Host</Data><Data Name='Company'>Microsoft Corporation</Data><Data Name='OriginalFileName'>wscript.exe</Data><Data Name='CommandLine'>C:\Windows\SysWOW64\wscript.exe "C:\Users\Administrator\0.5840876.jse" </Data><Data Name='CurrentDirectory'>C:\Windows\system32</Data><Data Name='User'>EC2AMAZ-UTVJU8R\Administrator</Data><Data Name='LogonGuid'>{a24b1ed4-8370-6534-891a-0f0000000000}</Data><Data Name='LogonId'>0xf1a89</Data><Data Name='TerminalSessionId'>2</Data><Data Name='IntegrityLevel'>High</Data><Data Name='Hashes'>SHA1=5D7F2AFD2FF69D379B69DD94033B51EC537E8E52,MD5=F2748908C6B873CB1970DF4C07223E72,SHA256=0FBB4F848D9FB14D7BF81B0454203810869C527C3435E8747A2213DD86F8129A,IMPHASH=3602F3C025378F418F804C5D183603FE</Data><Data Name='ParentProcessGuid'>{a24b1ed4-aeb5-653a-e039-000000001202}</Data><Data Name='ParentProcessId'>5576</Data><Data Name='ParentImage'>C:\Program Files (x86)\Microsoft Office\root\Office16\WINWORD.EXE</Data><Data Name='ParentCommandLine'>"C:\Program Files (x86)\Microsoft Office\Root\Office16\WINWORD.EXE" /Automation -Embedding</Data></EventData></Event>)";
+    int result = OS_ReadXMLString(base_config, xml);
+    assert_int_equal(result,0);
+    OS_ClearXML(xml);
+    free(xml);
+}
+
+static void eventchannel_xml_test_1(void **state) {
+    OS_XML *xml = NULL;
+
+    if(os_calloc(1, sizeof(OS_XML), xml), xml == NULL)
+        return;
+
+    char *base_config = R"(<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/><EventID>1</EventID><Version>5</Version><Level>4</Level><Task>1</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2023-10-26T18:19:29.000498200Z'/><EventRecordID>89781</EventRecordID><Correlation/><Execution ProcessID='2748' ThreadID='3832'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>EC2AMAZ-UTVJU8R</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>technique_id=T1047,technique_name=Windows Management Instrumentation</Data><Data Name='UtcTime'>2023-10-26 18:19:28.736</Data><Data Name='ProcessGuid'>{a24b1ed4-adb0-653a-c339-000000001202}</Data><Data Name='ProcessId'>5576</Data><Data Name='Image'>C:\Windows\System32\wbem\WmiPrvSE.exe</Data><Data Name='FileVersion'>10.0.17763.1 (WinBuild.160101.0800)</Data><Data Name='Description'>WMI Provider Host</Data><Data Name='Product'>Microsoft® Windows® Operating System</Data><Data Name='Company'>Microsoft Corporation</Data><Data Name='OriginalFileName'>Wmiprvse.exe</Data><Data Name='CommandLine'>C:\Windows\system32\wbem\wmiprvse.exe -secured -Embedding</Data><Data Name='CurrentDirectory'>C:\Windows\system32\</Data><Data Name='User'>NT AUTHORITY\NETWORK SERVICE</Data><Data Name='LogonGuid'>{a24b1ed4-8152-6534-e403-000000000000}</Data><Data Name='LogonId'>0x3e4</Data><Data Name='TerminalSessionId'>0</Data><Data Name='IntegrityLevel'>System</Data><Data Name='Hashes'>SHA1=67C25C8F28B5FA7F5BAA85BF1D2726AED48E9CF0,MD5=06C66FF5CCDC2D22344A3EB761A4D38A,SHA256=B5C78BEF3883E3099F7EF844DA1446DB29107E5C0223B97F29E7FAFAB5527F15,IMPHASH=CFECEDC01015A4FD1BAACAC9E592D88B</Data><Data Name='ParentProcessGuid'>{a24b1ed4-8151-6534-1000-000000001202}</Data><Data Name='ParentProcessId'>768</Data><Data Name='ParentImage'>C:\Windows\System32\svchost.exe</Data><Data Name='ParentCommandLine'>C:\Windows\system32\svchost.exe -k DcomLaunch -p</Data></EventData></Event>)";
+    int result = OS_ReadXMLString(base_config, xml);
+
+    assert_int_equal(result,0);
+
+    OS_ClearXML(xml);
+    free(xml);
+}
+
+static void eventchannel_xml_test_2(void **state) {
+    OS_XML *xml = NULL;
+
+    if(os_calloc(1, sizeof(OS_XML), xml), xml == NULL)
+        return;
+
+    char *base_config = R"(<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/><EventID>1</EventID><Version>5</Version><Level>4</Level><Task>1</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2023-10-26T18:19:29.796990900Z'/><EventRecordID>89783</EventRecordID><Correlation/><Execution ProcessID='2748' ThreadID='3832'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>EC2AMAZ-UTVJU8R</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>technique_id=T1137,technique_name=Office Application Startup</Data><Data Name='UtcTime'>2023-10-26 18:19:29.763</Data><Data Name='ProcessGuid'>{a24b1ed4-adb1-653a-c439-000000001202}</Data><Data Name='ProcessId'>312</Data><Data Name='Image'>C:\Program Files (x86)\Microsoft Office\root\vfs\ProgramFilesCommonX64\Microsoft Shared\OFFICE16\ai.exe</Data><Data Name='FileVersion'>0.14.8.0</Data><Data Name='Description'>Artificial Intelligence (AI) Host for the Microsoft® Windows® Operating System and Platform x64.</Data><Data Name='Product'>Artificial Intelligence</Data><Data Name='Company'>Microsoft Corporation</Data><Data Name='OriginalFileName'>ai</Data><Data Name='CommandLine'>"C:\Program Files (x86)\Microsoft Office\root\vfs\ProgramFilesCommonX64\Microsoft Shared\OFFICE16\ai.exe" "E71110FE-1DCB-4E68-A0FB-CB385CCB6185" "31DAB46F-6B7D-4239-949D-B0B248034B07" "6152" "C:\Program Files (x86)\Microsoft Office\Root\Office16\WINWORD.EXE" "WordCombinedFloatieLreOnline.onnx"</Data><Data Name='CurrentDirectory'>C:\Windows\system32\</Data><Data Name='User'>EC2AMAZ-UTVJU8R\Administrator</Data><Data Name='LogonGuid'>{a24b1ed4-8370-6534-891a-0f0000000000}</Data><Data Name='LogonId'>0xf1a89</Data><Data Name='TerminalSessionId'>2</Data><Data Name='IntegrityLevel'>High</Data><Data Name='Hashes'>SHA1=74E7673192C49EFFA41E27E1E4C0427112535C0A,MD5=E960B85D2D59AA7D6035C054BD944467,SHA256=330D1E3814F490B447A9752993E1ECAB068C138B33DC24201D869AB16B178D0C,IMPHASH=A61E9571F0D455433D4933F861F95E08</Data><Data Name='ParentProcessGuid'>{a24b1ed4-adad-653a-c139-000000001202}</Data><Data Name='ParentProcessId'>6152</Data><Data Name='ParentImage'>C:\Program Files (x86)\Microsoft Office\root\Office16\WINWORD.EXE</Data><Data Name='ParentCommandLine'>"C:\Program Files (x86)\Microsoft Office\Root\Office16\WINWORD.EXE" /Automation -Embedding</Data></EventData></Event>)";
+    int result = OS_ReadXMLString(base_config, xml);
+
+    assert_int_equal(result,0);
+
+    OS_ClearXML(xml);
+    free(xml);
+}
+
+static void eventchannel_xml_test_3(void **state) {
+    OS_XML *xml = NULL;
+
+    if(os_calloc(1, sizeof(OS_XML), xml), xml == NULL)
+        return;
+
+    char *base_config = R"(<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/><EventID>1</EventID><Version>5</Version><Level>4</Level><Task>1</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2023-10-26T18:19:32.839789600Z'/><EventRecordID>89787</EventRecordID><Correlation/><Execution ProcessID='2748' ThreadID='3832'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>EC2AMAZ-UTVJU8R</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>technique_id=T1202,technique_name=Indirect Command Execution</Data><Data Name='UtcTime'>2023-10-26 18:19:32.824</Data><Data Name='ProcessGuid'>{a24b1ed4-adb4-653a-c639-000000001202}</Data><Data Name='ProcessId'>3148</Data><Data Name='Image'>C:\Windows\SysWOW64\wscript.exe</Data><Data Name='FileVersion'>5.812.10240.16384</Data><Data Name='Description'>Microsoft ® Windows Based Script Host</Data><Data Name='Product'>Microsoft ® Windows Script Host</Data><Data Name='Company'>Microsoft Corporation</Data><Data Name='OriginalFileName'>wscript.exe</Data><Data Name='CommandLine'>C:\Windows\SysWOW64\wscript.exe "C:\Users\Administrator\0.603924.jse" </Data><Data Name='CurrentDirectory'>C:\Windows\system32\</Data><Data Name='User'>EC2AMAZ-UTVJU8R\Administrator</Data><Data Name='LogonGuid'>{a24b1ed4-8370-6534-891a-0f0000000000}</Data><Data Name='LogonId'>0xf1a89</Data><Data Name='TerminalSessionId'>2</Data><Data Name='IntegrityLevel'>High</Data><Data Name='Hashes'>SHA1=5D7F2AFD2FF69D379B69DD94033B51EC537E8E52,MD5=F2748908C6B873CB1970DF4C07223E72,SHA256=0FBB4F848D9FB14D7BF81B0454203810869C527C3435E8747A2213DD86F8129A,IMPHASH=3602F3C025378F418F804C5D183603FE</Data><Data Name='ParentProcessGuid'>{a24b1ed4-adad-653a-c139-000000001202}</Data><Data Name='ParentProcessId'>6152</Data><Data Name='ParentImage'>C:\Program Files (x86)\Microsoft Office\root\Office16\WINWORD.EXE</Data><Data Name='ParentCommandLine'>"C:\Program Files (x86)\Microsoft Office\Root\Office16\WINWORD.EXE" /Automation -Embedding</Data></EventData></Event>)";
+    int result = OS_ReadXMLString(base_config, xml);
+
+    assert_int_equal(result,0);
+
+    OS_ClearXML(xml);
+    free(xml);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_full_configuration, setup_test_pubsub, teardown_test_pubsub),
@@ -1423,6 +1479,12 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_invalid_tag, setup_test_bucket, teardown_test_bucket),
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_invalid_element, setup_test_bucket, teardown_test_bucket),
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_invalid_nodes, setup_test_bucket, teardown_test_bucket),
+
+        cmocka_unit_test_setup_teardown(test_complete_xml, NULL, NULL),
+        cmocka_unit_test_setup_teardown(eventchannel_xml_test_1, NULL, NULL),
+        cmocka_unit_test_setup_teardown(eventchannel_xml_test_2, NULL, NULL),
+        cmocka_unit_test_setup_teardown(eventchannel_xml_test_3, NULL, NULL),
+
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }


### PR DESCRIPTION
|Related issue|Manual testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/19742| |


## Description

The goal of this PR is to fix the XML parser used for eventchannel events.

As the parser was more restrictive, it was coming out by mistake when validating xml strings containing quotes. This caused a loss on windows event fields, especially the ones related to provider name that caused a mismatch on decoders and no alerts being triggered.

This is an example of a **full_log** being received in the manager, where there's only present a message field from the original event:
``` json
{
    "win":
    {
        "system":
        {
            "message": "Microsoft Defender Antivirus Real-time Protection scanning for malware and other potentially unwanted software was disabled."
        }
    }
}
```
When a correct case should be:

``` json
{
    "win":
    {
        "system":
        {
            "providerName": "Microsoft-Windows-WindowsUpdateClient",
            "providerGuid": "{945a8954-c147-4acd-923f-40c45405a658}",
            "eventID": "44",
            "version": "1",
            "level": "4",
            "task": "1",
            "opcode": "12",
            "keywords": "0x8000000000002004",
            "systemTime": "2023-10-24T10:33:58.8682712Z",
            "eventRecordID": "107068",
            "processID": "13984",
            "threadID": "5908",
            "channel": "System",
            "computer": "DESKTOP-U8OHD3A",
            "severityValue": "INFORMATION",
            "message": "Windows Update comenzó a descargar una actualización."
        },
        "eventdata":
        {
            "updateTitle": "Actualización de inteligencia de seguridad para Microsoft Defender Antivirus - KB2267602 (Versión 1.399.1226.0)",
            "updateGuid": "{1962a43c-acd5-433b-9c4e-106e51e2034c}",
            "updateRevisionNumber": "200"
        }
    }
}
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Valgrind
