### PR TITLE
Onboarding goal 11: add unit tests

### DIFF
--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -303,6 +303,9 @@ endif()
 list(APPEND shared_tests_names "test_rwlock_op")
 list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
 
+list(APPEND shared_tests_names "test_vector_op")
+list(APPEND shared_tests_flags " ")
+
 # Compiling tests
 list(LENGTH shared_tests_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/shared/test_vector_op.c
+++ b/src/unit_tests/shared/test_vector_op.c
@@ -1,0 +1,36 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "../headers/shared.h"
+#include "../wrappers/common.h"
+
+
+/* setup/teardown */
+static int group_setup(void ** state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int group_teardown(void ** state) {
+    test_mode = 0;
+    return 0;
+}
+
+/* tests */
+void test_vector_init(void **state)
+{
+    W_Vector * vector = W_Vector_init(0);
+    assert_non_null(vector);
+    W_Vector_free(vector);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_vector_init),
+    };
+
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -112,7 +112,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,strerror \
                              -Wl,--wrap,wdb_create_profile -Wl,--wrap,Privsep_GetUser -Wl,--wrap,Privsep_GetGroup -Wl,--wrap,chown \
                              -Wl,--wrap,chmod -Wl,--wrap,IsDir -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,get_node_name \
                              -Wl,--wrap,rbtree_insert \
-                             -Wl,--wrap,stat -Wl,--wrap,fgetpos ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,stat -Wl,--wrap,fgetpos \
+                             -Wl,--wrap,OS_StrBreak ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_agents_helpers")
 list(APPEND wdb_tests_flags "-Wl,--wrap,strerror \
@@ -140,7 +141,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_count_tables_with_name \
                              -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,time -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_close_v2 \
                              -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_finalize -Wl,--wrap,fgetpos \
                              -Wl,--wrap,fgetc -Wl,--wrap,wdb_global_create_backup -Wl,--wrap,wdb_global_get_most_recent_backup -Wl,--wrap,wdb_global_restore_backup \
-                             -Wl,--wrap,wdb_global_adjust_v4 ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,wdb_global_adjust_v4 -Wl,--wrap,OS_StrBreak ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_metadata")
 list(APPEND wdb_tests_flags "-Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_errmsg \

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -2909,6 +2909,28 @@ void test_get_agent_date_added_error_invalid_date(void **state) {
     assert_int_equal(0, date_add);
 }
 
+
+void test_get_agent_date_added_fgets_returns_null_error(void **state) {
+    time_t date_add = 0;
+    int agent_id = 1;
+
+    // Opening destination database file
+    expect_string(__wrap_fopen, path, "queue/agents-timestamp");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    // Getting data
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, 0);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, OS_SUCCESS);
+
+    date_add = get_agent_date_added(agent_id);
+
+    assert_int_equal(0, date_add);
+}
+
 void test_get_agent_date_added_success(void **state) {
     time_t date_add = 0;
     int agent_id = 1;
@@ -4339,6 +4361,7 @@ int main()
         /* Tests get_agent_date_added */
         cmocka_unit_test_setup_teardown(test_get_agent_date_added_error_open_file, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_get_agent_date_added_error_no_data, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_get_agent_date_added_fgets_returns_null_error, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_get_agent_date_added_error_no_date, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_get_agent_date_added_error_invalid_date, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_get_agent_date_added_success, setup_wdb_global_helpers, teardown_wdb_global_helpers),

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -2610,6 +2610,14 @@ void test_wdb_remove_group_db_success(void **state)
 
 /* Tests wdb_update_groups */
 
+void test_wdb_update_groups_error_no_directory(void **state) {
+    int ret = 0;
+
+    ret = wdb_update_groups(NULL, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
 void test_wdb_update_groups_error_json(void **state) {
     int ret = 0;
 
@@ -4237,6 +4245,7 @@ int main()
 
         cmocka_unit_test_setup_teardown(test_wdb_remove_group_db_success, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         /* Tests wdb_update_groups */
+        cmocka_unit_test_setup_teardown(test_wdb_update_groups_error_no_directory, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_update_groups_error_json, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_update_groups_error_max_path, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_update_groups_removing_group_db, setup_wdb_global_helpers, teardown_wdb_global_helpers),

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -3621,6 +3621,21 @@ void test_wdb_set_agent_groups_error_no_mode(void **state) {
     assert_int_equal(OS_INVALID,res);
 }
 
+void test_wdb_set_agent_groups_error_creating_json_data(void **state) {
+    int res;
+
+    test_struct_t *data = (test_struct_t*)* state;
+
+    // Debug message
+    expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
+    will_return(__wrap_cJSON_CreateObject, NULL);
+
+    res = wdb_set_agent_groups(data->id, data->groups_array, data->mode, NULL, NULL);
+
+    assert_int_equal(OS_INVALID,res);
+    os_free(data->data_in_str);
+}
+
 void test_wdb_set_agent_groups_socket_error(void **state) {
     int res;
 
@@ -4289,6 +4304,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_set_agent_groups_success, setup_wdb_global_helpers_add_agent, teardown_wdb_global_helpers_add_agent),
         cmocka_unit_test_setup_teardown(test_wdb_set_agent_groups_error_no_mode, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_set_agent_groups_query_error, setup_wdb_global_helpers_add_agent, teardown_wdb_global_helpers_add_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_set_agent_groups_error_creating_json_data, setup_wdb_global_helpers_add_agent, teardown_wdb_global_helpers_add_agent),
         cmocka_unit_test_setup_teardown(test_wdb_set_agent_groups_socket_error, setup_wdb_global_helpers_add_agent, teardown_wdb_global_helpers_add_agent),
         /* Tests wdb_get_distinct_agent_groups */
         cmocka_unit_test_setup_teardown(test_wdb_get_distinct_agent_groups_error_no_json_response, setup_wdb_global_helpers, teardown_wdb_global_helpers),

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -2931,6 +2931,29 @@ void test_get_agent_date_added_fgets_returns_null_error(void **state) {
     assert_int_equal(0, date_add);
 }
 
+void test_get_agent_date_added_fgets_returns_null_error2(void **state) {
+    time_t date_add = 0;
+    int agent_id = 1;
+
+    // Opening destination database file
+    expect_string(__wrap_fopen, path, "queue/agents-timestamp");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    // Getting data
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "001 agent1 any 2020:01:01 01-01-01");
+
+    will_return(__wrap_OS_StrBreak, NULL);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, OS_SUCCESS);
+
+    date_add = get_agent_date_added(agent_id);
+
+    assert_int_equal(0, date_add);
+}
+
 void test_get_agent_date_added_success(void **state) {
     time_t date_add = 0;
     int agent_id = 1;
@@ -4362,6 +4385,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_get_agent_date_added_error_open_file, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_get_agent_date_added_error_no_data, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_get_agent_date_added_fgets_returns_null_error, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_get_agent_date_added_fgets_returns_null_error2, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_get_agent_date_added_error_no_date, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_get_agent_date_added_error_invalid_date, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_get_agent_date_added_success, setup_wdb_global_helpers, teardown_wdb_global_helpers),

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -3412,6 +3412,17 @@ void test_wdb_parse_chunk_to_int_err(void **state) {
     memset(test_payload, '\0', OS_MAXSTR);
 }
 
+void test_wdb_parse_chunk_to_int_no_output_err(void **state) {
+    char* payload = NULL;
+    int** array = NULL;
+    int last_item = 0;
+    int last_len = 0;
+
+    wdbc_result status = wdb_parse_chunk_to_int(payload, array, "id", &last_item, &last_len);
+
+    assert_int_equal(WDBC_ERROR, status);
+}
+
 /* Tests wdb_parse_chunk_to_rbtree */
 
 void test_wdb_parse_chunk_to_rbtree_ok(void **state) {
@@ -4293,6 +4304,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_int_ok, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_int_due, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_int_err, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_int_no_output_err, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         /* Tests wdb_parse_chunk_to_rbtree */
         cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_rbtree_ok, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_rbtree_due, setup_wdb_global_helpers, teardown_wdb_global_helpers),

--- a/src/unit_tests/wrappers/wazuh/os_regex/os_regex_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_regex/os_regex_wrappers.c
@@ -109,3 +109,15 @@ const char *__wrap_OSRegex_Execute_ex(const char *str, OSRegex *reg, regex_match
 
     return __real_OSRegex_Execute_ex(str, reg, regex_match);
 }
+
+extern char **__real_OS_StrBreak(char match, const char *str, size_t size);
+char **__wrap_OS_StrBreak(char match, const char *str, size_t size) {
+    if (test_mode) {
+        if (str) {
+            check_expected(str);
+        }
+        return mock_type(char **);
+    }
+
+    return __real_OS_StrBreak(match, str, size);
+}

--- a/src/unit_tests/wrappers/wazuh/os_regex/os_regex_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_regex/os_regex_wrappers.h
@@ -25,4 +25,6 @@ const char *__wrap_OSRegex_Execute_ex(const char *str, OSRegex *reg, regex_match
 
 void __wrap_OSRegex_FreePattern(OSRegex *reg);
 
+char **__wrap_OS_StrBreak(char match, const char *str, size_t size);
+
 #endif


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors