### PR TITLE
Deletes duplicated `type` key in API Spec.

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1446,7 +1446,6 @@ components:
               type: string
           description: "Agent OS information"
         status_code:
-          type: integer
           description: "Agent connection status code"
           type: integer
           format: int32


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/20045|


## Description

Deleted duplicated `type` key in `spec.yaml`.