### PR TITLE
Adds validation to decoders and rules using logtest.

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -71,6 +71,11 @@ variables:
     </labels>
     </agent_config>
 
+  empty_file_xml:
+    <?xml version="1.0" ?>
+    <metadata>
+    </metadata>
+
   wrong_file_xml:
     <agent_confi>
 

--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -241,6 +241,39 @@ variables:
       <remote>
     </ossec_config>
 
+  invalid_ossec_xml:
+    <ossec_config>
+      <global>
+        <jsonout_output>yes</jsonout_output>
+        <alerts_log>yes</alerts_log>
+        <logall>no</logall>
+        <logall_json>no</logall_json>
+        <email_notification>no</email_notification>
+        <agents_disconnection_time>20s</agents_disconnection_time>
+        <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
+        <update_checkkk>no</update_checkkk>
+      </global>
+
+      <logging>
+        <log_format>plain</log_format>
+      </logging>
+
+      <alerts>
+        <log_alert_level>300</log_alert_level>
+        <email_alert_level>12</email_alert_level>
+      </alerts>
+
+      <remote>
+        <connection>secure</connection>
+        <port>1514</port>
+        <protocol>tcp</protocol>
+      </remote>
+
+      <syscheck>
+        <disabled>yes</disabled>
+      </syscheck>
+    </ossec_config>
+
   ossec_conf_with_invalid_cti_url:
     <ossec_config>
       <global>

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -835,98 +835,6 @@ stages:
           total_affected_items: 3
           total_failed_items: 0
 
-  #### Upload corrupted rules file
-  - name: Upload corrupted configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new-rules_corrupted.xml"
-      method: PUT
-      data: "{corrupted_rules_file}"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-        content-type: application/octet-stream
-    response:
-      status_code: 200
-    delay_after: !float "{cluster_sync_delay}"
-
-  - name: Request validation
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 1
-        data:
-          failed_items:
-            - error:
-                code: 1908
-              id:
-                - 'master-node'
-                - 'worker1'
-                - 'worker2'
-          total_affected_items: 0
-          total_failed_items: 3
-
-    #### Delete corrupted rules file
-  - name: Delete rules file
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new-rules_corrupted.xml"
-      method: DELETE
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-    delay_after: !float "{cluster_sync_delay}"
-
-  - name: Request cluster validation
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        nodes_list: 'worker1,worker2'
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - name: worker1
-              status: 'OK'
-            - name: worker2
-              status: 'OK'
-          failed_items: []
-          total_affected_items: 2
-          total_failed_items: 0
-
-  - name: Request cluster validation
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        nodes_list: 'master-node'
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - name: master-node
-              status: 'OK'
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-
 ---
 test_name: GET /cluster/api/config
 
@@ -2400,6 +2308,30 @@ stages:
           failed_items:
             - error:
                 code: 1113
+              id:
+                - 'worker1'
+          total_affected_items: 0
+          total_failed_items: 1
+
+  # PUT /cluster/{node_id}/configuration
+  - name: Try to upload an invalid xml
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      method: PUT
+      data: "{invalid_ossec_xml:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        error: 1
+        data:
+          affected_items: [ ]
+          failed_items:
+            - error:
+                code: 1908
               id:
                 - 'worker1'
           total_affected_items: 0

--- a/api/test/integration/test_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoder_endpoints.tavern.yaml
@@ -1251,6 +1251,29 @@ stages:
           total_failed_items: 1
         error: 1
 
+  - name: Upload empty xml decoder
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/empty_file.xml"
+      method: PUT
+      data: "{empty_file_xml:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items: [ ]
+          failed_items:
+            - error:
+                code: 1113
+              id:
+                - "etc/decoders/empty_file.xml"
+          total_affected_items: 0
+          total_failed_items: 1
+        error: 1
+
 ---
 test_name: DELETE /decoders/files/{filename}
 

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -998,49 +998,6 @@ stages:
           total_failed_items: 0
 
 ---
-test_name: GET /manager/validation (KO)
-
-stages:
-
-  #### Upload corrupted rules file
-  # PUT /rules/files
-  - name: Upload corrupted
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new-rules_corrupted.xml"
-      method: PUT
-      data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n  <rule id=\"111111\" level=\"XXX\">\n      <if_sid>5716</if_sid>\n      <srcip>1.1.1.1</srcip>\n      <description>sshd: authentication failed from IP 1.1.1.1.</description>\n      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n    </rule>\n  </group>\n"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-        content-type: application/octet-stream
-    response:
-      status_code: 200
-      json:
-        error: 0
-
-  # GET /manager/configuration/validation
-  - name: Request validation
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/validation"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 1
-        data:
-          affected_items: []
-          failed_items:
-            - error:
-                code: 1908
-              id:
-                - !anystr
-          total_affected_items: 0
-          total_failed_items: 1
-
----
 test_name: GET /manager/configuration/{component}/{configuration}
 
 stages:
@@ -1519,6 +1476,29 @@ stages:
           failed_items:
             - error:
                 code: 1113
+              id:
+                - 'manager'
+          total_affected_items: 0
+          total_failed_items: 1
+
+  - name: Try to upload an invalid xml
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: PUT
+      data: "{invalid_ossec_xml:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        error: 1
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1908
               id:
                 - 'manager'
           total_affected_items: 0

--- a/api/test/integration/test_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rule_endpoints.tavern.yaml
@@ -1943,6 +1943,29 @@ stages:
           total_failed_items: 1
         error: 1
 
+  - name: Upload invalid rule
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files/empty_file.xml"
+      method: PUT
+      data: "{empty_file_xml:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items: [ ]
+          failed_items:
+            - error:
+                code: 1113
+              id:
+                - "etc/rules/empty_file.xml"
+          total_affected_items: 0
+          total_failed_items: 1
+        error: 1
+
 ---
 test_name: DELETE /rules/files/{filename}
 

--- a/framework/wazuh/core/logtest.py
+++ b/framework/wazuh/core/logtest.py
@@ -43,7 +43,7 @@ def send_logtest_msg(command: str = None, parameters: dict = None) -> dict:
     return response
 
 
-def validate_dummy_logtest():
+def validate_dummy_logtest() -> dict:
     """
     Validates a dummy log test by sending a log test message.
 

--- a/framework/wazuh/core/logtest.py
+++ b/framework/wazuh/core/logtest.py
@@ -43,18 +43,8 @@ def send_logtest_msg(command: str = None, parameters: dict = None) -> dict:
     return response
 
 
-def validate_dummy_logtest() -> dict:
-    """
-    Validates a dummy log test by sending a log test message.
-
-    Parameters
-    ----------
-    None
-
-    Returns
-    -------
-    dict
-        A dictionary containing the response from the log test.
+def validate_dummy_logtest() -> None:
+    """Validates a dummy log test by sending a log test message.
 
     Raises
     ------

--- a/framework/wazuh/core/logtest.py
+++ b/framework/wazuh/core/logtest.py
@@ -65,5 +65,5 @@ def validate_dummy_logtest():
     parameters = {"location": "dummy", "log_format": "syslog", "event": "Hello"}
 
     response = send_logtest_msg(command, parameters)
-    if response.get('error', 1) == 1:
+    if response.get('data', {}).get('codemsg', -1) == -1:
         raise WazuhError(1113)

--- a/framework/wazuh/core/logtest.py
+++ b/framework/wazuh/core/logtest.py
@@ -8,6 +8,7 @@ import pytz
 
 from wazuh.core.common import LOGTEST_SOCKET, DECIMALS_DATE_FORMAT, origin_module
 from wazuh.core.wazuh_socket import WazuhSocketJSON, create_wazuh_socket_message
+from wazuh.core.exception import WazuhError
 
 
 def send_logtest_msg(command: str = None, parameters: dict = None) -> dict:
@@ -40,3 +41,29 @@ def send_logtest_msg(command: str = None, parameters: dict = None) -> dict:
         pass
 
     return response
+
+
+def validate_dummy_logtest():
+    """
+    Validates a dummy log test by sending a log test message.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    dict
+        A dictionary containing the response from the log test.
+
+    Raises
+    ------
+    WazuhError
+        If an error occurs during the log test with error code 1113.
+    """
+    command = "log_processing"
+    parameters = {"location": "dummy", "log_format": "syslog", "event": "Hello"}
+
+    response = send_logtest_msg(command, parameters)
+    if response.get('error', 1) == 1:
+        raise WazuhError(1113)

--- a/framework/wazuh/core/tests/test_logtest.py
+++ b/framework/wazuh/core/tests/test_logtest.py
@@ -8,8 +8,9 @@ import pytest
 
 with patch('wazuh.common.wazuh_uid'):
     with patch('wazuh.common.wazuh_gid'):
-        from wazuh.core.logtest import send_logtest_msg
+        from wazuh.core.logtest import send_logtest_msg, validate_dummy_logtest
         from wazuh.core.common import LOGTEST_SOCKET
+        from wazuh.core.exception import WazuhError
 
 
 @pytest.mark.parametrize('params', [
@@ -35,3 +36,15 @@ def test_send_logtest_msg(create_message_mock, close_mock, send_mock, init_mock,
         create_message_mock.assert_called_with(origin={'name': 'Logtest', 'module': 'framework'}, **params)
         assert response == {'data': {'response': True, 'output': {'timestamp': '1970-01-01T02:00:00.000000Z'}}}
 
+
+@patch('wazuh.core.logtest.WazuhSocketJSON.__init__', return_value=None)
+@patch('wazuh.core.logtest.WazuhSocketJSON.send')
+@patch('wazuh.core.logtest.WazuhSocketJSON.close')
+@patch('wazuh.core.logtest.create_wazuh_socket_message')
+def test_validate_dummy_logtest(create_message_mock, close_mock, send_mock, init_mock):
+    with patch('wazuh.core.logtest.WazuhSocketJSON.receive',
+               return_value={'data': {}, 'error': 1}):
+        with pytest.raises(WazuhError) as err_info:
+            validate_dummy_logtest()
+
+        assert err_info.value.code == 1113

--- a/framework/wazuh/core/tests/test_logtest.py
+++ b/framework/wazuh/core/tests/test_logtest.py
@@ -43,7 +43,7 @@ def test_send_logtest_msg(create_message_mock, close_mock, send_mock, init_mock,
 @patch('wazuh.core.logtest.create_wazuh_socket_message')
 def test_validate_dummy_logtest(create_message_mock, close_mock, send_mock, init_mock):
     with patch('wazuh.core.logtest.WazuhSocketJSON.receive',
-               return_value={'data': {}, 'error': 1}):
+               return_value={'data': {'codemsg': -1}, 'error': 0}):
         with pytest.raises(WazuhError) as err_info:
             validate_dummy_logtest()
 

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -366,7 +366,12 @@ def upload_decoder_file(filename: str, content: str, relative_dirname: str = Non
         upload_file(content, to_relative_path(full_path))
 
         # After uploading the file, validate it using a logtest dummy msg
-        validate_dummy_logtest()
+        try:
+            validate_dummy_logtest()
+        except WazuhError as exc:
+            if not overwrite and exists(full_path):
+                delete_decoder_file(filename=filename, relative_dirname=relative_dirname)
+                raise exc
 
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -18,6 +18,7 @@ from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.rule import format_rule_decoder_file
 from wazuh.core.utils import process_array, safe_move, validate_wazuh_xml, \
     upload_file, to_relative_path, full_copy
+from wazuh.core.logtest import validate_dummy_logtest
 from wazuh.rbac.decorators import expose_resources
 
 
@@ -363,6 +364,10 @@ def upload_decoder_file(filename: str, content: str, relative_dirname: str = Non
                                 relative_dirname=relative_dirname)
 
         upload_file(content, to_relative_path(full_path))
+
+        # After uploading the file, validate it using a logtest dummy msg
+        validate_dummy_logtest()
+
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)
         backup_file and exists(backup_file) and remove(backup_file)

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -193,7 +193,7 @@ def get_decoders_files(status: str = None, relative_dirname: str = None, filenam
 
 
 def get_decoder_file_path(filename: str,
-                     relative_dirname: str = None) -> str:
+                          relative_dirname: str = None) -> str:
     """Find decoder file with or without relative directory name.
 
     Parameters
@@ -212,7 +212,7 @@ def get_decoder_file_path(filename: str,
     # if the filename doesn't have a relative path, the search is only by name
     # relative_dirname parameter is set to None.
     relative_dirname = relative_dirname.rstrip('/') if relative_dirname else None
-    decoders = get_decoders_files(filename=filename, 
+    decoders = get_decoders_files(filename=filename,
                                   relative_dirname=relative_dirname).affected_items
     if len(decoders) == 0:
         return ''
@@ -227,10 +227,10 @@ def get_decoder_file_path(filename: str,
         decoder = min(decoders, key=lambda x: len(x['relative_dirname']))
         return join(common.WAZUH_PATH, decoder['relative_dirname'], filename)
     else:
-        return normpath(join(common.WAZUH_PATH,  decoders[0]['relative_dirname'], filename))
+        return normpath(join(common.WAZUH_PATH, decoders[0]['relative_dirname'], filename))
 
 
-def get_decoder_file(filename: str, raw: bool = False, 
+def get_decoder_file(filename: str, raw: bool = False,
                      relative_dirname: str = None) -> Union[str, AffectedItemsWazuhResult]:
     """Read content of a specified file.
 
@@ -253,8 +253,8 @@ def get_decoder_file(filename: str, raw: bool = False,
 
     full_path = get_decoder_file_path(filename, relative_dirname)
     if not full_path:
-        result.add_failed_item(id_=filename, 
-                                error=WazuhError(1503, extra_message=f"{filename}"))
+        result.add_failed_item(id_=filename,
+                               error=WazuhError(1503, extra_message=f"{filename}"))
         return result
 
     try:
@@ -267,10 +267,10 @@ def get_decoder_file(filename: str, raw: bool = False,
             result.affected_items.append(xmltodict.parse(f'<root>{file_content}</root>')['root'])
             result.total_affected_items = 1
     except ExpatError as exc:
-        result.add_failed_item(id_=filename, 
+        result.add_failed_item(id_=filename,
                                error=WazuhError(1501, extra_message=f"{filename}: {str(exc)}"))
     except OSError:
-        result.add_failed_item(id_=filename, 
+        result.add_failed_item(id_=filename,
                                error=WazuhError(1502, extra_message=f"{filename}"))
 
     return result
@@ -345,10 +345,10 @@ def upload_decoder_file(filename: str, content: str, relative_dirname: str = Non
         full_path = join(common.WAZUH_PATH, relative_dirname, filename)
         if wazuh_error:
             raise wazuh_error
-        
+
         if len(content) == 0:
             raise WazuhError(1112)
-        
+
         validate_wazuh_xml(content)
         # If file already exists and overwrite is False, raise exception
         if not overwrite and exists(full_path):
@@ -371,7 +371,8 @@ def upload_decoder_file(filename: str, content: str, relative_dirname: str = Non
         except WazuhError as exc:
             if not overwrite and exists(full_path):
                 delete_decoder_file(filename=filename, relative_dirname=relative_dirname)
-                raise exc
+
+            raise exc
 
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -492,7 +492,12 @@ def upload_rule_file(filename: str, content: str, relative_dirname: str = None,
         upload_file(content, to_relative_path(full_path))
 
         # After uploading the file, validate it using a logtest dummy msg
-        validate_dummy_logtest()
+        try:
+            validate_dummy_logtest()
+        except WazuhError as exc:
+            if not overwrite and exists(full_path):
+                delete_rule_file(filename=filename, relative_dirname=relative_dirname)
+                raise exc
 
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -497,7 +497,8 @@ def upload_rule_file(filename: str, content: str, relative_dirname: str = None,
         except WazuhError as exc:
             if not overwrite and exists(full_path):
                 delete_rule_file(filename=filename, relative_dirname=relative_dirname)
-                raise exc
+
+            raise exc
 
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -19,6 +19,7 @@ from wazuh.core.rule import check_status, load_rules_from_file, format_rule_deco
     RULE_REQUIREMENTS, SORT_FIELDS, RULE_FIELDS, RULE_FILES_FIELDS, RULE_FILES_REQUIRED_FIELDS
 from wazuh.core.utils import process_array, safe_move, \
     validate_wazuh_xml, upload_file, full_copy, to_relative_path
+from wazuh.core.logtest import validate_dummy_logtest
 from wazuh.rbac.decorators import expose_resources
 
 cluster_enabled = not read_cluster_config(from_import=True)['disabled']
@@ -489,6 +490,10 @@ def upload_rule_file(filename: str, content: str, relative_dirname: str = None,
             delete_rule_file(filename=filename, relative_dirname=relative_dirname)
 
         upload_file(content, to_relative_path(full_path))
+
+        # After uploading the file, validate it using a logtest dummy msg
+        validate_dummy_logtest()
+
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)
         backup_file and exists(backup_file) and remove(backup_file)

--- a/framework/wazuh/tests/test_decoder.py
+++ b/framework/wazuh/tests/test_decoder.py
@@ -257,7 +257,8 @@ def test_validate_upload_delete_dir(relative_dirname, res_path, err_code):
 @patch('wazuh.decoder.upload_file')
 @patch('wazuh.decoder.remove')
 @patch('wazuh.decoder.safe_move')
-def test_upload_file(mock_safe_move, mock_remove, mock_upload_file,
+@patch('wazuh.decoder.validate_dummy_logtest')
+def test_upload_file(mock_logtest, mock_safe_move, mock_remove, mock_upload_file,
                      mock_xml, mock_full_copy, mock_delete, mock_wazuh_paths,
                      file, relative_dirname, overwrite, decoder_path):
     """Test uploading a decoder file.

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -329,7 +329,8 @@ def test_validate_upload_delete_dir(relative_dirname, res_path, err_code):
 @patch('wazuh.rule.upload_file')
 @patch('wazuh.rule.remove')
 @patch('wazuh.rule.safe_move')
-def test_upload_file(mock_safe_move, mock_remove, mock_xml, mock_full_copy,
+@patch('wazuh.rule.validate_dummy_logtest')
+def test_upload_file(mock_logtest, mock_safe_move, mock_remove, mock_xml, mock_full_copy,
                      mock_delete, file, relative_dirname, overwrite, rule_path):
     """Test uploading a rule file.
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/17862|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Adds validation to PUT` /decoders/files/{filename} `and PUT `/rules/files/{filename}` for XML files using the logtest.