### PR TITLE
Use rwlock_lock_read/write instead of phtread_mutex to allow multiple readers of the open dbs pool.

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -81,7 +81,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_vacuum -Wl,--wrap,wdb_get_db_state -Wl,--wrap,wdb_finalize_all_statements \
                              -Wl,--wrap,wdb_update_last_vacuum_data -Wl,--wrap,wdb_get_db_free_pages_percentage -Wl,--wrap,wdb_global_get_distinct_agent_groups \
                              -Wl,--wrap,w_inc_global_agent_get_distinct_groups -Wl,--wrap,w_inc_global_agent_get_distinct_groups_time \
-                             ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,w_inc_global_open_time ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int \
@@ -130,7 +130,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,sqlite3_column_count -Wl,--wrap,sqlite3_column_type -Wl,--wrap,sqlite3_column_name -Wl,--wrap,sqlite3_column_double \
                              -Wl,--wrap,sqlite3_column_text -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_finalize -Wl,--wrap,sqlite3_reset \
                              -Wl,--wrap,sqlite3_clear_bindings -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_sql -Wl,--wrap,OS_SendSecureTCP  \
-                             -Wl,--wrap,OS_SetSendTimeout -Wl,--wrap,time -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_bind_text ${HASH_OP_WRAPPERS} ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,OS_SetSendTimeout -Wl,--wrap,time -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,rwlock_lock_write \
+                             -Wl,--wrap,rwlock_lock_read -Wl,--wrap,rwlock_unlock ${HASH_OP_WRAPPERS} ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_upgrade")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_count_tables_with_name \

--- a/src/unit_tests/wazuh_db/test_wazuh_db_state.c
+++ b/src/unit_tests/wazuh_db/test_wazuh_db_state.c
@@ -61,6 +61,8 @@ static int test_setup(void ** state) {
     wdb_state.queries_breakdown.agent_breakdown.syscollector.deprecated.osinfo_queries = 1;
     wdb_state.queries_breakdown.agent_breakdown.vulnerability.vulnerability_detector_queries = 8;
     wdb_state.queries_breakdown.agent_breakdown.sync.dbsync_queries = 5;
+    wdb_state.queries_breakdown.agent_breakdown.open_calls_time.tv_sec = 0;
+    wdb_state.queries_breakdown.agent_breakdown.open_calls_time.tv_usec = 123456;
     wdb_state.queries_breakdown.agent_breakdown.sql_time.tv_sec = 1;
     wdb_state.queries_breakdown.agent_breakdown.sql_time.tv_usec = 546332;
     wdb_state.queries_breakdown.agent_breakdown.remove_time.tv_sec = 0;
@@ -162,6 +164,8 @@ static int test_setup(void ** state) {
     wdb_state.queries_breakdown.global_breakdown.belongs.select_group_belong_queries = 10;
     wdb_state.queries_breakdown.global_breakdown.belongs.get_group_agent_queries = 0;
     wdb_state.queries_breakdown.global_breakdown.labels.get_labels_queries = 1;
+    wdb_state.queries_breakdown.global_breakdown.open_calls_time.tv_sec = 0;
+    wdb_state.queries_breakdown.global_breakdown.open_calls_time.tv_usec = 123456;
     wdb_state.queries_breakdown.global_breakdown.sql_time.tv_sec = 0;
     wdb_state.queries_breakdown.global_breakdown.sql_time.tv_usec = 1523;
     wdb_state.queries_breakdown.global_breakdown.backup_time.tv_sec = 1;
@@ -510,16 +514,18 @@ void test_wazuhdb_create_state_json(void ** state) {
     cJSON* time = cJSON_GetObjectItem(metrics, "time");
 
     assert_non_null(cJSON_GetObjectItem(time, "execution"));
-    assert_int_equal(cJSON_GetObjectItem(time, "execution")->valueint, 25996);
+    assert_int_equal(cJSON_GetObjectItem(time, "execution")->valueint, 26242);
 
     cJSON* execution_breakdown = cJSON_GetObjectItem(time, "execution_breakdown");
 
     assert_non_null(cJSON_GetObjectItem(execution_breakdown, "agent"));
-    assert_int_equal(cJSON_GetObjectItem(execution_breakdown, "agent")->valueint, 18425);
+    assert_int_equal(cJSON_GetObjectItem(execution_breakdown, "agent")->valueint, 18548);
 
     cJSON* agent_time_breakdown = cJSON_GetObjectItem(execution_breakdown, "agent_breakdown");
 
     cJSON* agent_time_db = cJSON_GetObjectItem(agent_time_breakdown, "db");
+    assert_non_null(cJSON_GetObjectItem(agent_time_db, "open"));
+    assert_int_equal(cJSON_GetObjectItem(agent_time_db, "open")->valueint, 123);
     assert_non_null(cJSON_GetObjectItem(agent_time_db, "sql"));
     assert_int_equal(cJSON_GetObjectItem(agent_time_db, "sql")->valueint, 1546);
     assert_non_null(cJSON_GetObjectItem(agent_time_db, "remove"));
@@ -610,11 +616,13 @@ void test_wazuhdb_create_state_json(void ** state) {
     assert_int_equal(cJSON_GetObjectItem(agent_sync_time, "dbsync")->valueint, 2);
 
     assert_non_null(cJSON_GetObjectItem(execution_breakdown, "global"));
-    assert_int_equal(cJSON_GetObjectItem(execution_breakdown, "global")->valueint, 6968);
+    assert_int_equal(cJSON_GetObjectItem(execution_breakdown, "global")->valueint, 7091);
 
     cJSON* global_time_breakdown = cJSON_GetObjectItem(execution_breakdown, "global_breakdown");
 
     cJSON* global_time_db = cJSON_GetObjectItem(global_time_breakdown, "db");
+    assert_non_null(cJSON_GetObjectItem(global_time_db, "open"));
+    assert_int_equal(cJSON_GetObjectItem(global_time_db, "open")->valueint, 123);
     assert_non_null(cJSON_GetObjectItem(global_time_db, "sql"));
     assert_int_equal(cJSON_GetObjectItem(global_time_db, "sql")->valueint, 1);
     assert_non_null(cJSON_GetObjectItem(global_time_db, "backup"));

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -100,13 +100,13 @@ void test_wdb_open_tasks_pool_success(void **state)
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, WDB_TASK_NAME);
     will_return(__wrap_OSHash_Get, data->wdb);
 
     expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     ret = wdb_open_tasks();
 
@@ -117,7 +117,13 @@ void test_wdb_open_tasks_create_error(void **state)
 {
     wdb_t *ret = NULL;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_any(__wrap_OSHash_Get, self);
+    expect_string(__wrap_OSHash_Get, key, WDB_TASK_NAME);
+    will_return(__wrap_OSHash_Get, NULL);
+    expect_function_call(__wrap_rwlock_unlock);
+
+    expect_function_call(__wrap_rwlock_lock_write);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, WDB_TASK_NAME);
     will_return(__wrap_OSHash_Get, NULL);
@@ -140,7 +146,7 @@ void test_wdb_open_tasks_create_error(void **state)
     will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
 
     expect_string(__wrap__merror, formatted_msg, "Couldn't create SQLite database 'queue/tasks/tasks.db'");
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     ret = wdb_open_tasks();
 
@@ -152,13 +158,13 @@ void test_wdb_open_global_pool_success(void **state)
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, WDB_GLOB_NAME);
     will_return(__wrap_OSHash_Get, data->wdb);
 
     expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     ret = wdb_open_global();
 
@@ -169,7 +175,13 @@ void test_wdb_open_global_create_fail(void **state)
 {
     wdb_t *ret = NULL;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_any(__wrap_OSHash_Get, self);
+    expect_string(__wrap_OSHash_Get, key, WDB_GLOB_NAME);
+    will_return(__wrap_OSHash_Get, NULL);
+    expect_function_call(__wrap_rwlock_unlock);
+
+    expect_function_call(__wrap_rwlock_lock_write);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, WDB_GLOB_NAME);
     will_return(__wrap_OSHash_Get, NULL);
@@ -193,7 +205,7 @@ void test_wdb_open_global_create_fail(void **state)
     will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
 
     expect_string(__wrap__merror, formatted_msg, "Couldn't create SQLite database 'queue/db/global.db'");
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     ret = wdb_open_global();
 
@@ -1660,15 +1672,15 @@ void test_wdb_check_fragmentation_node_null(void **state)
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->stmt[0] = (sqlite3_stmt*)1;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, NULL);
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -1684,10 +1696,10 @@ void test_wdb_check_fragmentation_get_state_error(void **state)
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->stmt[0] = (sqlite3_stmt*)1;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -1714,7 +1726,7 @@ void test_wdb_check_fragmentation_get_state_error(void **state)
     expect_string(__wrap__merror, formatted_msg, "Couldn't get current state for the database '000'");
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -1730,10 +1742,10 @@ void test_wdb_check_fragmentation_get_last_vacuum_data_error(void **state)
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->stmt[0] = (sqlite3_stmt*)1;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -1790,7 +1802,7 @@ void test_wdb_check_fragmentation_get_last_vacuum_data_error(void **state)
     expect_string(__wrap__merror, formatted_msg, "Couldn't get last vacuum info for the database '000'");
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -1809,10 +1821,10 @@ void test_wdb_check_fragmentation_commit_error(void **state)
     db_pool_begin->stmt[0] = (sqlite3_stmt*)1;
     db_pool_begin->transaction = 1;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -1902,7 +1914,7 @@ void test_wdb_check_fragmentation_commit_error(void **state)
     expect_string(__wrap__merror, formatted_msg, "Couldn't execute commit statement, before vacuum, for the database '000'");
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -1920,10 +1932,10 @@ void test_wdb_check_fragmentation_vacuum_error(void **state)
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->transaction = 0;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -2013,7 +2025,7 @@ void test_wdb_check_fragmentation_vacuum_error(void **state)
     expect_string(__wrap__merror, formatted_msg, "Couldn't execute vacuum for the database '000'");
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -2031,10 +2043,10 @@ void test_wdb_check_fragmentation_get_fragmentation_after_vacuum_error(void **st
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->transaction = 0;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -2139,7 +2151,7 @@ void test_wdb_check_fragmentation_get_fragmentation_after_vacuum_error(void **st
     expect_string(__wrap__merror, formatted_msg, "Couldn't get fragmentation after vacuum for the database '000'");
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -2157,10 +2169,10 @@ void test_wdb_check_fragmentation_update_last_vacuum_data_error(void **state)
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->transaction = 0;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -2287,7 +2299,7 @@ void test_wdb_check_fragmentation_update_last_vacuum_data_error(void **state)
     expect_string(__wrap__merror, formatted_msg, "Couldn't update last vacuum info for the database '000'");
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -2305,10 +2317,10 @@ void test_wdb_check_fragmentation_success_with_warning(void **state)
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->transaction = 0;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -2415,7 +2427,7 @@ void test_wdb_check_fragmentation_success_with_warning(void **state)
     expect_string(__wrap__mwarn, formatted_msg, "After vacuum, the database '000' has become just as fragmented or worse");
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -2433,10 +2445,10 @@ void test_wdb_check_fragmentation_success(void **state)
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->transaction = 0;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -2541,7 +2553,7 @@ void test_wdb_check_fragmentation_success(void **state)
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -2559,10 +2571,10 @@ void test_wdb_check_fragmentation_no_vacuum_free_pages(void **state)
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->transaction = 0;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -2618,7 +2630,7 @@ void test_wdb_check_fragmentation_no_vacuum_free_pages(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "No vacuum data in metadata table.");
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -2637,10 +2649,10 @@ void test_wdb_check_fragmentation_no_vacuum_current_fragmentation(void **state)
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->transaction = 0;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -2696,7 +2708,7 @@ void test_wdb_check_fragmentation_no_vacuum_current_fragmentation(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "No vacuum data in metadata table.");
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -2716,10 +2728,10 @@ void test_wdb_check_fragmentation_no_vacuum_current_fragmentation_delta(void **s
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->transaction = 0;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -2801,7 +2813,7 @@ void test_wdb_check_fragmentation_no_vacuum_current_fragmentation_delta(void **s
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -2821,10 +2833,10 @@ void test_wdb_check_fragmentation_vacuum_first(void **state)
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->transaction = 0;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -2929,7 +2941,7 @@ void test_wdb_check_fragmentation_vacuum_first(void **state)
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 
@@ -2949,10 +2961,10 @@ void test_wdb_check_fragmentation_vacuum_current_fragmentation_delta(void **stat
     os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
     db_pool_begin->transaction = 0;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_lock_read);
+    expect_function_call(__wrap_rwlock_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_rwlock_lock_read);
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "000");
     will_return(__wrap_OSHash_Get, db_pool_begin);
@@ -3083,7 +3095,7 @@ void test_wdb_check_fragmentation_vacuum_current_fragmentation_delta(void **stat
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
     expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     wdb_check_fragmentation();
 

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -72,6 +72,10 @@ void test_wdb_parse_global_open_global_fail(void **state)
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
 
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Couldn't open DB global");
@@ -109,6 +113,10 @@ void test_wdb_parse_global_substr_fail(void **state)
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
 
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'error'");
@@ -128,6 +136,9 @@ void test_wdb_parse_global_sql_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_sql);
 
     ret = wdb_parse(query, data->output, 0);
@@ -156,6 +167,9 @@ void test_wdb_parse_global_sql_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_sql);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -184,6 +198,9 @@ void test_wdb_parse_global_sql_fail(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_sql);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -226,6 +243,9 @@ void test_wdb_parse_global_insert_agent_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent);
 
     ret = wdb_parse(query, data->output, 0);
@@ -247,6 +267,9 @@ void test_wdb_parse_global_insert_agent_invalid_json(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -270,6 +293,9 @@ void test_wdb_parse_global_insert_agent_compliant_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -303,6 +329,9 @@ void test_wdb_parse_global_insert_agent_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -336,6 +365,9 @@ void test_wdb_parse_global_insert_agent_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -362,6 +394,9 @@ void test_wdb_parse_global_update_agent_name_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name);
 
     ret = wdb_parse(query, data->output, 0);
@@ -383,6 +418,9 @@ void test_wdb_parse_global_update_agent_name_invalid_json(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -406,6 +444,9 @@ void test_wdb_parse_global_update_agent_name_invalid_data(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -433,6 +474,9 @@ void test_wdb_parse_global_update_agent_name_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -458,6 +502,9 @@ void test_wdb_parse_global_update_agent_name_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -484,6 +531,9 @@ void test_wdb_parse_global_update_agent_data_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data);
 
     ret = wdb_parse(query, data->output, 0);
@@ -505,6 +555,9 @@ void test_wdb_parse_global_update_agent_data_invalid_json(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -561,6 +614,9 @@ void test_wdb_parse_global_update_agent_data_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -594,6 +650,9 @@ void test_wdb_parse_global_update_agent_data_invalid_data(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -650,6 +709,9 @@ void test_wdb_parse_global_update_agent_data_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -676,6 +738,9 @@ void test_wdb_parse_global_get_agent_labels_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_labels_get_labels);
 
     ret = wdb_parse(query, data->output, 0);
@@ -698,6 +763,9 @@ void test_wdb_parse_global_get_agent_labels_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_labels_get_labels);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -731,6 +799,9 @@ void test_wdb_parse_global_get_agent_labels_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_labels_get_labels);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -758,6 +829,9 @@ void test_wdb_parse_global_update_agent_keepalive_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive);
 
     ret = wdb_parse(query, data->output, 0);
@@ -779,6 +853,9 @@ void test_wdb_parse_global_update_agent_keepalive_invalid_json(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -802,6 +879,9 @@ void test_wdb_parse_global_update_agent_keepalive_invalid_data(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -831,6 +911,9 @@ void test_wdb_parse_global_update_agent_keepalive_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -858,6 +941,9 @@ void test_wdb_parse_global_update_agent_keepalive_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -884,6 +970,9 @@ void test_wdb_parse_global_update_connection_status_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status);
 
     ret = wdb_parse(query, data->output, 0);
@@ -905,6 +994,9 @@ void test_wdb_parse_global_update_connection_status_invalid_json(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -928,6 +1020,9 @@ void test_wdb_parse_global_update_connection_status_invalid_data(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -958,6 +1053,9 @@ void test_wdb_parse_global_update_connection_status_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -986,6 +1084,9 @@ void test_wdb_parse_global_update_connection_status_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1012,6 +1113,9 @@ void test_wdb_parse_global_update_status_code_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code);
 
     ret = wdb_parse(query, data->output, 0);
@@ -1033,6 +1137,9 @@ void test_wdb_parse_global_update_status_code_invalid_json(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1056,6 +1163,9 @@ void test_wdb_parse_global_update_status_code_invalid_data(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1086,6 +1196,9 @@ void test_wdb_parse_global_update_status_code_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1114,6 +1227,9 @@ void test_wdb_parse_global_update_status_code_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1140,6 +1256,9 @@ void test_wdb_parse_global_delete_agent_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_delete_agent);
 
     ret = wdb_parse(query, data->output, 0);
@@ -1162,6 +1281,9 @@ void test_wdb_parse_global_delete_agent_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_delete_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1186,6 +1308,9 @@ void test_wdb_parse_global_delete_agent_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_delete_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1212,6 +1337,9 @@ void test_wdb_parse_global_select_agent_name_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_name);
 
     ret = wdb_parse(query, data->output, 0);
@@ -1234,6 +1362,9 @@ void test_wdb_parse_global_select_agent_name_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_name);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1262,6 +1393,9 @@ void test_wdb_parse_global_select_agent_name_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_name);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1288,6 +1422,9 @@ void test_wdb_parse_global_select_agent_group_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_group);
 
     ret = wdb_parse(query, data->output, 0);
@@ -1310,6 +1447,9 @@ void test_wdb_parse_global_select_agent_group_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_group);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1338,6 +1478,9 @@ void test_wdb_parse_global_select_agent_group_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_group);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1364,6 +1507,9 @@ void test_wdb_parse_global_find_agent_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_find_agent);
 
     ret = wdb_parse(query, data->output, 0);
@@ -1385,6 +1531,9 @@ void test_wdb_parse_global_find_agent_invalid_json(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_find_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1408,6 +1557,9 @@ void test_wdb_parse_global_find_agent_invalid_data(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_find_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1435,6 +1587,9 @@ void test_wdb_parse_global_find_agent_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_find_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1464,6 +1619,9 @@ void test_wdb_parse_global_find_agent_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_find_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1490,6 +1648,9 @@ void test_wdb_parse_global_find_group_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_find_group);
 
     ret = wdb_parse(query, data->output, 0);
@@ -1512,6 +1673,9 @@ void test_wdb_parse_global_find_group_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_find_group);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1540,6 +1704,9 @@ void test_wdb_parse_global_find_group_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_find_group);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1566,6 +1733,9 @@ void test_wdb_parse_global_insert_agent_group_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_insert_agent_group);
 
     ret = wdb_parse(query, data->output, 0);
@@ -1588,6 +1758,9 @@ void test_wdb_parse_global_insert_agent_group_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_insert_agent_group);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1612,6 +1785,9 @@ void test_wdb_parse_global_insert_agent_group_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_insert_agent_group);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1638,6 +1814,9 @@ void test_wdb_parse_global_select_group_belong_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_belongs_select_group_belong);
 
     ret = wdb_parse(query, data->output, 0);
@@ -1660,6 +1839,9 @@ void test_wdb_parse_global_select_group_belong_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_belongs_select_group_belong);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1687,6 +1869,9 @@ void test_wdb_parse_global_select_group_belong_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_belongs_select_group_belong);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1713,6 +1898,9 @@ void test_wdb_parse_global_get_group_agents_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent);
 
     ret = wdb_parse(query, data->output, 0);
@@ -1733,6 +1921,9 @@ void test_wdb_parse_global_get_group_agents_group_missing(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1756,6 +1947,9 @@ void test_wdb_parse_global_get_group_agents_last_id_missing(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1779,6 +1973,9 @@ void test_wdb_parse_global_get_group_agents_last_id_value_missing(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1807,6 +2004,9 @@ void test_wdb_parse_global_get_group_agents_failed(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1835,6 +2035,9 @@ void test_wdb_parse_global_get_group_agents_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1861,6 +2064,9 @@ void test_wdb_parse_global_delete_group_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_delete_group);
 
     ret = wdb_parse(query, data->output, 0);
@@ -1883,6 +2089,9 @@ void test_wdb_parse_global_delete_group_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_delete_group);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1907,6 +2116,9 @@ void test_wdb_parse_global_delete_group_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_delete_group);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1933,6 +2145,9 @@ void test_wdb_parse_global_select_groups_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_select_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1961,6 +2176,9 @@ void test_wdb_parse_global_select_groups_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_select_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -1989,6 +2207,9 @@ void test_wdb_parse_global_sync_agent_info_get_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2015,6 +2236,9 @@ void test_wdb_parse_global_sync_agent_info_get_last_id_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2046,6 +2270,9 @@ void test_wdb_parse_global_sync_agent_info_get_size_limit(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2078,6 +2305,9 @@ void test_wdb_parse_global_sync_agent_info_set_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set);
 
     ret = wdb_parse(query, data->output, 0);
@@ -2099,6 +2329,9 @@ void test_wdb_parse_global_sync_agent_info_set_invalid_json(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2128,6 +2361,9 @@ void test_wdb_parse_global_sync_agent_info_set_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2156,6 +2392,9 @@ void test_wdb_parse_global_sync_agent_info_set_id_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2188,6 +2427,9 @@ void test_wdb_parse_global_sync_agent_info_set_del_label_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2224,6 +2466,9 @@ void test_wdb_parse_global_sync_agent_info_set_set_label_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2258,6 +2503,9 @@ void test_wdb_parse_global_sync_agent_info_set_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2284,6 +2532,9 @@ void test_wdb_parse_global_set_agent_groups_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
 
     ret = wdb_parse(query, data->output, 0);
@@ -2305,6 +2556,9 @@ void test_wdb_parse_global_set_agent_groups_invalid_json(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2328,6 +2582,9 @@ void test_wdb_parse_global_set_agent_groups_missing_field(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2351,6 +2608,9 @@ void test_wdb_parse_global_set_agent_groups_invalid_mode(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2377,6 +2637,9 @@ void test_wdb_parse_global_set_agent_groups_fail(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2403,6 +2666,9 @@ void test_wdb_parse_global_set_agent_groups_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2429,6 +2695,9 @@ void test_wdb_parse_global_sync_agent_groups_get_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
 
     ret = wdb_parse(query, data->output, 0);
@@ -2450,6 +2719,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_json(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2487,6 +2759,9 @@ void test_wdb_parse_global_sync_agent_groups_without_condition_field_succes(void
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2510,6 +2785,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_data_type(void 
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2533,6 +2811,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_negative(void *
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2556,6 +2837,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_condition_data_type(voi
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2579,6 +2863,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_set_synced_data_type(vo
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2602,6 +2889,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_get_hash_data_type(void
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2625,6 +2915,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delt
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2648,6 +2941,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delt
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2677,6 +2973,9 @@ void test_wdb_parse_global_sync_agent_groups_get_null_response(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2714,6 +3013,9 @@ void test_wdb_parse_global_sync_agent_groups_get_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2770,6 +3072,9 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_response(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2796,6 +3101,9 @@ void test_wdb_parse_global_get_groups_integrity_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity);
 
     ret = wdb_parse(query, data->output, 0);
@@ -2817,6 +3125,9 @@ void test_wdb_parse_global_get_groups_integrity_hash_length_expected_fail(void *
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2842,6 +3153,9 @@ void test_wdb_parse_global_get_groups_integrity_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2867,6 +3181,9 @@ void test_wdb_parse_global_get_groups_integrity_success_syncreq(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2892,6 +3209,9 @@ void test_wdb_parse_global_get_groups_integrity_success_synced(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2917,6 +3237,9 @@ void test_wdb_parse_global_get_groups_integrity_success_hash_mismatch(void **sta
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2943,6 +3266,9 @@ void test_wdb_parse_global_disconnect_agents_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents);
 
     ret = wdb_parse(query, data->output, 0);
@@ -2963,6 +3289,9 @@ void test_wdb_parse_global_disconnect_agents_last_id_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2986,6 +3315,9 @@ void test_wdb_parse_global_disconnect_agents_keepalive_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3009,6 +3341,9 @@ void test_wdb_parse_global_disconnect_agents_sync_status_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3040,6 +3375,9 @@ void test_wdb_parse_global_disconnect_agents_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3066,6 +3404,9 @@ void test_wdb_parse_global_get_all_agents_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_all_agents);
 
     ret = wdb_parse(query, data->output, 0);
@@ -3086,6 +3427,9 @@ void test_wdb_parse_global_get_all_agents_argument_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_all_agents);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3108,6 +3452,9 @@ void test_wdb_parse_global_get_all_agents_argument2_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_all_agents);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3137,6 +3484,9 @@ void test_wdb_parse_global_get_all_agents_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_all_agents);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3163,6 +3513,9 @@ void test_wdb_parse_global_get_agent_info_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agent_info);
 
     ret = wdb_parse(query, data->output, 0);
@@ -3185,6 +3538,9 @@ void test_wdb_parse_global_get_agent_info_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agent_info);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3213,6 +3569,9 @@ void test_wdb_parse_global_get_agent_info_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agent_info);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3239,6 +3598,9 @@ void test_wdb_parse_reset_agents_connection_syntax_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_reset_agents_connection);
 
     ret = wdb_parse(query, data->output, 0);
@@ -3262,6 +3624,9 @@ void test_wdb_parse_reset_agents_connection_query_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_reset_agents_connection);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3286,6 +3651,9 @@ void test_wdb_parse_reset_agents_connection_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_reset_agents_connection);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3312,6 +3680,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_syntax_error(void **s
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status);
 
     ret = wdb_parse(query, data->output, 0);
@@ -3332,6 +3703,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_status_error(void **s
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3355,6 +3729,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_last_id_error(void **
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3378,6 +3755,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_limit_error(void **st
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3411,6 +3791,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_limit_succes(void **s
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3442,6 +3825,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_query_success(void **
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3469,6 +3855,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_query_fail(void **sta
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3496,6 +3885,9 @@ void test_wdb_parse_global_get_backup_failed(void **state) {
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3523,6 +3915,9 @@ void test_wdb_parse_global_get_backup_success(void **state) {
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -3552,6 +3947,9 @@ void test_wdb_parse_global_restore_backup_invalid_syntax(void **state) {
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_pthread_mutex_lock);
@@ -3581,6 +3979,9 @@ void test_wdb_parse_global_restore_backup_success_missing_snapshot(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_pthread_mutex_lock);
@@ -3610,6 +4011,9 @@ void test_wdb_parse_global_restore_backup_success_pre_restore_true(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_pthread_mutex_lock);
@@ -3639,6 +4043,9 @@ void test_wdb_parse_global_restore_backup_success_pre_restore_false(void **state
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_pthread_mutex_lock);
@@ -3668,6 +4075,9 @@ void test_wdb_parse_global_restore_backup_success_pre_restore_missing(void **sta
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_pthread_mutex_lock);
@@ -3693,6 +4103,9 @@ void test_wdb_parse_global_vacuum_commit_error(void **state) {
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
 
     expect_function_call(__wrap_w_inc_global_vacuum);
     expect_function_call(__wrap_gettimeofday);
@@ -3725,6 +4138,9 @@ void test_wdb_parse_global_vacuum_vacuum_error(void **state) {
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
 
     expect_function_call(__wrap_w_inc_global_vacuum);
     expect_function_call(__wrap_gettimeofday);
@@ -3759,6 +4175,9 @@ void test_wdb_parse_global_vacuum_success_get_db_state_error(void **state) {
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
 
     expect_function_call(__wrap_w_inc_global_vacuum);
     expect_function_call(__wrap_gettimeofday);
@@ -3795,6 +4214,9 @@ void test_wdb_parse_global_vacuum_success_update_vacuum_data_error(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
 
     expect_function_call(__wrap_w_inc_global_vacuum);
     expect_function_call(__wrap_gettimeofday);
@@ -3834,6 +4256,9 @@ void test_wdb_parse_global_vacuum_success(void **state) {
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
 
     expect_function_call(__wrap_w_inc_global_vacuum);
     expect_function_call(__wrap_gettimeofday);
@@ -3873,6 +4298,9 @@ void test_wdb_parse_global_get_fragmentation_db_state_error(void **state) {
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
 
     expect_function_call(__wrap_w_inc_global_get_fragmentation);
     expect_function_call(__wrap_gettimeofday);
@@ -3905,6 +4333,9 @@ void test_wdb_parse_global_get_fragmentation_free_pages_error(void **state) {
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
 
     expect_function_call(__wrap_w_inc_global_get_fragmentation);
     expect_function_call(__wrap_gettimeofday);
@@ -3937,6 +4368,9 @@ void test_wdb_parse_global_get_fragmentation_success(void **state) {
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
 
     expect_function_call(__wrap_w_inc_global_get_fragmentation);
     expect_function_call(__wrap_gettimeofday);
@@ -3975,6 +4409,9 @@ void test_wdb_parse_global_get_distinct_agent_groups_success(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -4001,6 +4438,9 @@ void test_wdb_parse_global_get_distinct_agent_groups_success_with_last_hash(void
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -4028,6 +4468,9 @@ void test_wdb_parse_global_get_distinct_agent_groups_result_null(void **state)
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -4055,6 +4498,9 @@ void test_wdb_parse_global_get_distinct_agent_groups_result_null_with_last_hash(
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.c
@@ -30,6 +30,10 @@ void __wrap_w_inc_global() {
     function_called();
 }
 
+void __wrap_w_inc_global_open_time(){
+    function_called();
+}
+
 void __wrap_w_inc_global_sql(){
     function_called();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.h
@@ -24,6 +24,8 @@ void __wrap_w_inc_queries_total();
 
 void __wrap_w_inc_global();
 
+void __wrap_w_inc_global_open_time();
+
 void __wrap_w_inc_global_sql();
 
 void __wrap_w_inc_global_sql_time();

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -206,6 +206,8 @@ int main(int argc, char ** argv)
 
     // Start threads
 
+    rwlock_init(&pool_mutex);
+
     if (status = pthread_create(&thread_dealer, NULL, run_dealer, NULL), status != 0) {
         merror("Couldn't create 'run_dealer' thread: %s", strerror(status));
         goto failure;
@@ -264,6 +266,7 @@ int main(int argc, char ** argv)
     unlink(path_template);
     mdebug1("Template file removed again: %s", path_template);
 
+    rwlock_destroy(&pool_mutex);
     return EXIT_SUCCESS;
 
 failure:

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -325,12 +325,39 @@ STATIC int wdb_execute_single_int_select_query(wdb_t * wdb, const char *query, i
  */
 STATIC int wdb_get_last_vacuum_data(wdb_t* wdb, int *last_vacuum_time, int *last_vacuum_value);
 
+/**
+ * @brief Get a database from the database group
+ *
+ * @param[in] db_name Name of the database to search in the database pool.
+ * @return Returns the wdb object if it exists or NULL if it does not exist.
+ */
+STATIC wdb_t * wdb_get_db_from_pool(const char* db_name);
+
 wdb_config wconfig;
-pthread_mutex_t pool_mutex = PTHREAD_MUTEX_INITIALIZER;
+rwlock_t pool_mutex;
 wdb_t * db_pool_begin;
 wdb_t * db_pool_last;
 int db_pool_size;
 OSHash * open_dbs;
+
+STATIC wdb_t * wdb_get_db_from_pool(const char* db_name) {
+    wdb_t * wdb = NULL;
+
+    if (db_name == NULL) {
+        merror("The database name cannot be null.");
+        return NULL;
+    }
+
+    // Finds DB in pool, locking pool_mutex for read
+    rwlock_lock_read(&pool_mutex);
+    if (wdb = (wdb_t *)OSHash_Get(open_dbs, db_name), wdb) {
+        // The corresponding w_mutex_unlock(&wdb->mutex) is called in wdb_leave(wdb_t * wdb)
+        w_mutex_lock(&wdb->mutex);
+        wdb->refcount++;
+    }
+    rwlock_unlock(&pool_mutex);
+    return wdb;
+}
 
 // Opens global database and stores it in DB pool. It returns a locked database or NULL
 wdb_t * wdb_open_global() {
@@ -338,14 +365,20 @@ wdb_t * wdb_open_global() {
     sqlite3 *db = NULL;
     wdb_t * wdb = NULL;
 
-    w_mutex_lock(&pool_mutex);
+    // Finds DB in pool, locking pool_mutex for read
+    if (wdb = wdb_get_db_from_pool(WDB_GLOB_NAME), wdb) {
+        return wdb;
+    }
+
+    // Now try locking pool_mutex for writing
+    rwlock_lock_write(&pool_mutex);
 
     // Finds DB in pool
     if (wdb = (wdb_t *)OSHash_Get(open_dbs, WDB_GLOB_NAME), wdb) {
         // The corresponding w_mutex_unlock(&wdb->mutex) is called in wdb_leave(wdb_t * wdb)
         w_mutex_lock(&wdb->mutex);
         wdb->refcount++;
-        w_mutex_unlock(&pool_mutex);
+        rwlock_unlock(&pool_mutex);
         return wdb;
     } else {
         // Try to open DB
@@ -358,7 +391,7 @@ wdb_t * wdb_open_global() {
             // Creating database
             if (OS_SUCCESS != wdb_create_global(path)) {
                 merror("Couldn't create SQLite database '%s'", path);
-                w_mutex_unlock(&pool_mutex);
+                rwlock_unlock(&pool_mutex);
                 return wdb;
             }
 
@@ -366,7 +399,7 @@ wdb_t * wdb_open_global() {
             if (sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE, NULL)) {
                 merror("Can't open SQLite database '%s': %s", path, sqlite3_errmsg(db));
                 sqlite3_close_v2(db);
-                w_mutex_unlock(&pool_mutex);
+                rwlock_unlock(&pool_mutex);
                 return wdb;
             }
 
@@ -381,7 +414,7 @@ wdb_t * wdb_open_global() {
             w_mutex_lock(&wdb->mutex);
             wdb->refcount++;
             if (wdb = wdb_upgrade_global(wdb), !wdb) {
-                w_mutex_unlock(&pool_mutex);
+                rwlock_unlock(&pool_mutex);
                 return wdb;
             }
         }
@@ -389,7 +422,7 @@ wdb_t * wdb_open_global() {
         wdb_enable_foreign_keys(wdb->db);
     }
 
-    w_mutex_unlock(&pool_mutex);
+    rwlock_unlock(&pool_mutex);
     return wdb;
 }
 
@@ -398,9 +431,14 @@ wdb_t * wdb_open_mitre() {
     sqlite3 *db;
     wdb_t * wdb = NULL;
 
+    // Finds DB in pool, locking pool_mutex for read
+    if (wdb = wdb_get_db_from_pool(WDB_MITRE_NAME), wdb) {
+        return wdb;
+    }
+
     // Find BD in pool
 
-    w_mutex_lock(&pool_mutex);
+    rwlock_lock_write(&pool_mutex);
 
     if (wdb = (wdb_t *)OSHash_Get(open_dbs, WDB_MITRE_NAME), wdb) {
         goto success;
@@ -425,7 +463,7 @@ success:
     wdb->refcount++;
 
 end:
-    w_mutex_unlock(&pool_mutex);
+    rwlock_unlock(&pool_mutex);
     return wdb;
 }
 
@@ -438,9 +476,14 @@ wdb_t * wdb_open_agent2(int agent_id) {
 
     snprintf(sagent_id, sizeof(sagent_id), "%03d", agent_id);
 
+    // Finds DB in pool, locking pool_mutex for read
+    if (wdb = wdb_get_db_from_pool(sagent_id), wdb) {
+        return wdb;
+    }
+
     // Find BD in pool
 
-    w_mutex_lock(&pool_mutex);
+    rwlock_lock_write(&pool_mutex);
 
     if (wdb = (wdb_t *)OSHash_Get(open_dbs, sagent_id), wdb) {
         goto success;
@@ -485,7 +528,7 @@ success:
     wdb->refcount++;
 
 end:
-    w_mutex_unlock(&pool_mutex);
+    rwlock_unlock(&pool_mutex);
     return wdb;
 }
 
@@ -495,14 +538,19 @@ wdb_t * wdb_open_tasks() {
     sqlite3 *db = NULL;
     wdb_t * wdb = NULL;
 
-    w_mutex_lock(&pool_mutex);
+    // Finds DB in pool, locking pool_mutex for read
+    if (wdb = wdb_get_db_from_pool(WDB_TASK_NAME), wdb) {
+        return wdb;
+    }
+
+    rwlock_lock_write(&pool_mutex);
 
     // Finds DB in pool
     if (wdb = (wdb_t *)OSHash_Get(open_dbs, WDB_TASK_NAME), wdb) {
         // The corresponding w_mutex_unlock(&wdb->mutex) is called in wdb_leave(wdb_t * wdb)
         w_mutex_lock(&wdb->mutex);
         wdb->refcount++;
-        w_mutex_unlock(&pool_mutex);
+        rwlock_unlock(&pool_mutex);
         return wdb;
     } else {
         // Try to open DB
@@ -515,7 +563,7 @@ wdb_t * wdb_open_tasks() {
             // Creating database
             if (OS_SUCCESS != wdb_create_file(path, schema_task_manager_sql)) {
                 merror("Couldn't create SQLite database '%s'", path);
-                w_mutex_unlock(&pool_mutex);
+                rwlock_unlock(&pool_mutex);
                 return wdb;
             }
 
@@ -523,7 +571,7 @@ wdb_t * wdb_open_tasks() {
             if (sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE, NULL)) {
                 merror("Can't open SQLite database '%s': %s", path, sqlite3_errmsg(db));
                 sqlite3_close_v2(db);
-                w_mutex_unlock(&pool_mutex);
+                rwlock_unlock(&pool_mutex);
                 return wdb;
             }
 
@@ -539,7 +587,7 @@ wdb_t * wdb_open_tasks() {
     // The corresponding w_mutex_unlock(&wdb->mutex) is called in wdb_leave(wdb_t * wdb)
     w_mutex_lock(&wdb->mutex);
     wdb->refcount++;
-    w_mutex_unlock(&pool_mutex);
+    rwlock_unlock(&pool_mutex);
     return wdb;
 }
 
@@ -1041,7 +1089,7 @@ void wdb_close_all() {
     wdb_t * node;
 
     mdebug1("Closing all databases...");
-    w_mutex_lock(&pool_mutex);
+    rwlock_lock_write(&pool_mutex);
 
     while (node = db_pool_begin, node) {
         mdebug2("Closing database for agent %s", node->id);
@@ -1052,25 +1100,25 @@ void wdb_close_all() {
         }
     }
 
-    w_mutex_unlock(&pool_mutex);
+    rwlock_unlock(&pool_mutex);
 }
 
 void wdb_commit_old() {
     wdb_t * node;
     wdb_t * next;
 
-    w_mutex_lock(&pool_mutex);
+    rwlock_lock_read(&pool_mutex);
     wdb_t *copy = wdb_pool_copy();
-    w_mutex_unlock(&pool_mutex);
+    rwlock_unlock(&pool_mutex);
 
     for (wdb_t *i = copy; i != NULL; wdb_destroy(i), i = next) {
         next = i->next;
 
-        w_mutex_lock(&pool_mutex);
+        rwlock_lock_read(&pool_mutex);
         node = (wdb_t *)OSHash_Get(open_dbs, i->id);
 
         if (node == NULL) {
-            w_mutex_unlock(&pool_mutex);
+            rwlock_unlock(&pool_mutex);
             continue;
         }
 
@@ -1090,7 +1138,7 @@ void wdb_commit_old() {
         }
 
         w_mutex_unlock(&node->mutex);
-        w_mutex_unlock(&pool_mutex);
+        rwlock_unlock(&pool_mutex);
     }
 }
 
@@ -1098,9 +1146,9 @@ void wdb_check_fragmentation() {
     wdb_t * node;
     wdb_t * next;
 
-    w_mutex_lock(&pool_mutex);
+    rwlock_lock_read(&pool_mutex);
     wdb_t *copy = wdb_pool_copy();
-    w_mutex_unlock(&pool_mutex);
+    rwlock_unlock(&pool_mutex);
 
     for (wdb_t *i = copy; i != NULL; wdb_destroy(i), i = next) {
         int last_vacuum_time;
@@ -1110,11 +1158,11 @@ void wdb_check_fragmentation() {
         int fragmentation_after_vacuum;
         next = i->next;
 
-        w_mutex_lock(&pool_mutex);
+        rwlock_lock_read(&pool_mutex);
         node = (wdb_t *)OSHash_Get(open_dbs, i->id);
 
         if (node == NULL) {
-            w_mutex_unlock(&pool_mutex);
+            rwlock_unlock(&pool_mutex);
             continue;
         }
 
@@ -1144,7 +1192,7 @@ void wdb_check_fragmentation() {
                     if (wdb_commit2(node) < 0) {
                         merror("Couldn't execute commit statement, before vacuum, for the database '%s'", node->id);
                         w_mutex_unlock(&node->mutex);
-                        w_mutex_unlock(&pool_mutex);
+                        rwlock_unlock(&pool_mutex);
                         continue;
                     }
 
@@ -1154,7 +1202,7 @@ void wdb_check_fragmentation() {
                     if (wdb_vacuum(node->db) < 0) {
                         merror("Couldn't execute vacuum for the database '%s'", node->id);
                         w_mutex_unlock(&node->mutex);
-                        w_mutex_unlock(&pool_mutex);
+                        rwlock_unlock(&pool_mutex);
                         continue;
                     }
                     gettime(&ts_end);
@@ -1182,7 +1230,7 @@ void wdb_check_fragmentation() {
         }
 
         w_mutex_unlock(&node->mutex);
-        w_mutex_unlock(&pool_mutex);
+        rwlock_unlock(&pool_mutex);
     }
 }
 
@@ -1266,18 +1314,18 @@ void wdb_close_old() {
     wdb_t * node;
     wdb_t * next;
 
-    w_mutex_lock(&pool_mutex);
+    rwlock_lock_read(&pool_mutex);
     wdb_t *copy = wdb_pool_copy();
-    w_mutex_unlock(&pool_mutex);
+    rwlock_unlock(&pool_mutex);
 
     for (wdb_t *i = copy; i != NULL; wdb_destroy(i), i = next) {
         next = i->next;
 
-        w_mutex_lock(&pool_mutex);
+        rwlock_lock_write(&pool_mutex);
         node = (wdb_t *)OSHash_Get(open_dbs, i->id);
 
         if (node == NULL || db_pool_size <= wconfig.open_db_limit) {
-            w_mutex_unlock(&pool_mutex);
+            rwlock_unlock(&pool_mutex);
             continue;
         }
 
@@ -1291,7 +1339,7 @@ void wdb_close_old() {
             w_mutex_unlock(&node->mutex);
         }
 
-        w_mutex_unlock(&pool_mutex);
+        rwlock_unlock(&pool_mutex);
     }
 }
 
@@ -1688,7 +1736,7 @@ cJSON *wdb_remove_multiple_agents(char *agent_list) {
 
                 // Close the database only if it was open
 
-                w_mutex_lock(&pool_mutex);
+                rwlock_lock_write(&pool_mutex);
 
                 wdb = (wdb_t *)OSHash_Get(open_dbs, agent);
                 if (wdb) {
@@ -1697,7 +1745,7 @@ cJSON *wdb_remove_multiple_agents(char *agent_list) {
                     }
                 }
 
-                w_mutex_unlock(&pool_mutex);
+                rwlock_unlock(&pool_mutex);
 
                 mdebug1("Removing db for agent '%s'", agent);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -437,7 +437,7 @@ extern char *schema_global_upgrade_v4_sql;
 extern char *schema_global_upgrade_v5_sql;
 
 extern wdb_config wconfig;
-extern pthread_mutex_t pool_mutex;
+extern rwlock_t pool_mutex;
 extern wdb_t * db_pool;
 extern int db_pool_size;
 extern OSHash * open_dbs;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -284,7 +284,6 @@ int wdb_parse(char * input, char * output, int peer) {
             wdb_leave(wdb_global);
         }
 
-        w_inc_agent_open();
         gettimeofday(&begin, 0);
         if (wdb = wdb_open_agent2(agent_id), !wdb) {
             merror("Couldn't open DB for agent '%s'", sagent_id);
@@ -856,7 +855,6 @@ int wdb_parse(char * input, char * output, int peer) {
 
         mdebug2("Global query: %s", query);
 
-        w_inc_global_open();
         gettimeofday(&begin, 0);
         if (wdb = wdb_open_global(), !wdb) {
             mdebug2("Couldn't open DB global: %s/%s.db", WDB2_DIR, WDB_GLOB_NAME);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -284,11 +284,19 @@ int wdb_parse(char * input, char * output, int peer) {
             wdb_leave(wdb_global);
         }
 
+        w_inc_agent_open();
+        gettimeofday(&begin, 0);
         if (wdb = wdb_open_agent2(agent_id), !wdb) {
             merror("Couldn't open DB for agent '%s'", sagent_id);
             snprintf(output, OS_MAXSTR + 1, "err Couldn't open DB for agent %d", agent_id);
+            gettimeofday(&end, 0);
+            timersub(&end, &begin, &diff);
+            w_inc_agent_open_time(diff);
             return OS_INVALID;
         }
+        gettimeofday(&end, 0);
+        timersub(&end, &begin, &diff);
+        w_inc_agent_open_time(diff);
         // Add the current peer to wdb structure
         wdb->peer = peer;
 
@@ -594,7 +602,7 @@ int wdb_parse(char * input, char * output, int peer) {
             wdb_leave(wdb);
             snprintf(output, OS_MAXSTR + 1, "ok");
 
-            w_mutex_lock(&pool_mutex);
+            rwlock_lock_write(&pool_mutex);
 
             gettimeofday(&begin, 0);
             if (wdb_close(wdb, FALSE) < 0) {
@@ -610,7 +618,7 @@ int wdb_parse(char * input, char * output, int peer) {
             timersub(&end, &begin, &diff);
             w_inc_agent_remove_time(diff);
 
-            w_mutex_unlock(&pool_mutex);
+            rwlock_unlock(&pool_mutex);
             return result;
         } else if (strcmp(query, "begin") == 0) {
             w_inc_agent_begin();
@@ -643,7 +651,7 @@ int wdb_parse(char * input, char * output, int peer) {
             wdb_leave(wdb);
             snprintf(output, OS_MAXSTR + 1, "ok");
 
-            w_mutex_lock(&pool_mutex);
+            rwlock_lock_write(&pool_mutex);
 
             gettimeofday(&begin, 0);
             if (wdb_close(wdb, TRUE) < 0) {
@@ -655,7 +663,7 @@ int wdb_parse(char * input, char * output, int peer) {
             timersub(&end, &begin, &diff);
             w_inc_agent_close_time(diff);
 
-            w_mutex_unlock(&pool_mutex);
+            rwlock_unlock(&pool_mutex);
             return result;
         } else if (strncmp(query, "syscollector_", 7) == 0) {
             if (!next) {
@@ -848,16 +856,27 @@ int wdb_parse(char * input, char * output, int peer) {
 
         mdebug2("Global query: %s", query);
 
+        w_inc_global_open();
+        gettimeofday(&begin, 0);
         if (wdb = wdb_open_global(), !wdb) {
             mdebug2("Couldn't open DB global: %s/%s.db", WDB2_DIR, WDB_GLOB_NAME);
             snprintf(output, OS_MAXSTR + 1, "err Couldn't open DB global");
+            gettimeofday(&end, 0);
+            timersub(&end, &begin, &diff);
+            w_inc_global_open_time(diff);
             return OS_INVALID;
         } else if (!wdb->enabled) {
             mdebug2("Database disabled: %s/%s.db.", WDB2_DIR, WDB_GLOB_NAME);
             snprintf(output, OS_MAXSTR + 1, "err DB global disabled.");
             wdb_leave(wdb);
+            gettimeofday(&end, 0);
+            timersub(&end, &begin, &diff);
+            w_inc_global_open_time(diff);
             return OS_INVALID;
         }
+        gettimeofday(&end, 0);
+        timersub(&end, &begin, &diff);
+        w_inc_global_open_time(diff);
         // Add the current peer to wdb structure
         wdb->peer = peer;
 
@@ -6204,9 +6223,9 @@ int wdb_parse_global_backup(wdb_t** wdb, char* input, char* output) {
     }
     else if (strcmp(next, "restore") == 0) {
         // During a restore, the global wdb_t pointer may change. The mutex prevents anyone else from accesing it
-        w_mutex_lock(&pool_mutex);
+        rwlock_lock_write(&pool_mutex);
         result = wdb_parse_global_restore_backup(wdb, tail, output);
-        w_mutex_unlock(&pool_mutex);
+        rwlock_unlock(&pool_mutex);
     }
     else {
         snprintf(output, OS_MAXSTR + 1, "err Invalid backup action: %s", next);

--- a/src/wazuh_db/wdb_state.c
+++ b/src/wazuh_db/wdb_state.c
@@ -67,12 +67,6 @@ void w_inc_agent() {
     w_mutex_unlock(&db_state_t_mutex);
 }
 
-void w_inc_agent_open() {
-    w_mutex_lock(&db_state_t_mutex);
-    wdb_state.queries_breakdown.agent_breakdown.open_calls++;
-    w_mutex_unlock(&db_state_t_mutex);
-}
-
 void w_inc_agent_open_time(struct timeval time) {
     w_mutex_lock(&db_state_t_mutex);
     timeradd(&wdb_state.queries_breakdown.agent_breakdown.open_calls_time, &time, &wdb_state.queries_breakdown.agent_breakdown.open_calls_time);
@@ -487,12 +481,6 @@ void w_inc_agent_syscollector_deprecated_osinfo_time(struct timeval time) {
 void w_inc_global() {
     w_mutex_lock(&db_state_t_mutex);
     wdb_state.queries_breakdown.global_queries++;
-    w_mutex_unlock(&db_state_t_mutex);
-}
-
-void w_inc_global_open() {
-    w_mutex_lock(&db_state_t_mutex);
-    wdb_state.queries_breakdown.global_breakdown.open_calls++;
     w_mutex_unlock(&db_state_t_mutex);
 }
 
@@ -1052,7 +1040,6 @@ cJSON* wdb_create_state_json() {
     cJSON *_agent_db = cJSON_CreateObject();
     cJSON_AddItemToObject(_agent_breakdown, "db", _agent_db);
 
-    cJSON_AddNumberToObject(_agent_db, "open", wdb_state_cpy.queries_breakdown.agent_breakdown.open_calls);
     cJSON_AddNumberToObject(_agent_db, "begin", wdb_state_cpy.queries_breakdown.agent_breakdown.begin_queries);
     cJSON_AddNumberToObject(_agent_db, "close", wdb_state_cpy.queries_breakdown.agent_breakdown.close_queries);
     cJSON_AddNumberToObject(_agent_db, "commit", wdb_state_cpy.queries_breakdown.agent_breakdown.commit_queries);
@@ -1132,7 +1119,6 @@ cJSON* wdb_create_state_json() {
     cJSON *_global_db = cJSON_CreateObject();
     cJSON_AddItemToObject(_global_breakdown, "db", _global_db);
 
-    cJSON_AddNumberToObject(_global_db, "open", wdb_state_cpy.queries_breakdown.global_breakdown.open_calls);
     cJSON_AddNumberToObject(_global_db, "backup", wdb_state_cpy.queries_breakdown.global_breakdown.backup_queries);
     cJSON_AddNumberToObject(_global_db, "sql", wdb_state_cpy.queries_breakdown.global_breakdown.sql_queries);
     cJSON_AddNumberToObject(_global_db, "vacuum", wdb_state_cpy.queries_breakdown.global_breakdown.vacuum_queries);

--- a/src/wazuh_db/wdb_state.c
+++ b/src/wazuh_db/wdb_state.c
@@ -67,6 +67,18 @@ void w_inc_agent() {
     w_mutex_unlock(&db_state_t_mutex);
 }
 
+void w_inc_agent_open() {
+    w_mutex_lock(&db_state_t_mutex);
+    wdb_state.queries_breakdown.agent_breakdown.open_calls++;
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
+void w_inc_agent_open_time(struct timeval time) {
+    w_mutex_lock(&db_state_t_mutex);
+    timeradd(&wdb_state.queries_breakdown.agent_breakdown.open_calls_time, &time, &wdb_state.queries_breakdown.agent_breakdown.open_calls_time);
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
 void w_inc_agent_sql() {
     w_mutex_lock(&db_state_t_mutex);
     wdb_state.queries_breakdown.agent_breakdown.sql_queries++;
@@ -475,6 +487,18 @@ void w_inc_agent_syscollector_deprecated_osinfo_time(struct timeval time) {
 void w_inc_global() {
     w_mutex_lock(&db_state_t_mutex);
     wdb_state.queries_breakdown.global_queries++;
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
+void w_inc_global_open() {
+    w_mutex_lock(&db_state_t_mutex);
+    wdb_state.queries_breakdown.global_breakdown.open_calls++;
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
+void w_inc_global_open_time(struct timeval time) {
+    w_mutex_lock(&db_state_t_mutex);
+    timeradd(&wdb_state.queries_breakdown.global_breakdown.open_calls_time, &time, &wdb_state.queries_breakdown.global_breakdown.open_calls_time);
     w_mutex_unlock(&db_state_t_mutex);
 }
 
@@ -1028,6 +1052,7 @@ cJSON* wdb_create_state_json() {
     cJSON *_agent_db = cJSON_CreateObject();
     cJSON_AddItemToObject(_agent_breakdown, "db", _agent_db);
 
+    cJSON_AddNumberToObject(_agent_db, "open", wdb_state_cpy.queries_breakdown.agent_breakdown.open_calls);
     cJSON_AddNumberToObject(_agent_db, "begin", wdb_state_cpy.queries_breakdown.agent_breakdown.begin_queries);
     cJSON_AddNumberToObject(_agent_db, "close", wdb_state_cpy.queries_breakdown.agent_breakdown.close_queries);
     cJSON_AddNumberToObject(_agent_db, "commit", wdb_state_cpy.queries_breakdown.agent_breakdown.commit_queries);
@@ -1107,6 +1132,7 @@ cJSON* wdb_create_state_json() {
     cJSON *_global_db = cJSON_CreateObject();
     cJSON_AddItemToObject(_global_breakdown, "db", _global_db);
 
+    cJSON_AddNumberToObject(_global_db, "open", wdb_state_cpy.queries_breakdown.global_breakdown.open_calls);
     cJSON_AddNumberToObject(_global_db, "backup", wdb_state_cpy.queries_breakdown.global_breakdown.backup_queries);
     cJSON_AddNumberToObject(_global_db, "sql", wdb_state_cpy.queries_breakdown.global_breakdown.sql_queries);
     cJSON_AddNumberToObject(_global_db, "vacuum", wdb_state_cpy.queries_breakdown.global_breakdown.vacuum_queries);
@@ -1220,6 +1246,7 @@ cJSON* wdb_create_state_json() {
     cJSON *_agent_db_t = cJSON_CreateObject();
     cJSON_AddItemToObject(_agent_breakdown_t, "db", _agent_db_t);
 
+    cJSON_AddNumberToObject(_agent_db_t, "open", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.open_calls_time));
     cJSON_AddNumberToObject(_agent_db_t, "begin", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.begin_time));
     cJSON_AddNumberToObject(_agent_db_t, "close", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.close_time));
     cJSON_AddNumberToObject(_agent_db_t, "commit", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.commit_time));
@@ -1299,6 +1326,7 @@ cJSON* wdb_create_state_json() {
     cJSON *_global_db_t = cJSON_CreateObject();
     cJSON_AddItemToObject(_global_breakdown_t, "db", _global_db_t);
 
+    cJSON_AddNumberToObject(_global_db_t, "open", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.open_calls_time));
     cJSON_AddNumberToObject(_global_db_t, "backup", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.backup_time));
     cJSON_AddNumberToObject(_global_db_t, "sql", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.sql_time));
     cJSON_AddNumberToObject(_global_db_t, "vacuum", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.vacuum_time));
@@ -1403,6 +1431,7 @@ STATIC uint64_t get_agent_time(wdb_state_t *state){
     struct timeval task_time;
 
     timeradd(&state->queries_breakdown.agent_breakdown.sql_time, &state->queries_breakdown.agent_breakdown.remove_time, &task_time);
+    timeradd(&task_time, &state->queries_breakdown.agent_breakdown.open_calls_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.vacuum_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.get_fragmentation_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.begin_time, &task_time);
@@ -1444,6 +1473,7 @@ STATIC uint64_t get_global_time(wdb_state_t *state){
     struct timeval task_time;
 
     timeradd(&state->queries_breakdown.global_breakdown.sql_time, &state->queries_breakdown.global_breakdown.backup_time, &task_time);
+    timeradd(&task_time, &state->queries_breakdown.global_breakdown.open_calls_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.vacuum_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.get_fragmentation_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.insert_agent_time, &task_time);

--- a/src/wazuh_db/wdb_state.h
+++ b/src/wazuh_db/wdb_state.h
@@ -106,7 +106,6 @@ typedef struct _agent_breakdown_t {
     uint64_t sql_queries;
     uint64_t vacuum_queries;
     uint64_t get_fragmentation_queries;
-    uint64_t open_calls;
     struct timeval begin_time;
     struct timeval close_time;
     struct timeval commit_time;
@@ -197,7 +196,6 @@ typedef struct _global_breakdown_t {
     uint64_t sql_queries;
     uint64_t vacuum_queries;
     uint64_t get_fragmentation_queries;
-    uint64_t open_calls;
     struct timeval backup_time;
     struct timeval sql_time;
     struct timeval vacuum_time;
@@ -295,12 +293,6 @@ void w_inc_wazuhdb_remove_time(struct timeval time);
  *
  */
 void w_inc_agent();
-
-/**
- * @brief Increment open agent DB counter
- *
- */
-void w_inc_agent_open();
 
 /**
  * @brief Increment open agent DB time counter
@@ -714,12 +706,6 @@ void w_inc_agent_syscollector_deprecated_osinfo_time(struct timeval time);
  *
  */
 void w_inc_global();
-
-/**
- * @brief Increment open global counter
- *
- */
-void w_inc_global_open();
 
 /**
  * @brief Increment open global time counter

--- a/src/wazuh_db/wdb_state.h
+++ b/src/wazuh_db/wdb_state.h
@@ -106,6 +106,7 @@ typedef struct _agent_breakdown_t {
     uint64_t sql_queries;
     uint64_t vacuum_queries;
     uint64_t get_fragmentation_queries;
+    uint64_t open_calls;
     struct timeval begin_time;
     struct timeval close_time;
     struct timeval commit_time;
@@ -113,6 +114,7 @@ typedef struct _agent_breakdown_t {
     struct timeval sql_time;
     struct timeval vacuum_time;
     struct timeval get_fragmentation_time;
+    struct timeval open_calls_time;
     agent_ciscat_t ciscat;
     agent_rootcheck_t rootcheck;
     agent_sca_t sca;
@@ -195,10 +197,12 @@ typedef struct _global_breakdown_t {
     uint64_t sql_queries;
     uint64_t vacuum_queries;
     uint64_t get_fragmentation_queries;
+    uint64_t open_calls;
     struct timeval backup_time;
     struct timeval sql_time;
     struct timeval vacuum_time;
     struct timeval get_fragmentation_time;
+    struct timeval open_calls_time;
     global_agent_t agent;
     global_belongs_t belongs;
     global_group_t group;
@@ -291,6 +295,19 @@ void w_inc_wazuhdb_remove_time(struct timeval time);
  *
  */
 void w_inc_agent();
+
+/**
+ * @brief Increment open agent DB counter
+ *
+ */
+void w_inc_agent_open();
+
+/**
+ * @brief Increment open agent DB time counter
+ *
+ * @param time Value to increment the counter.
+ */
+void w_inc_agent_open_time(struct timeval time);
 
 /**
  * @brief Increment sql agent queries counter
@@ -697,6 +714,19 @@ void w_inc_agent_syscollector_deprecated_osinfo_time(struct timeval time);
  *
  */
 void w_inc_global();
+
+/**
+ * @brief Increment open global counter
+ *
+ */
+void w_inc_global_open();
+
+/**
+ * @brief Increment open global time counter
+ *
+ * @param time Value to increment the counter.
+ */
+void w_inc_global_open_time(struct timeval time);
 
 /**
  * @brief Increment sql global queries counter


### PR DESCRIPTION
|Related issue|
|---|
|#19960|

## Description

This PR adds the changes to use rwlock_lock_read/write instead of phtread_mutex when locking the open database pool on wazuh-db. This allows multiple threads to access the pool simultaneously as readers.

It also adds a new statistic named "open" that represents the time spent on calls to wdb_open_agent/global.

Diagram of sequence:
![image](https://github.com/wazuh/wazuh/assets/13004400/2c792e29-bdcf-4d04-b3ad-a5f1e7fce4c5)



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
