### PR TITLE
Flatbuffers - Add support for rejected CVEs

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
+++ b/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
@@ -172,9 +172,9 @@ table Scenario {
 table Metric {
     format: string;
     scenarios: [Scenario];
-    cvssV3_1: V3_1;
-    cvssV3_0: V3_0;
-    cvssV2_0: V2_0;
+    cvssV3_1: cvss.V3_1;
+    cvssV3_0: cvss.V3_0;
+    cvssV2_0: cvss.V2_0;
     other: Other;
 }
 
@@ -263,11 +263,10 @@ table Cna {
     tags: [string];
     taxonomyMappings: [TaxonomyMapping];
     x_remediations: Remediations;
-}
 
-table Container {
-    cna: Cna;
-    adp: [Adp];
+    /// Rejected CVEs
+    rejectedReasons: [Description];
+    replacedBy: [string];
 }
 
 table CveMetadata {
@@ -280,13 +279,21 @@ table CveMetadata {
     dateReserved: string;
     datePublished: string;
     state: string;
+
+    /// Rejected CVEs
+    dateRejected: string;
+}
+
+table Containers {
+    cna: Cna;
+    adp: [Adp];
 }
 
 table Entry {
     dataType: string;
     dataVersion: string;
     cveMetadata: CveMetadata;
-    containers: Container;
+    containers: Containers;
 }
 
 root_type Entry;

--- a/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
+++ b/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
@@ -263,8 +263,6 @@ table Cna {
     tags: [string];
     taxonomyMappings: [TaxonomyMapping];
     x_remediations: Remediations;
-
-    /// Rejected CVEs
     rejectedReasons: [Description];
     replacedBy: [string];
 }
@@ -279,8 +277,6 @@ table CveMetadata {
     dateReserved: string;
     datePublished: string;
     state: string;
-
-    /// Rejected CVEs
     dateRejected: string;
 }
 

--- a/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
+++ b/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
@@ -1,8 +1,8 @@
 namespace cve_v5;
 
 table CVSS_V3_1 {
-    version: string (required);
-    vectorString: string (required);
+    version: string;
+    vectorString: string;
     attackVector: string;
     attackComplexity: string;
     privilegesRequired: string;
@@ -12,7 +12,7 @@ table CVSS_V3_1 {
     integrityImpact: string;
     availabilityImpact: string;
     baseScore: float;
-    baseSeverity: string (required);
+    baseSeverity: string;
     exploitCodeMaturity: string;
     remediationLevel: string;
     reportConfidence: string;
@@ -34,8 +34,8 @@ table CVSS_V3_1 {
 }
 
 table CVSS_V3_0 {
-    version: string (required);
-    vectorString: string (required);
+    version: string;
+    vectorString: string;
     attackVector: string;
     attackComplexity: string;
     privilegesRequired: string;
@@ -45,7 +45,7 @@ table CVSS_V3_0 {
     integrityImpact: string;
     availabilityImpact: string;
     baseScore: float;
-    baseSeverity: string (required);
+    baseSeverity: string;
     exploitCodeMaturity: string;
     remediationLevel: string;
     reportConfidence: string;
@@ -67,8 +67,8 @@ table CVSS_V3_0 {
 }
 
 table CVSS_V2_0 {
-    version: string (required);
-    vectorString: string (required);
+    version: string;
+    vectorString: string;
     accessVector: string;
     accessComplexity: string;
     authentication: string;

--- a/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
+++ b/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
@@ -1,6 +1,6 @@
 namespace cve_v5;
 
-table V3_1 {
+table CVSS_V3_1 {
     version: string (required);
     vectorString: string (required);
     attackVector: string;
@@ -33,7 +33,7 @@ table V3_1 {
     environmentalSeverity: string;
 }
 
-table V3_0 {
+table CVSS_V3_0 {
     version: string (required);
     vectorString: string (required);
     attackVector: string;
@@ -66,7 +66,7 @@ table V3_0 {
     environmentalSeverity: string;
 }
 
-table V2_0 {
+table CVSS_V2_0 {
     version: string (required);
     vectorString: string (required);
     accessVector: string;
@@ -172,9 +172,9 @@ table Scenario {
 table Metric {
     format: string;
     scenarios: [Scenario];
-    cvssV3_1: cvss.V3_1;
-    cvssV3_0: cvss.V3_0;
-    cvssV2_0: cvss.V2_0;
+    cvssV3_1: CVSS_V3_1;
+    cvssV3_0: CVSS_V3_0;
+    cvssV2_0: CVSS_V2_0;
     other: Other;
 }
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.cpp
@@ -1,0 +1,241 @@
+/*
+ * Wazuh SyscollectorFlatbuffers
+ * Copyright (C) 2015, Wazuh Inc.
+ * November 8, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "cve5FB_test.hpp"
+#include "cve5_generated.h"
+#include "json.hpp"
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace CVE5_FB_TEST
+{
+    const char* INCLUDE_DIRECTORIES[] {FLATBUFFER_SCHEMAS_DIR, nullptr};
+
+    const char* SCHEMA_PATH {FLATBUFFER_SCHEMAS_DIR "cve5.fbs"};
+}
+
+auto constexpr PUBLISHED_CVE {R"(
+    {
+        "containers":
+        {
+            "adp":
+            [
+                {
+                    "affected":
+                    [
+                        {
+                            "defaultStatus": "unaffected",
+                            "platforms":
+                            [
+                                "bookworm"
+                            ],
+                            "product": "bash",
+                            "vendor": "debian"
+                        },
+                        {
+                            "defaultStatus": "affected",
+                            "platforms":
+                            [
+                                "bookworm"
+                            ],
+                            "product": "bash",
+                            "vendor": "debian"
+                        }
+                    ],
+                    "descriptions":
+                    [
+                        {
+                            "lang": "en",
+                            "value": "The /etc/profile.d/60alias.sh script in the Mandriva bash package for Bash 2.05b, 3.0, 3.2, 3.2.48, and 4.0 enables the --show-control-chars option in LS_OPTIONS, which allows local users to send escape sequences to terminal emulators, or hide the existence of a file, via a crafted filename."
+                        }
+                    ],
+                    "providerMetadata":
+                    {
+                        "orgId": "79363d38-fa19-49d1-9214-5f28da3f3ac5"
+                    },
+                    "references":
+                    [
+                        {
+                            "url": "https://security-tracker.debian.org/tracker/CVE-2010-0002"
+                        }
+                    ]
+                }
+            ],
+            "cna":
+            {
+                "affected":
+                [
+                    {
+                        "cpes":
+                        [
+                            "cpe:2.3:a:gnu:bash:2.05:b:*:*:*:*:*:*"
+                        ],
+                        "defaultStatus": "unaffected",
+                        "product": "bash b",
+                        "vendor": "gnu",
+                        "versions":
+                        [
+                            {
+                                "status": "affected",
+                                "version": "2.05"
+                            }
+                        ]
+                    }
+                ],
+                "descriptions":
+                [
+                    {
+                        "lang": "en",
+                        "value": "The /etc/profile.d/60alias.sh script in the Mandriva bash package for Bash 2.05b, 3.0, 3.2, 3.2.48, and 4.0 enables the --show-control-chars option in LS_OPTIONS, which allows local users to send escape sequences to terminal emulators, or hide the existence of a file, via a crafted filename."
+                    }
+                ],
+                "metrics":
+                [
+                    {
+                        "cvssV2_0":
+                        {
+                            "accessComplexity": "LOW",
+                            "accessVector": "LOCAL",
+                            "authentication": "NONE",
+                            "availabilityImpact": "PARTIAL",
+                            "baseScore": 2.1,
+                            "confidentialityImpact": "NONE",
+                            "integrityImpact": "NONE",
+                            "vectorString": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+                            "version": "2.0"
+                        },
+                        "format": "CVSS"
+                    }
+                ],
+                "problemTypes":
+                [
+                    {
+                        "descriptions":
+                        [
+                            {
+                                "description": "CWE-20",
+                                "lang": "en"
+                            }
+                        ]
+                    }
+                ],
+                "providerMetadata":
+                {
+                    "orgId": "00000000-0000-4000-A000-000000000000",
+                    "shortName": "@redhat.com"
+                },
+                "references":
+                [
+                    {
+                        "name": "https://qa.mandriva.com/show_bug.cgi?id=56882",
+                        "url": "https://qa.mandriva.com/show_bug.cgi?id=56882"
+                    }
+                ]
+            }
+        },
+        "cveMetadata":
+        {
+            "assignerOrgId": "00000000-0000-4000-A000-000000000000",
+            "assignerShortName": "@redhat.com",
+            "cveId": "CVE-2010-0002",
+            "datePublished": "2010-01-14T18:30:00.000Z",
+            "dateUpdated": "2011-08-08T04:00:00.000Z",
+            "state": "PUBLISHED"
+        },
+        "dataType": "CVE_RECORD",
+        "dataVersion": "5.0"
+    }
+)"};
+
+auto constexpr REJECTED_CVE {R"(
+    {
+        "containers": {
+            "cna": {
+                "providerMetadata": {
+                    "dateUpdated": "2023-03-09T14:02:53Z",
+                    "orgId": "00000000-0000-4000-A000-000000000003",
+                    "shortName": "nvd"
+                },
+                "rejectedReasons": [
+                    {
+                        "lang": "en",
+                        "value": "This candidate was in a CNA pool that was not assigned to any issues during 2022."
+                    }
+                ]
+            }
+        },
+        "cveMetadata": {
+            "assignerOrgId": "00000000-0000-4000-A000-000000000003",
+            "assignerShortName": "nvd",
+            "cveId": "CVE-2022-26053",
+            "datePublished": "2023-03-07T23:15:10Z",
+            "dateUpdated": "2023-03-09T14:02:53Z",
+            "state": "REJECTED"
+        },
+        "dataType": "CVE_RECORD",
+        "dataVersion": "5.0"
+    }
+)"};
+
+auto constexpr INVALID_CVE {R"( 
+    {
+        "unknowField": "unknownValue"
+    }
+)"};
+
+/**
+ * @brief Test that a published CVE can be parsed.
+ *
+ */
+TEST_F(Cve5FbTest, parsePublishedCve)
+{
+    // Load the schema
+    std::string schema;
+    EXPECT_TRUE(flatbuffers::LoadFile(CVE5_FB_TEST::SCHEMA_PATH, false, &schema));
+
+    // Parse the schema and the published CVE
+    flatbuffers::Parser parser;
+    EXPECT_TRUE(parser.Parse(schema.c_str(), CVE5_FB_TEST::INCLUDE_DIRECTORIES));
+    EXPECT_TRUE(parser.Parse(PUBLISHED_CVE));
+}
+
+/**
+ * @brief Test that a rejected CVE can be parsed.
+ *
+ */
+TEST_F(Cve5FbTest, parseRejectedCve)
+{
+    // Load the schema
+    std::string schema;
+    EXPECT_TRUE(flatbuffers::LoadFile(CVE5_FB_TEST::SCHEMA_PATH, false, &schema));
+
+    // Parse the schema and the published CVE
+    flatbuffers::Parser parser;
+    EXPECT_TRUE(parser.Parse(schema.c_str(), CVE5_FB_TEST::INCLUDE_DIRECTORIES));
+    EXPECT_TRUE(parser.Parse(REJECTED_CVE));
+}
+
+/**
+ * @brief Test that an invalid CVE cannot be parsed.
+ *
+ */
+TEST_F(Cve5FbTest, parseInvalidCve)
+{
+    // Load the schema
+    std::string schema;
+    EXPECT_TRUE(flatbuffers::LoadFile(CVE5_FB_TEST::SCHEMA_PATH, false, &schema));
+
+    // Parse the schema and the published CVE
+    flatbuffers::Parser parser;
+    EXPECT_TRUE(parser.Parse(schema.c_str(), CVE5_FB_TEST::INCLUDE_DIRECTORIES));
+    EXPECT_FALSE(parser.Parse(INVALID_CVE));
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Wazuh SyscollectorFlatbuffers
+ * Wazuh Vulnerability Scanner - Unit Tests
  * Copyright (C) 2015, Wazuh Inc.
  * November 8, 2023.
  *

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.cpp
@@ -21,7 +21,7 @@ namespace CVE5_FB_TEST
     const char* INCLUDE_DIRECTORIES[] {FLATBUFFER_SCHEMAS_DIR, nullptr};
 
     const char* SCHEMA_PATH {FLATBUFFER_SCHEMAS_DIR "cve5.fbs"};
-}
+} // namespace CVE5_FB_TEST
 
 auto constexpr PUBLISHED_CVE {R"(
     {

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.hpp
@@ -1,0 +1,30 @@
+/*
+ * Wazuh SyscollectorFlatbuffers
+ * Copyright (C) 2015, Wazuh Inc.
+ * November 8, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _CVE_5_FB_TEST_HPP
+#define _CVE_5_FB_TEST_HPP
+
+#include "flatbuffers/flatbuffers.h"
+#include "flatbuffers/idl.h"
+#include "flatbuffers/util.h"
+#include "gtest/gtest.h"
+#include <fstream>
+
+class Cve5FbTest : public ::testing::Test
+{
+protected:
+    // LCOV_EXCL_START
+    Cve5FbTest() = default;
+    ~Cve5FbTest() override = default;
+    // LCOV_EXCL_STOP
+};
+
+#endif //_CVE_5_FB_TEST_H

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.hpp
@@ -18,6 +18,12 @@
 #include "gtest/gtest.h"
 #include <fstream>
 
+/**
+ * @brief Tests for the CVE5 flatbuffer schema.
+ *
+ * @details The schema should be able to parse CVEv5 documents (full or partial) and fail gracefully when the document
+ * is invalid.
+ */
 class Cve5FbTest : public ::testing::Test
 {
 protected:

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/cve5FB_test.hpp
@@ -1,5 +1,5 @@
 /*
- * Wazuh SyscollectorFlatbuffers
+ * Wazuh Vulnerability Scanner - Unit Tests
  * Copyright (C) 2015, Wazuh Inc.
  * November 8, 2023.
  *


### PR DESCRIPTION
|Related issue|
|---|
| #19723 |

## Description
This PR updates the CVEv5 flatbuffer schema in order to allow the serialization of rejected CVEs

Change log:
- Added rejected CVEs fields to the schema
- Updated CVSS table name
- Removed required flag from schema (prevent failure when documents are filtered)

![image](https://github.com/wazuh/wazuh/assets/34063881/af0bb991-29ed-46c2-9f03-da60a0fc8216)

> **Important**
Due to these changes, the flatbuffer is not 100% CVEv5 compliant so some weird scenarios are possible. For example, having an ADP entry on a rejected CVE:

<details>
  <summary>Show more</summary>
  
```json
{
    "containers": {
        "adp": [
            {
                "affected": [
                    {
                        "defaultStatus": "unknown",
                        "platforms": [
                            "upstream"
                        ],
                        "product": "cvs",
                        "vendor": "canonical"
                    }
                ],
                "descriptions": [
                    {
                        "lang": "en",
                        "value": "Alen Zukich discovered a buffer overflow in the processing of version and author information in the CVS client. By tricking an user to connect to a malicious CVS server, an attacker could exploit this to execute arbitrary code with the privileges of the connecting user."
                    }
                ],
                "providerMetadata": {
                    "orgId": "cc1ad9ee-3454-478d-9317-d3e869d708bc",
                    "shortName": "canonical"
                },
                "references": [
                    {
                        "url": "https://ubuntu.com/security/notices/USN-117-1"
                    }
                ]
            }
        ],
        "cna": {
            "providerMetadata": {
                "dateUpdated": "2018-03-16T14:29:07Z",
                "orgId": "00000000-0000-4000-A000-000000000003",
                "shortName": "nvd"
            },
            "rejectedReasons": [
                {
                    "lang": "en",
                    "value": "** REJECT **  DO NOT USE THIS CANDIDATE NUMBER.  ConsultIDs: none.  Reason: This candidate was in a CNA pool that was not assigned to any issues during 2017.  Notes: none."
                }
            ]
        }
    },
    "cveMetadata": {
        "assignerOrgId": "00000000-0000-4000-A000-000000000003",
        "assignerShortName": "nvd",
        "cveId": "CVE-2017-4085",
        "datePublished": "2018-03-16T14:29:07Z",
        "dateUpdated": "2018-03-16T14:29:07Z",
        "state": "REJECTED"
    },
    "dataType": "CVE_RECORD",
    "dataVersion": "5.0"
}
```
- CVEv5 schema validation:
![image](https://github.com/wazuh/wazuh/assets/34063881/815e551a-eb15-4f8c-b714-908fd1829a4c)

- Flatbuffer conversion:
```
Parsing CVE-2017-4085.json
Success: 1
failed:  0
Total:   1
```

</details>


## Results
I've converted all the generated documents, and all the rejected ones were successfully parsed:

```
Success: 227436
failed:  0
Total:   227436
```