### PR TITLE
Let Windows agent delete state file on stop

### DIFF
--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -221,6 +221,9 @@ int local_start()
                      0,
                      (LPDWORD)&threadID);
 
+    /* Delete agent state file at exit */
+    atexit(DeleteState);
+
     /* Socket connection */
     agt->sock = -1;
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #16253|

The agent holds a file called _wazuh-agent.state_ containing data related to the connection. We expect this file to disappear at the agent's stop.

This PR aims to fix this behavior in the Windows agent, that was not deleting the file properly.

## Tests

- [x] Get the agent connect & stop → The file disappears.
- [x] Prevent the agent from connecting, start & stop the agent → The file disappears.
- https://github.com/wazuh/wazuh-qa/pull/4716

We did both tests to ensure that the `atexit()` call was in the correct position.

### Screenshots

|Before this fix|After this fix|
|---|---|
|![Screenshot 2023-11-20 131845](https://github.com/wazuh/wazuh/assets/10536251/bcb55d58-d3b5-4102-b08c-d7cc3d24f5cb)|![Screenshot 2023-11-20 131854](https://github.com/wazuh/wazuh/assets/10536251/ad39e600-e7a9-48a8-b0a1-5bcfb60c17fe)|





