### PR TITLE
Complete /manager/version/check endpoint tests

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -163,6 +163,40 @@ variables:
         <email_notification>no</email_notification>
         <agents_disconnection_time>20s</agents_disconnection_time>
         <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
+        <update_check>yes</update_check>
+      </global>
+
+      <logging>
+        <log_format>plain</log_format>
+      </logging>
+
+      <alerts>
+        <log_alert_level>300</log_alert_level>
+        <email_alert_level>12</email_alert_level>
+      </alerts>
+
+      <remote>
+        <connection>secure</connection>
+        <port>1514</port>
+        <protocol>tcp</protocol>
+      </remote>
+
+      <syscheck>
+        <disabled>yes</disabled>
+      </syscheck>
+    </ossec_config>
+
+  valid_ossec_conf_with_update_check_disabled:
+    <ossec_config>
+      <global>
+        <jsonout_output>yes</jsonout_output>
+        <alerts_log>yes</alerts_log>
+        <logall>no</logall>
+        <logall_json>no</logall_json>
+        <email_notification>no</email_notification>
+        <agents_disconnection_time>20s</agents_disconnection_time>
+        <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
+        <update_check>no</update_check>
       </global>
 
       <logging>
@@ -200,4 +234,38 @@ variables:
       </alerts>
 
       <remote>
+    </ossec_config>
+
+  ossec_conf_with_invalid_cti_url:
+    <ossec_config>
+      <global>
+        <jsonout_output>yes</jsonout_output>
+        <alerts_log>yes</alerts_log>
+        <logall>no</logall>
+        <logall_json>no</logall_json>
+        <email_notification>no</email_notification>
+        <agents_disconnection_time>20s</agents_disconnection_time>
+        <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
+        <update_check>yes</update_check>
+        <cti-url>http://localhost:4041</cti-url>
+      </global>
+
+      <logging>
+        <log_format>plain</log_format>
+      </logging>
+
+      <alerts>
+        <log_alert_level>300</log_alert_level>
+        <email_alert_level>12</email_alert_level>
+      </alerts>
+
+      <remote>
+        <connection>secure</connection>
+        <port>1514</port>
+        <protocol>tcp</protocol>
+      </remote>
+
+      <syscheck>
+        <disabled>yes</disabled>
+      </syscheck>
     </ossec_config>

--- a/api/test/integration/env/configurations/manager/manager/configuration_files/ossec-update-check.conf
+++ b/api/test/integration/env/configurations/manager/manager/configuration_files/ossec-update-check.conf
@@ -1,0 +1,5 @@
+<root>
+    <global>
+        <cti-url>https://cti.wazuh.com</cti-url>
+     </global>
+</root>

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -508,3 +508,27 @@ def healthcheck_agent_restart(response, agents_list):
     time.sleep(20)
     # Wait for active agent status (up to 25 seconds)
     check_agent_active_status(agents_list)
+
+
+def validate_update_check_response(response):
+    """Check if the last_available_* dicts have the correct keys and values.
+
+    Parameters
+    ----------
+    response : Request response
+    """
+    available_update_keys = ["last_available_major", "last_available_minor", "last_available_patch"]
+    keys_to_check = [
+        ("tag", str), ("description", (str, type(None))), ("title", str), ("published_date", str), ("semver", dict)
+    ]
+
+    data = response.json()['data']
+
+    for available_update in available_update_keys:
+        available_update_data = data[available_update]
+
+        assert isinstance(available_update_data, dict)
+
+        if available_update_data != {}:
+            for key, value_type in keys_to_check:
+                assert isinstance(available_update_data[key], value_type)

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -61,7 +61,7 @@ stages:
               max_agents: !anystr
               openssl_support: !anystr
               path: !anystr
-              type: !anystr
+              type: !anything
               tz_name: !anystr
               tz_offset: !anystr
               version: !anystr
@@ -1567,6 +1567,18 @@ marks:
   - xfail
 
 stages:
+  - name: Get wazuh version
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      save:
+        json:
+          wazuh_version: data.api_version
 
   - name: Get available updates
     request:
@@ -1581,35 +1593,10 @@ stages:
         error: 0
         data:
           last_check_date: !anystr
-          current_version: v4.8.0
+          current_version: "v{wazuh_version:s}"
           update_check: true
-          last_available_major:
-            tag: v5.0.0
-            description: ""
-            title: Wazuh 5.0.0
-            published_date: '2023-10-05T12:48:00Z'
-            semver:
-              major: 5
-              minor: 0
-              patch: 0
-          last_available_minor:
-            tag: v4.9.1
-            description: ""
-            title: Wazuh 4.9.1
-            published_date: '2023-10-05T12:47:00Z'
-            semver:
-              major: 4
-              minor: 9
-              patch: 1
-          last_available_patch:
-            tag: v4.8.2
-            description: ""
-            title: Wazuh 4.8.2
-            published_date: '2023-10-05T12:46:00Z'
-            semver:
-              major: 4
-              minor: 8
-              patch: 2
+      verify_response_with:
+        - function: tavern_utils:validate_update_check_response
 
   - name: Get available updates with force option
     request:
@@ -1626,35 +1613,11 @@ stages:
         error: 0
         data:
           last_check_date: !anystr
-          current_version: v4.8.0
+          current_version: "v{wazuh_version:s}"
           update_check: true
-          last_available_major:
-            tag: v5.0.0
-            description: ""
-            title: Wazuh 5.0.0
-            published_date: '2023-10-05T12:48:00Z'
-            semver:
-              major: 5
-              minor: 0
-              patch: 0
-          last_available_minor:
-            tag: v4.9.1
-            description: ""
-            title: Wazuh 4.9.1
-            published_date: '2023-10-05T12:47:00Z'
-            semver:
-              major: 4
-              minor: 9
-              patch: 1
-          last_available_patch:
-            tag: v4.8.2
-            description: ""
-            title: Wazuh 4.8.2
-            published_date: '2023-10-05T12:46:00Z'
-            semver:
-              major: 4
-              minor: 8
-              patch: 2
+      verify_response_with:
+        - function: tavern_utils:validate_update_check_response
+
 
 ---
 test_name: GET /manager/version/check with update_check disabled
@@ -1664,6 +1627,58 @@ marks:
 
 stages:
 
+  - name: Get wazuh version
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      save:
+        json:
+          wazuh_version: data.api_version
+
+  - name: Disable the update check
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: PUT
+      data: "{valid_ossec_conf_with_update_check_disabled:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - 'manager'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+        error: 0
+
+  - name: Restart manager to apply the configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - !anystr
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+    delay_after: 20
+
   - name: Get available updates
     request:
       verify: false
@@ -1676,12 +1691,11 @@ stages:
       json:
         error: 0
         data:
-          last_check_date: !anystr
-          current_version: v4.8.0
+          last_check_date: ''
+          current_version: "v{wazuh_version:s}"
           update_check: false
-          last_available_major: {}
-          last_available_minor: {}
-          last_available_patch: {}
+      verify_response_with:
+        - function: tavern_utils:validate_update_check_response
 
   - name: Get available updates with force option
     request:
@@ -1697,17 +1711,94 @@ stages:
       json:
         error: 0
         data:
-          last_check_date: !anystr
-          current_version: v4.8.0
+          last_check_date: ''
+          current_version: "v{wazuh_version:s}"
           update_check: false
-          last_available_major: {}
-          last_available_minor: {}
-          last_available_patch: {}
+      verify_response_with:
+        - function: tavern_utils:validate_update_check_response
+
+  - name: Enable the update check
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: PUT
+      data: "{valid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - 'manager'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+        error: 0
+
+  - name: Restart manager to apply the configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - !anystr
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+    delay_after: 20
 
 ---
 test_name: GET /manager/version/check with update check service error
 
 stages:
+
+  - name: Set an invalid CTI url
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: PUT
+      data: "{ossec_conf_with_invalid_cti_url:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - 'manager'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+        error: 0
+
+  - name: Restart manager to apply the configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - !anystr
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+    delay_after: 20
 
   - name: Get available updates
     request:

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -61,7 +61,7 @@ stages:
               max_agents: !anystr
               openssl_support: !anystr
               path: !anystr
-              type: !anything
+              type: !anystr
               tz_name: !anystr
               tz_offset: !anystr
               version: !anystr
@@ -1595,6 +1595,7 @@ stages:
           last_check_date: !anystr
           current_version: "v{wazuh_version:s}"
           update_check: true
+          uuid: !anystr
       verify_response_with:
         - function: tavern_utils:validate_update_check_response
 
@@ -1615,6 +1616,7 @@ stages:
           last_check_date: !anystr
           current_version: "v{wazuh_version:s}"
           update_check: true
+          uuid: !anystr
       verify_response_with:
         - function: tavern_utils:validate_update_check_response
 

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1674,7 +1674,7 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: 20
+    delay_after: 50
 
   - name: Get available updates
     request:
@@ -1751,7 +1751,7 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: 20
+    delay_after: 50
 
 ---
 test_name: GET /manager/version/check with update check service error
@@ -1795,7 +1795,7 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: 20
+    delay_after: 50
 
   - name: Get available updates
     request:

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1622,9 +1622,6 @@ stages:
 ---
 test_name: GET /manager/version/check with update_check disabled
 
-marks:
-  - xfail
-
 stages:
 
   - name: Get wazuh version

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -333,6 +333,8 @@ async def query_update_check_service(installation_uid: str) -> dict:
         last_check_date=get_utc_now()
     )
 
+    update_information['uuid'] = installation_uid
+
     async with aiohttp.ClientSession(connector=_get_connector()) as session:
         try:
             async with session.get(RELEASE_UPDATES_URL, headers=headers) as response:

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -282,7 +282,7 @@ def _get_connector() -> aiohttp.TCPConnector:
 
 def get_update_information_template(
         update_check: bool,
-        current_version: str = wazuh.__version__,
+        current_version: str = f"v{wazuh.__version__}",
         last_check_date: Optional[datetime] = None
 ) -> dict:
     """Build and return a template for the update_information dict.

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -327,6 +327,7 @@ async def test_query_update_check_service_returns_correct_data_when_status_200(
     client_session_get_mock.assert_called()
 
     assert update_information['status_code'] == status
+    assert update_information['uuid'] == installation_uid
 
     if len(major):
         assert (

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -247,7 +247,7 @@ def test_get_update_information_template(last_check_date, update_check):
     assert 'update_check' in template
     assert template['update_check'] == update_check
     assert 'current_version' in template
-    assert template['current_version'] == wazuh.__version__
+    assert template['current_version'] == f"v{wazuh.__version__}"
     assert 'last_available_major' in template
     assert 'last_available_minor' in template
     assert 'last_available_patch' in template

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -412,11 +412,14 @@ def get_update_information(update_information: dict) -> WazuhResult:
     if not update_information:
         # Return an empty response because the update_check is disabled
         return WazuhResult({'data': get_update_information_template(update_check=False)})
+    status_code = update_information.pop('status_code')
+    uuid = update_information.get('uuid')
+    tag = update_information.get('current_version')
 
-    if update_information['status_code'] != 200:
-        raise WazuhInternalError(2100, extra_message=update_information['message'])
+    if status_code != 200:
+        extra_message = f"{uuid}, {tag}" if status_code == 401 else update_information['message']
+        raise WazuhInternalError(2100, extra_message=extra_message)
 
-    update_information.pop('status_code')
     update_information.pop('message', None)
 
     return WazuhResult({'data': update_information})


### PR DESCRIPTION
|Related issue|
|---|
| #19788 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR completes the AIT for `/manager/version/check` endpoint.

These tests are marked as XFAIL because the CTI server still don't exists.

## Tests

To run these locally we need to build using the branch `feature/18725-update-check-service-system-cp`, which includes a commit to configure the `cti-url` in the `ossec.conf`. 

```
docker compose -f env/docker-compose.yml  --profile cluster build --build-arg WAZUH_BRANCH=feature/18725-update-check-service-system-cp --build-arg ENV_MODE=cluster --no-cache
```

Also, is needed to point the `cti-url` to the local CTI server, in the `ossec-update-check.conf` file. By example:

```xml
<root>
    <global>
        <cti-url>http://172.20.0.1:4041</cti-url>
     </global>
</root>
```

* Local execution

```python
(framework) ➜  integration git:(19788-complete-endpoint-tests) ✗ pytest --disable-warnings --nobuild -s -vv 'test_manager_endpoints.tavern.yaml'
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.9.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/nstefani/.pyenv/versions/3.9.9/envs/framework/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.9', 'Platform': 'Linux-6.5.4-76060504-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '6.2.2', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '1.0.4', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '3.1.1', 'trio': '0.7.0', 'cov': '2.12.0', 'metadata': '2.0.4'}}
rootdir: /home/nstefani/git/wazuh/api/test/integration, configfile: pytest.ini
plugins: aiohttp-1.0.4, asyncio-0.18.1, tavern-1.23.5, html-3.1.1, trio-0.7.0, cov-2.12.0, metadata-2.0.4
asyncio: mode=auto
collected 35 items

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED
test_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED
test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED
test_manager_endpoints.tavern.yaml::GET /manager/version/check XPASS
test_manager_endpoints.tavern.yaml::GET /manager/version/check with update_check disabled XPASS
test_manager_endpoints.tavern.yaml::GET /manager/version/check with update check service error PASSED
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED

===================================================================================== 33 passed, 2 xpassed in 171.53s (0:02:51) =====================================================================================
```