### PR TITLE
RockDB Create folders recursively

### DIFF
--- a/src/shared_modules/utils/rocksDBQueue.hpp
+++ b/src/shared_modules/utils/rocksDBQueue.hpp
@@ -13,6 +13,7 @@
 #define _ROCKSDB_QUEUE_HPP
 
 #include "rocksdb/db.h"
+#include <filesystem>
 #include <functional>
 #include <iostream>
 #include <stdexcept>
@@ -28,6 +29,9 @@ public:
         // RocksDB initialization.
         rocksdb::Options options;
         rocksdb::DB* db;
+
+        // Create directories recursively if they do not exist
+        std::filesystem::create_directories(std::filesystem::path(connectorName));
 
         options.create_if_missing = true;
         rocksdb::Status status = rocksdb::DB::Open(options, connectorName, &db);

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -13,8 +13,9 @@
 #define _ROCKS_DB_WRAPPER_HPP
 
 #include "rocksDBIterator.hpp"
-#include <iostream>
 #include <rocksdb/db.h>
+#include <filesystem>
+#include <iostream>
 #include <string>
 
 namespace Utils
@@ -31,6 +32,10 @@ namespace Utils
             rocksdb::Options options;
             options.create_if_missing = true;
             rocksdb::DB* dbRawPtr;
+
+            // Create directories recursively if they do not exist
+            std::filesystem::create_directories(std::filesystem::path(dbPath));
+
             const auto status {rocksdb::DB::Open(options, dbPath, &dbRawPtr)};
             if (!status.ok())
             {

--- a/src/shared_modules/utils/tests/rocksDBSafeQueue_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBSafeQueue_test.cpp
@@ -146,3 +146,14 @@ TEST_F(RocksDBSafeQueueTest, CancelBlockingPop)
     t2.join();
 }
 
+TEST_F(RocksDBSafeQueueTest, CreateFolderRecursively)
+{
+    const std::string DATABASE_NAME {"folder1/folder2/test.db"};
+
+    EXPECT_NO_THROW({
+            (std::make_unique<Utils::SafeQueue<std::string, RocksDBQueue<std::string>>>(RocksDBQueue<std::string>(DATABASE_NAME)));
+        });
+
+    std::error_code ec;
+    std::filesystem::remove_all(DATABASE_NAME, ec);
+}

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
@@ -327,7 +327,7 @@ TEST_F(RocksDBWrapperTest, TestRangeForLoopWithBinaryBuffers)
  */
 TEST_F(RocksDBWrapperTest, TestCreateFolderRecursively)
 {
-    static const std::string DATABASE_NAME {"folder1/folder2/test.db"};
+    const std::string DATABASE_NAME {"folder1/folder2/test.db"};
 
     std::optional<Utils::RocksDBWrapper> db_wrapper;
 

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
@@ -320,3 +320,21 @@ TEST_F(RocksDBWrapperTest, TestRangeForLoopWithBinaryBuffers)
 
     EXPECT_EQ(counter, NUM_ELEMENTS);
 }
+
+/**
+ * @brief Tests create folders and directories recursively based
+ * on the provided path argument when initializing RocksDB instances
+ */
+TEST_F(RocksDBWrapperTest, TestCreateFolderRecursively)
+{
+    static const std::string DATABASE_NAME {"folder1/folder2/test.db"};
+
+    std::optional<Utils::RocksDBWrapper> db_wrapper;
+
+    EXPECT_NO_THROW({
+        db_wrapper = Utils::RocksDBWrapper(DATABASE_NAME);
+    });
+
+    db_wrapper->deleteAll();
+    std::filesystem::remove_all(DATABASE_NAME);
+}


### PR DESCRIPTION
|Related issue|
|---|
|#19886|

## Description

Improve the functionality of RocksDB by adding the capability to create folders and directories recursively based on the provided path argument when initializing RocksDB instances. Now, if the specified path contains nested directories that do not exist, RocksDB create them.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Added unit tests (for new features)
