### PR TITLE
Modify server to allow responses to the client from modules

### DIFF
--- a/src/engine/source/api/include/api/api.hpp
+++ b/src/engine/source/api/include/api/api.hpp
@@ -52,14 +52,16 @@ public:
     }
 
     /**
-     * @brief Process a request
+     * @brief Processes a request and invokes a callback function with the response.
      *
-     * Process a request as a string and return the response as a string, this
-     * method is thread-safe and verify the request before calling the handler.
-     * @param message Request message
-     * @return std::string Response message
+     * This method takes a JSON-formatted request message, processes it, and generates
+     * a response. The response is then passed to the provided callback function.
+     *
+     * @param message The JSON-formatted request message.
+     * @param callbackFn A callback function that will be invoked with the generated response.
+     *
      */
-    std::string processRequest(const std::string& message)
+    void processRequest(const std::string& message, std::function<void(const std::string&)> callbackFn)
     {
         wpResponse wresponse {};
         json::Json jrequest {};
@@ -71,7 +73,8 @@ public:
         catch (const std::exception& e)
         {
             wresponse = base::utils::wazuhProtocol::WazuhResponse::invalidJsonRequest();
-            return wresponse.toString();
+            callbackFn(wresponse.toString());
+            return;
         }
 
         try
@@ -91,7 +94,8 @@ public:
             LOG_DEBUG("Exception in Api::processRequest: %s", e.what());
             wresponse = base::utils::wazuhProtocol::WazuhResponse::unknownError();
         }
-        return wresponse.toString();
+
+        callbackFn(wresponse.toString());
     }
 
     /**

--- a/src/engine/source/cmds/src/start.cpp
+++ b/src/engine/source/cmds/src/start.cpp
@@ -415,7 +415,7 @@ void runStart(ConfHandler confManager)
             // API Endpoint
             auto apiMetricScope = metrics->getMetricsScope("endpointAPI");
             auto apiMetricScopeDelta = metrics->getMetricsScope("endpointAPIRate", true);
-            auto apiHandler = std::bind(&api::Api::processRequest, api, std::placeholders::_1);
+            auto apiHandler = std::bind(&api::Api::processRequest, api, std::placeholders::_1, std::placeholders::_2);
             auto apiClientFactory = std::make_shared<ph::WStreamFactory>(apiHandler); // API endpoint
             apiClientFactory->setErrorResponse(base::utils::wazuhProtocol::WazuhResponse::unknownError().toString());
             apiClientFactory->setBusyResponse(base::utils::wazuhProtocol::WazuhResponse::busyServer().toString());

--- a/src/engine/source/server/include/server/endpoints/unixStream.hpp
+++ b/src/engine/source/server/include/server/endpoints/unixStream.hpp
@@ -67,7 +67,7 @@ private:
      * @param response Shared memory where the callback executed by the AsyncHandle will write the response
      */
     void processMessages(std::weak_ptr<uvw::PipeHandle> clientRef,
-                         std::vector<std::weak_ptr<uvw::AsyncHandle>> asyncs,
+                         std::shared_ptr<std::vector<std::weak_ptr<uvw::AsyncHandle>>> asyncs,
                          std::shared_ptr<ProtocolHandler> protocolHandler,
                          std::vector<std::string>&& requests);
 
@@ -82,7 +82,7 @@ private:
      * @param message Message to be processed
      */
     void createAndEnqueueTask(std::weak_ptr<uvw::PipeHandle> wClient,
-                              std::vector<std::weak_ptr<uvw::AsyncHandle>> asyncs,
+                              std::shared_ptr<std::vector<std::weak_ptr<uvw::AsyncHandle>>> asyncs,
                               std::shared_ptr<ProtocolHandler> protocolHandler,
                               std::string&& request);
 
@@ -95,7 +95,7 @@ private:
      */
     void configureCloseClient(std::shared_ptr<uvw::PipeHandle> client,
                               std::shared_ptr<uvw::TimerHandle> timer,
-                              std::vector<std::weak_ptr<uvw::AsyncHandle>> async);
+                              std::shared_ptr<std::vector<std::weak_ptr<uvw::AsyncHandle>>> async);
 
     /**
      * @brief Create a Timer resource, this timer will be used to close the client connection if it doesn't send any
@@ -107,7 +107,7 @@ private:
      * @return Timer resource
      */
     std::shared_ptr<uvw::TimerHandle> createTimer(std::weak_ptr<uvw::PipeHandle> wClient,
-                                                  std::vector<std::weak_ptr<uvw::AsyncHandle>> asyncs);
+                                                  std::shared_ptr<std::vector<std::weak_ptr<uvw::AsyncHandle>>> asyncs);
 
 public:
     /**

--- a/src/engine/source/server/include/server/endpoints/unixStream.hpp
+++ b/src/engine/source/server/include/server/endpoints/unixStream.hpp
@@ -79,7 +79,7 @@ private:
      * @param client Handle to the client that sent the message
      * @param asyncs Array of AsyncHandler instance that will be used to send the event using send()
      * @param protocolHandler Protocol handler to process the message
-     * @param message Message to be processed
+     * @param request Message to be processed
      */
     void createAndEnqueueTask(std::weak_ptr<uvw::PipeHandle> wClient,
                               std::shared_ptr<std::vector<std::weak_ptr<uvw::AsyncHandle>>> asyncs,

--- a/src/engine/source/server/include/server/protocolHandler.hpp
+++ b/src/engine/source/server/include/server/protocolHandler.hpp
@@ -68,6 +68,18 @@ public:
     virtual std::tuple<std::unique_ptr<char[]>, std::size_t> streamToSend(std::shared_ptr<std::string> message) = 0;
 
     /**
+     * @brief Generate the data to send to the client
+     *
+     * Generate the data to send to the client, it is used to generate the data to send to the client,
+     * The message is the response of processing the message received from the client.
+     * @param message Message to send to the client
+     * @return Data to send to the client, and the size of the data
+     *
+     * @note this method not throw any exception.
+     */
+    virtual std::tuple<std::unique_ptr<char[]>, std::size_t> streamToSend(const std::string& message) = 0;
+
+    /**
      * @brief Get busy response to send to the client (if the server is busy)
      *
      * Get busy response to send to the client (if the server is busy), it is used to generate the data to send to the

--- a/src/engine/source/server/include/server/protocolHandler.hpp
+++ b/src/engine/source/server/include/server/protocolHandler.hpp
@@ -1,6 +1,7 @@
 #ifndef _SERVER_PROTOCOL_HANDLER_BASE_HPP
 #define _SERVER_PROTOCOL_HANDLER_BASE_HPP
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -46,12 +47,12 @@ public:
      * Process the message received from the server, it is used to process the message received from the server and
      * generate the data to send to the client.
      * @param message Message received from the server
-     * @return The response of processing the message to send to the client
+     * @param callbackFn A callback function that will be invoked with the generated response.
      *
      * @note If the method throws an exception, the connection should be closed witout sending any data to the client.
      * @note The message is the response of processing the message received from the client.
      */
-    virtual std::string onMessage(const std::string& message) = 0;
+    virtual void onMessage(const std::string& message, std::function<void(const std::string&)> callbackFn) = 0;
 
 
     /**

--- a/src/engine/source/server/include/server/protocolHandlers/wStream.hpp
+++ b/src/engine/source/server/include/server/protocolHandlers/wStream.hpp
@@ -39,7 +39,7 @@ public:
     /**
      * @brief Construct a new WStream object
      *
-     * @param m_onMessageCallback Callback to be called when a message is received
+     * @param onMessageCallback Callback to be called when a message is received
      * @param maxPayloadSize Maximum payload size in bytes (default 10 MB)
      */
     WStream(std::function<void(const std::string&, std::function<void(const std::string&)>)> onMessageCallback, int maxPayloadSize = 1024 * 1024 * 10)
@@ -97,6 +97,11 @@ public:
      * @copydoc ProtocolHandler::streamToSend
      */
     std::tuple<std::unique_ptr<char[]>, std::size_t> streamToSend(std::shared_ptr<std::string> message) override;
+
+    /**
+     * @copydoc ProtocolHandler::streamToSend
+     */
+    std::tuple<std::unique_ptr<char[]>, std::size_t> streamToSend(const std::string& message) override;
 
     /**
      * @copydoc ProtocolHandler::getBusyResponse

--- a/src/engine/source/server/src/endpoints/unixStream.cpp
+++ b/src/engine/source/server/src/endpoints/unixStream.cpp
@@ -214,9 +214,8 @@ void UnixStream::processMessages(std::weak_ptr<uvw::PipeHandle> wClient,
         if (0 == m_taskQueueSize)
         {
             auto callbackFn =
-                [wClient, address = m_address, protocolHandler, metric = m_metric](const std::string& res) -> void
+                [wClient, address = m_address, protocolHandler, metric = m_metric](const std::string& response) -> void
             {
-                auto response = std::make_shared<std::string>(res);
                 auto responseTimer = std::make_shared<base::chrono::Timer>();
 
                 // Check if client is closed

--- a/src/engine/source/server/src/protocolHandlers/wStream.cpp
+++ b/src/engine/source/server/src/protocolHandlers/wStream.cpp
@@ -57,6 +57,15 @@ std::tuple<std::unique_ptr<char[]>, std::size_t> WStream::streamToSend(std::shar
     return {std::move(buffer), size + 4};
 }
 
+std::tuple<std::unique_ptr<char[]>, std::size_t> WStream::streamToSend(const std::string& message)
+{
+    auto size = message.size();
+    auto buffer = std::make_unique<char[]>(size + 4);
+    std::memcpy(buffer.get(), &size, 4);
+    std::memcpy(buffer.get() + 4, message.data(), size);
+    return {std::move(buffer), size + 4};
+}
+
 std::tuple<std::unique_ptr<char[]>, std::size_t> WStream::getBusyResponse()
 {
     return streamToSend(m_busyResponse);

--- a/src/engine/test/source/server/unixStream_test.cpp
+++ b/src/engine/test/source/server/unixStream_test.cpp
@@ -89,7 +89,7 @@ public:
     }
 
     // Loopback
-    std::string onMessage(const std::string& message) override
+    void onMessage(const std::string& message, std::function<void(const std::string&)> callback) override
     {
         if (*enableBlockQueueWorkers)
         {
@@ -106,7 +106,7 @@ public:
         }
         (*m_processedMessages)++;
 
-        return message;
+        callback(message);
     }
 
     // Do nothing
@@ -288,6 +288,7 @@ TEST_F(UnixStreamTest, MultipleEchoMessages)
     for (const auto& message : messages)
     {
         auto res = send(clientSockfd, message.c_str(), message.size(), 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
         ASSERT_EQ(res, message.size());
         totalSize += message.size();
     }
@@ -365,6 +366,7 @@ TEST_F(UnixStreamTest, MultipleConnections)
     for (int i = 0; i < numClients; ++i)
     {
         auto res = send(clientSockets[i], messages[i].c_str(), messages[i].size(), 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
         ASSERT_EQ(res, messages[i].size());
     }
 
@@ -442,6 +444,7 @@ TEST_F(UnixStreamTest, QueueWorker_SameClient)
         message += std::to_string(i);
         message += "<END>";
         auto res = send(clientSockfd, message.c_str(), message.size(), 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
         ASSERT_EQ(res, message.size());
         expectedResponse += message;
     }
@@ -607,6 +610,7 @@ TEST_F(UnixStreamTest, taskQueueSizeTestAndOverflow)
         message += std::to_string(i);
         message += "<END>";
         auto res = send(clientSockfd, message.c_str(), message.size(), 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
         ASSERT_EQ(res, message.size());
         sendedMessages++;
         expectedProcessedMessages += message;
@@ -617,6 +621,7 @@ TEST_F(UnixStreamTest, taskQueueSizeTestAndOverflow)
         int clientSockfd2 = createUnixSocketClient(m_socketPath);
         std::string message = "Hello, busy World! message<END>";
         auto res = send(clientSockfd2, message.c_str(), message.size(), 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
         ASSERT_EQ(res, message.size());
         sendedMessages++;
         busyMessage++; // This message is sended but not processed
@@ -662,6 +667,7 @@ TEST_F(UnixStreamTest, taskQueueSizeTestAndOverflow)
             message += std::to_string(i);
             message += "<END>";
             auto res = send(clientSockfd, message.c_str(), message.size(), 0);
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
             ASSERT_EQ(res, message.size());
             sendedMessages++;
             busyMessage++; // This message is sended but not processed
@@ -713,35 +719,6 @@ TEST_F(UnixStreamTest, taskQueueSizeTestAndOverflow)
 
     // Check the number of messages processed
     ASSERT_EQ(*(m_factory->m_processedMessages), sendedMessages - busyMessage);
-
-    // Read the response from the client
-    std::string response {};
-    response.reserve(expectedProcessedMessages.size());
-    attempts = 0;
-
-    while (response.length() < expectedProcessedMessages.size())
-    {
-        ASSERT_LT(attempts++, maxAttempts) << "Messages not received from client";
-        char buffer[1024] = {};
-        // Non-blocking read
-        ssize_t received = recv(clientSockfd, buffer, sizeof(buffer), MSG_DONTWAIT);
-        if (received == 0)
-        {
-            // Connection closed
-            FAIL() << "Connection closed";
-        }
-        if (received == -1)
-        {
-            // No data available
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-            continue;
-        }
-        ASSERT_GT(received, 0);
-        response.append(buffer, received);
-    };
-
-    // Check the messages received by the client (the order is not guaranteed)
-    ASSERT_EQ(expectedProcessedMessages.length(), response.length()) << "Response not expected";
 
     server.close();
     stopHandler->send();


### PR DESCRIPTION
|Related issue|
|---|
|#20358|

## Description

The current implementation of the Wazuh engine processes API requests synchronously, leading to inefficiencies, particularly when handling test events. The API thread waits for the router thread to process and store messages, causing unnecessary delays. This PR aims to improve the responsiveness and efficiency of the server by enabling asynchronous responses from modules.
