### PR TITLE
Adding a subscription for translations content

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -26,6 +26,7 @@
 #include "storeModel.hpp"
 #include "updateCVECandidates.hpp"
 #include "updateCVEDescription.hpp"
+#include "upsertTranslation.hpp"
 #include "vulnerabilityCandidate_generated.h"
 #include "vulnerabilityDescription_generated.h"
 #include "vulnerabilityRemediations_generated.h"
@@ -178,6 +179,31 @@ public:
                 {
                     std::cout << "Processing message" << std::endl;
                     TMessageProcessor::processMessage(message, orchestrationLambda);
+                    std::cout << "Message processed" << std::endl;
+                }
+                catch (const std::exception& e)
+                {
+                    std::cout << "Error processing message: " << e.what() << std::endl;
+                    // TO DO -> call to reinitialize the database.
+                }
+            });
+
+        // Subscription to vulnerability detector translations update events.
+        m_translationsSubscription = std::make_unique<TRouterSubscriber>(
+            updaterPolicy.at("translationsTopic"), "vulnerability_feed_manager", isLocalSubscriber);
+
+        m_translationsSubscription->subscribe(
+            [&](const std::vector<char>& message)
+            {
+                auto translationsLambda = [&](const nlohmann::json& resource)
+                {
+                    UpsertTranslation::upsertTranslationEntry(resource, *m_translationsDatabase);
+                };
+
+                try
+                {
+                    std::cout << "Processing message" << std::endl;
+                    TMessageProcessor::processMessage(message, translationsLambda);
                     std::cout << "Message processed" << std::endl;
                 }
                 catch (const std::exception& e)
@@ -362,6 +388,7 @@ public:
 
 private:
     std::unique_ptr<TRouterSubscriber> m_contentUpdateSubscription;
+    std::unique_ptr<TRouterSubscriber> m_translationsSubscription;
     std::unique_ptr<TContentRegister> m_contentRegistration;
     std::shared_ptr<TIndexerConnector> m_indexerConnector;
     std::unique_ptr<Utils::RocksDBWrapper> m_descriptionsDatabase;

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -191,8 +191,13 @@ public:
             });
 
         // Subscription to vulnerability detector translations update events.
+        const auto translationsUpdaterPolicy = TPolicyManager::instance().getTranslationsUpdaterConfiguration();
+
+        m_translationsRegistration =
+            std::make_unique<TContentRegister>(translationsUpdaterPolicy.at("topicName"), translationsUpdaterPolicy);
+
         m_translationsSubscription = std::make_unique<TRouterSubscriber>(
-            updaterPolicy.at("translationsTopic"), FEED_MANAGER_SUBSCRIBER_ID, isLocalSubscriber);
+            translationsUpdaterPolicy.at("topicName"), FEED_MANAGER_SUBSCRIBER_ID, isLocalSubscriber);
 
         m_translationsSubscription->subscribe(
             [&](const std::vector<char>& message)
@@ -356,7 +361,9 @@ public:
      */
     void update(nlohmann::json& data) override
     {
-        m_contentRegistration->changeSchedulerInterval(data.at("updater").at("interval").get<size_t>());
+        auto interval = data.at("updater").at("interval").get<size_t>();
+        m_contentRegistration->changeSchedulerInterval(interval);
+        m_translationsRegistration->changeSchedulerInterval(interval);
     }
     // LCOV_EXCL_STOP
 
@@ -392,6 +399,7 @@ private:
     std::unique_ptr<TRouterSubscriber> m_contentUpdateSubscription;
     std::unique_ptr<TRouterSubscriber> m_translationsSubscription;
     std::unique_ptr<TContentRegister> m_contentRegistration;
+    std::unique_ptr<TContentRegister> m_translationsRegistration;
     std::shared_ptr<TIndexerConnector> m_indexerConnector;
     std::unique_ptr<Utils::RocksDBWrapper> m_descriptionsDatabase;
     std::unique_ptr<Utils::RocksDBWrapper> m_remediationsDatabase;

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -44,6 +44,8 @@ constexpr auto CVES_DATABASE_PATH {"queue/vd/cves"};
 
 constexpr auto CACHE_SIZE {2048};
 
+constexpr auto FEED_MANAGER_SUBSCRIBER_ID {"vulnerability_feed_manager"};
+
 using namespace NSVulnerabilityScanner;
 
 /**
@@ -158,7 +160,7 @@ public:
 
         // Subscription to vulnerability detector content update events.
         m_contentUpdateSubscription = std::make_unique<TRouterSubscriber>(
-            updaterPolicy.at("topicName"), "vulnerability_feed_manager", isLocalSubscriber);
+            updaterPolicy.at("topicName"), FEED_MANAGER_SUBSCRIBER_ID, isLocalSubscriber);
 
         m_contentUpdateSubscription->subscribe(
             [&](const std::vector<char>& message)
@@ -190,7 +192,7 @@ public:
 
         // Subscription to vulnerability detector translations update events.
         m_translationsSubscription = std::make_unique<TRouterSubscriber>(
-            updaterPolicy.at("translationsTopic"), "vulnerability_feed_manager", isLocalSubscriber);
+            updaterPolicy.at("translationsTopic"), FEED_MANAGER_SUBSCRIBER_ID, isLocalSubscriber);
 
         m_translationsSubscription->subscribe(
             [&](const std::vector<char>& message)

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/upsertTranslation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/upsertTranslation.hpp
@@ -114,48 +114,42 @@ private:
                 }
             }
         }
+        else
+        {
+            throw std::runtime_error {"Resource to update not found."};
+        }
     }
 
 public:
     /**
      * @brief Creates or modifies a translation entry in a rocksdb database.
      *
-     * @param data JSON with the required information to create or update a translation entry.
+     * @param item JSON with the required information to create or update a translation entry.
      * @param rocksDbWrapper rocksdb wrapper instance.
      */
-    static void upsertTranslationEntry(const nlohmann::json& data, Utils::RocksDBWrapper& rocksDbWrapper)
+    static void upsertTranslationEntry(const nlohmann::json& item, Utils::RocksDBWrapper& rocksDbWrapper)
     {
-        if (data.contains("data"))
+        if (item.contains("type") && item.contains("resource"))
         {
-            for (const auto& item : data.at("data"))
-            {
-                if (item.contains("type") && item.contains("resource"))
-                {
-                    const auto type = item.at("type").get_ref<const std::string&>();
+            const auto type = item.at("type").get_ref<const std::string&>();
 
-                    if (type.compare("create") == 0)
-                    {
-                        insertTranslationEntry(item, rocksDbWrapper);
-                    }
-                    else if (type.compare("update") == 0)
-                    {
-                        updateTranslationEntry(item, rocksDbWrapper);
-                    }
-                    else
-                    {
-                        throw std::runtime_error("Invalid operation type: " + type + " for " +
-                                                 item.at("resource").get_ref<const std::string&>());
-                    }
-                }
-                else
-                {
-                    throw std::runtime_error(R"(Invalid data format. Missing "type" or "resource" key.)");
-                }
+            if (type.compare("create") == 0)
+            {
+                insertTranslationEntry(item, rocksDbWrapper);
+            }
+            else if (type.compare("update") == 0)
+            {
+                updateTranslationEntry(item, rocksDbWrapper);
+            }
+            else
+            {
+                throw std::runtime_error("Invalid operation type: " + type + " for " +
+                                         item.at("resource").get_ref<const std::string&>());
             }
         }
         else
         {
-            throw std::runtime_error(R"(Invalid data format. Missing "data" key.)");
+            throw std::runtime_error(R"(Invalid data format. Missing "type" or "resource" key.)");
         }
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -124,6 +124,7 @@ private:
                 Utils::parseStrToTime(newPolicy.at("vulnerability-detection").at("feed-update-interval"));
             newPolicy["updater"]["ondemand"] = false;
             newPolicy["updater"]["topicName"] = "vulnerability_feed_manager";
+            newPolicy["updater"]["translationsTopic"] = "vulnerability_feed_manager_translations";
             newPolicy["updater"]["configData"] = nlohmann::json::object();
             newPolicy["updater"]["configData"]["contentSource"] = "cti-api";
             newPolicy["updater"]["configData"]["compressionType"] = "raw";

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -124,7 +124,6 @@ private:
                 Utils::parseStrToTime(newPolicy.at("vulnerability-detection").at("feed-update-interval"));
             newPolicy["updater"]["ondemand"] = false;
             newPolicy["updater"]["topicName"] = "vulnerability_feed_manager";
-            newPolicy["updater"]["translationsTopic"] = "vulnerability_feed_manager_translations";
             newPolicy["updater"]["configData"] = nlohmann::json::object();
             newPolicy["updater"]["configData"]["contentSource"] = "cti-api";
             newPolicy["updater"]["configData"]["compressionType"] = "raw";
@@ -145,6 +144,24 @@ private:
             newPolicy["updater"]["configData"]["apiParameters"]["offset"]["name"] = "offset";
             newPolicy["updater"]["configData"]["apiParameters"]["offset"]["step"] = 100;
             newPolicy["updater"]["configData"]["apiParameters"]["offset"]["start"] = 0;
+        }
+
+        if (!newPolicy.contains("translationsUpdater"))
+        {
+            newPolicy["translationsUpdater"] = nlohmann::json::object();
+            newPolicy["translationsUpdater"]["interval"] =
+                Utils::parseStrToTime(newPolicy.at("vulnerability-detection").at("feed-update-interval"));
+            newPolicy["translationsUpdater"]["ondemand"] = false;
+            newPolicy["translationsUpdater"]["topicName"] = "vulnerability_feed_manager_translations";
+            newPolicy["translationsUpdater"]["configData"] = nlohmann::json::object();
+            newPolicy["translationsUpdater"]["configData"]["contentSource"] = "offline";
+            newPolicy["translationsUpdater"]["configData"]["compressionType"] = "xz";
+            newPolicy["translationsUpdater"]["configData"]["versionedContent"] = "false";
+            newPolicy["translationsUpdater"]["configData"]["deleteDownloadedContent"] = true;
+            newPolicy["translationsUpdater"]["configData"]["outputFolder"] = "/tmp/vd_updater";
+            newPolicy["translationsUpdater"]["configData"]["dataFormat"] = "json";
+            newPolicy["translationsUpdater"]["configData"]["url"] = "file:///tmp/testFile/file.xz";
+            newPolicy["translationsUpdater"]["configData"]["offset"] = 0;
         }
 
         return newPolicy;
@@ -370,6 +387,16 @@ public:
     nlohmann::json getUpdaterConfiguration() const
     {
         return m_configuration.at("updater");
+    }
+
+    /**
+     * @brief Get translations updater configuration.
+     *
+     * @return nlohmann::json Configuration.
+     */
+    nlohmann::json getTranslationsUpdaterConfiguration() const
+    {
+        return m_configuration.at("translationsUpdater");
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -95,7 +95,8 @@ void DatabaseFeedManagerTest::TearDown()
 
 TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
 {
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
@@ -107,7 +108,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
 
     spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
         configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     flatbuffers::FlatBufferBuilder fbBuilder;
     auto vdOriginalData = NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilder,
@@ -146,7 +147,8 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
 
 TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
 {
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
@@ -158,7 +160,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
 
     spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
         configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     flatbuffers::FlatBufferBuilder fbBuilder;
     auto vdOriginalData = NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilder,
@@ -192,7 +194,8 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
 
 TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
 {
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
@@ -204,7 +207,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
 
     spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
         configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     {
         uint8_t corruptedData[] = {
@@ -230,7 +233,8 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
 
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesSuccess)
 {
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
@@ -241,7 +245,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesSuccess)
 
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
 
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
 
@@ -271,7 +275,8 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesSuccess)
 
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesNoPackageName)
 {
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
@@ -282,7 +287,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesNoPackageName)
 
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
 
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
 
@@ -303,7 +308,8 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesNoPackageName)
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_ValidData)
 {
     // Test setup
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -316,7 +322,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_ValidData)
 
     spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
         configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     // Simulate saved data, store before variable instance.
     {
@@ -354,7 +360,8 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_ValidData)
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_DataNotFound)
 {
     // Test setup
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -367,7 +374,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_DataNotFound)
 
     spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
         configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
 
@@ -388,7 +395,8 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_DataNotFound)
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_InvalidData)
 {
     // Test setup
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -401,7 +409,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_InvalidData)
 
     spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
         configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     // Simulate corrupted data, store before variable instance.
     {
@@ -431,7 +439,8 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_InvalidData)
 TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheMiss)
 {
     // Test setup
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -444,7 +453,7 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheMiss)
 
     spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
         configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     // Simulate saved data, store before variable instance.
     {
@@ -511,7 +520,8 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheMiss)
 TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheHit)
 {
     // Test setup
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -524,7 +534,7 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheHit)
 
     spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
         configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     // Simulate saved data, store before variable instance.
     {
@@ -618,7 +628,8 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheHit)
 TEST_F(DatabaseFeedManagerTest, PackageTranslationNoTranslationFound)
 {
     // Test setup
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -631,7 +642,7 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationNoTranslationFound)
 
     spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
         configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     // Simulate saved data, store before variable instance.
     {
@@ -696,7 +707,8 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationNoTranslationFound)
 TEST_F(DatabaseFeedManagerTest, PackageTranslationInvalidDatabase)
 {
     // Test setup
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    const auto configurationParameters =
+        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -709,7 +721,7 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationInvalidDatabase)
 
     spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
         configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
     // Simulate corrupted data, store before variable instance.
     {

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -95,13 +95,14 @@ void DatabaseFeedManagerTest::TearDown()
 
 TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
 {
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -147,13 +148,14 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
 
 TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
 {
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -194,13 +196,14 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
 
 TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
 {
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -233,8 +236,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
 
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesSuccess)
 {
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
@@ -244,6 +246,8 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesSuccess)
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
 
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
@@ -275,8 +279,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesSuccess)
 
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesNoPackageName)
 {
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
@@ -286,6 +289,8 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesNoPackageName)
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
 
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     EXPECT_CALL(*spRouterSubscriberMock, subscribe(_)).Times(2);
 
@@ -308,14 +313,15 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesNoPackageName)
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_ValidData)
 {
     // Test setup
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -360,14 +366,15 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_ValidData)
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_DataNotFound)
 {
     // Test setup
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -395,14 +402,15 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_DataNotFound)
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_InvalidData)
 {
     // Test setup
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -439,14 +447,15 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_InvalidData)
 TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheMiss)
 {
     // Test setup
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -520,14 +529,15 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheMiss)
 TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheHit)
 {
     // Test setup
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -628,14 +638,15 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheHit)
 TEST_F(DatabaseFeedManagerTest, PackageTranslationNoTranslationFound)
 {
     // Test setup
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -707,14 +718,15 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationNoTranslationFound)
 TEST_F(DatabaseFeedManagerTest, PackageTranslationInvalidDatabase)
 {
     // Test setup
-    const auto configurationParameters =
-        R"( {"topicName": "topicNameTest", "translationsTopic" : "translationsTestTopic"} )"_json;
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
     spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationsUpdaterConfiguration())
+        .WillRepeatedly(Return(configurationParameters));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockPolicyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockPolicyManager.hpp
@@ -97,6 +97,13 @@ public:
     MOCK_METHOD(nlohmann::json, getUpdaterConfiguration, (), (const));
 
     /**
+     * @brief Mock method for getTranslationsUpdaterConfiguration.
+     *
+     * @note This method is intended for testing purposes and does not perform any real action.
+     */
+    MOCK_METHOD(nlohmann::json, getTranslationsUpdaterConfiguration, (), (const));
+
+    /**
      * @brief Mock method for getExclusions.
      *
      * @note This method is intended for testing purposes and does not perform any real action.

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolinePolicyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolinePolicyManager.hpp
@@ -142,6 +142,16 @@ public:
     }
 
     /**
+     * @brief Get translations updater configuration.
+     *
+     * @return nlohmann::json Configuration.
+     */
+    nlohmann::json getTranslationsUpdaterConfiguration() const
+    {
+        return spPolicyManagerMock->getTranslationsUpdaterConfiguration();
+    }
+
+    /**
      * @brief Get exclusions.
      *
      * @return nlohmann::json Exclusions configuration.

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
@@ -213,7 +213,7 @@ TEST_F(PolicyManagerTest, validConfigurationCheckParameters)
     EXPECT_STREQ(m_policyManager->getCTIUrl().c_str(), "https://cti-url.com");
     EXPECT_STREQ(
         m_policyManager->getUpdaterConfiguration().dump().c_str(),
-        R"({"configData":{"apiParameters":{"itemsPerRequest":{"name":"limit","value":100},"offset":{"name":"offset","start":0,"step":100}},"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-api","dataFormat":"json","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"/tmp/vd_updater","s3FileName":"content.filtered.1.xz","url":"https://cti-url.com","versionedContent":"cti-api"},"interval":3600,"ondemand":false,"topicName":"vulnerability_feed_manager","translationsTopic":"vulnerability_feed_manager_translations"})");
+        R"({"configData":{"apiParameters":{"itemsPerRequest":{"name":"limit","value":100},"offset":{"name":"offset","start":0,"step":100}},"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-api","dataFormat":"json","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"/tmp/vd_updater","s3FileName":"content.filtered.1.xz","url":"https://cti-url.com","versionedContent":"cti-api"},"interval":3600,"ondemand":false,"topicName":"vulnerability_feed_manager"})");
 }
 TEST_F(PolicyManagerTest, validConfigurationDefaultValues)
 {

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
@@ -213,7 +213,7 @@ TEST_F(PolicyManagerTest, validConfigurationCheckParameters)
     EXPECT_STREQ(m_policyManager->getCTIUrl().c_str(), "https://cti-url.com");
     EXPECT_STREQ(
         m_policyManager->getUpdaterConfiguration().dump().c_str(),
-        R"({"configData":{"apiParameters":{"itemsPerRequest":{"name":"limit","value":100},"offset":{"name":"offset","start":0,"step":100}},"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-api","dataFormat":"json","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"/tmp/vd_updater","s3FileName":"content.filtered.1.xz","url":"https://cti-url.com","versionedContent":"cti-api"},"interval":3600,"ondemand":false,"topicName":"vulnerability_feed_manager"})");
+        R"({"configData":{"apiParameters":{"itemsPerRequest":{"name":"limit","value":100},"offset":{"name":"offset","start":0,"step":100}},"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-api","dataFormat":"json","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"/tmp/vd_updater","s3FileName":"content.filtered.1.xz","url":"https://cti-url.com","versionedContent":"cti-api"},"interval":3600,"ondemand":false,"topicName":"vulnerability_feed_manager","translationsTopic":"vulnerability_feed_manager_translations"})");
 }
 TEST_F(PolicyManagerTest, validConfigurationDefaultValues)
 {

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/upsertTranslation_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/upsertTranslation_test.cpp
@@ -14,141 +14,113 @@
 const std::string CREATE_EXAMPLE {
     R"(
         {
-                "data": [
-                    {
-                    "offset": 5,
-                    "type": "create",
-                    "version": 1,
-                    "context": "translation",
-                    "resource": "WT-3",
-                    "payload": {
-                        "target": "windows",
-                        "source": {
-                        "vendor": "^The Apache Software",
-                        "product": "^Apache Tomcat.*",
-                        "version": ""
-                        },
-                        "translation": [{
-                        "vendor": "apache",
-                        "product": "tomcat",
-                        "version": ""
-                        }],
-                        "action": [
-                            0,
-                            1
-                        ]
-                    }
-                    }
+            "offset": 5,
+            "type": "create",
+            "version": 1,
+            "context": "translation",
+            "resource": "WT-3",
+            "payload": {
+                "target": "windows",
+                "source": {
+                "vendor": "^The Apache Software",
+                "product": "^Apache Tomcat.*",
+                "version": ""
+                },
+                "translation": [{
+                "vendor": "apache",
+                "product": "tomcat",
+                "version": ""
+                }],
+                "action": [
+                    0,
+                    1
                 ]
-                }
+            }
+        }
     )"};
 
 const std::string UPDATE_EXAMPLE {
     R"(
-            {
-            "data": [
+        {
+            "resource": "WT-1",
+            "type": "update",
+            "operations": [
                 {
-                "resource": "WT-1",
-                "type": "update",
-                "operations": [
-                    {
-                    "op": "replace",
-                    "path": "/source/product",
-                    "value": "Microsoft Edge Browser"
-                    },
-                    {
-                    "op": "replace",
-                    "path": "/source/vendor",
-                    "value": "Microsoft"
-                    }
-                ]
+                "op": "replace",
+                "path": "/source/product",
+                "value": "Microsoft Edge Browser"
+                },
+                {
+                "op": "replace",
+                "path": "/source/vendor",
+                "value": "Microsoft"
                 }
             ]
-            }
+        }
     )"};
 
 const std::string EMPTY_DATA_EXAMPLE {
     R"(
-            {
-                "data": [
-                    {}
-                ]
-            }
+        {
+        }
     )"};
-
-const std::string NO_DATA_EXAMPLE {
-    R"(
-        {}
-)"};
 
 const std::string NO_RESOURCE_EXAMPLE {
     R"(
-            {
-            "data": [
+        {
+            "type": "update",
+            "operations": [
                 {
-                "type": "update",
-                "operations": [
-                    {
-                    "op": "replace",
-                    "path": "/source/product/",
-                    "value": "Microsoft Edge Browser"
-                    },
-                    {
-                    "op": "replace",
-                    "path": "/source/vendor/",
-                    "value": "Microsoft"
-                    }
-                ]
+                "op": "replace",
+                "path": "/source/product/",
+                "value": "Microsoft Edge Browser"
+                },
+                {
+                "op": "replace",
+                "path": "/source/vendor/",
+                "value": "Microsoft"
                 }
             ]
-            }
+        }
     )"};
 
 const std::string NO_TYPE_EXAMPLE {
     R"(
-            {
-            "data": [
+        {
+            "resource": "WT-1",
+            "operations": [
                 {
-                "resource": "WT-1",
-                "operations": [
-                    {
-                    "op": "replace",
-                    "path": "/source/product/",
-                    "value": "Microsoft Edge Browser"
-                    },
-                    {
-                    "op": "replace",
-                    "path": "/source/vendor/",
-                    "value": "Microsoft"
-                    }
-                ]
+                "op": "replace",
+                "path": "/source/product/",
+                "value": "Microsoft Edge Browser"
+                },
+                {
+                "op": "replace",
+                "path": "/source/vendor/",
+                "value": "Microsoft"
                 }
             ]
-            }
+        }
     )"};
 
 const std::string INVALID_TYPE_EXAMPLE {
     R"(
-            {
-            "data": [
+        {
+            "resource": "WT-1",
+            "type": "modify",
+            "operations": [
                 {
-                "resource": "WT-1",
-                "type": "modify",
-                "operations": [
-                    {
-                    "op": "replace",
-                    "path": "/source/product/",
-                    "value": "Microsoft Edge Browser"
-                    },
-                    {
-                    "op": "replace",
-                    "path": "/source/vendor/",
-                    "value": "Microsoft"
-                    }
-                ]
+                "op": "replace",
+                "path": "/source/product/",
+                "value": "Microsoft Edge Browser"
+                },
+                {
+                "op": "replace",
+                "path": "/source/vendor/",
+                "value": "Microsoft"
                 }
             ]
-            }
+        }
     )"};
 
 TEST_F(UpsertTranslationTest, EmptyData)
@@ -167,29 +139,6 @@ TEST_F(UpsertTranslationTest, EmptyData)
     catch (const std::runtime_error& e)
     {
         EXPECT_STREQ(e.what(), R"(Invalid data format. Missing "type" or "resource" key.)");
-    }
-    catch (...)
-    {
-        FAIL() << "Expected std::runtime_error";
-    }
-}
-
-TEST_F(UpsertTranslationTest, NoData)
-{
-    // Create rocksdb wrapper instance.
-    Utils::RocksDBWrapper rocksDbWrapper(TRANSLATION_DATABASE_PATH);
-
-    // Update Wazuh translation entry.
-    nlohmann::json upsertExampleJSON = nlohmann::json::parse(NO_DATA_EXAMPLE);
-
-    try
-    {
-        UpsertTranslation::upsertTranslationEntry(upsertExampleJSON, rocksDbWrapper);
-        FAIL() << "Expected std::runtime_error";
-    }
-    catch (const std::runtime_error& e)
-    {
-        EXPECT_STREQ(e.what(), R"(Invalid data format. Missing "data" key.)");
     }
     catch (...)
     {

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/config.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/config.json
@@ -1,3 +1,4 @@
 {
-    "topicName" : "test"
+    "topicName" : "test",
+    "translationsTopicName" : "translationsTest"
 }

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
@@ -51,19 +51,38 @@ public:
     }
 
     /**
+     * @brief This method sets the topic for the translations subscriber.
+     *
+     * @param topic The topic to subscribe to.
+     */
+    void setTranslationsUpdaterConfiguration(const std::string& topic)
+    {
+        m_translationsTopic = topic;
+    }
+
+    /**
      * @brief Retrieves the UpdaterConfiguration.
      *
      * @return nlohmann::json A simple JSON object with the configured topic.
      */
     nlohmann::json getUpdaterConfiguration()
     {
-        auto updaterConfiguration = nlohmann::json::object();
-        updaterConfiguration["topicName"] = m_topic;
-        return updaterConfiguration;
+        return {{"topicName", m_topic}};
+    }
+
+    /**
+     * @brief Retrieves the TranslationsUpdaterConfiguration.
+     *
+     * @return nlohmann::json A simple JSON object with the configured topic.
+     */
+    nlohmann::json getTranslationsUpdaterConfiguration()
+    {
+        return {{"topicName", m_translationsTopic}};
     }
 
 private:
     std::string m_topic;
+    std::string m_translationsTopic;
 };
 
 /**
@@ -110,6 +129,7 @@ int main(const int argc, const char* argv[])
         routerProvider->start();
 
         DummyPolicyManager::instance().setUpdaterConfiguration(configuration.at("topicName"));
+        DummyPolicyManager::instance().setTranslationsUpdaterConfiguration(configuration.at("translationsTopicName"));
 
         auto databaseFeedManager =
             std::make_shared<TDatabaseFeedManager<DummyIndexerConnector, DummyPolicyManager, DummyContentRegister>>(

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
@@ -25,6 +25,17 @@ int main(const int argc, const char* argv[])
 {
     try
     {
+        // Reset required directories
+        auto path = std::filesystem::path("queue/vd/");
+        if (std::filesystem::exists(path))
+        {
+            std::filesystem::remove_all(path);
+        }
+        if (!std::filesystem::create_directories(path))
+        {
+            throw std::runtime_error("Unable to create directory");
+        }
+
         auto& routerModule = RouterModule::instance();
         auto& vulnerabilityScanner = VulnerabilityScanner::instance();
         CmdLineArgs cmdLineArgs(argc, argv);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #19945 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR creates a new registration for the translations topic and subscribes to this content to update the corresponding DB.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

A manual test with the testtool was performed.
The following file was used 

<details><summary>Details</summary>
<p>

```
root@ubuntu-jammy:/tmp/vd_updater/contents# cat file.json 
{
    "data": [
        {
            "type": "create",
            "resource": "WT-3",
            "payload": {
                "target": "windows",
                "source": {
                    "vendor": "^The Apache Software",
                    "product": "^Apache Tomcat.*",
                    "version": ""
                },
                "translation": [
                    {
                        "vendor": "apache",
                        "product": "tomcat",
                        "version": ""
                    }
                ],
                "action": [
                    0,
                    1
                ]
            }
        },
        {
            "type": "create",
            "resource": "WT-4",
            "payload": {
                "target": "windows2",
                "source": {
                    "vendor": "^The Apache Software2",
                    "product": "^Apache Tomcat2.*",
                    "version": ""
                },
                "translation": [
                    {
                        "vendor": "apache2",
                        "product": "tomcat2",
                        "version": ""
                    }
                ],
                "action": [
                    0,
                    1
                ]
            }
        }
    ]
}
```

</p>
</details> 

The message was processed successfully 

![2023-11-11_13-14](https://github.com/wazuh/wazuh/assets/65046601/c714bbca-f58a-48d7-8e23-45e0b25ee2de)

And the entries are saved in the DB

![2023-11-11_13-14_1](https://github.com/wazuh/wazuh/assets/65046601/b6a94ee9-6147-4964-9907-2c139fbef2f4)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Added unit tests (for new features)
