### PR TITLE
Changes in the xml parser are reverted

### DIFF
--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -324,13 +324,8 @@ static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_
                     _xml_ungetc(c, _lxml);
                 }
                 location = 0;
-                /* _R_CONFE is scaped in cases when the tag is <tagname />
-                Space and line ending characters are escaped for linux, windows and mac */
-            } else if (c == _R_CONFE || isspace(c) || c == '\n' || c == '\r') {
-                continue;
             } else {
-                xml_error(_lxml, "XMLERR: Syntax error: '%c'", c);
-                goto end;
+                continue;
             }
         }
 

--- a/src/unit_tests/os_xml/test_os_xml.c
+++ b/src/unit_tests/os_xml/test_os_xml.c
@@ -224,14 +224,6 @@ void test_simple_nodes5(void **state) {
     assert_int_equal(OS_ReadXML(data->xml_file_name, &data->xml), OS_INVALID);
 }
 
-void test_simple_nodes6(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-    char *parse_str = "{\"body\": {\"<ossec_config></ossec_config>\"}}";
-
-    create_xml_file(parse_str, data->xml_file_name, 256);
-    assert_int_equal(OS_ReadXML(data->xml_file_name, &data->xml), OS_INVALID);
-}
-
 void test_multiple_nodes(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *parse_str = "<root1></root1>""<root2></root2>""<root3/>";
@@ -1080,7 +1072,6 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_simple_nodes3, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_simple_nodes4, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_simple_nodes5, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_simple_nodes6, test_setup, test_teardown),
 
         // Multiple XML nodes test
         cmocka_unit_test_setup_teardown(test_multiple_nodes, test_setup, test_teardown),


### PR DESCRIPTION
|Related issue|Previous PR
|---|---|
|#19742 [#381](https://github.com/wazuh/internal-devel-requests/issues/381) [#382](https://github.com/wazuh/internal-devel-requests/issues/382)|https://github.com/wazuh/wazuh/pull/16681|


## Description
Controls added to the xml parser are reverted to allow eventchannel event processing.

## Logs/Alerts example
The following example records are to be processed by the parser.
`<Data Name="CurrentDirectory">C:\Windows\syste\System32\</Data>`

## Test
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)