### PR TITLE
Deletes repeated get_component_stats controller.

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -866,42 +866,6 @@ async def get_daemon_stats(request, agent_id: str, pretty: bool = False, wait_fo
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_component_stats(request, pretty=False, wait_for_complete=False, agent_id=None, component=None):
-    """Get a specified agent's component stats.
-
-    Parameters
-    ----------
-    request : connexion.request
-    agent_id : str
-        ID of the agent from which the statistics are obtained.
-    pretty : bool
-        Show results in human-readable format.
-    wait_for_complete : bool
-        Disable timeout response.
-    daemons_list : list
-        List of the daemons to get statistical information from.
-
-    Returns
-    -------
-    web.Response
-        API response.
-    """
-    daemons_list = daemons_list or []
-    f_kwargs = {'agent_list': [agent_id],
-                'daemons_list': daemons_list}
-
-    dapi = DistributedAPI(f=stats.get_daemons_stats_agents,
-                          f_kwargs=remove_nones_to_dict(f_kwargs),
-                          request_type='distributed_master',
-                          is_async=False,
-                          wait_for_complete=wait_for_complete,
-                          logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies'])
-    data = raise_if_exc(await dapi.distribute_function())
-
-    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
-
-
 async def get_component_stats(request, pretty: bool = False, wait_for_complete: bool = False, agent_id: str = None,
                               component: str = None) -> web.Response:
     """Get a specified agent's component stats.


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18594|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Deletes the repeated `get_componenet_status` function used as a controller.