### PR TITLE
Content Manager - Add retry feature to `CtiApiDownloader`

### DIFF
--- a/src/shared_modules/content_manager/doc/components/CTI_API_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/CTI_API_DOWNLOADER.md
@@ -11,7 +11,7 @@ The output content files will be stored in any of the following output directori
 The download process can be summarized as follows:
 1. Get the last CTI API consumer offset. This is done by performing an HTTP GET query to CTI. This value will be used as the last possible offset to query.
 2. Set the range of offsets to be downloaded, starting from `currentOffset` (set in the context) and with a range-width of `1000`. So, for example, if the current offset is equal to `N`, the range will be from offset `N` to offset `N + 1000`. 
-3. Download the offsets range from **step 2** and update `currentOffset` with the last downloaded offset.
+3. Download the offsets range from **step 2** and update `currentOffset` with the last downloaded offset. The download will be retried indefinitely if the server responses with an 5xx HTTP error code.
 4. Dump the downloaded offsets into an output file. This file path will be generated as `<output-folder>/<currentOffset>-<contentFileName>`.
 5. Push the new file path (from **step 4**) to the context [data paths](../../src/components/updaterContext.hpp).
 6. If the last possible offset (from **step 1**) has been downloaded, the process finishes. Otherwise, the process continues with the **step 2**.

--- a/src/shared_modules/content_manager/doc/components/CTI_API_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/CTI_API_DOWNLOADER.md
@@ -11,7 +11,7 @@ The output content files will be stored in any of the following output directori
 The download process can be summarized as follows:
 1. Get the last CTI API consumer offset. This is done by performing an HTTP GET query to CTI. This value will be used as the last possible offset to query.
 2. Set the range of offsets to be downloaded, starting from `currentOffset` (set in the context) and with a range-width of `1000`. So, for example, if the current offset is equal to `N`, the range will be from offset `N` to offset `N + 1000`. 
-3. Download the offsets range from **step 2** and update `currentOffset` with the last downloaded offset. The download will be retried indefinitely if the server responses with an 5xx HTTP error code.
+3. Download the offsets range from **step 2** and update `currentOffset` with the last downloaded offset. The download will be retried indefinitely if the server responds with an 5xx HTTP error code.
 4. Dump the downloaded offsets into an output file. This file path will be generated as `<output-folder>/<currentOffset>-<contentFileName>`.
 5. Push the new file path (from **step 4**) to the context [data paths](../../src/components/updaterContext.hpp).
 6. If the last possible offset (from **step 1**) has been downloaded, the process finishes. Otherwise, the process continues with the **step 2**.

--- a/src/shared_modules/content_manager/src/components/CtiApiDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiApiDownloader.hpp
@@ -14,8 +14,42 @@
 #include "IURLRequest.hpp"
 #include "updaterContext.hpp"
 #include "utils/chainOfResponsability.hpp"
+#include <algorithm>
+#include <chrono>
 #include <iostream>
 #include <memory>
+#include <string>
+#include <thread>
+
+/**
+ * @brief Custom exception used to identify 5xx HTTP errors when downloading from the CTI server.
+ *
+ */
+class cti_server_5xx_error : public std::exception
+{
+    std::string m_what; ///< Exception message.
+
+public:
+    /**
+     * @brief Class constructor.
+     *
+     * @param what Exception message.
+     */
+    cti_server_5xx_error(std::string what)
+        : m_what(std::move(what))
+    {
+    }
+
+    /**
+     * @brief Returns the exception message.
+     *
+     * @return const char* Message.
+     */
+    const char* what()
+    {
+        return m_what.c_str();
+    }
+};
 
 /**
  * @class CtiApiDownloader
@@ -103,9 +137,6 @@ private:
         const auto onError {
             [this](const std::string& message, [[maybe_unused]] const long statusCode)
             {
-                // Set the status of the stage
-                m_context->data.at("stageStatus").push_back(R"({"stage": "CtiApiDownloader", "status": "fail"})"_json);
-
                 throw std::runtime_error("CtiApiDownloader - Could not get response from API because: " + message);
             }};
 
@@ -121,28 +152,53 @@ private:
      */
     void downloadContent(int toOffset, const std::string& fullFilePath) const
     {
+        // Define the parameters for the request.
+        const auto queryParameters = "/changes?from_offset=" + std::to_string(m_context->currentOffset) +
+                                     "&to_offset=" + std::to_string(toOffset);
+
+        // On download success routine.
         const auto onSuccess {[]([[maybe_unused]] const std::string& data)
                               {
                                   std::cout << "CtiApiDownloader - Request processed successfully.\n";
                               }};
 
+        // On download error routine.
         const auto onError {
-            [this](const std::string& message, [[maybe_unused]] const long statusCode)
+            [](const std::string& message, const long statusCode)
             {
-                // Set the status of the stage
-                m_context->data.at("stageStatus").push_back(R"({"stage": "CtiApiDownloader", "status": "fail"})"_json);
+                const std::string exceptionMessage {"Error " + std::to_string(statusCode) + " from server: " + message};
 
-                throw std::runtime_error("CtiApiDownloader - Could not get response from API because: " + message);
+                if (statusCode >= 500 && statusCode <= 599)
+                {
+                    throw cti_server_5xx_error {exceptionMessage};
+                }
+                throw std::runtime_error {exceptionMessage};
             }};
 
-        const auto fromOffset = m_context->currentOffset;
+        // Loop for retrying the downloads from the server until the download is successful or there is an HTTP error
+        // different from 5xx.
+        auto sleepTime {0};
+        auto retry {true};
+        while (retry)
+        {
+            try
+            {
+                m_urlRequest.get(HttpURL(m_url + queryParameters), onSuccess, onError, fullFilePath);
+                retry = false;
+            }
+            catch (const cti_server_5xx_error& e)
+            {
+                constexpr auto SLEEP_TIME_DELTA {3};
+                constexpr auto SLEEP_TIME_THRESHOLD {30};
 
-        // make the parameters for the request
-        const auto queryParameters =
-            "/changes?from_offset=" + std::to_string(fromOffset) + "&to_offset=" + std::to_string(toOffset);
-
-        // Make a get request to the API to get the content.
-        m_urlRequest.get(HttpURL(m_url + queryParameters), onSuccess, onError, fullFilePath);
+                // Sleep and, if necessary, increase sleep time.
+                std::this_thread::sleep_for(std::chrono::seconds(sleepTime));
+                if (sleepTime < SLEEP_TIME_THRESHOLD)
+                {
+                    sleepTime = std::clamp(sleepTime + SLEEP_TIME_DELTA, 0, SLEEP_TIME_THRESHOLD);
+                }
+            }
+        }
     }
 
     IURLRequest& m_urlRequest;                    ///< Interface to perform HTTP requests
@@ -176,7 +232,16 @@ public:
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
         m_context = context;
-        download();
+
+        try
+        {
+            download();
+        }
+        catch (const std::exception& e)
+        {
+            m_context->data.at("stageStatus").push_back(R"({"stage": "CtiApiDownloader", "status": "fail"})"_json);
+            throw;
+        }
 
         return AbstractHandler<std::shared_ptr<UpdaterContext>>::handleRequest(context);
     }

--- a/src/shared_modules/content_manager/src/components/CtiApiDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiApiDownloader.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 
 /**
  * @brief Custom exception used to identify server HTTP errors when downloading from the CTI server.
@@ -136,7 +137,7 @@ private:
                               }};
 
         const auto onError {
-            [this](const std::string& message, [[maybe_unused]] const long statusCode)
+            [](const std::string& message, [[maybe_unused]] const long statusCode)
             {
                 throw std::runtime_error("CtiApiDownloader - Could not get response from API because: " + message);
             }};
@@ -190,7 +191,7 @@ private:
                 m_urlRequest.get(HttpURL(m_url + queryParameters), onSuccess, onError, fullFilePath);
                 retry = false;
             }
-            catch (cti_server_error e)
+            catch (const cti_server_error& e)
             {
                 constexpr auto SLEEP_TIME_THRESHOLD {30};
 

--- a/src/shared_modules/content_manager/src/components/CtiApiDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiApiDownloader.hpp
@@ -23,10 +23,10 @@
 #include <thread>
 
 /**
- * @brief Custom exception used to identify 5xx HTTP errors when downloading from the CTI server.
+ * @brief Custom exception used to identify server HTTP errors when downloading from the CTI server.
  *
  */
-class cti_server_5xx_error : public std::exception
+class cti_server_error : public std::exception
 {
     std::string m_what; ///< Exception message.
 
@@ -36,7 +36,7 @@ public:
      *
      * @param what Exception message.
      */
-    cti_server_5xx_error(std::string what)
+    cti_server_error(std::string what)
         : m_what(std::move(what))
     {
     }
@@ -169,9 +169,10 @@ private:
             {
                 const std::string exceptionMessage {"Error " + std::to_string(statusCode) + " from server: " + message};
 
+                // If there is an error from the server, throw a different exception.
                 if (statusCode >= 500 && statusCode <= 599)
                 {
-                    throw cti_server_5xx_error {exceptionMessage};
+                    throw cti_server_error {exceptionMessage};
                 }
                 throw std::runtime_error {exceptionMessage};
             }};
@@ -189,7 +190,7 @@ private:
                 m_urlRequest.get(HttpURL(m_url + queryParameters), onSuccess, onError, fullFilePath);
                 retry = false;
             }
-            catch (cti_server_5xx_error e)
+            catch (cti_server_error e)
             {
                 constexpr auto SLEEP_TIME_THRESHOLD {30};
 

--- a/src/shared_modules/content_manager/src/components/CtiApiDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiApiDownloader.hpp
@@ -26,7 +26,7 @@
  * @brief Custom exception used to identify server HTTP errors when downloading from the CTI server.
  *
  */
-class cti_server_error : public std::exception
+class cti_server_error : public std::exception // NOLINT
 {
     std::string m_what; ///< Exception message.
 
@@ -36,7 +36,7 @@ public:
      *
      * @param what Exception message.
      */
-    cti_server_error(std::string what)
+    explicit cti_server_error(std::string what)
         : m_what(std::move(what))
     {
     }
@@ -46,7 +46,7 @@ public:
      *
      * @return const char* Message.
      */
-    const char* what()
+    const char* what() const noexcept override
     {
         return m_what.c_str();
     }

--- a/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.cpp
@@ -134,7 +134,7 @@ TEST_F(CtiApiDownloaderTest, TestHandleAnInvalidUrl)
 }
 
 /**
- * @brief Test the retry feature of the downloader when the server responses with 5xx errors.
+ * @brief Test the retry feature of the downloader when the server responds with 5xx errors.
  *
  */
 TEST_F(CtiApiDownloaderTest, DownloadServerErrorWithRetry)
@@ -158,7 +158,7 @@ TEST_F(CtiApiDownloaderTest, DownloadServerErrorWithRetry)
 }
 
 /**
- * @brief Test the downloader when the server responses with 4xx errors.
+ * @brief Test the downloader when the server responds with 4xx errors.
  *
  */
 TEST_F(CtiApiDownloaderTest, DownloadClientErrorNoRetry)
@@ -176,7 +176,7 @@ TEST_F(CtiApiDownloaderTest, DownloadClientErrorNoRetry)
 }
 
 /**
- * @brief Test the downloader when the server responses with both 4xx and 5xx errors.
+ * @brief Test the downloader when the server responds with both 4xx and 5xx errors.
  *
  */
 TEST_F(CtiApiDownloaderTest, DownloadClientAndServerErrorsRetryAndFail)

--- a/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.cpp
@@ -134,10 +134,10 @@ TEST_F(CtiApiDownloaderTest, TestHandleAnInvalidUrl)
 }
 
 /**
- * @brief
+ * @brief Test the retry feature of the downloader when the server responses with 5xx errors.
  *
  */
-TEST_F(CtiApiDownloaderTest, RetryDownloadWhen5xxError)
+TEST_F(CtiApiDownloaderTest, DownloadServerErrorWithRetry)
 {
     // Push two errors to the server.
     m_spFakeServer->pushError(500);
@@ -155,4 +155,22 @@ TEST_F(CtiApiDownloaderTest, RetryDownloadWhen5xxError)
 
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
     EXPECT_TRUE(std::filesystem::exists(contentPath));
+}
+
+/**
+ * @brief Test the downloader when the server responses with 4xx errors.
+ *
+ */
+TEST_F(CtiApiDownloaderTest, DownloadClientErrorNoRetry)
+{
+    // Push one error to the server.
+    m_spFakeServer->pushError(400);
+
+    // Set expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = FAIL_STATUS;
+
+    ASSERT_THROW(m_spCtiApiDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
 }

--- a/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.cpp
@@ -14,22 +14,14 @@
 #include "gtest/gtest.h"
 #include <filesystem>
 
+const auto OK_STATUS = R"([{"stage":"CtiApiDownloader","status":"ok"}])"_json;
+const auto FAIL_STATUS = R"([{"stage":"CtiApiDownloader","status":"fail"}])"_json;
+
 /**
  * @brief Tests handle a valid request with raw data.
  */
 TEST_F(CtiApiDownloaderTest, TestHandleValidRequestWithRawData)
 {
-    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
-
-    const auto expectedStageStatus = R"(
-        [
-            {
-                "stage": "CtiApiDownloader",
-                "status": "ok"
-            }
-        ]
-    )"_json;
-
     const auto& fileName {
         m_spUpdaterContext->spUpdaterBaseContext->configData.at("contentFileName").get<std::string>()};
     const auto contentPath {static_cast<std::string>(m_spUpdaterBaseContext->contentsFolder) + "/3-" + fileName};
@@ -41,7 +33,7 @@ TEST_F(CtiApiDownloaderTest, TestHandleValidRequestWithRawData)
 
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
-    EXPECT_EQ(stageStatus, expectedStageStatus);
+    EXPECT_EQ(stageStatus, OK_STATUS);
 
     // It's true because the compressionType is `raw`
     EXPECT_TRUE(std::filesystem::exists(contentPath));
@@ -58,17 +50,6 @@ TEST_F(CtiApiDownloaderTest, TestHandleValidRequestWithCompressedData)
     m_spUpdaterBaseContext->configData["url"] = "http://localhost:4444/xz/consumers";
     m_spUpdaterBaseContext->configData["compressionType"] = "xz";
 
-    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
-
-    const auto expectedStageStatus = R"(
-        [
-            {
-                "stage": "CtiApiDownloader",
-                "status": "ok"
-            }
-        ]
-    )"_json;
-
     const auto& fileName {
         m_spUpdaterContext->spUpdaterBaseContext->configData.at("contentFileName").get<std::string>()};
     const auto contentPath {static_cast<std::string>(m_spUpdaterBaseContext->contentsFolder) + "/3-" + fileName};
@@ -80,7 +61,7 @@ TEST_F(CtiApiDownloaderTest, TestHandleValidRequestWithCompressedData)
 
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
-    EXPECT_EQ(stageStatus, expectedStageStatus);
+    EXPECT_EQ(stageStatus, OK_STATUS);
 
     // It's false because the compressionType isn't `raw`
     EXPECT_FALSE(std::filesystem::exists(contentPath));
@@ -101,24 +82,13 @@ TEST_F(CtiApiDownloaderTest, TestHandleValidRequestWithCompressedDataAndInvalidO
     m_spUpdaterBaseContext->downloadsFolder = m_spUpdaterBaseContext->outputFolder / DOWNLOAD_FOLDER;
     m_spUpdaterBaseContext->contentsFolder = m_spUpdaterBaseContext->outputFolder / CONTENTS_FOLDER;
 
-    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
-
-    const auto expectedStageStatus = R"(
-        [
-            {
-                "stage": "CtiApiDownloader",
-                "status": "fail"
-            }
-        ]
-    )"_json;
-
     EXPECT_THROW(m_spCtiApiDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
 
     EXPECT_TRUE(m_spUpdaterContext->data.at("paths").empty());
 
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
-    EXPECT_EQ(stageStatus, expectedStageStatus);
+    EXPECT_EQ(stageStatus, FAIL_STATUS);
 }
 
 /**
@@ -133,24 +103,13 @@ TEST_F(CtiApiDownloaderTest, TestHandleAnEmptyUrl)
     m_spUpdaterBaseContext->downloadsFolder = m_spUpdaterBaseContext->outputFolder / DOWNLOAD_FOLDER;
     m_spUpdaterBaseContext->contentsFolder = m_spUpdaterBaseContext->outputFolder / CONTENTS_FOLDER;
 
-    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
-
-    const auto expectedStageStatus = R"(
-        [
-            {
-                "stage": "CtiApiDownloader",
-                "status": "fail"
-            }
-        ]
-    )"_json;
-
     EXPECT_THROW(m_spCtiApiDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
 
     EXPECT_TRUE(m_spUpdaterContext->data.at("paths").empty());
 
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
-    EXPECT_EQ(stageStatus, expectedStageStatus);
+    EXPECT_EQ(stageStatus, FAIL_STATUS);
 }
 
 /**
@@ -165,22 +124,35 @@ TEST_F(CtiApiDownloaderTest, TestHandleAnInvalidUrl)
     m_spUpdaterBaseContext->downloadsFolder = m_spUpdaterBaseContext->outputFolder / DOWNLOAD_FOLDER;
     m_spUpdaterBaseContext->contentsFolder = m_spUpdaterBaseContext->outputFolder / CONTENTS_FOLDER;
 
-    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
-
-    const auto expectedStageStatus = R"(
-        [
-            {
-                "stage": "CtiApiDownloader",
-                "status": "fail"
-            }
-        ]
-    )"_json;
-
     EXPECT_THROW(m_spCtiApiDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
 
     EXPECT_TRUE(m_spUpdaterContext->data.at("paths").empty());
 
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
-    EXPECT_EQ(stageStatus, expectedStageStatus);
+    EXPECT_EQ(stageStatus, FAIL_STATUS);
+}
+
+/**
+ * @brief
+ *
+ */
+TEST_F(CtiApiDownloaderTest, RetryDownloadWhen5xxError)
+{
+    // Push two errors to the server.
+    m_spFakeServer->pushError(500);
+    m_spFakeServer->pushError(599);
+
+    const auto& filename {m_spUpdaterBaseContext->configData.at("contentFileName").get<const std::string>()};
+    const auto contentPath {m_spUpdaterBaseContext->contentsFolder.string() + "/3-" + filename};
+
+    // Set expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"].push_back(contentPath);
+    expectedData["stageStatus"] = OK_STATUS;
+
+    ASSERT_NO_THROW(m_spCtiApiDownloader->handleRequest(m_spUpdaterContext));
+
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+    EXPECT_TRUE(std::filesystem::exists(contentPath));
 }

--- a/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.hpp
@@ -86,6 +86,8 @@ protected:
         m_spUpdaterContext.reset();
         // Reset UpdaterBaseContext
         m_spUpdaterBaseContext.reset();
+        // Clear fake server error codes.
+        m_spFakeServer->clearErrorsQueue();
     }
 
     /**

--- a/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.hpp
@@ -63,6 +63,7 @@ protected:
         )"_json;
         // Create a updater context
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
+        m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
         m_spUpdaterContext->currentOffset = 0;
         // Create folders
         std::filesystem::create_directory(m_spUpdaterBaseContext->outputFolder);

--- a/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
+++ b/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
@@ -192,6 +192,13 @@ public:
                         })"_json;
                          res.set_content(response.dump(), "text/plain");
                      });
+        m_server.Get("/errors/5xx",
+                     [](const httplib::Request& req, httplib::Response& res)
+                     {
+                         const auto response {"Internal server error."};
+                         res.status = 500;
+                         res.set_content(response, "text/plain");
+                     });
         m_server.set_keep_alive_max_count(1);
         m_server.listen(m_host.c_str(), m_port);
     }

--- a/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
+++ b/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
@@ -97,9 +97,9 @@ public:
                      [](const httplib::Request& req, httplib::Response& res)
                      {
                          const auto response = R"(
-                        {
-                            "key": "value"
-                        })"_json;
+                         {
+                             "key": "value"
+                         })"_json;
                          res.set_content(response.dump(), "text/plain");
                      });
         m_server.Get("/xz",

--- a/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
+++ b/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
@@ -14,6 +14,7 @@
 
 #include "external/cpp-httplib/httplib.h"
 #include "external/nlohmann/json.hpp"
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <queue>
@@ -82,6 +83,16 @@ public:
     void pushError(const unsigned long& errorCode)
     {
         m_errorsQueue.push(errorCode);
+    }
+
+    /**
+     * @brief Clears the errors queue.
+     *
+     */
+    void clearErrorsQueue()
+    {
+        std::queue<unsigned long> emptyQueue;
+        std::swap(m_errorsQueue, emptyQueue);
     }
 
     /**

--- a/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
+++ b/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
@@ -16,6 +16,7 @@
 #include "external/nlohmann/json.hpp"
 #include <filesystem>
 #include <fstream>
+#include <queue>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -31,6 +32,19 @@ private:
     std::thread m_thread;
     std::string m_host;
     int m_port;
+    std::queue<unsigned long> m_errorsQueue; ///< Errors queue used to return error codes for some queries.
+
+    /**
+     * @brief Pops and returns the last error code from the error queue.
+     *
+     * @return unsigned long Error code.
+     */
+    unsigned long popError()
+    {
+        const auto errorCode {m_errorsQueue.front()};
+        m_errorsQueue.pop();
+        return errorCode;
+    }
 
 public:
     /**
@@ -61,6 +75,16 @@ public:
     }
 
     /**
+     * @brief Appends an error to the error queue.
+     *
+     * @param errorCode Error code to push.
+     */
+    void pushError(const unsigned long& errorCode)
+    {
+        m_errorsQueue.push(errorCode);
+    }
+
+    /**
      * @brief Starts the server and listens for new connections.
      *
      * Setups a fake endpoint, configures the server and starts listening
@@ -73,9 +97,9 @@ public:
                      [](const httplib::Request& req, httplib::Response& res)
                      {
                          const auto response = R"(
-                         {
-                             "key": "value"
-                         })"_json;
+                        {
+                            "key": "value"
+                        })"_json;
                          res.set_content(response.dump(), "text/plain");
                      });
         m_server.Get("/xz",
@@ -139,65 +163,67 @@ public:
                          res.set_content(response.dump(), "text/plain");
                      });
         m_server.Get("/raw/consumers/changes",
-                     [](const httplib::Request& req, httplib::Response& res)
+                     [this](const httplib::Request& req, httplib::Response& res)
                      {
-                         const auto response = R"(
-                        {
-                            "data":
-                            [
-                                {
-                                    "offset": 1,
-                                    "type": "create",
-                                    "version": 1,
-                                    "context": "vulnerabilities",
-                                    "resource": "CVE-2020-0546",
-                                    "payload":
+                         if (m_errorsQueue.empty())
+                         {
+                             const auto response = R"(
+                            {
+                                "data":
+                                [
                                     {
-                                        "description": "not defined",
-                                        "identifier": "CVE-2020-0546",
-                                        "references":
+                                        "offset": 1,
+                                        "type": "create",
+                                        "version": 1,
+                                        "context": "vulnerabilities",
+                                        "resource": "CVE-2020-0546",
+                                        "payload":
+                                        {
+                                            "description": "not defined",
+                                            "identifier": "CVE-2020-0546",
+                                            "references":
+                                            [
+                                                {
+                                                    "url": "https://security.archlinux.org/CVE-2020-0546"
+                                                }
+                                            ],
+                                            "state": "PUBLISHED"
+                                        }
+                                    },
+                                    {
+                                        "offset": 2,
+                                        "type": "update",
+                                        "version": 2,
+                                        "context": "vulnerabilities",
+                                        "resource": "CVE-2020-0546",
+                                        "operations":
+                                        []
+                                    },
+                                    {
+                                        "offset": 3,
+                                        "type": "update",
+                                        "version": 2,
+                                        "context": "vulnerabilities",
+                                        "resource": "CVE-2020-0546",
+                                        "operations":
                                         [
                                             {
-                                                "url": "https://security.archlinux.org/CVE-2020-0546"
+                                                "op": "replace",
+                                                "path": "/description",
+                                                "value": "lalala"
                                             }
-                                        ],
-                                        "state": "PUBLISHED"
+                                        ]
                                     }
-                                },
-                                {
-                                    "offset": 2,
-                                    "type": "update",
-                                    "version": 2,
-                                    "context": "vulnerabilities",
-                                    "resource": "CVE-2020-0546",
-                                    "operations":
-                                    []
-                                },
-                                {
-                                    "offset": 3,
-                                    "type": "update",
-                                    "version": 2,
-                                    "context": "vulnerabilities",
-                                    "resource": "CVE-2020-0546",
-                                    "operations":
-                                    [
-                                        {
-                                            "op": "replace",
-                                            "path": "/description",
-                                            "value": "lalala"
-                                        }
-                                    ]
-                                }
-                            ]
-                        })"_json;
-                         res.set_content(response.dump(), "text/plain");
-                     });
-        m_server.Get("/errors/5xx",
-                     [](const httplib::Request& req, httplib::Response& res)
-                     {
-                         const auto response {"Internal server error."};
-                         res.status = 500;
-                         res.set_content(response, "text/plain");
+                                ]
+                            })"_json;
+                             res.set_content(response.dump(), "text/plain");
+                         }
+                         else
+                         {
+                             constexpr auto RESPONSE {"Something bad happened."};
+                             res.status = popError();
+                             res.set_content(RESPONSE, "text/plain");
+                         }
                      });
         m_server.set_keep_alive_max_count(1);
         m_server.listen(m_host.c_str(), m_port);


### PR DESCRIPTION
|Related issue|
|---|
|#20362 |

## Description

This PR adds a retry feature to the `CtiApiDownloader` stage of the Content Updater orchestration.

## Results

### Test tool

CTI server was recreated using a script that fails always except for every 5 queries.

Usage: `python script.py <PORT_NUMBER>`

<details><summary>Script</summary>

```python
from http.server import BaseHTTPRequestHandler, HTTPServer
import sys
import json
import os

# Check arguments presence.
if len(sys.argv) != 2:
    print("Usage:", sys.argv[0], "<port>")
    exit(1)

# Check port argument.
if not sys.argv[1].isnumeric() or int(sys.argv[1]) > 65535:
    print(sys.argv[1], "is not a valid port number.")
    exit(1)

PORT=sys.argv[1]
HTTP_SUCCESS_CODE=200
HTTP_ERROR_CODE=500

current_attempt=1

class handler(BaseHTTPRequestHandler):

    def do_GET(self):
        global current_attempt
        code = 0
        content_type = ''
        response = ''
        endpoint_hit = True

        if self.path == '/':
            response = bytes(json.dumps(
            {
                'data': {
                    'last_offset': 3
                }
            }), encoding='utf8')
            code = HTTP_SUCCESS_CODE
            content_type = 'text/plain'
        elif '/changes' in self.path:
            if current_attempt % 5 == 0:
                code = HTTP_SUCCESS_CODE
                content_type = 'text/plain'
                response = bytes(json.dumps(
                {
                    'data': [
                        {
                            "offset": 1,
                            "type": "create",
                            "version": 1,
                            "context": "vulnerabilities",
                            "resource": "CVE-2020-0546",
                            "payload":
                            {
                                "description": "not defined",
                                "identifier": "CVE-2020-0546",
                                "references":
                                [
                                    {
                                        "url": "https://security.archlinux.org/CVE-2020-0546"
                                    }
                                ],
                                "state": "PUBLISHED"
                            }
                        },
                        {
                            "offset": 2,
                            "type": "update",
                            "version": 2,
                            "context": "vulnerabilities",
                            "resource": "CVE-2020-0546",
                            "operations":
                            []
                        }
                    ]
                }), encoding='utf8')
            else:
                current_attempt = current_attempt + 1
                code = HTTP_ERROR_CODE
                content_type = 'text/plain'
                response = bytes("Internal server error", encoding='utf8')
        else:
            endpoint_hit = False

        if endpoint_hit:
            self.send_response(code)
            self.send_header('Content-type', content_type)
            self.end_headers()
            self.wfile.write(response)

with HTTPServer(('', int(PORT)), handler) as server:
    server.serve_forever()
```
</details>

<details><summary>Config</summary>

```json
{
            "topicName": "test",
            "interval": 10,
            "ondemand": true,
            "configData":
            {
                "contentSource": "cti-api",
                "compressionType": "raw",
                "versionedContent": "false",
                "deleteDownloadedContent": true,
                "url": "127.0.0.1:8888/",
                "outputFolder": "/tmp/testProvider",
                "dataFormat": "json",
                "contentFileName": "example.json",
                "databasePath": "/tmp/content_updater/rocksdb",
                "offset": 0
            }
}
```
</details>

- Normal execution of the mock server (download gets done in the fifth try)
```bash
# ./content_manager_test_tool | ts '[%M:%S]'
[53:36] ActionOrchestrator - Starting process
[53:36] API offset to be used: 0
[53:36] Output folders created.
[53:36] FactoryContentUpdater - Starting process
[53:36] Creating 'cti-api' downloader
[53:36] Creating 'raw' content decompressor
[53:36] Version updater not needed
[53:36] Downloaded content cleaner created
[53:36] FactoryContentUpdater - Finishing process
[53:36] ActionOrchestrator - Finishing process
[53:36] ActionOrchestrator - Running process
[53:36] CtiApiDownloader - Starting
[53:36] CtiApiDownloader - Request processed successfully.
[53:36] Error 500 from server: HTTP response code said error
[53:37] Error 500 from server: HTTP response code said error
[53:39] Error 500 from server: HTTP response code said error
[53:41] changing interval
[53:43] Error 500 from server: HTTP response code said error
[53:51] CtiApiDownloader - Request processed successfully.
[53:51] CtiApiDownloader - Finishing
[53:51] SkipStep - Executing
[53:51] PubSubPublisher - Data published
[53:51] SkipStep - Executing
[53:51] All files in the folder have been deleted.
[54:01] Action: Initiating scheduling action for test
[54:01] ActionOrchestrator - Running process
[54:01] CtiApiDownloader - Starting
[54:01] CtiApiDownloader - Request processed successfully.
[54:01] CtiApiDownloader - Request processed successfully.
[54:01] CtiApiDownloader - Finishing
[54:01] SkipStep - Executing
[54:01] PubSubPublisher - Data published
[54:01] SkipStep - Executing
[54:01] All files in the folder have been deleted.
```

- Execution with no successful responses (no download is done, retries keep being made)
```bash
# ./content_manager_test_tool | ts '[%M:%S]'
[56:42] ActionOrchestrator - Starting process
[56:42] API offset to be used: 0
[56:42] Output folders created.
[56:42] FactoryContentUpdater - Starting process
[56:42] Creating 'cti-api' downloader
[56:42] Creating 'raw' content decompressor
[56:42] Version updater not needed
[56:42] Downloaded content cleaner created
[56:42] FactoryContentUpdater - Finishing process
[56:42] ActionOrchestrator - Finishing process
[56:42] ActionOrchestrator - Running process
[56:42] CtiApiDownloader - Starting
[56:42] CtiApiDownloader - Request processed successfully.
[56:42] Error 500 from server: HTTP response code said error
[56:43] Error 500 from server: HTTP response code said error
[56:45] Error 500 from server: HTTP response code said error
[56:47] changing interval
[56:49] Error 500 from server: HTTP response code said error
[56:57] Error 500 from server: HTTP response code said error
[57:13] Error 500 from server: HTTP response code said error
[57:43] Error 500 from server: HTTP response code said error
[58:13] Error 500 from server: HTTP response code said error
```

## Coverage

Coverage at 100%.

![image](https://github.com/wazuh/wazuh/assets/42682247/80de484b-ed16-4829-bdb7-e49596bd188d)
