### PR TITLE
Fix Vulnerability Detection for Windows 11 21H2

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -23207,6 +23207,32 @@ void test_wm_vuldet_get_software_success() {
     assert_int_equal(result, OS_SUCCESS);
 }
 
+// Test wm_vuln_check_msu_type with WS2022 and w10/w11 with upper/lower version pattern
+void test_wm_vuln_check_msu_type_win10_win11_upper_lower(void **state) {
+    vu_msu_vul_entry *msu = NULL;
+    os_calloc(1, sizeof(vu_msu_vul_entry), msu);
+
+    char *msu_products_windows[] = {
+        "Windows Server 2022",
+        "Windows 10 Version 1903",
+        "Windows 11 version 21H2",
+        "Windows 11 Version 23H2"
+    };
+
+    char *msu_check_types_windows[] = {
+        "1", "1903", "21h2", "23h2"
+    };
+
+    for (int i = 0; i < array_size(msu_products_windows); i++) {
+        msu->product = msu_products_windows[i];
+        wm_vuln_check_msu_type(msu, NULL);
+        assert_string_equal(msu->check_type, msu_check_types_windows[i]);
+        os_free(msu->check_type);
+    }
+
+    os_free(msu);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -23837,6 +23863,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_insert_deps, setup_parsed_oval_for_deps, teardown_parsed_oval_for_deps),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_insert_deps_prepare_error, setup_parsed_oval_for_deps, teardown_parsed_oval_for_deps),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_insert_deps_step_error, setup_parsed_oval_for_deps, teardown_parsed_oval_for_deps),
+        // Tests wm_vuln_check_msu_type
+        cmocka_unit_test(test_wm_vuln_check_msu_type_win10_win11_upper_lower),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -9111,6 +9111,7 @@ void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
     const char *win10_pattern = "Windows 10";
     const char *win11_pattern = "Windows 11";
     const char *version_pattern = " Version ";
+    const char *version_pattern_lower = " version ";
 
     size_t w10_patter_len = strlen(win10_pattern);
     size_t w11_patter_len = strlen(win11_pattern);
@@ -9126,7 +9127,9 @@ void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
         return;
     }
 
-    if (!strncmp(msu->product + w11_patter_len, version_pattern, ver_patter_len)) {
+    // In MSU, the version pattern for Win11 can be upper or lower case
+    if (!strncmp(msu->product + w11_patter_len, version_pattern, ver_patter_len) ||
+        !strncmp(msu->product + w11_patter_len, version_pattern_lower, ver_patter_len)) {
         msu->check_type = w_tolower_str(strtok(msu->product + w11_patter_len + ver_patter_len, " "));
         return;
     }


### PR DESCRIPTION
|Related issue|
|---|
|#20374|

## Description

With this PR, we added the condition to obtain the MSU check type of a Windows 11 21H2 product, where exclusively for this case the version pattern changes, which meant that the vulnerability could not be related to its corresponding hotfix, and this meant that its vulnerabilities were not reported.

With the current change, the strings of both the vulnerabilities we previously detected in Windows 11 (22H2, 23H2, etc) and this particular case (21H2) are now detected.
- Product with `version` in upper case: *`Windows 11 Version 22H2`* or *`Windows 11 Version 23H2`*
- Product with lower case `version`: *`Windows 11 version 21H2`*

## Logs/Alerts example
Below are the logs of a vulnerability affecting Windows 11 agent 21H2:
- Without the fix:
```
wazuh-modulesd:vulnerability-detector[470] wm_vuln_detector_nvd.c:3792 at wm_vuldet_check_hotfix(): DEBUG: (5454): We have not found a hotfix that solves 'CVE-2023-44487' for agent '017' in the Microsoft feed, so it is not possible to know it is vulnerable.
```
- With the fix:
```
wazuh-modulesd:vulnerability-detector[470] wm_vuln_detector_nvd.c:2414 at wm_vuldet_process_agent_nvd_vulnerabilities(): DEBUG: (5467): Agent '017' is vulnerable to 'CVE-2023-44487'. Condition: 'KB5031358 patch is not installed'
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
- [x] Added unit tests (for new features)

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
