### PR TITLE
Content Manager - Handle orchestration exceptions

### DIFF
--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -183,7 +183,14 @@ private:
 
     void runAction(const ActionID id)
     {
-        m_orchestration->run();
+        try
+        {
+            m_orchestration->run();
+        }
+        catch (const std::exception& e)
+        {
+            std::cout << "Action failed: " << e.what() << std::endl;
+        }
 
         m_actionInProgress = false;
     }

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -190,7 +190,7 @@ private:
         }
         catch (const std::exception& e)
         {
-            std::cout << "Action failed: " << e.what() << std::endl;
+            std::cout << "Action for '" << m_topicName << "' failed: " << e.what() << std::endl;
         }
 
         m_actionInProgress = false;

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -153,8 +153,9 @@ public:
         }
         else
         {
-            std::cerr << "Action: Ondemand request - another action in progress for " << m_topicName
-                      << std::endl; // LCOV_EXCL_LINE
+            // LCOV_EXCL_START
+            std::cerr << "Action: Ondemand request - another action in progress for " << m_topicName << std::endl;
+            // LCOV_EXCL_STOP
         }
     }
 

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -85,6 +85,7 @@ public:
         }
         catch (const std::exception& e)
         {
+            cleanContext();
             throw std::invalid_argument {"Orchestration run failed. " + std::string {e.what()}};
         }
     }
@@ -99,6 +100,15 @@ private:
      * @brief Context used on the content updater orchestration.
      */
     std::shared_ptr<UpdaterBaseContext> m_spBaseContext;
+
+    /**
+     * @brief Clean ContentUpdater persistent data. Useful for cleaning the context when an exception is thrown.
+     *
+     */
+    void cleanContext() const
+    {
+        m_spBaseContext->downloadedFileHash.clear();
+    }
 };
 
 #endif // _ACTION_ORCHESTRATOR_HPP


### PR DESCRIPTION
|Related issue|
|---|
| #20080 |

## Description

This PR makes the content manager module catch the possible exceptions thrown in each content updater execution.

Change log:
- Catch the exceptions of the triggered actions
- Add UTs that validate this new feature
- Fix LCOV flags on `action.hpp`

## Results

### Test tool

- Launch Content Manager configured to download from a server that is initially disabled.

```bash
# ./content_manager_test_tool 
ActionOrchestrator - Starting process
API offset to be used: 0
Output folders created.
FactoryContentUpdater - Starting process
Creating 's3' downloader
Creating 'raw' content decompressor
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
ActionOrchestrator - Running process
Action failed: Orchestration run failed. S3Downloader - Could not get response from S3 because: Couldn't connect to server
changing interval
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
Action failed: Orchestration run failed. S3Downloader - Could not get response from S3 because: Couldn't connect to server
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
Action failed: Orchestration run failed. S3Downloader - Could not get response from S3 because: Couldn't connect to server
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
S3Downloader - Download done successfully
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
S3Downloader - Download done successfully
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
S3Downloader - Download done successfully
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
S3Downloader - Download done successfully
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.
Server stopped
Action: Scheduler stopped for test
```

- Same as above but with an OfflineDownloader, creating the input file in the middle:
```bash
# ./content_manager_test_tool
ActionOrchestrator - Starting process
API offset to be used: 0
The previous output folder: "/tmp/testProvider" will be removed.
Output folders created.
FactoryContentUpdater - Starting process
Creating 'offline' downloader
Creating 'raw' content decompressor
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
ActionOrchestrator - Running process
Action failed: Orchestration run failed. Download failed: Unable to open '/home/test.txt' for hashing.
changing interval
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
Action failed: Orchestration run failed. Download failed: Unable to open '/home/test.txt' for hashing.
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.
Server stopped
Action: Scheduler stopped for test
```