### PR TITLE
Content Manager - Add HTTP download capability to the `OfflineDownloader`

### DIFF
--- a/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-The [offline downloader](../../src/components/offlineDownloader.hpp) stage is part of the Content Manager orchestration and is in charge of downloading a file in an offline mode by whether copying a file from the local filesystem or downloading it from an HTTP server (the stage will deduce which approach to use depending on the URL prefix). The input file hash is calculated and stored in order to avoid processing the same file multiple times in the next orchestration executions.
+The [offline downloader](../../src/components/offlineDownloader.hpp) stage is part of the Content Manager orchestration and is in charge of downloading a file in offline mode by whether copying a file from the local filesystem or downloading it from an HTTP server (the stage will deduce which approach to use depending on the URL prefix). The input file hash is calculated and stored in order to avoid processing the same file multiple times in the next orchestration executions.
 
 The download will be made into any of the following output directories:
 - Downloads folder: If the input file is compressed.

--- a/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
@@ -15,7 +15,7 @@ If the download is successful, this stage also updates the context [data paths](
 The context fields related to this stage are:
 
 - `configData`
-  + `url`: Used as input file URL. **IMPORTANT**: If it has the `file://` prefix, the file will be copied from the filesystem. If it has the `http://` or `https://` prefixes, the file will be downloaded from a server pointed by the URL.
+  + `url`: Used as input file URL. **IMPORTANT**: If it has the `file://` prefix, the file will be copied from the filesystem. If it has the `http://` or `https://` prefixes, the file will be downloaded from a server pointed by the URL. Any other prefix will invalidate the URL.
   + `compressionType`: Used to know whether the input file is compressed or not.
 - `downloadsFolder`: Used as output folder when the input file is compressed.
 - `contentsFolder`: Used as output folder when the input file is not compressed.

--- a/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/OFFLINE_DOWNLOADER.md
@@ -2,22 +2,20 @@
 
 ## Details
 
-The [offline downloader](../../src/components/offlineDownloader.hpp) stage is part of the Content Manager orchestration and is in charge of copying an input file from the local filesystem to be processed by the following stages. The input file hash is calculated and stored in order to avoid processing the same file multiple times in the next orchestration executions.
+The [offline downloader](../../src/components/offlineDownloader.hpp) stage is part of the Content Manager orchestration and is in charge of downloading a file in an offline mode by whether copying a file from the local filesystem or downloading it from an HTTP server (the stage will deduce which approach to use depending on the URL prefix). The input file hash is calculated and stored in order to avoid processing the same file multiple times in the next orchestration executions.
 
-The copy will be made into any of the following output directories:
+The download will be made into any of the following output directories:
 - Downloads folder: If the input file is compressed.
 - Contents folder: If the input file is not compressed.
 
-If the copy is successful, this stage also updates the context [data paths](../../src/components/updaterContext.hpp) field with the destination path of the copied file. If the input file doesn't exist, no paths will be appended.
-
-> Note: Despite the class name, there is no such download performed. The copy is made entirely locally.
+If the download is successful, this stage also updates the context [data paths](../../src/components/updaterContext.hpp) field with the destination path of the downloaded file. For the copy case, if the input file doesn't exist, no paths will be appended.
 
 ## Relation with the UpdaterContext
 
 The context fields related to this stage are:
 
 - `configData`
-  + `url`: Used as input file path. The prefix `file://` is allowed.
+  + `url`: Used as input file URL. **IMPORTANT**: If it has the `file://` prefix, the file will be copied from the filesystem. If it has the `http://` or `https://` prefixes, the file will be downloaded from a server pointed by the URL.
   + `compressionType`: Used to know whether the input file is compressed or not.
 - `downloadsFolder`: Used as output folder when the input file is compressed.
 - `contentsFolder`: Used as output folder when the input file is not compressed.

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -58,7 +58,7 @@ public:
         }
         if ("offline" == downloaderType)
         {
-            return std::make_shared<OfflineDownloader>();
+            return std::make_shared<OfflineDownloader>(HTTPRequest::instance());
         }
 
         throw std::invalid_argument {"Invalid 'contentSource' type: " + downloaderType};

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -122,7 +122,7 @@ private:
         const auto onError {
             [&returnCode](const std::string& errorMessage, const long errorCode)
             {
-                logWarn(WM_CONTENTUPDATER, "Error '%d' when downloading file: %s", errorCode, errorMessage);
+                logWarn(WM_CONTENTUPDATER, "Error '%d' when downloading file: %s", errorCode, errorMessage.c_str());
                 returnCode = false;
             }};
 
@@ -176,7 +176,7 @@ private:
         }
         else
         {
-            throw std::runtime_error {"Unkown URL prefix for " + fileUrl.string()};
+            throw std::runtime_error {"Unknown URL prefix for " + fileUrl.string()};
         }
 
         // Just process the new file if the hash is different from the last one.

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -170,6 +170,13 @@ private:
 
             // Download finished: Insert path into context.
             context.data.at("paths").push_back(outputFilePath.string());
+            return;
+        }
+
+        if (httpDownload)
+        {
+            // Remove temporary downloaded file.
+            std::filesystem::remove(inputFilePath);
         }
     }
 

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -115,16 +115,21 @@ private:
      *
      * @param inputFileURL URL from where to download the file.
      * @param outputFilepath Output path where to store the downloaded file.
+     * @return true if the file was downloaded, otherwise false.
      */
-    void downloadFile(const std::filesystem::path& inputFileURL, const std::filesystem::path& outputFilepath) const
+    bool downloadFile(const std::filesystem::path& inputFileURL, const std::filesystem::path& outputFilepath) const
     {
-        const auto onError {[](const std::string& errorMessage, const long errorCode)
+        auto returnCode {true};
+        const auto onError {[&returnCode](const std::string& errorMessage, const long errorCode)
                             {
-                                throw std::runtime_error {"(" + std::to_string(errorCode) + ") " + errorMessage};
+                                std::cout << "Error " << std::to_string(errorCode)
+                                          << " when downloading file: " << errorMessage << std::endl;
+                                returnCode = false;
                             }};
 
         // Download file from URL.
         m_urlRequest.download(HttpURL(inputFileURL), outputFilepath, onError);
+        return returnCode;
     }
 
     /**
@@ -165,7 +170,10 @@ private:
         }
         else if (Utils::startsWith(fileUrl, HTTP_PREFIX) || Utils::startsWith(fileUrl, HTTPS_PREFIX))
         {
-            downloadFile(fileUrl, outputFilePath);
+            if (!downloadFile(fileUrl, outputFilePath))
+            {
+                return;
+            }
         }
         else
         {

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -100,8 +100,7 @@ private:
         // Check input file existence.
         if (!std::filesystem::exists(unprefixedUrl))
         {
-            logWarn(
-                    WM_CONTENTUPDATER, "File '%s' doesn't exist. Skipping download.", inputFilePath.string().c_str());
+            logWarn(WM_CONTENTUPDATER, "File '%s' doesn't exist. Skipping download.", inputFilepath.string().c_str());
             return false;
         }
 
@@ -120,12 +119,12 @@ private:
     bool downloadFile(const std::filesystem::path& inputFileURL, const std::filesystem::path& outputFilepath) const
     {
         auto returnCode {true};
-        const auto onError {[&returnCode](const std::string& errorMessage, const long errorCode)
-                            {
-                                std::cout << "Error " << std::to_string(errorCode)
-                                          << " when downloading file: " << errorMessage << std::endl;
-                                returnCode = false;
-                            }};
+        const auto onError {
+            [&returnCode](const std::string& errorMessage, const long errorCode)
+            {
+                logWarn(WM_CONTENTUPDATER, "Error '%d' when downloading file: %s", errorCode, errorMessage);
+                returnCode = false;
+            }};
 
         // Download file from URL.
         m_urlRequest.download(HttpURL(inputFileURL), outputFilepath, onError);

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -30,8 +30,8 @@
 /**
  * @class OfflineDownloader
  *
- * @brief Class in charge of copying a file from the filesystem and update the context accordingly, as a step of a chain
- * of responsibility.
+ * @brief Class in charge of downloading a file in offline mode and updating the context accordingly, as a step of a
+ * chain of responsibility.
  *
  */
 class OfflineDownloader final : public AbstractHandler<std::shared_ptr<UpdaterContext>>
@@ -128,9 +128,7 @@ private:
     }
 
     /**
-     * @brief Downloads the requested local file and update the context accordingly.
-     *
-     * @note Despite the method name, there is no such download since the file is present in the filesystem.
+     * @brief Downloads a file in offline mode and updates the context accordingly.
      *
      * @param context Updater context.
      */
@@ -196,7 +194,7 @@ public:
         : m_urlRequest(urlRequest) {};
 
     /**
-     * @brief Copies a file from the local filesystem in order to be processed and passes the control to the next chain
+     * @brief Downloads a file in offline mode in order to be processed and passes the control to the next chain
      * stage.
      *
      * @param context Updater context.

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
@@ -301,9 +301,9 @@ TEST_F(OfflineDownloaderTest, HttpDownloadInvalidURL)
     nlohmann::json expectedData;
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
-    expectedData["stageStatus"].push_back(FAIL_STATUS);
+    expectedData["stageStatus"].push_back(OK_STATUS);
 
-    ASSERT_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext), std::runtime_error);
+    ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
 }
 

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
@@ -308,7 +308,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadInvalidURL)
 }
 
 /**
- * @brief Tests the download of twice the same file from an HTTP server.
+ * @brief Tests the download of the same file twice from an HTTP server.
  *
  */
 TEST_F(OfflineDownloaderTest, HttpDownloadFileTwice)
@@ -340,7 +340,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadFileTwice)
 }
 
 /**
- * @brief Tests the download of twice the same file: once from an HTTP server, and once from the filesystem.
+ * @brief Tests the download of the same file twice. Once from an HTTP server, and once from the local filesystem.
  *
  */
 TEST_F(OfflineDownloaderTest, HttpAndLocalDownloadFileTwice)

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
@@ -30,8 +30,8 @@ protected:
     ~OfflineDownloaderTest() override = default;
 
     const std::filesystem::path m_tempPath {std::filesystem::temp_directory_path()};          ///< Temporary path.
-    const std::filesystem::path m_inputFilePathRaw {"file://" / m_tempPath / "testFile.txt"}; ///< Raw input test path.
-    const std::filesystem::path m_inputFilePathCompressed {"file://" / m_tempPath /
+    const std::filesystem::path m_inputFilePathRaw {m_tempPath / "testFile.txt"}; ///< Raw input test path.
+    const std::filesystem::path m_inputFilePathCompressed {m_tempPath /
                                                            "testFile.txt.gz"}; ///< Compressed input test path.
     const std::filesystem::path m_outputFolder {m_tempPath / "offline-downloader-tests"}; ///< Output test folder.
     std::shared_ptr<UpdaterContext> m_spUpdaterContext;         ///< UpdaterContext used on tests.

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
@@ -12,6 +12,7 @@
 #ifndef _OFFLINE_DOWNLOADER_TEST
 #define _OFFLINE_DOWNLOADER_TEST
 
+#include "fakes/fakeServer.hpp"
 #include "offlineDownloader.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
@@ -29,13 +30,15 @@ protected:
     OfflineDownloaderTest() = default;
     ~OfflineDownloaderTest() override = default;
 
-    const std::filesystem::path m_tempPath {std::filesystem::temp_directory_path()};          ///< Temporary path.
-    const std::filesystem::path m_inputFilePathRaw {m_tempPath / "testFile.txt"}; ///< Raw input test path.
+    const std::filesystem::path m_tempPath {std::filesystem::temp_directory_path()}; ///< Temporary path.
+    const std::filesystem::path m_inputFilePathRaw {m_tempPath / "testFile.txt"};    ///< Raw input test path.
     const std::filesystem::path m_inputFilePathCompressed {m_tempPath /
                                                            "testFile.txt.gz"}; ///< Compressed input test path.
     const std::filesystem::path m_outputFolder {m_tempPath / "offline-downloader-tests"}; ///< Output test folder.
     std::shared_ptr<UpdaterContext> m_spUpdaterContext;         ///< UpdaterContext used on tests.
     std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on tests.
+
+    inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Fake HTTP server used in tests.
 
     /**
      * @brief Set up routine for each test fixture.
@@ -78,6 +81,27 @@ protected:
         std::filesystem::remove(m_inputFilePathRaw);
         std::filesystem::remove(m_inputFilePathCompressed);
         std::filesystem::remove_all(m_outputFolder);
+    }
+
+    /**
+     * @brief Set up routine for the test suite.
+     *
+     */
+    static void SetUpTestSuite()
+    {
+        if (!m_spFakeServer)
+        {
+            m_spFakeServer = std::make_unique<FakeServer>("localhost", 4444);
+        }
+    }
+
+    /**
+     * @brief Tear down routine for the test suite.
+     *
+     */
+    static void TearDownTestSuite()
+    {
+        m_spFakeServer.reset();
     }
 };
 


### PR DESCRIPTION
|Related issue|
|---|
|#20394 |

## Description

This PR adds a new functionality to the offline downloader. With these changes, the downloader will be able to download files from an HTTP server if the URL starts with the prefixes `http://` or `https://`.

If the URL prefix is `file://`, the downloader will perform a local copy instead of the HTTP download.

Change log:
- OfflineDownloader class updater with this new functionality.
- OfflineDownloader tests added.
- OfflineDownloader docu updated.

## Results

### Coverage

Coverage at 100%:
![image](https://github.com/wazuh/wazuh/assets/42682247/478a7df8-9502-4934-85d6-e33c857ce749)

### Test tool

#### Downloading file from the filesystem

Config:
```json
"topicName": "test",
"interval": 10,
"ondemand": true,
"configData":
{
    "contentSource": "offline",
    "compressionType": "raw",
    "versionedContent": "false",
    "deleteDownloadedContent": true,
    "url": "file:///tmp/test.txt",
    "outputFolder": "/tmp/testProvider",
    "dataFormat": "json",
    "contentFileName": "example.json",
    "databasePath": "/tmp/content_updater/rocksdb",
    "offset": 0
}
```

Executing the tool, and modifying the file between executions:
```bash
# echo "test" >> /tmp/test.txt

# ./content_manager_test_tool &
[1] 15470
ActionOrchestrator - Starting process
API offset to be used: 0
The previous output folder: "/tmp/testProvider" will be removed.
Output folders created.
FactoryContentUpdater - Starting process
Creating 'offline' downloader
Creating 'raw' content decompressor
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.

changing interval
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.

# echo "test" >> /tmp/test.txt
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.
```

#### Downloading file from HTTP server

Config:
```json
"topicName": "test",
"interval": 10,
"ondemand": true,
"configData":
{
    "contentSource": "offline",
    "compressionType": "raw",
    "versionedContent": "false",
    "deleteDownloadedContent": true,
    "url": "http://localhost:8888/test.txt",
    "outputFolder": "/tmp/testProvider",
    "dataFormat": "json",
    "contentFileName": "example.json",
    "databasePath": "/tmp/content_updater/rocksdb",
    "offset": 0
}
```

Executing the tool, and modifying the file between executions:
```bash
# echo "test" >> /home/platform-main/.rtr/ci/test_server_files/test.txt 
# ./content_manager_test_tool &
[1] 15955

ActionOrchestrator - Starting process
API offset to be used: 0
Output folders created.
FactoryContentUpdater - Starting process
Creating 'offline' downloader
Creating 'raw' content decompressor
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.

changing interval
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.

# echo "test" >> /home/platform-main/.rtr/ci/test_server_files/test.txt 
 Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - Data published
SkipStep - Executing
All files in the folder have been deleted.

Action: Initiating scheduling action for test
ActionOrchestrator - Running process
OfflineDownloader - Download done successfully
SkipStep - Executing
PubSubPublisher - No data data to publish
SkipStep - Executing
All files in the folder have been deleted.
```

#### Downloading a file with an invalid prefix

Config:
```json
"topicName": "test",
"interval": 10,
"ondemand": true,
"configData":
{
    "contentSource": "offline",
    "compressionType": "raw",
    "versionedContent": "false",
    "deleteDownloadedContent": true,
    "url": "ftp://localhost:8888/test.txt",
    "outputFolder": "/tmp/testProvider",
    "dataFormat": "json",
    "contentFileName": "example.json",
    "databasePath": "/tmp/content_updater/rocksdb",
    "offset": 0
}
```

Execution:
```bash
# ./content_manager_test_tool 
ActionOrchestrator - Starting process
API offset to be used: 0
Output folders created.
FactoryContentUpdater - Starting process
Creating 'offline' downloader
Creating 'raw' content decompressor
Version updater not needed
Downloaded content cleaner created
FactoryContentUpdater - Finishing process
ActionOrchestrator - Finishing process
ActionOrchestrator - Running process
Action for 'test' failed: Orchestration run failed. Download failed: Unkown URL prefix for ftp://localhost:8888/test.txt

changing interval
Action: Initiating scheduling action for test
ActionOrchestrator - Running process
Action for 'test' failed: Orchestration run failed. Download failed: Unkown URL prefix for ftp://localhost:8888/test.txt
```