### PR TITLE
Debian10/Ubuntu20 CIS 4.3.6 fix sudo timestamp_timeout

### DIFF
--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -3408,11 +3408,14 @@ checks:
       - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
       - soc_2: ["CC6.1", "CC6.3"]
-    condition: all
+    condition: none
     rules:
-      - 'c:sudo -V -> r:Authentication timestamp timeout:\s*\t*15.0 minutes'
-      - 'f:/etc/sudoers -> n:timestamp_timeout=(\d+) compare <=15'
-      - 'd:/etc/sudoers.d -> r:\.* -> n:timestamp_timeout=(\d+) compare <=15'
+      - 'c:sudo -V -> n:Authentication timestamp timeout: (\d+) minutes compare > 15'
+      - 'c:sudo -V -> n:Authentication timestamp timeout: -(\d+) minutes compare > 0'
+      - 'f:/etc/sudoers -> n:timestamp_timeout\s*\t*=\s*\t*(\d+) compare > 15'
+      - 'f:/etc/sudoers -> n:timestamp_timeout\s*\t*=\s*\t*-(\d+) compare > 0'
+      - 'd:/etc/sudoers.d -> r:\.* -> n:timestamp_timeout\s*\t*=\s*\t*(\d+) compare > 15'
+      - 'd:/etc/sudoers.d -> r:\.* -> n:timestamp_timeout\s*\t*=\s*\t*-(\d+) compare > 0'
 
   # 4.3.7 Ensure access to the su command is restricted. (Automated)
   - id: 2643

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -3264,11 +3264,14 @@ checks:
       - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
       - soc_2: ["CC6.1", "CC6.3"]
-    condition: all
+    condition: none
     rules:
-      - 'c:sudo -V -> r:Authentication timestamp timeout:\s*\t*15.0 minutes'
-      - 'f:/etc/sudoers -> n:timestamp_timeout=(\d+) compare <=15'
-      - 'd:/etc/sudoers.d -> r:\.* -> n:timestamp_timeout=(\d+) compare <=15'
+      - 'c:sudo -V -> n:Authentication timestamp timeout: (\d+) minutes compare > 15'
+      - 'c:sudo -V -> n:Authentication timestamp timeout: -(\d+) minutes compare > 0'
+      - 'f:/etc/sudoers -> n:timestamp_timeout\s*\t*=\s*\t*(\d+) compare > 15'
+      - 'f:/etc/sudoers -> n:timestamp_timeout\s*\t*=\s*\t*-(\d+) compare > 0'
+      - 'd:/etc/sudoers.d -> r:\.* -> n:timestamp_timeout\s*\t*=\s*\t*(\d+) compare > 15'
+      - 'd:/etc/sudoers.d -> r:\.* -> n:timestamp_timeout\s*\t*=\s*\t*-(\d+) compare > 0'
 
   # 4.3.7 Ensure access to the su command is restricted. (Automated)
   - id: 19136


### PR DESCRIPTION
|Related issue|
|---|
| #20238 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
contribution

## Description

The current check for timeout incorporates `sudo -V` which does not actually return the default timestamp.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors