### PR TITLE
Reduce some vacuum settings values to make it more usable

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -386,21 +386,21 @@ wazuh_db.rlimit_nofile=458752
 
 # Indicates the max fragmentation allowed.
 # [0..100]
-wazuh_db.max_fragmentation=95
+wazuh_db.max_fragmentation=90
 
 # Indicates the allowed fragmentation threshold.
 # [0..100]
-wazuh_db.fragmentation_threshold=80
+wazuh_db.fragmentation_threshold=75
 
 # Indicates the allowed fragmentation difference between the last time the vacuum was performed and the current measurement.
 # [0..100]
 wazuh_db.fragmentation_delta=5
 
 # Indicates the minimum percentage of free pages present in a database that can trigger a vacuum. [0..99]
-wazuh_db.free_pages_percentage=5
+wazuh_db.free_pages_percentage=0
 
 # Interval for database fragmentation check, in seconds [1..30758400]
-wazuh_db.check_fragmentation_interval=43200
+wazuh_db.check_fragmentation_interval=7200
 
 # Wazuh Command Module - If it should accept remote commands from the manager
 wazuh_command.remote_commands=0

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -2124,7 +2124,7 @@ void test_wdb_check_fragmentation_get_fragmentation_after_vacuum_error(void **st
 
     will_return(__wrap_time_diff, 2);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2250,7 +2250,7 @@ void test_wdb_check_fragmentation_update_last_vacuum_data_error(void **state)
 
     will_return(__wrap_time_diff, 2);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2372,7 +2372,7 @@ void test_wdb_check_fragmentation_success_with_warning(void **state)
 
     will_return(__wrap_time_diff, 2);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2500,7 +2500,7 @@ void test_wdb_check_fragmentation_success(void **state)
 
     will_return(__wrap_time_diff, 2);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2888,7 +2888,7 @@ void test_wdb_check_fragmentation_vacuum_first(void **state)
 
     will_return(__wrap_time_diff, 2);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -3042,7 +3042,7 @@ void test_wdb_check_fragmentation_vacuum_current_fragmentation_delta(void **stat
 
     will_return(__wrap_time_diff, 2);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Vacuum executed on the '000' database. Time: 2000.000 ms.");
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1158,7 +1158,7 @@ void wdb_check_fragmentation() {
                         continue;
                     }
                     gettime(&ts_end);
-                    mdebug2("Vacuum executed on the '%s' database. Time: %.3f ms.", node->id, time_diff(&ts_start, &ts_end) * 1e3);
+                    mdebug1("Vacuum executed on the '%s' database. Time: %.3f ms.", node->id, time_diff(&ts_start, &ts_end) * 1e3);
 
                     // save fragmentation after vacuum
                     if (fragmentation_after_vacuum = wdb_get_db_state(node), fragmentation_after_vacuum == OS_INVALID) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/17928|

## Description

This PR modifies the default vacuum settings to the following values:

```
wazuh_db.max_fragmentation=90
wazuh_db.fragmentation_threshold=75
wazuh_db.fragmentation_delta=5
wazuh_db.free_pages_percentage=0
wazuh_db.check_fragmentation_interval=7200
```

This is necessary to avoid blocks in high load environments, which execute lots of queries in `wazuh-db` that start to lose performance because DB fragmentation.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade