### PR TITLE
Add decoders queries test cases

### DIFF
--- a/api/test/integration/test_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoder_endpoints.tavern.yaml
@@ -315,6 +315,33 @@ stages:
           failed_items: []
           total_affected_items: 0
           total_failed_items: !anyint
+  
+  - name: Get decoders using a nested query
+    request:
+      verify: False
+      <<: *get_decoders
+      params:
+        q: status=enabled;(name=agent-buffer,name=wazuh)
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: 2
+          total_failed_items: !anyint
+
+  - name: Try to get decoders using an invalid query
+    request:
+      verify: False
+      <<: *get_decoders
+      params:
+        q: status
+    response:
+      status_code: 400
+      json:
+        error: 1407
 
   - name: Get distinct decoders
     request:

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -254,6 +254,12 @@ def test_cut_array_ko(limit, offset, expected_exception):
          'datetime>2017-10-26;datetime<2018-05-15T12:34:12.001000Z', None, None, None, None, None, False,
          [{'item': 'value_1', 'datetime': '2018-05-15T12:34:12Z'}], 1),
 
+        ([{'name': 'value_1', 'status': 'disabled'},
+          {'name': 'value_2', 'status': 'enabled'},
+          {'name': 'value_3', 'status': 'enabled'}],
+         'status=enabled;(name=value_1,name=value_3)', None, None, None, None, None, False,
+         [{'name': 'value_3', 'status': 'enabled'}], 1),
+
         # Test cases with filters, limit and search
         ([{'item': 'value_1', 'some': 't'}, {'item': 'value_2', 'some': 'a'}, {'item': 'value_3', 'some': 'b'}],
          None, {'item': 'value_1', 'some': 't'}, 1, None, None, None, False,


### PR DESCRIPTION
|Related issue|
|---|
|Closes #18504 |

## Description

Adds two test cases for the query parameter to ensure that the functionality of the `process_array` function is identical to `WazuhDBQuery`. 

### Tests

Artifacts: [artifacts.zip](https://github.com/wazuh/wazuh/files/13512837/artifacts.zip)

<details><summary>test_decoder_endpoints.tavern.yaml</summary>

```console
============================= test session starts ==============================
platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-1.2.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.19.0-1028-aws-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'asyncio': '0.18.1', 'html': '2.1.1', 'trio': '0.7.0', 'metadata': '3.0.0', 'tavern': '1.23.5', 'aiohttp': '1.0.4'}}
rootdir: /tmp/Test_integration_endpoints_B4122_test_files/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, html-2.1.1, trio-0.7.0, metadata-3.0.0, tavern-1.23.5, aiohttp-1.0.4
asyncio: mode=auto
collecting ... collected 25 items

test_decoder_endpoints.tavern.yaml::GET /decoders PASSED                 [  4%]
test_decoder_endpoints.tavern.yaml::GET /decoders[filename] PASSED       [  8%]
test_decoder_endpoints.tavern.yaml::GET /decoders[relative_dirname] PASSED [ 12%]
test_decoder_endpoints.tavern.yaml::GET /decoders[name] PASSED           [ 16%]
test_decoder_endpoints.tavern.yaml::GET /decoders[position] PASSED       [ 20%]
test_decoder_endpoints.tavern.yaml::GET /decoders[status] PASSED         [ 24%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name} PASSED  [ 28%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[filename] PASSED [ 32%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[relative_dirname] PASSED [ 36%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[name] PASSED [ 40%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[position] PASSED [ 44%]
test_decoder_endpoints.tavern.yaml::GET /decoders/{decoder_name}[status] PASSED [ 48%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files PASSED           [ 52%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files[filename] PASSED [ 56%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files[relative_dirname] PASSED [ 60%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files[status] PASSED   [ 64%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents PASSED         [ 68%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[filename] PASSED [ 72%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[name] PASSED   [ 76%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[relative_dirname] PASSED [ 80%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[position] PASSED [ 84%]
test_decoder_endpoints.tavern.yaml::GET /decoders/parents[status] PASSED [ 88%]
test_decoder_endpoints.tavern.yaml::GET /decoders/files/(filename) PASSED [ 92%]
test_decoder_endpoints.tavern.yaml::PUT /decoders/files/{filename} PASSED [ 96%]
test_decoder_endpoints.tavern.yaml::DELETE /decoders/files/{filename} PASSED [100%]

=============================== warnings summary ===============================
../../../../../home/ubuntu/.local/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/ubuntu/.local/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_decoder_endpoints.tavern.yaml: 25 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- generated html file: file:///tmp/Test_integration_endpoints_B4122_test_files/api/test/integration/Test_integration_endpoints_B4122_test_decoder_endpoints.html -
================= 25 passed, 26 warnings in 433.95s (0:07:13) ==================
```

</details>