### PR TITLE
Ubuntu20 CIS 4.2.1 should pass if no files in conf.d

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -2690,9 +2690,10 @@ checks:
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
       - pci_dss_v4.0: ["1.3.1", "7.1"]
       - soc_2: ["CC5.2", "CC6.1"]
-    condition: all
+    condition: none
     rules:
-      - 'c:sh -c "stat -Lc "%a %u/%U %g/%G" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*.conf" -> r:\d && !r:^600 0/root 0/root'
+      - 'c:stat -Lc "%a %u/%U %g/%G" /etc/ssh/sshd_config -> r:\d && !r:^600 0/root 0/root'
+      - 'c:find /etc/ssh/sshd_config.d -name "*.conf" -exec stat -Lc "%a %u/%U %g/%G" {} \; -> r:\d && !r:^600 0/root 0/root'
 
   # 4.2.2 Ensure permissions on SSH private host key files are configured. (Automated) - Not Implemented
 

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -2692,8 +2692,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/ssh/sshd_config -> r:600\s*\t*-rw-------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
-      - 'c:sh -c "stat -L /etc/ssh/sshd_config.d/*.conf" -> r:Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:sh -c "stat -Lc "%a %u/%U %g/%G" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*.conf" -> r:\d && !r:^600 0/root 0/root'
 
   # 4.2.2 Ensure permissions on SSH private host key files are configured. (Automated) - Not Implemented
 


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

contribution

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Currently, the test for sshd config permissions fails if there are no files in the sshd_condif.d directory.

Further, if there are multiple files, it passes if only one of those files has the correct permissions.

This change combines the stat with the master config file so it does not fail if the config.d directory is empty. And it causes the test to fail if the stat returns any lines that do not reflect root ownership with 0600 permissions.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
This is not a change to compiled code

- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

<!-- Ruleset required checks, rules/decoder -->
There are not tests for SCA files AFAICT
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors