### PR TITLE
Prevent WPK rollback from rebooting the host on Windows agent

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -133,7 +133,7 @@ function get_uninstall_string {
             foreach ($subsubpath in $subpath) {
                 if ($subsubpath -match "InstallProperties") {
                     if ($subsubpath.GetValue("Publisher") -match $Env:WAZUH_PUBLISHER_VALUE) {
-                        $UninstallString = $subsubpath.GetValue("UninstallString") + " /quiet"
+                        $UninstallString = $subsubpath.GetValue("UninstallString") + " /quiet /norestart"
                     }
                 }
             }


### PR DESCRIPTION
|Related issue|
|---|
| Fixes #19994 |

As explained in the issue above, this PR aims to modify the WPK installer to prevent upgrades from attempting to reboot the agent's host on upgrade failure.

## Tests

- [x] Test a failing WPK upgrade with rollback.