### PR TITLE
Fix undefined references with local target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1009,7 +1009,10 @@ ${LIBPLIST_LIB}:
 LIBFFI_FLAGS = "CFLAGS=-fPIC"
 
 ${LIBFFI_LIB}:
-	cd ${EXTERNAL_LIBFFI} && ./configure $(LIBFFI_FLAGS) && ${MAKE}
+	cd ${EXTERNAL_LIBFFI} && test -e server || (./configure $(LIBFFI_FLAGS) && ${MAKE})
+ifneq (${TARGET},server)
+	cd ${EXTERNAL_LIBFFI} && test -e server && mv server $(TARGET) || true
+endif
 
 #### zlib ##########
 

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -119,17 +119,21 @@ void* wm_database_main(wm_database *data) {
     // agents synchronization with the database using the keys. In advance,
     // the agent addition and removal from the database will be held by authd
     // in the master.
+#ifndef LOCAL
     wm_sync_agents();
+#endif
 
     // Groups synchronization with the database
     wdb_update_groups(SHAREDCFG_DIR, &wdb_wmdb_sock);
 
     // Legacy agent-group files need to be synchronized with the database
     // and then removed in case an upgrade has just been performed.
+#ifndef LOCAL
     wm_sync_legacy_groups_files();
 
     // Remove dangling agent databases
     wm_clean_dangling_wdb_dbs();
+#endif
 
 #ifdef INOTIFY_ENABLED
     if (data->real_time) {


### PR DESCRIPTION
|Related issue|
|---|
|#16667|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

1. The functions `wm_sync_agents`, `wm_sync_legacy_groups_files` and `wm_clean_dangling_wdb_dbs` were defined under `#ifndef LOCAL` but they were called in all cases, _local_ included.

After solving this, another issue appeared:

2. The `TARGET=local` definition conflicts with a parameter in the _libffi_'s Makefile. That makes _libffi_ compile the sources into _src/external/libffi/local_. This creates a conflict in the precompiled package in the _server_ folder, which, when trying to compile again but within _local_, throws an error.

## Solution

1. To avoid this problem, it was enough to simply add the `#ifndef LOCAL` parameters to the calls to the mentioned functions.

2. In this case, a check was added so that if it is a precompiled package, it does not compile again. And in that same case, rename the _server_ folder to the current target (_local_) so it can be found later for assembling _libwazuhext.so_ (https://github.com/wazuh/wazuh/pull/3339):

```bash
${LIBFFI_LIB}:
	cd ${EXTERNAL_LIBFFI} && test -e server || (./configure $(LIBFFI_FLAGS) && ${MAKE})
ifneq (${TARGET},server)
	cd ${EXTERNAL_LIBFFI} && test -e server && mv server $(TARGET) || true
endif
```

## Output

```
make TARGET=server
```

<Details>
<summary>Output</summary>

```
General settings:
    TARGET:             server
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/24
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:main
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT
Compiler:
    CFLAGS            -pthread -Iexternal/libdb/build_unix/ -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Wl,--start-group -Iexternal/audit-userspace/lib -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -Isyscheckd/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lshared_modules/dbsync/build/lib -Lshared_modules/rsync/build/lib  -Lwazuh_modules/syscollector/build/lib -Ldata_provider/build/lib -Lsyscheckd/build/lib
    LIBS              -lrt -ldl -lm 
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/home/mcervilla/Projects/wazuh/src'

Done building server

```
</Details>


```
make TARGET=local
```

<Details>
<summary>Output</summary>

```
General settings:
    TARGET:             local
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/24
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:main
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -DLOCAL
Compiler:
    CFLAGS            -pthread -Iexternal/libdb/build_unix/ -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Wl,--start-group -Iexternal/audit-userspace/lib -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -DLOCAL -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -Isyscheckd/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lshared_modules/dbsync/build/lib -Lshared_modules/rsync/build/lib  -Lwazuh_modules/syscollector/build/lib -Ldata_provider/build/lib -Lsyscheckd/build/lib
    LIBS              -lrt -ldl -lm 
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/home/mcervilla/Projects/wazuh/src'

Done building local

```
</Details>

```
make TARGET=agent
```

<Details>
<summary>Output</summary>

```
General settings:
    TARGET:             agent
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/24
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:main
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -DCLIENT
Compiler:
    CFLAGS            -pthread -Iexternal/libdb/build_unix/ -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Wl,--start-group -Iexternal/audit-userspace/lib -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -DCLIENT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -Isyscheckd/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lshared_modules/dbsync/build/lib -Lshared_modules/rsync/build/lib  -Lwazuh_modules/syscollector/build/lib -Ldata_provider/build/lib -Lsyscheckd/build/lib
    LIBS              -lrt -ldl -lm 
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/home/mcervilla/Projects/wazuh/src'

Done building agent

```
</Details>


## Tests

- Compilation without warnings in every supported platform.
  - [X] Linux (local, server and agent installation) (source and precompiled packages)
- [X] Source installation.