### PR TITLE
Fix compilation error in ubuntu 20.04

### DIFF
--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -192,7 +192,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, ubuntu-22.04, ubuntu-20.04 ]
+        os: [ ubuntu-latest, ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -189,7 +189,11 @@ jobs:
 
   vulnerability-scanner-modules-asan:
     needs: style-and-documentation
-    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, ubuntu-22.04, ubuntu-20.04 ]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repository

--- a/src/shared_modules/content_manager/CMakeLists.txt
+++ b/src/shared_modules/content_manager/CMakeLists.txt
@@ -4,6 +4,9 @@ project(content_manager)
 
 enable_testing()
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if (NOT SRC_FOLDER)
     get_filename_component(SRC_FOLDER     ${CMAKE_SOURCE_DIR}/../../ ABSOLUTE)
 endif()

--- a/src/shared_modules/content_manager/tests/component/CMakeLists.txt
+++ b/src/shared_modules/content_manager/tests/component/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(${PROJECT_NAME}
     urlrequest
     router
     rocksdb
+    pthread
 )
 
 target_link_libraries(${PROJECT_NAME} content_manager)

--- a/src/shared_modules/content_manager/tests/unit/CMakeLists.txt
+++ b/src/shared_modules/content_manager/tests/unit/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(${PROJECT_NAME}
     wazuhext
     lzma
     rocksdb
+    pthread
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/src/shared_modules/content_manager/testtool/CMakeLists.txt
+++ b/src/shared_modules/content_manager/testtool/CMakeLists.txt
@@ -10,4 +10,6 @@ file(GLOB CONTENT_MANAGER_TEST_TOOL_SRC "*.cpp")
 
 add_executable(content_manager_test_tool ${CONTENT_MANAGER_TEST_TOOL_SRC})
 
-target_link_libraries(content_manager_test_tool content_manager)
+target_link_libraries(content_manager_test_tool
+        content_manager
+        pthread)

--- a/src/shared_modules/indexer_connector/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/CMakeLists.txt
@@ -4,6 +4,9 @@ project(indexer_connector)
 
 enable_testing()
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_definitions(-DPROMISE_TYPE=PromiseType::NORMAL)
 
 if (NOT SRC_FOLDER)

--- a/src/shared_modules/indexer_connector/tests/unit/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/tests/unit/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(${PROJECT_NAME}
         gtest
         gtest_main
         indexer_connector
+        pthread
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/src/shared_modules/router/CMakeLists.txt
+++ b/src/shared_modules/router/CMakeLists.txt
@@ -4,6 +4,9 @@ project(router)
 
 enable_testing()
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_definitions(-DPROMISE_TYPE=PromiseType::NORMAL)
 
 if (NOT SRC_FOLDER)

--- a/src/shared_modules/router/tests/component/CMakeLists.txt
+++ b/src/shared_modules/router/tests/component/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(${PROJECT_NAME}
         gtest
         gtest_main
         router
+        pthread
         )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/src/shared_modules/router/tests/unit/CMakeLists.txt
+++ b/src/shared_modules/router/tests/unit/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(${PROJECT_NAME}
         gtest
         gtest_main
         router
+        pthread
         )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
@@ -4,6 +4,9 @@ project(vulnerability_scanner)
 
 enable_testing()
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_definitions(-DPROMISE_TYPE=PromiseType::NORMAL)
 
 if (NOT SRC_FOLDER)

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/CMakeLists.txt
@@ -16,3 +16,6 @@ include_directories("../include")
 add_library(database_feed STATIC
     ${DATABASE_FEED_SRC}
     )
+
+target_link_libraries(database_feed
+        pthread)

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(database_feed_manager_unit_test
     optimized gmock_main
     rocksdb
     flatbuffers
+    pthread
 )
 
 add_test(NAME database_feed_manager_unit_test

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(policy_manager_unit_test
     debug gtestd
     optimized gtest
     router
-        pthread
+    pthread
 )
 
 add_test(NAME policy_manager_unit_test

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(policy_manager_unit_test
     debug gtestd
     optimized gtest
     router
+        pthread
 )
 
 add_test(NAME policy_manager_unit_test


### PR DESCRIPTION
|Related issue|
|---|
|#19964|

## Description

Fix compilation error in Ubuntu 20.04 related to pthread

It was tested on a new virtual machine with Ubuntu 20.04

C++17 was explicitly added in several CMakeLists.txt

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation