### PR TITLE
Content Manager - Trigger orchestration on start

### DIFF
--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -68,6 +68,10 @@ public:
             {
                 // Use while with condition variable to avoid spurious wakeups.
                 std::unique_lock<std::mutex> lock(m_mutex);
+
+                // Run action on start, independently of the interval time.
+                runAction(ActionID::SCHEDULED);
+
                 while (m_schedulerRunning)
                 {
                     m_cv.wait_for(lock, std::chrono::seconds(this->m_interval));

--- a/src/shared_modules/content_manager/tests/component/action_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.cpp
@@ -26,15 +26,9 @@ TEST_F(ActionTest, TestInstantiation)
     const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
     const auto& outputFolder {m_parameters.at("configData").at("outputFolder").get_ref<const std::string&>()};
 
-    auto routerProvider {std::make_shared<RouterProvider>(topicName)};
-
-    EXPECT_NO_THROW(routerProvider->start());
-
-    EXPECT_NO_THROW(std::make_shared<Action>(routerProvider, topicName, m_parameters));
+    EXPECT_NO_THROW(std::make_shared<Action>(m_spRouterProvider, topicName, m_parameters));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
-
-    EXPECT_NO_THROW(routerProvider->stop());
 }
 
 /*
@@ -47,15 +41,9 @@ TEST_F(ActionTest, TestInstantiationWhitoutConfigData)
 
     const auto& topicName {parameters.at("topicName").get_ref<const std::string&>()};
 
-    auto routerProvider {std::make_shared<RouterProvider>(topicName)};
-
-    EXPECT_NO_THROW(routerProvider->start());
-
     parameters.erase("configData");
 
-    EXPECT_THROW(std::make_shared<Action>(routerProvider, topicName, parameters), std::invalid_argument);
-
-    EXPECT_NO_THROW(routerProvider->stop());
+    EXPECT_THROW(std::make_shared<Action>(m_spRouterProvider, topicName, parameters), std::invalid_argument);
 }
 
 /*
@@ -70,11 +58,7 @@ TEST_F(ActionTest, TestInstantiationAndStartActionSchedulerForRawData)
     const auto contentPath {outputFolder + "/" + CONTENTS_FOLDER + "/3-" + fileName};
     const auto downloadPath {outputFolder + "/" + DOWNLOAD_FOLDER + "/3-" + fileName};
 
-    auto routerProvider {std::make_shared<RouterProvider>(topicName)};
-
-    EXPECT_NO_THROW(routerProvider->start());
-
-    auto action {std::make_shared<Action>(routerProvider, topicName, m_parameters)};
+    auto action {std::make_shared<Action>(m_spRouterProvider, topicName, m_parameters)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -90,8 +74,6 @@ TEST_F(ActionTest, TestInstantiationAndStartActionSchedulerForRawData)
     EXPECT_TRUE(std::filesystem::exists(contentPath));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
-
-    EXPECT_NO_THROW(routerProvider->stop());
 }
 
 /*
@@ -111,11 +93,7 @@ TEST_F(ActionTest, TestInstantiationAndStartActionSchedulerForRawDataWithDeleteD
     const auto contentPath {outputFolder + "/" + CONTENTS_FOLDER + "/3-" + fileName};
     const auto downloadPath {outputFolder + "/" + DOWNLOAD_FOLDER + "/3-" + fileName};
 
-    auto routerProvider {std::make_shared<RouterProvider>(topicName)};
-
-    EXPECT_NO_THROW(routerProvider->start());
-
-    auto action {std::make_shared<Action>(routerProvider, topicName, m_parameters)};
+    auto action {std::make_shared<Action>(m_spRouterProvider, topicName, m_parameters)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -131,8 +109,6 @@ TEST_F(ActionTest, TestInstantiationAndStartActionSchedulerForRawDataWithDeleteD
     EXPECT_TRUE(std::filesystem::exists(contentPath));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
-
-    EXPECT_NO_THROW(routerProvider->stop());
 }
 
 /*
@@ -151,11 +127,7 @@ TEST_F(ActionTest, TestInstantiationAndStartActionSchedulerForCompressedData)
     const auto contentPath {outputFolder + "/" + CONTENTS_FOLDER + "/3-" + fileName};
     const auto downloadPath {outputFolder + "/" + DOWNLOAD_FOLDER + "/3-" + fileName};
 
-    auto routerProvider {std::make_shared<RouterProvider>(topicName)};
-
-    EXPECT_NO_THROW(routerProvider->start());
-
-    auto action {std::make_shared<Action>(routerProvider, topicName, m_parameters)};
+    auto action {std::make_shared<Action>(m_spRouterProvider, topicName, m_parameters)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -171,8 +143,6 @@ TEST_F(ActionTest, TestInstantiationAndStartActionSchedulerForCompressedData)
     EXPECT_TRUE(std::filesystem::exists(contentPath));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
-
-    EXPECT_NO_THROW(routerProvider->stop());
 }
 
 /*
@@ -183,13 +153,9 @@ TEST_F(ActionTest, TestInstantiationAndRegisterActionOnDemandForRawData)
     const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
     const auto& outputFolder {m_parameters.at("configData").at("outputFolder").get_ref<const std::string&>()};
 
-    auto routerProvider {std::make_shared<RouterProvider>(topicName)};
-
-    EXPECT_NO_THROW(routerProvider->start());
-
     m_parameters["ondemand"] = true;
 
-    auto action {std::make_shared<Action>(routerProvider, topicName, m_parameters)};
+    auto action {std::make_shared<Action>(m_spRouterProvider, topicName, m_parameters)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -198,8 +164,6 @@ TEST_F(ActionTest, TestInstantiationAndRegisterActionOnDemandForRawData)
     EXPECT_NO_THROW(action->unregisterActionOnDemand());
 
     EXPECT_NO_THROW(action->clearEndpoints());
-
-    EXPECT_NO_THROW(routerProvider->stop());
 }
 
 /*
@@ -214,14 +178,10 @@ TEST_F(ActionTest, TestInstantiationOfTwoActionsWithTheSameTopicName)
     auto parametersWithoutDatabasePath = m_parameters;
     parametersWithoutDatabasePath.at("configData").erase("databasePath");
 
-    auto routerProvider {std::make_shared<RouterProvider>(topicName)};
-
-    EXPECT_NO_THROW(routerProvider->start());
-
     m_parameters["ondemand"] = true;
 
-    auto action1 {std::make_shared<Action>(routerProvider, topicName, m_parameters)};
-    auto action2 {std::make_shared<Action>(routerProvider, topicName, parametersWithoutDatabasePath)};
+    auto action1 {std::make_shared<Action>(m_spRouterProvider, topicName, m_parameters)};
+    auto action2 {std::make_shared<Action>(m_spRouterProvider, topicName, parametersWithoutDatabasePath)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -231,8 +191,6 @@ TEST_F(ActionTest, TestInstantiationOfTwoActionsWithTheSameTopicName)
     EXPECT_NO_THROW(action1->unregisterActionOnDemand());
 
     EXPECT_NO_THROW(action1->clearEndpoints());
-
-    EXPECT_NO_THROW(routerProvider->stop());
 }
 
 /*
@@ -248,11 +206,7 @@ TEST_F(ActionTest, TestInstantiationAndRunActionOnDemand)
     const auto contentPath {outputFolder + "/" + CONTENTS_FOLDER + "/3-" + fileName};
     const auto downloadPath {outputFolder + "/" + DOWNLOAD_FOLDER + "/3-" + fileName};
 
-    auto routerProvider {std::make_shared<RouterProvider>(topicName)};
-
-    EXPECT_NO_THROW(routerProvider->start());
-
-    auto action {std::make_shared<Action>(routerProvider, topicName, m_parameters)};
+    auto action {std::make_shared<Action>(m_spRouterProvider, topicName, m_parameters)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -271,6 +225,41 @@ TEST_F(ActionTest, TestInstantiationAndRunActionOnDemand)
     EXPECT_TRUE(std::filesystem::exists(contentPath));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
+}
 
-    EXPECT_NO_THROW(routerProvider->stop());
+/**
+ * @brief Tests the on-start execution of the action.
+ *
+ */
+TEST_F(ActionTest, ActionOnStartExecution)
+{
+    constexpr auto ACTION_INTERVAL {100};
+    constexpr auto WAIT_TIME {1};
+
+    const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
+    const auto& outputFolder {m_parameters.at("configData").at("outputFolder").get_ref<const std::string&>()};
+    const auto& fileName {m_parameters.at("configData").at("contentFileName").get_ref<const std::string&>()};
+
+    // Make the interval big enough to be sure the action is not triggered a second time.
+    auto& interval {m_parameters.at("interval").get_ref<size_t&>()};
+    interval = ACTION_INTERVAL;
+
+    // Init action.
+    auto action {std::make_shared<Action>(m_spRouterProvider, topicName, m_parameters)};
+
+    // Check output folder existence.
+    EXPECT_TRUE(std::filesystem::exists(outputFolder));
+
+    // Start scheduling.
+    EXPECT_NO_THROW(action->startActionScheduler(interval));
+
+    // Wait just for a little time.
+    std::this_thread::sleep_for(std::chrono::seconds(WAIT_TIME));
+
+    // Stop scheduling.
+    EXPECT_NO_THROW(action->stopActionScheduler());
+
+    // Check that the download has been correctly made.
+    const auto contentFilePath {outputFolder + "/" + CONTENTS_FOLDER + "/3-" + fileName};
+    EXPECT_TRUE(std::filesystem::exists(contentFilePath));
 }

--- a/src/shared_modules/content_manager/tests/component/action_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.hpp
@@ -13,6 +13,7 @@
 #define _ACTION_TEST_HPP
 
 #include "fakes/fakeServer.hpp"
+#include "routerProvider.hpp"
 #include "gtest/gtest.h"
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
@@ -31,6 +32,8 @@ protected:
     nlohmann::json m_parameters; ///< Parameters used to create the Action
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Pointer to FakeServer class
+
+    std::shared_ptr<RouterProvider> m_spRouterProvider; ///< Router provider used on tests.
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -57,6 +60,11 @@ protected:
                 }
             }
         )"_json;
+
+        // Init router provider.
+        const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
+        m_spRouterProvider = std::make_shared<RouterProvider>(topicName);
+        m_spRouterProvider->start();
     }
 
     /**
@@ -73,6 +81,9 @@ protected:
             // Delete the output folder.
             std::filesystem::remove_all(outputFolder);
         }
+
+        // Stop router provider.
+        m_spRouterProvider->stop();
     }
 
     /**


### PR DESCRIPTION
|Related issue|
|---|
|#19987 |

## Description

This PR forces the `ContentUpdater` orchestration to be triggered on start, independently of the time interval set on the input config.

Change log:
- Modify `action.hpp`, forcing the on-start execution.
- Modify `ActionTest` component tests to test this new functionality. Some other general improvements have been made in this class.


## Results

I ran the test tool with an interval equal to `10`, and with the help of `ts` to add timestamps to the output:
```
# ./content_manager_test_tool | ts '[%H:%M:%S]'
```

Results:
![image](https://github.com/wazuh/wazuh/assets/42682247/8ea20392-276b-4f42-a838-f7eff3351183)
1. **Second 39:** Orchestration is constructed.
2. **Second 39:** Orchestration is triggered (first execution)
3. **Second 45:** Orchestration is triggered (second execution after 5 seconds due to [this](https://github.com/wazuh/wazuh/blob/32dbbaa7cf3f5665e3d8d05c9dfe339eb292b00b/src/shared_modules/content_manager/testtool/main.cpp#L57))
4. **Second 55:** Orchestration is triggered (third execution after 10 seconds)
