### PR TITLE
Debian10/Ubuntu20 CIS 4.2.5 SSHD lowercase LogLevel, allow tabs

### DIFF
--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -2924,8 +2924,8 @@ checks:
     condition: all
     rules:
       - 'c:sshd -T -> r:^\s*LogLevel\s+INFO|^\s*LogLevel\s*VERBOSE|^\s*loglevel\s+INFO|^\s*loglevel\s+VERBOSE'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*LogLevel\s+ && !r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
-      - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> r:^\s*LogLevel\s+ && >!r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*LogLevel && !r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
+      - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> r:^\s*LogLevel && >!r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
 
   # 4.2.6 Ensure SSH PAM is enabled. (Automated)
   - id: 2620

--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -2923,9 +2923,9 @@ checks:
       - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
     condition: all
     rules:
-      - 'c:sshd -T -> r:^\s*LogLevel\s+INFO|^\s*LogLevel\s*VERBOSE'
-      - 'not f:/etc/ssh/sshd_config -> !r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
-      - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> !r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
+      - 'c:sshd -T -> r:^\s*LogLevel\s+INFO|^\s*LogLevel\s*VERBOSE|^\s*loglevel\s+INFO|^\s*loglevel\s+VERBOSE'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*LogLevel\s+ && !r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
+      - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> r:^\s*LogLevel\s+ && >!r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
 
   # 4.2.6 Ensure SSH PAM is enabled. (Automated)
   - id: 2620

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -2769,9 +2769,9 @@ checks:
       - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
     condition: all
     rules:
-      - 'c:sshd -T -> r:^\s*loglevel\s+INFO|^\s*loglevel\s+VERBOSE'
+      - 'c:sshd -T -> r:^\s*LogLevel\s+INFO|^\s*LogLevel\s*VERBOSE|^\s*loglevel\s+INFO|^\s*loglevel\s+VERBOSE'
       - 'not f:/etc/ssh/sshd_config -> r:^\s*LogLevel\s+ && !r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
-      - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> !r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
+      - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> r:^\s*LogLevel\s+ && >!r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
 
   # 4.2.6 Ensure SSH PAM is enabled. (Automated)
   - id: 19113

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -2770,8 +2770,8 @@ checks:
     condition: all
     rules:
       - 'c:sshd -T -> r:^\s*LogLevel\s+INFO|^\s*LogLevel\s*VERBOSE|^\s*loglevel\s+INFO|^\s*loglevel\s+VERBOSE'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*LogLevel\s+ && !r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
-      - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> r:^\s*LogLevel\s+ && >!r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*LogLevel && !r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
+      - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> r:^\s*LogLevel && >!r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
 
   # 4.2.6 Ensure SSH PAM is enabled. (Automated)
   - id: 19113

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -2769,9 +2769,9 @@ checks:
       - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
     condition: all
     rules:
-      - 'c:sshd -T -> r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
-      - 'not f:/etc/ssh/sshd_config -> !r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
-      - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> !r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
+      - 'c:sshd -T -> r:^\s*loglevel\s+INFO|^\s*loglevel\s+VERBOSE'
+      - 'not f:/etc/ssh/sshd_config -> r:^\s*LogLevel\s+ && !r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
+      - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> !r:^\s*\t*LogLevel\s+INFO|^\s*\t*LogLevel\s+VERBOSE|^\s*\t*LogLevel\t+INFO|^\s*\t*LogLevel\t+VERBOSE'
 
   # 4.2.6 Ensure SSH PAM is enabled. (Automated)
   - id: 19113


### PR DESCRIPTION
Debian10/Ubuntu20 CIS 4.2.5 SSHD lowercase LogLevel in command and allow some tabs in config

|Related issue|
|---|
| #20286 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

In the check for CIS 4.2.5, the command runs `sshd -T` and compares the output to "LogLevel", but `sshd -T` folds the case of the settings down and the test should compare to "loglevel" instead of "LogLevel". This creates a false positive in the results.

Also, the default configuration file can have tabs between the word "LogLevel" and its setting, so allow spaces or tabes there. This creates another false positive in the results.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors