### PR TITLE
Ubuntu20/Debian10 CIS 2.2.16 should pass if nothing listens on port 25

### DIFF
--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -1897,9 +1897,9 @@ checks:
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
       - soc_2: ["CC6.3", "CC6.6"]
-    condition: all
+    condition: none
     rules:
-      - 'c:ss -lntu -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.+LISTEN|::1:25\.*LISTEN'
+      - 'c:ss -Hlntu "( sport = :25 )" -> r:\s+LISTEN\s+ && !r:\s+127.0.0.1:25\s+|\s+::1:25\s+'
 
   # 2.2.17 Ensure rsync service is either not installed or is masked. (Automated)
   - id: 2579

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -1716,9 +1716,9 @@ checks:
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
       - soc_2: ["CC6.3", "CC6.6"]
-    condition: all
+    condition: none
     rules:
-      - 'c:ss -lntu -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.*LISTEN|::1:25\.*LISTEN'
+      - 'c:ss -Hlntu "( sport = :25 )" -> r:\s+LISTEN\s+ && !r:\s+127.0.0.1:25\s+|\s+::1:25\s+'
 
   # 2.2.17 Ensure rsync service is either not installed or is masked. (Automated)
   - id: 19071


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The CIS control for 2.2.16 test whether there are port 25 listeners accessible from other servers. Thus, it should pass if SMTP is not running or is listening on a Unix socket. It currently fails in both those cases.

The problem is solved checking that there are no port 25 listeners that are not on localhost (127.0.0.1 or ::1), instead of looking for a port 25 listener on localhost.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->
There is no change to the compiled code and there is no test automation for SCAs so AFAICT there are no tests that can or should be run.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors