### PR TITLE
Fix shuffle request warning

### DIFF
--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -216,7 +216,7 @@ def send_msg(msg: str, url: str) -> None:
             URL of the integration.
     """
     headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
-    res     = requests.post(url, data=msg, headers=headers, verify=False)
+    res     = requests.post(url, data=msg, headers=headers, timeout=10)
     debug("# Response received: %s" % res.json)
 
 def get_json_alert(file_location: str) -> any:

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -213,4 +213,4 @@ def test_send_msg():
     headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
     with patch('requests.post', return_value=requests.Response) as request_post:
         shuffle.send_msg(msg_template, sys_args_template[3])
-        request_post.assert_called_once_with(sys_args_template[3], data=msg_template, headers=headers, verify=False)
+        request_post.assert_called_once_with(sys_args_template[3], data=msg_template, headers=headers, timeout=10)


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/19604 |


## Description

Enables SSL certificate verification for the requests performed in the shuffle integration.

> I also added the `timeout` parameter to avoid indefinitely hang ups.

## Configuration options

```xml
<integration>
   <name>shuffle</name>
   <hook_url>https://shuffler.io/api/v1/hooks/WEBHOOK_ID</hook_url>
   <level>3</level>
   <alert_format>json</alert_format>
</integration>
```

Also, the value `integrator.debug` from the configuration in `internal_options.conf` was set to 2.

## Logs/Alerts example



<details><summary>ossec.log</summary>

```console
root@wazuh-master:/# cat /var/ossec/logs/ossec.log | grep wazuh-integratord
...
2023/11/02 15:02:42 wazuh-integratord[9334] integrator.c:143 at OS_IntegratorD(): INFO: Enabling integration for: 'shuffle'.
2023/11/02 15:02:42 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:43 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:44 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:45 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:46 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:47 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:47 wazuh-integratord[9334] integrator.c:161 at OS_IntegratorD(): DEBUG: Sending new alert.
2023/11/02 15:02:47 wazuh-integratord[9334] integrator.c:293 at OS_IntegratorD(): DEBUG: File /tmp/shuffle-1698937367-1525090471.alert was written.
2023/11/02 15:02:47 wazuh-integratord[9334] integrator.c:442 at OS_IntegratorD(): DEBUG: Running script with args: integrations /tmp/shuffle-1698937367-1525090471.alert  https://shuffler.io/api/v1/hooks/WEBHOOK_ID debug 
2023/11/02 15:02:48 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Running Shuffle script
2023/11/02 15:02:48 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # JSON file for options  doesn't exist
2023/11/02 15:02:48 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Opening options file at '' with 'None'
2023/11/02 15:02:48 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Opening alert file at '/tmp/shuffle-1698937367-1525090471.alert' with '{'timestamp': '2023-11-02T15:02:47.286+0000', 'rule': {'level': 7, 'description': 'Host-based anomaly detection event (rootcheck).', 'id': '510', 'firedtimes': 1, 'mail': False, 'groups': ['ossec', 'rootcheck'], 'pci_dss': ['10.6.1'], 'gdpr': ['IV_35.7.d']}, 'agent': {'id': '000', 'name': 'wazuh-master'}, 'manager': {'name': 'wazuh-master'}, 'id': '1698937367.5919', 'cluster': {'name': 'wazuh', 'node': 'master-node'}, 'full_log': "Trojaned version of file '/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", 'decoder': {'name': 'rootcheck'}, 'data': {'title': 'Trojaned version of file detected.', 'file': '/bin/diff'}, 'location': 'rootcheck'}'
2023/11/02 15:02:48 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Generating message
2023/11/02 15:02:48 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Sending message {"severity": 2, "pretext": "WAZUH Alert", "title": "Host-based anomaly detection event (rootcheck).", "text": "Trojaned version of file '/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", "rule_id": "510", "timestamp": "2023-11-02T15:02:47.286+0000", "id": "1698937367.5919", "all_fields": {"timestamp": "2023-11-02T15:02:47.286+0000", "rule": {"level": 7, "description": "Host-based anomaly detection event (rootcheck).", "id": "510", "firedtimes": 1, "mail": false, "groups": ["ossec", "rootcheck"], "pci_dss": ["10.6.1"], "gdpr": ["IV_35.7.d"]}, "agent": {"id": "000", "name": "wazuh-master"}, "manager": {"name": "wazuh-master"}, "id": "1698937367.5919", "cluster": {"name": "wazuh", "node": "master-node"}, "full_log": "Trojaned version of file '/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", "decoder": {"name": "rootcheck"}, "data": {"title": "Trojaned version of file detected.", "file": "/bin/diff"}, "location": "rootcheck"}} to Shuffle server
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Response received: {'success': True, 'execution_id': '2f1ba88a-ae56-490c-8422-6906a04341b7'}
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:464 at OS_IntegratorD(): DEBUG: Command ran successfully.
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:161 at OS_IntegratorD(): DEBUG: Sending new alert.
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:293 at OS_IntegratorD(): DEBUG: File /tmp/shuffle-1698937369--872166936.alert was written.
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:442 at OS_IntegratorD(): DEBUG: Running script with args: integrations /tmp/shuffle-1698937369--872166936.alert  https://shuffler.io/api/v1/hooks/WEBHOOK_ID debug 
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Running Shuffle script
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # JSON file for options  doesn't exist
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Opening options file at '' with 'None'
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Opening alert file at '/tmp/shuffle-1698937369--872166936.alert' with '{'timestamp': '2023-11-02T15:02:47.299+0000', 'rule': {'level': 7, 'description': 'Host-based anomaly detection event (rootcheck).', 'id': '510', 'firedtimes': 2, 'mail': False, 'groups': ['ossec', 'rootcheck'], 'pci_dss': ['10.6.1'], 'gdpr': ['IV_35.7.d']}, 'agent': {'id': '000', 'name': 'wazuh-master'}, 'manager': {'name': 'wazuh-master'}, 'id': '1698937367.6298', 'cluster': {'name': 'wazuh', 'node': 'master-node'}, 'full_log': "Trojaned version of file '/usr/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", 'decoder': {'name': 'rootcheck'}, 'data': {'title': 'Trojaned version of file detected.', 'file': '/usr/bin/diff'}, 'location': 'rootcheck'}'
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Generating message
2023/11/02 15:02:49 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Sending message {"severity": 2, "pretext": "WAZUH Alert", "title": "Host-based anomaly detection event (rootcheck).", "text": "Trojaned version of file '/usr/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", "rule_id": "510", "timestamp": "2023-11-02T15:02:47.299+0000", "id": "1698937367.6298", "all_fields": {"timestamp": "2023-11-02T15:02:47.299+0000", "rule": {"level": 7, "description": "Host-based anomaly detection event (rootcheck).", "id": "510", "firedtimes": 2, "mail": false, "groups": ["ossec", "rootcheck"], "pci_dss": ["10.6.1"], "gdpr": ["IV_35.7.d"]}, "agent": {"id": "000", "name": "wazuh-master"}, "manager": {"name": "wazuh-master"}, "id": "1698937367.6298", "cluster": {"name": "wazuh", "node": "master-node"}, "full_log": "Trojaned version of file '/usr/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", "decoder": {"name": "rootcheck"}, "data": {"title": "Trojaned version of file detected.", "file": "/usr/bin/diff"}, "location": "rootcheck"}} to Shuffle server
2023/11/02 15:02:50 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Response received: {'success': True, 'execution_id': '27cc4848-3f5b-481a-ab8e-9fd27fb612a7'}
2023/11/02 15:02:50 wazuh-integratord[9334] integrator.c:464 at OS_IntegratorD(): DEBUG: Command ran successfully.
2023/11/02 15:02:50 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:51 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:51 wazuh-db[9373] wdb_parser.c:263 at wdb_parse(): DEBUG: Agent 000 query: syscollector_processes save2 {"attributes":{"argvs":null,"checksum":"e7fe09400e20503248ba8e715e6641fa2393fd4c","cmd":"/var/ossec/bin/wazuh-integratord","egroup":"wazuh","euser":"wazuh","fgroup":"wazuh","name":"wazuh-integrato","nice":5,"nlwp":2,"pgrp":9333,"pid":"9334","ppid":1,"priority":25,"processor":2,"resident":3776,"rgroup":"wazuh","ruser":"wazuh","scan_time":"2023/11/02 15:02:51","session":9333,"sgroup":"wazuh","share":704,"size":21753,"start_time":1698937362,"state":"S","stime":0,"suser":"wazuh","tgid":9334,"tty":0,"utime":0,"vm_size":87012},"index":"9334","timestamp":""}
2023/11/02 15:02:52 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:53 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:54 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:55 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:56 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:57 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:58 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:02:59 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:03:00 wazuh-integratord[9334] integrator.c:154 at OS_IntegratorD(): DEBUG: jqueue_next()
2023/11/02 15:03:00 wazuh-integratord[9334] integrator.c:161 at OS_IntegratorD(): DEBUG: Sending new alert.
2023/11/02 15:03:00 wazuh-integratord[9334] integrator.c:293 at OS_IntegratorD(): DEBUG: File /tmp/shuffle-1698937380-1791047886.alert was written.
2023/11/02 15:03:00 wazuh-integratord[9334] integrator.c:442 at OS_IntegratorD(): DEBUG: Running script with args: integrations /tmp/shuffle-1698937380-1791047886.alert  https://shuffler.io/api/v1/hooks/WEBHOOK_ID debug 
2023/11/02 15:03:00 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Running Shuffle script
2023/11/02 15:03:00 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # JSON file for options  doesn't exist
2023/11/02 15:03:00 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Opening options file at '' with 'None'
2023/11/02 15:03:00 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Opening alert file at '/tmp/shuffle-1698937380-1791047886.alert' with '{'timestamp': '2023-11-02T15:02:59.027+0000', 'rule': {'level': 3, 'description': 'Wazuh server started.', 'id': '502', 'firedtimes': 1, 'mail': False, 'groups': ['ossec'], 'pci_dss': ['10.6.1'], 'gpg13': ['10.1'], 'gdpr': ['IV_35.7.d'], 'hipaa': ['164.312.b'], 'nist_800_53': ['AU.6'], 'tsc': ['CC7.2', 'CC7.3']}, 'agent': {'id': '000', 'name': 'wazuh-master'}, 'manager': {'name': 'wazuh-master'}, 'id': '1698937379.6685', 'cluster': {'name': 'wazuh', 'node': 'master-node'}, 'full_log': 'ossec: Manager started.', 'decoder': {'name': 'ossec'}, 'location': 'wazuh-monitord'}'
2023/11/02 15:03:00 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Generating message
2023/11/02 15:03:00 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Sending message {"severity": 1, "pretext": "WAZUH Alert", "title": "Wazuh server started.", "text": "ossec: Manager started.", "rule_id": "502", "timestamp": "2023-11-02T15:02:59.027+0000", "id": "1698937379.6685", "all_fields": {"timestamp": "2023-11-02T15:02:59.027+0000", "rule": {"level": 3, "description": "Wazuh server started.", "id": "502", "firedtimes": 1, "mail": false, "groups": ["ossec"], "pci_dss": ["10.6.1"], "gpg13": ["10.1"], "gdpr": ["IV_35.7.d"], "hipaa": ["164.312.b"], "nist_800_53": ["AU.6"], "tsc": ["CC7.2", "CC7.3"]}, "agent": {"id": "000", "name": "wazuh-master"}, "manager": {"name": "wazuh-master"}, "id": "1698937379.6685", "cluster": {"name": "wazuh", "node": "master-node"}, "full_log": "ossec: Manager started.", "decoder": {"name": "ossec"}, "location": "wazuh-monitord"}} to Shuffle server
2023/11/02 15:03:01 wazuh-integratord[9334] integrator.c:451 at OS_IntegratorD(): DEBUG: # Response received: {'success': True, 'execution_id': '0789ddf3-f363-4095-b450-272087ba0f74'}
2023/11/02 15:03:01 wazuh-integratord[9334] integrator.c:464 at OS_IntegratorD(): DEBUG: Command ran successfully.
```

</details>

<details><summary>integrations.log</summary>

```console
root@wazuh-master:/# cat /var/ossec/logs/integrations.log
...
/tmp/shuffle-1698937367-1525090471.alert  https://shuffler.io/api/v1/hooks/WEBHOOK_ID debug 
# Running Shuffle script
# JSON file for options  doesn't exist
# Opening options file at '' with 'None'
# Opening alert file at '/tmp/shuffle-1698937367-1525090471.alert' with '{'timestamp': '2023-11-02T15:02:47.286+0000', 'rule': {'level': 7, 'description': 'Host-based anomaly detection event (rootcheck).', 'id': '510', 'firedtimes': 1, 'mail': False, 'groups': ['ossec', 'rootcheck'], 'pci_dss': ['10.6.1'], 'gdpr': ['IV_35.7.d']}, 'agent': {'id': '000', 'name': 'wazuh-master'}, 'manager': {'name': 'wazuh-master'}, 'id': '1698937367.5919', 'cluster': {'name': 'wazuh', 'node': 'master-node'}, 'full_log': "Trojaned version of file '/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", 'decoder': {'name': 'rootcheck'}, 'data': {'title': 'Trojaned version of file detected.', 'file': '/bin/diff'}, 'location': 'rootcheck'}'
# Generating message
# Sending message {"severity": 2, "pretext": "WAZUH Alert", "title": "Host-based anomaly detection event (rootcheck).", "text": "Trojaned version of file '/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", "rule_id": "510", "timestamp": "2023-11-02T15:02:47.286+0000", "id": "1698937367.5919", "all_fields": {"timestamp": "2023-11-02T15:02:47.286+0000", "rule": {"level": 7, "description": "Host-based anomaly detection event (rootcheck).", "id": "510", "firedtimes": 1, "mail": false, "groups": ["ossec", "rootcheck"], "pci_dss": ["10.6.1"], "gdpr": ["IV_35.7.d"]}, "agent": {"id": "000", "name": "wazuh-master"}, "manager": {"name": "wazuh-master"}, "id": "1698937367.5919", "cluster": {"name": "wazuh", "node": "master-node"}, "full_log": "Trojaned version of file '/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", "decoder": {"name": "rootcheck"}, "data": {"title": "Trojaned version of file detected.", "file": "/bin/diff"}, "location": "rootcheck"}} to Shuffle server
# Response received: {'success': True, 'execution_id': '2f1ba88a-ae56-490c-8422-6906a04341b7'}
/tmp/shuffle-1698937369--872166936.alert  https://shuffler.io/api/v1/hooks/WEBHOOK_ID debug 
# Running Shuffle script
# JSON file for options  doesn't exist
# Opening options file at '' with 'None'
# Opening alert file at '/tmp/shuffle-1698937369--872166936.alert' with '{'timestamp': '2023-11-02T15:02:47.299+0000', 'rule': {'level': 7, 'description': 'Host-based anomaly detection event (rootcheck).', 'id': '510', 'firedtimes': 2, 'mail': False, 'groups': ['ossec', 'rootcheck'], 'pci_dss': ['10.6.1'], 'gdpr': ['IV_35.7.d']}, 'agent': {'id': '000', 'name': 'wazuh-master'}, 'manager': {'name': 'wazuh-master'}, 'id': '1698937367.6298', 'cluster': {'name': 'wazuh', 'node': 'master-node'}, 'full_log': "Trojaned version of file '/usr/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", 'decoder': {'name': 'rootcheck'}, 'data': {'title': 'Trojaned version of file detected.', 'file': '/usr/bin/diff'}, 'location': 'rootcheck'}'
# Generating message
# Sending message {"severity": 2, "pretext": "WAZUH Alert", "title": "Host-based anomaly detection event (rootcheck).", "text": "Trojaned version of file '/usr/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", "rule_id": "510", "timestamp": "2023-11-02T15:02:47.299+0000", "id": "1698937367.6298", "all_fields": {"timestamp": "2023-11-02T15:02:47.299+0000", "rule": {"level": 7, "description": "Host-based anomaly detection event (rootcheck).", "id": "510", "firedtimes": 2, "mail": false, "groups": ["ossec", "rootcheck"], "pci_dss": ["10.6.1"], "gdpr": ["IV_35.7.d"]}, "agent": {"id": "000", "name": "wazuh-master"}, "manager": {"name": "wazuh-master"}, "id": "1698937367.6298", "cluster": {"name": "wazuh", "node": "master-node"}, "full_log": "Trojaned version of file '/usr/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", "decoder": {"name": "rootcheck"}, "data": {"title": "Trojaned version of file detected.", "file": "/usr/bin/diff"}, "location": "rootcheck"}} to Shuffle server
# Response received: {'success': True, 'execution_id': '27cc4848-3f5b-481a-ab8e-9fd27fb612a7'}
/tmp/shuffle-1698937380-1791047886.alert  https://shuffler.io/api/v1/hooks/WEBHOOK_ID debug 
# Running Shuffle script
# JSON file for options  doesn't exist
# Opening options file at '' with 'None'
# Opening alert file at '/tmp/shuffle-1698937380-1791047886.alert' with '{'timestamp': '2023-11-02T15:02:59.027+0000', 'rule': {'level': 3, 'description': 'Wazuh server started.', 'id': '502', 'firedtimes': 1, 'mail': False, 'groups': ['ossec'], 'pci_dss': ['10.6.1'], 'gpg13': ['10.1'], 'gdpr': ['IV_35.7.d'], 'hipaa': ['164.312.b'], 'nist_800_53': ['AU.6'], 'tsc': ['CC7.2', 'CC7.3']}, 'agent': {'id': '000', 'name': 'wazuh-master'}, 'manager': {'name': 'wazuh-master'}, 'id': '1698937379.6685', 'cluster': {'name': 'wazuh', 'node': 'master-node'}, 'full_log': 'ossec: Manager started.', 'decoder': {'name': 'ossec'}, 'location': 'wazuh-monitord'}'
# Generating message
# Sending message {"severity": 1, "pretext": "WAZUH Alert", "title": "Wazuh server started.", "text": "ossec: Manager started.", "rule_id": "502", "timestamp": "2023-11-02T15:02:59.027+0000", "id": "1698937379.6685", "all_fields": {"timestamp": "2023-11-02T15:02:59.027+0000", "rule": {"level": 3, "description": "Wazuh server started.", "id": "502", "firedtimes": 1, "mail": false, "groups": ["ossec"], "pci_dss": ["10.6.1"], "gpg13": ["10.1"], "gdpr": ["IV_35.7.d"], "hipaa": ["164.312.b"], "nist_800_53": ["AU.6"], "tsc": ["CC7.2", "CC7.3"]}, "agent": {"id": "000", "name": "wazuh-master"}, "manager": {"name": "wazuh-master"}, "id": "1698937379.6685", "cluster": {"name": "wazuh", "node": "master-node"}, "full_log": "ossec: Manager started.", "decoder": {"name": "ossec"}, "location": "wazuh-monitord"}} to Shuffle server
# Response received: {'success': True, 'execution_id': '0789ddf3-f363-4095-b450-272087ba0f74'}
```

</details>

<details><summary>Emails</summary>

![shuffle](https://github.com/wazuh/wazuh/assets/51374959/c525dcb7-5681-4f4e-aa27-65d6bd7cc53e)

</details>

## Tests

<details><summary>pytest integrations/</summary>

```console
(venv) gasti@pop-os:~/work/wazuh$ pytest integrations/
============================================================================ test session starts =============================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0
rootdir: /home/gasti/work/wazuh
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 103 items                                                                                                                                                          

integrations/tests/test_maltiverse.py ..............................................                                                                                   [ 44%]
integrations/tests/test_pagerduty.py ..........                                                                                                                        [ 54%]
integrations/tests/test_shuffle.py ..................                                                                                                                  [ 71%]
integrations/tests/test_slack.py ..........                                                                                                                            [ 81%]
integrations/tests/test_virustotal.py ...................                                                                                                              [100%]

============================================================================== warnings summary ==============================================================================
venv/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28
  /home/gasti/work/wazuh/venv/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================= 103 passed, 1 warning in 0.24s =======================================================================
```

</details>