### PR TITLE
Backport docker-compose v2 to 4.7.0

### DIFF
--- a/api/test/integration/pytest.ini
+++ b/api/test/integration/pytest.ini
@@ -2,6 +2,7 @@
 render_collapsed = True
 tavern-strict=json:off headers:off
 tavern-global-cfg=common.yaml
+asyncio_mode=auto
 markers =
     standalone: mark a test to be passed in a Wazuh standalone environment.
     cluster: mark a test to be passed in a Wazuh cluster environment.

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -441,7 +441,7 @@ def check_agentd_started(response, agents_list):
         while tries < 80:
             try:
                 # Save agentd logs in a list
-                command = f"docker exec env_wazuh-agent{int(agent_id)}_1 grep agentd /var/ossec/logs/ossec.log"
+                command = f"docker exec env-wazuh-agent{int(agent_id)}-1 grep agentd /var/ossec/logs/ossec.log"
                 output = subprocess.check_output(command.split()).decode().strip().split('\n')
             except subprocess.SubprocessError as exc:
                 raise subprocess.SubprocessError(f"Error while trying to get logs from agent {agent_id}") from exc
@@ -475,7 +475,7 @@ def check_agent_active_status(agents_list):
     while tries < 25:
         try:
             # Get active agents
-            output = subprocess.check_output(f"docker exec env_wazuh-master_1 /var/ossec/framework/python/bin/python3 "
+            output = subprocess.check_output(f"docker exec env-wazuh-master-1 /var/ossec/framework/python/bin/python3 "
                                              f"{active_agents_script_path}".split()).decode().strip()
         except subprocess.SubprocessError as exc:
             raise subprocess.SubprocessError("Error while trying to get agents") from exc


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/20046 |

## Description

This PR backports the changes implemented to migrate to docker-compose v2 implemented in 4.7.1 to 4.7.0.

## Tests

Artifacts: [archive.zip](https://github.com/wazuh/wazuh/files/13279928/archive.zip)
Artifacts of the failed check with the correct jenkins library version: [artifacts.zip](https://github.com/wazuh/wazuh/files/13297790/artifacts.zip)


<details><summary>Logs</summary>

```console
============================= test session starts ==============================
platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-1.2.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.19.0-1028-aws-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'asyncio': '0.18.1', 'html': '2.1.1', 'trio': '0.7.0', 'metadata': '3.0.0', 'tavern': '1.23.5', 'aiohttp': '1.0.4'}}
rootdir: /tmp/Test_integration_endpoints_B4059_test_files/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, html-2.1.1, trio-0.7.0, metadata-3.0.0, tavern-1.23.5, aiohttp-1.0.4
asyncio: mode=auto
collecting ... collected 5 items

test_webhook_endpoints.tavern.yaml::POST /events PASSED                  [ 20%]
test_webhook_endpoints.tavern.yaml::POST /events with invalid formats PASSED [ 40%]
test_webhook_endpoints.tavern.yaml::POST /events with more than 100 events PASSED [ 60%]
test_webhook_endpoints.tavern.yaml::POST /events with big events PASSED  [ 80%]
test_webhook_endpoints.tavern.yaml::Try to send more than 30 requests per minute PASSED [100%]

=============================== warnings summary ===============================
../../../../../home/ubuntu/.local/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/ubuntu/.local/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_webhook_endpoints.tavern.yaml::POST /events
test_webhook_endpoints.tavern.yaml::POST /events with invalid formats
test_webhook_endpoints.tavern.yaml::POST /events with more than 100 events
test_webhook_endpoints.tavern.yaml::POST /events with big events
test_webhook_endpoints.tavern.yaml::Try to send more than 30 requests per minute
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- generated html file: file:///tmp/Test_integration_endpoints_B4059_test_files/api/test/integration/Test_integration_endpoints_B4059_test_webhook_endpoints.html -
================== 5 passed, 6 warnings in 196.01s (0:03:16) ===================
```

</details>

> The integration tests are failing because it's not using the related jenkins branch as the shared library.