### PR TITLE
Utils - Fix XzHelper closing of output file

### DIFF
--- a/src/shared_modules/utils/tests/xzHelper_test.cpp
+++ b/src/shared_modules/utils/tests/xzHelper_test.cpp
@@ -49,9 +49,6 @@ const auto UNCOMPRESSED_INPUT_FILE {INPUT_PATH / "sample.json"};
 const auto COMPRESSED_INPUT_FILE_ST {INPUT_PATH / "sample.json.st.xz"};
 const auto COMPRESSED_INPUT_FILE_MT {INPUT_PATH / "sample.json.mt.xz"};
 
-const auto DECOMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample.json"};
-const auto COMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample.json.xz"};
-
 const auto UNCOMPRESSED_REFERENCE_FILE {UNCOMPRESSED_INPUT_FILE};
 const auto COMPRESSED_REFERENCE_FILE_ST {COMPRESSED_INPUT_FILE_ST};
 const auto COMPRESSED_REFERENCE_FILE_MT {COMPRESSED_INPUT_FILE_MT};
@@ -70,6 +67,9 @@ std::vector<uint8_t> XzHelperTest::loadFile(const std::filesystem::path& filePat
  */
 TEST_F(XzHelperTest, NonExistingInputFile)
 {
+    const auto DECOMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-NonExistingInputFile.json"};
+    const auto COMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-NonExistingInputFile.json.xz"};
+    
     EXPECT_THROW(Utils::XzHelper(INPUT_PATH / "nofile.json", COMPRESSED_OUTPUT_FILE).compress(), std::runtime_error);
     EXPECT_THROW(Utils::XzHelper(INPUT_PATH / "nofile.json.xz", DECOMPRESSED_OUTPUT_FILE).decompress(),
                  std::runtime_error);
@@ -94,6 +94,7 @@ TEST_F(XzHelperTest, InvalidOutputFile)
 TEST_F(XzHelperTest, CompressFileOutputToFileSingleThread)
 {
     // Setup
+    const auto COMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-CompressFileOutputToFileSingleThread.json.xz"};
     Utils::XzHelper xz(UNCOMPRESSED_INPUT_FILE, COMPRESSED_OUTPUT_FILE);
 
     // Compress
@@ -110,6 +111,7 @@ TEST_F(XzHelperTest, CompressFileOutputToFileSingleThread)
 TEST_F(XzHelperTest, CompressFileOutputToFileMultithread)
 {
     // Setup
+    const auto COMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-CompressFileOutputToFileMultithread.json.xz"};
     Utils::XzHelper xz(UNCOMPRESSED_INPUT_FILE, COMPRESSED_OUTPUT_FILE, MAX_THREAD_COUNT);
 
     // Compress
@@ -126,6 +128,7 @@ TEST_F(XzHelperTest, CompressFileOutputToFileMultithread)
 TEST_F(XzHelperTest, DecompressFileOutputToFileSingleThread)
 {
     // Setup
+    const auto DECOMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-DecompressFileOutputToFileSingleThread.json"};
     Utils::XzHelper xz(COMPRESSED_INPUT_FILE_ST, DECOMPRESSED_OUTPUT_FILE);
 
     // Decompress
@@ -142,6 +145,7 @@ TEST_F(XzHelperTest, DecompressFileOutputToFileSingleThread)
 TEST_F(XzHelperTest, DecompressFileOutputToFileMultiThread)
 {
     // Setup
+    const auto DECOMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-DecompressFileOutputToFileMultiThread.json"};
     Utils::XzHelper xz(COMPRESSED_INPUT_FILE_MT, DECOMPRESSED_OUTPUT_FILE, MAX_THREAD_COUNT);
 
     // Decompress
@@ -158,6 +162,7 @@ TEST_F(XzHelperTest, DecompressFileOutputToFileMultiThread)
 TEST_F(XzHelperTest, DecompressWithNonExistingInputFile)
 {
     // Setup
+    const auto DECOMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-DecompressWithNonExistingInputFile.json"};
     Utils::XzHelper xz(INPUT_PATH / "nofile.json", DECOMPRESSED_OUTPUT_FILE);
 
     // Decompress, expect exception
@@ -171,6 +176,7 @@ TEST_F(XzHelperTest, DecompressWithNonExistingInputFile)
 TEST_F(XzHelperTest, DecompressInvalidDataFile)
 {
     // Setup: the input file is not compressed so it is invalid
+    const auto DECOMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-DecompressInvalidDataFile.json"};
     Utils::XzHelper xz(UNCOMPRESSED_INPUT_FILE, DECOMPRESSED_OUTPUT_FILE);
 
     // Decompress, expect exception
@@ -347,6 +353,7 @@ TEST_F(XzHelperTest, CompressDataVectorToFile)
     const auto inputData {loadFile(UNCOMPRESSED_INPUT_FILE)};
 
     // Compress
+    const auto COMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-CompressDataVectorToFile.json.xz"};
     Utils::XzHelper xz(inputData, COMPRESSED_OUTPUT_FILE);
     ASSERT_NO_THROW(xz.compress());
 
@@ -365,6 +372,7 @@ TEST_F(XzHelperTest, CompressStringToFile)
     std::string inputString(inputData.begin(), inputData.end());
 
     // Compress
+    const auto COMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-CompressStringToFile.json.xz"};
     Utils::XzHelper xz(inputString, COMPRESSED_OUTPUT_FILE);
     ASSERT_NO_THROW(xz.compress());
 
@@ -382,6 +390,7 @@ TEST_F(XzHelperTest, DecompressDataVectorToFile)
     const auto inputData {loadFile(COMPRESSED_INPUT_FILE_ST)};
 
     // Decompress
+    const auto DECOMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-DecompressDataVectorToFile.json"};
     Utils::XzHelper xz(inputData, DECOMPRESSED_OUTPUT_FILE);
     ASSERT_NO_THROW(xz.decompress());
 
@@ -403,6 +412,7 @@ TEST_F(XzHelperTest, CompressAndDecompressFileToDataVector)
     Utils::XzHelper(UNCOMPRESSED_INPUT_FILE, compressedData).compress();
 
     // Decompress vector into file
+    const auto DECOMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-CompressAndDecompressFileToDataVector.json"};
     Utils::XzHelper(compressedData, DECOMPRESSED_OUTPUT_FILE).decompress();
 
     // Check that the output decompressed file equals the initial input file
@@ -420,6 +430,7 @@ TEST_F(XzHelperTest, CompressAndDecompressDataVectorToFile)
     const auto inputData {loadFile(UNCOMPRESSED_INPUT_FILE)};
 
     // Compress vector into file
+    const auto COMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-CompressAndDecompressDataVectorToFile.json.xz"};
     Utils::XzHelper(inputData, COMPRESSED_OUTPUT_FILE).compress();
 
     // Decompress file into vector
@@ -444,6 +455,7 @@ TEST_F(XzHelperTest, CompressMTAndDecompressSTFileToDataVector)
     Utils::XzHelper(UNCOMPRESSED_INPUT_FILE, compressedData, MAX_THREAD_COUNT).compress();
 
     // Decompress vector into file in multi-thread mode
+    const auto DECOMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-CompressMTAndDecompressSTFileToDataVector.json"};
     Utils::XzHelper(compressedData, DECOMPRESSED_OUTPUT_FILE).decompress();
 
     // Check that the output decompressed file equals the initial input file
@@ -464,6 +476,7 @@ TEST_F(XzHelperTest, CompressSTAndDecompressMTFileToDataVector)
     Utils::XzHelper(UNCOMPRESSED_INPUT_FILE, compressedData).compress();
 
     // Decompress vector into file in multi-thread mode
+    const auto DECOMPRESSED_OUTPUT_FILE {OUTPUT_PATH / "sample-CompressSTAndDecompressMTFileToDataVector.json"};
     Utils::XzHelper(compressedData, DECOMPRESSED_OUTPUT_FILE, MAX_THREAD_COUNT).decompress();
 
     // Check that the output decompressed file equals the initial input file

--- a/src/shared_modules/utils/tests/xzHelper_test.hpp
+++ b/src/shared_modules/utils/tests/xzHelper_test.hpp
@@ -29,21 +29,20 @@ protected:
     ~XzHelperTest() override = default;
 
     /**
-     * @brief Initial conditions for tests
+     * @brief Set the Up Test Suite object
      *
      */
     // cppcheck-suppress unusedFunction
-    void SetUp() override
+    static void SetUpTestSuite()
     {
         std::filesystem::create_directory(OUTPUT_PATH);
     }
 
     /**
-     * @brief Tear down routine for tests
-     *
+     * @brief Tear down test suite.
      */
     // cppcheck-suppress unusedFunction
-    void TearDown() override
+    static void TearDownTestSuite()
     {
         std::filesystem::remove_all(OUTPUT_PATH);
     }

--- a/src/shared_modules/utils/xz/fileDataCollector.hpp
+++ b/src/shared_modules/utils/xz/fileDataCollector.hpp
@@ -55,6 +55,12 @@ namespace Xz
             }
         }
 
+        /*! @copydoc IDataCollector::finish() */
+        void finish() override
+        {
+            m_file.close();
+        }
+
         /*! @copydoc IDataCollector::setBuffer() */
         void setBuffer(uint8_t** buffer, size_t& buffSize) override
         {

--- a/src/shared_modules/utils/xz/iDataCollector.hpp
+++ b/src/shared_modules/utils/xz/iDataCollector.hpp
@@ -34,6 +34,12 @@ namespace Xz
         virtual void begin() = 0;
 
         /**
+         * @brief Called at the end of the process so that the collector can close its state properly
+         *
+         */
+        virtual void finish() {};
+
+        /**
          * @brief Set the output buffer
          *
          * @param[out] buffer Buffer to hold the partial output data

--- a/src/shared_modules/utils/xz/wrapper.hpp
+++ b/src/shared_modules/utils/xz/wrapper.hpp
@@ -197,6 +197,7 @@ namespace Xz
             {
                 // Process ended successfully, save remaining output data
                 dataCollector.dataReady(m_strm.avail_out);
+                dataCollector.finish();
             }
             else
             {


### PR DESCRIPTION
|Related issue|
|---|
| Closes #20280|

## Description

This PR fixes a bug in the `XzHelper`. When compressing/decompressing to a file the output file was only closed on the destruction of the `FileDataCollector` instance, which is destructed together with the `XzHelper` instance.
This caused that if the output file was read before the `XzHelper` was destructed the file could still be incomplete.

## Tests

<details>
<summary>
UT report
</summary>

```
ft@ft-nb:~/wazuh/repos/dev/wazuh-vuln-refactor/src/build/shared_modules/utils/tests$ ./utils_unit_test --gtest_filter=Xz*
Note: Google Test filter = Xz*
[==========] Running 27 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 27 tests from XzHelperTest
[ RUN      ] XzHelperTest.NonExistingInputFile
[       OK ] XzHelperTest.NonExistingInputFile (0 ms)
[ RUN      ] XzHelperTest.InvalidOutputFile
[       OK ] XzHelperTest.InvalidOutputFile (0 ms)
[ RUN      ] XzHelperTest.CompressFileOutputToFileSingleThread
[       OK ] XzHelperTest.CompressFileOutputToFileSingleThread (97 ms)
[ RUN      ] XzHelperTest.CompressFileOutputToFileMultithread
[       OK ] XzHelperTest.CompressFileOutputToFileMultithread (70 ms)
[ RUN      ] XzHelperTest.DecompressFileOutputToFileSingleThread
[       OK ] XzHelperTest.DecompressFileOutputToFileSingleThread (3 ms)
[ RUN      ] XzHelperTest.DecompressFileOutputToFileMultiThread
[       OK ] XzHelperTest.DecompressFileOutputToFileMultiThread (3 ms)
[ RUN      ] XzHelperTest.DecompressWithNonExistingInputFile
[       OK ] XzHelperTest.DecompressWithNonExistingInputFile (0 ms)
[ RUN      ] XzHelperTest.DecompressInvalidDataFile
[       OK ] XzHelperTest.DecompressInvalidDataFile (0 ms)
[ RUN      ] XzHelperTest.CompressDataVectorToDataVectorSingleThread
[       OK ] XzHelperTest.CompressDataVectorToDataVectorSingleThread (105 ms)
[ RUN      ] XzHelperTest.CompressDataVectorToDataVectorMultiThread
[       OK ] XzHelperTest.CompressDataVectorToDataVectorMultiThread (108 ms)
[ RUN      ] XzHelperTest.CompressStringToDataVectorSingleThread
[       OK ] XzHelperTest.CompressStringToDataVectorSingleThread (107 ms)
[ RUN      ] XzHelperTest.CompressStringToDataVectorMultiThread
[       OK ] XzHelperTest.CompressStringToDataVectorMultiThread (103 ms)
[ RUN      ] XzHelperTest.DecompressInvalidData
[       OK ] XzHelperTest.DecompressInvalidData (46 ms)
[ RUN      ] XzHelperTest.DecompressDataVectorToDataVectorSingleThread
[       OK ] XzHelperTest.DecompressDataVectorToDataVectorSingleThread (48 ms)
[ RUN      ] XzHelperTest.DecompressDataVectorToDataVectorMultiThread
[       OK ] XzHelperTest.DecompressDataVectorToDataVectorMultiThread (48 ms)
[ RUN      ] XzHelperTest.CompressFileOutputToDataVector
[       OK ] XzHelperTest.CompressFileOutputToDataVector (59 ms)
[ RUN      ] XzHelperTest.DecompressFileOutputToDataVector
[       OK ] XzHelperTest.DecompressFileOutputToDataVector (47 ms)
[ RUN      ] XzHelperTest.CompressDataVectorToFile
[       OK ] XzHelperTest.CompressDataVectorToFile (105 ms)
[ RUN      ] XzHelperTest.CompressStringToFile
[       OK ] XzHelperTest.CompressStringToFile (118 ms)
[ RUN      ] XzHelperTest.DecompressDataVectorToFile
[       OK ] XzHelperTest.DecompressDataVectorToFile (5 ms)
[ RUN      ] XzHelperTest.CompressAndDecompressFileToDataVector
[       OK ] XzHelperTest.CompressAndDecompressFileToDataVector (71 ms)
[ RUN      ] XzHelperTest.CompressAndDecompressDataVectorToFile
[       OK ] XzHelperTest.CompressAndDecompressDataVectorToFile (105 ms)
[ RUN      ] XzHelperTest.CompressMTAndDecompressSTFileToDataVector
[       OK ] XzHelperTest.CompressMTAndDecompressSTFileToDataVector (61 ms)
[ RUN      ] XzHelperTest.CompressSTAndDecompressMTFileToDataVector
[       OK ] XzHelperTest.CompressSTAndDecompressMTFileToDataVector (60 ms)
[ RUN      ] XzHelperTest.CompressAndDecompressVectorWithNonDefaultPreset
[       OK ] XzHelperTest.CompressAndDecompressVectorWithNonDefaultPreset (58 ms)
[ RUN      ] XzHelperTest.CompressWithDifferentPresets
[       OK ] XzHelperTest.CompressWithDifferentPresets (108 ms)
[ RUN      ] XzHelperTest.InvalidCompressionPresetThrows
[       OK ] XzHelperTest.InvalidCompressionPresetThrows (45 ms)
[----------] 27 tests from XzHelperTest (1591 ms total)

[----------] Global test environment tear-down
[==========] 27 tests from 1 test suite ran. (1592 ms total)
[  PASSED  ] 27 tests.
```

</details>
