### PR TITLE
Fix error in SCA Policy For Windows 11 Enterprise

### DIFF
--- a/ruleset/sca/windows/cis_win11_enterprise.yml
+++ b/ruleset/sca/windows/cis_win11_enterprise.yml
@@ -9326,8 +9326,8 @@ checks:
       - soc_2: ["CC6.8"]
     condition: any
     rules:
-      - 'not r:KEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Policies\PassportForWork\Biometrics'
-      - 'not r:KEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Policies\PassportForWork\Biometrics -> EnableESSwithSupportedPeripherals'
+      - 'not r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Policies\PassportForWork\Biometrics'
+      - 'not r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Policies\PassportForWork\Biometrics -> EnableESSwithSupportedPeripherals'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\GameDVR -> EnableESSwithSupportedPeripherals -> 1'
 
   # 18.10.80.1 (L2) Ensure 'Allow suggested apps in Windows Ink Workspace' is set to 'Disabled'. (Automated)


### PR DESCRIPTION
|Wazuh version| Component | 
|---| --- |
| 4.8.0| SCA | 

This PR aims to fix a typographical error in one of the rules in the Windows 11 SCA.

- [x] Typographical errors with rules in the check