### PR TITLE
Content Manager - Add `S3Downloader` unit tests

### DIFF
--- a/src/shared_modules/content_manager/tests/unit/S3Downloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/S3Downloader_test.cpp
@@ -14,6 +14,8 @@
 #include "fakes/fakeServer.hpp"
 #include "json.hpp"
 #include "updaterContext.hpp"
+#include "gtest/gtest.h"
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 

--- a/src/shared_modules/content_manager/tests/unit/S3Downloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/S3Downloader_test.cpp
@@ -41,6 +41,7 @@ void S3DownloaderTest::SetUp()
     m_spUpdaterContext->spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
     m_spUpdaterContext->spUpdaterBaseContext->downloadsFolder = (m_outputFolder / "downloads").string();
     m_spUpdaterContext->spUpdaterBaseContext->contentsFolder = (m_outputFolder / "contents").string();
+    m_spUpdaterContext->spUpdaterBaseContext->configData["url"] = "localhost:4444/";
 
     std::filesystem::create_directory(m_outputFolder);
     std::filesystem::create_directory(m_spUpdaterContext->spUpdaterBaseContext->downloadsFolder);
@@ -74,10 +75,9 @@ TEST_F(S3DownloaderTest, DownloadBadURL)
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(FAIL_STATUS);
 
-    // Set invalid config data.
-    m_spUpdaterContext->spUpdaterBaseContext->configData["url"] = "localhost:999999";
+    // Set invalid config data. This will make the downloader to download from 'localhost:4444/invalid_file'.
     m_spUpdaterContext->spUpdaterBaseContext->configData["compressionType"] = "raw";
-    m_spUpdaterContext->spUpdaterBaseContext->configData["s3FileName"] = "filename";
+    m_spUpdaterContext->spUpdaterBaseContext->configData["s3FileName"] = "invalid_file";
 
     // Run downloader.
     ASSERT_THROW(S3Downloader().handleRequest(m_spUpdaterContext), std::runtime_error);
@@ -102,7 +102,6 @@ TEST_F(S3DownloaderTest, DownloadRawFile)
     expectedData["stageStatus"].push_back(OK_STATUS);
 
     // Set config data. This will make the downloader to download from 'localhost:4444/raw'.
-    m_spUpdaterContext->spUpdaterBaseContext->configData["url"] = "localhost:4444/";
     m_spUpdaterContext->spUpdaterBaseContext->configData["compressionType"] = "raw";
     m_spUpdaterContext->spUpdaterBaseContext->configData["s3FileName"] = "raw";
 
@@ -132,7 +131,6 @@ TEST_F(S3DownloaderTest, DownloadCompressedFile)
     expectedData["stageStatus"].push_back(OK_STATUS);
 
     // Set config data. This will make the downloader to download from 'localhost:4444/xz'.
-    m_spUpdaterContext->spUpdaterBaseContext->configData["url"] = "localhost:4444/";
     m_spUpdaterContext->spUpdaterBaseContext->configData["compressionType"] = "xz";
     m_spUpdaterContext->spUpdaterBaseContext->configData["s3FileName"] = "xz";
 

--- a/src/shared_modules/content_manager/tests/unit/S3Downloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/S3Downloader_test.cpp
@@ -11,13 +11,135 @@
 
 #include "S3Downloader_test.hpp"
 #include "S3Downloader.hpp"
+#include "fakes/fakeServer.hpp"
+#include "json.hpp"
 #include "updaterContext.hpp"
+#include <memory>
+#include <stdexcept>
 
-/*
- * @brief Tests the instantiation of the S3Downloader class
- */
-TEST_F(S3DownloaderTest, instantiation)
+const auto OK_STATUS = R"({"stage":"S3Downloader","status":"ok"})"_json;
+const auto FAIL_STATUS = R"({"stage":"S3Downloader","status":"fail"})"_json;
+
+void S3DownloaderTest::SetUpTestSuite()
 {
-    // Check that the S3Downloader class can be instantiated
+    if (!m_spFakeServer)
+    {
+        m_spFakeServer = std::make_unique<FakeServer>("localhost", 4444);
+    }
+}
+
+void S3DownloaderTest::TearDownTestSuite()
+{
+    m_spFakeServer.reset();
+}
+
+void S3DownloaderTest::SetUp()
+{
+    m_spUpdaterContext = std::make_shared<UpdaterContext>();
+    m_spUpdaterContext->spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+    m_spUpdaterContext->spUpdaterBaseContext->downloadsFolder = (m_outputFolder / "downloads").string();
+    m_spUpdaterContext->spUpdaterBaseContext->contentsFolder = (m_outputFolder / "contents").string();
+
+    std::filesystem::create_directory(m_outputFolder);
+    std::filesystem::create_directory(m_spUpdaterContext->spUpdaterBaseContext->downloadsFolder);
+    std::filesystem::create_directory(m_spUpdaterContext->spUpdaterBaseContext->contentsFolder);
+}
+
+void S3DownloaderTest::TearDown()
+{
+    std::filesystem::remove_all(m_outputFolder);
+}
+
+/**
+ * @brief Tests the instantiation of the class.
+ *
+ */
+TEST_F(S3DownloaderTest, Instantiation)
+{
     EXPECT_NO_THROW(std::make_shared<S3Downloader>());
+    EXPECT_NO_THROW(S3Downloader());
+}
+
+/**
+ * @brief Tests the downloader with an invalid URL.
+ *
+ */
+TEST_F(S3DownloaderTest, DownloadBadURL)
+{
+    // Set up expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = nlohmann::json::array();
+    expectedData["stageStatus"].push_back(FAIL_STATUS);
+
+    // Set invalid config data.
+    m_spUpdaterContext->spUpdaterBaseContext->configData["url"] = "localhost:999999";
+    m_spUpdaterContext->spUpdaterBaseContext->configData["compressionType"] = "raw";
+    m_spUpdaterContext->spUpdaterBaseContext->configData["s3FileName"] = "filename";
+
+    // Run downloader.
+    ASSERT_THROW(S3Downloader().handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    // Check expected data.
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}
+
+/**
+ * @brief Tests the download of a raw file.
+ *
+ */
+TEST_F(S3DownloaderTest, DownloadRawFile)
+{
+    // Given that the file is not compressed, the download should be made into de 'contentsFolder'.
+    const auto expectedFilepath {m_spUpdaterContext->spUpdaterBaseContext->contentsFolder / "raw"};
+
+    // Set up expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"].push_back(expectedFilepath.string());
+    expectedData["stageStatus"] = nlohmann::json::array();
+    expectedData["stageStatus"].push_back(OK_STATUS);
+
+    // Set config data. This will make the downloader to download from 'localhost:4444/raw'.
+    m_spUpdaterContext->spUpdaterBaseContext->configData["url"] = "localhost:4444/";
+    m_spUpdaterContext->spUpdaterBaseContext->configData["compressionType"] = "raw";
+    m_spUpdaterContext->spUpdaterBaseContext->configData["s3FileName"] = "raw";
+
+    // Run downloader.
+    ASSERT_NO_THROW(S3Downloader().handleRequest(m_spUpdaterContext));
+
+    // Check expected data.
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+
+    // Check downloaded file exists.
+    EXPECT_TRUE(std::filesystem::exists(expectedFilepath));
+}
+
+/**
+ * @brief Tests the download of a compressed file.
+ *
+ */
+TEST_F(S3DownloaderTest, DownloadCompressedFile)
+{
+    // Given that the file is compressed, the download should be made into de 'downloadsFolder'.
+    const auto expectedFilepath {m_spUpdaterContext->spUpdaterBaseContext->downloadsFolder / "xz"};
+
+    // Set up expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"].push_back(expectedFilepath.string());
+    expectedData["stageStatus"] = nlohmann::json::array();
+    expectedData["stageStatus"].push_back(OK_STATUS);
+
+    // Set config data. This will make the downloader to download from 'localhost:4444/xz'.
+    m_spUpdaterContext->spUpdaterBaseContext->configData["url"] = "localhost:4444/";
+    m_spUpdaterContext->spUpdaterBaseContext->configData["compressionType"] = "xz";
+    m_spUpdaterContext->spUpdaterBaseContext->configData["s3FileName"] = "xz";
+
+    // Run downloader.
+    ASSERT_NO_THROW(S3Downloader().handleRequest(m_spUpdaterContext));
+
+    // Check expected data.
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+
+    // Check downloaded file exists.
+    EXPECT_TRUE(std::filesystem::exists(expectedFilepath));
 }

--- a/src/shared_modules/content_manager/tests/unit/S3Downloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/S3Downloader_test.hpp
@@ -12,16 +12,50 @@
 #ifndef _S3_DOWNLOADER_TEST_HPP
 #define _S3_DOWNLOADER_TEST_HPP
 
+#include "fakes/fakeServer.hpp"
+#include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <filesystem>
+#include <memory>
 
 /**
  * @brief Runs unit tests for S3Downloader
+ *
  */
 class S3DownloaderTest : public ::testing::Test
 {
 protected:
     S3DownloaderTest() = default;
     ~S3DownloaderTest() override = default;
+
+    std::shared_ptr<UpdaterContext> m_spUpdaterContext; ///< Context used in tests.
+    const std::filesystem::path m_outputFolder {std::filesystem::temp_directory_path() /
+                                                "s3DownloaderTest"}; ///< Output folder for tests.
+    inline static std::unique_ptr<FakeServer> m_spFakeServer;        ///< Fake HTTP server used in tests.
+
+    /**
+     * @brief Setup routine for the test suite.
+     *
+     */
+    static void SetUpTestSuite();
+
+    /**
+     * @brief Teardown routine for the test suite.
+     *
+     */
+    static void TearDownTestSuite();
+
+    /**
+     * @brief Setup routine for each test fixture.
+     *
+     */
+    void SetUp() override;
+
+    /**
+     * @brief Teardown routine for each test fixture.
+     *
+     */
+    void TearDown() override;
 };
 
 #endif //_S3_DOWNLOADER_TEST_HPP


### PR DESCRIPTION
|Related issue|
|---|
| #19963 |

## Description

This PR adds unit tests that were missing for the `S3Downloader` class.

Change list:
- Add new tests for `S3Downloader` class, making use of a pre-existing fake HTTP server.

## Results

100% of test coverage:

![image](https://github.com/wazuh/wazuh/assets/42682247/9ba9537e-7f43-480a-8bab-071338eb3cc6)
