### PR TITLE
Let the manager reject agents with higher versions by default

### DIFF
--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -15,7 +15,7 @@
 #define AD_CONF_UNPARSED 3
 #define AD_CONF_UNDEFINED 2
 
-#define AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT true   ///< Default allow_higher_versions value (true)
+#define AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT false    ///< Default allow_higher_versions value (false)
 
 #include <time.h>
 

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -26,7 +26,7 @@
 #define REMOTED_NET_PROTOCOL_TCP_UDP (REMOTED_NET_PROTOCOL_TCP | REMOTED_NET_PROTOCOL_UDP) ///< Either UDP or TCP
 #define REMOTED_RIDS_CLOSING_TIME_DEFAULT   (5 * 60) ///< Default rids_closing_time value (5 minutes)
 
-#define REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT true   ///< Default allow_higher_versions value (true)
+#define REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT false  ///< Default allow_higher_versions value (false)
 
 #include "shared.h"
 #include "global-config.h"

--- a/src/unit_tests/os_auth/test_authd-config.c
+++ b/src/unit_tests/os_auth/test_authd-config.c
@@ -88,7 +88,7 @@ static void test_w_authd_parse_agents_invalid_value(void **state) {
     expect_string(__wrap__mwarn, formatted_msg,
                  "(9001): Ignored invalid value 'invalid_value' for 'allow_higher_versions'.");
     w_authd_parse_agents(node, &config);
-    assert_true(config.allow_higher_versions);
+    assert_int_equal(config.allow_higher_versions, AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT);
 
     os_free(node[0]->element);
     os_free(node[0]->content);
@@ -110,7 +110,7 @@ static void test_w_authd_parse_agents_invalid_element(void **state) {
     expect_string(__wrap__mwarn, formatted_msg,
                   "(1230): Invalid element in the configuration: 'invalid_element'.");
     w_authd_parse_agents(node, &config);
-    assert_true(config.allow_higher_versions);
+    assert_int_equal(config.allow_higher_versions, AUTHD_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT);
 
     os_free(node[0]->element);
     os_free(node[0]->content);

--- a/src/unit_tests/remoted/test_remote-config.c
+++ b/src/unit_tests/remoted/test_remote-config.c
@@ -178,7 +178,7 @@ static void test_w_remoted_parse_agents_invalid_value(void **state) {
     expect_string(__wrap__mwarn, formatted_msg,
                   "(9001): Ignored invalid value 'invalid_value' for 'allow_higher_versions'.");
     w_remoted_parse_agents(node, &logr);
-    assert_true(logr.allow_higher_versions);
+    assert_int_equal(logr.allow_higher_versions, REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT);
 
     os_free(node[0]->element);
     os_free(node[0]->content);
@@ -200,7 +200,7 @@ static void test_w_remoted_parse_agents_invalid_element(void **state) {
     expect_string(__wrap__mwarn, formatted_msg,
                   "(1230): Invalid element in the configuration: 'invalid_element'.");
     w_remoted_parse_agents(node, &logr);
-    assert_true(logr.allow_higher_versions);
+    assert_int_equal(logr.allow_higher_versions, REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT);
 
     os_free(node[0]->element);
     os_free(node[0]->content);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20366|

According to the description of the issue above, this PR aims to change the default value of `<allow_higher_versions>` to `no`. This way, the manager will reject connection attempts from agents with a version higher than them.

## Tests

We're testing a clean installation. No changes in _ossec.conf_.

### Before

#### Authd

```
GET https://localhost:55000/manager/configuration/auth/auth | jq ".data.affected_items[0].auth.agents"
```

```json
{
  "allow_higher_versions": "yes"
}
```

#### Remoted

```
GET https://localhost:55000/manager/configuration/request/remote | jq ".data.affected_items[0].remote[0].agents"
```

```json
{
  "allow_higher_versions": "yes"
}
```

### After

#### Authd

```
GET https://localhost:55000/manager/configuration/auth/auth | jq ".data.affected_items[0].auth.agents"
```

```json
{
  "allow_higher_versions": "no"
}
```

#### Remoted

```
GET https://localhost:55000/manager/configuration/request/remote | jq ".data.affected_items[0].remote[0].agents"
```

```json
{
  "allow_higher_versions": "no"
}
```