### PR TITLE
Avoid inserting CVEDescription with empty CVSS

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
@@ -37,9 +37,17 @@ public:
             throw std::runtime_error("CVE5 buffer is empty");
         }
         auto cve5Entry = cve_v5::GetEntry(data->cve5Buffer.data());
-        StoreRemediationsModel::updateRemediation(cve5Entry, m_remediationsDatabase);
-        UpdateCVECandidates::storeVulnerabilityCandidate(cve5Entry, m_feedsDatabases);
-        UpdateCVEDescription::storeVulnerabilityDescription(cve5Entry, m_descriptionsDatabase);
+        if (cve5Entry->cveMetadata())
+        {
+            auto cveMetadata = cve5Entry->cveMetadata();
+            if (cveMetadata->state() && cveMetadata->state()->str().compare("REJECTED") != 0)
+            {
+                StoreRemediationsModel::updateRemediation(cve5Entry, m_remediationsDatabase);
+                UpdateCVECandidates::storeVulnerabilityCandidate(cve5Entry, m_feedsDatabases);
+                UpdateCVEDescription::storeVulnerabilityDescription(cve5Entry, m_descriptionsDatabase);
+            }
+        }
+
         return AbstractHandler<std::shared_ptr<EventContext>>::handleRequest(data);
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -124,8 +124,8 @@ public:
 
             VulnDescFBReferenceStr = VulnDescFBReferenceStr.substr(0, VulnDescFBReferenceStr.size() - 2);
 
-            if (!(VulnDescFBClassificationStr.empty() || VulnDescFBDescriptionStr.empty() ||
-                  VulnDescFBSeverityStr.empty() || VulnDescFBScoreVersionStr.empty()))
+            // Empty description or empty URL reference are not CVE5 Compliant.
+            if (!(VulnDescFBDescriptionStr.empty() || VulnDescFBReferenceStr.empty()))
             {
                 flatbuffers::FlatBufferBuilder builder;
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -124,25 +124,30 @@ public:
 
             VulnDescFBReferenceStr = VulnDescFBReferenceStr.substr(0, VulnDescFBReferenceStr.size() - 2);
 
-            flatbuffers::FlatBufferBuilder builder;
+            if (!(VulnDescFBClassificationStr.empty() || VulnDescFBDescriptionStr.empty() ||
+                  VulnDescFBSeverityStr.empty() || VulnDescFBScoreVersionStr.empty()))
+            {
+                flatbuffers::FlatBufferBuilder builder;
 
-            auto vulnerabilityDescriptionFB =
-                NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                             VulnDescFBScoreBase,
-                                                                             VulnDescFBClassificationStr.c_str(),
-                                                                             VulnDescFBDescriptionStr.c_str(),
-                                                                             VulnDescFBSeverityStr.c_str(),
-                                                                             VulnDescFBScoreVersionStr.c_str(),
-                                                                             VulnDescFBReferenceStr.c_str());
+                auto vulnerabilityDescriptionFB =
+                    NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                                 VulnDescFBScoreBase,
+                                                                                 VulnDescFBClassificationStr.c_str(),
+                                                                                 VulnDescFBDescriptionStr.c_str(),
+                                                                                 VulnDescFBSeverityStr.c_str(),
+                                                                                 VulnDescFBScoreVersionStr.c_str(),
+                                                                                 VulnDescFBReferenceStr.c_str());
 
-            builder.Finish(vulnerabilityDescriptionFB);
+                builder.Finish(vulnerabilityDescriptionFB);
 
-            const uint8_t* buffer = builder.GetBufferPointer();
-            size_t flatbufferSize = builder.GetSize();
+                const uint8_t* buffer = builder.GetBufferPointer();
+                size_t flatbufferSize = builder.GetSize();
 
-            std::string key {cve5Flatbuffer->cveMetadata()->cveId()->str()};
-            const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer), flatbufferSize);
-            rocksDBWrapper.put(key, VulnerabilityDescriptionSlice);
+                std::string key {cve5Flatbuffer->cveMetadata()->cveId()->str()};
+                const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer),
+                                                                   flatbufferSize);
+                rocksDBWrapper.put(key, VulnerabilityDescriptionSlice);
+            }
         }
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -450,7 +450,7 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr);
+    ASSERT_TRUE(rocksDBWrapper.get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -504,7 +504,7 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_0)
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(CVE_JSON_STR_CVSS_V3_0, vulnerabilityDescriptionFBStr);
+    ASSERT_TRUE(rocksDBWrapper.get(CVE_JSON_STR_CVSS_V3_0, vulnerabilityDescriptionFBStr));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -556,7 +556,7 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV2_0)
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(CVE_JSON_STR_CVSS_V2_0, vulnerabilityDescriptionFBStr);
+    ASSERT_TRUE(rocksDBWrapper.get(CVE_JSON_STR_CVSS_V2_0, vulnerabilityDescriptionFBStr));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -584,7 +584,7 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV2_0)
               "https://github.com/stripe/stripe-cli/security/advisories/GHSA-4cx6-fj7j-pjx9");
 }
 
-TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics1)
+TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
 {
     std::string cve5FlatbufferSchemaStr;
 
@@ -614,10 +614,26 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics1)
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_FALSE(rocksDBWrapper.get(CVE_JSON_STR_MISSING_METRICS, vulnerabilityDescriptionFBStr));
+    ASSERT_TRUE(rocksDBWrapper.get(CVE_JSON_STR_MISSING_METRICS, vulnerabilityDescriptionFBStr));
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
+                                           vulnerabilityDescriptionFBStr.size());
+    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
+
+    // Read flatbuffer values.
+    auto vulnerabilityDescription =
+        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
+
+    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->scoreBase(), 0);
+    EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
+    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->reference()->str(), "https://security.archlinux.org/CVE-2022-1154");
 }
 
-TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics2)
+TEST_F(UpdateCVEDescriptionTest, RejectedCVE5Entry)
 {
     std::string cve5FlatbufferSchemaStr;
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -389,6 +389,37 @@ const std::string JSON_STR_MISSING_METRICS {
                 "dataVersion": "5.0"
 })"};
 
+const std::string CVE_JSON_STR_REJECTED_CVE {"CVE-2012-6177"};
+const std::string JSON_STR_REJECTED_CVE {
+    R"(
+            {
+                "containers": {
+                    "cna": {
+                        "providerMetadata": {
+                            "orgId": "00000000-0000-4000-A000-000000000003",
+                            "shortName": "nvd",
+                            "dateUpdated": "2017-05-11T14:29:20Z"
+                        },
+                        "rejectedReasons": [
+                            {
+                            "lang": "en",
+                            "value": "** REJECT **  DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: The CNA or individual who requested this candidate did not associate it with any vulnerability during 2012. Notes: none."
+                            }
+                        ]
+                    }
+                },
+                "cveMetadata": {
+                    "cveId": "CVE-2012-6177",
+                    "assignerOrgId": "00000000-0000-4000-A000-000000000003",
+                    "assignerShortName": "nvd",
+                    "dateUpdated": "2017-05-11T14:29:20Z",
+                    "datePublished": "2017-05-11T14:29:20Z",
+                    "state": "REJECTED"
+                },
+                "dataType": "CVE_RECORD",
+                "dataVersion": "5.0"
+            })"};
+
 TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
 {
     std::string cve5FlatbufferSchemaStr;
@@ -553,7 +584,7 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV2_0)
               "https://github.com/stripe/stripe-cli/security/advisories/GHSA-4cx6-fj7j-pjx9");
 }
 
-TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
+TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics1)
 {
     std::string cve5FlatbufferSchemaStr;
 
@@ -583,21 +614,38 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    rocksDBWrapper.get(CVE_JSON_STR_MISSING_METRICS, vulnerabilityDescriptionFBStr);
+    ASSERT_FALSE(rocksDBWrapper.get(CVE_JSON_STR_MISSING_METRICS, vulnerabilityDescriptionFBStr));
+}
+
+TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics2)
+{
+    std::string cve5FlatbufferSchemaStr;
+
+    // Read schemas from filesystem.
+    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr));
+    ASSERT_EQ(valid, true);
+    ASSERT_EQ(JSON_STR_REJECTED_CVE.empty(), false);
+
+    // Parse schemas and JSON example.
+    flatbuffers::Parser parser;
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
+             parser.Parse(JSON_STR_REJECTED_CVE.c_str()));
+    ASSERT_EQ(valid, true);
+
+    // Get flatbuffer pointer
+    uint8_t* buf = parser.builder_.GetBufferPointer();
+    size_t flatbufferSize = parser.builder_.GetSize();
 
     // Verify flatbuffer.
-    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
-                                           vulnerabilityDescriptionFBStr.size());
-    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
+    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
+    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
+    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
-    // Read flatbuffer values.
-    auto vulnerabilityDescription =
-        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
+    // Call function.
+    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
 
-    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->scoreBase(), (float)0);
-    EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
-    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->reference()->str(), "https://security.archlinux.org/CVE-2022-1154");
+    // Get flatbuffer from vulnerability description database.
+    std::string vulnerabilityDescriptionFBStr;
+    ASSERT_FALSE(rocksDBWrapper.get(CVE_JSON_STR_REJECTED_CVE, vulnerabilityDescriptionFBStr));
 }


### PR DESCRIPTION
|Related issue|
|---|
|#20236|

## Description

This PR adds a check to avoid inserting in the description database elements with empty CVSS information.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux