### PR TITLE
Debian10/Ubuntu20 CIS 4.1.1 fix cron is-active

### DIFF
--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -2651,7 +2651,7 @@ checks:
     condition: all
     rules:
       - "c:systemctl is-enabled cron -> r:^enabled"
-      - "c:systemctl status cron -> r:^active"
+      - "c:systemctl is-active cron -> r:^active"
 
   # 4.1.2 Ensure permissions on /etc/crontab are configured. (Automated)
   - id: 2609

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -2472,7 +2472,7 @@ checks:
     condition: all
     rules:
       - "c:systemctl is-enabled cron -> r:^enabled"
-      - "c:systemctl status cron -> r:^active"
+      - "c:systemctl is-active cron -> r:^active"
 
   # 4.1.2 Ensure permissions on /etc/crontab are configured. (Automated)
   - id: 19101


### PR DESCRIPTION
|Related issue|
|---|
| #20234 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
contribution

## Description

Replaces `systemctl status` with `systemctl is-active`

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors