### PR TITLE
multiarch field default value changed to NULL

### DIFF
--- a/src/data_provider/src/packages/appxWindowsWrapper.h
+++ b/src/data_provider/src/packages/appxWindowsWrapper.h
@@ -112,7 +112,7 @@ class AppxWindowsWrapper final : public IPackageWrapper
 
         std::string multiarch() const override
         {
-            return UNKNOWN_VALUE;
+            return std::string();
         }
 
     private:

--- a/src/data_provider/src/packages/brewWrapper.h
+++ b/src/data_provider/src/packages/brewWrapper.h
@@ -33,7 +33,6 @@ class BrewWrapper final : public IPackageWrapper
             , m_size{0}
             , m_vendor{UNKNOWN_VALUE}
             , m_installTime{UNKNOWN_VALUE}
-            , m_multiarch{UNKNOWN_VALUE}
         {
             const auto rows { Utils::split(Utils::getFileContent(ctx.filePath + "/" + ctx.package + "/" + ctx.version + "/.brew/" + ctx.package + ".rb"), '\n')};
 

--- a/src/data_provider/src/packages/macportsWrapper.h
+++ b/src/data_provider/src/packages/macportsWrapper.h
@@ -39,7 +39,6 @@ class MacportsWrapper final : public IPackageWrapper
             , m_osPatch {UNKNOWN_VALUE}
             , m_source{UNKNOWN_VALUE}
             , m_location{UNKNOWN_VALUE}
-            , m_multiarch{UNKNOWN_VALUE}
             , m_priority{UNKNOWN_VALUE}
             , m_size{0}
             , m_vendor{UNKNOWN_VALUE}

--- a/src/data_provider/src/packages/packageLinuxApkParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxApkParserHelper.h
@@ -42,8 +42,8 @@ namespace PackageLinuxHelper
         packageInfo["location"] = UNKNOWN_VALUE;
         packageInfo["groups"] = UNKNOWN_VALUE;
         packageInfo["priority"] = UNKNOWN_VALUE;
-        packageInfo["multiarch"] = UNKNOWN_VALUE;
         packageInfo["source"] = UNKNOWN_VALUE;
+        // The multiarch field won't have a default value
 
         // Lambda to check if a string is empty and assign default value.
         const auto loadData = [&packageInfo](const std::pair<std::type_index, std::string>& key,

--- a/src/data_provider/src/packages/packagesNPM.hpp
+++ b/src/data_provider/src/packages/packagesNPM.hpp
@@ -57,7 +57,7 @@ class NPM final
                     packageInfo["size"] = 0;
                     packageInfo["vendor"] = UNKNOWN_VALUE;
                     packageInfo["install_time"] = UNKNOWN_VALUE;
-                    packageInfo["multiarch"] = UNKNOWN_VALUE;
+                    // The multiarch field won't have a default value
 
                     // Iterate over fields
                     for (const auto& [key, value] : NPM_FIELDS)

--- a/src/data_provider/src/packages/packagesPYPI.hpp
+++ b/src/data_provider/src/packages/packagesPYPI.hpp
@@ -48,7 +48,7 @@ class PYPI final : public TFileSystem, public TFileIO
             packageInfo["size"] = 0;
             packageInfo["vendor"] = UNKNOWN_VALUE;
             packageInfo["install_time"] = UNKNOWN_VALUE;
-            packageInfo["multiarch"] = UNKNOWN_VALUE;
+            // The multiarch field won't have a default value
 
             TFileIO::readLineByLine(path,
                                     [&packageInfo](const std::string & line) -> bool

--- a/src/data_provider/src/packages/solarisWrapper.h
+++ b/src/data_provider/src/packages/solarisWrapper.h
@@ -207,7 +207,7 @@ class SolarisWrapper final : public IPackageWrapper
 
         std::string multiarch() const override
         {
-            return UNKNOWN_VALUE;
+            return std::string();
         }
 
     private:


### PR DESCRIPTION
|Related issue|
|---|
|#19722|

## Description

This PR fixed the problem in API endpoint syscollector/packages when the packages multiarch db column was a space character (' ').
Now the default value for multiarch db column is NULL.

## Logs
Successful tests were done on Ubuntu manager (agent 000):
![image](https://github.com/wazuh/wazuh/assets/101227434/5985be22-f2ce-4992-ab79-55a24145fce7)

Successful tests were done on Windows 10 agent (agent 007):
![image](https://github.com/wazuh/wazuh/assets/101227434/b589fcbe-47e0-4fab-95eb-7443ebe3ed68)

Successful tests were done on MacOs Monterey agent (agent 008):
![image](https://github.com/wazuh/wazuh/assets/101227434/fa558b40-81eb-4a88-9348-623acf92a149)

## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- Test packages report in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X