### PR TITLE
Set CURL_DEP variable to avoid libcurl.so dependency on libsysinfo.so

### DIFF
--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -221,6 +221,7 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 target_link_libraries(sysinfo wazuhext)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(CURL_DEP "wazuhext")
   target_link_libraries(sysinfo urlrequest)
   if(CMAKE_CHECK_CENTOS5)
       set(USE_HTTP 1)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20427|

## Description
This PR sets CURL_DEP variable in data_provider CMakeLists.txt to avoid libcurl.so dependency on libsysinfo.so.

## Tests

- Verify that libcurl.so dependency is not present on libsysinfo.so and libsyscollector.so
  - [x] Linux Debian agent
  - [x] Linux Debian manager
  - [x] Linux Centos agent