### PR TITLE
Content Manager - Drop RocksDB initialization responsibility

### DIFF
--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -45,7 +45,7 @@ private:
     {
         const auto& databasePath {context.configData.at("databasePath").get_ref<const std::string&>()};
 
-        // Initialize RocksDB driver instance. If the database doesn't exists, this will throw.
+        // Initialize RocksDB driver instance.
         context.spRocksDB = std::make_unique<Utils::RocksDBWrapper>(databasePath, false);
     }
 
@@ -100,7 +100,7 @@ public:
      */
     std::shared_ptr<UpdaterBaseContext> handleRequest(std::shared_ptr<UpdaterBaseContext> context) override
     {
-        // Open database if the database folder was given.
+        // Open database if the database folder is given.
         if (context->configData.contains("databasePath") &&
             !context->configData.at("databasePath").get_ref<const std::string&>().empty())
         {

--- a/src/shared_modules/content_manager/tests/unit/executionContext_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/executionContext_test.cpp
@@ -12,6 +12,7 @@
 #include "executionContext_test.hpp"
 #include "executionContext.hpp"
 #include "updaterContext.hpp"
+#include "utils/rocksDBWrapper.hpp"
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -112,129 +113,26 @@ TEST_F(ExecutionContextTest, TestValidCaseWhenTheOutputFolderPathIsNotEmptyAndEx
 }
 
 /**
- * @brief Test the correct instantiation of the RocksDB database.
+ * @brief Test the opening of the RocksDB database when it is not initialized.
  *
  */
-TEST_F(ExecutionContextTest, DatabaseGeneration)
+TEST_F(ExecutionContextTest, NotCreatedDatabaseOpening)
 {
-    constexpr auto OFFSET {0};
-
     m_spUpdaterBaseContext->configData["databasePath"] = m_databasePath.string();
-    m_spUpdaterBaseContext->configData["offset"] = OFFSET;
-
-    EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
-    EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString(), std::to_string(OFFSET));
-}
-
-/**
- * @brief Test the correct instantiation of the RocksDB database. A negative offset is set in the config.
- *
- */
-TEST_F(ExecutionContextTest, DatabaseGenerationNegativeOffset)
-{
-    constexpr auto OFFSET {-1};
-
-    m_spUpdaterBaseContext->configData["databasePath"] = m_databasePath.string();
-    m_spUpdaterBaseContext->configData["offset"] = OFFSET;
 
     EXPECT_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext), std::runtime_error);
-    EXPECT_TRUE(std::filesystem::exists(m_databasePath));
 }
 
 /**
- * @brief Test the correct instantiation of the RocksDB database. A positive offset is set in the config.
+ * @brief Test the opening of the RocksDB database when it is already initialized.
  *
  */
-TEST_F(ExecutionContextTest, DatabaseGenerationPositiveOffset)
+TEST_F(ExecutionContextTest, CreatedDatabaseOpening)
 {
-    constexpr auto OFFSET {100};
+    // Create database.
+    Utils::RocksDBWrapper(m_databasePath.string());
 
     m_spUpdaterBaseContext->configData["databasePath"] = m_databasePath.string();
-    m_spUpdaterBaseContext->configData["offset"] = OFFSET;
 
     EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
-    EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString(), std::to_string(OFFSET));
-}
-
-/**
- * @brief Test the correct instantiation of the RocksDB database in two sequential executions. The second execution has
- * a config offset that is less than the config offset from first execution. The first offset should remain after both
- * executions.
- *
- */
-TEST_F(ExecutionContextTest, DatabaseGenerationConfigOffsetLessThanDatabaseOffset)
-{
-    constexpr auto FIRST_OFFSET {100};
-    constexpr auto SECOND_OFFSET {50};
-
-    // First execution.
-    m_spUpdaterBaseContext->configData["databasePath"] = m_databasePath.string();
-    m_spUpdaterBaseContext->configData["offset"] = FIRST_OFFSET;
-    EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
-    EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString(), std::to_string(FIRST_OFFSET));
-
-    // Call RocksDBWrapper destructor.
-    m_spUpdaterBaseContext->spRocksDB.reset();
-
-    // Second execution.
-    m_spUpdaterBaseContext->configData["offset"] = SECOND_OFFSET;
-    EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
-    EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString(), std::to_string(FIRST_OFFSET));
-}
-
-/**
- * @brief Test the correct instantiation of the RocksDB database in two sequential executions. The second execution has
- * a config offset that is greater than the config offset from first execution. The second offset should remain after
- * both executions.
- *
- */
-TEST_F(ExecutionContextTest, DatabaseGenerationConfigOffsetGreaterThanDatabaseOffset)
-{
-    constexpr auto FIRST_OFFSET {100};
-    constexpr auto SECOND_OFFSET {500};
-
-    // First execution.
-    m_spUpdaterBaseContext->configData["databasePath"] = m_databasePath.string();
-    m_spUpdaterBaseContext->configData["offset"] = FIRST_OFFSET;
-    EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
-    EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString(), std::to_string(FIRST_OFFSET));
-
-    // Call RocksDBWrapper destructor.
-    m_spUpdaterBaseContext->spRocksDB.reset();
-
-    // Second execution.
-    m_spUpdaterBaseContext->configData["offset"] = SECOND_OFFSET;
-    EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
-    EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString(), std::to_string(SECOND_OFFSET));
-}
-
-/**
- * @brief Test the correct instantiation of the RocksDB database in two sequential executions. Both executions have
- * the same config offset.
- *
- */
-TEST_F(ExecutionContextTest, DatabaseGenerationConfigOffsetEqualToDatabaseOffset)
-{
-    constexpr auto OFFSET {100};
-
-    // First execution.
-    m_spUpdaterBaseContext->configData["databasePath"] = m_databasePath.string();
-    m_spUpdaterBaseContext->configData["offset"] = OFFSET;
-    EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
-    EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString(), std::to_string(OFFSET));
-
-    // Call RocksDBWrapper destructor.
-    m_spUpdaterBaseContext->spRocksDB.reset();
-
-    // Second execution.
-    EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
-    EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString(), std::to_string(OFFSET));
 }

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -13,9 +13,9 @@
 #define _ROCKS_DB_WRAPPER_HPP
 
 #include "rocksDBIterator.hpp"
-#include <rocksdb/db.h>
 #include <filesystem>
 #include <iostream>
+#include <rocksdb/db.h>
 #include <string>
 
 namespace Utils
@@ -27,10 +27,17 @@ namespace Utils
     class RocksDBWrapper
     {
     public:
-        explicit RocksDBWrapper(const std::string& dbPath)
+        /**
+         * @brief Reads and, if specified, initializes a RocksDB database.
+         *
+         * @param dbPath Path where the database should be stored.
+         * @param createIfMissing If true, the database will be initialized if it's not already. If false, an exception
+         * will be raised if the database doesn't exist.
+         */
+        explicit RocksDBWrapper(const std::string& dbPath, const bool& createIfMissing = true)
         {
             rocksdb::Options options;
-            options.create_if_missing = true;
+            options.create_if_missing = createIfMissing;
             rocksdb::DB* dbRawPtr;
 
             // Create directories recursively if they do not exist
@@ -39,7 +46,7 @@ namespace Utils
             const auto status {rocksdb::DB::Open(options, dbPath, &dbRawPtr)};
             if (!status.ok())
             {
-                throw std::runtime_error("Failed to open RocksDB database");
+                throw std::runtime_error {"Failed to open RocksDB database: " + status.ToString()};
             }
             // Assigns the raw pointer to the unique_ptr. When db goes out of scope, it will automatically delete the
             // allocated RocksDB instance.

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
@@ -10,6 +10,10 @@
  */
 
 #include "rocksDBWrapper_test.hpp"
+#include "rocksDBWrapper.hpp"
+#include "gtest/gtest.h"
+#include <filesystem>
+#include <stdexcept>
 
 /**
  * @brief Tests the put function
@@ -331,10 +335,19 @@ TEST_F(RocksDBWrapperTest, TestCreateFolderRecursively)
 
     std::optional<Utils::RocksDBWrapper> db_wrapper;
 
-    EXPECT_NO_THROW({
-        db_wrapper = Utils::RocksDBWrapper(DATABASE_NAME);
-    });
+    EXPECT_NO_THROW({ db_wrapper = Utils::RocksDBWrapper(DATABASE_NAME); });
 
     db_wrapper->deleteAll();
     std::filesystem::remove_all(DATABASE_NAME);
+}
+
+/**
+ * @brief Tests the opening of a database that doesn't exist. An exception is expected given that the 'createIfMissing'
+ * parameter is 'false'.
+ *
+ */
+TEST_F(RocksDBWrapperTest, OpenInexistantDatabase)
+{
+    const auto DATABASE_NAME {"OpenInexistantDatabase"};
+    EXPECT_THROW(Utils::RocksDBWrapper rocksDbConnector(DATABASE_NAME, false), std::runtime_error);
 }


### PR DESCRIPTION
|Related issue|
|---|
| #19947 |

## Description

This PR drops the responsibility of initializing the RocksDB database in the Content Manager module. With these changes, the module assumes that the database has already been created. If the database doesn't exist, the execution of the tool will end up in error.

Change log:
- Modified `ExecutionContext` class in order to not create the database if it doesn't exist.
- Added `ExecutionContext` tests.
- Modified Content Manager test tool to allow the creation of the database before executing the Content Manager module.
- Modified `RocksDBWrapper` so that the wrapper accepts a `createIfMissing` parameter.
- Added `RocksDBWrapper` tests.
- Update `ActionTest` tests.

## Results

### Test tool

- Execution with `"createDatabase": false`
```bash
# ./content_manager_test_tool 
ActionOrchestrator - Starting process
terminate called after throwing an instance of 'std::invalid_argument'
  what():  Orchestration creation failed. Failed to open RocksDB database: Invalid argument: /tmp/content_manager_database/CURRENT: does not exist (create_if_missing is false)
Aborted (core dumped)
```

- Execution with `"createDatabase": true`
```bash
# ./content_manager_test_tool 
ActionOrchestrator - Starting process
Output folders created.
FactoryContentUpdater - Starting process
Creating 'api' downloader
Creating 'raw' content decompressor
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
changing interval
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
APIDownloader - Starting
APIDownloader - Finishing - Download done successfully
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.
```

- Execution with `"createDatabase": true`, `"initialOffset": "970000"`, and `"contentSource": "cti-api"`:
```bash
# ./content_manager_test_tool 
ActionOrchestrator - Starting process
Output folders created.
FactoryContentUpdater - Starting process
Creating 'cti-api' downloader
Creating 'raw' content decompressor
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
changing interval
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
CtiApiDownloader - Starting
CtiApiDownloader - Request processed successfully.
CtiApiDownloader - Request processed successfully.
CtiApiDownloader - Request processed successfully.
CtiApiDownloader - Request processed successfully.
CtiApiDownloader - Request processed successfully.
CtiApiDownloader - Request processed successfully.
CtiApiDownloader - Request processed successfully.
CtiApiDownloader - Request processed successfully.
CtiApiDownloader - Request processed successfully.
CtiApiDownloader - Request processed successfully.
CtiApiDownloader - Finishing
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.

# ls /tmp/testProvider/contents/
971000-example.json  972000-example.json  973000-example.json  974000-example.json  975000-example.json  976000-example.json  977000-example.json  978000-example.json  978572-example.json
```