### PR TITLE
Upgrade pyarrow to 14.0.1

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -61,9 +61,8 @@ packaging==20.9
 pathlib==1.0.1
 protobuf==3.19.6
 proto-plus==1.19.0
+pyarrow==14.0.1
 psutil==5.9.0
-pyarrow==13.0.0
-pyarrow_hotfix==0.5
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.21


### PR DESCRIPTION
|Related issue|
|---|
|#20354|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Closes #20354. Bump up the PyArrow version to `14.0.1`