### PR TITLE
Added permissions change for merged.mg files in upgrade

### DIFF
--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -218,7 +218,10 @@ WazuhUpgrade()
         fi
     fi
     ./src/init/delete-oldusers.sh $OSSEC_GROUP
-
+    
+    # Set merged.mg permissions to new ones
+    find $PREINSTALLEDDIR/etc/shared/ -type f -name 'merged.mg' -exec chmod 644 {} \;
+    
     # Remove unnecessary `execa` socket
     if [ -f "$DIRECTORY/queue/alerts/execa" ]; then
         rm -f $DIRECTORY/queue/alerts/execa


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-jenkins/issues/5929|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR fixes a permissions discordance in the merged.mg files, when updating a manager sources update. After this change, the merged.mg files will be set to `644` permissions.
<!--
Add a clear description of how the problem has been solved.
-->

## Logs example

<!--
Paste here related logs
-->

<details>
<summary>Ubuntu22</summary>

```console
root@server-slave-ubu22:/home/vagrant# curl -sO https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-manager/wazuh-manager_4.5.4-1_amd64.deb

root@server-slave-ubu22:/home/vagrant# dpkg -i wazuh-manager_4.5.4-1_amd64.deb 
Selecting previously unselected package wazuh-manager.
(Reading database ... 73182 files and directories currently installed.)
Preparing to unpack wazuh-manager_4.5.4-1_amd64.deb ...
Unpacking wazuh-manager (4.5.4-1) ...
Setting up wazuh-manager (4.5.4-1) ...

root@server-slave-ubu22:/home/vagrant# /var/ossec/bin/wazuh-control start
Starting Wazuh v4.5.4...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2023/11/17 12:08:00 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
Started wazuh-modulesd...
Completed.

root@server-slave-ubu22:/home/vagrant# ls -la /var/ossec/etc/shared/default/merged.mg 
-rw-rw---- 1 wazuh wazuh 899315 Nov 17 12:08 /var/ossec/etc/shared/default/merged.mg
 
root@server-slave-ubu22:/home/vagrant/wazuh# cd wazuh/

root@server-slave-ubu22:/home/vagrant/wazuh# git checkout fix/5929-change-mergedmg-permissions

root@server-slave-ubu22:/home/vagrant/wazuh# ./install.sh 
 Wazuh v4.7.1 (Rev. 40705) Installation Script - https://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux server-slave-ubu22 5.15.0-25-generic (ubuntu 22.04)
  - User: root
  - Host: server-slave-ubu22


  -- Press ENTER to continue or Ctrl-C to abort. --


 - You already have Wazuh installed. Do you want to update it? (y/n): y

    - Installation will be made at  /var/ossec .

4- Installing the system

root@server-slave-ubu22:/home/vagrant/wazuh# ls -la /var/ossec/etc/shared/default/merged.mg 
-rw-r--r-- 1 wazuh wazuh 899415 Nov 17 12:17 /var/ossec/etc/shared/default/merged.mg
```
</details>

<details>
<summary>Centos7</summary>

```console
```
</details>

## Tests
- Tests for Linux deb
  - [x] Upgrade with sources
- Tests for Linux RPM
  - [ ] Upgrade with sources
