### PR TITLE
Creating a Wazuh-DB communication wrapper

### DIFF
--- a/src/shared_modules/utils/socketDBWrapper.hpp
+++ b/src/shared_modules/utils/socketDBWrapper.hpp
@@ -1,0 +1,99 @@
+/*
+ * Socket DB Wrapper
+ * Copyright (C) 2015, Wazuh Inc.
+ * October 30, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _SOCKET_DB_WRAPPER_HPP
+#define _SOCKET_DB_WRAPPER_HPP
+
+#include "json.hpp"
+#include "socketClient.hpp"
+#include <condition_variable>
+#include <mutex>
+#include <string>
+
+auto constexpr DB_WRAPPER_QUERY_WAIT_TIME {500};
+
+auto constexpr DB_WRAPPER_OK {"ok"};
+auto constexpr DB_WRAPPER_ERROR {"err"};
+auto constexpr DB_WRAPPER_UNKNOWN {"unk"};
+auto constexpr DB_WRAPPER_IGNORE {"ign"};
+auto constexpr DB_WRAPPER_DUE {"due"};
+
+class SocketDBWrapper final
+{
+private:
+    std::shared_ptr<SocketClient<Socket<OSPrimitives, sizeHeaderProtocol>, EpollWrapper>> m_dbSocket;
+    std::string m_response;
+    std::mutex m_mutex;
+    std::condition_variable m_conditionVariable;
+
+public:
+    explicit SocketDBWrapper(const std::string& socketPath)
+        : m_dbSocket {
+              std::make_shared<SocketClient<Socket<OSPrimitives, sizeHeaderProtocol>, EpollWrapper>>(socketPath)}
+    {
+        m_dbSocket->connect(
+            [&](const char* body, uint32_t bodySize, const char* header, uint32_t headerSize)
+            {
+                std::unique_lock<std::mutex> lock {m_mutex};
+                m_response = std::string(body, bodySize);
+                m_conditionVariable.notify_one();
+            });
+    }
+
+    void query(const std::string& query, nlohmann::json& response)
+    {
+        std::unique_lock<std::mutex> lock {m_mutex};
+        m_dbSocket->send(query.c_str(), query.size());
+        auto res = m_conditionVariable.wait_for(lock, std::chrono::milliseconds(DB_WRAPPER_QUERY_WAIT_TIME));
+
+        if (res == std::cv_status::timeout)
+        {
+            throw std::runtime_error("Timeout waiting for DB response");
+        }
+
+        if (m_response.empty())
+        {
+            throw std::runtime_error("Empty DB response");
+        }
+
+        if (0 == m_response.compare(0, 3, DB_WRAPPER_ERROR))
+        {
+            throw std::runtime_error("DB query error: " + m_response.substr(4));
+        }
+
+        if (0 == m_response.compare(0, 3, DB_WRAPPER_IGNORE))
+        {
+            throw std::runtime_error("DB query ignored: " + m_response.substr(4));
+        }
+
+        if (0 == m_response.compare(0, 3, DB_WRAPPER_UNKNOWN))
+        {
+            throw std::runtime_error("DB query unknown response: " + m_response.substr(4));
+        }
+
+        if (0 == m_response.compare(0, 3, DB_WRAPPER_DUE))
+        {
+            // TODO: Implement due response
+            throw std::runtime_error("DB query with pending data");
+        }
+
+        if (0 == m_response.compare(0, 2, DB_WRAPPER_OK))
+        {
+            response = nlohmann::json::parse(m_response.substr(3));
+        }
+        else
+        {
+            throw std::runtime_error("DB query invalid response: " + m_response);
+        }
+    }
+};
+
+#endif // _SOCKET_DB_WRAPPER_HPP

--- a/src/shared_modules/utils/socketDBWrapper.hpp
+++ b/src/shared_modules/utils/socketDBWrapper.hpp
@@ -29,7 +29,7 @@ auto constexpr DB_WRAPPER_DUE {"due"};
 class SocketDBWrapper final
 {
 private:
-    std::shared_ptr<SocketClient<Socket<OSPrimitives, sizeHeaderProtocol>, EpollWrapper>> m_dbSocket;
+    std::shared_ptr<SocketClient<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>> m_dbSocket;
     std::string m_response;
     std::mutex m_mutex;
     std::condition_variable m_conditionVariable;
@@ -37,7 +37,7 @@ private:
 public:
     explicit SocketDBWrapper(const std::string& socketPath)
         : m_dbSocket {
-              std::make_shared<SocketClient<Socket<OSPrimitives, sizeHeaderProtocol>, EpollWrapper>>(socketPath)}
+              std::make_shared<SocketClient<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>>(socketPath)}
     {
         m_dbSocket->connect(
             [&](const char* body, uint32_t bodySize, const char* header, uint32_t headerSize)

--- a/src/shared_modules/utils/socketWrapper.hpp
+++ b/src/shared_modules/utils/socketWrapper.hpp
@@ -32,8 +32,8 @@ constexpr auto INVALID_SOCKET {-1};
 constexpr auto SOCKET_ERROR {-1};
 using PACKET_FIELD_TYPE = uint32_t;
 using HEADER_FIELD_TYPE = uint32_t;
-constexpr ssize_t PACKET_FIELD_SIZE {sizeof(PACKET_FIELD_TYPE)};
-constexpr ssize_t HEADER_FIELD_SIZE {sizeof(HEADER_FIELD_TYPE)};
+constexpr auto PACKET_FIELD_SIZE {sizeof(PACKET_FIELD_TYPE)};
+constexpr auto HEADER_FIELD_SIZE {sizeof(HEADER_FIELD_TYPE)};
 constexpr auto BUFFER_MAX_SIZE {8192 * 8};
 
 enum class SocketType
@@ -140,9 +140,9 @@ public:
                             uint32_t sizeHeader = 0)
     {
 
-        if (sizeof(Header::packetSize) + sizeof(Header::headerSize) + sizeHeader + sizeBody > BUFFER_MAX_SIZE)
+        if (sizeof(Header) + sizeHeader + sizeBody > BUFFER_MAX_SIZE)
         {
-            buffer.resize(sizeof(Header::packetSize) + sizeof(Header::headerSize) + sizeHeader + sizeBody + 1);
+            buffer.resize(sizeof(Header) + sizeHeader + sizeBody + 1);
         }
 
         // Write packet and header size to the buffer.
@@ -152,16 +152,12 @@ public:
 
         if (sizeHeader > 0)
         {
-            std::copy(dataHeader,
-                      dataHeader + sizeHeader,
-                      std::begin(buffer) + sizeof(Header::packetSize) + sizeof(Header::headerSize));
+            std::copy(dataHeader, dataHeader + sizeHeader, std::begin(buffer) + sizeof(Header));
         }
 
-        std::copy(dataBody,
-                  dataBody + sizeBody,
-                  std::begin(buffer) + sizeof(Header::packetSize) + sizeof(Header::headerSize) + sizeHeader);
+        std::copy(dataBody, dataBody + sizeBody, std::begin(buffer) + sizeof(Header) + sizeHeader);
 
-        bufferSize = sizeof(Header::packetSize) + sizeof(Header::headerSize) + sizeHeader + sizeBody;
+        bufferSize = sizeof(Header) + sizeHeader + sizeBody;
     }
 
     /**
@@ -200,7 +196,7 @@ public:
      * @brief Structure used to write the header and packet size to the buffer.
      *
      */
-    struct Header
+    struct __attribute__((__packed__)) Header
     {
         PACKET_FIELD_TYPE packetSize;
         HEADER_FIELD_TYPE headerSize;
@@ -232,18 +228,18 @@ public:
                             const char* dataHeader = nullptr,
                             uint32_t sizeHeader = 0)
     {
-        if (sizeof(Header::packetSize) + sizeBody > BUFFER_MAX_SIZE)
+        if (sizeof(Header) + sizeBody > BUFFER_MAX_SIZE)
         {
-            buffer.resize(sizeof(Header::packetSize) + sizeBody + 1);
+            buffer.resize(sizeof(Header) + sizeBody + 1);
         }
 
         // Write packet size to the buffer.
         struct Header* pHeader = reinterpret_cast<struct Header*>(buffer.data());
         pHeader->packetSize = sizeBody;
 
-        std::copy(dataBody, dataBody + sizeBody, std::begin(buffer) + sizeof(Header::packetSize));
+        std::copy(dataBody, dataBody + sizeBody, std::begin(buffer) + sizeof(Header));
 
-        bufferSize = sizeof(Header::packetSize) + sizeBody;
+        bufferSize = sizeof(Header) + sizeBody;
     }
 
     /**
@@ -282,7 +278,7 @@ public:
      * @brief Structure used to write the packet size to the buffer.
      *
      */
-    struct Header
+    struct __attribute__((__packed__)) Header
     {
         PACKET_FIELD_TYPE packetSize;
     };

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -322,6 +322,25 @@ namespace Utils
         return ret;
     }
 
+    /**
+     * @brief Checks that the string is alphanumeric and contains all of the special characters passed as argument.
+     *
+     * @param str Original string.
+     * @param specialCharacters Special characters string.
+     * @return true
+     * @return false
+     */
+    static bool isAlphaNumericWithSpecialCharacters(const std::string& str, const std::string& specialCharacters)
+    {
+        return str.compare("") != 0 ? std::all_of(std::begin(str),
+                                                  std::end(str),
+                                                  [&specialCharacters](const auto& character) {
+                                                      return std::isalnum(character) ||
+                                                             specialCharacters.find(character) != std::string::npos;
+                                                  })
+                                    : false;
+    }
+
     static bool isNumber(const std::string& str)
     {
         std::string::const_iterator it = str.begin();

--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -25,6 +25,8 @@ file(GLOB UTIL_CXX_UNITTEST_COMMON_SRC
     "filterMsgDispatcher_test.cpp"
     "loggerHelper_test.cpp"
     "globHelper_test.cpp"
+    "socketDBWrapper_test.cpp"
+    "wazuhDBQueryBuilder_test.cpp"
     "main.cpp"
 )
 
@@ -102,5 +104,3 @@ endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
 add_test(NAME utils_unit_test
          COMMAND utils_unit_test)
-
-

--- a/src/shared_modules/utils/tests/socketDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/socketDBWrapper_test.cpp
@@ -1,0 +1,103 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * Oct 30, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "socketDBWrapper_test.hpp"
+#include "json.hpp"
+#include "socketDBWrapper.hpp"
+
+// temp header
+#include "wazuhDBQueryBuilder.hpp"
+#include <chrono>
+#include <thread>
+
+TEST_F(SocketDBWrapperTest, EmptyTest)
+{
+    m_query = "SELECT * FROM test_table;";
+    m_response = "";
+
+    nlohmann::json output;
+    SocketDBWrapper socketDBWrapper(TEST_SOCKET);
+    // The exception captured here is the timeout
+    EXPECT_THROW(socketDBWrapper.query(m_query, output), std::exception);
+}
+
+TEST_F(SocketDBWrapperTest, ErrorTest)
+{
+    m_query = "SELECT * FROM test_table;";
+    m_response = "err Things happened";
+
+    nlohmann::json output;
+    SocketDBWrapper socketDBWrapper(TEST_SOCKET);
+    EXPECT_THROW(socketDBWrapper.query(m_query, output), std::exception);
+}
+
+TEST_F(SocketDBWrapperTest, UnknownTest)
+{
+    m_query = "SELECT * FROM test_table;";
+    m_response = "unk Things happened";
+
+    nlohmann::json output;
+    SocketDBWrapper socketDBWrapper(TEST_SOCKET);
+    EXPECT_THROW(socketDBWrapper.query(m_query, output), std::exception);
+}
+
+TEST_F(SocketDBWrapperTest, IgnoreTest)
+{
+    m_query = "SELECT * FROM test_table;";
+    m_response = "ign Things happened";
+
+    nlohmann::json output;
+    SocketDBWrapper socketDBWrapper(TEST_SOCKET);
+    EXPECT_THROW(socketDBWrapper.query(m_query, output), std::exception);
+}
+
+TEST_F(SocketDBWrapperTest, DueTest)
+{
+    m_query = "SELECT * FROM test_table;";
+    m_response = "due Things happened";
+
+    nlohmann::json output;
+    SocketDBWrapper socketDBWrapper(TEST_SOCKET);
+    EXPECT_THROW(socketDBWrapper.query(m_query, output), std::exception);
+}
+
+TEST_F(SocketDBWrapperTest, InvalidTest)
+{
+    m_query = "SELECT * FROM test_table;";
+    m_response = "Invalid";
+
+    nlohmann::json output;
+    SocketDBWrapper socketDBWrapper(TEST_SOCKET);
+    EXPECT_THROW(socketDBWrapper.query(m_query, output), std::exception);
+}
+
+TEST_F(SocketDBWrapperTest, TimeoutTest)
+{
+    m_query = "SELECT * FROM test_table;";
+    m_response = R"(ok [{"field": "value"}])";
+    m_sleepTime = DB_WRAPPER_QUERY_WAIT_TIME + 10;
+
+    nlohmann::json output;
+    SocketDBWrapper socketDBWrapper(TEST_SOCKET);
+    EXPECT_THROW(socketDBWrapper.query(m_query, output), std::exception);
+}
+
+TEST_F(SocketDBWrapperTest, SuccessTest)
+{
+    m_query = "SELECT * FROM test_table;";
+    m_response = R"(ok [{"field": "value"}])";
+
+    nlohmann::json output;
+    SocketDBWrapper socketDBWrapper(TEST_SOCKET);
+    socketDBWrapper.query(m_query, output);
+
+    ASSERT_EQ(output[0].at("field"), "value");
+}

--- a/src/shared_modules/utils/tests/socketDBWrapper_test.hpp
+++ b/src/shared_modules/utils/tests/socketDBWrapper_test.hpp
@@ -1,0 +1,62 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * Oct 30, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _SOCKET_DB_WRAPPER_TEST_HPP
+#define _SOCKET_DB_WRAPPER_TEST_HPP
+
+#include "socketServer.hpp"
+#include "gtest/gtest.h"
+#include <thread>
+#include <chrono>
+
+auto constexpr TEST_SOCKET {"/temp/temp_sock"};
+
+class SocketDBWrapperTest : public ::testing::Test
+{
+protected:
+    SocketDBWrapperTest(): m_sleepTime {0} {};
+    virtual ~SocketDBWrapperTest() = default;
+
+    void SetUp() override
+    {
+        m_socketServer =
+            std::make_shared<SocketServer<Socket<OSPrimitives, sizeHeaderProtocol>, EpollWrapper>>(TEST_SOCKET);
+
+        m_socketServer->listen(
+            [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
+            {
+                std::ignore = dataHeader;
+                std::ignore = sizeHeader;
+
+                std::string receivedMsg(data, size);
+                ASSERT_EQ(receivedMsg, m_query);
+
+                std::this_thread::sleep_for(std::chrono::milliseconds(m_sleepTime));
+
+                m_socketServer->send(fd, m_response.c_str(), m_response.size());
+            });
+    };
+    void TearDown() override
+    {
+        m_socketServer->stop();
+        m_socketServer.reset();
+        m_query.clear();
+        m_response.clear();
+        m_sleepTime = 0;
+    };
+
+    std::shared_ptr<SocketServer<Socket<OSPrimitives, sizeHeaderProtocol>, EpollWrapper>> m_socketServer;
+    std::string m_query;
+    std::string m_response;
+    int m_sleepTime;
+};
+
+#endif // _SOCKET_DB_WRAPPER_TEST_HPP

--- a/src/shared_modules/utils/tests/socketDBWrapper_test.hpp
+++ b/src/shared_modules/utils/tests/socketDBWrapper_test.hpp
@@ -14,21 +14,22 @@
 
 #include "socketServer.hpp"
 #include "gtest/gtest.h"
-#include <thread>
 #include <chrono>
+#include <thread>
 
-auto constexpr TEST_SOCKET {"/temp/temp_sock"};
+auto constexpr TEST_SOCKET {"tmp/temp_sock"};
 
 class SocketDBWrapperTest : public ::testing::Test
 {
 protected:
-    SocketDBWrapperTest(): m_sleepTime {0} {};
+    SocketDBWrapperTest()
+        : m_sleepTime {0} {};
     virtual ~SocketDBWrapperTest() = default;
 
     void SetUp() override
     {
         m_socketServer =
-            std::make_shared<SocketServer<Socket<OSPrimitives, sizeHeaderProtocol>, EpollWrapper>>(TEST_SOCKET);
+            std::make_shared<SocketServer<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>>(TEST_SOCKET);
 
         m_socketServer->listen(
             [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
@@ -53,7 +54,7 @@ protected:
         m_sleepTime = 0;
     };
 
-    std::shared_ptr<SocketServer<Socket<OSPrimitives, sizeHeaderProtocol>, EpollWrapper>> m_socketServer;
+    std::shared_ptr<SocketServer<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>> m_socketServer;
     std::string m_query;
     std::string m_response;
     int m_sleepTime;

--- a/src/shared_modules/utils/tests/socketWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/socketWrapper_test.cpp
@@ -101,8 +101,8 @@ TEST_F(SocketWrapperTest, DISABLED_ReadSuccess)
 
     // Set up the test data.
     const int sock = 123;
-    const ssize_t metaDataSize = PACKET_SIZE;
-    const std::vector<char> header(HEADER_SIZE, 0);
+    const ssize_t metaDataSize = PACKET_FIELD_SIZE;
+    const std::vector<char> header(HEADER_FIELD_SIZE, 0);
     std::vector<char> data(10, 0);
     for (size_t i = 0; i < data.size(); i++)
     {
@@ -124,7 +124,7 @@ TEST_F(SocketWrapperTest, DISABLED_ReadSuccess)
                             [&data, &header](int, void* buffer, size_t size, int)
                             {
                                 std::copy(header.begin(), header.end(), (char*)buffer);
-                                std::copy(data.begin(), data.end(), (char*)buffer + HEADER_SIZE);
+                                std::copy(data.begin(), data.end(), (char*)buffer + HEADER_FIELD_SIZE);
                                 return size;
                             }),
                         Return(packetSize)));
@@ -164,8 +164,8 @@ TEST_F(SocketWrapperTest, DISABLED_ReadPartialHeader)
 
     // Set up the test data.
     const int sock = 123;
-    const ssize_t metaDataSize = PACKET_SIZE;
-    const std::vector<char> header(HEADER_SIZE, 0);
+    const ssize_t metaDataSize = PACKET_FIELD_SIZE;
+    const std::vector<char> header(HEADER_FIELD_SIZE, 0);
     std::vector<char> data(10, 0);
     for (size_t i = 0; i < data.size(); i++)
     {
@@ -187,7 +187,7 @@ TEST_F(SocketWrapperTest, DISABLED_ReadPartialHeader)
                             [&data, &header](int, void* buffer, size_t, int)
                             {
                                 std::copy(header.begin(), header.end(), (char*)buffer);
-                                std::copy(data.begin(), data.end(), (char*)buffer + HEADER_SIZE);
+                                std::copy(data.begin(), data.end(), (char*)buffer + HEADER_FIELD_SIZE);
                             }),
                         Return(packetSize)));
 
@@ -229,8 +229,8 @@ TEST_F(SocketWrapperTest, DISABLED_ReadPartialBody)
 
     // Set up the test data.
     const int sock = 123;
-    const ssize_t metaDataSize = PACKET_SIZE;
-    const std::vector<char> header(HEADER_SIZE, 0);
+    const ssize_t metaDataSize = PACKET_FIELD_SIZE;
+    const std::vector<char> header(HEADER_FIELD_SIZE, 0);
     std::vector<char> data(10, 0);
     for (size_t i = 0; i < data.size(); i++)
     {
@@ -248,14 +248,14 @@ TEST_F(SocketWrapperTest, DISABLED_ReadPartialBody)
                             [&data, &header](int, void* buffer, size_t, int)
                             {
                                 std::copy(header.begin(), header.end(), (char*)buffer);
-                                std::copy(data.begin(), data.begin() + data.size() / 2, (char*)buffer + HEADER_SIZE);
+                                std::copy(data.begin(), data.begin() + data.size() / 2, (char*)buffer + HEADER_FIELD_SIZE);
                             }),
                         Return(packetSize)))
         .WillOnce(DoAll(Invoke(
                             [&data, &header](int, void* buffer, size_t, int) {
                                 std::copy(data.begin() + data.size() / 2,
                                           data.end(),
-                                          (char*)buffer + HEADER_SIZE + data.size() / 2);
+                                          (char*)buffer + HEADER_FIELD_SIZE + data.size() / 2);
                             }),
                         Return(packetSize)));
 
@@ -297,11 +297,11 @@ TEST_F(SocketWrapperTest, DISABLED_ReadSuccessBufferIncrement)
 
     // Set up the test data.
     const int sock = 123;
-    const ssize_t metaDataSize = PACKET_SIZE;
-    const std::vector<char> header(HEADER_SIZE, 0);
+    const ssize_t metaDataSize = PACKET_FIELD_SIZE;
+    const std::vector<char> header(HEADER_FIELD_SIZE, 0);
     const size_t initialRecvBufferSize = socketWrapper.recvBufferSize();
     const size_t targetSize = socketWrapper.recvBufferSize() * 2;
-    std::vector<char> data(targetSize - HEADER_SIZE, 0);
+    std::vector<char> data(targetSize - HEADER_FIELD_SIZE, 0);
     for (size_t i = 0; i < data.size(); i++)
     {
         data[i] = i + '0';
@@ -322,7 +322,7 @@ TEST_F(SocketWrapperTest, DISABLED_ReadSuccessBufferIncrement)
                             [&data, &header](int, void* buffer, size_t size, int)
                             {
                                 std::copy(header.begin(), header.end(), (char*)buffer);
-                                std::copy(data.begin(), data.end(), (char*)buffer + HEADER_SIZE);
+                                std::copy(data.begin(), data.end(), (char*)buffer + HEADER_FIELD_SIZE);
                                 return size;
                             }),
                         Return(packetSize)));

--- a/src/shared_modules/utils/tests/socket_test.cpp
+++ b/src/shared_modules/utils/tests/socket_test.cpp
@@ -15,11 +15,9 @@
 #include <chrono>
 #include <future>
 
-void SocketTest::SetUp() {}
+TYPED_TEST_SUITE_P(SocketTest);
 
-void SocketTest::TearDown() {}
-
-TEST_F(SocketTest, SingleDelayedServerStart)
+TYPED_TEST_P(SocketTest, SingleDelayedServerStart)
 {
     constexpr size_t MESSAGE_QUANTITY {1000000};
     std::string socketPath {"/tmp/echo_sock"};
@@ -30,7 +28,7 @@ TEST_F(SocketTest, SingleDelayedServerStart)
         [&]()
         {
             std::this_thread::sleep_for(std::chrono::seconds(2));
-            SocketServer<Socket<OSPrimitives>, EpollWrapper> server {socketPath};
+            SocketServer<Socket<OSPrimitives, TypeParam>, EpollWrapper> server {socketPath};
             server.listen(
                 [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
                 {
@@ -51,7 +49,7 @@ TEST_F(SocketTest, SingleDelayedServerStart)
             promise.get_future().wait_for(std::chrono::seconds(10));
         });
 
-    SocketClient<Socket<OSPrimitives>, EpollWrapper> client {socketPath};
+    SocketClient<Socket<OSPrimitives, TypeParam>, EpollWrapper> client {socketPath};
     client.connect(
         [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
         {
@@ -70,13 +68,13 @@ TEST_F(SocketTest, SingleDelayedServerStart)
     EXPECT_EQ(counter, MESSAGE_QUANTITY);
 }
 
-TEST_F(SocketTest, SingleDelayedClient)
+TYPED_TEST_P(SocketTest, SingleDelayedClient)
 {
     constexpr size_t MESSAGE_QUANTITY {1000000};
     std::string socketPath {"/tmp/echo_sock"};
     std::promise<void> promise;
 
-    SocketServer<Socket<OSPrimitives>, EpollWrapper> server {socketPath};
+    SocketServer<Socket<OSPrimitives, TypeParam>, EpollWrapper> server {socketPath};
     std::atomic<size_t> counter {0};
     server.listen(
         [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
@@ -94,7 +92,7 @@ TEST_F(SocketTest, SingleDelayedClient)
             }
         });
 
-    SocketClient<Socket<OSPrimitives>, EpollWrapper> client {socketPath};
+    SocketClient<Socket<OSPrimitives, TypeParam>, EpollWrapper> client {socketPath};
     client.connect(
         [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
         {
@@ -115,14 +113,14 @@ TEST_F(SocketTest, SingleDelayedClient)
     EXPECT_EQ(counter, MESSAGE_QUANTITY);
 }
 
-TEST_F(SocketTest, MultipleClients)
+TYPED_TEST_P(SocketTest, MultipleClients)
 {
     constexpr size_t MESSAGE_QUANTITY {10000};
     std::string socketPath {"/tmp/echo_sock"};
     std::promise<void> promise;
     constexpr size_t CLIENTS {10};
 
-    SocketServer<Socket<OSPrimitives>, EpollWrapper> server {socketPath};
+    SocketServer<Socket<OSPrimitives, TypeParam>, EpollWrapper> server {socketPath};
     std::atomic<size_t> counter {0};
     server.listen(
         [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
@@ -145,7 +143,7 @@ TEST_F(SocketTest, MultipleClients)
         threads.emplace_back(
             [&]()
             {
-                SocketClient<Socket<OSPrimitives>, EpollWrapper> client {socketPath};
+                SocketClient<Socket<OSPrimitives, TypeParam>, EpollWrapper> client {socketPath};
                 client.connect(
                     [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
                     {
@@ -175,13 +173,13 @@ TEST_F(SocketTest, MultipleClients)
     EXPECT_EQ(counter, MESSAGE_QUANTITY);
 }
 
-TEST_F(SocketTest, SingleDelayedClientWithReconnectionSendMessageOffline)
+TYPED_TEST_P(SocketTest, SingleDelayedClientWithReconnectionSendMessageOffline)
 {
     constexpr size_t MESSAGE_QUANTITY {100};
     std::string socketPath {"/tmp/echo_sock"};
     std::promise<void> promise;
 
-    SocketServer<Socket<OSPrimitives>, EpollWrapper> server {socketPath};
+    SocketServer<Socket<OSPrimitives, TypeParam>, EpollWrapper> server {socketPath};
     std::atomic<size_t> counter {0};
     server.listen(
         [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
@@ -199,7 +197,7 @@ TEST_F(SocketTest, SingleDelayedClientWithReconnectionSendMessageOffline)
             }
         });
 
-    SocketClient<Socket<OSPrimitives>, EpollWrapper> client {socketPath};
+    SocketClient<Socket<OSPrimitives, TypeParam>, EpollWrapper> client {socketPath};
     client.connect(
         [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
         {
@@ -248,13 +246,13 @@ TEST_F(SocketTest, SingleDelayedClientWithReconnectionSendMessageOffline)
     EXPECT_EQ(counter, MESSAGE_QUANTITY);
 }
 
-TEST_F(SocketTest, SingleDelayedClientWithReconnectionOnline)
+TYPED_TEST_P(SocketTest, SingleDelayedClientWithReconnectionOnline)
 {
     constexpr size_t MESSAGE_QUANTITY {100};
     std::string socketPath {"/tmp/echo_sock"};
     std::promise<void> promise;
 
-    SocketServer<Socket<OSPrimitives>, EpollWrapper> server {socketPath};
+    SocketServer<Socket<OSPrimitives, TypeParam>, EpollWrapper> server {socketPath};
     std::atomic<size_t> counter {0};
     server.listen(
         [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
@@ -272,7 +270,7 @@ TEST_F(SocketTest, SingleDelayedClientWithReconnectionOnline)
             }
         });
 
-    SocketClient<Socket<OSPrimitives>, EpollWrapper> client {socketPath};
+    SocketClient<Socket<OSPrimitives, TypeParam>, EpollWrapper> client {socketPath};
     client.connect(
         [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
         {
@@ -321,13 +319,13 @@ TEST_F(SocketTest, SingleDelayedClientWithReconnectionOnline)
     EXPECT_EQ(counter, MESSAGE_QUANTITY);
 }
 
-TEST_F(SocketTest, SingleDelayedClientWithReconnectionServerReset)
+TYPED_TEST_P(SocketTest, SingleDelayedClientWithReconnectionServerReset)
 {
     constexpr size_t MESSAGE_QUANTITY {100};
     std::string socketPath {"/tmp/echo_sock"};
     std::promise<void> promise;
 
-    auto server = std::make_unique<SocketServer<Socket<OSPrimitives>, EpollWrapper>>(socketPath);
+    auto server = std::make_unique<SocketServer<Socket<OSPrimitives, TypeParam>, EpollWrapper>>(socketPath);
     std::atomic<size_t> counter {0};
     server->listen(
         [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
@@ -345,7 +343,7 @@ TEST_F(SocketTest, SingleDelayedClientWithReconnectionServerReset)
             }
         });
 
-    SocketClient<Socket<OSPrimitives>, EpollWrapper> client {socketPath};
+    SocketClient<Socket<OSPrimitives, TypeParam>, EpollWrapper> client {socketPath};
     client.connect(
         [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
         {
@@ -374,7 +372,7 @@ TEST_F(SocketTest, SingleDelayedClientWithReconnectionServerReset)
 
     std::promise<void> promise2;
     counter = 0;
-    server = std::make_unique<SocketServer<Socket<OSPrimitives>, EpollWrapper>>(socketPath);
+    server = std::make_unique<SocketServer<Socket<OSPrimitives, TypeParam>, EpollWrapper>>(socketPath);
 
     server->listen(
         [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
@@ -395,3 +393,17 @@ TEST_F(SocketTest, SingleDelayedClientWithReconnectionServerReset)
 
     EXPECT_EQ(counter, MESSAGE_QUANTITY);
 }
+
+// All tests must be registered
+
+REGISTER_TYPED_TEST_SUITE_P(SocketTest,
+                            SingleDelayedServerStart,
+                            SingleDelayedClient,
+                            MultipleClients,
+                            SingleDelayedClientWithReconnectionSendMessageOffline,
+                            SingleDelayedClientWithReconnectionOnline,
+                            SingleDelayedClientWithReconnectionServerReset);
+
+// Configuring typed-tests
+using protocolTypes = ::testing::Types<appendHeaderProtocol, sizeHeaderProtocol>;
+INSTANTIATE_TYPED_TEST_SUITE_P(TypedSocketTests, SocketTest, protocolTypes);

--- a/src/shared_modules/utils/tests/socket_test.cpp
+++ b/src/shared_modules/utils/tests/socket_test.cpp
@@ -405,5 +405,5 @@ REGISTER_TYPED_TEST_SUITE_P(SocketTest,
                             SingleDelayedClientWithReconnectionServerReset);
 
 // Configuring typed-tests
-using protocolTypes = ::testing::Types<appendHeaderProtocol, sizeHeaderProtocol>;
-INSTANTIATE_TYPED_TEST_SUITE_P(TypedSocketTests, SocketTest, protocolTypes);
+using ProtocolTypes = ::testing::Types<AppendHeaderProtocol, SizeHeaderProtocol>;
+INSTANTIATE_TYPED_TEST_SUITE_P(TypedSocketTests, SocketTest, ProtocolTypes);

--- a/src/shared_modules/utils/tests/socket_test.hpp
+++ b/src/shared_modules/utils/tests/socket_test.hpp
@@ -14,13 +14,14 @@
 
 #include "gtest/gtest.h"
 
+template <typename T>
 class SocketTest : public ::testing::Test
 {
 protected:
     SocketTest() = default;
     virtual ~SocketTest() = default;
 
-    void SetUp();
-    void TearDown();
+    void SetUp() {};
+    void TearDown() {};
 };
 #endif // _SOCKET_TEST_HPP

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -525,3 +525,26 @@ TEST_F(StringUtilsTest,parseStrToTimeOneSarasa)
 {
   EXPECT_EQ(Utils::parseStrToTime("1invalid"),-1);
 }
+
+/*
+ * isAlphaNumericWithSpecialCharacters() tests
+ */
+
+/**
+ * @brief Validates the string is alphanumeric and contains all of the special characters passed as argument.
+ *
+ */
+TEST_F(StringUtilsTest, IsAlphaNumericWithSpecialCharacters)
+{
+    const std::string stringBase1 {"random_string"};
+    const std::string stringBase2 {"r4nd0mS7r1n6"};
+    const std::string stringBase3 {"random-_-string"};
+    const std::string stringBase4 {"random*string"};
+    const std::string stringBase5 {""};
+    EXPECT_TRUE(Utils::isAlphaNumericWithSpecialCharacters(stringBase1, "_"));
+    EXPECT_TRUE(Utils::isAlphaNumericWithSpecialCharacters(stringBase1, "__"));
+    EXPECT_TRUE(Utils::isAlphaNumericWithSpecialCharacters(stringBase2, ""));
+    EXPECT_TRUE(Utils::isAlphaNumericWithSpecialCharacters(stringBase3, "-_"));
+    EXPECT_TRUE(Utils::isAlphaNumericWithSpecialCharacters(stringBase4, "*"));
+    EXPECT_FALSE(Utils::isAlphaNumericWithSpecialCharacters(stringBase5, "-_*"));
+}

--- a/src/shared_modules/utils/tests/wazuhDBQueryBuilder_test.cpp
+++ b/src/shared_modules/utils/tests/wazuhDBQueryBuilder_test.cpp
@@ -65,6 +65,30 @@ TEST_F(WazuhDBQueryBuilderTest, WhereOrTest)
     EXPECT_EQ(message, "agent 0 sql SELECT * FROM sys_programs WHERE name = 'bash' OR version = '1' ");
 }
 
+TEST_F(WazuhDBQueryBuilderTest, WhereIsNullTest)
+{
+    std::string message = WazuhDBQueryBuilder::builder()
+                              .agent("0")
+                              .selectAll()
+                              .fromTable("sys_programs")
+                              .whereColumn("name")
+                              .isNull()
+                              .build();
+    EXPECT_EQ(message, "agent 0 sql SELECT * FROM sys_programs WHERE name IS NULL ");
+}
+
+TEST_F(WazuhDBQueryBuilderTest, WhereIsNotNullTest)
+{
+    std::string message = WazuhDBQueryBuilder::builder()
+                              .agent("0")
+                              .selectAll()
+                              .fromTable("sys_programs")
+                              .whereColumn("name")
+                              .isNotNull()
+                              .build();
+    EXPECT_EQ(message, "agent 0 sql SELECT * FROM sys_programs WHERE name IS NOT NULL ");
+}
+
 TEST_F(WazuhDBQueryBuilderTest, InvalidValue)
 {
     EXPECT_THROW(WazuhDBQueryBuilder::builder()

--- a/src/shared_modules/utils/tests/wazuhDBQueryBuilder_test.cpp
+++ b/src/shared_modules/utils/tests/wazuhDBQueryBuilder_test.cpp
@@ -1,0 +1,126 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * Nov 1, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "wazuhDBQueryBuilder_test.hpp"
+#include "wazuhDBQueryBuilder.hpp"
+#include <string>
+
+TEST_F(WazuhDBQueryBuilderTest, GlobalTest)
+{
+    std::string message = WazuhDBQueryBuilder::builder().global().selectAll().fromTable("agent").build();
+    EXPECT_EQ(message, "global sql SELECT * FROM agent ");
+}
+
+TEST_F(WazuhDBQueryBuilderTest, AgentTest)
+{
+    std::string message = WazuhDBQueryBuilder::builder().agent("0").selectAll().fromTable("sys_programs").build();
+    EXPECT_EQ(message, "agent 0 sql SELECT * FROM sys_programs ");
+}
+
+TEST_F(WazuhDBQueryBuilderTest, WhereTest)
+{
+    std::string message = WazuhDBQueryBuilder::builder()
+                              .agent("0")
+                              .selectAll()
+                              .fromTable("sys_programs")
+                              .whereColumn("name")
+                              .equalsTo("bash")
+                              .build();
+    EXPECT_EQ(message, "agent 0 sql SELECT * FROM sys_programs WHERE name = 'bash' ");
+}
+
+TEST_F(WazuhDBQueryBuilderTest, WhereAndTest)
+{
+    std::string message = WazuhDBQueryBuilder::builder()
+                              .agent("0")
+                              .selectAll()
+                              .fromTable("sys_programs")
+                              .whereColumn("name")
+                              .equalsTo("bash")
+                              .andColumn("version")
+                              .equalsTo("1")
+                              .build();
+    EXPECT_EQ(message, "agent 0 sql SELECT * FROM sys_programs WHERE name = 'bash' AND version = '1' ");
+}
+
+TEST_F(WazuhDBQueryBuilderTest, WhereOrTest)
+{
+    std::string message = WazuhDBQueryBuilder::builder()
+                              .agent("0")
+                              .selectAll()
+                              .fromTable("sys_programs")
+                              .whereColumn("name")
+                              .equalsTo("bash")
+                              .orColumn("version")
+                              .equalsTo("1")
+                              .build();
+    EXPECT_EQ(message, "agent 0 sql SELECT * FROM sys_programs WHERE name = 'bash' OR version = '1' ");
+}
+
+TEST_F(WazuhDBQueryBuilderTest, InvalidValue)
+{
+    EXPECT_THROW(WazuhDBQueryBuilder::builder()
+                     .agent("0")
+                     .selectAll()
+                     .fromTable("sys_programs")
+                     .whereColumn("name")
+                     .equalsTo("bash'")
+                     .build(),
+                 std::runtime_error);
+}
+
+TEST_F(WazuhDBQueryBuilderTest, InvalidColumn)
+{
+    EXPECT_THROW(WazuhDBQueryBuilder::builder()
+                     .agent("0")
+                     .selectAll()
+                     .fromTable("sys_programs")
+                     .whereColumn("name'")
+                     .equalsTo("bash")
+                     .build(),
+                 std::runtime_error);
+}
+
+TEST_F(WazuhDBQueryBuilderTest, InvalidTable)
+{
+    EXPECT_THROW(WazuhDBQueryBuilder::builder()
+                     .agent("0")
+                     .selectAll()
+                     .fromTable("sys_programs'")
+                     .whereColumn("name")
+                     .equalsTo("bash")
+                     .build(),
+                 std::runtime_error);
+}
+
+TEST_F(WazuhDBQueryBuilderTest, GlobalGetCommand)
+{
+    std::string message = WazuhDBQueryBuilder::builder().globalGetCommand("agent-info 1").build();
+    EXPECT_EQ(message, "global get-agent-info 1 ");
+}
+
+TEST_F(WazuhDBQueryBuilderTest, GlobalFindCommand)
+{
+    std::string message = WazuhDBQueryBuilder::builder().globalFindCommand("agent 1").build();
+    EXPECT_EQ(message, "global find-agent 1 ");
+}
+
+TEST_F(WazuhDBQueryBuilderTest, GlobalSelectCommand)
+{
+    std::string message = WazuhDBQueryBuilder::builder().globalSelectCommand("agent-name 1").build();
+    EXPECT_EQ(message, "global select-agent-name 1 ");
+}
+
+TEST_F(WazuhDBQueryBuilderTest, AgentGetCommand)
+{
+    std::string message = WazuhDBQueryBuilder::builder().agentGetOsInfoCommand("1").build();
+    EXPECT_EQ(message, "agent 1 osinfo get ");
+}

--- a/src/shared_modules/utils/tests/wazuhDBQueryBuilder_test.hpp
+++ b/src/shared_modules/utils/tests/wazuhDBQueryBuilder_test.hpp
@@ -1,0 +1,27 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * Nov 1, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _WAZUH_DB_QUERY_BUILDER_TEST_HPP
+#define _WAZUH_DB_QUERY_BUILDER_TEST_HPP
+
+#include "gtest/gtest.h"
+
+class WazuhDBQueryBuilderTest : public ::testing::Test
+{
+protected:
+    WazuhDBQueryBuilderTest() = default;
+    virtual ~WazuhDBQueryBuilderTest() = default;
+
+    void SetUp() override {};
+    void TearDown() override {};
+};
+
+#endif // _WAZUH_DB_QUERY_BUILDER_TEST_HPP

--- a/src/shared_modules/utils/wazuhDBQueryBuilder.hpp
+++ b/src/shared_modules/utils/wazuhDBQueryBuilder.hpp
@@ -1,0 +1,146 @@
+/*
+ * Wazuh DB Query Builder
+ * Copyright (C) 2015, Wazuh Inc.
+ * October 31, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _WAZUH_DB_QUERY_BUILDER_HPP
+#define _WAZUH_DB_QUERY_BUILDER_HPP
+
+#include "builder.hpp"
+#include "stringHelper.h"
+#include <string>
+
+constexpr auto WAZUH_DB_ALLOWED_CHARS {"-_ "};
+
+class WazuhDBQueryBuilder final : public Utils::Builder<WazuhDBQueryBuilder>
+{
+private:
+    std::string m_query;
+
+public:
+    WazuhDBQueryBuilder& global()
+    {
+        m_query += "global sql ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& agent(const std::string& id)
+    {
+        if (!Utils::isNumber(id))
+        {
+            throw std::runtime_error("Invalid agent id");
+        }
+
+        m_query += "agent " + id + " sql ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& selectAll()
+    {
+        m_query += "SELECT * ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& fromTable(const std::string& table)
+    {
+        if (!Utils::isAlphaNumericWithSpecialCharacters(table, WAZUH_DB_ALLOWED_CHARS))
+        {
+            throw std::runtime_error("Invalid table name");
+        }
+        m_query += "FROM " + table + " ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& whereColumn(const std::string& column)
+    {
+        if (!Utils::isAlphaNumericWithSpecialCharacters(column, WAZUH_DB_ALLOWED_CHARS))
+        {
+            throw std::runtime_error("Invalid column name");
+        }
+        m_query += "WHERE " + column + " ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& equalsTo(const std::string& value)
+    {
+        if (!Utils::isAlphaNumericWithSpecialCharacters(value, WAZUH_DB_ALLOWED_CHARS))
+        {
+            throw std::runtime_error("Invalid value");
+        }
+        m_query += "= '" + value + "' ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& andColumn(const std::string& column)
+    {
+        if (!Utils::isAlphaNumericWithSpecialCharacters(column, WAZUH_DB_ALLOWED_CHARS))
+        {
+            throw std::runtime_error("Invalid column name");
+        }
+        m_query += "AND " + column + " ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& orColumn(const std::string& column)
+    {
+        if (!Utils::isAlphaNumericWithSpecialCharacters(column, WAZUH_DB_ALLOWED_CHARS))
+        {
+            throw std::runtime_error("Invalid column name");
+        }
+        m_query += "OR " + column + " ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& globalGetCommand(const std::string& command)
+    {
+        if (!Utils::isAlphaNumericWithSpecialCharacters(command, WAZUH_DB_ALLOWED_CHARS))
+        {
+            throw std::runtime_error("Invalid command");
+        }
+        m_query += "global get-" + command + " ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& globalFindCommand(const std::string& command)
+    {
+        if (!Utils::isAlphaNumericWithSpecialCharacters(command, WAZUH_DB_ALLOWED_CHARS))
+        {
+            throw std::runtime_error("Invalid command");
+        }
+        m_query += "global find-" + command + " ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& globalSelectCommand(const std::string& command)
+    {
+        if (!Utils::isAlphaNumericWithSpecialCharacters(command, WAZUH_DB_ALLOWED_CHARS))
+        {
+            throw std::runtime_error("Invalid command");
+        }
+        m_query += "global select-" + command + " ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& agentGetOsInfoCommand(const std::string& id)
+    {
+        if (!Utils::isNumber(id))
+        {
+            throw std::runtime_error("Invalid agent id");
+        }
+        m_query += "agent " + id + " osinfo get ";
+        return *this;
+    }
+
+    std::string build()
+    {
+        return m_query;
+    }
+};
+
+#endif /* _WAZUH_DB_QUERY_BUILDER_HPP */

--- a/src/shared_modules/utils/wazuhDBQueryBuilder.hpp
+++ b/src/shared_modules/utils/wazuhDBQueryBuilder.hpp
@@ -67,6 +67,18 @@ public:
         return *this;
     }
 
+    WazuhDBQueryBuilder& isNull()
+    {
+        m_query += "IS NULL ";
+        return *this;
+    }
+
+    WazuhDBQueryBuilder& isNotNull()
+    {
+        m_query += "IS NOT NULL ";
+        return *this;
+    }
+
     WazuhDBQueryBuilder& equalsTo(const std::string& value)
     {
         if (!Utils::isAlphaNumericWithSpecialCharacters(value, WAZUH_DB_ALLOWED_CHARS))

--- a/src/wazuh_modules/vulnerability_scanner/testtool/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/CMakeLists.txt
@@ -2,3 +2,4 @@ cmake_minimum_required(VERSION 3.12.4)
 
 add_subdirectory(scanner)
 add_subdirectory(databaseFeedManager)
+add_subdirectory(wazuhDBQuery)

--- a/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/CMakeLists.txt
@@ -10,3 +10,5 @@ file(GLOB WAZUH_DB_QUERY_TESTTOOL_SRC
 add_executable(${PROJECT_NAME}
     ${WAZUH_DB_QUERY_TESTTOOL_SRC}
     )
+
+target_link_libraries(${PROJECT_NAME} pthread)

--- a/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.12.4)
+project(wazuh_db_query_testtool)
+
+set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
+
+file(GLOB WAZUH_DB_QUERY_TESTTOOL_SRC
+    "*.cpp"
+    )
+
+add_executable(${PROJECT_NAME}
+    ${WAZUH_DB_QUERY_TESTTOOL_SRC}
+    )

--- a/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/argsParser.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/argsParser.hpp
@@ -1,0 +1,88 @@
+/*
+ * Wazuh cmdLineParser
+ * Copyright (C) 2015, Wazuh Inc.
+ * Nov 1, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _CMD_ARGS_PARSER_HPP_
+#define _CMD_ARGS_PARSER_HPP_
+
+#include "json.hpp"
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+/**
+ * @brief Class to parse command line arguments.
+ */
+class CmdLineArgs
+{
+public:
+    /**
+     * @brief Constructor for CmdLineArgs.
+     * @param argc Number of arguments.
+     * @param argv Arguments.
+     */
+    explicit CmdLineArgs(const int argc, const char* argv[])
+        : m_configurationFilePath {paramValueOf(argc, argv, "-c")}
+    {
+    }
+
+    /**
+     * @brief Gets the configuration file path.
+     * @return Configuration file path.
+     */
+    const std::string& getConfigurationFilePath() const
+    {
+        return m_configurationFilePath;
+    }
+
+    /**
+     * @brief Shows the help to the user.
+     */
+    static void showHelp()
+    {
+        std::cout << "\nUsage: WazuhDBQuery <option(s)>\n"
+                  << "Options:\n"
+                  << "\t-h \t\t\tShow this help message\n"
+                  << "\t-c CONFIG_FILE\tSpecifies the configuration file.\n"
+                  << "\nExample:"
+                  << "\n\t./WazuhDBQuery -c config.json\n"
+                  << std::endl;
+    }
+
+private:
+    static std::string paramValueOf(const int argc,
+                                    const char* argv[],
+                                    const std::string& switchValue,
+                                    const std::pair<bool, std::string>& required = std::make_pair(true, ""))
+    {
+        for (int i = 1; i < argc; ++i)
+        {
+            const std::string currentValue {argv[i]};
+
+            if (currentValue == switchValue && i + 1 < argc)
+            {
+                // Switch found
+                return argv[i + 1];
+            }
+        }
+
+        if (required.first)
+        {
+            throw std::runtime_error {"Switch value: " + switchValue + " not found."};
+        }
+
+        return required.second;
+    }
+
+    const std::string m_configurationFilePath;
+};
+
+#endif // _CMD_ARGS_PARSER_HPP_

--- a/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/config.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/config.json
@@ -1,0 +1,75 @@
+{
+    "queries": [
+        [
+            {
+                "method": "global"
+            },
+            {
+                "method": "selectAll"
+            },
+            {
+                "method": "fromTable",
+                "arg": "metadata"
+            }
+        ],
+        [
+            {
+                "method": "global"
+            },
+            {
+                "method": "selectAll"
+            },
+            {
+                "method": "fromTable",
+                "arg": "agent"
+            },
+            {
+                "method": "whereColumn",
+                "arg": "id"
+            },
+            {
+                "method": "equalsTo",
+                "arg": "0"
+            }
+        ],
+        [
+            {
+                "method": "agent",
+                "arg": "0"
+            },
+            {
+                "method": "selectAll"
+            },
+            {
+                "method": "fromTable",
+                "arg": "sys_programs"
+            },
+            {
+                "method": "whereColumn",
+                "arg": "name"
+            },
+            {
+                "method": "equalsTo",
+                "arg": "bash"
+            }
+        ],
+        [
+            {
+                "method": "globalGetCommand",
+                "arg": "agent-info 0"
+            }
+        ],
+        [
+            {
+                "method": "globalSelectCommand",
+                "arg": "groups"
+            }
+        ],
+        [
+            {
+                "method": "agentGetOsInfoCommand",
+                "arg": "0"
+            }
+        ]
+    ]
+}

--- a/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/main.cpp
@@ -1,0 +1,77 @@
+/*
+ * Wazuh Vulnerability scanner
+ * Copyright (C) 2015, Wazuh Inc.
+ * Nov 1, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "argsParser.hpp"
+#include "json.hpp"
+#include "socketDBWrapper.hpp"
+#include "wazuhDBQueryBuilder.hpp"
+#include <iostream>
+#include <unordered_map>
+
+auto constexpr WAZUH_DB_SOCK {"/var/ossec/queue/db/wdb"};
+
+const std::unordered_map<std::string, WazuhDBQueryBuilder& (WazuhDBQueryBuilder::*)()> funcMap {
+    {"global", &WazuhDBQueryBuilder::global}, {"selectAll", &WazuhDBQueryBuilder::selectAll}};
+
+const std::unordered_map<std::string, WazuhDBQueryBuilder& (WazuhDBQueryBuilder::*)(const std::string&)> funcArgMap {
+    {"agent", &WazuhDBQueryBuilder::agent},
+    {"fromTable", &WazuhDBQueryBuilder::fromTable},
+    {"equalsTo", &WazuhDBQueryBuilder::equalsTo},
+    {"whereColumn", &WazuhDBQueryBuilder::whereColumn},
+    {"andColumn", &WazuhDBQueryBuilder::andColumn},
+    {"orColumn", &WazuhDBQueryBuilder::orColumn},
+    {"globalGetCommand", &WazuhDBQueryBuilder::globalGetCommand},
+    {"globalFindCommand", &WazuhDBQueryBuilder::globalFindCommand},
+    {"globalSelectCommand", &WazuhDBQueryBuilder::globalSelectCommand},
+    {"agentGetOsInfoCommand", &WazuhDBQueryBuilder::agentGetOsInfoCommand}};
+
+int main(const int argc, const char* argv[])
+{
+    try
+    {
+        CmdLineArgs cmdLineArgs(argc, argv);
+
+        // Read json configuration file
+        auto configuration = nlohmann::json::parse(std::ifstream(cmdLineArgs.getConfigurationFilePath()));
+
+        SocketDBWrapper socketDBWrapper(WAZUH_DB_SOCK);
+        nlohmann::json response;
+
+        for (const auto& query : configuration.at("queries"))
+        {
+            auto wazuhDBQueryBuilder = WazuhDBQueryBuilder::builder();
+
+            for (const auto& element : query)
+            {
+                if (!element.contains("arg"))
+                {
+                    (wazuhDBQueryBuilder.*(funcMap.at(element.at("method"))))();
+                }
+                else
+                {
+                    (wazuhDBQueryBuilder.*(funcArgMap.at(element.at("method"))))(element.at("arg"));
+                }
+            }
+
+            auto queryStr = wazuhDBQueryBuilder.build();
+            socketDBWrapper.query(queryStr, response);
+
+            std::cout << "Response to \"" << queryStr << "\":\n" << response.dump(4) << std::endl;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << e.what() << std::endl;
+        CmdLineArgs::showHelp();
+        return 1;
+    }
+    return 0;
+}

--- a/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/main.cpp
@@ -18,10 +18,10 @@
 
 auto constexpr WAZUH_DB_SOCK {"/var/ossec/queue/db/wdb"};
 
-const std::unordered_map<std::string, WazuhDBQueryBuilder& (WazuhDBQueryBuilder::*)()> funcMap {
+const std::unordered_map<std::string, WazuhDBQueryBuilder& (WazuhDBQueryBuilder::*)()> FUNC_MAP {
     {"global", &WazuhDBQueryBuilder::global}, {"selectAll", &WazuhDBQueryBuilder::selectAll}};
 
-const std::unordered_map<std::string, WazuhDBQueryBuilder& (WazuhDBQueryBuilder::*)(const std::string&)> funcArgMap {
+const std::unordered_map<std::string, WazuhDBQueryBuilder& (WazuhDBQueryBuilder::*)(const std::string&)> FUNC_ARG_MAP {
     {"agent", &WazuhDBQueryBuilder::agent},
     {"fromTable", &WazuhDBQueryBuilder::fromTable},
     {"equalsTo", &WazuhDBQueryBuilder::equalsTo},
@@ -53,11 +53,11 @@ int main(const int argc, const char* argv[])
             {
                 if (!element.contains("arg"))
                 {
-                    (wazuhDBQueryBuilder.*(funcMap.at(element.at("method"))))();
+                    (wazuhDBQueryBuilder.*(FUNC_MAP.at(element.at("method"))))();
                 }
                 else
                 {
-                    (wazuhDBQueryBuilder.*(funcArgMap.at(element.at("method"))))(element.at("arg"));
+                    (wazuhDBQueryBuilder.*(FUNC_ARG_MAP.at(element.at("method"))))(element.at("arg"));
                 }
             }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19942 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR creates a wrapper to communicate with a DB that listens at a socket (Wazuh-DB).
A helper to create the queries was added and also a test tool to verify the communication.

A new protocol for the `socketWrapper` was required.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

The `shared_modules/utils` tests pass

![2023-11-02_00-07](https://github.com/wazuh/wazuh/assets/65046601/b2fe6b57-42b3-41de-bced-eed0973b8401)

This is the result of the testtool

<details><summary>Details</summary>
<p>

```
root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery# ./wazuh_db_query_testtool  -c ./config.json 
Response to "global sql SELECT * FROM metadata ":
[
    {
        "key": "db_version",
        "value": "5"
    }
]
Response to "global sql SELECT * FROM agent WHERE id = '0' ":
[
    {
        "connection_status": "active",
        "date_add": 1698682174,
        "disconnection_time": 0,
        "group_config_status": "synced",
        "group_sync_status": "synced",
        "id": 0,
        "ip": "127.0.0.1",
        "last_keepalive": 253402300799,
        "manager_host": "ubuntu-jammy",
        "name": "ubuntu-jammy",
        "node_name": "node01",
        "os_arch": "x86_64",
        "os_codename": "Jammy Jellyfish",
        "os_major": "22",
        "os_minor": "04",
        "os_name": "Ubuntu",
        "os_platform": "ubuntu",
        "os_uname": "Linux |ubuntu-jammy |5.15.0-88-generic |#98-Ubuntu SMP Mon Oct 2 15:18:56 UTC 2023 |x86_64",
        "os_version": "22.04.3 LTS",
        "register_ip": "127.0.0.1",
        "status_code": 0,
        "sync_status": "synced",
        "version": "Wazuh v4.8.0"
    }
]
Response to "agent 0 sql SELECT * FROM sys_programs WHERE name = 'bash' ":
[
    {
        "architecture": "amd64",
        "checksum": "b9623b2b6e989e9fb7d133601e6bd50dd9d7e2a6",
        "description": "GNU Bourne Again SHell",
        "format": "deb",
        "install_time": " ",
        "item_id": "db991e708531efc1f7db618b5f4bcc6b1c7d4301",
        "location": " ",
        "multiarch": "foreign",
        "name": "bash",
        "priority": "required",
        "scan_id": 0,
        "scan_time": "2023/10/30 16:12:21",
        "section": "shells",
        "size": 1864,
        "source": " ",
        "triaged": 0,
        "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
        "version": "5.1-6ubuntu1"
    }
]
Response to "global get-agent-info 0 ":
[
    {
        "connection_status": "active",
        "date_add": 1698682174,
        "disconnection_time": 0,
        "group_config_status": "synced",
        "group_sync_status": "synced",
        "id": 0,
        "ip": "127.0.0.1",
        "last_keepalive": 253402300799,
        "manager_host": "ubuntu-jammy",
        "name": "ubuntu-jammy",
        "node_name": "node01",
        "os_arch": "x86_64",
        "os_codename": "Jammy Jellyfish",
        "os_major": "22",
        "os_minor": "04",
        "os_name": "Ubuntu",
        "os_platform": "ubuntu",
        "os_uname": "Linux |ubuntu-jammy |5.15.0-88-generic |#98-Ubuntu SMP Mon Oct 2 15:18:56 UTC 2023 |x86_64",
        "os_version": "22.04.3 LTS",
        "register_ip": "127.0.0.1",
        "status_code": 0,
        "sync_status": "synced",
        "version": "Wazuh v4.8.0"
    }
]
Response to "global select-groups ":
[
    {
        "name": "default"
    }
]
Response to "agent 0 osinfo get ":
[
    {
        "architecture": "x86_64",
        "checksum": "1698683788306095321",
        "hostname": "ubuntu-jammy",
        "os_codename": "jammy",
        "os_major": "22",
        "os_minor": "04",
        "os_name": "Ubuntu",
        "os_patch": "3",
        "os_platform": "ubuntu",
        "os_version": "22.04.3 LTS (Jammy Jellyfish)",
        "reference": "35acc2cf0c07a73421a451ae118fb4a433db2c41",
        "release": "5.15.0-87-generic",
        "scan_id": 0,
        "scan_time": "2023/10/30 16:36:30",
        "sysname": "Linux",
        "triaged": 0,
        "version": "#97-Ubuntu SMP Mon Oct 2 21:09:21 UTC 2023"
    }
]
```

</p>
</details> 

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

- [x] Added unit tests (for new features)
