### PR TITLE
Debian10/Ubuntu20 CIS 2.1.2.1 chrony sources check

### DIFF
--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -1330,7 +1330,7 @@ checks:
       - soc_2: ["CC4.1", "CC5.2"]
     condition: any
     rules:
-      - "not c:ps -ef -> r:^_chrony && r:/chronyd"
+      - 'd:/etc/chrony/sources.d -> r:\.+.sources$ -> r:^server\.+|^pool\.+'
       - 'f:/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
 
   # 2.1.2.2 Ensure chrony is running as user _chrony. (Automated)

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -1149,10 +1149,10 @@ checks:
       - pci_dss_v3.2.1: ["10.4"]
       - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
       - soc_2: ["CC4.1", "CC5.2"]
-    condition: all
+    condition: any
     rules:
-      - "c:ps -ef -> r:^_chrony && r:/chronyd"
-      - 'f:/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
+      - 'd:/etc/chrony/sources.d -> r:\.+.sources$ -> r:^server\.+|^pool\.+'
+>>      - 'f:/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
 
   # 2.1.2.2 Ensure chrony is running as user _chrony. (Automated)
   - id: 19047


### PR DESCRIPTION
Debian10/Ubuntu20 CIS 2.1.2.1 should pass if sources are present in conf file or in sources.d, and should not pass due to chrony running under a different user or being disabled.

|Related issue|
|---|
| #20232 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

Contribution

## Description

The check has been updated to pass when any of the following are true.

- There is a pool or server specified in /etc/chrony/chrony.conf
- There is a pool or server specified in a *.sources file in the directory /etc/chrony/sources.d

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors