### PR TITLE
Fix AWS configuration profiles parsing

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -135,6 +135,8 @@ def set_profile_dict_config(boto_config: dict, profile: str, profile_config: dic
     profile_config : dict
         The user config dict containing the profile configuration.
     """
+    profile = remove_prefix(profile, 'profile ')
+
     # Set s3 config
     if f'{profile}.s3' in str(profile_config):
         s3_config = {
@@ -168,6 +170,24 @@ def set_profile_dict_config(boto_config: dict, profile: str, profile_config: dic
             )
         }
         boto_config['config'].proxies_config = proxies_config
+
+
+def remove_prefix(text: str, prefix: str) -> str:
+    """Removes the prefix from the text if it exists. Otherwise, it returns the text unchanged.
+    
+    Parameters
+    ----------
+    text : str
+        Text to remove the prefix from.
+    prefix : str    
+        Prefix to be removed.
+    
+    Returns
+    -------
+    str
+        Text without the prefix.
+    """
+    return text[len(prefix):] if text.startswith(prefix) else text
 
 
 ################################################################################
@@ -361,7 +381,11 @@ class WazuhIntegration:
             aws_config = get_aws_config_params()
 
             # Set profile
-            profile = profile if profile is not None else 'default'
+            if profile is not None:
+                if profile not in aws_config.sections():
+                    profile = f"profile {profile}"
+            else:
+                profile = 'default'
 
             try:
                 # Get profile config dictionary


### PR DESCRIPTION
|Related issue|
|---|
| Closes #20352 |


## Description

Adds the `profile` prefix to the configuration profile specified through the command line.

### Logs

<details><summary>Credentials</summary>

```console
root@wazuh-master:/# cat /root/.aws/credentials
[dev]
aws_access_key_id=foo
aws_secret_access_key=bar
region=us-east-1
```

</details>

<details><summary>Configuration</summary>

With profile prefix

```console
root@wazuh-master:/# cat /root/.aws/config
[profile dev]
region=us-east-1
max_attempts=5
retry_mode=standard
dev.s3.max_concurrent_requests = 10
dev.s3.max_queue_size = 1000
dev.proxy.host = localhost
dev.proxy.port = 8080
signature_version = s3v4
```

Without profile prefix

```console
root@wazuh-master:/# cat /root/.aws/config
[dev]
region=us-east-1
max_attempts=5
retry_mode=standard
dev.s3.max_concurrent_requests = 10
dev.s3.max_queue_size = 1000
dev.proxy.host = localhost
dev.proxy.port = 8080
signature_version = s3v4
```

</details>

<details><summary>Execution before changes</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/wodles/aws/aws-s3.py --aws_profile dev -b wazuh-xxx-cloudtrail -t cloudtrail -d2
DEBUG: +++ Debug mode on - Level: 2
No profile named: 'dev' was found in the user config file
```

</details>

<details><summary>Execution after the changes</summary>

<details><summary>Profile [dev]</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/wodles/aws/aws_s3.py --aws_profile dev -b wazuh-xxx-cloudtrail -t cloudtrail -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Retries parameters found in user profile. Using profile 'dev' retries configuration
DEBUG: Created Config object using profile: 'dev' configuration
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
```

</details>

<details><summary>Profile [profile dev]</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/wodles/aws/aws_s3.py --aws_profile dev -b wazuh-xxx-cloudtrail -t cloudtrail -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Retries parameters found in user profile. Using profile 'profile dev' retries configuration
DEBUG: Created Config object using profile: 'profile dev' configuration
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
```

</details>

<details><summary>Profile [default] implicit</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/wodles/aws/aws_s3.py -b wazuh-xxx-cloudtrail -t cloudtrail -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Retries parameters found in user profile. Using profile 'default' retries configuration
DEBUG: Created Config object using profile: 'default' configuration
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
```

</details>

<details><summary>Profile [default] explicit</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/wodles/aws/aws_s3.py --aws_profile default -b wazuh-xxx-cloudtrail -t cloudtrail -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Retries parameters found in user profile. Using profile 'default' retries configuration
DEBUG: Created Config object using profile: 'default' configuration
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
```

</details>

<details><summary>Profile [profile default]</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/wodles/aws/aws_s3.py --aws_profile default -b wazuh-xxx-cloudtrail -t cloudtrail -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Retries parameters found in user profile. Using profile 'profile default' retries configuration
DEBUG: Created Config object using profile: 'profile default' configuration
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/11/30
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
```

</details>

```console
# S3 config
DEBUG: {'max_concurrent_requests': 10, 'max_queue_size': 1000, 'multipart_threshold': '8MB', 'multipart_chunksize': '8MB', 'max_bandwidth': None, 'use_accelerate_endpoint': False, 'addressing_style': 'auto'}

# Proxies config
DEBUG: {'host': 'localhost', 'port': 8080, 'username': None, 'password': None}
```


</details>