### PR TITLE
Updated warning message for invalid registry type

### DIFF
--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -52,7 +52,7 @@
 #define FIM_WHODATA_RENDER_EVENT                "(6933): Error rendering the event. Error %lu."
 #define FIM_WHODATA_RENDER_PARAM                "(6934): Invalid number of rendered parameters."
 #define FIM_DB_TEMPORARY_FILE_POSITION          "(6935): Unable to reposition temporary file to beginning. Error[%d]: '%s'"
-#define FIM_REG_VAL_WRONG_TYPE                  "(6936): Wrong registry value type processed for report_changes."
+#define FIM_REG_VAL_WRONG_TYPE                  "(6936): Wrong registry value type processed for report_changes. Check registry path: '%s'"
 #define FIM_INVALID_REG_OPTION_SKIP             "(6937): Invalid option '%s' for attribute '%s'. The registry '%s' not be monitored."
 #define FIM_REGISTRY_EVENT_NULL_ENTRY           "(6938): Invalid null registry event."
 #define FIM_REGISTRY_EVENT_NULL_ENTRY_KEY       "(6939): Invalid registry event with a null key was detected."

--- a/src/syscheckd/src/fim_diff_changes.c
+++ b/src/syscheckd/src/fim_diff_changes.c
@@ -374,7 +374,7 @@ int fim_diff_registry_tmp(const char *value_data,
 
             default:
                 // Wrong type
-                mwarn(FIM_REG_VAL_WRONG_TYPE);
+                mwarn(FIM_REG_VAL_WRONG_TYPE, diff->file_origin);
                 ret = -1;
                 break;
         }


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/20422 |

## Description

Added the registry path to the warning message to help troubleshooting.

When a key as multiple subkeys with multiple values, the expected behavior is to monitor the ones that can be monitored (REG_SZ, REG_MULTI_SZ, REG_DWORD, REG_DWORD_BIG_ENDIAN, and REG_QWORD) and ignore the ones which cannot be monitored.

At this point, adding the path of the values which cannot be monitored with `report_changes` attribute to the log message would provide valuable information to the user. Currently it creates only FUD on the user.

**N.B:** I believe I needed to update [this test](https://github.com/wazuh/wazuh/blob/a8f413c81c0e3f7b1a79b1bf08ffbcd5bbcbaa01/src/unit_tests/syscheckd/test_fim_diff_changes.c#L1218) yet I was not sure how to properly do that.

## Configuration options

None.

## Logs/Alerts example

Before:
```yaml
WARNING: (6936): Wrong registry value type processed for report_changes.
```

After:
```yaml
WARNING: (6936): Wrong registry value type processed for report_changes. Check registry path: '...'
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors