### PR TITLE
Remove wheel dependency

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -85,7 +85,6 @@ urllib3==1.26.5
 uvloop==0.17.0
 websocket-client==0.57.0
 Werkzeug==2.2.3
-wheel==0.38.4
 xmltodict==0.12.0
 yarl==1.7.0
 zipp==3.3.2


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/19920 |

## Description

Removes the `wheel` dependency which must be installed before all the other ones. See https://github.com/wazuh/wazuh/issues/19920#issuecomment-1821090488 for more details.

> [!Note]
> I've also modified the team's internal documentation development installation steps