### PR TITLE
Debian10/Ubuntu20 CIS 4.4.1 allow spaces in password creation requirements

### DIFF
--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -3457,13 +3457,13 @@ checks:
       - soc_2: ["CC6.1"]
     condition: all
     rules:
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && n:minlen\s*=\s*(\d+) compare >= 14'
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && n:minclass\s*=\s*(\d+) compare >= 4'
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:dcredit = -1'
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:ucredit = -1'
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:lcredit = -1'
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:ocredit = -1'
-      - 'f:/etc/pam.d/common-password -> !r:^\s*# && n:password\s*requisite\s*pam_pwquality.so\s*retry=(\d+) compare <=3'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && n:minlen\s*\t*=\s*\t*(\d+) compare >= 14'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && n:minclass\s*\t*=\s*\t*(\d+) compare >= 4'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:dcredit\s*\t*=\s*\t*-1'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:ucredit\s*\t*=\s*\t*-1'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:lcredit\s*\t*=\s*\t*-1'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:ocredit\s*\t*=\s*\t*-1'
+      - 'f:/etc/pam.d/common-password -> !r:^\s*# && n:password\s*\t*requisite\s*\t*pam_pwquality.so\s*\t*retry\s*\t*=\s*\t*(\d+) compare <=3'
 
   # 4.4.2 Ensure lockout for failed password attempts is configured. (Automated)
   - id: 2645

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -3313,13 +3313,13 @@ checks:
       - soc_2: ["CC6.1"]
     condition: all
     rules:
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && n:minlen\s*=\s*(\d+) compare >= 14'
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && n:minclass\s*=\s*(\d+) compare >= 4'
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:dcredit = -1'
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:ucredit = -1'
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:lcredit = -1'
-      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:ocredit = -1'
-      - 'f:/etc/pam.d/common-password -> !r:^\s*# && n:password\s*requisite\s*pam_pwquality.so\s*retry=(\d+) compare <=3'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && n:minlen\s*\t*=\s*\t*(\d+) compare >= 14'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && n:minclass\s*\t*=\s*\t*(\d+) compare >= 4'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:dcredit\s*\t*=\s*\t*-1'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:ucredit\s*\t*=\s*\t*-1'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:lcredit\s*\t*=\s*\t*-1'
+      - 'f:/etc/security/pwquality.conf -> !r:^\s*# && r:ocredit\s*\t*=\s*\t*-1'
+      - 'f:/etc/pam.d/common-password -> !r:^\s*# && n:password\s*\t*requisite\s*\t*pam_pwquality.so\s*\t*retry\s*\t*=\s*\t*(\d+) compare <=3'
 
   # 4.4.2 Ensure lockout for failed password attempts is configured. (Automated)
   - id: 19138


### PR DESCRIPTION
Debian10/Ubuntu20 CIS 4.4.1 allow spaces around equals sign in password creation requirements

|Related issue|
|---|
| #20283 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The test as written rejects password requirement settings that include whitespace around the equals sign. As a result, uncommenting and editing the examples in the distributed configuration file will fail.

Similarly, mirroring the tabs in other lines in the original /etc/pam.d/common-password file will fail because the existing checks look for spaces where the distributed files use tabs.

The attached change allows more general whitespace. 

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->
None.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors