### PR TITLE
Agent log changed when cannot connect to a server.

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -171,7 +171,7 @@ void start_agent(int is_startup)
         sleep(agt->server[current_server_id].retry_interval);
 
         /* Wait for server reply */
-        mwarn(AG_WAIT_SERVER, agt->server[current_server_id].rip);
+        mwarn(AG_WAIT_SERVER, agt->server[current_server_id].rip, __ossec_version);
 
         /* If there is a next server, try it */
         if (agt->server[current_server_id + 1].rip) {

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -293,7 +293,7 @@
 #define INV_DEF         "(2302): Invalid definition for %s.%s: '%s'."
 
 /* Agent errors */
-#define AG_WAIT_SERVER  "(4101): Waiting for server reply (not started). Tried: '%s'."
+#define AG_WAIT_SERVER  "(4101): Waiting for server reply (not started). Tried: '%s'. Ensure that the manager version is '%s' or higher."
 #define AG_CONNECTED    "(4102): Connected to the server ([%s]:%d/%s)."
 #define AG_USINGIP      "(4103): Server IP address already set. Trying that before the hostname."
 #define AG_INV_HOST     "(4104): Invalid hostname: '%s'."


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/20359|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The log:

` "(4101): Waiting for server reply (not started). Tried: '%s'."`
will be changed to

`"(4101): Waiting for server reply (not started). Tried: '%s'. Ensure that the manager version is 4.7.0 or higher."`

to warn the user when the agent is unable to connect to a manager lower than 4.6.0.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade