### PR TITLE
Add manager/version/check field descriptions and uuid in example

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -4378,7 +4378,7 @@ components:
                   format: int32
         uuid:
           type: string
-          description: "Identificator of the Wazuh instance"
+          description: "Identifier of the Wazuh instance"
 
     # Rules models
     RuleFile:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1297,6 +1297,19 @@ components:
                   - $ref: '#/components/schemas/WazuhRemotedStats'
         - $ref: '#/components/schemas/AllItemsResponse'
 
+    AllItemsResponseNewVersions:
+      allOf:
+        - $ref: '#/components/schemas/AllItemsResponse'
+        - type: object
+          required:
+            - affected_items
+          properties:
+            affected_items:
+              type: array
+              description: "Items that successfully applied the API call action"
+              items:
+                $ref: '#/components/schemas/NewVersions'
+
     BasicInfo:
       type: object
       properties:
@@ -4275,6 +4288,97 @@ components:
           nullable: true
           format: date-time
           description: "Date when the latest scan started. If no scans have been run, null will be returned"
+
+    NewVersions:
+      type: object
+      properties:
+        last_check_date:
+          type: string
+          description: "Datetime of the last query to the CTI service"
+        current_version:
+          type: string
+          description: "Current version in the format vX.Y.Z"
+        update_check:
+          type: boolean
+          description: "Flag that indicates if the service is enabled"
+        last_available_major:
+          type: object
+          description: "Information about the most recent available major update"
+          properties:
+            tag:
+              type: string
+              description: "Version in the format vX.Y.Z"
+            description:
+              type: string
+            title:
+              type: string
+            published_date:
+              type: string
+            semver:
+              type: object
+              properties:
+                major:
+                  type: integer
+                  format: int32
+                minor:
+                  type: integer
+                  format: int32
+                patch:
+                  type: integer
+                  format: int32
+        last_available_minor:
+          type: object
+          description: "Information about the most recent available minor update"
+          properties:
+            tag:
+              type: string
+              description: "Version in the format vX.Y.Z"
+            description:
+              type: string
+            title:
+              type: string
+            published_date:
+              type: string
+            semver:
+              type: object
+              properties:
+                major:
+                  type: integer
+                  format: int32
+                minor:
+                  type: integer
+                  format: int32
+                patch:
+                  type: integer
+                  format: int32
+        last_available_patch:
+          type: object
+          description: "Information about the most recent available patch update"
+          properties:
+            tag:
+              type: string
+              description: "Version in the format vX.Y.Z"
+            description:
+              type: string
+            title:
+              type: string
+            published_date:
+              type: string
+            semver:
+              type: object
+              properties:
+                major:
+                  type: integer
+                  format: int32
+                minor:
+                  type: integer
+                  format: int32
+                patch:
+                  type: integer
+                  format: int32
+        uuid:
+          type: string
+          description: "Identificator of the Wazuh instance"
 
     # Rules models
     RuleFile:
@@ -13084,7 +13188,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse'
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseNewVersions'
               example:
                 data:
                   last_check_date: '2023-10-09T15:39:57.616301+00:00'
@@ -13117,6 +13226,7 @@ paths:
                       major: 4
                       minor: 8
                       patch: 2
+                  uuid": "edc90f7f-fca4-446c-8985-e69520948e42"
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'


### PR DESCRIPTION
|Related issue|
|---|
| #20444 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR adds the missing uuid field example and field descriptions for the `GET /manager/version/check` endpoint.

## Logs/Alerts example

* Descriptions

![image](https://github.com/wazuh/wazuh/assets/7127104/67c743e7-cb8b-449f-a325-4e72af4bc455)

* UUID field example

![image](https://github.com/wazuh/wazuh/assets/7127104/a16fda8e-97f7-44a2-a0e1-a58f0619b13e)
