### PR TITLE
Content Manager - Add logging messages

### DIFF
--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -69,6 +69,7 @@ public:
                 std::unique_lock<std::mutex> lock(m_mutex);
 
                 // Run action on start, independently of the interval time.
+                logInfo(WM_CONTENTUPDATER, "Starting on-start action for '%s'", m_topicName.c_str());
                 runAction(ActionID::SCHEDULED);
 
                 while (m_schedulerRunning)
@@ -79,14 +80,14 @@ public:
                         bool expected = false;
                         if (m_actionInProgress.compare_exchange_strong(expected, true))
                         {
-                            logInfo(WM_CONTENTUPDATER, "Initiating scheduling action for %s", m_topicName.c_str());
+                            logInfo(WM_CONTENTUPDATER, "Starting scheduled action for '%s'", m_topicName.c_str());
                             runAction(ActionID::SCHEDULED);
                         }
                         else
                         {
                             // LCOV_EXCL_START
                             logInfo(WM_CONTENTUPDATER,
-                                    "Request scheduling - Download in progress. The scheduling is ignored for %s",
+                                    "Action in progress for '%s', scheduled request ignored",
                                     m_topicName.c_str());
                             // LCOV_EXCL_STOP
                         }
@@ -147,13 +148,13 @@ public:
         auto expected = false;
         if (m_actionInProgress.compare_exchange_strong(expected, true))
         {
-            logInfo(WM_CONTENTUPDATER, "Ondemand request - Starting action for %s", m_topicName.c_str());
+            logInfo(WM_CONTENTUPDATER, "Starting on-demand action for '%s'", m_topicName.c_str());
             runAction(ActionID::ON_DEMAND);
         }
         else
         {
             // LCOV_EXCL_START
-            logInfo(WM_CONTENTUPDATER, "Ondemand request - Another action in progress for %s", m_topicName.c_str());
+            logInfo(WM_CONTENTUPDATER, "Action in progress for '%s', on-demand request ignored", m_topicName.c_str());
             // LCOV_EXCL_STOP
         }
     }

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -19,7 +19,6 @@
 #include <chrono>
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
-#include <iostream>
 #include <thread>
 #include <utility>
 

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -183,6 +183,8 @@ private:
 
     void runAction(const ActionID id)
     {
+        logInfo(WM_CONTENTUPDATER, "Action for '%s' started", m_topicName.c_str());
+
         try
         {
             m_orchestration->run();
@@ -192,6 +194,7 @@ private:
             logError(WM_CONTENTUPDATER, "Action for '%s' failed: %s", m_topicName.c_str(), e.what());
         }
 
+        logInfo(WM_CONTENTUPDATER, "Action for '%s' finished", m_topicName.c_str());
         m_actionInProgress = false;
     }
 };

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -189,7 +189,7 @@ private:
         }
         catch (const std::exception& e)
         {
-            logError("Action for '%s' failed: %s", m_topicName.c_str(), e.what());
+            logError(WM_CONTENTUPDATER, "Action for '%s' failed: %s", m_topicName.c_str(), e.what());
         }
 
         m_actionInProgress = false;

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -108,7 +108,7 @@ public:
         {
             m_schedulerThread.join();
         }
-        logInfo(WM_CONTENTUPDATER, "Scheduler stopped for %s", m_topicName.c_str());
+        logInfo(WM_CONTENTUPDATER, "Scheduler stopped for '%s'", m_topicName.c_str());
     }
 
     /**
@@ -147,13 +147,13 @@ public:
         auto expected = false;
         if (m_actionInProgress.compare_exchange_strong(expected, true))
         {
-            logInfo(WM_CONTENTUPDATER, "Ondemand request - starting action for %s", m_topicName.c_str());
+            logInfo(WM_CONTENTUPDATER, "Ondemand request - Starting action for %s", m_topicName.c_str());
             runAction(ActionID::ON_DEMAND);
         }
         else
         {
             // LCOV_EXCL_START
-            logInfo(WM_CONTENTUPDATER, "Ondemand request - another action in progress for %s", m_topicName.c_str());
+            logInfo(WM_CONTENTUPDATER, "Ondemand request - Another action in progress for %s", m_topicName.c_str());
             // LCOV_EXCL_STOP
         }
     }

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -72,7 +72,7 @@ public:
             auto spUpdaterContext {std::make_shared<UpdaterContext>()};
             spUpdaterContext->spUpdaterBaseContext = m_spBaseContext;
 
-            logInfo(WM_CONTENTUPDATER, "Running '%s' content update", m_spBaseContext->topicName.c_str());
+            logDebug2(WM_CONTENTUPDATER, "Running '%s' content update", m_spBaseContext->topicName.c_str());
 
             // If the database exists, get the last offset
             if (m_spBaseContext->spRocksDB)

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -36,12 +36,14 @@ public:
     {
         try
         {
-            logDebug1(WM_CONTENTUPDATER, "Creating content updater orchestration");
             // Create a context
             m_spBaseContext = std::make_shared<UpdaterBaseContext>();
             m_spBaseContext->topicName = parameters.at("topicName");
             m_spBaseContext->configData = parameters.at("configData");
             m_spBaseContext->spChannel = channel;
+
+            logDebug1(
+                WM_CONTENTUPDATER, "Creating '%s' Content Updater orchestration", m_spBaseContext->topicName.c_str());
 
             // Create and run the execution context
             auto executionContext {std::make_shared<ExecutionContext>()};
@@ -70,7 +72,7 @@ public:
             auto spUpdaterContext {std::make_shared<UpdaterContext>()};
             spUpdaterContext->spUpdaterBaseContext = m_spBaseContext;
 
-            logInfo(WM_CONTENTUPDATER, "Running content update. Topic: %s", m_spBaseContext->topicName.c_str());
+            logInfo(WM_CONTENTUPDATER, "Running '%s' content update", m_spBaseContext->topicName.c_str());
 
             // If the database exists, get the last offset
             if (m_spBaseContext->spRocksDB)
@@ -85,7 +87,7 @@ public:
         catch (const std::exception& e)
         {
             cleanContext();
-            throw std::invalid_argument {"Orchestration run failed. " + std::string {e.what()}};
+            throw std::invalid_argument {"Orchestration run failed: " + std::string {e.what()}};
         }
     }
 

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -17,7 +17,6 @@
 #include "components/updaterContext.hpp"
 #include "routerProvider.hpp"
 #include "utils/rocksDBWrapper.hpp"
-#include <iostream>
 #include <memory>
 
 /**

--- a/src/shared_modules/content_manager/src/components/APIDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/APIDownloader.hpp
@@ -72,7 +72,7 @@ private:
      */
     void downloadContent()
     {
-        logDebug2(WM_CONTENTUPDATER, "Attempting to download from API '%s'", m_url.c_str());
+        logDebug2(WM_CONTENTUPDATER, "Downloading from API '%s'", m_url.c_str());
 
         const auto onError {
             [this](const std::string& message, [[maybe_unused]] const long statusCode)

--- a/src/shared_modules/content_manager/src/components/APIDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/APIDownloader.hpp
@@ -15,7 +15,6 @@
 #include "IURLRequest.hpp"
 #include "updaterContext.hpp"
 #include "utils/chainOfResponsability.hpp"
-#include <iostream>
 #include <memory>
 
 /**

--- a/src/shared_modules/content_manager/src/components/APIDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/APIDownloader.hpp
@@ -115,7 +115,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
-        logDebug2(WM_CONTENTUPDATER, "APIDownloader - Starting process");
+        logDebug1(WM_CONTENTUPDATER, "APIDownloader - Starting process");
 
         m_context = context;
         download();

--- a/src/shared_modules/content_manager/src/components/APIDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/APIDownloader.hpp
@@ -33,7 +33,6 @@ private:
      */
     void download()
     {
-        logDebug2(WM_CONTENTUPDATER, "APIDownloader - Starting");
         // Get the parameters needed to download the content.
         getParameters();
 
@@ -45,8 +44,6 @@ private:
 
         // Set the status of the stage
         m_context->data.at("stageStatus").push_back(R"({"stage": "APIDownloader", "status": "ok"})"_json);
-
-        logDebug2(WM_CONTENTUPDATER, "APIDownloader - Finishing - Download done successfully");
     }
 
     /**
@@ -75,6 +72,8 @@ private:
      */
     void downloadContent()
     {
+        logDebug2(WM_CONTENTUPDATER, "Attempting to download from API '%s'", m_url.c_str());
+
         const auto onError {
             [this](const std::string& message, [[maybe_unused]] const long statusCode)
             {
@@ -116,6 +115,8 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
+        logDebug2(WM_CONTENTUPDATER, "APIDownloader - Starting process");
+
         m_context = context;
         download();
 

--- a/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
@@ -39,7 +39,7 @@ private:
         // Set the content type as offset.
         context.data.at("type") = "offsets";
 
-        logDebug2(WM_CONTENTUPDATER, "CtiOffsetDownloader - Starting");
+        logDebug2(WM_CONTENTUPDATER, "Initial API offset: %d", context.currentOffset);
         // Get the parameters needed to download the content.
         getParameters(context);
 
@@ -69,8 +69,6 @@ private:
             // Save the path of the downloaded content in the context.
             context.data.at("paths").push_back(fullFilePath);
         }
-
-        logDebug2(WM_CONTENTUPDATER, "CtiOffsetDownloader - Finishing");
     }
 
     /**
@@ -105,11 +103,11 @@ private:
         const auto queryParameters =
             "/changes?from_offset=" + std::to_string(context.currentOffset) + "&to_offset=" + std::to_string(toOffset);
 
-        // On download success routine.
-        const auto onSuccess {[]([[maybe_unused]] const std::string& data)
-                              {
-                                  logDebug2(WM_CONTENTUPDATER, "CtiOffsetDownloader - Request processed successfully.");
-                              }};
+        // Empty on download success routine.
+        const auto onSuccess {[]([[maybe_unused]] const std::string& data) {
+        }};
+
+        logDebug2(WM_CONTENTUPDATER, "Downloading offsets from: '%s'", (m_url + queryParameters).c_str());
 
         // Download the content.
         performQueryWithRetry(m_url, onSuccess, queryParameters, fullFilePath);

--- a/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
@@ -12,6 +12,7 @@
 #ifndef _XZ_DECOMPRESSOR_HPP
 #define _XZ_DECOMPRESSOR_HPP
 
+#include "../sharedDefs.hpp"
 #include "json.hpp"
 #include "updaterContext.hpp"
 #include "utils/chainOfResponsability.hpp"
@@ -37,6 +38,8 @@ private:
     {
         for (auto& path : context.data.at("paths"))
         {
+            logDebug2(WM_CONTENTUPDATER, "Attempting to decompress '%s'", path.get_ref<const std::string&>().c_str());
+
             std::filesystem::path inputPath {path};
             try
             {
@@ -73,6 +76,8 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
+        logDebug2(WM_CONTENTUPDATER, "XZDecompressor - Starting process");
+
         decompress(*context);
 
         return AbstractHandler<std::shared_ptr<UpdaterContext>>::handleRequest(context);

--- a/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
@@ -52,7 +52,7 @@ private:
                 std::filesystem::path outputPath {path};
 
                 logDebug2(WM_CONTENTUPDATER,
-                          "Attempting to decompress '%s' into '%s'",
+                          "Decompressing '%s' into '%s'",
                           inputPath.string().c_str(),
                           outputPath.string().c_str());
                 Utils::XzHelper(inputPath, outputPath).decompress();

--- a/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
@@ -38,8 +38,6 @@ private:
     {
         for (auto& path : context.data.at("paths"))
         {
-            logDebug2(WM_CONTENTUPDATER, "Attempting to decompress '%s'", path.get_ref<const std::string&>().c_str());
-
             std::filesystem::path inputPath {path};
             try
             {
@@ -53,6 +51,10 @@ private:
                                   context.spUpdaterBaseContext->configData.at("dataFormat").get<std::string>());
                 std::filesystem::path outputPath {path};
 
+                logDebug2(WM_CONTENTUPDATER,
+                          "Attempting to decompress '%s' into '%s'",
+                          inputPath.string().c_str(),
+                          outputPath.string().c_str());
                 Utils::XzHelper(inputPath, outputPath).decompress();
             }
             catch (const std::exception& e)

--- a/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
@@ -17,7 +17,6 @@
 #include "utils/chainOfResponsability.hpp"
 #include "utils/stringHelper.h"
 #include "utils/xzHelper.hpp"
-#include <iostream>
 #include <memory>
 
 /**

--- a/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/XZDecompressor.hpp
@@ -76,7 +76,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
-        logDebug2(WM_CONTENTUPDATER, "XZDecompressor - Starting process");
+        logDebug1(WM_CONTENTUPDATER, "XZDecompressor - Starting process");
 
         decompress(*context);
 

--- a/src/shared_modules/content_manager/src/components/cleanUpContent.hpp
+++ b/src/shared_modules/content_manager/src/components/cleanUpContent.hpp
@@ -49,8 +49,6 @@ private:
 
         // Create the folder again.
         std::filesystem::create_directory(path);
-
-        logDebug1(WM_CONTENTUPDATER, "All files in the folder have been deleted.");
     }
 
 public:
@@ -62,6 +60,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
+        logDebug2(WM_CONTENTUPDATER, "CleanUpContent - Starting process");
 
         cleanUp(*context);
 

--- a/src/shared_modules/content_manager/src/components/cleanUpContent.hpp
+++ b/src/shared_modules/content_manager/src/components/cleanUpContent.hpp
@@ -16,7 +16,6 @@
 #include "updaterContext.hpp"
 #include "utils/chainOfResponsability.hpp"
 #include <filesystem>
-#include <iostream>
 #include <memory>
 
 /**

--- a/src/shared_modules/content_manager/src/components/cleanUpContent.hpp
+++ b/src/shared_modules/content_manager/src/components/cleanUpContent.hpp
@@ -60,7 +60,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
-        logDebug2(WM_CONTENTUPDATER, "CleanUpContent - Starting process");
+        logDebug1(WM_CONTENTUPDATER, "CleanUpContent - Starting process");
 
         cleanUp(*context);
 

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <cstdlib>
 #include <filesystem>
-#include <iostream>
 #include <memory>
 #include <string>
 

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -144,14 +144,13 @@ private:
         }
 
         // Create the folders.
+        logDebug2(WM_CONTENTUPDATER, "Attempting to create output folders at '%s'", outputFolderPath.string().c_str());
         std::filesystem::create_directory(outputFolderPath);
         std::filesystem::create_directory(outputFolderPath / DOWNLOAD_FOLDER);
         std::filesystem::create_directory(outputFolderPath / CONTENTS_FOLDER);
 
         context.downloadsFolder = outputFolderPath / DOWNLOAD_FOLDER;
         context.contentsFolder = outputFolderPath / CONTENTS_FOLDER;
-
-        logDebug2(WM_CONTENTUPDATER, "Output folders created.");
     }
 
 public:
@@ -163,6 +162,8 @@ public:
      */
     std::shared_ptr<UpdaterBaseContext> handleRequest(std::shared_ptr<UpdaterBaseContext> context) override
     {
+        logDebug1(WM_CONTENTUPDATER, "ExecutionContext - Starting process");
+
         // Check if the database path is given and not empty.
         if (context->configData.contains("databasePath") &&
             !context->configData.at("databasePath").get<std::string>().empty())

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -108,8 +108,6 @@ private:
             // Put the current offset in the database.
             context.spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)), std::to_string(currentOffset));
         }
-
-        logDebug2(WM_CONTENTUPDATER, "API offset to be used: %d", currentOffset);
     }
 
     /**
@@ -139,8 +137,8 @@ private:
         if (std::filesystem::exists(outputFolderPath))
         {
             // Delete the output folder to avoid conflicts.
-            logDebug1(WM_CONTENTUPDATER,
-                      "The previous output folder: %s will be removed.",
+            logDebug2(WM_CONTENTUPDATER,
+                      "Attempting to remove previous output folder '%s'",
                       outputFolderPath.string().c_str());
             std::filesystem::remove_all(outputFolderPath);
         }

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -137,14 +137,12 @@ private:
         if (std::filesystem::exists(outputFolderPath))
         {
             // Delete the output folder to avoid conflicts.
-            logDebug2(WM_CONTENTUPDATER,
-                      "Attempting to remove previous output folder '%s'",
-                      outputFolderPath.string().c_str());
+            logDebug2(WM_CONTENTUPDATER, "Removing previous output folder '%s'", outputFolderPath.string().c_str());
             std::filesystem::remove_all(outputFolderPath);
         }
 
         // Create the folders.
-        logDebug2(WM_CONTENTUPDATER, "Attempting to create output folders at '%s'", outputFolderPath.string().c_str());
+        logDebug2(WM_CONTENTUPDATER, "Creating output folders at '%s'", outputFolderPath.string().c_str());
         std::filesystem::create_directory(outputFolderPath);
         std::filesystem::create_directory(outputFolderPath / DOWNLOAD_FOLDER);
         std::filesystem::create_directory(outputFolderPath / CONTENTS_FOLDER);

--- a/src/shared_modules/content_manager/src/components/factoryCleaner.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryCleaner.hpp
@@ -17,7 +17,6 @@
 #include "skipStep.hpp"
 #include "updaterContext.hpp"
 #include "utils/chainOfResponsability.hpp"
-#include <iostream>
 #include <memory>
 
 /**

--- a/src/shared_modules/content_manager/src/components/factoryCleaner.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryCleaner.hpp
@@ -36,14 +36,13 @@ public:
      */
     static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(const nlohmann::json& config)
     {
-        if (config.at("deleteDownloadedContent").get<bool>())
+        if (config.at("deleteDownloadedContent").get_ref<const bool&>())
         {
-            logDebug2(WM_CONTENTUPDATER, "Downloaded content cleaner created");
             return std::make_shared<CleanUpContent>();
+            logDebug2(WM_CONTENTUPDATER, "Content cleaner created");
         }
         else
         {
-            logDebug2(WM_CONTENTUPDATER, "Downloaded content cleaner not needed");
             return std::make_shared<SkipStep>();
         }
     }

--- a/src/shared_modules/content_manager/src/components/factoryCleaner.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryCleaner.hpp
@@ -39,7 +39,7 @@ public:
         if (config.at("deleteDownloadedContent").get_ref<const bool&>())
         {
             return std::make_shared<CleanUpContent>();
-            logDebug2(WM_CONTENTUPDATER, "Content cleaner created");
+            logDebug1(WM_CONTENTUPDATER, "Content cleaner created");
         }
         else
         {

--- a/src/shared_modules/content_manager/src/components/factoryCleaner.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryCleaner.hpp
@@ -38,8 +38,8 @@ public:
     {
         if (config.at("deleteDownloadedContent").get_ref<const bool&>())
         {
-            return std::make_shared<CleanUpContent>();
             logDebug1(WM_CONTENTUPDATER, "Content cleaner created");
+            return std::make_shared<CleanUpContent>();
         }
         else
         {

--- a/src/shared_modules/content_manager/src/components/factoryContentUpdater.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryContentUpdater.hpp
@@ -41,7 +41,7 @@ public:
      */
     static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(nlohmann::json& config)
     {
-        logDebug2(WM_CONTENTUPDATER, "FactoryContentUpdater - Starting process");
+        logDebug1(WM_CONTENTUPDATER, "FactoryContentUpdater - Starting process");
 
         auto factoryDownloader {FactoryDownloader::create(config)};
         auto factoryDecompressor {FactoryDecompressor::create(config)};

--- a/src/shared_modules/content_manager/src/components/factoryContentUpdater.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryContentUpdater.hpp
@@ -12,6 +12,7 @@
 #ifndef _FACTORY_CONTENT_UPDATER_HPP
 #define _FACTORY_CONTENT_UPDATER_HPP
 
+#include "../sharedDefs.hpp"
 #include "factoryCleaner.hpp"
 #include "factoryDecompressor.hpp"
 #include "factoryDownloader.hpp"
@@ -56,8 +57,6 @@ public:
             ->setNext(factoryPublisher)
             ->setNext(factoryVersionUpdater)
             ->setNext(factoryCleaner);
-
-        logDebug2(WM_CONTENTUPDATER, "FactoryContentUpdater - Finishing process");
 
         return updaterChain;
     }

--- a/src/shared_modules/content_manager/src/components/factoryDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDecompressor.hpp
@@ -12,6 +12,7 @@
 #ifndef _FACTORY_DECOMPRESSOR_HPP
 #define _FACTORY_DECOMPRESSOR_HPP
 
+#include "../sharedDefs.hpp"
 #include "XZDecompressor.hpp"
 #include "gzipDecompressor.hpp"
 #include "skipStep.hpp"
@@ -69,7 +70,7 @@ public:
             decompressorType = deduceCompressionType(config.at("url").get_ref<const std::string&>());
         }
 
-        logDebug2(WM_CONTENTUPDATER, "Creating '%s' content decompressor", decompressorType.c_str());
+        logDebug2(WM_CONTENTUPDATER, "Attempting to create '%s' decompressor", decompressorType.c_str());
 
         if ("xz" == decompressorType)
         {

--- a/src/shared_modules/content_manager/src/components/factoryDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDecompressor.hpp
@@ -70,7 +70,7 @@ public:
             decompressorType = deduceCompressionType(config.at("url").get_ref<const std::string&>());
         }
 
-        logDebug1(WM_CONTENTUPDATER, "Attempting to create '%s' decompressor", decompressorType.c_str());
+        logDebug1(WM_CONTENTUPDATER, "Creating '%s' decompressor", decompressorType.c_str());
 
         if ("xz" == decompressorType)
         {

--- a/src/shared_modules/content_manager/src/components/factoryDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDecompressor.hpp
@@ -70,7 +70,7 @@ public:
             decompressorType = deduceCompressionType(config.at("url").get_ref<const std::string&>());
         }
 
-        logDebug2(WM_CONTENTUPDATER, "Attempting to create '%s' decompressor", decompressorType.c_str());
+        logDebug1(WM_CONTENTUPDATER, "Attempting to create '%s' decompressor", decompressorType.c_str());
 
         if ("xz" == decompressorType)
         {

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -21,7 +21,6 @@
 #include "offlineDownloader.hpp"
 #include "updaterContext.hpp"
 #include "utils/chainOfResponsability.hpp"
-#include <iostream>
 #include <memory>
 #include <string>
 

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -12,6 +12,7 @@
 #ifndef _FACTORY_DOWNLOADER_HPP
 #define _FACTORY_DOWNLOADER_HPP
 
+#include "../sharedDefs.hpp"
 #include "APIDownloader.hpp"
 #include "CtiOffsetDownloader.hpp"
 #include "CtiSnapshotDownloader.hpp"
@@ -41,8 +42,8 @@ public:
      */
     static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(const nlohmann::json& config)
     {
-        auto const downloaderType {config.at("contentSource").get<std::string>()};
-        logDebug2(WM_CONTENTUPDATER, "Creating '%s' downloader", downloaderType.c_str());
+        auto const downloaderType {config.at("contentSource").get_ref<const std::string&>()};
+        logDebug2(WM_CONTENTUPDATER, "Attempting to create '%s' downloader", downloaderType.c_str());
 
         if ("api" == downloaderType)
         {

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -43,7 +43,7 @@ public:
     static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(const nlohmann::json& config)
     {
         auto const downloaderType {config.at("contentSource").get_ref<const std::string&>()};
-        logDebug1(WM_CONTENTUPDATER, "Attempting to create '%s' downloader", downloaderType.c_str());
+        logDebug1(WM_CONTENTUPDATER, "Creating '%s' downloader", downloaderType.c_str());
 
         if ("api" == downloaderType)
         {

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -43,7 +43,7 @@ public:
     static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(const nlohmann::json& config)
     {
         auto const downloaderType {config.at("contentSource").get_ref<const std::string&>()};
-        logDebug2(WM_CONTENTUPDATER, "Attempting to create '%s' downloader", downloaderType.c_str());
+        logDebug1(WM_CONTENTUPDATER, "Attempting to create '%s' downloader", downloaderType.c_str());
 
         if ("api" == downloaderType)
         {

--- a/src/shared_modules/content_manager/src/components/factoryVersionUpdater.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryVersionUpdater.hpp
@@ -16,7 +16,6 @@
 #include "updateCtiApiOffset.hpp"
 #include "updaterContext.hpp"
 #include "utils/chainOfResponsability.hpp"
-#include <iostream>
 #include <memory>
 #include <string>
 

--- a/src/shared_modules/content_manager/src/components/factoryVersionUpdater.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryVersionUpdater.hpp
@@ -38,7 +38,7 @@ public:
     static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(const nlohmann::json& config)
     {
         auto const versionUpdaterType {config.at("versionedContent").get_ref<const std::string&>()};
-        logDebug1(WM_CONTENTUPDATER, "Attempting to create '%s' version updater", versionUpdaterType.c_str());
+        logDebug1(WM_CONTENTUPDATER, "Creating '%s' version updater", versionUpdaterType.c_str());
 
         if (versionUpdaterType.compare("cti-api") == 0)
         {

--- a/src/shared_modules/content_manager/src/components/factoryVersionUpdater.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryVersionUpdater.hpp
@@ -38,7 +38,7 @@ public:
     static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(const nlohmann::json& config)
     {
         auto const versionUpdaterType {config.at("versionedContent").get_ref<const std::string&>()};
-        logDebug2(WM_CONTENTUPDATER, "Attempting to create '%s' version updater", versionUpdaterType.c_str());
+        logDebug1(WM_CONTENTUPDATER, "Attempting to create '%s' version updater", versionUpdaterType.c_str());
 
         if (versionUpdaterType.compare("cti-api") == 0)
         {

--- a/src/shared_modules/content_manager/src/components/factoryVersionUpdater.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryVersionUpdater.hpp
@@ -12,6 +12,7 @@
 #ifndef _FACTORY_VERSION_UPDATER_HPP
 #define _FACTORY_VERSION_UPDATER_HPP
 
+#include "../sharedDefs.hpp"
 #include "skipStep.hpp"
 #include "updateCtiApiOffset.hpp"
 #include "updaterContext.hpp"
@@ -36,17 +37,15 @@ public:
      */
     static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(const nlohmann::json& config)
     {
-
-        auto const versionUpdaterType {config.at("versionedContent").get<std::string>()};
+        auto const versionUpdaterType {config.at("versionedContent").get_ref<const std::string&>()};
+        logDebug2(WM_CONTENTUPDATER, "Attempting to create '%s' version updater", versionUpdaterType.c_str());
 
         if (versionUpdaterType.compare("cti-api") == 0)
         {
-            logDebug2(WM_CONTENTUPDATER, "Creating '%s' version updater", versionUpdaterType.c_str());
             return std::make_shared<UpdateCtiApiOffset>();
         }
         if (versionUpdaterType.compare("false") == 0)
         {
-            logDebug2(WM_CONTENTUPDATER, "Version updater not needed");
             return std::make_shared<SkipStep>();
         }
         else

--- a/src/shared_modules/content_manager/src/components/fileDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/fileDownloader.hpp
@@ -138,7 +138,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
-        logDebug2(WM_CONTENTUPDATER, "FileDownloader - Starting process");
+        logDebug1(WM_CONTENTUPDATER, "FileDownloader - Starting process");
 
         try
         {

--- a/src/shared_modules/content_manager/src/components/fileDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/fileDownloader.hpp
@@ -109,13 +109,16 @@ private:
                             }};
 
         // Download and store file.
+        logDebug2(WM_CONTENTUPDATER, "Attempting to download file from '%s'", url.string().c_str());
         HTTPRequest::instance().download(HttpURL(url), outputFilePath, onError);
 
         // Just process the new file if the hash is different from the last one.
         auto downloadFileHash {hashFile(outputFilePath)};
         if (context.spUpdaterBaseContext->downloadedFileHash == downloadFileHash)
         {
-            logDebug1(WM_CONTENTUPDATER, "Content file didn't change from last download");
+            logDebug2(WM_CONTENTUPDATER,
+                      "File '%s' didn't change from last download so it won't be published",
+                      outputFilePath.string().c_str());
             return;
         }
 
@@ -135,6 +138,8 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
+        logDebug2(WM_CONTENTUPDATER, "FileDownloader - Starting process");
+
         try
         {
             download(*context);
@@ -149,8 +154,6 @@ public:
 
         // Push success state.
         pushStageStatus(context->data, "ok");
-
-        logDebug2(WM_CONTENTUPDATER, "FileDownloader - Download done successfully");
 
         return AbstractHandler<std::shared_ptr<UpdaterContext>>::handleRequest(context);
     }

--- a/src/shared_modules/content_manager/src/components/fileDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/fileDownloader.hpp
@@ -109,7 +109,7 @@ private:
                             }};
 
         // Download and store file.
-        logDebug2(WM_CONTENTUPDATER, "Attempting to download file from '%s'", url.string().c_str());
+        logDebug2(WM_CONTENTUPDATER, "Downloading file from '%s'", url.string().c_str());
         HTTPRequest::instance().download(HttpURL(url), outputFilePath, onError);
 
         // Just process the new file if the hash is different from the last one.

--- a/src/shared_modules/content_manager/src/components/fileDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/fileDownloader.hpp
@@ -22,7 +22,6 @@
 #include <array>
 #include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/shared_modules/content_manager/src/components/gzipDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/gzipDecompressor.hpp
@@ -71,10 +71,8 @@ private:
             outputPath = Utils::rightTrim(outputPath, inputPath.extension());
 
             // Decompress.
-            logDebug2(WM_CONTENTUPDATER,
-                      "Attempting to decompress '%s' into '%s'",
-                      inputPath.string().c_str(),
-                      outputPath.c_str());
+            logDebug2(
+                WM_CONTENTUPDATER, "Decompressing '%s' into '%s'", inputPath.string().c_str(), outputPath.c_str());
             Utils::ZlibHelper::gzipDecompress(inputPath, outputPath);
 
             // Decompression finished: Update context path.

--- a/src/shared_modules/content_manager/src/components/gzipDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/gzipDecompressor.hpp
@@ -56,6 +56,8 @@ private:
     {
         for (auto& path : context.data.at("paths"))
         {
+            logDebug2(WM_CONTENTUPDATER, "Attempting to decompress '%s'", path.get_ref<const std::string&>().c_str());
+
             // Copy input path.
             std::filesystem::path inputPath {path};
             auto outputPath {path.get<std::string>()};
@@ -87,6 +89,8 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
+        logDebug2(WM_CONTENTUPDATER, "GzipDecompressor - Starting process");
+
         try
         {
             decompress(*context);
@@ -101,8 +105,6 @@ public:
 
         // Push success state.
         pushStageStatus(context->data, "ok");
-
-        logDebug2(WM_CONTENTUPDATER, "GzipDecompressor - Finishing process");
 
         return AbstractHandler<std::shared_ptr<UpdaterContext>>::handleRequest(context);
     }

--- a/src/shared_modules/content_manager/src/components/gzipDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/gzipDecompressor.hpp
@@ -56,8 +56,6 @@ private:
     {
         for (auto& path : context.data.at("paths"))
         {
-            logDebug2(WM_CONTENTUPDATER, "Attempting to decompress '%s'", path.get_ref<const std::string&>().c_str());
-
             // Copy input path.
             std::filesystem::path inputPath {path};
             auto outputPath {path.get<std::string>()};
@@ -73,6 +71,10 @@ private:
             outputPath = Utils::rightTrim(outputPath, inputPath.extension());
 
             // Decompress.
+            logDebug2(WM_CONTENTUPDATER,
+                      "Attempting to decompress '%s' into '%s'",
+                      inputPath.string().c_str(),
+                      outputPath.c_str());
             Utils::ZlibHelper::gzipDecompress(inputPath, outputPath);
 
             // Decompression finished: Update context path.

--- a/src/shared_modules/content_manager/src/components/gzipDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/gzipDecompressor.hpp
@@ -89,7 +89,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
-        logDebug2(WM_CONTENTUPDATER, "GzipDecompressor - Starting process");
+        logDebug1(WM_CONTENTUPDATER, "GzipDecompressor - Starting process");
 
         try
         {

--- a/src/shared_modules/content_manager/src/components/gzipDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/gzipDecompressor.hpp
@@ -19,7 +19,6 @@
 #include "utils/stringHelper.h"
 #include "utils/zlibHelper.hpp"
 #include <filesystem>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -106,7 +106,7 @@ private:
 
         // Copy file, overriding the output one if necessary.
         logDebug2(WM_CONTENTUPDATER,
-                  "Attempting to copy file from '%s' into '%s'",
+                  "Copying file from '%s' into '%s'",
                   inputFilepath.string().c_str(),
                   outputFilepath.string().c_str());
         std::filesystem::copy(unprefixedUrl, outputFilepath, std::filesystem::copy_options::overwrite_existing);
@@ -132,7 +132,7 @@ private:
 
         // Download file from URL.
         logDebug2(WM_CONTENTUPDATER,
-                  "Attempting to download file from '%s' into '%s'",
+                  "Downloading file from '%s' into '%s'",
                   inputFileURL.string().c_str(),
                   outputFilepath.string().c_str());
         m_urlRequest.download(HttpURL(inputFileURL), outputFilepath, onError);

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -106,7 +106,7 @@ private:
 
         // Copy file, overriding the output one if necessary.
         logDebug2(WM_CONTENTUPDATER,
-                  "Attempting to copy file '%s' into '%s'",
+                  "Attempting to copy file from '%s' into '%s'",
                   inputFilepath.string().c_str(),
                   outputFilepath.string().c_str());
         std::filesystem::copy(unprefixedUrl, outputFilepath, std::filesystem::copy_options::overwrite_existing);
@@ -132,7 +132,7 @@ private:
 
         // Download file from URL.
         logDebug2(WM_CONTENTUPDATER,
-                  "Attempting to download file  from '%s' into '%s'",
+                  "Attempting to download file from '%s' into '%s'",
                   inputFileURL.string().c_str(),
                   outputFilepath.string().c_str());
         m_urlRequest.download(HttpURL(inputFileURL), outputFilepath, onError);
@@ -222,7 +222,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
-        logDebug2(WM_CONTENTUPDATER, "OfflineDownloader - Starting process");
+        logDebug1(WM_CONTENTUPDATER, "OfflineDownloader - Starting process");
 
         try
         {

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -105,6 +105,10 @@ private:
         }
 
         // Copy file, overriding the output one if necessary.
+        logDebug2(WM_CONTENTUPDATER,
+                  "Attempting to copy file '%s' into '%s'",
+                  inputFilepath.string().c_str(),
+                  outputFilepath.string().c_str());
         std::filesystem::copy(unprefixedUrl, outputFilepath, std::filesystem::copy_options::overwrite_existing);
         return true;
     }
@@ -127,6 +131,10 @@ private:
             }};
 
         // Download file from URL.
+        logDebug2(WM_CONTENTUPDATER,
+                  "Attempting to download file  from '%s' into '%s'",
+                  inputFileURL.string().c_str(),
+                  outputFilepath.string().c_str());
         m_urlRequest.download(HttpURL(inputFileURL), outputFilepath, onError);
         return returnCode;
     }
@@ -188,7 +196,12 @@ private:
 
             // Download finished: Insert path into context.
             context.data.at("paths").push_back(outputFilePath.string());
+            return;
         }
+
+        logDebug2(WM_CONTENTUPDATER,
+                  "File '%s' didn't change from last download so it won't be published",
+                  outputFilePath.string().c_str());
     }
 
 public:
@@ -209,6 +222,8 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
+        logDebug2(WM_CONTENTUPDATER, "OfflineDownloader - Starting process");
+
         try
         {
             download(*context);
@@ -223,8 +238,6 @@ public:
 
         // Push success state.
         pushStageStatus(context->data, "ok");
-
-        logDebug2(WM_CONTENTUPDATER, "OfflineDownloader - Download done successfully");
 
         return AbstractHandler<std::shared_ptr<UpdaterContext>>::handleRequest(context);
     }

--- a/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
+++ b/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
@@ -15,7 +15,6 @@
 #include "../sharedDefs.hpp"
 #include "updaterContext.hpp"
 #include "utils/chainOfResponsability.hpp"
-#include <iostream>
 #include <memory>
 
 /**

--- a/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
+++ b/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
@@ -39,13 +39,13 @@ private:
             // serialize the JSON object
             const auto stringifyJson = context.data.dump();
 
+            logDebug2(WM_CONTENTUPDATER, "Data to be published: '%s'", stringifyJson.c_str());
+
             context.spUpdaterBaseContext->spChannel->send({stringifyJson.begin(), stringifyJson.end()});
-            logDebug2(WM_CONTENTUPDATER, "PubSubPublisher - Data published");
+            return;
         }
-        else
-        {
-            logDebug2(WM_CONTENTUPDATER, "PubSubPublisher - No data data to publish");
-        }
+
+        logDebug2(WM_CONTENTUPDATER, "No data to publish");
     }
 
 public:
@@ -57,6 +57,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
+        logDebug2(WM_CONTENTUPDATER, "PubSubPublisher - Starting process");
 
         publish(*context);
 

--- a/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
+++ b/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
@@ -42,10 +42,11 @@ private:
             logDebug2(WM_CONTENTUPDATER, "Data to be published: '%s'", stringifyJson.c_str());
 
             context.spUpdaterBaseContext->spChannel->send({stringifyJson.begin(), stringifyJson.end()});
+            logInfo(WM_CONTENTUPDATER, "Data published");
             return;
         }
 
-        logDebug2(WM_CONTENTUPDATER, "No data to publish");
+        logInfo(WM_CONTENTUPDATER, "No data to publish");
     }
 
 public:

--- a/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
+++ b/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
@@ -46,7 +46,7 @@ private:
             return;
         }
 
-        logInfo(WM_CONTENTUPDATER, "No data to publish");
+        logDebug2(WM_CONTENTUPDATER, "No data to publish");
     }
 
 public:

--- a/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
+++ b/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
@@ -57,7 +57,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
-        logDebug2(WM_CONTENTUPDATER, "PubSubPublisher - Starting process");
+        logDebug1(WM_CONTENTUPDATER, "PubSubPublisher - Starting process");
 
         publish(*context);
 

--- a/src/shared_modules/content_manager/src/components/skipStep.hpp
+++ b/src/shared_modules/content_manager/src/components/skipStep.hpp
@@ -45,8 +45,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
-
-        logDebug2(WM_CONTENTUPDATER, "SkipStep - Executing");
+        logDebug2(WM_CONTENTUPDATER, "SkipStep - Starting process");
 
         for (auto const& action : preActions)
         {

--- a/src/shared_modules/content_manager/src/components/skipStep.hpp
+++ b/src/shared_modules/content_manager/src/components/skipStep.hpp
@@ -45,7 +45,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
-        logDebug2(WM_CONTENTUPDATER, "SkipStep - Starting process");
+        logDebug1(WM_CONTENTUPDATER, "SkipStep - Starting process");
 
         for (auto const& action : preActions)
         {

--- a/src/shared_modules/content_manager/src/components/updateCtiApiOffset.hpp
+++ b/src/shared_modules/content_manager/src/components/updateCtiApiOffset.hpp
@@ -63,7 +63,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
-        logDebug2(WM_CONTENTUPDATER, "UpdateCtiApiOffset - Starting process");
+        logDebug1(WM_CONTENTUPDATER, "UpdateCtiApiOffset - Starting process");
 
         update(*context);
 

--- a/src/shared_modules/content_manager/src/components/updateCtiApiOffset.hpp
+++ b/src/shared_modules/content_manager/src/components/updateCtiApiOffset.hpp
@@ -12,6 +12,7 @@
 #ifndef _UPDATE_CTI_API_OFFSET_HPP
 #define _UPDATE_CTI_API_OFFSET_HPP
 
+#include "../sharedDefs.hpp"
 #include "updaterContext.hpp"
 #include "utils/chainOfResponsability.hpp"
 #include "utils/timeHelper.h"
@@ -62,6 +63,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
+        logDebug2(WM_CONTENTUPDATER, "UpdateCtiApiOffset - Starting process");
 
         update(*context);
 

--- a/src/shared_modules/content_manager/src/components/zipDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/zipDecompressor.hpp
@@ -60,6 +60,8 @@ private:
 
         for (const auto& path : context.data.at("paths"))
         {
+            logDebug2(WM_CONTENTUPDATER, "Attempting to decompress '%s'", path.get_ref<const std::string&>().c_str());
+
             // Decompress and move paths.
             auto decompressedFiles {Utils::ZlibHelper::zipDecompress(path, outputFolder)};
             newPaths.insert(newPaths.end(),
@@ -80,6 +82,8 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
+        logDebug2(WM_CONTENTUPDATER, "ZipDecompressor - Starting process");
+
         try
         {
             decompress(*context);
@@ -94,8 +98,6 @@ public:
 
         // Push success state.
         pushStageStatus(context->data, "ok");
-
-        logDebug2(WM_CONTENTUPDATER, "ZipDecompressor - Finishing process");
 
         return AbstractHandler<std::shared_ptr<UpdaterContext>>::handleRequest(context);
     }

--- a/src/shared_modules/content_manager/src/components/zipDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/zipDecompressor.hpp
@@ -61,7 +61,7 @@ private:
         for (const auto& path : context.data.at("paths"))
         {
             logDebug2(WM_CONTENTUPDATER,
-                      "Attempting to decompress '%s' into '%s'",
+                      "Decompressing '%s' into '%s'",
                       path.get_ref<const std::string&>().c_str(),
                       outputFolder.string().c_str());
 

--- a/src/shared_modules/content_manager/src/components/zipDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/zipDecompressor.hpp
@@ -82,7 +82,7 @@ public:
      */
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
-        logDebug2(WM_CONTENTUPDATER, "ZipDecompressor - Starting process");
+        logDebug1(WM_CONTENTUPDATER, "ZipDecompressor - Starting process");
 
         try
         {

--- a/src/shared_modules/content_manager/src/components/zipDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/zipDecompressor.hpp
@@ -18,7 +18,6 @@
 #include "utils/chainOfResponsability.hpp"
 #include "utils/zlibHelper.hpp"
 #include <filesystem>
-#include <iostream>
 #include <iterator>
 #include <memory>
 #include <string>

--- a/src/shared_modules/content_manager/src/components/zipDecompressor.hpp
+++ b/src/shared_modules/content_manager/src/components/zipDecompressor.hpp
@@ -60,7 +60,10 @@ private:
 
         for (const auto& path : context.data.at("paths"))
         {
-            logDebug2(WM_CONTENTUPDATER, "Attempting to decompress '%s'", path.get_ref<const std::string&>().c_str());
+            logDebug2(WM_CONTENTUPDATER,
+                      "Attempting to decompress '%s' into '%s'",
+                      path.get_ref<const std::string&>().c_str(),
+                      outputFolder.string().c_str());
 
             // Decompress and move paths.
             auto decompressedFiles {Utils::ZlibHelper::zipDecompress(path, outputFolder)};

--- a/src/shared_modules/content_manager/src/contentModuleFacade.cpp
+++ b/src/shared_modules/content_manager/src/contentModuleFacade.cpp
@@ -52,7 +52,7 @@ void ContentModuleFacade::startScheduling(const std::string& name, size_t interv
     }
     catch (const std::exception& e)
     {
-        logError(WM_CONTENTUPDATER, "startScheduling: %s", e.what());
+        logError(WM_CONTENTUPDATER, "Couldn't start scheduled action: %s", e.what());
     }
 }
 void ContentModuleFacade::startOndemand(const std::string& name)
@@ -64,7 +64,7 @@ void ContentModuleFacade::startOndemand(const std::string& name)
     }
     catch (const std::exception& e)
     {
-        logError(WM_CONTENTUPDATER, "startOnDemand: %s", e.what());
+        logError(WM_CONTENTUPDATER, "Couldn't start on-demand action: %s", e.what());
     }
 }
 
@@ -77,6 +77,6 @@ void ContentModuleFacade::changeSchedulerInterval(const std::string& name, const
     }
     catch (const std::exception& e)
     {
-        logError(WM_CONTENTUPDATER, "changeSchedulingTime: %s", e.what());
+        logError(WM_CONTENTUPDATER, "Couldn't change scheduled interval: %s", e.what());
     }
 }

--- a/src/shared_modules/content_manager/src/contentModuleFacade.hpp
+++ b/src/shared_modules/content_manager/src/contentModuleFacade.hpp
@@ -14,7 +14,6 @@
 
 #include "contentProvider.hpp"
 #include <filesystem>
-#include <iostream>
 
 constexpr auto CONTENT_MODULE_ENDPOINT_NAME {"content"};
 

--- a/src/shared_modules/content_manager/src/contentProvider.hpp
+++ b/src/shared_modules/content_manager/src/contentProvider.hpp
@@ -17,7 +17,6 @@
 #include "routerSubscriber.hpp"
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -1,7 +1,6 @@
 #include "contentManager.hpp"
 #include "contentRegister.hpp"
 #include "defs.h"
-#include "loggerHelper.h"
 #include <chrono>
 #include <iostream>
 #include <thread>
@@ -61,28 +60,31 @@ int main()
            const std::string& func,
            const std::string& message)
         {
-            if (!VERBOSE && (logLevel == Log::LOGLEVEL_DEBUG || logLevel == Log::LOGLEVEL_DEBUG_VERBOSE))
-            {
-                // Don't log debug logs when VERBOSE is false.
-                return;
-            }
-
-            auto pos = file.find_last_of('/');
+            auto pos {file.find_last_of('/')};
             if (pos != std::string::npos)
             {
                 pos++;
             }
-            std::string fileName = file.substr(pos, file.size() - pos);
+            const auto fileName {file.substr(pos, file.size() - pos)};
 
-            if (logLevel != Log::LOGLEVEL_ERROR && logLevel != Log::LOGLEVEL_CRITICAL)
+            if (logLevel == LOGLEVEL_ERROR || logLevel == LOGLEVEL_CRITICAL)
             {
-                std::cout << tag << ":" << fileName << ":" << line << " " << func << ": " << message.c_str()
-                          << std::endl;
+                // Error logs.
+                std::cerr << tag << ": " << message.c_str() << std::endl;
+            }
+            else if (logLevel == LOGLEVEL_INFO || logLevel == LOGLEVEL_WARNING)
+            {
+                // Info and warning logs.
+                std::cout << tag << ": " << message.c_str() << std::endl;
             }
             else
             {
-                std::cerr << tag << ":" << fileName << ":" << line << " " << func << ": " << message.c_str()
-                          << std::endl;
+                // Debug logs.
+                if (VERBOSE)
+                {
+                    std::cout << tag << ":" << fileName << ":" << line << " " << func << ": " << message.c_str()
+                              << std::endl;
+                }
             }
         });
 

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -44,6 +44,9 @@ static const nlohmann::json CONFIG_PARAMETERS =
         }
         )"_json;
 
+// Enable/Disable logging verbosity.
+static const auto VERBOSE {true};
+
 int main()
 {
     auto& instance = ContentModule::instance();
@@ -57,6 +60,12 @@ int main()
            const std::string& func,
            const std::string& message)
         {
+            if (!VERBOSE && (logLevel == LOG_DEBUG || logLevel == LOG_DEBUG_VERBOSE))
+            {
+                // Don't log debug logs when VERBOSE is false.
+                return;
+            }
+
             auto pos = file.find_last_of('/');
             if (pos != std::string::npos)
             {
@@ -66,16 +75,17 @@ int main()
 
             if (logLevel != LOGLEVEL_ERROR)
             {
-                std::cout << tag << ":" << fileName << ":" << line << " " << func << " : " << message.c_str()
+                std::cout << tag << ":" << fileName << ":" << line << " " << func << ": " << message.c_str()
                           << std::endl;
             }
             else
             {
-                std::cerr << tag << ":" << fileName << ":" << line << " " << func << " : " << message.c_str()
+                std::cerr << tag << ":" << fileName << ":" << line << " " << func << ": " << message.c_str()
                           << std::endl;
             }
         });
-    // CLiente -> vulnenability  detector
+
+    // Client -> Vulnerability detector
     ContentRegister registerer {CONFIG_PARAMETERS.at("topicName").get<std::string>(), CONFIG_PARAMETERS};
     std::this_thread::sleep_for(std::chrono::seconds(5));
     std::cout << "changing interval" << std::endl;

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -1,6 +1,7 @@
 #include "contentManager.hpp"
 #include "contentRegister.hpp"
 #include "defs.h"
+#include "loggerHelper.h"
 #include <chrono>
 #include <iostream>
 #include <thread>
@@ -45,7 +46,7 @@ static const nlohmann::json CONFIG_PARAMETERS =
         )"_json;
 
 // Enable/Disable logging verbosity.
-static const auto VERBOSE {true};
+static const auto VERBOSE {false};
 
 int main()
 {
@@ -60,7 +61,7 @@ int main()
            const std::string& func,
            const std::string& message)
         {
-            if (!VERBOSE && (logLevel == LOG_DEBUG || logLevel == LOG_DEBUG_VERBOSE))
+            if (!VERBOSE && (logLevel == Log::LOGLEVEL_DEBUG || logLevel == Log::LOGLEVEL_DEBUG_VERBOSE))
             {
                 // Don't log debug logs when VERBOSE is false.
                 return;
@@ -73,7 +74,7 @@ int main()
             }
             std::string fileName = file.substr(pos, file.size() - pos);
 
-            if (logLevel != LOGLEVEL_ERROR)
+            if (logLevel != Log::LOGLEVEL_ERROR && logLevel != Log::LOGLEVEL_CRITICAL)
             {
                 std::cout << tag << ":" << fileName << ":" << line << " " << func << ": " << message.c_str()
                           << std::endl;

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -3,6 +3,8 @@
 #include "defs.h"
 #include <chrono>
 #include <iostream>
+#include <map>
+#include <string>
 #include <thread>
 
 /*
@@ -71,22 +73,32 @@ void logFunction(const int logLevel,
     }
     const auto fileName {file.substr(pos, file.size() - pos)};
 
+    // Set log level tag.
+    static const std::map<int, std::string> LOG_LEVEL_TAGS {{LOGLEVEL_DEBUG_VERBOSE, "DEBUG_VERBOSE"},
+                                                            {LOGLEVEL_DEBUG, "DEBUG"},
+                                                            {LOGLEVEL_INFO, "INFO"},
+                                                            {LOGLEVEL_WARNING, "WARNING"},
+                                                            {LOGLEVEL_ERROR, "ERROR"},
+                                                            {LOGLEVEL_CRITICAL, "CRITICAL"}};
+    const auto levelTag {"[" + LOG_LEVEL_TAGS.at(logLevel) + "]"};
+
     if (logLevel == LOGLEVEL_ERROR || logLevel == LOGLEVEL_CRITICAL)
     {
         // Error logs.
-        std::cerr << tag << ": " << message.c_str() << std::endl;
+        std::cerr << tag << ":" << levelTag << ": " << message.c_str() << std::endl;
     }
     else if (logLevel == LOGLEVEL_INFO || logLevel == LOGLEVEL_WARNING)
     {
         // Info and warning logs.
-        std::cout << tag << ": " << message.c_str() << std::endl;
+        std::cout << tag << ":" << levelTag << ": " << message.c_str() << std::endl;
     }
     else
     {
         // Debug logs.
         if (VERBOSE)
         {
-            std::cout << tag << ":" << fileName << ":" << line << " " << func << ": " << message.c_str() << std::endl;
+            std::cout << tag << ":" << levelTag << ":" << fileName << ":" << line << " " << func << ": "
+                      << message.c_str() << std::endl;
         }
     }
 }

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -47,7 +47,7 @@ static const nlohmann::json CONFIG_PARAMETERS =
         )"_json;
 
 // Enable/Disable logging verbosity.
-static const auto VERBOSE {false};
+static const auto VERBOSE {true};
 
 /**
  * @brief Log function callback used on the Content Manager test tool.


### PR DESCRIPTION
|Related issue|
|---|
|#20440 |

## Description

This PR adds more messages to the logging mechanism of the Content Manager module.

I've defined two different "zones" where different log levels are used:
- Action zone: files under `src/`.
- Components zone: files under `src/components`.

The criteria used for each log level are the following:
- Error: Just at `actions` zone. Critical errors.
- Warning: Just at `components` zone. Non-critical errors.
- Info: Just at `actions` zone. Started/stopped actions. Exception: PubSubPublisher class.
- Debug: Just at `components` zone Orchestration creation and steps run.
- Debug2: Just at `components` zone. Components run details.

I've added a verbose mode to the test tool. If enabled, all log levels are shown. If not, both debug-level logs are hidden.

## Results

- Not verbose mode.
```bash
# ./content_manager_test_tool 
wazuh-modulesd:content-updater: Starting on-start action for 'test'
wazuh-modulesd:content-updater: Action for 'test' started
wazuh-modulesd:content-updater: Running 'test' content update
wazuh-modulesd:content-updater: Action for 'test' finished
changing interval
wazuh-modulesd:content-updater: Starting scheduled action for 'test'
wazuh-modulesd:content-updater: Action for 'test' started
wazuh-modulesd:content-updater: Running 'test' content update
wazuh-modulesd:content-updater: Action for 'test' finished
```

- Not verbose mode. Error raised.
```bash
# ./content_manager_test_tool 
wazuh-modulesd:content-updater: Starting on-start action for 'test'
wazuh-modulesd:content-updater: Action for 'test' started
wazuh-modulesd:content-updater: Running 'test' content update
wazuh-modulesd:content-updater: Action for 'test' failed: Orchestration run failed: APIDownloader - Could not get response from API because: HTTP response code said error
wazuh-modulesd:content-updater: Action for 'test' finished
```

- Verbose mode. Download from API.
```bash
# ./content_manager_test_tool 
wazuh-modulesd:content-updater:actionOrchestrator.hpp:45 ActionOrchestrator: Creating 'test' Content Updater orchestration
wazuh-modulesd:content-updater:executionContext.hpp:165 handleRequest: ExecutionContext - Starting process
wazuh-modulesd:content-updater:executionContext.hpp:140 createOutputFolder: Attempting to remove previous output folder '/tmp/testProvider'
wazuh-modulesd:content-updater:executionContext.hpp:147 createOutputFolder: Attempting to create output folders at '/tmp/testProvider'
wazuh-modulesd:content-updater:factoryContentUpdater.hpp:44 create: FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:factoryDownloader.hpp:45 create: Attempting to create 'api' downloader
wazuh-modulesd:content-updater:factoryDecompressor.hpp:73 create: Attempting to create 'raw' decompressor
wazuh-modulesd:content-updater:factoryVersionUpdater.hpp:41 create: Attempting to create 'false' version updater
wazuh-modulesd:content-updater:actionOrchestrator.hpp:55 ActionOrchestrator: Content updater orchestration created
wazuh-modulesd:content-updater: Starting on-start action for 'test'
wazuh-modulesd:content-updater: Action for 'test' started
wazuh-modulesd:content-updater: Running 'test' content update
wazuh-modulesd:content-updater:APIDownloader.hpp:118 handleRequest: APIDownloader - Starting process
wazuh-modulesd:content-updater:APIDownloader.hpp:75 downloadContent: Attempting to download from API 'https://jsonplaceholder.typicode.com/todos/1'
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:60 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:42 publish: Data to be published: '{"paths":["/tmp/testProvider/contents/example.json"],"stageStatus":[{"stage":"APIDownloader","status":"ok"}]}'
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater: Action for 'test' finished
```

- Verbose mode. Download from CTI API. Configured with an initial offset of 974000.
```bash
# ./content_manager_test_tool 
wazuh-modulesd:content-updater:actionOrchestrator.hpp:45 ActionOrchestrator: Creating 'test' Content Updater orchestration
wazuh-modulesd:content-updater:executionContext.hpp:165 handleRequest: ExecutionContext - Starting process
wazuh-modulesd:content-updater:executionContext.hpp:140 createOutputFolder: Attempting to remove previous output folder '/tmp/testProvider'
wazuh-modulesd:content-updater:executionContext.hpp:147 createOutputFolder: Attempting to create output folders at '/tmp/testProvider'
wazuh-modulesd:content-updater:factoryContentUpdater.hpp:44 create: FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:factoryDownloader.hpp:45 create: Attempting to create 'cti-api' downloader
wazuh-modulesd:content-updater:factoryDecompressor.hpp:73 create: Attempting to create 'raw' decompressor
wazuh-modulesd:content-updater:factoryVersionUpdater.hpp:41 create: Attempting to create 'cti-api' version updater
wazuh-modulesd:content-updater:actionOrchestrator.hpp:55 ActionOrchestrator: Content updater orchestration created
wazuh-modulesd:content-updater: Starting on-start action for 'test'
wazuh-modulesd:content-updater: Action for 'test' started
wazuh-modulesd:content-updater: Running 'test' content update
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:252 handleRequest: CtiApiDownloader - Starting process
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:73 download: Initial API offset: 974000
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:192 performQueryWithRetry: Attempting to download content from: 'https://cti-dev.wazuh.com/api/v1/catalog/contexts/vulnerabilities_ap/consumers/test_ap'
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:142 getConsumerLastOffset: Last consumer offset: 978576
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:192 performQueryWithRetry: Attempting to download content from: 'https://cti-dev.wazuh.com/api/v1/catalog/contexts/vulnerabilities_ap/consumers/test_ap/changes?from_offset=974000&to_offset=975000'
changing interval
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:192 performQueryWithRetry: Attempting to download content from: 'https://cti-dev.wazuh.com/api/v1/catalog/contexts/vulnerabilities_ap/consumers/test_ap/changes?from_offset=975000&to_offset=976000'
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:192 performQueryWithRetry: Attempting to download content from: 'https://cti-dev.wazuh.com/api/v1/catalog/contexts/vulnerabilities_ap/consumers/test_ap/changes?from_offset=976000&to_offset=977000'
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:192 performQueryWithRetry: Attempting to download content from: 'https://cti-dev.wazuh.com/api/v1/catalog/contexts/vulnerabilities_ap/consumers/test_ap/changes?from_offset=977000&to_offset=978000'
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:192 performQueryWithRetry: Attempting to download content from: 'https://cti-dev.wazuh.com/api/v1/catalog/contexts/vulnerabilities_ap/consumers/test_ap/changes?from_offset=978000&to_offset=978576'
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:60 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:42 publish: Data to be published: '{"paths":["/tmp/testProvider/contents/975000-example.json","/tmp/testProvider/contents/976000-example.json","/tmp/testProvider/contents/977000-example.json","/tmp/testProvider/contents/978000-example.json","/tmp/testProvider/contents/978576-example.json"],"stageStatus":[{"stage":"CtiApiDownloader","status":"ok"}]}'
wazuh-modulesd:content-updater:updateCtiApiOffset.hpp:66 handleRequest: UpdateCtiApiOffset - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater: Action for 'test' finished
wazuh-modulesd:content-updater: Starting scheduled action for 'test'
wazuh-modulesd:content-updater: Action for 'test' started
wazuh-modulesd:content-updater: Running 'test' content update
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:252 handleRequest: CtiApiDownloader - Starting process
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:73 download: Initial API offset: 978576
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:192 performQueryWithRetry: Attempting to download content from: 'https://cti-dev.wazuh.com/api/v1/catalog/contexts/vulnerabilities_ap/consumers/test_ap'
wazuh-modulesd:content-updater:CtiApiDownloader.hpp:142 getConsumerLastOffset: Last consumer offset: 978576
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:60 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:48 publish: No data to publish
wazuh-modulesd:content-updater:updateCtiApiOffset.hpp:66 handleRequest: UpdateCtiApiOffset - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater: Action for 'test' finished
```

- Verbose mode. Remote file download.
```bash
# ./content_manager_test_tool 
wazuh-modulesd:content-updater:actionOrchestrator.hpp:45 ActionOrchestrator: Creating 'test' Content Updater orchestration
wazuh-modulesd:content-updater:executionContext.hpp:165 handleRequest: ExecutionContext - Starting process
wazuh-modulesd:content-updater:executionContext.hpp:140 createOutputFolder: Attempting to remove previous output folder '/tmp/testProvider'
wazuh-modulesd:content-updater:executionContext.hpp:147 createOutputFolder: Attempting to create output folders at '/tmp/testProvider'
wazuh-modulesd:content-updater:factoryContentUpdater.hpp:44 create: FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:factoryDownloader.hpp:45 create: Attempting to create 'file' downloader
wazuh-modulesd:content-updater:factoryDecompressor.hpp:73 create: Attempting to create 'zip' decompressor
wazuh-modulesd:content-updater:factoryVersionUpdater.hpp:41 create: Attempting to create 'false' version updater
wazuh-modulesd:content-updater:actionOrchestrator.hpp:55 ActionOrchestrator: Content updater orchestration created
wazuh-modulesd:content-updater: Starting on-start action for 'test'
wazuh-modulesd:content-updater: Action for 'test' started
wazuh-modulesd:content-updater: Running 'test' content update
wazuh-modulesd:content-updater:fileDownloader.hpp:141 handleRequest: FileDownloader - Starting process
wazuh-modulesd:content-updater:fileDownloader.hpp:112 download: Attempting to download file from 'https://s3.us-east-1.amazonaws.com/cti-snapshots/store/contexts/vulnerabilities_ap/consumers/test_ap/978572_1698749927.zip'
changing interval
wazuh-modulesd:content-updater:zipDecompressor.hpp:85 handleRequest: ZipDecompressor - Starting process
wazuh-modulesd:content-updater:zipDecompressor.hpp:63 decompress: Attempting to decompress '/tmp/testProvider/downloads/978572_1698749927.zip'
wazuh-modulesd:content-updater:pubSubPublisher.hpp:60 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:42 publish: Data to be published: '{"paths":["/tmp/testProvider/contents/vulnerabilities_ap_test_ap_978572_1698749927.json"],"stageStatus":[{"stage":"FileDownloader","status":"ok"},{"stage":"ZipDecompressor","status":"ok"}]}'
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater: Action for 'test' finished
wazuh-modulesd:content-updater:onDemandManager.cpp:68 stopServer: Server stopped
wazuh-modulesd:content-updater: Scheduler stopped for 'test'
```

- Verbose mode. Offline download from filesystem.
```bash
# ./content_manager_test_tool 
wazuh-modulesd:content-updater:actionOrchestrator.hpp:45 ActionOrchestrator: Creating 'test' Content Updater orchestration
wazuh-modulesd:content-updater:executionContext.hpp:165 handleRequest: ExecutionContext - Starting process
wazuh-modulesd:content-updater:executionContext.hpp:140 createOutputFolder: Attempting to remove previous output folder '/tmp/testProvider'
wazuh-modulesd:content-updater:executionContext.hpp:147 createOutputFolder: Attempting to create output folders at '/tmp/testProvider'
wazuh-modulesd:content-updater:factoryContentUpdater.hpp:44 create: FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:factoryDownloader.hpp:45 create: Attempting to create 'offline' downloader
wazuh-modulesd:content-updater:factoryDecompressor.hpp:73 create: Attempting to create 'xz' decompressor
wazuh-modulesd:content-updater:factoryVersionUpdater.hpp:41 create: Attempting to create 'false' version updater
wazuh-modulesd:content-updater:actionOrchestrator.hpp:55 ActionOrchestrator: Content updater orchestration created
wazuh-modulesd:content-updater: Starting on-start action for 'test'
wazuh-modulesd:content-updater: Action for 'test' started
wazuh-modulesd:content-updater: Running 'test' content update
wazuh-modulesd:content-updater:offlineDownloader.hpp:225 handleRequest: OfflineDownloader - Starting process
wazuh-modulesd:content-updater:offlineDownloader.hpp:108 copyFile: Attempting to copy file from 'file:///home/content.xz' into '/tmp/testProvider/downloads/content.xz'
wazuh-modulesd:content-updater:XZDecompressor.hpp:79 handleRequest: XZDecompressor - Starting process
wazuh-modulesd:content-updater:XZDecompressor.hpp:41 decompress: Attempting to decompress '/tmp/testProvider/downloads/content.xz'
wazuh-modulesd:content-updater:pubSubPublisher.hpp:60 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:42 publish: Data to be published: '{"paths":["/tmp/testProvider/contents/content.json"],"stageStatus":[{"stage":"OfflineDownloader","status":"ok"},{"stage":"XZDecompressor","status":"ok"}]}'
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater: Action for 'test' finished
changing interval
wazuh-modulesd:content-updater: Starting scheduled action for 'test'
wazuh-modulesd:content-updater: Action for 'test' started
wazuh-modulesd:content-updater: Running 'test' content update
wazuh-modulesd:content-updater:offlineDownloader.hpp:225 handleRequest: OfflineDownloader - Starting process
wazuh-modulesd:content-updater:offlineDownloader.hpp:108 copyFile: Attempting to copy file from 'file:///home/content.xz' into '/tmp/testProvider/downloads/content.xz'
wazuh-modulesd:content-updater:offlineDownloader.hpp:202 download: File '/tmp/testProvider/downloads/content.xz' didn't change from last download so it won't be published
wazuh-modulesd:content-updater:XZDecompressor.hpp:79 handleRequest: XZDecompressor - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:60 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:48 publish: No data to publish
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater: Action for 'test' finished
```