### PR TITLE
Fix registry alerts in legacy Windows agent

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -1261,6 +1261,7 @@ static int fim_process_alert(_sdb * sdb, Eventinfo *lf, cJSON * event) {
     cJSON *old_attributes = NULL;
     cJSON *audit = NULL;
     cJSON *object = NULL;
+    int version = 0;
     char *entry_type = NULL;
     fim_decoders_t *decoder = NULL;
     syscheck_event_t event_type;
@@ -1316,6 +1317,13 @@ static int fim_process_alert(_sdb * sdb, Eventinfo *lf, cJSON * event) {
             }
 
             break;
+
+        case cJSON_Number:
+            if (strcmp(object->string, "version") == 0) {
+                version = object->valueint;
+            }
+
+            break;
         }
     }
 
@@ -1325,7 +1333,7 @@ static int fim_process_alert(_sdb * sdb, Eventinfo *lf, cJSON * event) {
         return -1;
     }
 
-    if ((strcmp("registry_key", entry_type) == 0) || (strcmp("registry_value", entry_type) == 0)) {
+    if (((strcmp("registry_key", entry_type) == 0) || (strcmp("registry_value", entry_type) == 0)) && version >= 3) {
         if (lf->fields[FIM_REGISTRY_HASH].value == NULL) {
             mdebug1("No member 'index' in Syscheck JSON payload");
             return -1;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/20152|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

In this PR we are fixing a bug caused by the lack of version checking of the alerts in Windows agents, for registry monitoring.
If an agent version `<4.6.0` connects with a manager `>=4.6.0`, and tries to send a Windows registry alert, this will cause the `index` field to be required in the alert, which in the old agents does not exist yet. Causing the error commented in the issue.
To solve it, we only have to make sure that the `version` field of the alert is `>=3`.

## Configuration options
![image](https://github.com/wazuh/wazuh/assets/60003131/bbc07491-7332-490b-9914-2c473dea9e07)
   
```
<frequency>10</frequency>
<windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\test</windows_registry>
```


## Logs/Alerts example

```
** Alert 1699871706.1326176: - ossec,syscheck,syscheck_entry_added,syscheck_registry,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2023 Nov 13 10:35:06 (windows11) any->syscheck
Rule: 752 (level 5) -> 'Registry Value Entry Added to the System'
Registry Value '[x64] HKEY_LOCAL_MACHINE\Software\test\valuetest' added
Mode: scheduled

Attributes:
 - Size: 1
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation