### PR TITLE
Add Darwin 23 default macOS ULS config

### DIFF
--- a/etc/templates/config/darwin/23/localfile-extra.template
+++ b/etc/templates/config/darwin/23/localfile-extra.template
@@ -1,0 +1,5 @@
+  <localfile>
+    <location>macos</location>
+    <log_format>macos</log_format>
+    <query type="trace,log,activity" level="info">(process == "sudo") or (process == "sessionlogoutd" and message contains "logout is complete.") or (process == "sshd") or (process == "tccd" and message contains "Update Access Record") or (message contains "SessionAgentNotificationCenter") or (process == "screensharingd" and message contains "Authentication") or (process == "securityd" and eventMessage contains "Session" and subsystem == "com.apple.securityd")</query>
+  </localfile>


### PR DESCRIPTION
|Related issue|
|---|
|#19986|

Adds the macOS ULS configuration block to the default configuration of Darwin 23 systems