### PR TITLE
Add unit tests to the AWS module

### DIFF
--- a/wodles/aws/tests/test_s3_log_handler.py
+++ b/wodles/aws/tests/test_s3_log_handler.py
@@ -5,6 +5,7 @@
 import sys
 import os
 import io
+import re
 from unittest.mock import patch, MagicMock, call
 import pytest
 import json
@@ -24,6 +25,16 @@ SAMPLE_PARQUET_EVENT_1 = {'key1': 'value1', 'key2': 'value2'}
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 logs_path = os.path.join(test_data_path, 'log_files')
+
+
+def test_method_raises_not_implemented():
+    """Test that obtain_logs and process_file methods raise NotImplementedError."""
+    handler = s3_log_handler.AWSS3LogHandler()
+    with pytest.raises(NotImplementedError):
+        handler.obtain_logs("test_bucket", "test_log_path")
+
+    with pytest.raises(NotImplementedError):
+        handler.process_file({"message": "test_message"})
 
 
 @patch('wazuh_integration.WazuhIntegration.get_sts_client')
@@ -133,11 +144,82 @@ def test_protected_remove_none_fields(content, expected):
     s3_log_handler.AWSSubscriberBucket._remove_none_fields(content)
     assert content == expected
 
+
+@pytest.mark.parametrize(
+    "bucket_name, log_path, content, expected_logs",
+    [
+        (
+            "test_bucket",
+            "logs/sample.jsonl.gz",
+            '{"event": "data1"}\n{"event": "data2"}\n',
+            [{"event": "data1"}, {"event": "data2"}],
+        ),
+        (
+            "test_bucket",
+            "logs/sample.csv",
+            "Name, Age, City\nJohn, 30, New York",
+            [{"Age": "30", "City": "New York", "Name": "John", "source": "custom"}],
+        ),
+    ],
+    ids=[
+        "JSONL Sample Data",
+        "CSV Sample Data",
+    ],
+)
+def test_obtain_logs_processes_different_data_types(bucket_name, log_path, content, expected_logs):
+    """Test the 'obtain_logs' function of AWSSubscriberBucket class."""
+    with patch('s3_log_handler.wazuh_integration.WazuhIntegration.__init__'):
+        with patch('s3_log_handler.AWSSubscriberBucket.decompress_file', return_value=io.StringIO(content)):
+            formatted_logs = s3_log_handler.AWSSubscriberBucket().obtain_logs(bucket=bucket_name, log_path=log_path)
+
+            assert formatted_logs == expected_logs
+            assert formatted_logs is not None
+
+
+@patch('s3_log_handler.aws_tools.debug')
+def test_process_file_sends_expected_messages(mock_debug):
+    """Test the 'process_file' function of AWSSubscriberBucket class."""
+    with patch('s3_log_handler.wazuh_integration.WazuhIntegration.__init__'):
+        processor = s3_log_handler.AWSSubscriberBucket()
+        processor.discard_regex = re.compile('your_regex_pattern_here')
+        processor.discard_field = 'your_discard_field_value'
+
+        message_body = {'log_path': 'log.txt', 'bucket_path': 'bucket'}
+        formatted_logs = [{'full_log': 'some log entry matching discard regex'}]
+
+        processor.obtain_logs = MagicMock(return_value=formatted_logs)
+        processor.event_should_be_skipped = MagicMock(return_value=False)
+        processor.send_msg = MagicMock()
+
+        formatted_logs_no_full_log = [{'other_field': 'some value'}]
+        processor.obtain_logs.return_value = formatted_logs_no_full_log
+        processor.process_file(message_body)
+
+        expected_msg = {
+            'integration': 'aws',
+            'aws': {
+                'log_info': {
+                    'log_file': 'log.txt',
+                    's3bucket': 'bucket'
+                }
+            }
+        }
+        expected_msg['aws'].update(formatted_logs_no_full_log[0]) 
+        processor.send_msg.assert_called_once_with(expected_msg)
+
+        log_with_match = {'full_log': 'some log entry matching discard regex'}
+        formatted_logs_with_match = [log_with_match]
+
+        processor.obtain_logs.return_value = formatted_logs_with_match
+        processor.process_file(message_body)
+        processor.send_msg.assert_called_once()
+
+
 @pytest.mark.parametrize("content, expected_calls", [
     (['{"event1": "data1"}', '{"event2": "data2"}'], [call('{"event1": "data1"}', dump_json=False), call('{"event2": "data2"}', dump_json=False)])
 ])
 def test_protected_process_jsonl(content, expected_calls):
-    """Test the 'process_file' function of AWSSubscriberBucket class."""
+    """Test the 'process_file' function of AWSSLSubscriberBucket class."""
     aws_ssl_subscriber_bucket = utils.get_mocked_aws_sl_subscriber_bucket()
     message_body = {'bucket_path': 'example-bucket', 'log_path': 'example-log.parquet'}
     mocked_obtain_logs = MagicMock(return_value=content)
@@ -148,3 +230,4 @@ def test_protected_process_jsonl(content, expected_calls):
 
     mocked_obtain_logs.assert_called_once_with(bucket='example-bucket', log_path='example-log.parquet')
     mock_send_msg.assert_has_calls(expected_calls)
+

--- a/wodles/aws/tests/test_s3_log_handler.py
+++ b/wodles/aws/tests/test_s3_log_handler.py
@@ -115,6 +115,14 @@ def test_process_jsonl(content, expected):
     assert s3_log_handler.AWSSubscriberBucket._process_jsonl(content) == expected
 
 
+def test_json_event_generator():
+    """Test the _json_event_generator function of AWSSubscriberBucket class."""
+    data = '{"event": "data1"}{"event": "data2"}'
+    generator = s3_log_handler.AWSSubscriberBucket._json_event_generator(data)
+    events = list(generator)
+    assert events == [{"event": "data1"}, {"event": "data2"}]
+
+
 @pytest.mark.parametrize("content, expected", [
     ({'example1': None, 'example2': 'some_value'}, {'example2': 'some_value'}),
     ({'example1': {'a': None, 'b': None}, 'example2': {'a': 1, 'b': None}},

--- a/wodles/aws/tests/test_tools.py
+++ b/wodles/aws/tests/test_tools.py
@@ -5,6 +5,7 @@
 import argparse
 import os
 import sys
+import io
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -159,6 +160,22 @@ def test_arg_valid_iam_role_duration_raises_exception_when_invalid_duration_prov
     """
     with pytest.raises(argparse.ArgumentTypeError):
         aws_tools.arg_valid_iam_role_duration(arg_string)
+
+
+def test_arg_validate_security_lake_auth_params():
+    """Test the arg_validate_security_lake_auth_params function of aws_tools."""
+    captured_output = io.StringIO()
+    sys.stdout = captured_output
+
+    with pytest.raises(SystemExit) as excinfo:
+        aws_tools.arg_validate_security_lake_auth_params('external_id', None, None)
+
+    output = captured_output.getvalue().strip()
+
+    assert output == 'ERROR: Used a subscriber but no --iam_role_arn provided.'
+    assert excinfo.value.code == 21
+
+    sys.stdout = sys.__stdout__
 
 
 @patch('configparser.RawConfigParser')

--- a/wodles/aws/tests/test_tools.py
+++ b/wodles/aws/tests/test_tools.py
@@ -162,17 +162,22 @@ def test_arg_valid_iam_role_duration_raises_exception_when_invalid_duration_prov
         aws_tools.arg_valid_iam_role_duration(arg_string)
 
 
-def test_arg_validate_security_lake_auth_params():
+@pytest.mark.parametrize("test_input, expected_output", [
+    (('external_id', None, None), "ERROR: Used a subscriber but no --iam_role_arn provided."),
+    (('external_id', None, 'iam_role_arn'), "ERROR: Used a subscriber but no --queue provided."),
+    ((None, 'name', 'iam_role_arn'), "ERROR: Used a subscriber but no --external_id provided.")
+])
+def test_arg_validate_security_lake_auth_params(test_input, expected_output):
     """Test the arg_validate_security_lake_auth_params function of aws_tools."""
     captured_output = io.StringIO()
     sys.stdout = captured_output
 
     with pytest.raises(SystemExit) as excinfo:
-        aws_tools.arg_validate_security_lake_auth_params('external_id', None, None)
+        aws_tools.arg_validate_security_lake_auth_params(*test_input)
 
     output = captured_output.getvalue().strip()
 
-    assert output == 'ERROR: Used a subscriber but no --iam_role_arn provided.'
+    assert output == expected_output
     assert excinfo.value.code == 21
 
     sys.stdout = sys.__stdout__


### PR DESCRIPTION
|Related issue|
|---|
| #18596  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Tests were added to the AWS module to cover as much code as possible, as mentioned in https://github.com/wazuh/wazuh/issues/18596. The function that was added, default_config, was also covered


## Tests

```
============================================================================================ 47 passed in 0.23s ============================================================================================
(unittest-env) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest wodles/aws/tests/test_aws.py 
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.4.0, pluggy-0.13.1
rootdir: /home/wazuh/Git/wazuh
plugins: aiohttp-0.3.0, metadata-3.0.0, html-2.1.1, trio-0.7.0, asyncio-0.15.1
collected 47 items                                                                                                                                                                                         

wodles/aws/tests/test_aws.py ...............................................                                                                                                                         [100%]

============================================================================================ 47 passed in 0.21s ============================================================================================
```

