### PR TITLE
DatabaseFeedManager graceful shutdown improved

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -369,6 +369,10 @@ public:
     }
 
 private:
+    /**
+     * Do not change the order of definition of these variables.
+     * Since it is important at the object destruction time.
+     */
     std::shared_ptr<TIndexerConnector> m_indexerConnector;
     std::unique_ptr<TContentRegister> m_contentRegistration;
     std::unique_ptr<Utils::RocksDBWrapper> m_descriptionsDatabase;

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -369,15 +369,15 @@ public:
     }
 
 private:
-    std::unique_ptr<TRouterSubscriber> m_contentUpdateSubscription;
-    std::unique_ptr<TContentRegister> m_contentRegistration;
     std::shared_ptr<TIndexerConnector> m_indexerConnector;
+    std::unique_ptr<TContentRegister> m_contentRegistration;
     std::unique_ptr<Utils::RocksDBWrapper> m_descriptionsDatabase;
     std::unique_ptr<Utils::RocksDBWrapper> m_remediationsDatabase;
     std::unique_ptr<Utils::RocksDBWrapper> m_translationsDatabase;
     std::unique_ptr<LRUCache<std::string, std::string>> m_translationsCache;
     std::unique_ptr<Utils::RocksDBWrapper> m_cvesDatabase;
     std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>> m_feedsDatabases;
+    std::unique_ptr<TRouterSubscriber> m_contentUpdateSubscription;
 };
 
 using DatabaseFeedManager = TDatabaseFeedManager<>;

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(database_feed_manager_unit_test
     optimized gmock
     optimized gtest_main
     optimized gmock_main
+    router
     rocksdb
     flatbuffers
     pthread

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -20,6 +20,8 @@
 #include "flatbuffers/flatbuffer_builder.h"
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
+#include "routerModule.hpp"
+#include "routerProvider.hpp"
 #include <filesystem>
 #include <string_view>
 
@@ -134,6 +136,58 @@ void DatabaseFeedManagerTest::SetUp()
         rocksDBWrapper.put(PACKAGE_NAME + "_" + item.at("candidates").at(0).at("cveId").get<std::string>(),
                            vulnerabilityCandidate);
     }
+
+    nlohmann::json jsonFileContent;
+    nlohmann::json jsonItem = R"(
+        {
+            "offset": 0,
+            "type": "create",
+            "version": 1,
+            "context": "all_vendors_071123",
+            "resource": "CVE-0000-0000",
+            "payload": {
+                "containers": {
+                    "cna": {
+                        "providerMetadata": {
+                            "dateUpdated": "2017-05-11T14:29:20Z",
+                            "orgId": "00000000-0000-4000-A000-000000000003",
+                            "shortName": "nvd"
+                        },
+                        "rejectedReasons": [
+                            {
+                                "lang": "en",
+                                "value": "** REJECT **"
+                            }
+                        ]
+                    }
+                },
+                "cveMetadata": {
+                    "assignerOrgId": "00000000-0000-4000-A000-000000000003",
+                    "assignerShortName": "nvd",
+                    "cveId": "CVE-0000-0000",
+                    "datePublished": "2017-05-11T14:29:20Z",
+                    "dateUpdated": "2017-05-11T14:29:20Z",
+                    "state": "REJECTED"
+                },
+                "dataType": "CVE_RECORD",
+                "dataVersion": "5.0"
+            }
+        }
+    )"_json;
+    int cveNumber = 1;
+    for (auto itemNumber = 0; itemNumber < 1000; itemNumber++)
+    {
+        jsonItem["offset"] = 57001 + itemNumber;
+        std::ostringstream itemCVEId;
+        itemCVEId << "CVE-" << std::dec << std::setw(4) << std::setfill('0') << (std::rand() % 20 + 2000) << "-"
+                  << std::dec << std::setw(4) << std::setfill('0') << itemNumber;
+        jsonItem["resource"] = itemCVEId.str();
+        jsonItem["payload"]["cveMetadata"]["cveId"] = itemCVEId.str();
+        jsonFileContent["data"].push_back(jsonItem);
+    }
+
+    std::ofstream file {"GracefulShutdown.json"};
+    file << jsonFileContent.dump();
 };
 
 void DatabaseFeedManagerTest::TearDown()
@@ -144,6 +198,7 @@ void DatabaseFeedManagerTest::TearDown()
     spContentRegisterMock.reset();
     spRouterSubscriberMock.reset();
     std::filesystem::remove_all(COMMON_DATABASE_DIR);
+    std::remove("GracefulShutdown.json");
 };
 
 TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
@@ -792,6 +847,59 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationInvalidDatabase)
 TEST_F(DatabaseFeedManagerTest, PackageTranslationInvalidCache)
 {
     // ToDo It's necessary the write function to store a value corrupted and run this test.
+}
+
+void DatabaseFeedManagerTest_GracefulShutdown()
+{
+    // Test setup
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
+
+    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+
+    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
+    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+
+    spContentRegisterMock = std::make_shared<MockContentRegister>(
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
+
+    auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+
+    RouterModule::instance().start();
+    auto routerProvider = std::make_shared<RouterProvider>(configurationParameters.at("topicName"));
+    routerProvider->start();
+
+    auto routerMessageJson = R"(
+    {
+        "paths":
+        [
+            "GracefulShutdown.json"
+        ],
+        "stageStatus":
+        [
+            {
+                "stage": "download",
+                "status": "ok"
+            }
+        ]
+    }
+    )"_json;
+
+    const auto routerMessagePayload = routerMessageJson.dump();
+    const auto routerMessage = std::vector<char>(routerMessagePayload.begin(), routerMessagePayload.end());
+
+    auto spDatabaseFeedManager {std::make_shared<
+        TDatabaseFeedManager<TrampolineIndexerConnector, TrampolinePolicyManager, TrampolineContentRegister>>(
+        spIndexerConnectorTramp)};
+
+    routerProvider->send(routerMessage);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    spDatabaseFeedManager.reset();
+}
+
+TEST_F(DatabaseFeedManagerTest, GracefulShutdown)
+{
+    EXPECT_NO_THROW(DatabaseFeedManagerTest_GracefulShutdown());
 }
 
 /* DatabaseFeedManagerMessageProcessor tests */

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -136,58 +136,6 @@ void DatabaseFeedManagerTest::SetUp()
         rocksDBWrapper.put(PACKAGE_NAME + "_" + item.at("candidates").at(0).at("cveId").get<std::string>(),
                            vulnerabilityCandidate);
     }
-
-    nlohmann::json jsonFileContent;
-    nlohmann::json jsonItem = R"(
-        {
-            "offset": 0,
-            "type": "create",
-            "version": 1,
-            "context": "all_vendors_071123",
-            "resource": "CVE-0000-0000",
-            "payload": {
-                "containers": {
-                    "cna": {
-                        "providerMetadata": {
-                            "dateUpdated": "2017-05-11T14:29:20Z",
-                            "orgId": "00000000-0000-4000-A000-000000000003",
-                            "shortName": "nvd"
-                        },
-                        "rejectedReasons": [
-                            {
-                                "lang": "en",
-                                "value": "** REJECT **"
-                            }
-                        ]
-                    }
-                },
-                "cveMetadata": {
-                    "assignerOrgId": "00000000-0000-4000-A000-000000000003",
-                    "assignerShortName": "nvd",
-                    "cveId": "CVE-0000-0000",
-                    "datePublished": "2017-05-11T14:29:20Z",
-                    "dateUpdated": "2017-05-11T14:29:20Z",
-                    "state": "REJECTED"
-                },
-                "dataType": "CVE_RECORD",
-                "dataVersion": "5.0"
-            }
-        }
-    )"_json;
-    int cveNumber = 1;
-    for (auto itemNumber = 0; itemNumber < 1000; itemNumber++)
-    {
-        jsonItem["offset"] = 57001 + itemNumber;
-        std::ostringstream itemCVEId;
-        itemCVEId << "CVE-" << std::dec << std::setw(4) << std::setfill('0') << (std::rand() % 20 + 2000) << "-"
-                  << std::dec << std::setw(4) << std::setfill('0') << itemNumber;
-        jsonItem["resource"] = itemCVEId.str();
-        jsonItem["payload"]["cveMetadata"]["cveId"] = itemCVEId.str();
-        jsonFileContent["data"].push_back(jsonItem);
-    }
-
-    std::ofstream file {"GracefulShutdown.json"};
-    file << jsonFileContent.dump();
 };
 
 void DatabaseFeedManagerTest::TearDown()
@@ -198,7 +146,6 @@ void DatabaseFeedManagerTest::TearDown()
     spContentRegisterMock.reset();
     spRouterSubscriberMock.reset();
     std::filesystem::remove_all(COMMON_DATABASE_DIR);
-    std::remove("GracefulShutdown.json");
 };
 
 TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
@@ -852,6 +799,58 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationInvalidCache)
 void DatabaseFeedManagerTest_GracefulShutdown()
 {
     // Test setup
+    nlohmann::json jsonFileContent;
+    nlohmann::json jsonItem = R"(
+        {
+            "offset": 0,
+            "type": "create",
+            "version": 1,
+            "context": "all_vendors_071123",
+            "resource": "CVE-0000-0000",
+            "payload": {
+                "containers": {
+                    "cna": {
+                        "providerMetadata": {
+                            "dateUpdated": "2017-05-11T14:29:20Z",
+                            "orgId": "00000000-0000-4000-A000-000000000003",
+                            "shortName": "nvd"
+                        },
+                        "rejectedReasons": [
+                            {
+                                "lang": "en",
+                                "value": "** REJECT **"
+                            }
+                        ]
+                    }
+                },
+                "cveMetadata": {
+                    "assignerOrgId": "00000000-0000-4000-A000-000000000003",
+                    "assignerShortName": "nvd",
+                    "cveId": "CVE-0000-0000",
+                    "datePublished": "2017-05-11T14:29:20Z",
+                    "dateUpdated": "2017-05-11T14:29:20Z",
+                    "state": "REJECTED"
+                },
+                "dataType": "CVE_RECORD",
+                "dataVersion": "5.0"
+            }
+        }
+    )"_json;
+    int cveNumber = 1;
+    for (auto itemNumber = 0; itemNumber < 1000; itemNumber++)
+    {
+        jsonItem["offset"] = 57001 + itemNumber;
+        std::ostringstream itemCVEId;
+        itemCVEId << "CVE-" << std::dec << std::setw(4) << std::setfill('0') << (std::rand() % 20 + 2000) << "-"
+                  << std::dec << std::setw(4) << std::setfill('0') << itemNumber;
+        jsonItem["resource"] = itemCVEId.str();
+        jsonItem["payload"]["cveMetadata"]["cveId"] = itemCVEId.str();
+        jsonFileContent["data"].push_back(jsonItem);
+    }
+
+    std::ofstream file {"GracefulShutdown.json"};
+    file << jsonFileContent.dump();
+
     const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
     std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
 
@@ -895,6 +894,8 @@ void DatabaseFeedManagerTest_GracefulShutdown()
     routerProvider->send(routerMessage);
     std::this_thread::sleep_for(std::chrono::seconds(1));
     spDatabaseFeedManager.reset();
+
+    std::remove("GracefulShutdown.json");
 }
 
 TEST_F(DatabaseFeedManagerTest, GracefulShutdown)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20274 |

## Description

This PR modified the class TDatabaseFeedManager to allow a graceful shutdown when it already has some messages to process.

## Tests

New UT added "DatabaseFeedManagerTest.GracefulShutdown".

![image](https://github.com/wazuh/wazuh/assets/101227434/c54cf9e3-7536-4088-add6-2ffb9abef674)

- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] UT running ok