### PR TITLE
Fix group number check for /etc/cron.allow

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -2642,7 +2642,7 @@ checks:
     rules:
       - "f:/etc/cron.allow"
       - "not f:/etc/cron.deny"
-      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.allow -> r:640\s*\t*-rw-r-----\s*\t*0\s*\t*root\s*\t*0\s*\t*crontab'
+      - 'c:stat -Lc "%a %A %u %U %G" /etc/cron.allow -> r:640 -rw-r----- 0 root crontab'
 
   # 4.1.9 Ensure at is restricted to authorized users. (Automated)
   - id: 19108


### PR DESCRIPTION
|Related issue|
|---|
| #19314 |

## Description

Check 19107 in cis_ubuntu20-04.yml applies to CIS 4.1.8 which says "/etc/cron.allow is group owned by the group crontab"

The existing check asserts the group ID of the file is 0 ... which is root, not crontab.

The CIS check does not specify a group ID for crontab, so I remove the GID from the formatted output of stat.

Also, since the check specifies the format, we do not need \s*\t* ... so we can make the expression clearer by using the spaces specified in the format string.

## Configuration options

None

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

There are no automated tests for SCA rulesets

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors