### PR TITLE
Fix cluster logging bug when debug mode is activated

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -9,6 +9,7 @@ import os.path
 import shutil
 import zlib
 from asyncio import wait_for
+from collections import defaultdict
 from functools import partial
 from operator import eq
 from os import listdir, path, remove, stat, walk
@@ -144,11 +145,13 @@ def walk_dir(dirname, recursive, files, excluded_files, excluded_extensions, get
     -------
     walk_files : dict
         Paths (keys) and metadata (values) of the requested files found inside 'dirname'.
+    result_logs: dict
+        Dict containing debug or any error messages emitted in the process.
     """
     if previous_status is None:
         previous_status = {}
     walk_files = {}
-
+    result_logs = {'debug': defaultdict(list), 'error': defaultdict(list)}
     full_dirname = path.join(common.WAZUH_PATH, dirname)
     # Get list of all files and directories inside 'full_dirname'.
     try:
@@ -186,14 +189,14 @@ def walk_dir(dirname, recursive, files, excluded_files, excluded_extensions, get
                             # Use the relative file path as a key to save its metadata dictionary.
                             walk_files[relative_file_path] = file_metadata
                     except FileNotFoundError as e:
-                        logger.debug(f"File {file_} was deleted in previous iteration: {e}")
+                        result_logs['debug'][root_].append(f"File {file_} was deleted in previous iteration: {e}")
                     except PermissionError as e:
-                        logger.error(f"Can't read metadata from file {file_}: {e}")
+                        result_logs['error'][root_].append(f"Can't read metadata from file {file_}: {e}")
             else:
                 break
     except OSError as e:
         raise WazuhInternalError(3015, e)
-    return walk_files
+    return walk_files, result_logs
 
 
 def get_files_status(previous_status=None, get_hash=True):
@@ -210,6 +213,8 @@ def get_files_status(previous_status=None, get_hash=True):
     -------
     final_items : dict
         Paths (keys) and metadata (values) of all the files requested in cluster.json['files'].
+    result_logs: dict
+        Dict containing debug or any error messages emitted in the process.
     """
     if previous_status is None:
         previous_status = {}
@@ -217,17 +222,24 @@ def get_files_status(previous_status=None, get_hash=True):
     cluster_items = get_cluster_items()
 
     final_items = {}
+    result_logs = {'debug': defaultdict(dict), 'warning': defaultdict(list), 'error': defaultdict(dict)}
     for file_path, item in cluster_items['files'].items():
         if file_path == "excluded_files" or file_path == "excluded_extensions":
             continue
         try:
-            final_items.update(
-                walk_dir(file_path, item['recursive'], item['files'], cluster_items['files']['excluded_files'],
-                         cluster_items['files']['excluded_extensions'], file_path, previous_status, get_hash))
+            items, logs = walk_dir(file_path, item['recursive'], item['files'],
+                                   cluster_items['files']['excluded_files'],
+                                   cluster_items['files']['excluded_extensions'],
+                                   file_path, previous_status, get_hash)
+            if 'debug' in logs and logs['debug']:
+                result_logs['debug'][file_path].update(dict(logs['debug']))
+            if 'error' in logs and logs['error']:
+                result_logs['error'][file_path].update(dict(logs['error']))
+            final_items.update(items)
         except Exception as e:
-            logger.warning(f"Error getting file status: {e}.")
+            result_logs['warning'][file_path].append(f"Error getting file status: {e}.")
 
-    return final_items
+    return final_items, result_logs
 
 
 def get_ruleset_status(previous_status):
@@ -253,9 +265,9 @@ def get_ruleset_status(previous_status):
         if file_path == "excluded_files" or file_path == "excluded_extensions" or file_path not in user_ruleset:
             continue
         try:
-            final_items.update(
-                walk_dir(file_path, item['recursive'], item['files'], cluster_items['files']['excluded_files'],
-                         cluster_items['files']['excluded_extensions'], file_path, previous_status, True))
+            items, _ = walk_dir(file_path, item['recursive'], item['files'], cluster_items['files']['excluded_files'],
+                                cluster_items['files']['excluded_extensions'], file_path, previous_status, True)
+            final_items.update(items)
         except Exception as e:
             logger.warning(f"Error getting file status: {e}.")
 
@@ -315,9 +327,12 @@ def compress_files(name, list_path, cluster_control_json=None, max_zip_size=None
     -------
     compress_file_path : str
         Path where the compress file has been saved.
+    result_logs: dict
+        Dict containing warning and debug messages emitted in the process.
     """
     zip_size = 0
     exceeded_size = False
+    result_logs = {'warning': defaultdict(list), 'debug': defaultdict(list)}
     compress_level = get_cluster_items()['intervals']['communication']['compress_level']
     if max_zip_size is None:
         max_zip_size = get_cluster_items()['intervals']['communication']['max_zip_size']
@@ -337,7 +352,8 @@ def compress_files(name, list_path, cluster_control_json=None, max_zip_size=None
                 with open(path.join(common.WAZUH_PATH, file), 'rb') as rf:
                     new_file = rf.read()
                     if len(new_file) > max_zip_size:
-                        logger.warning(f'File too large to be synced: {path.join(common.WAZUH_PATH, file)}')
+                        result_logs['warning'][file].append(f'File too large to be synced: '
+                                                            f'{path.join(common.WAZUH_PATH, file)}')
                         update_cluster_control(file, cluster_control_json)
                         continue
                     # Compress the content of each file and surrounds it with separators.
@@ -350,13 +366,14 @@ def compress_files(name, list_path, cluster_control_json=None, max_zip_size=None
                     wf.write(new_file)
                 else:
                     # Otherwise, remove it from cluster_control_json.
-                    logger.warning('Maximum zip size exceeded. Not all files will be compressed during this sync.')
+                    result_logs['warning'][file].append(f'Maximum zip size exceeded for compressed file. '
+                                                        'Not all files will be compressed during this sync.')
                     exceeded_size = True
                     update_cluster_control(file, cluster_control_json)
             except zlib.error as e:
                 raise WazuhError(3001, str(e))
             except Exception as e:
-                logger.debug(str(WazuhException(3001, str(e))))
+                result_logs['debug'][file].append(f"Exception raised: " + str(WazuhException(3001, str(e))))
                 update_cluster_control(file, cluster_control_json, exists=False)
 
         try:
@@ -366,7 +383,7 @@ def compress_files(name, list_path, cluster_control_json=None, max_zip_size=None
         except Exception as e:
             raise WazuhError(3001, str(e))
 
-    return zip_file_path
+    return zip_file_path, result_logs
 
 
 async def async_decompress_files(zip_path, ko_files_name="files_metadata.json"):

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -366,7 +366,7 @@ def compress_files(name, list_path, cluster_control_json=None, max_zip_size=None
                     wf.write(new_file)
                 else:
                     # Otherwise, remove it from cluster_control_json.
-                    result_logs['warning'][file].append(f'Maximum zip size exceeded for compressed file. '
+                    result_logs['warning'][file].append('Maximum zip size exceeded. '
                                                         'Not all files will be compressed during this sync.')
                     exceeded_size = True
                     update_cluster_control(file, cluster_control_json)

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -25,7 +25,6 @@ from wazuh import Wazuh
 from wazuh.core import common, exception
 from wazuh.core import utils
 from wazuh.core.cluster import cluster, utils as cluster_utils
-from wazuh.core.common import DECIMALS_DATE_FORMAT
 from wazuh.core.wdb import WazuhDBConnection
 
 class Response:
@@ -1437,8 +1436,10 @@ class SyncFiles(SyncTask):
 
         self.logger.debug(f"Compressing {'files and ' if files else ''}"
                           f"'files_metadata.json' of {metadata_len} files.")
-        compressed_data = await cluster.run_in_pool(self.server.loop, task_pool, cluster.compress_files,
-                                                    self.server.name, files, files_metadata, zip_limit)
+        compressed_data, logs = await cluster.run_in_pool(self.server.loop, task_pool, cluster.compress_files,
+                                                          self.server.name, files, files_metadata, zip_limit)
+
+        cluster_utils.log_subprocess_execution(self.logger, logs)
 
         try:
             # Start the synchronization process with peer node and get a taskID.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -19,7 +19,7 @@ from wazuh.core import cluster as metadata, common, exception, utils
 from wazuh.core.agent import Agent
 from wazuh.core.cluster import server, cluster, common as c_common
 from wazuh.core.cluster.dapi import dapi
-from wazuh.core.cluster.utils import context_tag
+from wazuh.core.cluster.utils import context_tag, log_subprocess_execution
 from wazuh.core.common import DECIMALS_DATE_FORMAT
 from wazuh.core.utils import get_utc_now, get_utc_strptime
 from wazuh.core.wdb import AsyncWazuhDBConnection
@@ -1078,8 +1078,11 @@ class Master(server.AbstractServer):
             before = perf_counter()
             file_integrity_logger.info("Starting.")
             try:
-                self.integrity_control = await cluster.run_in_pool(self.loop, self.task_pool, cluster.get_files_status,
-                                                                   self.integrity_control)
+                self.integrity_control, logs = await cluster.run_in_pool(self.loop,
+                                                                         self.task_pool,
+                                                                         cluster.get_files_status,
+                                                                         self.integrity_control)
+                log_subprocess_execution(file_integrity_logger, logs)
             except Exception as e:
                 file_integrity_logger.error(f"Error calculating local file integrity: {e}")
             finally:

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -367,7 +367,7 @@ def test_compress_files_ko(mock_path_exists, mock_path_dirname, mock_mkdir_with_
 
         with patch('zlib.compress', return_value=b'compressed_test_content'):
             _, logs = cluster.compress_files('some_name', ['some/path', 'another/path'], {'ko_file': 'file'})
-            assert logs['warning']['some/path'] == ['Maximum zip size exceeded for compressed file. '
+            assert logs['warning']['some/path'] == ['Maximum zip size exceeded. '
                                                     'Not all files will be compressed during this sync.']
 
         with patch('zlib.compress', return_value='compressed_test_content'):

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -7,13 +7,12 @@ import os
 import sys
 import zipfile
 import zlib
-from datetime import datetime
+from collections import defaultdict
 from time import time
 from unittest.mock import MagicMock, mock_open, patch, call, ANY
 
 import pytest
 from wazuh.core import common
-from wazuh.core.utils import get_date_from_timestamp
 
 with patch('wazuh.common.wazuh_uid'):
     with patch('wazuh.common.wazuh_gid'):
@@ -127,7 +126,11 @@ def test_walk_dir(walk_mock, path_join_mock, blake2b_mock, getmtime_mock):
 
     # Check the first if and nested else
     assert cluster.walk_dir(dirname="/foo/bar", recursive=False, files=['all'], excluded_files=['ar.conf'],
-                            excluded_extensions=[".xml", ".txt"], get_cluster_item_key="") == {}
+                            excluded_extensions=[".xml", ".txt"], get_cluster_item_key="") == ({},
+                                                                                               {'debug': defaultdict(
+                                                                                                   list),
+                                                                                                'error': defaultdict(
+                                                                                                    list)})
     walk_mock.assert_called_once_with(path_join_mock.return_value, topdown=True)
     path_join_mock.assert_called_once_with(common.WAZUH_PATH, '/foo/bar')
     blake2b_mock.assert_not_called()
@@ -138,8 +141,9 @@ def test_walk_dir(walk_mock, path_join_mock, blake2b_mock, getmtime_mock):
     # Check nested if
     assert cluster.walk_dir(dirname="/foo/bar", recursive=True, files=['all'], excluded_files=['ar.conf', 'spam'],
                             excluded_extensions=[".xml", ".txt"], get_cluster_item_key="",
-                            previous_status={path_join_mock.return_value: {'mod_time': 45}}) == {
-               path_join_mock.return_value: {'mod_time': 45}}
+                            previous_status={path_join_mock.return_value: {'mod_time': 45}}) == (
+               {path_join_mock.return_value: {'mod_time': 45}},
+               {'debug': defaultdict(list), 'error': defaultdict(list)})
 
     walk_mock.assert_called_once_with(path_join_mock.return_value, topdown=True)
     path_join_mock.assert_has_calls([call(common.WAZUH_PATH, '/foo/bar'),
@@ -153,10 +157,10 @@ def test_walk_dir(walk_mock, path_join_mock, blake2b_mock, getmtime_mock):
 
     assert cluster.walk_dir(dirname="/foo/bar", recursive=True, files=['all'], excluded_files=['ar.conf', 'spam'],
                             excluded_extensions=[".xml", ".txt"], get_cluster_item_key="",
-                            previous_status={path_join_mock.return_value: {'mod_time': 35}}) == {
-
-               '/mock/foo/bar': {'mod_time': 45, 'cluster_item_key': '', 'merged': True, 'merge_type': 'TYPE',
-                                 'merge_name': '/mock/foo/bar', 'hash': 'hash'}}
+                            previous_status={path_join_mock.return_value: {'mod_time': 35}}) == (
+               {'/mock/foo/bar': {'mod_time': 45, 'cluster_item_key': '', 'merged': True, 'merge_type': 'TYPE',
+                                  'merge_name': '/mock/foo/bar', 'hash': 'hash'}},
+               {'debug': defaultdict(list), 'error': defaultdict(list)})
 
     walk_mock.assert_called_once_with(path_join_mock.return_value, topdown=True)
     path_join_mock.assert_has_calls([call(common.WAZUH_PATH, '/foo/bar'),
@@ -171,10 +175,10 @@ def test_walk_dir(walk_mock, path_join_mock, blake2b_mock, getmtime_mock):
     # Check the key error
     assert cluster.walk_dir(dirname="/foo/bar", recursive=True, files=['all'], excluded_files=['ar.conf', 'spam'],
                             excluded_extensions=[".xml", ".txt"], get_cluster_item_key="",
-                            previous_status={path_join_mock.return_value: {'mod_mock_time': 35}}) == {
-
-               '/mock/foo/bar': {'mod_time': 45, 'cluster_item_key': '', 'merged': True, 'merge_type': 'TYPE',
-                                 'merge_name': '/mock/foo/bar', 'hash': 'hash'}}
+                            previous_status={path_join_mock.return_value: {'mod_mock_time': 35}}) == (
+               {'/mock/foo/bar': {'mod_time': 45, 'cluster_item_key': '', 'merged': True, 'merge_type': 'TYPE',
+                                  'merge_name': '/mock/foo/bar', 'hash': 'hash'}},
+               {'debug': defaultdict(list), 'error': defaultdict(list)})
 
     walk_mock.assert_called_once_with(path_join_mock.return_value, topdown=True)
     path_join_mock.assert_has_calls([call(common.WAZUH_PATH, '/foo/bar'),
@@ -189,17 +193,16 @@ def test_walk_dir(walk_mock, path_join_mock, blake2b_mock, getmtime_mock):
 @patch('os.path.join', return_value='/foo/bar')
 def test_walk_dir_ko(mock_path_join, mock_walk):
     """Check all errors that can be raised by the function walk_dir."""
-    with patch.object(wazuh.core.cluster.cluster.logger, "debug") as mock_logger:
-        with patch('os.path.getmtime', side_effect=FileNotFoundError):
-            cluster.walk_dir("/foo/bar", True, ["all"], ["ar.conf"], [".xml", ".txt"], "",
-                             {'/foo/bar/': {'mod_time': True}})
-            mock_logger.assert_called_with("File spam was deleted in previous iteration: ")
 
-    with patch.object(wazuh.core.cluster.cluster.logger, "error") as mock_logger:
-        with patch('os.path.getmtime', side_effect=PermissionError):
-            cluster.walk_dir("/foo/bar", True, ["all"], ["ar.conf"], [".xml", ".txt"], "",
-                             {'/foo/bar/': {'mod_time': True}})
-            mock_logger.assert_called_with("Can't read metadata from file spam: ")
+    with patch('os.path.getmtime', side_effect=FileNotFoundError):
+        _, logs = cluster.walk_dir("/foo/bar", True, ["all"], ["ar.conf"], [".xml", ".txt"], "",
+                         {'/foo/bar/': {'mod_time': True}})
+        assert logs['debug']['/foo/bar'] == ["File spam was deleted in previous iteration: "]
+
+    with patch('os.path.getmtime', side_effect=PermissionError):
+        _, logs = cluster.walk_dir("/foo/bar", True, ["all"], ["ar.conf"], [".xml", ".txt"], "",
+                         {'/foo/bar/': {'mod_time': True}})
+        assert logs['error']['/foo/bar'] == ["Can't read metadata from file spam: "]
 
     with patch('wazuh.core.cluster.cluster.walk', side_effect=OSError):
         with pytest.raises(WazuhInternalError, match=r'.* 3015 .*'):
@@ -242,14 +245,15 @@ def test_get_files_status(mock_get_cluster_items):
 
     test_dict = {"path": "metadata"}
 
-    with patch('wazuh.core.cluster.cluster.walk_dir', return_value=test_dict):
-        assert isinstance(cluster.get_files_status(), dict)
-        assert cluster.get_files_status()["path"] == test_dict["path"]
+    with patch('wazuh.core.cluster.cluster.walk_dir', return_value=(test_dict, {})):
+        assert isinstance(cluster.get_files_status(), tuple) and \
+               all(isinstance(d, dict) for d in cluster.get_files_status())
+
+        assert cluster.get_files_status()[0]["path"] == (test_dict["path"])
 
     with patch('wazuh.core.cluster.cluster.walk_dir', side_effect=Exception):
-        with patch.object(wazuh.core.cluster.cluster.logger, "warning") as logger_mock:
-            cluster.get_files_status()
-            logger_mock.assert_called_once_with(f"Error getting file status: .")
+        _, logs = cluster.get_files_status()
+        assert logs['warning']['etc/'] == [f"Error getting file status: ."]
 
 
 @patch('wazuh.core.cluster.cluster.get_cluster_items', return_value={
@@ -283,7 +287,7 @@ def test_get_ruleset_status(mock_get_cluster_items):
              ['~', '.tmp', '.lock', '.swp'], 'etc/lists/', {}, True)
     ]
 
-    with patch("wazuh.core.cluster.cluster.walk_dir", return_value=test_dict) as walk_dir_mock:
+    with patch("wazuh.core.cluster.cluster.walk_dir", return_value=(test_dict, {})) as walk_dir_mock:
         result = cluster.get_ruleset_status({})
         assert isinstance(result, dict)
         assert result["path"] == test_dict["path"]["hash"]
@@ -332,7 +336,8 @@ def test_compress_files_ok(mock_path_exists, mock_path_dirname, mock_mkdir_with_
     mock_get_cluster_items.return_value = {'intervals': {'communication': {'max_zip_size': 10000, 'compress_level': 0}}}
 
     with patch('builtins.open', mock_open(read_data='test_content')) as open_mock:
-        assert isinstance(cluster.compress_files('some_name', ['some/path', 'another/path'], {'ko_file': 'file'}), str)
+        assert isinstance(cluster.compress_files('some_name', ['some/path', 'another/path'], {'ko_file': 'file'}),
+                          tuple)
         assert open_mock.call_args_list == [call(ANY, 'ab'), call(os.path.join(common.WAZUH_PATH, 'some/path'), 'rb'),
                                             call(os.path.join(common.WAZUH_PATH, 'another/path'), 'rb')]
         assert open_mock.return_value.write.call_args_list == [
@@ -350,10 +355,9 @@ def test_compress_files_ko(mock_path_exists, mock_path_dirname, mock_mkdir_with_
     """Check if the compressing function is raising every exception."""
     with patch('builtins.open', mock_open(read_data='test_content')):
         mock_get_cluster_items.return_value = {'intervals': {'communication': {'max_zip_size': 5,'compress_level': 0}}}
-        with patch.object(wazuh.core.cluster.cluster.logger, 'warning') as warning_logger:
-                cluster.compress_files('some_name', ['some/path'], {'missing': {}, 'shared': {}})
-                warning_logger.assert_called_with(f'File too large to be synced: '
-                                                  f'{os.path.join(common.WAZUH_PATH, "some/path")}')
+        _, logs = cluster.compress_files('some_name', ['some/path'], {'missing': {}, 'shared': {}})
+        assert logs['warning']['some/path'] == [f'File too large to be synced: '
+                                                f'{os.path.join(common.WAZUH_PATH, "some/path")}']
 
         mock_get_cluster_items.return_value = {'intervals': {'communication': {'max_zip_size': 15, 'compress_level': 0}}
                                                }
@@ -362,10 +366,9 @@ def test_compress_files_ko(mock_path_exists, mock_path_dirname, mock_mkdir_with_
                 cluster.compress_files('some_name', ['some/path'], {'ko_file': 'file'})
 
         with patch('zlib.compress', return_value=b'compressed_test_content'):
-            with patch.object(wazuh.core.cluster.cluster.logger, 'warning') as warning_logger:
-                cluster.compress_files('some_name', ['some/path', 'another/path'], {'ko_file': 'file'})
-                warning_logger.assert_called_with('Maximum zip size exceeded. Not all files will be compressed '
-                                                  'during this sync.')
+            _, logs = cluster.compress_files('some_name', ['some/path', 'another/path'], {'ko_file': 'file'})
+            assert logs['warning']['some/path'] == ['Maximum zip size exceeded for compressed file. '
+                                                    'Not all files will be compressed during this sync.']
 
         with patch('zlib.compress', return_value='compressed_test_content'):
             with pytest.raises(WazuhError, match=r'.* 3001 .*'):

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -1735,8 +1735,9 @@ async def test_sync_task_sync():
 @patch("json.dumps", return_value='')
 @patch("os.path.relpath", return_value="path")
 @patch("os.unlink", return_value="unlinked path")
-@patch("wazuh.core.cluster.cluster.compress_files", return_value="files/path/")
-async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock, json_dumps_mock):
+@patch("wazuh.core.cluster.cluster.compress_files", return_value=("files/path/", {}))
+@patch("wazuh.core.cluster.utils.log_subprocess_execution")
+async def test_sync_files_sync_ok(log_subprocess_mock, compress_files_mock, unlink_mock, relpath_mock, json_dumps_mock):
     """Check if the methods to synchronize files are defined."""
     files_to_sync = {"path1": "metadata1"}
     files_metadata = {"path2": "metadata2"}
@@ -1779,6 +1780,7 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
     # Test second condition
     with patch.object(logging.getLogger("wazuh"), "error") as logger_mock:
         await sync_files.sync(files_to_sync, files_metadata, 1, task_pool=None)
+        log_subprocess_mock.assert_called()
         json_dumps_mock.assert_called_once_with(
             exception.WazuhClusterError(code=3020, extra_message="cmd"),
             cls=cluster_common.WazuhJSONEncoder)
@@ -1794,6 +1796,7 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
                 logger_debug_mock.assert_has_calls([call(
                     f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of 1 files."),
                     call("Sending zip file."), call("Zip file sent."), call("Decreasing sync size limit to 30.00 MB.")])
+                log_subprocess_mock.assert_called()
                 logger_error_mock.assert_called_once_with("Error sending zip file: ")
                 compress_files_mock.assert_has_calls([call('Testing', {'path1': 'metadata1'},
                                                            {'path2': 'metadata2'}, None)] * 2)
@@ -1814,6 +1817,7 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
                 logger_debug_mock.assert_has_calls([call(
                     f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of 1 files."),
                     call("Sending zip file."), call("Zip file sent."), call('Increasing sync size limit to 37.50 MB.')])
+                log_subprocess_mock.assert_called()
                 logger_error_mock.assert_called_once_with(
                     f"Error sending zip file: {exception.WazuhException(3016, 'cmd_e')}")
                 compress_files_mock.assert_called_once_with('Testing', {'path1': 'metadata1'},
@@ -1835,6 +1839,7 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
             logger_debug_mock.assert_has_calls([call(
                 f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of 1 files."),
                 call("Sending zip file."), call("Zip file sent."), call("Increasing sync size limit to 46.88 MB.")])
+            log_subprocess_mock.assert_called()
             compress_files_mock.assert_called_once_with('Testing', {'path1': 'metadata1'}, {'path2': 'metadata2'}, None)
             unlink_mock.assert_called_once_with("files/path/")
             relpath_mock.assert_called_once_with('files/path/', common.WAZUH_PATH)

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1611,7 +1611,7 @@ async def test_master_file_status_update_ok(sleep_mock):
 @pytest.mark.asyncio
 @freeze_time("2021-11-02")
 @patch('asyncio.sleep')
-@patch('wazuh.core.cluster.master.cluster.run_in_pool', return_value=[])
+@patch('wazuh.core.cluster.master.cluster.run_in_pool', return_value={})
 async def test_master_file_status_update_ok(run_in_pool_mock, asyncio_sleep_mock):
     """Check if the file status is properly obtained."""
 
@@ -1660,7 +1660,6 @@ async def test_master_file_status_update_ok(run_in_pool_mock, asyncio_sleep_mock
         except Exception:
             assert "Starting." in logger_mock._info
             assert "Finished in 0.000s. Calculated metadata of 0 files." in logger_mock._info
-            # assert "Error calculating local file integrity: " in logger_mock._error
             setup_task_logger_mock.assert_called_once_with('Local integrity')
             assert master_class.integrity_control == run_in_pool_mock.return_value
 

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -1032,8 +1032,6 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
 
             os_remove_mock.assert_any_call("queue/testing/")
             assert result_logs['error'] == defaultdict(list)
-            assert result_logs['debug'] == {"shared": ["Received 1 shared files to update from master."],
-                                            "missing": ["Received 1 missing files to update from master."]}
             assert result_logs['debug2'] == {"filename1": ["Processing file filename1", "Processing file filename1"],
                                              "filename3": ["Remove file: 'filename3'"]}
             path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, 'filename1'),
@@ -1064,8 +1062,6 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
                                                 "string indices must be integers"]
                                     }
 
-    assert result_logs['debug'] == {'shared': ["Received 1 shared files to update from master."],
-                                    'missing': ["Received 1 missing files to update from master."]}
     assert result_logs['debug2'] == {'filename1': ["Processing file filename1"],
                                      'filename3': ["Remove file: 'filename3'",
                                                    "File filename3 doesn't exist."],
@@ -1098,8 +1094,6 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
                                                "string indices must be integers"],
                                     'missing': ["Error processing missing file 'filename2': "
                                                 "string indices must be integers"]}
-    assert result_logs['debug'] == {'shared': ["Received 1 shared files to update from master."],
-                                    'missing': ["Received 1 missing files to update from master."]}
     assert result_logs['debug2'] == {'filename1': ["Processing file filename1"],
                                      'filename2': ["Processing file filename2"],
                                      'filename3': ["Remove file: 'filename3'", "File filename3 doesn't exist."]}
@@ -1134,7 +1128,6 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
             listdir_mock.assert_called_once()
 
             assert result_logs['error'] == defaultdict(list)
-            assert result_logs['debug'] == defaultdict(list)
             assert result_logs['debug2'] == {'filename3': ["Remove file: 'filename3'",
                                                            "File filename3 doesn't exist."]}
             assert result_logs['generic_errors'] == []
@@ -1157,7 +1150,6 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
         cluster_items=cluster_items)
 
     assert result_logs['error'] == defaultdict(list)
-    assert result_logs['debug'] == defaultdict(list)
     assert result_logs['debug2'] == {'filename3': ["Remove file: 'filename3'",
                                                    "File filename3 doesn't exist."],
                                      '': ["Error removing directory '': [Errno 2] No such file or directory: "

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import logging
 import sys
+from collections import defaultdict
 from unittest.mock import patch, MagicMock, AsyncMock, call, ANY
 
 import pytest
@@ -659,10 +660,12 @@ async def test_worker_handler_recv_agent_groups_information(get_chunks_in_task_i
 @patch.object(logging.getLogger("wazuh.Integrity check"), "error")
 @patch("wazuh.core.cluster.cluster.get_files_status", return_value={})
 @patch("wazuh.core.cluster.worker.client.common.Handler.send_request")
-@patch('wazuh.core.cluster.worker.cluster.run_in_pool', return_value={'path': 'test'})
+@patch('wazuh.core.cluster.worker.cluster.run_in_pool', return_value=({'path': 'test'}, {}))
 @patch("wazuh.core.cluster.common.SyncFiles.request_permission", return_value=True)
-async def test_worker_handler_sync_integrity(request_permission_mock, run_in_pool_mock, send_request_mock,
-                                             get_files_status, error_mock, sync_mock, json_dumps_mock):
+@patch("wazuh.core.cluster.utils.log_subprocess_execution")
+async def test_worker_handler_sync_integrity(log_subprocess_mock, request_permission_mock, run_in_pool_mock,
+                                             send_request_mock, get_files_status, error_mock, sync_mock,
+                                             json_dumps_mock):
     """Check if files status are correctly obtained and sent to the master."""
 
     async def asyncio_sleep_mock(delay, result=None, *, loop=None):
@@ -877,8 +880,7 @@ async def test_worker_handler_process_files_from_master_ok(update_files_mock, se
     decompress_files_mock.return_value = (ko_files[0], zip_path)
     await worker_handler.process_files_from_master(name="task_id", file_received=EventMock())
 
-    update_files_mock.assert_called_once_with(ko_files[0], zip_path, cluster_items,
-                                              worker_handler.task_loggers['Integrity sync'])
+    update_files_mock.assert_called_once_with(ko_files[0], zip_path, cluster_items)
     send_request_mock.assert_not_called()
     logger_debug_mock.assert_has_calls(
         [call("Worker does not meet integrity checks. Actions required."), call("Updating local files: Start."),
@@ -900,8 +902,7 @@ async def test_worker_handler_process_files_from_master_ok(update_files_mock, se
     decompress_files_mock.return_value = (ko_files[1], zip_path)
     await worker_handler.process_files_from_master(name="task_id", file_received=EventMock())
 
-    update_files_mock.assert_called_once_with(ko_files[1], zip_path, cluster_items,
-                                              worker_handler.task_loggers['Integrity sync'])
+    update_files_mock.assert_called_once_with(ko_files[1], zip_path, cluster_items)
     send_request_mock.assert_not_called()
     logger_debug_mock.assert_has_calls(
         [call("Worker does not meet integrity checks. Actions required."), call("Updating local files: Start."),
@@ -1010,255 +1011,167 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
                                                          open_mock):
     """Check if the method is properly receiving and updating files."""
 
-    class LoggerMock:
-        """Auxiliary class."""
-
-        def __init__(self):
-            self._debug2 = []
-            self._debug = []
-            self._error = []
-
-        def debug(self, debug):
-            self._debug.append(debug)
-
-        def debug2(self, debug):
-            self._debug2.append(debug)
-
-        def error(self, error):
-            self._error.append(error)
-
     all_mocks = [wazuh_gid_mock, wazuh_uid_mock, path_join_mock, mkdir_with_mode_mock, safe_move_mock, open_mock,
                  path_exists_mock]
 
-    with patch.object(LoggerMock, "debug") as logger_debug_mock:
-        with patch.object(LoggerMock, "debug2") as logger_debug2_mock:
-            with patch.object(LoggerMock, "error") as logger_error_mock:
-                # As the method has two large for, we will make the condition for the first one equal to something empty
-                worker_handler.cluster_items["files"]["cluster_item_key"]["remove_subdirs_if_empty"] = {}
+    # As the method has two large for, we will make the condition for the first one equal to something empty
+    worker_handler.cluster_items["files"]["cluster_item_key"]["remove_subdirs_if_empty"] = {}
 
-                # Test the first for: for -> if -> for -> try
-                # In the nested method, with the first value sent to the 'update_master_files_in_worker' (shared), we
-                # are testing the if, meanwhile with the second (missing), we are testing the else.
-                with patch("wazuh.core.cluster.cluster.unmerge_info", return_value=[("name", "content", "_")]):
-                    with patch("os.remove") as os_remove_mock:
-                        worker_handler.update_master_files_in_worker(
-                            ko_files={"shared": {
-                                "filename1": {"merged": "value", "cluster_item_key": "cluster_item_key"}},
-                                "missing": {
-                                    "filename1": {"merged": None, "cluster_item_key": "cluster_item_key"}},
-                                "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, zip_path="/zip/path",
-                            cluster_items=cluster_items, logger=LoggerMock())
+    # Test the first for: for -> if -> for -> try
+    # In the nested method, with the first value sent to the 'update_master_files_in_worker' (shared), we
+    # are testing the if, meanwhile with the second (missing), we are testing the else.
+    with patch("wazuh.core.cluster.cluster.unmerge_info", return_value=[("name", "content", "_")]):
+        with patch("os.remove") as os_remove_mock:
+            result_logs = worker_handler.update_master_files_in_worker(
+                ko_files={"shared": {
+                    "filename1": {"merged": "value", "cluster_item_key": "cluster_item_key"}},
+                    "missing": {
+                        "filename1": {"merged": None, "cluster_item_key": "cluster_item_key"}},
+                    "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, zip_path="/zip/path",
+                cluster_items=cluster_items)
 
-                        os_remove_mock.assert_any_call("queue/testing/")
-                        logger_error_mock.assert_not_called()
-                        logger_debug_mock.assert_has_calls(
-                            [call("Received 1 shared files to update from master."),
-                             call("Received 1 missing files to update from master.")])
-                        logger_debug2_mock.assert_has_calls(
-                            [call("Processing file filename1"),
-                             call("Processing file filename1"),
-                             call("Remove file: 'filename3'")])
-                        path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, 'filename1'),
-                                                         call(core_common.WAZUH_PATH, 'name'),
-                                                         call(core_common.WAZUH_PATH, 'filename1'),
-                                                         call('/zip/path', 'filename1'),
-                                                         call(core_common.WAZUH_PATH, 'filename3')])
-                        wazuh_uid_mock.assert_called_with()
-                        wazuh_gid_mock.assert_called_with()
-                        mkdir_with_mode_mock.assert_any_call("queue/testing")
-                        assert safe_move_mock.call_count == 2
-                        open_mock.assert_called_once()
-                        path_exists_mock.assert_called_once()
+            os_remove_mock.assert_any_call("queue/testing/")
+            assert result_logs['error'] == defaultdict(list)
+            assert result_logs['debug'] == {"shared": ["Received 1 shared files to update from master."],
+                                            "missing": ["Received 1 missing files to update from master."]}
+            assert result_logs['debug2'] == {"filename1": ["Processing file filename1", "Processing file filename1"],
+                                             "filename3": ["Remove file: 'filename3'"]}
+            path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, 'filename1'),
+                                             call(core_common.WAZUH_PATH, 'name'),
+                                             call(core_common.WAZUH_PATH, 'filename1'),
+                                             call('/zip/path', 'filename1'),
+                                             call(core_common.WAZUH_PATH, 'filename3')])
+            wazuh_uid_mock.assert_called_with()
+            wazuh_gid_mock.assert_called_with()
+            mkdir_with_mode_mock.assert_any_call("queue/testing")
+            assert safe_move_mock.call_count == 2
+            open_mock.assert_called_once()
+            path_exists_mock.assert_called_once()
 
-                        # Reset all mocks
-                        for mock in all_mocks:
-                            mock.reset_mock()
+            # Reset all mocks
+            for mock in all_mocks:
+                mock.reset_mock()
 
-                # Test the first for: for -> if -> for -> except AND for -> elif -> for -> try -> except -> if
-                worker_handler.update_master_files_in_worker(
-                    {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
-                     "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-                    cluster_items=cluster_items, logger=LoggerMock())
+    # Test the first for: for -> if -> for -> except AND for -> elif -> for -> try -> except -> if
+    result_logs = worker_handler.update_master_files_in_worker(
+        {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
+         "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+        cluster_items=cluster_items)
 
-                logger_error_mock.assert_has_calls(
-                    [call("Error processing shared file 'filename1': string indices must be integers"),
-                     call("Error processing missing file 'filename2': string indices must be integers"),
-                     call("Found errors: 1 overwriting, 1 creating and 0 removing", exc_info=False)])
-                logger_debug_mock.assert_has_calls(
-                    [call("Received 1 shared files to update from master."),
-                     call("Received 1 missing files to update from master."),
-                     call("Received 1 shared files to update from master."),
-                     call("Received 1 missing files to update from master.")])
-                logger_debug2_mock.assert_has_calls(
-                    [call("Processing file filename1"),
-                     call("Processing file filename1"),
-                     call("Remove file: 'filename3'"),
-                     call("Processing file filename1"),
-                     call("Processing file filename2"),
-                     call("Remove file: 'filename3'"),
-                     call("File filename3 doesn't exist.")])
-                path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename1"),
-                                                 call(core_common.WAZUH_PATH, "filename2"),
-                                                 call(core_common.WAZUH_PATH, "filename3")])
-                wazuh_uid_mock.assert_not_called()
-                wazuh_gid_mock.assert_not_called()
-                mkdir_with_mode_mock.assert_not_called()
-                safe_move_mock.assert_not_called()
-                open_mock.assert_not_called()
-                path_exists_mock.assert_not_called()
+    assert result_logs['error'] == {'shared': ["Error processing shared file 'filename1': "
+                                               "string indices must be integers"],
+                                    'missing': ["Error processing missing file 'filename2': "
+                                                "string indices must be integers"]
+                                    }
 
-                # Reset all mocks
-                for mock in all_mocks:
-                    mock.reset_mock()
+    assert result_logs['debug'] == {'shared': ["Received 1 shared files to update from master."],
+                                    'missing': ["Received 1 missing files to update from master."]}
+    assert result_logs['debug2'] == {'filename1': ["Processing file filename1"],
+                                     'filename3': ["Remove file: 'filename3'",
+                                                   "File filename3 doesn't exist."],
+                                     'filename2': ["Processing file filename2"]}
+    assert result_logs['generic_errors'] == ["Found errors: 1 overwriting, 1 creating and 0 removing"]
 
-                # Test the first for: for -> if -> for -> except AND for -> elif -> for -> try -> except -> else AND
-                # for -> elif -> for -> except
-                path_join_mock.return_value = "queue/testing_mock/"
-                worker_handler.update_master_files_in_worker(
-                    {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
-                     "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-                    cluster_items=cluster_items, logger=LoggerMock())
+    path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename1"),
+                                     call(core_common.WAZUH_PATH, "filename2"),
+                                     call(core_common.WAZUH_PATH, "filename3")])
+    wazuh_uid_mock.assert_not_called()
+    wazuh_gid_mock.assert_not_called()
+    mkdir_with_mode_mock.assert_not_called()
+    safe_move_mock.assert_not_called()
+    open_mock.assert_not_called()
+    path_exists_mock.assert_not_called()
 
-                logger_error_mock.assert_has_calls(
-                    [call("Error processing shared file 'filename1': string indices must be integers"),
-                     call("Error processing missing file 'filename2': string indices must be integers"),
-                     call("Found errors: 1 overwriting, 1 creating and 0 removing", exc_info=False),
-                     call("Error processing shared file 'filename1': string indices must be integers"),
-                     call("Error processing missing file 'filename2': string indices must be integers"),
-                     call("Found errors: 1 overwriting, 1 creating and 0 removing", exc_info=False)])
-                logger_debug_mock.assert_has_calls(
-                    [call("Received 1 shared files to update from master."),
-                     call("Received 1 missing files to update from master."),
-                     call("Received 1 shared files to update from master."),
-                     call("Received 1 missing files to update from master."),
-                     call("Received 1 shared files to update from master."),
-                     call("Received 1 missing files to update from master."), ])
-                logger_debug2_mock.assert_has_calls(
-                    [call("Processing file filename1"),
-                     call("Processing file filename1"),
-                     call("Remove file: 'filename3'"),
-                     call("Processing file filename1"),
-                     call("Processing file filename2"),
-                     call("Remove file: 'filename3'"),
-                     call("File filename3 doesn't exist."),
-                     call("Processing file filename1"),
-                     call("Processing file filename2"),
-                     call("Remove file: 'filename3'"),
-                     call("File filename3 doesn't exist.")])
-                path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename1"),
-                                                 call(core_common.WAZUH_PATH, "filename2"),
-                                                 call(core_common.WAZUH_PATH, "filename3")])
-                wazuh_uid_mock.assert_not_called()
-                wazuh_gid_mock.assert_not_called()
-                mkdir_with_mode_mock.assert_not_called()
-                safe_move_mock.assert_not_called()
-                open_mock.assert_not_called()
-                path_exists_mock.assert_not_called()
+    # Reset all mocks
+    for mock in all_mocks:
+        mock.reset_mock()
 
-                # Reset all mocks
-                for mock in all_mocks:
-                    mock.reset_mock()
+    # Test the first for: for -> if -> for -> except AND for -> elif -> for -> try -> except -> else AND
+    # for -> elif -> for -> except
+    path_join_mock.return_value = "queue/testing_mock/"
+    result_logs = worker_handler.update_master_files_in_worker(
+        {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
+         "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+        cluster_items=cluster_items)
 
-                # Now, we are going to test the second for
-                worker_handler.cluster_items["files"]["cluster_item_key"]["remove_subdirs_if_empty"] = {
-                    "dir1": "value1"}
-                worker_handler.cluster_items["files"]["excluded_files"] = "dir_files"
+    assert result_logs['error'] == {'shared': ["Error processing shared file 'filename1': "
+                                               "string indices must be integers"],
+                                    'missing': ["Error processing missing file 'filename2': "
+                                                "string indices must be integers"]}
+    assert result_logs['debug'] == {'shared': ["Received 1 shared files to update from master."],
+                                    'missing': ["Received 1 missing files to update from master."]}
+    assert result_logs['debug2'] == {'filename1': ["Processing file filename1"],
+                                     'filename2': ["Processing file filename2"],
+                                     'filename3': ["Remove file: 'filename3'", "File filename3 doesn't exist."]}
+    assert result_logs['generic_errors'] == ["Found errors: 1 overwriting, 1 creating and 0 removing"]
 
-                # Test the try
-                with patch("os.listdir", return_value="dir_files") as listdir_mock:
-                    with patch("shutil.rmtree") as rmtree_mock:
-                        worker_handler.update_master_files_in_worker(
-                            {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-                            cluster_items=cluster_items, logger=LoggerMock())
-                        rmtree_mock.assert_called_once()
-                        listdir_mock.assert_called_once()
+    path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename1"),
+                                     call(core_common.WAZUH_PATH, "filename2"),
+                                     call(core_common.WAZUH_PATH, "filename3")])
+    wazuh_uid_mock.assert_not_called()
+    wazuh_gid_mock.assert_not_called()
+    mkdir_with_mode_mock.assert_not_called()
+    safe_move_mock.assert_not_called()
+    open_mock.assert_not_called()
+    path_exists_mock.assert_not_called()
 
-                        logger_error_mock.assert_has_calls(
-                            [call("Error processing shared file 'filename1': string indices must be integers"),
-                             call("Error processing missing file 'filename2': string indices must be integers"),
-                             call("Found errors: 1 overwriting, 1 creating and 0 removing", exc_info=False),
-                             call("Error processing shared file 'filename1': string indices must be integers"),
-                             call("Error processing missing file 'filename2': string indices must be integers"),
-                             call("Found errors: 1 overwriting, 1 creating and 0 removing", exc_info=False)])
-                        logger_debug_mock.assert_has_calls(
-                            [call("Received 1 shared files to update from master."),
-                             call("Received 1 missing files to update from master."),
-                             call("Received 1 shared files to update from master."),
-                             call("Received 1 missing files to update from master."),
-                             call("Received 1 shared files to update from master."),
-                             call("Received 1 missing files to update from master."), ])
-                        logger_debug2_mock.assert_has_calls(
-                            [call("Processing file filename1"),
-                             call("Processing file filename1"),
-                             call("Remove file: 'filename3'"),
-                             call("Processing file filename1"),
-                             call("Processing file filename2"),
-                             call("Remove file: 'filename3'"),
-                             call("File filename3 doesn't exist."),
-                             call("Processing file filename1"),
-                             call("Processing file filename2"),
-                             call("Remove file: 'filename3'"),
-                             call("File filename3 doesn't exist."),
-                             call("Remove file: 'filename3'"),
-                             call("File filename3 doesn't exist.")])
-                        path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename3"),
-                                                         call(core_common.WAZUH_PATH, "")])
-                        wazuh_uid_mock.assert_not_called()
-                        wazuh_gid_mock.assert_not_called()
-                        mkdir_with_mode_mock.assert_not_called()
-                        safe_move_mock.assert_not_called()
-                        open_mock.assert_not_called()
-                        path_exists_mock.assert_not_called()
+    # Reset all mocks
+    for mock in all_mocks:
+        mock.reset_mock()
 
-                        # Reset all mocks
-                        for mock in all_mocks:
-                            mock.reset_mock()
+    # Now, we are going to test the second for
+    worker_handler.cluster_items["files"]["cluster_item_key"]["remove_subdirs_if_empty"] = {
+        "dir1": "value1"}
+    worker_handler.cluster_items["files"]["excluded_files"] = "dir_files"
 
-                # Test the exception
-                worker_handler.update_master_files_in_worker(
-                    {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-                    cluster_items=cluster_items, logger=LoggerMock())
+    # Test the try
+    with patch("os.listdir", return_value="dir_files") as listdir_mock:
+        with patch("shutil.rmtree") as rmtree_mock:
+            result_logs = worker_handler.update_master_files_in_worker(
+                {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+                cluster_items=cluster_items)
+            rmtree_mock.assert_called_once()
+            listdir_mock.assert_called_once()
 
-                logger_error_mock.assert_has_calls(
-                    [call("Error processing shared file 'filename1': string indices must be integers"),
-                     call("Error processing missing file 'filename2': string indices must be integers"),
-                     call("Found errors: 1 overwriting, 1 creating and 0 removing", exc_info=False),
-                     call("Error processing shared file 'filename1': string indices must be integers"),
-                     call("Error processing missing file 'filename2': string indices must be integers"),
-                     call("Found errors: 1 overwriting, 1 creating and 0 removing", exc_info=False),
-                     call("Found errors: 0 overwriting, 0 creating and 1 removing", exc_info=False)])
-                logger_debug_mock.assert_has_calls(
-                    [call("Received 1 shared files to update from master."),
-                     call("Received 1 missing files to update from master."),
-                     call("Received 1 shared files to update from master."),
-                     call("Received 1 missing files to update from master."),
-                     call("Received 1 shared files to update from master."),
-                     call("Received 1 missing files to update from master."), ])
-                logger_debug2_mock.assert_has_calls(
-                    [call("Processing file filename1"),
-                     call("Processing file filename1"),
-                     call("Remove file: 'filename3'"),
-                     call("Processing file filename1"),
-                     call("Processing file filename2"),
-                     call("Remove file: 'filename3'"),
-                     call("File filename3 doesn't exist."),
-                     call("Processing file filename1"),
-                     call("Processing file filename2"),
-                     call("Remove file: 'filename3'"),
-                     call("File filename3 doesn't exist."),
-                     call("Remove file: 'filename3'"),
-                     call("File filename3 doesn't exist."),
-                     call("Remove file: 'filename3'"),
-                     call("File filename3 doesn't exist."),
-                     call("Error removing directory '': [Errno 2] No such file or directory: 'queue/testing_mock/'")])
-                path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename3"),
-                                                 call(core_common.WAZUH_PATH, "")])
-                wazuh_uid_mock.assert_not_called()
-                wazuh_gid_mock.assert_not_called()
-                mkdir_with_mode_mock.assert_not_called()
-                safe_move_mock.assert_not_called()
-                open_mock.assert_not_called()
-                path_exists_mock.assert_not_called()
+            assert result_logs['error'] == defaultdict(list)
+            assert result_logs['debug'] == defaultdict(list)
+            assert result_logs['debug2'] == {'filename3': ["Remove file: 'filename3'",
+                                                           "File filename3 doesn't exist."]}
+            assert result_logs['generic_errors'] == []
+            path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename3"),
+                                             call(core_common.WAZUH_PATH, "")])
+            wazuh_uid_mock.assert_not_called()
+            wazuh_gid_mock.assert_not_called()
+            mkdir_with_mode_mock.assert_not_called()
+            safe_move_mock.assert_not_called()
+            open_mock.assert_not_called()
+            path_exists_mock.assert_not_called()
+
+            # Reset all mocks
+            for mock in all_mocks:
+                mock.reset_mock()
+
+    # Test the exception
+    result_logs = worker_handler.update_master_files_in_worker(
+        {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+        cluster_items=cluster_items)
+
+    assert result_logs['error'] == defaultdict(list)
+    assert result_logs['debug'] == defaultdict(list)
+    assert result_logs['debug2'] == {'filename3': ["Remove file: 'filename3'",
+                                                   "File filename3 doesn't exist."],
+                                     '': ["Error removing directory '': [Errno 2] No such file or directory: "
+                                          "'queue/testing_mock/'"]}
+    assert result_logs['generic_errors'] == ["Found errors: 0 overwriting, 0 creating and 1 removing"]
+
+    path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename3"),
+                                     call(core_common.WAZUH_PATH, "")])
+    wazuh_uid_mock.assert_not_called()
+    wazuh_gid_mock.assert_not_called()
+    mkdir_with_mode_mock.assert_not_called()
+    safe_move_mock.assert_not_called()
+    open_mock.assert_not_called()
+    path_exists_mock.assert_not_called()
 
 
 def test_worker_handler_get_logger():

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -308,8 +308,7 @@ class ClusterLogger(WazuhLogger):
 
 
 def log_subprocess_execution(logger_instance: logging.Logger, logs: dict):
-    """
-    Log messages returned by functions that are executed in cluster's subprocesses.
+    """Log messages returned by functions that are executed in cluster's subprocesses.
 
     Parameters
     ----------

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -307,6 +307,30 @@ class ClusterLogger(WazuhLogger):
         self.logger.setLevel(debug_level)
 
 
+def log_subprocess_execution(logger_instance: logging.Logger, logs: dict):
+    """
+    Log messages returned by functions that are executed in cluster's subprocesses.
+
+    Parameters
+    ----------
+    logger_instance: Logger object
+        Instance of the used logger.
+    logs: dict
+        Dict containing messages of different logging level.
+    """
+    if 'debug' in logs and logs['debug']:
+        logger_instance.debug(f"{dict(logs['debug'])}")
+    if 'debug2' in logs and logs['debug2']:
+        logger_instance.debug2(f"{dict(logs['debug2'])}")
+    if 'warning' in logs and logs['warning']:
+        logger_instance.warning(f"{dict(logs['warning'])}")
+    if 'error' in logs and logs['error']:
+        logger_instance.error(f"{dict(logs['error'])}")
+    if 'generic_errors' in logs and logs['generic_errors']:
+        for error in logs['generic_errors']:
+            logger_instance.error(error, exc_info=False)
+
+
 def process_spawn_sleep(child):
     """Task to force the cluster pool spawn all its children and create their PID files.
 

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import shutil
+from collections import defaultdict
 from datetime import datetime, timezone
 from time import perf_counter
 from typing import Tuple, Dict, Callable, List
@@ -15,6 +16,7 @@ from typing import Union
 
 from wazuh.core import cluster as metadata, common, exception, utils
 from wazuh.core.cluster import client, cluster, common as c_common
+from wazuh.core.cluster.utils import log_subprocess_execution
 from wazuh.core.cluster.dapi import dapi
 from wazuh.core.utils import safe_move, get_utc_now
 from wazuh.core.wdb import AsyncWazuhDBConnection
@@ -509,9 +511,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                     if self.check_integrity_free and await integrity_check.request_permission():
                         logger.info("Starting.")
                         self.integrity_check_status['date_start'] = start_time
-                        self.server.integrity_control = await cluster.run_in_pool(self.loop, self.server.task_pool,
-                                                                           cluster.get_files_status,
-                                                                           self.server.integrity_control)
+                        self.server.integrity_control, logs = await cluster.run_in_pool(
+                                                                                    self.loop, self.server.task_pool,
+                                                                                    cluster.get_files_status,
+                                                                                    self.server.integrity_control)
+                        log_subprocess_execution(logger, logs)
                         await integrity_check.sync(files={}, files_metadata=self.server.integrity_control,
                                                    metadata_len=len(self.server.integrity_control),
                                                    task_pool=self.server.task_pool)
@@ -646,8 +650,9 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 # Update or remove files in this worker node according to their status (missing, extra or shared).
                 logger.debug("Worker does not meet integrity checks. Actions required.")
                 logger.debug("Updating local files: Start.")
-                await cluster.run_in_pool(self.loop, self.server.task_pool, self.update_master_files_in_worker,
-                                          ko_files, zip_path, self.cluster_items, self.task_loggers['Integrity sync'])
+                logs = await cluster.run_in_pool(self.loop, self.server.task_pool, self.update_master_files_in_worker,
+                                                 ko_files, zip_path, self.cluster_items)
+                log_subprocess_execution(self.task_loggers['Integrity sync'], logs)
                 logger.debug("Updating local files: End.")
 
             logger.info(f"Finished in {get_utc_now().timestamp() - self.integrity_sync_status['date_start']:.3f}s.")
@@ -663,7 +668,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             zip_path and shutil.rmtree(zip_path)
 
     @staticmethod
-    def update_master_files_in_worker(ko_files: Dict, zip_path: str, cluster_items: Dict, logger):
+    def update_master_files_in_worker(ko_files: Dict, zip_path: str, cluster_items: Dict):
         """Iterate over received files and updates them locally.
 
         Parameters
@@ -674,8 +679,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             Pathname of the unzipped directory received from master and containing the files to update.
         cluster_items : dict
             Object containing cluster internal variables from the cluster.json file.
-        logger : Logger object
-            Logger to use.
+
+        Returns
+        -------
+        result_logs : dict
+            Dict containing debug or any error messages emitted in the process.
         """
 
         def overwrite_or_create_files(filename_: str, data_: Dict):
@@ -719,36 +727,42 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                           )
 
         errors = {'shared': 0, 'missing': 0, 'extra': 0}
+        result_logs = {'debug': defaultdict(list), 'debug2': defaultdict(list),
+                       'error': defaultdict(list), 'generic_errors': []}
 
         for filetype, files in ko_files.items():
             # Overwrite local files marked as shared or missing.
             if filetype == 'shared' or filetype == 'missing':
-                logger.debug(f"Received {len(ko_files[filetype])} {filetype} files to update from master.")
+                result_logs['debug'][filetype].append(f"Received {len(ko_files[filetype])} {filetype} files to "
+                                                      f"update from master.")
                 for filename, data in files.items():
                     try:
-                        logger.debug2(f"Processing file {filename}")
+                        result_logs['debug2'][filename].append(f"Processing file {filename}")
                         overwrite_or_create_files(filename, data)
                     except Exception as e:
                         errors[filetype] += 1
-                        logger.error(f"Error processing {filetype} file '{filename}': {e}")
+                        result_logs['error'][filetype].append(f"Error processing {filetype} "
+                                                              f"file '{filename}': {e}")
                         continue
             # Remove local files marked as extra.
             elif filetype == 'extra':
                 for file_to_remove in files:
                     try:
-                        logger.debug2(f"Remove file: '{file_to_remove}'")
+                        result_logs['debug2'][file_to_remove].append(f"Remove file: '{file_to_remove}'")
                         file_path = os.path.join(common.WAZUH_PATH, file_to_remove)
                         try:
                             os.remove(file_path)
                         except OSError as e:
                             if e.errno == errno.ENOENT:
-                                logger.debug2(f"File {file_to_remove} doesn't exist.")
+                                result_logs['debug2'][file_to_remove].append(f"File {file_to_remove} "
+                                                                             f"doesn't exist.")
                                 continue
                             else:
                                 raise e
                     except Exception as e:
                         errors['extra'] += 1
-                        logger.debug2(f"Error removing file '{file_to_remove}': {e}")
+                        result_logs["debug2"][file_to_remove].append(f"Error removing file "
+                                                                     f"'{file_to_remove}': {e}")
                         continue
 
         # Once files are deleted, check and remove subdirectories which are now empty, as specified in cluster.json.
@@ -762,12 +776,14 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                     shutil.rmtree(full_path)
             except Exception as e:
                 errors['extra'] += 1
-                logger.debug2(f"Error removing directory '{directory}': {e}")
+                result_logs["debug2"][directory].append(f"Error removing directory '{directory}': {e}")
                 continue
 
         if sum(errors.values()) > 0:
-            logger.error(f"Found errors: {errors['shared']} overwriting, {errors['missing']} creating and "
-                         f"{errors['extra']} removing", exc_info=False)
+            result_logs['generic_errors'].append(f"Found errors: {errors['shared']} overwriting, "
+                                                 f"{errors['missing']} creating and "
+                                                 f"{errors['extra']} removing")
+        return result_logs
 
     def get_logger(self, logger_tag: str = ''):
         """Get current logger. In workers it will always return the main logger.

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -727,14 +727,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                           )
 
         errors = {'shared': 0, 'missing': 0, 'extra': 0}
-        result_logs = {'debug': defaultdict(list), 'debug2': defaultdict(list),
-                       'error': defaultdict(list), 'generic_errors': []}
+        result_logs = {'debug2': defaultdict(list), 'error': defaultdict(list), 'generic_errors': []}
 
         for filetype, files in ko_files.items():
             # Overwrite local files marked as shared or missing.
             if filetype == 'shared' or filetype == 'missing':
-                result_logs['debug'][filetype].append(f"Received {len(ko_files[filetype])} {filetype} files to "
-                                                      f"update from master.")
                 for filename, data in files.items():
                     try:
                         result_logs['debug2'][filename].append(f"Processing file {filename}")


### PR DESCRIPTION
|Related issue|
|---|
| #19800 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Closes #19800. Fixes a race condition of the `ClusterLogger` instance used to log into `cluster.log` in debug mode due to using it in multiple processes.

## Logs/Alerts example

<details><summary>cluster.log D API logs</summary>

```log
grep "D API" ../../../cluster.log 
2023/10/26 16:28:00 DEBUG: [Worker 7fc9a61a8cd5] [D API] Received request: b'master*608347 {"f": {"__callable__": {"__name__": "get_status", "__module__": "wazuh.manager", "__qualname__": "get_status", "__type__": "function"}}, "f_kwargs": {}, "request_type": "distributed_master", "wait_for_complete": false, "from_cluster": true, "is_async": false, "local_client_arg": null, "basic_services": ["wazuh-modulesd", "wazuh-analysisd", "wazuh-execd", "wazuh-db", "wazuh-remoted"], "rbac_permissions": {"agent:create": {"*:*:*": "allow"}, "group:create": {"*:*:*": "allow"}, "agent:read": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:delete": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:modify_group": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:reconnect": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:restart": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:upgrade": {"agent:id:*": "allow", "agent:group:*": "allow"}, "group:read": {"group:id:*": "allow"}, "group:delete": {"group:id:*": "allow"}, "group:update_config": {"group:id:*": "allow"}, "group:modify_assignments": {"group:id:*": "allow"}, "active-response:command": {"agent:id:*": "allow"}, "security:create": {"*:*:*": "allow"}, "security:create_user": {"*:*:*": "allow"}, "security:read_config": {"*:*:*": "allow"}, "security:update_config": {"*:*:*": "allow"}, "security:revoke": {"*:*:*": "allow"}, "security:edit_run_as": {"*:*:*": "allow"}, "security:read": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:update": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:delete": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "cluster:status": {"*:*:*": "allow"}, "manager:read": {"*:*:*": "allow"}, "manager:read_api_config": {"*:*:*": "allow"}, "manager:update_config": {"*:*:*": "allow"}, "manager:restart": {"*:*:*": "allow"}, "cluster:read_api_config": {"node:id:*": "allow"}, "cluster:read": {"node:id:*": "allow"}, "cluster:restart": {"node:id:*": "allow"}, "cluster:update_config": {"node:id:*": "allow"}, "ciscat:read": {"agent:id:*": "allow"}, "decoders:read": {"decoder:file:*": "allow"}, "decoders:delete": {"decoder:file:*": "allow"}, "decoders:update": {"*:*:*": "allow"}, "lists:read": {"list:file:*": "allow"}, "lists:delete": {"list:file:*": "allow"}, "lists:update": {"*:*:*": "allow"}, "rootcheck:clear": {"agent:id:*": "allow"}, "rootcheck:read": {"agent:id:*": "allow"}, "rootcheck:run": {"agent:id:*": "allow"}, "rules:read": {"rule:file:*": "allow"}, "rules:delete": {"rule:file:*": "allow"}, "rules:update": {"*:*:*": "allow"}, "mitre:read": {"*:*:*": "allow"}, "sca:read": {"agent:id:*": "allow"}, "syscheck:clear": {"agent:id:*": "allow"}, "syscheck:read": {"agent:id:*": "allow"}, "syscheck:run": {"agent:id:*": "allow"}, "syscollector:read": {"agent:id:*": "allow"}, "logtest:run": {"*:*:*": "allow"}, "task:status": {"*:*:*": "allow"}, "vulnerability:read": {"agent:id:*": "allow"}, "vulnerability:run": {"*:*:*": "allow"}, "event:ingest": {"*:*:*": "allow"}, "rbac_mode": "white"}, "current_user": "", "broadcasting": false, "nodes": ["wd_master_1", "7fc9a61a8cd5"], "api_timeout": 10}'
2023/10/26 16:28:00 INFO: [Worker 7fc9a61a8cd5] [D API] Receiving request: get_status from master (608347)
2023/10/26 16:28:00 DEBUG: [Worker 7fc9a61a8cd5] [D API] Receiving parameters {}
2023/10/26 16:28:00 DEBUG: [Worker 7fc9a61a8cd5] [D API] Starting to execute request locally
2023/10/26 16:28:00 DEBUG: [Worker 7fc9a61a8cd5] [D API] Finished executing request locally
2023/10/26 16:28:00 DEBUG: [Worker 7fc9a61a8cd5] [D API] Time calculating request result: 0.005s
2023/10/26 16:28:04 DEBUG: [Worker 7fc9a61a8cd5] [D API] Received request: b'master*260414 {"f": {"__callable__": {"__name__": "get_status", "__module__": "wazuh.manager", "__qualname__": "get_status", "__type__": "function"}}, "f_kwargs": {}, "request_type": "distributed_master", "wait_for_complete": false, "from_cluster": true, "is_async": false, "local_client_arg": null, "basic_services": ["wazuh-modulesd", "wazuh-analysisd", "wazuh-execd", "wazuh-db", "wazuh-remoted"], "rbac_permissions": {"agent:create": {"*:*:*": "allow"}, "group:create": {"*:*:*": "allow"}, "agent:read": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:delete": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:modify_group": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:reconnect": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:restart": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:upgrade": {"agent:id:*": "allow", "agent:group:*": "allow"}, "group:read": {"group:id:*": "allow"}, "group:delete": {"group:id:*": "allow"}, "group:update_config": {"group:id:*": "allow"}, "group:modify_assignments": {"group:id:*": "allow"}, "active-response:command": {"agent:id:*": "allow"}, "security:create": {"*:*:*": "allow"}, "security:create_user": {"*:*:*": "allow"}, "security:read_config": {"*:*:*": "allow"}, "security:update_config": {"*:*:*": "allow"}, "security:revoke": {"*:*:*": "allow"}, "security:edit_run_as": {"*:*:*": "allow"}, "security:read": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:update": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:delete": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "cluster:status": {"*:*:*": "allow"}, "manager:read": {"*:*:*": "allow"}, "manager:read_api_config": {"*:*:*": "allow"}, "manager:update_config": {"*:*:*": "allow"}, "manager:restart": {"*:*:*": "allow"}, "cluster:read_api_config": {"node:id:*": "allow"}, "cluster:read": {"node:id:*": "allow"}, "cluster:restart": {"node:id:*": "allow"}, "cluster:update_config": {"node:id:*": "allow"}, "ciscat:read": {"agent:id:*": "allow"}, "decoders:read": {"decoder:file:*": "allow"}, "decoders:delete": {"decoder:file:*": "allow"}, "decoders:update": {"*:*:*": "allow"}, "lists:read": {"list:file:*": "allow"}, "lists:delete": {"list:file:*": "allow"}, "lists:update": {"*:*:*": "allow"}, "rootcheck:clear": {"agent:id:*": "allow"}, "rootcheck:read": {"agent:id:*": "allow"}, "rootcheck:run": {"agent:id:*": "allow"}, "rules:read": {"rule:file:*": "allow"}, "rules:delete": {"rule:file:*": "allow"}, "rules:update": {"*:*:*": "allow"}, "mitre:read": {"*:*:*": "allow"}, "sca:read": {"agent:id:*": "allow"}, "syscheck:clear": {"agent:id:*": "allow"}, "syscheck:read": {"agent:id:*": "allow"}, "syscheck:run": {"agent:id:*": "allow"}, "syscollector:read": {"agent:id:*": "allow"}, "logtest:run": {"*:*:*": "allow"}, "task:status": {"*:*:*": "allow"}, "vulnerability:read": {"agent:id:*": "allow"}, "vulnerability:run": {"*:*:*": "allow"}, "event:ingest": {"*:*:*": "allow"}, "rbac_mode": "white"}, "current_user": "", "broadcasting": false, "nodes": ["wd_master_1", "7fc9a61a8cd5"], "api_timeout": 10}'
2023/10/26 16:28:04 INFO: [Worker 7fc9a61a8cd5] [D API] Receiving request: get_status from master (260414)
2023/10/26 16:28:04 DEBUG: [Worker 7fc9a61a8cd5] [D API] Receiving parameters {}
2023/10/26 16:28:04 DEBUG: [Worker 7fc9a61a8cd5] [D API] Starting to execute request locally
2023/10/26 16:28:04 DEBUG: [Worker 7fc9a61a8cd5] [D API] Finished executing request locally
2023/10/26 16:28:04 DEBUG: [Worker 7fc9a61a8cd5] [D API] Time calculating request result: 0.006s
2023/10/26 16:28:06 DEBUG: [Worker 7fc9a61a8cd5] [D API] Received request: b'master*1025796 {"f": {"__callable__": {"__name__": "get_status", "__module__": "wazuh.manager", "__qualname__": "get_status", "__type__": "function"}}, "f_kwargs": {}, "request_type": "distributed_master", "wait_for_complete": false, "from_cluster": true, "is_async": false, "local_client_arg": null, "basic_services": ["wazuh-modulesd", "wazuh-analysisd", "wazuh-execd", "wazuh-db", "wazuh-remoted"], "rbac_permissions": {"agent:create": {"*:*:*": "allow"}, "group:create": {"*:*:*": "allow"}, "agent:read": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:delete": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:modify_group": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:reconnect": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:restart": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:upgrade": {"agent:id:*": "allow", "agent:group:*": "allow"}, "group:read": {"group:id:*": "allow"}, "group:delete": {"group:id:*": "allow"}, "group:update_config": {"group:id:*": "allow"}, "group:modify_assignments": {"group:id:*": "allow"}, "active-response:command": {"agent:id:*": "allow"}, "security:create": {"*:*:*": "allow"}, "security:create_user": {"*:*:*": "allow"}, "security:read_config": {"*:*:*": "allow"}, "security:update_config": {"*:*:*": "allow"}, "security:revoke": {"*:*:*": "allow"}, "security:edit_run_as": {"*:*:*": "allow"}, "security:read": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:update": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:delete": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "cluster:status": {"*:*:*": "allow"}, "manager:read": {"*:*:*": "allow"}, "manager:read_api_config": {"*:*:*": "allow"}, "manager:update_config": {"*:*:*": "allow"}, "manager:restart": {"*:*:*": "allow"}, "cluster:read_api_config": {"node:id:*": "allow"}, "cluster:read": {"node:id:*": "allow"}, "cluster:restart": {"node:id:*": "allow"}, "cluster:update_config": {"node:id:*": "allow"}, "ciscat:read": {"agent:id:*": "allow"}, "decoders:read": {"decoder:file:*": "allow"}, "decoders:delete": {"decoder:file:*": "allow"}, "decoders:update": {"*:*:*": "allow"}, "lists:read": {"list:file:*": "allow"}, "lists:delete": {"list:file:*": "allow"}, "lists:update": {"*:*:*": "allow"}, "rootcheck:clear": {"agent:id:*": "allow"}, "rootcheck:read": {"agent:id:*": "allow"}, "rootcheck:run": {"agent:id:*": "allow"}, "rules:read": {"rule:file:*": "allow"}, "rules:delete": {"rule:file:*": "allow"}, "rules:update": {"*:*:*": "allow"}, "mitre:read": {"*:*:*": "allow"}, "sca:read": {"agent:id:*": "allow"}, "syscheck:clear": {"agent:id:*": "allow"}, "syscheck:read": {"agent:id:*": "allow"}, "syscheck:run": {"agent:id:*": "allow"}, "syscollector:read": {"agent:id:*": "allow"}, "logtest:run": {"*:*:*": "allow"}, "task:status": {"*:*:*": "allow"}, "vulnerability:read": {"agent:id:*": "allow"}, "vulnerability:run": {"*:*:*": "allow"}, "event:ingest": {"*:*:*": "allow"}, "rbac_mode": "white"}, "current_user": "", "broadcasting": false, "nodes": ["wd_master_1", "7fc9a61a8cd5"], "api_timeout": 10}'
2023/10/26 16:28:06 INFO: [Worker 7fc9a61a8cd5] [D API] Receiving request: get_status from master (1025796)
2023/10/26 16:28:06 DEBUG: [Worker 7fc9a61a8cd5] [D API] Receiving parameters {}
2023/10/26 16:28:06 DEBUG: [Worker 7fc9a61a8cd5] [D API] Starting to execute request locally
2023/10/26 16:28:06 DEBUG: [Worker 7fc9a61a8cd5] [D API] Finished executing request locally
2023/10/26 16:28:06 DEBUG: [Worker 7fc9a61a8cd5] [D API] Time calculating request result: 0.006s
2023/10/26 16:28:09 DEBUG: [Worker 7fc9a61a8cd5] [D API] Received request: b'master*933438 {"f": {"__callable__": {"__name__": "get_status", "__module__": "wazuh.manager", "__qualname__": "get_status", "__type__": "function"}}, "f_kwargs": {}, "request_type": "distributed_master", "wait_for_complete": false, "from_cluster": true, "is_async": false, "local_client_arg": null, "basic_services": ["wazuh-modulesd", "wazuh-analysisd", "wazuh-execd", "wazuh-db", "wazuh-remoted"], "rbac_permissions": {"agent:create": {"*:*:*": "allow"}, "group:create": {"*:*:*": "allow"}, "agent:read": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:delete": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:modify_group": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:reconnect": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:restart": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:upgrade": {"agent:id:*": "allow", "agent:group:*": "allow"}, "group:read": {"group:id:*": "allow"}, "group:delete": {"group:id:*": "allow"}, "group:update_config": {"group:id:*": "allow"}, "group:modify_assignments": {"group:id:*": "allow"}, "active-response:command": {"agent:id:*": "allow"}, "security:create": {"*:*:*": "allow"}, "security:create_user": {"*:*:*": "allow"}, "security:read_config": {"*:*:*": "allow"}, "security:update_config": {"*:*:*": "allow"}, "security:revoke": {"*:*:*": "allow"}, "security:edit_run_as": {"*:*:*": "allow"}, "security:read": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:update": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:delete": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "cluster:status": {"*:*:*": "allow"}, "manager:read": {"*:*:*": "allow"}, "manager:read_api_config": {"*:*:*": "allow"}, "manager:update_config": {"*:*:*": "allow"}, "manager:restart": {"*:*:*": "allow"}, "cluster:read_api_config": {"node:id:*": "allow"}, "cluster:read": {"node:id:*": "allow"}, "cluster:restart": {"node:id:*": "allow"}, "cluster:update_config": {"node:id:*": "allow"}, "ciscat:read": {"agent:id:*": "allow"}, "decoders:read": {"decoder:file:*": "allow"}, "decoders:delete": {"decoder:file:*": "allow"}, "decoders:update": {"*:*:*": "allow"}, "lists:read": {"list:file:*": "allow"}, "lists:delete": {"list:file:*": "allow"}, "lists:update": {"*:*:*": "allow"}, "rootcheck:clear": {"agent:id:*": "allow"}, "rootcheck:read": {"agent:id:*": "allow"}, "rootcheck:run": {"agent:id:*": "allow"}, "rules:read": {"rule:file:*": "allow"}, "rules:delete": {"rule:file:*": "allow"}, "rules:update": {"*:*:*": "allow"}, "mitre:read": {"*:*:*": "allow"}, "sca:read": {"agent:id:*": "allow"}, "syscheck:clear": {"agent:id:*": "allow"}, "syscheck:read": {"agent:id:*": "allow"}, "syscheck:run": {"agent:id:*": "allow"}, "syscollector:read": {"agent:id:*": "allow"}, "logtest:run": {"*:*:*": "allow"}, "task:status": {"*:*:*": "allow"}, "vulnerability:read": {"agent:id:*": "allow"}, "vulnerability:run": {"*:*:*": "allow"}, "event:ingest": {"*:*:*": "allow"}, "rbac_mode": "white"}, "current_user": "", "broadcasting": false, "nodes": ["wd_master_1", "7fc9a61a8cd5"], "api_timeout": 10}'
2023/10/26 16:28:09 INFO: [Worker 7fc9a61a8cd5] [D API] Receiving request: get_status from master (933438)
2023/10/26 16:28:09 DEBUG: [Worker 7fc9a61a8cd5] [D API] Receiving parameters {}
2023/10/26 16:28:09 DEBUG: [Worker 7fc9a61a8cd5] [D API] Starting to execute request locally
2023/10/26 16:28:09 DEBUG: [Worker 7fc9a61a8cd5] [D API] Finished executing request locally
2023/10/26 16:28:09 DEBUG: [Worker 7fc9a61a8cd5] [D API] Time calculating request result: 0.008s
2023/10/26 16:28:12 DEBUG: [Worker 7fc9a61a8cd5] [D API] Received request: b'master*77305 {"f": {"__callable__": {"__name__": "get_status", "__module__": "wazuh.manager", "__qualname__": "get_status", "__type__": "function"}}, "f_kwargs": {}, "request_type": "distributed_master", "wait_for_complete": false, "from_cluster": true, "is_async": false, "local_client_arg": null, "basic_services": ["wazuh-modulesd", "wazuh-analysisd", "wazuh-execd", "wazuh-db", "wazuh-remoted"], "rbac_permissions": {"agent:create": {"*:*:*": "allow"}, "group:create": {"*:*:*": "allow"}, "agent:read": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:delete": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:modify_group": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:reconnect": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:restart": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:upgrade": {"agent:id:*": "allow", "agent:group:*": "allow"}, "group:read": {"group:id:*": "allow"}, "group:delete": {"group:id:*": "allow"}, "group:update_config": {"group:id:*": "allow"}, "group:modify_assignments": {"group:id:*": "allow"}, "active-response:command": {"agent:id:*": "allow"}, "security:create": {"*:*:*": "allow"}, "security:create_user": {"*:*:*": "allow"}, "security:read_config": {"*:*:*": "allow"}, "security:update_config": {"*:*:*": "allow"}, "security:revoke": {"*:*:*": "allow"}, "security:edit_run_as": {"*:*:*": "allow"}, "security:read": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:update": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:delete": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "cluster:status": {"*:*:*": "allow"}, "manager:read": {"*:*:*": "allow"}, "manager:read_api_config": {"*:*:*": "allow"}, "manager:update_config": {"*:*:*": "allow"}, "manager:restart": {"*:*:*": "allow"}, "cluster:read_api_config": {"node:id:*": "allow"}, "cluster:read": {"node:id:*": "allow"}, "cluster:restart": {"node:id:*": "allow"}, "cluster:update_config": {"node:id:*": "allow"}, "ciscat:read": {"agent:id:*": "allow"}, "decoders:read": {"decoder:file:*": "allow"}, "decoders:delete": {"decoder:file:*": "allow"}, "decoders:update": {"*:*:*": "allow"}, "lists:read": {"list:file:*": "allow"}, "lists:delete": {"list:file:*": "allow"}, "lists:update": {"*:*:*": "allow"}, "rootcheck:clear": {"agent:id:*": "allow"}, "rootcheck:read": {"agent:id:*": "allow"}, "rootcheck:run": {"agent:id:*": "allow"}, "rules:read": {"rule:file:*": "allow"}, "rules:delete": {"rule:file:*": "allow"}, "rules:update": {"*:*:*": "allow"}, "mitre:read": {"*:*:*": "allow"}, "sca:read": {"agent:id:*": "allow"}, "syscheck:clear": {"agent:id:*": "allow"}, "syscheck:read": {"agent:id:*": "allow"}, "syscheck:run": {"agent:id:*": "allow"}, "syscollector:read": {"agent:id:*": "allow"}, "logtest:run": {"*:*:*": "allow"}, "task:status": {"*:*:*": "allow"}, "vulnerability:read": {"agent:id:*": "allow"}, "vulnerability:run": {"*:*:*": "allow"}, "event:ingest": {"*:*:*": "allow"}, "rbac_mode": "white"}, "current_user": "", "broadcasting": false, "nodes": ["wd_master_1", "7fc9a61a8cd5"], "api_timeout": 10}'
2023/10/26 16:28:12 INFO: [Worker 7fc9a61a8cd5] [D API] Receiving request: get_status from master (77305)
2023/10/26 16:28:12 DEBUG: [Worker 7fc9a61a8cd5] [D API] Receiving parameters {}
2023/10/26 16:28:12 DEBUG: [Worker 7fc9a61a8cd5] [D API] Starting to execute request locally
2023/10/26 16:28:12 DEBUG: [Worker 7fc9a61a8cd5] [D API] Finished executing request locally
2023/10/26 16:28:12 DEBUG: [Worker 7fc9a61a8cd5] [D API] Time calculating request result: 0.009s
```

</details>


## Tests

<details><summary>Framework UTs</summary>

```console

pytest framework/ --disable-warnings 
====================================================================== test session starts ======================================================================
platform linux -- Python 3.9.18, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh/framework
plugins: cov-3.0.0, aiohttp-1.0.4, trio-0.7.0, anyio-3.6.2, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 2200 items                                                                                                                                            

framework/scripts/tests/test_agent_groups.py ..............                                                                                               [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                             [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                    [  1%]
framework/scripts/tests/test_rbac_control.py .........                                                                                                    [  2%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                    [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                      [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                     [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                        [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                    [  7%]
framework/wazuh/core/cluster/tests/test_common.py ....................................................................................                    [ 10%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                 [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............                                                                                    [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                          [ 12%]
framework/wazuh/core/cluster/tests/test_master.py ...............................................                                                         [ 15%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                           [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ............                                                                                             [ 16%]
framework/wazuh/core/cluster/tests/test_worker.py ..................................                                                                      [ 18%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                         [ 19%]
framework/wazuh/core/tests/test_agent.py ................................................................................................................ [ 24%]
.....................................                                                                                                                     [ 25%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                        [ 27%]
framework/wazuh/core/tests/test_common.py .........                                                                                                       [ 28%]
framework/wazuh/core/tests/test_configuration.py .......................................................................                                  [ 31%]
framework/wazuh/core/tests/test_database.py .............                                                                                                 [ 31%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                               [ 32%]
framework/wazuh/core/tests/test_exception.py ..........                                                                                                   [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                    [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                             [ 33%]
framework/wazuh/core/tests/test_manager.py ................                                                                                               [ 33%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                    [ 34%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                   [ 34%]
framework/wazuh/core/tests/test_results.py ........................................                                                                       [ 36%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                [ 37%]
framework/wazuh/core/tests/test_rule.py .......................                                                                                           [ 38%]
framework/wazuh/core/tests/test_sca.py .............................                                                                                      [ 39%]
framework/wazuh/core/tests/test_security.py .............                                                                                                 [ 40%]
framework/wazuh/core/tests/test_stats.py .................                                                                                                [ 40%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                       [ 41%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                       [ 41%]
framework/wazuh/core/tests/test_task.py ........                                                                                                          [ 41%]
framework/wazuh/core/tests/test_utils.py ................................................................................................................ [ 46%]
......................................................................................................................................................... [ 53%]
.........                                                                                                                                                 [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                       [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py .......................                                                                                    [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                      [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                    [ 57%]
framework/wazuh/core/tests/test_wlogging.py ............                                                                                                  [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                        [ 58%]
framework/wazuh/rbac/tests/test_decorators.py ........................................................................................................... [ 63%]
..                                                                                                                                                        [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py .........................................................                                        [ 65%]
framework/wazuh/rbac/tests/test_orm.py ...................................................................                                                [ 68%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                               [ 69%]
framework/wazuh/tests/test_active_response.py ............                                                                                                [ 69%]
framework/wazuh/tests/test_agent.py ..................................................................................................................... [ 75%]
.....                                                                                                                                                     [ 75%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                              [ 77%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                    [ 79%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                          [ 79%]
framework/wazuh/tests/test_decoder.py ..........................................................                                                          [ 82%]
framework/wazuh/tests/test_event.py ....                                                                                                                  [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                               [ 82%]
framework/wazuh/tests/test_logtest.py ......                                                                                                              [ 83%]
framework/wazuh/tests/test_manager.py ....................................                                                                                [ 84%]
framework/wazuh/tests/test_mitre.py .......                                                                                                               [ 85%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                [ 87%]
framework/wazuh/tests/test_rule.py ..........................................................................                                             [ 90%]
framework/wazuh/tests/test_sca.py ...........                                                                                                             [ 91%]
framework/wazuh/tests/test_security.py .......................................................................                                            [ 94%]
framework/wazuh/tests/test_stats.py ...............                                                                                                       [ 95%]
framework/wazuh/tests/test_syscheck.py .........................                                                                                          [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                   [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                           [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................................                                                                      [100%]

========================================================= 2200 passed, 50 warnings in 248.87s (0:04:08) =========================================================

```

</details>

<details><summary>test_cluster_endpoints</summary>

```console
pytest test_cluster_endpoints.tavern.yaml
================================================================= test session starts =================================================================
platform linux -- Python 3.8.10, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 49 items                                                                                                                                    

test_cluster_endpoints.tavern.yaml .................................................                                                            [100%]

===================================================== 49 passed, 2 warnings in 826.39s (0:13:46) ======================================================
```

</details>
