### PR TITLE
Logging level modified when a recv error raises in wazuhdb

### DIFF
--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -378,7 +378,7 @@ void * run_worker(__attribute__((unused)) void * args) {
 
         switch (length) {
         case -1:
-            merror("at run_worker(): at recv(): %s (%d)", strerror(errno), errno);
+            mdebug1("at run_worker(): at recv(): %s (%d)", strerror(errno), errno);
             close(peer);
             continue;
 


### PR DESCRIPTION
|Related issue|
|---|
|#19532|

The logging level has been changed for workers of `wazuh-db` when a recv() error is raised.