### PR TITLE
Remove unit tests workflows inputs parameter

### DIFF
--- a/.github/workflows/api-unit-tests.yml
+++ b/.github/workflows/api-unit-tests.yml
@@ -2,11 +2,6 @@ name: API unit tests
 
 on:
   workflow_dispatch:
-    inputs:
-      base_branch:
-        description: 'Base branch'
-        required: true
-        default: 'main'
   pull_request:
     paths:
       - '.github/workflows/api-unit-tests.yml'

--- a/.github/workflows/external-integrations-unit-tests.yml
+++ b/.github/workflows/external-integrations-unit-tests.yml
@@ -2,11 +2,6 @@ name: External integrations unit tests
 
 on:
   workflow_dispatch:
-    inputs:
-      base_branch:
-        description: 'Base branch'
-        required: true
-        default: 'main'
   pull_request:
     paths:
       - '.github/workflows/external-integrations-unit-tests.yml'

--- a/.github/workflows/framework-unit-tests.yml
+++ b/.github/workflows/framework-unit-tests.yml
@@ -2,11 +2,6 @@ name: Framework unit tests
 
 on:
   workflow_dispatch:
-    inputs:
-      base_branch:
-        description: 'Base branch'
-        required: true
-        default: 'main'
   pull_request:
     paths:
       - '.github/workflows/framework-unit-tests.yml'

--- a/.github/workflows/wodles-unit-tests.yml
+++ b/.github/workflows/wodles-unit-tests.yml
@@ -2,11 +2,6 @@ name: Wodles unit tests
 
 on:
   workflow_dispatch:
-    inputs:
-      base_branch:
-        description: 'Base branch'
-        required: true
-        default: 'main'
   pull_request:
     paths:
       - '.github/workflows/wodles-unit-tests.yml'


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20325 |

## Description

Removes the `workflow_dispatch.inputs` parameter from the Framework unit tests workflows.