### PR TITLE
Update cis_ubuntu22-04.yml

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -3819,8 +3819,8 @@ checks:
       - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003"]
     condition: all
     rules:
-      - "c:sshd -T -> -> n:^clientaliveinterval\\s*\\t*(\\d+) compare > 0"
-      - "c:sshd -T -> -> n:^clientalivecountmax\\s*\\t*(\\d+) compare > 0"
+      - "c:sshd -T -> n:^clientaliveinterval\\s*\\t*(\\d+) compare > 0"
+      - "c:sshd -T -> n:^clientalivecountmax\\s*\\t*(\\d+) compare > 0"
 
   # 5.3.1 Ensure sudo is installed. (Automated)
   - id: 28654


### PR DESCRIPTION
|Related issue|
|---|
|#20252|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
The SCA for Ubuntu 22.04 checks the idle timeout for SSH under point 5.2.22. If the `->` paramter is used twice, a check cannot be completed successfully.

## Change
Adjusting the parameters

|  Previously | After |
| --- | --- |
| `c:sshd -T -> -> n:^clientaliveinterval\\s*\\t*(\\d+) compare > 0` | `c:sshd -T -> n:^clientaliveinterval\\s*\\t*(\\d+) compare > 0`|
| `c:sshd -T -> -> n:^clientalivecountmax\\s*\\t*(\\d+) compare > 0` | `c:sshd -T -> n:^clientalivecountmax\\s*\\t*(\\d+) compare > 0` |