### PR TITLE
Fix logging functionality in content manager module.

### DIFF
--- a/src/headers/logging_helper.h
+++ b/src/headers/logging_helper.h
@@ -9,16 +9,16 @@
  * Foundation.
  */
 
-
 #ifndef _LOGGINGHELPER_H
 #define _LOGGINGHELPER_H
 
-typedef enum modules_log_level_t {
-    LOG_ERROR,
-    LOG_ERROR_EXIT,
+typedef enum modules_log_level_t
+{
+    LOG_DEBUG,
     LOG_INFO,
     LOG_WARNING,
-    LOG_DEBUG,
+    LOG_ERROR,
+    LOG_ERROR_EXIT,
     LOG_DEBUG_VERBOSE
 } modules_log_level_t;
 
@@ -40,10 +40,10 @@ void taggedLogFunction(modules_log_level_t level, const char* log, const char* t
 void loggingFunction(modules_log_level_t level, const char* log);
 
 /**
-* @brief Global function to send a error log message
-*
-* @param log Message to send into the log as error
-*/
+ * @brief Global function to send a error log message
+ *
+ * @param log Message to send into the log as error
+ */
 void loggingErrorFunction(const char* log);
 
 #endif //_LOGGINGHELPER_H

--- a/src/shared_modules/content_manager/include/contentManager.hpp
+++ b/src/shared_modules/content_manager/include/contentManager.hpp
@@ -12,7 +12,6 @@
 #ifndef _CONTENT_MODULE_HPP
 #define _CONTENT_MODULE_HPP
 
-#include "logging_helper.h"
 #include "singleton.hpp"
 #include <functional>
 #include <memory>

--- a/src/shared_modules/content_manager/include/content_manager.h
+++ b/src/shared_modules/content_manager/include/content_manager.h
@@ -26,7 +26,6 @@ extern "C"
 #endif
 
 #include "common/commonDefs.h"
-#include "logging_helper.h"
 
     EXPORTED void content_manager_start(full_log_fnc_t callbackLog);
 

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -15,7 +15,6 @@
 #include "actionOrchestrator.hpp"
 #include "onDemandManager.hpp"
 #include "routerProvider.hpp"
-#include "sharedDefs.hpp"
 #include <atomic>
 #include <chrono>
 #include <external/nlohmann/json.hpp>
@@ -81,13 +80,14 @@ public:
                         bool expected = false;
                         if (m_actionInProgress.compare_exchange_strong(expected, true))
                         {
-                            logInfo("Initiating scheduling action for %s", m_topicName.c_str());
+                            logInfo(WM_CONTENTUPDATER, "Initiating scheduling action for %s", m_topicName.c_str());
                             runAction(ActionID::SCHEDULED);
                         }
                         else
                         {
                             // LCOV_EXCL_START
-                            logInfo("Request scheduling - Download in progress. The scheduling is ignored for %s",
+                            logInfo(WM_CONTENTUPDATER,
+                                    "Request scheduling - Download in progress. The scheduling is ignored for %s",
                                     m_topicName.c_str());
                             // LCOV_EXCL_STOP
                         }
@@ -109,7 +109,7 @@ public:
         {
             m_schedulerThread.join();
         }
-        logInfo("Scheduler stopped for %s", m_topicName.c_str());
+        logInfo(WM_CONTENTUPDATER, "Scheduler stopped for %s", m_topicName.c_str());
     }
 
     /**
@@ -148,13 +148,13 @@ public:
         auto expected = false;
         if (m_actionInProgress.compare_exchange_strong(expected, true))
         {
-            logInfo("Ondemand request - starting action for %s", m_topicName.c_str());
+            logInfo(WM_CONTENTUPDATER, "Ondemand request - starting action for %s", m_topicName.c_str());
             runAction(ActionID::ON_DEMAND);
         }
         else
         {
             // LCOV_EXCL_START
-            logInfo("Ondemand request - another action in progress for %s", m_topicName.c_str());
+            logInfo(WM_CONTENTUPDATER, "Ondemand request - another action in progress for %s", m_topicName.c_str());
             // LCOV_EXCL_STOP
         }
     }

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -16,7 +16,6 @@
 #include "components/factoryContentUpdater.hpp"
 #include "components/updaterContext.hpp"
 #include "routerProvider.hpp"
-#include "sharedDefs.hpp"
 #include "utils/rocksDBWrapper.hpp"
 #include <iostream>
 #include <memory>

--- a/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/factoryDownloader.hpp
@@ -42,7 +42,7 @@ public:
     static std::shared_ptr<AbstractHandler<std::shared_ptr<UpdaterContext>>> create(const nlohmann::json& config)
     {
         auto const downloaderType {config.at("contentSource").get<std::string>()};
-        logDebug2("Creating '%s' downloader", downloaderType.c_str());
+        logDebug2(WM_CONTENTUPDATER, "Creating '%s' downloader", downloaderType.c_str());
 
         if ("api" == downloaderType)
         {

--- a/src/shared_modules/content_manager/src/contentModuleFacade.cpp
+++ b/src/shared_modules/content_manager/src/contentModuleFacade.cpp
@@ -10,7 +10,12 @@
  */
 
 #include "contentModuleFacade.hpp"
-#include "sharedDefs.hpp"
+namespace Log
+{
+    std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
 
 void ContentModuleFacade::start(
     const std::function<

--- a/src/shared_modules/content_manager/src/onDemandManager.cpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.cpp
@@ -10,7 +10,7 @@
  */
 
 #include "onDemandManager.hpp"
-#include "sharedDefs.hpp"
+#include "../sharedDefs.hpp"
 #include <filesystem>
 #include <utility>
 

--- a/src/shared_modules/content_manager/src/onDemandManager.hpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.hpp
@@ -17,7 +17,6 @@
 #include <functional>
 #include <map>
 #include <shared_mutex>
-
 /**
  * @brief OnDemandManager class.
  *

--- a/src/shared_modules/content_manager/src/sharedDefs.hpp
+++ b/src/shared_modules/content_manager/src/sharedDefs.hpp
@@ -9,6 +9,10 @@
  * Foundation.
  */
 
+#ifndef _SHARED_DEFS_H
+#define _SHARED_DEFS_H
+
 #define WM_CONTENTUPDATER "wazuh-modulesd:content-updater"
 
 #include "loggerHelper.h"
+#endif // _SHARED_DEFS_H

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -17,6 +17,13 @@
 #include <string>
 #include <vector>
 
+namespace Log
+{
+    std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
+
 /*
  * @brief Tests the instantiation of the ActionOrchestratorTest class
  */

--- a/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.cpp
@@ -17,6 +17,13 @@
 #include <memory>
 #include <vector>
 
+namespace Log
+{
+    std::function<void(
+            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
+
 // Folder containing all the input files.
 const auto INPUT_FILES_DIR {std::filesystem::current_path() / "input_files" / "zipDecompressor"};
 

--- a/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.cpp
@@ -20,7 +20,7 @@
 namespace Log
 {
     std::function<void(
-            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
         GLOBAL_LOG_FUNCTION;
 };
 

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -1,5 +1,6 @@
 #include "contentManager.hpp"
 #include "contentRegister.hpp"
+#include "defs.h"
 #include <chrono>
 #include <iostream>
 #include <thread>
@@ -63,7 +64,7 @@ int main()
             }
             std::string fileName = file.substr(pos, file.size() - pos);
 
-            if (logLevel != LOG_ERROR)
+            if (logLevel != LOGLEVEL_ERROR)
             {
                 std::cout << tag << ":" << fileName << ":" << line << " " << func << " : " << message.c_str()
                           << std::endl;

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -20,7 +20,7 @@
 namespace Log
 {
     std::function<void(
-            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
         GLOBAL_LOG_FUNCTION;
 };
 

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -17,6 +17,12 @@
 #include <fstream>
 
 #define IC_NAME "indexer-connnector"
+namespace Log
+{
+    std::function<void(
+            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
 
 // TODO: remove the LCOV flags when the implementation of this class is completed
 // LCOV_EXCL_START

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -17,6 +17,13 @@
 #include "rsync_exception.h"
 #include <string>
 
+namespace Log
+{
+    std::function<void(
+            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -20,8 +20,8 @@
 namespace Log
 {
     std::function<void(
-            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
-        GLOBAL_LOG_FUNCTION;
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+    GLOBAL_LOG_FUNCTION;
 };
 
 #ifdef __cplusplus

--- a/src/shared_modules/utils/loggerHelper.h
+++ b/src/shared_modules/utils/loggerHelper.h
@@ -51,7 +51,7 @@ namespace Log
         const char* func;
     };
 
-    static std::function<void(
+    extern std::function<void(
         const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
         GLOBAL_LOG_FUNCTION;
 

--- a/src/shared_modules/utils/loggerHelper.h
+++ b/src/shared_modules/utils/loggerHelper.h
@@ -50,10 +50,13 @@ namespace Log
         int line;
         const char* func;
     };
+// Remove visibility of this extern function
+#pragma GCC visibility push(hidden)
 
     extern std::function<void(
         const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
         GLOBAL_LOG_FUNCTION;
+#pragma GCC visibility pop
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"

--- a/src/shared_modules/utils/tests/loggerHelper_test.cpp
+++ b/src/shared_modules/utils/tests/loggerHelper_test.cpp
@@ -14,6 +14,13 @@
 #include <regex>
 #include <sstream>
 
+namespace Log
+{
+    std::function<void(
+            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
+
 constexpr auto INFO_REGEX = "info Tag .+\\.cpp \\d+ TestBody Testing Info log\\n";
 constexpr auto ERROR_REGEX = "error Tag .+\\.cpp \\d+ TestBody Testing Error log\\n";
 constexpr auto DEBUG_REGEX = "debug Tag .+\\.cpp \\d+ TestBody Testing Debug log\\n";

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
@@ -18,6 +18,13 @@
 #include <functional>
 #include <string>
 
+namespace Log
+{
+    std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
+
 // TODO: Remove LCOV flags once the implementation of the 'Indexer Connector' module is completed
 // LCOV_EXCL_START
 void VulnerabilityScanner::start(

--- a/src/wazuh_modules/vulnerability_scanner/tests/component/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/component/main.cpp
@@ -11,6 +11,13 @@
 
 #include <gtest/gtest.h>
 
+namespace Log
+{
+    std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -31,7 +31,7 @@ using ::testing::Return;
 namespace Log
 {
     std::function<void(
-            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
         GLOBAL_LOG_FUNCTION;
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -28,6 +28,13 @@
 using ::testing::_;
 using ::testing::Return;
 
+namespace Log
+{
+    std::function<void(
+            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
+
 constexpr auto COMMON_DATABASE_DIR {"queue/vd"}; //<<Used for all databases
 
 constexpr auto CVEID_TEST_OK {"cveid_test_ok"};

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
@@ -10,6 +10,13 @@
  */
 #include "policyManager_test.h"
 
+namespace Log
+{
+    std::function<void(
+            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
+
 void PolicyManagerTest::SetUp()
 {
     m_policyManager = std::make_unique<PolicyManager>();

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
@@ -13,7 +13,7 @@
 namespace Log
 {
     std::function<void(
-            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
         GLOBAL_LOG_FUNCTION;
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/main.cpp
@@ -11,6 +11,13 @@
 
 #include <gtest/gtest.h>
 
+namespace Log
+{
+    std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
@@ -19,6 +19,13 @@
 #include <filesystem>
 #include <iostream>
 
+namespace Log
+{
+    std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        GLOBAL_LOG_FUNCTION;
+};
+
 /**
  * @brief Dummy class to replace real IndexerConnector.
  *

--- a/src/wazuh_modules/wm_vulnerability_scanner.h
+++ b/src/wazuh_modules/wm_vulnerability_scanner.h
@@ -12,7 +12,7 @@
 #ifndef _WM_VULNERABILITY_SCANNER
 #define _WM_VULNERABILITY_SCANNER
 
-#define WM_VULNERABILITY_SCANNER_LOGTAG ARGV0 ":vulnerability_scanner"
+#define WM_VULNERABILITY_SCANNER_LOGTAG ARGV0 ":vulnerability-scanner"
 
 #include "wmodules.h"
 
@@ -20,7 +20,7 @@ extern const wm_context WM_VULNERABILITY_SCANNER_CONTEXT;
 
 typedef struct wm_vulnerability_scanner_t
 {
-    cJSON * vulnerability_detection;
+    cJSON* vulnerability_detection;
 } wm_vulnerability_scanner_t;
 
 #endif /* _WM_VULNERABILITY_SCANNER */


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20512 |

# Description

- Fix multiple definitions of global std::function used to log messages.
- Add missing TAGs in some log calls.
- Fix typo in tag name for some calls.
