### PR TITLE
vulnerability scanner module dump function fixed

### DIFF
--- a/src/wazuh_modules/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/wm_vulnerability_scanner.c
@@ -57,7 +57,16 @@ void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t * data)
 
         if (vulnerability_scanner_start_ptr)
         {
-            cJSON * config_json = wm_vulnerability_scanner_dump(data);
+            cJSON *config_json = cJSON_CreateObject();
+            cJSON_AddItemToObject(config_json, "vulnerability-detection", cJSON_Duplicate(data->vulnerability_detection, TRUE));
+            if(indexer_config == NULL)
+            {
+                cJSON_AddItemToObject(config_json, "indexer", cJSON_CreateObject());
+            }
+            else
+            {
+                cJSON_AddItemToObject(config_json, "indexer", cJSON_Duplicate(indexer_config, TRUE));
+            }
             wm_vulnerability_scanner_log_config(config_json);
             vulnerability_scanner_start_ptr(NULL, config_json);
             cJSON_Delete(config_json);
@@ -98,14 +107,6 @@ void wm_vulnerability_scanner_stop(__attribute__((unused))wm_vulnerability_scann
 cJSON* wm_vulnerability_scanner_dump(wm_vulnerability_scanner_t * data)
 {
     cJSON *root = cJSON_CreateObject();
-    cJSON_AddItemToObject(root, "vulnerability-detection", data->vulnerability_detection);
-    if(indexer_config == NULL)
-    {
-        cJSON_AddItemToObject(root, "indexer", cJSON_CreateObject());
-    }
-    else
-    {
-        cJSON_AddItemToObject(root, "indexer", indexer_config);
-    }
+    cJSON_AddItemToObject(root, "vulnerability-detection", cJSON_Duplicate(data->vulnerability_detection, TRUE));
     return root;
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20002|

## Description

This PR fixes the JSON returned by the function "wm_vulnerability_scanner_dump".
Also, the configuration JSON was modified to fix this bug.

## Tests

API request was successfully done:
![image](https://github.com/wazuh/wazuh/assets/101227434/b8a13f9b-93a8-4419-a738-35967e180c5e)

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] run API request successfully