### PR TITLE
Add new SSL Protocol option and message for deprecated TLS versions in Wazuh API

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -41,7 +41,7 @@ default_api_configuration = {
         "cert": "server.crt",
         "use_ca": False,
         "ca": "ca.crt",
-        "ssl_protocol": "TLSv1.2",
+        "ssl_protocol": "auto",
         "ssl_ciphers": ""
     },
     "logs": {

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -11,7 +11,7 @@
 #  cert: "server.crt"
 #  use_ca: False
 #  ca: "ca.crt"
-#  ssl_protocol: "TLSv1.2"
+#  ssl_protocol: "auto"
 #  ssl_ciphers: ""
 
 # Modify API's intervals (time in seconds)

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -9967,7 +9967,7 @@ paths:
                           cert: "/var/ossec/api/configuration/ssl/server.crt"
                           use_ca: false
                           ca: "/var/ossec/api/configuration/ssl/ca.crt"
-                          ssl_protocol: "TLSv1.2"
+                          ssl_protocol: "auto"
                           ssl_ciphers: ""
                         logs:
                           level: info
@@ -10005,7 +10005,7 @@ paths:
                           cert: "/var/ossec/api/configuration/ssl/server.crt"
                           use_ca: false
                           ca: "/var/ossec/api/configuration/ssl/ca.crt"
-                          ssl_protocol: "TLSv1.2"
+                          ssl_protocol: "auto"
                           ssl_ciphers: ""
                         logs:
                           path: /var/ossec/logs/api.log
@@ -10042,7 +10042,7 @@ paths:
                           cert: "/var/ossec/api/configuration/ssl/server.crt"
                           use_ca: false
                           ca: "/var/ossec/api/configuration/ssl/ca.crt"
-                          ssl_protocol: "TLSv1.2"
+                          ssl_protocol: "auto"
                           ssl_ciphers: ""
                         logs:
                           path: /var/ossec/logs/api.log
@@ -12901,7 +12901,7 @@ paths:
                           cert: "/var/ossec/api/configuration/ssl/server.crt"
                           use_ca: false
                           ca: "/var/ossec/api/configuration/ssl/ca.crt"
-                          ssl_protocol: "TLSv1.2"
+                          ssl_protocol: "auto"
                           ssl_ciphers: ""
                         access:
                           max_login_attempts: 50

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -22,7 +22,7 @@ custom_api_configuration = {
         "cert": "server.crt",
         "use_ca": False,
         "ca": "ca.crt",
-        "ssl_protocol": "TLSv1.2",
+        "ssl_protocol": "auto",
         "ssl_ciphers": ""
     },
     "logs": {

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -91,7 +91,7 @@ api_config_schema = {
                 "ca": {"type": "string",
                        "pattern": r"^[\w\-.]+$"},
                 "ssl_protocol": {"type": "string", "enum": ["tls", "tlsv1", "tlsv1.1", "tlsv1.2", "TLS",
-                                                            "TLSv1", "TLSv1.1", "TLSv1.2"]},
+                                                            "TLSv1", "TLSv1.1", "TLSv1.2", "auto", "AUTO"]},
                 "ssl_ciphers": {"type": "string"}
             },
         },


### PR DESCRIPTION
|Related issue|
|---|
| #20396 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description #20396 

Closes #20396. It adds a new option for the `https.ssl_protocol` API configuration option and deprecates the existing ones, showing a message in case these are used to warn the users of its removal in the next minor.

## Logs/Alerts example

### Default case: `ssl_protocol` set with `auto`

```console
# /var/ossec/bin/wazuh-apid -f -d
Starting API in foreground
2023/11/24 09:49:17 INFO: Checking RBAC database integrity...
2023/11/24 09:49:17 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2023/11/24 09:49:17 INFO: RBAC database integrity check finished successfully
2023/11/24 09:49:20 INFO: Listening on 0.0.0.0:55000..
======== Running on https://0.0.0.0:55000 ========
(Press CTRL+C to quit)
```

### Deprecated case: `ssl_protocol` set with `tlsv1.2`
```console
# /var/ossec/bin/wazuh-apid -f -d
2023/11/24 09:48:17 WARNING: The `tlsv1.2` SSL protocol option was deprecated in 4.8 and will be removed in the next minor in favor of the `auto` option and the manual setting of the minimum and maximum TLS supported versions.
Starting API in foreground
2023/11/24 09:48:17 INFO: Checking RBAC database integrity...
2023/11/24 09:48:17 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2023/11/24 09:48:17 INFO: RBAC database integrity check finished successfully
2023/11/24 09:48:20 INFO: Listening on 0.0.0.0:55000..
======== Running on https://0.0.0.0:55000 ========
(Press CTRL+C to quit)
```

