### PR TITLE
Add `pyarrow_hotfix` dependency to fix `pyarrow` security vulnerability

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -62,6 +62,7 @@ protobuf==3.19.6
 proto-plus==1.19.0
 psutil==5.8.0
 pyarrow==8.0.0
+pyarrow_hotfix==0.5
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.20

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -47,6 +47,7 @@ except ImportError:
 
 try:
     import pyarrow.parquet as pq
+    import pyarrow_hotfix
 except ImportError:
     print('ERROR: pyarrow module is required.')
     sys.exit(10)


### PR DESCRIPTION
|Related issue|
|---|
| #18984 |


## Description

Closes #18984. Adds the `pyarrow_hotfix` dependency to the Wazuh embedded Python interpreter in order to fix a security vulnerability affecting `pyarrow` versions prior to `14.0.1`. The analysis and AWS module testing can be found in the issue.

> Note: for Wazuh `4.8.0` we should be able to update the `pyarrow` version and remove the hotfix dependency since support for CentOS 6, which generated issues with installing the latest version, was dropped.

