### PR TITLE
Content Manager - Add `CtiApiDownloader` and `ApiDownloader` documentation

### DIFF
--- a/src/shared_modules/content_manager/doc/components/API_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/API_DOWNLOADER.md
@@ -16,7 +16,7 @@ The context fields related to this stage are:
 
 - `configData`
   + `url`: Used as the API URL to download from.
-  + `compressionType`: Used to know whether the input file is compressed or not.
+  + `compressionType`: Used to determine whether the input file is compressed or not.
   + `contentfileName`: Used as name for the output content file.
 - `downloadsFolder`: Used as output folder when the input file is compressed.
 - `contentsFolder`: Used as output folder when the input file is not compressed.

--- a/src/shared_modules/content_manager/doc/components/API_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/API_DOWNLOADER.md
@@ -1,0 +1,24 @@
+# API Downloader stage
+
+## Details
+
+The [API downloader](../../src/components/APIDownloader.hpp) stage is part of the Content Manager orchestration and is in charge of downloading content from an API to be then processed by the following stages. The downloaded content is stored in an output file, whose path will be then published for the consumers to read.
+
+The output content file can be stored into any of the two following output directories:
+- Downloads folder: If the input file is compressed.
+- Contents folder: If the input file is not compressed.
+
+If the download is successful, this stage also updates the context [data paths](../../src/components/updaterContext.hpp) with the download destination path.
+
+## Relation with the UpdaterContext
+
+The context fields related to this stage are:
+
+- `configData`
+  + `url`: Used as the API URL to download from.
+  + `compressionType`: Used to know whether the input file is compressed or not.
+  + `contentfileName`: Used as name for the output content file.
+- `downloadsFolder`: Used as output folder when the input file is compressed.
+- `contentsFolder`: Used as output folder when the input file is not compressed.
+- `data`: Used to read and update the paths under the `paths` key. The stage status is also updated on this member.
+- `outputFolder`: Used as the destination file path base.

--- a/src/shared_modules/content_manager/doc/components/CTI_API_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/CTI_API_DOWNLOADER.md
@@ -1,0 +1,46 @@
+# CTI API Downloader stage
+
+## Details
+
+The [CTI API downloader](../../src/components/CtiApiDownloader.hpp) stage is part of the Content Manager orchestration and is in charge of downloading content from a CTI API to be then processed by the following stages. The downloaded content is stored in one or multiple output files, whose paths will be then published for the consumers to read.
+
+The output content files can be stored into any of the two following output directories:
+- Downloads folder: If the input files are compressed.
+- Contents folder: If the input files are not compressed.
+
+The download process can be summarized as follows:
+1. Get the last CTI API consumer offset. This is done by performing an HTTP GET query to CTI. This value will be used as the last possible offset to query.
+2. Set the range of offsets to be downloaded, starting from `currentOffset` (set in the context) and with a range-width of `1000`. So, for example, if the current offset is equal to `N`, the range will be from offset `N` to offset `N + 1000`. 
+3. Download the offsets range from **step 2** and update `currentOffset` with the last downloaded offset.
+4. Dump the downloaded offsets into an output file. This file path will be generated as `<output-folder>/<currentOffset>-<contentFileName>`.
+5. Push the new file path (from **step 4**) to the context [data paths](../../src/components/updaterContext.hpp).
+6. If the last possible offset (from **step 1**) has been downloaded, the process finishes. Otherwise, the process continues with the **step 2**.
+
+### Download process example
+
+Given the following conditions:
+- Last possible offset: `3200`.
+- Initial current offset: `0` (first execution ever). 
+- Content compressed: No.
+- Output folder: `/tmp/`.
+- Content filename: `data.json`.
+
+The output files will be:
+- `/tmp/contents/1000-data.json` (data from offsets 0 to 1000)
+- `/tmp/contents/2000-data.json` (data from offsets 1000 to 2000)
+- `/tmp/contents/3000-data.json` (data from offsets 2000 to 3000)
+- `/tmp/contents/3200-data.json` (data from offsets 3000 to 3200)
+
+## Relation with the UpdaterContext
+
+The context fields related to this stage are:
+
+- `configData`
+  + `url`: Used as the CTI API URL to download from.
+  + `compressionType`: Used to know whether the input file is compressed or not.
+  + `contentfileName`: Used as name for the output content file.
+- `downloadsFolder`: Used as output folder when the input file is compressed.
+- `contentsFolder`: Used as output folder when the input file is not compressed.
+- `data`: Used to read and update the paths under the `paths` key. The stage status is also updated on this member.
+- `outputFolder`: Used as the destination file path base.
+- `currentOffset`: Used as the first offset that will be fetched from the API. It is also updated with the last offset fetched, so next time the download begins with the new (and more advanced) offset value.

--- a/src/shared_modules/content_manager/doc/components/CTI_API_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/CTI_API_DOWNLOADER.md
@@ -4,7 +4,7 @@
 
 The [CTI API downloader](../../src/components/CtiApiDownloader.hpp) stage is part of the Content Manager orchestration and is in charge of downloading content from a CTI API to be then processed by the following stages. The downloaded content is stored in one or multiple output files, whose paths will be then published for the consumers to read.
 
-The output content files can be stored into any of the two following output directories:
+The output content files will be stored in any of the following output directories:
 - Downloads folder: If the input files are compressed.
 - Contents folder: If the input files are not compressed.
 
@@ -37,10 +37,10 @@ The context fields related to this stage are:
 
 - `configData`
   + `url`: Used as the CTI API URL to download from.
-  + `compressionType`: Used to know whether the input file is compressed or not.
+  + `compressionType`: Used to determine whether the input file is compressed or not.
   + `contentfileName`: Used as name for the output content file.
 - `downloadsFolder`: Used as output folder when the input file is compressed.
 - `contentsFolder`: Used as output folder when the input file is not compressed.
 - `data`: Used to read and update the paths under the `paths` key. The stage status is also updated on this member.
 - `outputFolder`: Used as the destination file path base.
-- `currentOffset`: Used as the first offset that will be fetched from the API. It is also updated with the last offset fetched, so next time the download begins with the new (and more advanced) offset value.
+- `currentOffset`: Used as the first offset that will be fetched from the API. It is also updated with the last offset fetched, so next time the download begins with the new offset value.

--- a/src/shared_modules/content_manager/doc/components/EXECUTION_CONTEXT.md
+++ b/src/shared_modules/content_manager/doc/components/EXECUTION_CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-The `execution context` stage is part of the Content Manager orchestration initialization and is in charge of preparing the execution environment before any orchestration is started. This stage implementation can be seen in the [ExecutionContext](../../src/components/executionContext.hpp) class.
+The [execution context](../../src/components/executionContext.hpp) stage is part of the Content Manager orchestration initialization and is in charge of preparing the execution environment before any orchestration is started. This stage implementation can be seen in the [ExecutionContext](../../src/components/executionContext.hpp) class.
 
 The tasks that this stage performs are:
 - **Set up context**: Configure some of the fields present on the Updater Context.

--- a/src/shared_modules/content_manager/doc/components/GZIP_DECOMPRESSOR.md
+++ b/src/shared_modules/content_manager/doc/components/GZIP_DECOMPRESSOR.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-The `gzip decompressor` stage is part of the Content Manager orchestration and is in charge of decompressing the `.gz` files fetched in the download stage. If the decompression is successful, this stage also updates the context [data paths](../../src/components/updaterContext.hpp).
+The [gzip decompressor](../../src/components/gzipDecompressor.hpp) stage is part of the Content Manager orchestration and is in charge of decompressing the `.gz` files fetched in the download stage. If the decompression is successful, this stage also updates the context [data paths](../../src/components/updaterContext.hpp).
 
 ### Paths update example
 

--- a/src/shared_modules/content_manager/include/contentManager.hpp
+++ b/src/shared_modules/content_manager/include/contentManager.hpp
@@ -37,8 +37,10 @@ public:
     /**
      * @brief Starts module facade.
      *
+     * @param logFunction Log function.
+     *
      */
-    void start(const std::function<void(const modules_log_level_t, const std::string&)>& /*logFunction*/);
+    void start(const std::function<void(const modules_log_level_t, const std::string&)>& logFunction);
 
     /**
      * @brief Stop module facade.


### PR DESCRIPTION
|Related issue|
|---|
|#19865 |

## Description

This PR adds two new files that document the way the `CtiApiDownloader` and `ApiDownloader` classes work.
