### PR TITLE
Fix error in indexer connector unit tests

### DIFF
--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -215,14 +215,14 @@ jobs:
       - name: Indexer connector
         uses: ./.github/actions/compile_and_test
         with:
-          path: src/shared_modules/content_manager
+          path: src/shared_modules/indexer_connector
           asan: "true"
 
       # content manager
       - name: Content manager
         uses: ./.github/actions/compile_and_test
         with:
-          path: src/shared_modules/indexer_connector
+          path: src/shared_modules/content_manager
           asan: "true"
 
       # Vulnerability scanner

--- a/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
@@ -39,7 +39,7 @@ public:
      * @param port port of the fake OpenSearch server
      * @param health health status of the fake OpenSearch server.
      */
-    FakeOpenSearchServer(std::string host, int port, std::string health = "green")
+    FakeOpenSearchServer(std::string host, int port, std::string health)
         : m_thread(&FakeOpenSearchServer::run, this)
         , m_host(std::move(host))
         , m_health(std::move(health))

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.hpp
@@ -53,13 +53,16 @@ protected:
     // cppcheck-suppress unusedFunction
     static void SetUpTestSuite()
     {
+        const std::string host {"localhost"};
+
         if (!m_fakeOpenSearchGreenServer)
         {
-            m_fakeOpenSearchGreenServer = std::make_unique<FakeOpenSearchServer>("localhost", 9201);
+            m_fakeOpenSearchGreenServer = std::make_unique<FakeOpenSearchServer>(host, 9201, "green");
         }
+
         if (!m_fakeOpenSearchRedServer)
         {
-            m_fakeOpenSearchRedServer = std::make_unique<FakeOpenSearchServer>("localhost", 9202, "red");
+            m_fakeOpenSearchRedServer = std::make_unique<FakeOpenSearchServer>(host, 9202, "red");
         }
     }
 

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.hpp
@@ -52,13 +52,16 @@ protected:
     // cppcheck-suppress unusedFunction
     static void SetUpTestSuite()
     {
+        const std::string host {"localhost"};
+
         if (!m_fakeOpenSearchGreenServer)
         {
-            m_fakeOpenSearchGreenServer = std::make_unique<FakeOpenSearchServer>("localhost", 9201);
+            m_fakeOpenSearchGreenServer = std::make_unique<FakeOpenSearchServer>(host, 9201, "green");
         }
+
         if (!m_fakeOpenSearchRedServer)
         {
-            m_fakeOpenSearchRedServer = std::make_unique<FakeOpenSearchServer>("localhost", 9202, "red");
+            m_fakeOpenSearchRedServer = std::make_unique<FakeOpenSearchServer>(host, 9202, "red");
         }
     }
 


### PR DESCRIPTION
|Related issue|
|---|
| #19971 |

## Description
This PR fixes an error present on the ASAN execution of the [indexer_connector](https://github.com/wazuh/wazuh/tree/dev-14153-vulndet-refactor/src/shared_modules/indexer_connector) unit tests.

The error points to this line:
https://github.com/wazuh/wazuh/blob/2a917bc55957d704c0806017fcbe43759cba8264/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp#L84


The conclusion, based upon the back-trace provided by ASAN, was that the string literal provided on the constructor goes out of scope at some point, and the memory region that allocates it becomes forbidden:
https://github.com/wazuh/wazuh/blob/2a917bc55957d704c0806017fcbe43759cba8264/src/shared_modules/indexer_connector/tests/unit/monitoring_test.hpp#L58


## Test

In order to validate the changes, a workflow execution was triggered:
- [Workflow execution](https://github.com/wazuh/wazuh/actions/runs/6719384340)
- [Changes](https://github.com/wazuh/wazuh/commit/47cbfe7d7831a5c4246442ec0a5ec7d27137edfd)