### PR TITLE
Offline Downloader - Avoid exception if input file doesn't exist

### DIFF
--- a/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
@@ -8,7 +8,7 @@ The copy will be made into any of the following output directories:
 - Downloads folder: If the input file is compressed.
 - Contents folder: If the input file is not compressed.
 
-If the copy is successful, this stage also updates the context [data paths](../../src/components/updaterContext.hpp) field with the destination path of the copied file.
+If the copy is successful, this stage also updates the context [data paths](../../src/components/updaterContext.hpp) field with the destination path of the copied file. If the input file doesn't exist, no paths will be appended.
 
 > Note: Despite the class name, there is no such download performed. The copy is made entirely locally.
 

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -74,7 +74,9 @@ private:
             return Utils::asciiToHex(hash.hash());
         }
 
+        // LCOV_EXCL_START
         throw std::runtime_error {"Unable to open '" + filepath.string() + "' for hashing."};
+        // LCOV_EXCL_STOP
     };
 
     /**

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -95,6 +95,13 @@ private:
         }
         const std::filesystem::path inputFilePath {url};
 
+        // Check input file existence.
+        if (!std::filesystem::exists(inputFilePath))
+        {
+            std::cout << "File " << inputFilePath << " doesn't exist. Skipping download." << std::endl;
+            return;
+        }
+
         // Process input file hash.
         auto inputFileHash {hashFile(inputFilePath)};
 

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
@@ -158,13 +158,14 @@ TEST_F(OfflineDownloaderTest, TwoFileDownloadsOverrideOutput)
 }
 
 /**
- * @brief Tests the download with an URL with an invalid format.
+ * @brief Tests the download of a raw file with an inexistant content folder. Exception is expected.
  *
  */
-TEST_F(OfflineDownloaderTest, InvalidURLFormat)
+TEST_F(OfflineDownloaderTest, InexistantContentFolder)
 {
-    m_spUpdaterBaseContext->configData["url"] = 0;
+    m_spUpdaterBaseContext->configData["url"] = m_inputFilePathRaw.string();
     m_spUpdaterBaseContext->configData["compressionType"] = "raw";
+    m_spUpdaterBaseContext->contentsFolder = m_outputFolder / "inexistantFolder";
 
     nlohmann::json expectedData;
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 const auto OK_STATUS = R"({"stage":"OfflineDownloader","status":"ok"})"_json;
+const auto FAIL_STATUS = R"({"stage":"OfflineDownloader","status":"fail"})"_json;
 
 /**
  * @brief Tests the correct instantiation of the class.
@@ -154,4 +155,22 @@ TEST_F(OfflineDownloaderTest, TwoFileDownloadsOverrideOutput)
     ASSERT_NO_THROW(OfflineDownloader().handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
     EXPECT_TRUE(std::filesystem::exists(m_spUpdaterBaseContext->contentsFolder / m_inputFilePathRaw.filename()));
+}
+
+/**
+ * @brief Tests the download with an URL with an invalid format.
+ *
+ */
+TEST_F(OfflineDownloaderTest, InvalidURLFormat)
+{
+    m_spUpdaterBaseContext->configData["url"] = 0;
+    m_spUpdaterBaseContext->configData["compressionType"] = "raw";
+
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = nlohmann::json::array();
+    expectedData["stageStatus"].push_back(FAIL_STATUS);
+
+    ASSERT_THROW(OfflineDownloader().handleRequest(m_spUpdaterContext), std::runtime_error);
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
 }

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
@@ -18,7 +18,6 @@
 #include <memory>
 
 const auto OK_STATUS = R"({"stage":"OfflineDownloader","status":"ok"})"_json;
-const auto FAIL_STATUS = R"({"stage":"OfflineDownloader","status":"fail"})"_json;
 
 /**
  * @brief Tests the correct instantiation of the class.
@@ -72,7 +71,7 @@ TEST_F(OfflineDownloaderTest, CompressedFileDownload)
 }
 
 /**
- * @brief Tests the download of an inexistant file. Exception is expected, as well as a fail stage status.
+ * @brief Tests the download of an inexistant file.
  *
  */
 TEST_F(OfflineDownloaderTest, InexistantFileDownload)
@@ -83,9 +82,9 @@ TEST_F(OfflineDownloaderTest, InexistantFileDownload)
     nlohmann::json expectedData;
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
-    expectedData["stageStatus"].push_back(FAIL_STATUS);
+    expectedData["stageStatus"].push_back(OK_STATUS);
 
-    ASSERT_THROW(OfflineDownloader().handleRequest(m_spUpdaterContext), std::runtime_error);
+    ASSERT_NO_THROW(OfflineDownloader().handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#20193|

## Description

This PR modifies the `OfflineDownloader` class of the Content Manager module in order to no longer throw exception when the input file doesn't exist.

Change log:
- OfflineDownloader implementation, documentation, and UTs modified.

## Results

### Test tool

Config:
```json
{
    "topicName": "test",
    "interval": 10,
    "ondemand": true,
    "configData":
    {
        "contentSource": "offline",
        "compressionType": "raw",
        "versionedContent": "false",
        "deleteDownloadedContent": true,
        "url": "file:///home/i-dont.exist",
        "outputFolder": "/tmp/testProvider",
        "dataFormat": "json",
        "contentFileName": "example.json",
        "s3FileName": "content.filtered_little.1.xz",
        "databasePath": "/tmp/content_updater/rocksdb",
        "offset": 0
    }
}
```

- Normal execution
```bash
# ./content_manager_test_tool 
ActionOrchestrator - Starting process
API offset to be used: 0
Output folders created.
FactoryContentUpdater - Starting process
Creating 'offline' downloader
Creating 'raw' content decompressor
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
ActionOrchestrator - Running process
File "/home/i-dont.exist" doesn't exist. Skipping download.
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.

changing interval
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
File "/home/i-dont.exist" doesn't exist. Skipping download.
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.

Action: Initiating scheduling action for test
ActionOrchestrator - Running process
File "/home/i-dont.exist" doesn't exist. Skipping download.
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.
```

- Execution creating the file in the middle
```bash
# ./content_manager_test_tool &
[1] 8050
ActionOrchestrator - Starting process
API offset to be used: 0
Output folders created.
FactoryContentUpdater - Starting process
Creating 'offline' downloader
Creating 'raw' content decompressor
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
ActionOrchestrator - Running process
File "/home/i-dont.exist" doesn't exist. Skipping download.
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.

# touch /home/i-dont.exist

changing interval
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.
```