### PR TITLE
Allowing the non-blocking communication with the router module

### DIFF
--- a/src/shared_modules/router/src/remoteProvider.hpp
+++ b/src/shared_modules/router/src/remoteProvider.hpp
@@ -41,8 +41,7 @@ public:
     explicit RemoteProvider(std::string endpoint, const std::string& socketPath)
         : m_endpointName {std::move(endpoint)}
     {
-        nlohmann::json jsonMsg {{"EndpointName", m_endpointName}, {"MessageType", "InitProvider"}};
-        RemoteStateHelper::sendRegistrationMessage(jsonMsg);
+        RemoteStateHelper::sendInitProviderMessage(m_endpointName);
 
         m_socketClient =
             std::make_shared<SocketClient<Socket<OSPrimitives>, EpollWrapper>>(socketPath + m_endpointName);
@@ -62,15 +61,7 @@ public:
 
     ~RemoteProvider()
     {
-        nlohmann::json jsonMsg {{"EndpointName", m_endpointName}, {"MessageType", "RemoveProvider"}};
-        try
-        {
-            RemoteStateHelper::sendRegistrationMessage(jsonMsg, true);
-        }
-        catch (const std::exception& e)
-        {
-            std::cerr << "Unable to send RemoveProvider message: " << e.what() << std::endl;
-        }
+        RemoteStateHelper::sendRemoveProviderMessage(m_endpointName);
     }
 };
 

--- a/src/shared_modules/router/src/remoteProvider.hpp
+++ b/src/shared_modules/router/src/remoteProvider.hpp
@@ -63,7 +63,14 @@ public:
     ~RemoteProvider()
     {
         nlohmann::json jsonMsg {{"EndpointName", m_endpointName}, {"MessageType", "RemoveProvider"}};
-        RemoteStateHelper::sendRegistrationMessage(jsonMsg);
+        try
+        {
+            RemoteStateHelper::sendRegistrationMessage(jsonMsg, true);
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr << "Unable to send RemoveProvider message: " << e.what() << std::endl;
+        }
     }
 };
 

--- a/src/shared_modules/router/src/remoteStateHelper.hpp
+++ b/src/shared_modules/router/src/remoteStateHelper.hpp
@@ -36,12 +36,12 @@ public:
      *
      * @param jsonMsg Message to be sent.
      */
-    static void sendRegistrationMessage(const nlohmann::json& jsonMsg)
+    static void sendRegistrationMessage(const nlohmann::json& jsonMsg, bool stopIfSocketRemoved = false)
     {
         std::promise<void> promiseObj;
         auto futureObj = promiseObj.get_future();
-        auto socketClient =
-            std::make_shared<SocketClient<Socket<OSPrimitives>, EpollWrapper>>(REMOTE_SUBSCRIPTION_ENDPOINT);
+        auto socketClient = std::make_shared<SocketClient<Socket<OSPrimitives>, EpollWrapper>>(
+            REMOTE_SUBSCRIPTION_ENDPOINT, stopIfSocketRemoved);
         socketClient->connect(
             [&](const char* body, uint32_t bodySize, const char*, uint32_t)
             {

--- a/src/shared_modules/router/src/remoteStateHelper.hpp
+++ b/src/shared_modules/router/src/remoteStateHelper.hpp
@@ -72,18 +72,34 @@ private:
     }
 
 public:
+    /**
+     * @brief Creates and sends the init provider message.
+     *
+     * @param endpointName Name of the endpoint.
+     */
     static void sendInitProviderMessage(const std::string& endpointName)
     {
         nlohmann::json jsonMsg {{"EndpointName", endpointName}, {"MessageType", "InitProvider"}};
         sendRouterServerMessage(jsonMsg, false);
     }
 
+    /**
+     * @brief Creates and sends the remove provider message.
+     *
+     * @param endpointName Name of the endpoint.
+     */
     static void sendRemoveProviderMessage(const std::string& endpointName)
     {
         nlohmann::json jsonMsg {{"EndpointName", endpointName}, {"MessageType", "RemoveProvider"}};
         sendRouterServerMessage(jsonMsg, true);
     }
 
+    /**
+     * @brief Creates and sends the remove subscriber message.
+     *
+     * @param endpointName Name of the endpoint.
+     * @param subscriberId Id of the subscriber.
+     */
     static void sendRemoveSubscriberMessage(const std::string& endpointName, const std::string& subscriberId)
     {
         nlohmann::json jsonMsg {

--- a/src/shared_modules/router/src/remoteStateHelper.hpp
+++ b/src/shared_modules/router/src/remoteStateHelper.hpp
@@ -30,39 +30,65 @@ private:
     RemoteStateHelper() = default;
     ~RemoteStateHelper() = default;
 
-public:
     /**
      * @brief Registration message process.
      *
      * @param jsonMsg Message to be sent.
      */
-    static void sendRegistrationMessage(const nlohmann::json& jsonMsg, bool stopIfSocketRemoved = false)
+    static void sendRouterServerMessage(const nlohmann::json& jsonMsg, bool stopIfSocketRemoved)
     {
-        std::promise<void> promiseObj;
-        auto futureObj = promiseObj.get_future();
-        auto socketClient = std::make_shared<SocketClient<Socket<OSPrimitives>, EpollWrapper>>(
-            REMOTE_SUBSCRIPTION_ENDPOINT, stopIfSocketRemoved);
-        socketClient->connect(
-            [&](const char* body, uint32_t bodySize, const char*, uint32_t)
-            {
-                try
+        try
+        {
+            std::promise<void> promiseObj;
+            auto futureObj = promiseObj.get_future();
+            auto socketClient = std::make_shared<SocketClient<Socket<OSPrimitives>, EpollWrapper>>(
+                REMOTE_SUBSCRIPTION_ENDPOINT, stopIfSocketRemoved);
+            socketClient->connect(
+                [&](const char* body, uint32_t bodySize, const char*, uint32_t)
                 {
-                    auto result = nlohmann::json::parse(body, body + bodySize);
-                    if (result.at("Result") != "OK")
+                    try
                     {
-                        throw std::runtime_error(result.at("Result"));
+                        auto result = nlohmann::json::parse(body, body + bodySize);
+                        if (result.at("Result") != "OK")
+                        {
+                            throw std::runtime_error(result.at("Result"));
+                        }
                     }
-                }
-                catch (const std::exception& e)
-                {
-                    std::cerr << "RemoteProvider: Invalid result: " << e.what() << std::endl;
-                }
-                promiseObj.set_value();
-            });
+                    catch (const std::exception& e)
+                    {
+                        std::cerr << "RemoteProvider: Invalid result: " << e.what() << std::endl;
+                    }
+                    promiseObj.set_value();
+                });
 
-        const auto msg = jsonMsg.dump();
-        socketClient->send(msg.data(), msg.size());
-        futureObj.wait();
+            const auto msg = jsonMsg.dump();
+            socketClient->send(msg.data(), msg.size());
+            futureObj.wait();
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr << "RemoteStateHelper failed to send message: " << e.what() << std::endl;
+        }
+    }
+
+public:
+    static void sendInitProviderMessage(const std::string& endpointName)
+    {
+        nlohmann::json jsonMsg {{"EndpointName", endpointName}, {"MessageType", "InitProvider"}};
+        sendRouterServerMessage(jsonMsg, false);
+    }
+
+    static void sendRemoveProviderMessage(const std::string& endpointName)
+    {
+        nlohmann::json jsonMsg {{"EndpointName", endpointName}, {"MessageType", "RemoveProvider"}};
+        sendRouterServerMessage(jsonMsg, true);
+    }
+
+    static void sendRemoveSubscriberMessage(const std::string& endpointName, const std::string& subscriberId)
+    {
+        nlohmann::json jsonMsg {
+            {"EndpointName", endpointName}, {"MessageType", "RemoveSubscriber"}, {"SubscriberId", subscriberId}};
+        sendRouterServerMessage(jsonMsg, true);
     }
 };
 

--- a/src/shared_modules/router/src/remoteSubscriber.hpp
+++ b/src/shared_modules/router/src/remoteSubscriber.hpp
@@ -110,7 +110,14 @@ public:
         nlohmann::json jsonMsg {
             {"EndpointName", m_endpointName}, {"MessageType", "RemoveSubscriber"}, {"SubscriberId", m_subscriberId}};
 
-        RemoteStateHelper::sendRegistrationMessage(jsonMsg);
+        try
+        {
+            RemoteStateHelper::sendRegistrationMessage(jsonMsg, true);
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr << "Unable to send RemoveSubscriber message: " << e.what() << std::endl;
+        }
     }
 };
 

--- a/src/shared_modules/router/src/remoteSubscriber.hpp
+++ b/src/shared_modules/router/src/remoteSubscriber.hpp
@@ -107,17 +107,7 @@ public:
 
     ~RemoteSubscriber()
     {
-        nlohmann::json jsonMsg {
-            {"EndpointName", m_endpointName}, {"MessageType", "RemoveSubscriber"}, {"SubscriberId", m_subscriberId}};
-
-        try
-        {
-            RemoteStateHelper::sendRegistrationMessage(jsonMsg, true);
-        }
-        catch (const std::exception& e)
-        {
-            std::cerr << "Unable to send RemoveSubscriber message: " << e.what() << std::endl;
-        }
+        RemoteStateHelper::sendRemoveSubscriberMessage(m_endpointName, m_subscriberId);
     }
 };
 

--- a/src/shared_modules/router/tests/CMakeLists.txt
+++ b/src/shared_modules/router/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.12.4)
 include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
 include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
 include_directories(${SRC_FOLDER}/shared_modules/router/)
+include_directories(${SRC_FOLDER}/shared_modules/router/src)
 
 link_directories(${SRC_FOLDER}/external/googletest/lib/)
 

--- a/src/shared_modules/router/tests/component/interface_c_test.hpp
+++ b/src/shared_modules/router/tests/component/interface_c_test.hpp
@@ -43,4 +43,28 @@ protected:
      */
     ROUTER_PROVIDER_HANDLE m_routerProviderHandle {};
 };
+
+/**
+ * @brief RouterCInterfaceTest class with no SetUp.
+ *
+ */
+class RouterCInterfaceTestNoSetUp : public ::testing::Test
+{
+protected:
+    RouterCInterfaceTestNoSetUp() = default;
+    ~RouterCInterfaceTestNoSetUp() override = default;
+
+    /**
+     * @brief Test setup routine.
+     *
+     */
+    void SetUp() override {};
+
+    /**
+     * @brief Test teardown routine.
+     *
+     */
+    void TearDown() override;
+};
+
 #endif //_ROUTER_C_INTERFACE_TESTS_HPP

--- a/src/shared_modules/router/tests/component/remoteStateHelper_test.cpp
+++ b/src/shared_modules/router/tests/component/remoteStateHelper_test.cpp
@@ -13,59 +13,33 @@
 #include "src/remoteStateHelper.hpp"
 #include <external/nlohmann/json.hpp>
 
-/*
- * @brief Tests semd a registration message with invalid MessageType
+/**
+ * @brief Tests sendInitProviderMessage method.
+ *
  */
-TEST_F(RemoteStateHelperTest, TestSendInvalidMessageType)
+TEST_F(RemoteStateHelperTest, sendInitProviderMessageTest)
 {
-    const auto invalidMessage = R"(
-        {
-            "EndpointName": "test-remote",
-            "MessageType": "invalidMessageType"
-        }
-    )"_json;
-
-    // It doesn't throw an exception, because it's already handled in the function
-    EXPECT_NO_THROW(RemoteStateHelper::sendRegistrationMessage(invalidMessage));
+    auto endpointName {"test-remote"};
+    EXPECT_NO_THROW(RemoteStateHelper::sendInitProviderMessage(endpointName));
 }
 
-/*
- * @brief Tests send a registration message without data
+/**
+ * @brief Tests sendRemoveProviderMessage method.
+ *
  */
-TEST_F(RemoteStateHelperTest, TestSendEmptyMessage)
+TEST_F(RemoteStateHelperTest, sendRemoveProviderMessageTest)
 {
-    const auto emptyMessage = R"({})"_json;
-
-    // It doesn't throw an exception, because it's already handled in the function
-    EXPECT_NO_THROW(RemoteStateHelper::sendRegistrationMessage(emptyMessage));
+    auto endpointName {"test-remote"};
+    EXPECT_NO_THROW(RemoteStateHelper::sendRemoveProviderMessage(endpointName));
 }
 
-/*
- * @brief Tests send a registration message with valid MessageType
+/**
+ * @brief Tests sendRemoveSubscriberMessage method.
+ *
  */
-TEST_F(RemoteStateHelperTest, TestSendValidMessageType)
+TEST_F(RemoteStateHelperTest, sendRemoveSubscriberMessageTest)
 {
-    const auto message = R"(
-        {
-            "EndpointName": "test-remote",
-            "MessageType": "InitProvider"
-        }
-    )"_json;
-
-    EXPECT_NO_THROW(RemoteStateHelper::sendRegistrationMessage(message));
-}
-
-/*
- * @brief Tests send a registration message without EndpointName
- */
-TEST_F(RemoteStateHelperTest, TestSendMessageWithoutEndpointName)
-{
-    const auto message = R"(
-        {
-            "MessageType": "InitProvider"
-        }
-    )"_json;
-
-    // It doesn't throw an exception, because it's already handled in the function
-    EXPECT_NO_THROW(RemoteStateHelper::sendRegistrationMessage(message));
+    auto endpointName {"test-remote"};
+    auto subscriberId {"test-subscriber"};
+    EXPECT_NO_THROW(RemoteStateHelper::sendRemoveSubscriberMessage(endpointName, subscriberId));
 }

--- a/src/shared_modules/utils/socketClient.hpp
+++ b/src/shared_modules/utils/socketClient.hpp
@@ -41,6 +41,7 @@ private:
     std::mutex m_mutex;
     int m_stopFD[2] = {-1, -1};
     std::shared_mutex m_socketMutex;
+    bool m_stopIfSocketRemoved;
 
     void sendPendingMessages()
     {
@@ -57,11 +58,12 @@ private:
     }
 
 public:
-    explicit SocketClient(std::string socketPath)
+    explicit SocketClient(std::string socketPath, bool stopIfSocketRemoved = false)
         : m_socketPath {std::move(socketPath)}
         , m_epoll {std::make_shared<TEpoll>()}
         , m_socket {std::make_shared<TSocket>()}
         , m_shouldStop {false}
+        , m_stopIfSocketRemoved {stopIfSocketRemoved}
     {
         int result = ::pipe(m_stopFD);
         if (result == -1)
@@ -176,6 +178,12 @@ public:
 
         while (!m_shouldStop)
         {
+            if (m_stopIfSocketRemoved && !std::filesystem::exists(m_socketPath))
+            {
+                m_shouldStop = true;
+                throw std::runtime_error("Socket doesn't exist.");
+            }
+
             try
             {
                 std::lock_guard<std::shared_mutex> lock(m_socketMutex);

--- a/src/shared_modules/utils/socketDBWrapper.hpp
+++ b/src/shared_modules/utils/socketDBWrapper.hpp
@@ -37,7 +37,7 @@ private:
 public:
     explicit SocketDBWrapper(const std::string& socketPath)
         : m_dbSocket {
-              std::make_shared<SocketClient<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>>(socketPath)}
+              std::make_shared<SocketClient<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>>(socketPath, true)}
     {
         m_dbSocket->connect(
             [&](const char* body, uint32_t bodySize, const char* header, uint32_t headerSize)

--- a/src/shared_modules/utils/socketServer.hpp
+++ b/src/shared_modules/utils/socketServer.hpp
@@ -95,6 +95,8 @@ public:
         stop();
         ::close(m_stopFD[0]);
         ::close(m_stopFD[1]);
+
+        std::filesystem::remove_all(m_socketPath);
     }
 
     void stop()

--- a/src/shared_modules/utils/socketWrapper.hpp
+++ b/src/shared_modules/utils/socketWrapper.hpp
@@ -373,7 +373,7 @@ public:
                 // Check if connection have some error.
                 if (errno != EINPROGRESS && errno != EAGAIN)
                 {
-                    throw std::runtime_error {std::string("Error connecting to socket: ") + strerror(errno)};
+                    throw std::system_error(errno, std::generic_category(), "Error connecting to socket");
                 }
             }
 

--- a/src/shared_modules/utils/tests/socketDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/socketDBWrapper_test.cpp
@@ -101,3 +101,8 @@ TEST_F(SocketDBWrapperTest, SuccessTest)
 
     ASSERT_EQ(output[0].at("field"), "value");
 }
+
+TEST_F(SocketDBWrapperTestNoSetUp, NoSocketTest)
+{
+    EXPECT_THROW(SocketDBWrapper socketDBWrapper(TEST_SOCKET), std::exception);
+}

--- a/src/shared_modules/utils/tests/socketDBWrapper_test.hpp
+++ b/src/shared_modules/utils/tests/socketDBWrapper_test.hpp
@@ -60,4 +60,14 @@ protected:
     int m_sleepTime;
 };
 
+class SocketDBWrapperTestNoSetUp : public ::testing::Test
+{
+protected:
+    SocketDBWrapperTestNoSetUp() = default;
+    ~SocketDBWrapperTestNoSetUp() override = default;
+
+    void SetUp() override {};
+    void TearDown() override {};
+};
+
 #endif // _SOCKET_DB_WRAPPER_TEST_HPP


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20143|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds a new parameter to determine the behavior of the `socketClient` in case the router broker is down.
It was added to the destructor of the remote provider and the remote subscriber, and the `socketDBWrapper`.

The test that reproduces the hang was also added.

<!--
Add a clear description of how the problem has been solved.
-->


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

It was confirmed in a manual test that now `wazuh-remoted` ends gracefully in the special conditions of the bug

![2023-11-09_23-52](https://github.com/wazuh/wazuh/assets/65046601/ce20c956-e802-4e2a-93de-6da6dc89baaa)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- [x] Added unit tests (for new features)
