### PR TITLE
Update the local DBs for REJECTED resources

### DIFF
--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -430,6 +430,18 @@ namespace Utils
         }
 
         /**
+         * @brief Get an iterator to the database for a column family.
+         * @param columnFamily Column family to seek.
+         * @return RocksDBIterator Iterator to the database.
+         */
+        RocksDBIterator begin(const std::string& columnFamily)
+        {
+            return RocksDBIterator {std::shared_ptr<rocksdb::Iterator>(m_db->NewIterator(
+                                        rocksdb::ReadOptions(), m_columnFamiliesHandlesMap.at(columnFamily))),
+                                    ""};
+        }
+
+        /**
          * @brief Get an iterator to the end of the database.
          * @return const RocksDBIterator Iterator to the end of the database.
          */

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
@@ -254,6 +254,17 @@ TEST_F(RocksDBWrapperTest, TestRangeForLoop)
     }
 
     EXPECT_EQ(counter, NUM_ELEMENTS);
+
+    counter = 0;
+
+    for (const auto& [key, value] : db_wrapper->begin())
+    {
+        EXPECT_EQ(key, elements[counter].first);
+        EXPECT_EQ(value, elements[counter].second);
+        ++counter;
+    }
+
+    EXPECT_EQ(counter, NUM_ELEMENTS);
 }
 
 /**
@@ -466,6 +477,15 @@ TEST_F(RocksDBWrapperTest, TestColumFamilyDBSeek)
     {
         auto counter {0};
         for (const auto& [key, value] : cfDb->seek(prefix, "key_" + prefix + "_"))
+        {
+            EXPECT_EQ(key, "key_" + prefix + "_" + std::to_string(counter));
+            EXPECT_EQ(value, "value_" + prefix + "_" + std::to_string(counter));
+            ++counter;
+        }
+        EXPECT_EQ(counter, 3);
+
+        counter = 0;
+        for (const auto& [key, value] : cfDb->begin(prefix))
         {
             EXPECT_EQ(key, "key_" + prefix + "_" + std::to_string(counter));
             EXPECT_EQ(value, "value_" + prefix + "_" + std::to_string(counter));

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.hpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.hpp
@@ -17,6 +17,7 @@
 #include <filesystem>
 
 static const std::string DATABASE_NAME {"test.db"};
+static const std::string DATABASE_CF_NAME {"testCF"};
 
 /**
  * @brief Tests the RocksDBWrapper class

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -315,7 +315,7 @@ public:
         packageNameWithSeparator.append(packageName);
         packageNameWithSeparator.append("_CVE");
 
-        for (const auto& [key, value] : m_feedsDatabases.at(cnaName)->seek(packageNameWithSeparator))
+        for (const auto& [key, value] : m_feedsDatabases.at(cnaName)->seek(ROCKSDB_DEFAULT_COLUMN, packageNameWithSeparator))
         {
             auto candidatesArray = GetScanVulnerabilityCandidateArray(reinterpret_cast<const uint8_t*>(value.data()));
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -315,7 +315,8 @@ public:
         packageNameWithSeparator.append(packageName);
         packageNameWithSeparator.append("_CVE");
 
-        for (const auto& [key, value] : m_feedsDatabases.at(cnaName)->seek(ROCKSDB_DEFAULT_COLUMN, packageNameWithSeparator))
+        for (const auto& [key, value] :
+             m_feedsDatabases.at(cnaName)->seek(ROCKSDB_DEFAULT_COLUMN, packageNameWithSeparator))
         {
             auto candidatesArray = GetScanVulnerabilityCandidateArray(reinterpret_cast<const uint8_t*>(value.data()));
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
@@ -83,7 +83,7 @@ public:
 
         else if ("delete" == data->resource.at("type"))
         {
-            data->cvesDatabase->delete_(data->resource.at("resource"));
+            // CVE removal not supported.
         }
 
         else

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
@@ -37,14 +37,37 @@ public:
             throw std::runtime_error("CVE5 buffer is empty");
         }
         auto cve5Entry = cve_v5::GetEntry(data->cve5Buffer.data());
-        if (cve5Entry->cveMetadata())
+        auto type = data->resource.at("type").get<std::string>();
+        auto state = cve5Entry->cveMetadata()
+                         ? cve5Entry->cveMetadata()->state() ? cve5Entry->cveMetadata()->state()->str() : ""
+                         : "";
+
+        if ("update" == type)
         {
-            auto cveMetadata = cve5Entry->cveMetadata();
-            if (cveMetadata->state() && cveMetadata->state()->str().compare("REJECTED") != 0)
+            // We clean the candidates DBs to keep the data synced
+            UpdateCVECandidates::removeVulnerabilityCandidate(cve5Entry, m_feedsDatabases);
+            if ("PUBLISHED" == state)
             {
                 StoreRemediationsModel::updateRemediation(cve5Entry, m_remediationsDatabase);
-                UpdateCVECandidates::storeVulnerabilityCandidate(cve5Entry, m_feedsDatabases);
                 UpdateCVEDescription::storeVulnerabilityDescription(cve5Entry, m_descriptionsDatabase);
+                UpdateCVECandidates::storeVulnerabilityCandidate(cve5Entry, m_feedsDatabases);
+            }
+            else if ("REJECTED" == state)
+            {
+                StoreRemediationsModel::removeRemediation(cve5Entry, m_remediationsDatabase);
+                UpdateCVEDescription::removeVulnerabilityDescription(cve5Entry, m_descriptionsDatabase);
+            }
+        }
+        else if ("create" == type)
+        {
+            if ("PUBLISHED" == state)
+            {
+                StoreRemediationsModel::updateRemediation(cve5Entry, m_remediationsDatabase);
+                UpdateCVEDescription::storeVulnerabilityDescription(cve5Entry, m_descriptionsDatabase);
+                UpdateCVECandidates::storeVulnerabilityCandidate(cve5Entry, m_feedsDatabases);
+            }
+            else if ("REJECTED" == state)
+            {
             }
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -101,6 +101,23 @@ public:
             remediationsDatabase.put(data->cveMetadata()->cveId()->c_str(), value);
         }
     }
+
+    /**
+     * @brief Deletes a remediation from the database
+     *
+     * @param data Flatbuffer object containing the CVE information.
+     * @param remediationsDatabase Database of remediations.
+     */
+    static void removeRemediation(const cve_v5::Entry* data, Utils::RocksDBWrapper& remediationsDatabase)
+    {
+        if (!data->cveMetadata() || !data->cveMetadata()->cveId())
+        {
+            return;
+        }
+
+        std::string key {data->cveMetadata()->cveId()->str()};
+        remediationsDatabase.delete_(key);
+    }
 };
 
 #endif // _STORE_REMEDIATIONS_MODEL_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
@@ -63,6 +63,11 @@ public:
         }
     }
 
+    /**
+     * @brief Reads the candidates DB directory and adds all the DBs found to the map.
+     *
+     * @param map All the candidates DBs will be stored in this map.
+     */
     void static openAllDBs(std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>>& map)
     {
         if (std::filesystem::exists(std::filesystem::path(CANDIDATES_DATABASE_PATH)))

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
@@ -16,6 +16,7 @@
 #include "flatbuffers/flatbuffers.h"
 #include "rocksDBWrapper.hpp"
 #include "vulnerabilityCandidate_generated.h"
+#include <filesystem>
 
 const std::unordered_map<std::string, NSVulnerabilityScanner::Status> VERSION_STATUS_MAP {
     {"unaffected", NSVulnerabilityScanner::Status::Status_unaffected},
@@ -23,6 +24,7 @@ const std::unordered_map<std::string, NSVulnerabilityScanner::Status> VERSION_ST
     {"unknown", NSVulnerabilityScanner::Status::Status_unknown}};
 
 constexpr auto CANDIDATES_DATABASE_PATH {"queue/vd/candidates"};
+constexpr auto CANDIDATES_CVE_COLUMN_NAME {"cveId"};
 
 /**
  * @brief Helper class to centralize the map lookup and dynamic fill.
@@ -55,7 +57,24 @@ public:
                 }
             }
 
-            map.emplace(shortName, std::make_unique<Utils::RocksDBWrapper>(dbPath));
+            map.emplace(shortName,
+                        std::make_unique<Utils::RocksDBWrapper>(
+                            dbPath, std::vector<std::string>({CANDIDATES_CVE_COLUMN_NAME})));
+        }
+    }
+
+    void static openAllDBs(std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>>& map)
+    {
+        if (std::filesystem::exists(std::filesystem::path(CANDIDATES_DATABASE_PATH)))
+        {
+            for (const auto& entry : std::filesystem::directory_iterator(CANDIDATES_DATABASE_PATH))
+            {
+                if (entry.is_directory())
+                {
+                    std::string shortName {entry.path().filename().string()};
+                    findAndOpen(shortName, map);
+                }
+            }
         }
     }
 };
@@ -167,13 +186,18 @@ public:
                     NSVulnerabilityScanner::CreateScanVulnerabilityCandidateArrayDirect(value.second, &value.first);
                 value.second.Finish(finalArray);
 
-                const auto buffer = value.second.GetBufferPointer();
-                const auto flatbufferSize = value.second.GetSize();
-
-                const rocksdb::Slice slice(reinterpret_cast<const char*>(buffer), flatbufferSize);
                 const auto finalKey = key + "_" + cveId->str();
+                const auto reverseKey = cveId->str() + "_" + key;
 
-                dbMap.at(shortName)->put(finalKey, slice);
+                // Inserting both entries in different column families in batch
+                std::vector<std::tuple<std::string, std::string, rocksdb::Slice>> columnKeyValueVector {
+                    {ROCKSDB_DEFAULT_COLUMN,
+                     finalKey,
+                     rocksdb::Slice(reinterpret_cast<const char*>(value.second.GetBufferPointer()),
+                                    value.second.GetSize())},
+                    {CANDIDATES_CVE_COLUMN_NAME, reverseKey, finalKey}};
+
+                dbMap.at(shortName)->put(columnKeyValueVector);
             }
         };
 
@@ -213,6 +237,40 @@ public:
             CandidatesDBHelper::findAndOpen(shortName, dbMap);
 
             candidateLambda(cna->affected(), shortName);
+        }
+    }
+
+    /**
+     * @brief Deletes all the candidates related to a CVE from all the databases.
+     *
+     * @param cve5Flatbuffer Flatbuffer object containing the CVE information.
+     * @param dbMap Map with rocksdb instances.
+     */
+    static void removeVulnerabilityCandidate(const cve_v5::Entry* cve5Flatbuffer,
+                                             std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>>& dbMap)
+    {
+        if (!cve5Flatbuffer->cveMetadata() || !cve5Flatbuffer->cveMetadata()->cveId())
+        {
+            return;
+        }
+
+        std::string cveId {cve5Flatbuffer->cveMetadata()->cveId()->str()};
+        CandidatesDBHelper::openAllDBs(dbMap);
+
+        for (const auto& [shortName, db] : dbMap)
+        {
+            std::vector<std::pair<std::string, std::string>> columnKeyVector;
+
+            for (const auto& [key, value] : db->seek(CANDIDATES_CVE_COLUMN_NAME, cveId))
+            {
+                columnKeyVector.emplace_back(std::make_pair(ROCKSDB_DEFAULT_COLUMN, value.ToString()));
+                columnKeyVector.emplace_back(std::make_pair(CANDIDATES_CVE_COLUMN_NAME, key));
+            }
+
+            if (!columnKeyVector.empty())
+            {
+                db->delete_(columnKeyVector);
+            }
         }
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -150,6 +150,23 @@ public:
             }
         }
     }
+
+    /**
+     * @brief Deletes a vulnerability description from the database.
+     *
+     * @param data Flatbuffer object containing the CVE information.
+     * @param descriptionsDatabase Database of vulnerability descriptions.
+     */
+    static void removeVulnerabilityDescription(const cve_v5::Entry* data, Utils::RocksDBWrapper& descriptionsDatabase)
+    {
+        if (!data->cveMetadata() || !data->cveMetadata()->cveId())
+        {
+            return;
+        }
+
+        std::string key {data->cveMetadata()->cveId()->str()};
+        descriptionsDatabase.delete_(key);
+    }
 };
 
 #endif // _UPDATE_CVE_DESCRIPTION_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
@@ -666,7 +666,7 @@ TEST_F(StoreRemediationsModelTest, DeleteRemediation)
 
     // Parse schema.
     flatbuffers::Parser parser;
-    valid = parser.Parse(schemaStr.c_str(), FB_INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_VALID);
+    valid = parser.Parse(schemaStr.c_str(), FB_INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_VALID_ONE_BLOCK);
     EXPECT_TRUE(valid);
 
     // Create a test Entry object with Windows remediations

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
@@ -654,3 +654,41 @@ TEST_F(StoreRemediationsModelTest, x_remediationsNotPresent)
     std::string response;
     EXPECT_EQ(false, rocksDBWrapper.get(key, response));
 }
+
+TEST_F(StoreRemediationsModelTest, DeleteRemediation)
+{
+    // Define schema variable and parse JSON object.
+    std::string schemaStr;
+
+    // Load file with schema.
+    bool valid = flatbuffers::LoadFile(FLATBUFFER_SCHEMA.c_str(), false, &schemaStr);
+    EXPECT_TRUE(valid);
+
+    // Parse schema.
+    flatbuffers::Parser parser;
+    valid = parser.Parse(schemaStr.c_str(), FB_INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_VALID);
+    EXPECT_TRUE(valid);
+
+    // Create a test Entry object with Windows remediations
+    auto jbuf = parser.builder_.GetBufferPointer();
+    flatbuffers::Verifier jverifier(jbuf, parser.builder_.GetSize());
+    EXPECT_TRUE(cve_v5::VerifyEntryBuffer(jverifier));
+    auto entry = cve_v5::GetEntry(jbuf);
+
+    // Create a mock RocksDBWrapper object
+    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+
+    // Call the updateRemediation function with the test data
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+
+    // Make sure the entry was inserted
+    std::string response;
+    std::string cveId {"CVE-1337-1234"};
+    EXPECT_EQ(true, rocksDBWrapper.get(cveId, response));
+
+    // Call the removeRemediation function
+    EXPECT_NO_THROW(StoreRemediationsModel::removeRemediation(entry, rocksDBWrapper));
+
+    // Asserts there's no element with the key provided.
+    EXPECT_EQ(false, rocksDBWrapper.get(cveId, response));
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/updateCVECandidates_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/updateCVECandidates_test.cpp
@@ -315,3 +315,43 @@ TEST_F(UpdateCVECandidatesTest, UpdateCVECandidateSuccess)
     EXPECT_EQ(canonicalData2->platforms()->Get(5)->str(), "lucid");
     EXPECT_EQ(canonicalData2->versions()->size(), 0);
 }
+
+TEST_F(UpdateCVECandidatesTest, RemoveCandidates)
+{
+    std::string cve5FlatbufferSchemaStr;
+
+    // Read schemas from filesystem.
+    bool valid = flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr);
+    ASSERT_EQ(valid, true);
+
+    // Parse schemas and JSON example.
+    flatbuffers::Parser parser;
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(cveInput.c_str()));
+    ASSERT_EQ(valid, true);
+
+    // Get flatbuffer pointer
+    uint8_t* buf = parser.builder_.GetBufferPointer();
+    size_t flatbufferSize = parser.builder_.GetSize();
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
+    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
+    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
+
+    // Call function.
+    UpdateCVECandidates::storeVulnerabilityCandidate(cve5Flatbuffer, m_dbMap);
+
+    // Verify data
+    rocksdb::PinnableSlice slice;
+    EXPECT_TRUE(m_dbMap.at("debian")->get("bash_CVE-2010-0002", slice));
+    EXPECT_TRUE(m_dbMap.at("nvd")->get("bash_CVE-2010-0002", slice));
+    EXPECT_TRUE(m_dbMap.at("canonical")->get("bash_CVE-2010-0002", slice));
+
+    // Remove candidates
+    EXPECT_NO_THROW(UpdateCVECandidates::removeVulnerabilityCandidate(cve5Flatbuffer, m_dbMap));
+
+    // Verify data
+    EXPECT_FALSE(m_dbMap.at("debian")->get("bash_CVE-2010-0002", slice));
+    EXPECT_FALSE(m_dbMap.at("nvd")->get("bash_CVE-2010-0002", slice));
+    EXPECT_FALSE(m_dbMap.at("canonical")->get("bash_CVE-2010-0002", slice));
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
@@ -275,16 +275,6 @@ auto constexpr UPDATED_DATA {R"(
     }
 )"};
 
-auto constexpr DELETED_RESOURCE {R"(
-    {
-        "offset": 3,
-        "type": "delete",
-        "version": 1,
-        "context": "vulnerabilities",
-        "resource": "CVE-2010-0002"
-    }
-)"};
-
 auto constexpr INVALID_TYPE {R"(
     {
         "offset": 3,
@@ -373,35 +363,6 @@ TEST_F(EventDecoderTest, TestUpdatedResource)
     std::string jsongen;
     flatbuffers::GenText(parser, reinterpret_cast<const uint8_t*>(slice.data()), &jsongen);
     EXPECT_EQ(nlohmann::json::parse(jsongen), nlohmann::json::parse(UPDATED_DATA));
-}
-
-/*
- * @brief Test the deletion of a resource.
- */
-TEST_F(EventDecoderTest, TestDeletedResource)
-{
-    std::vector<char> message {};
-    auto jsonResource = nlohmann::json::parse(CREATED_RESOURCE);
-    auto eventContext = std::make_shared<EventContext>(
-        EventContext {.message = message, .resource = jsonResource, .cvesDatabase = m_cvesDb});
-
-    std::shared_ptr<EventDecoder> eventDecoder;
-
-    // Instantiation of the EventDecoder class.
-    EXPECT_NO_THROW(eventDecoder = std::make_shared<EventDecoder>());
-
-    // HandleRequest
-    EXPECT_NO_THROW(eventDecoder->handleRequest(eventContext));
-
-    // Apply update
-    auto deletedJsonResource = nlohmann::json::parse(DELETED_RESOURCE);
-    auto deletedEventContext = std::make_shared<EventContext>(
-        EventContext {.message = message, .resource = deletedJsonResource, .cvesDatabase = m_cvesDb});
-    EXPECT_NO_THROW(eventDecoder->handleRequest(deletedEventContext));
-
-    // Verify flatbuffer.
-    rocksdb::PinnableSlice slice;
-    EXPECT_FALSE(m_cvesDb->get(CVE_ID, slice));
 }
 
 /*

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -474,6 +474,43 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
               "https://chromereleases.googleblog.com/2022/02/stable-channel-update-for-desktop_14.html");
 }
 
+TEST_F(UpdateCVEDescriptionTest, RemoveDescription)
+{
+    std::string cve5FlatbufferSchemaStr;
+
+    // Read schemas from filesystem.
+    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr));
+    ASSERT_EQ(valid, true);
+    ASSERT_EQ(JSON_STR_CVSS_V3_1.empty(), false);
+
+    // Parse schemas and JSON example.
+    flatbuffers::Parser parser;
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
+             parser.Parse(JSON_STR_CVSS_V3_1.c_str()));
+    ASSERT_EQ(valid, true);
+
+    // Get flatbuffer pointer
+    uint8_t* buf = parser.builder_.GetBufferPointer();
+    size_t flatbufferSize = parser.builder_.GetSize();
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
+    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
+    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
+
+    // Call function.
+    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
+
+    // Get flatbuffer from vulnerability description database.
+    std::string vulnerabilityDescriptionFBStr;
+    ASSERT_TRUE(rocksDBWrapper.get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr));
+
+    // Remove entry and verify
+    UpdateCVEDescription::removeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
+    ASSERT_FALSE(rocksDBWrapper.get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr));
+}
+
 TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_0)
 {
     std::string cve5FlatbufferSchemaStr;

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/argsParser.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/argsParser.hpp
@@ -13,6 +13,7 @@
 #define _CMD_ARGS_PARSER_HPP_
 
 #include "json.hpp"
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -108,17 +109,32 @@ private:
 
     static std::vector<std::string> splitActions(const std::string& values)
     {
-        std::vector<std::string> actionsValues;
-        std::stringstream ss {values};
-
-        while (ss.good())
+        if (std::filesystem::is_directory(values))
         {
-            std::string substr;
-            getline(ss, substr, ','); // Getting each string between ',' character
-            actionsValues.push_back(std::move(substr));
+            std::vector<std::string> files;
+            for (const auto& entry : std::filesystem::directory_iterator(values))
+            {
+                if (entry.is_regular_file())
+                {
+                    files.push_back(entry.path().string());
+                }
+            }
+            return files;
         }
+        else
+        {
+            std::vector<std::string> actionsValues;
+            std::stringstream ss {values};
 
-        return actionsValues;
+            while (ss.good())
+            {
+                std::string substr;
+                getline(ss, substr, ','); // Getting each string between ',' character
+                actionsValues.push_back(std::move(substr));
+            }
+
+            return actionsValues;
+        }
     }
 
     const std::string m_configurationFilePath;

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/argsParser.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/argsParser.hpp
@@ -33,6 +33,7 @@ public:
         : m_dbPath {paramValueOf(argc, argv, "-d")}
         , m_fbsPath {paramValueOf(argc, argv, "-f")}
         , m_key {paramValueOf(argc, argv, "-k", std::make_pair(false, ""))}
+        , m_columnFamilies {parseColumnFamilies(paramValueOf(argc, argv, "-c", std::make_pair(false, "")))}
     {
     }
 
@@ -67,6 +68,16 @@ public:
     }
 
     /**
+     * @brief Get the requested column families.
+     *
+     * @return std::vector<std::string> Column families.
+     */
+    std::vector<std::string> getColumnFamilies()
+    {
+        return m_columnFamilies;
+    }
+
+    /**
      * @brief Shows the help to the user.
      */
     static void showHelp()
@@ -74,8 +85,13 @@ public:
         std::cout << "\nUsage: rocksDBQuery <option(s)>\n"
                   << "Options:\n"
                   << "\t-h \t\t\tShow this help message\n"
+                  << "\t-d <path> \t\tPath to the rocksDB database\n"
+                  << "\t-f <path> \t\tPath to the .fbs schema file\n"
+                  << "\t-c <columnFamilies> \t\tComma separated list of column families to query\n"
+                  << "\t-k <key> \t\tKey to query\n"
                   << "\nExample:"
                   << "\n\t./rocksDBQuery -d rocksDBPath/ -f schema.fbs \n"
+                  << "\n\t./rocksDBQuery -d rocksDBPath/ -f schema.fbs -c cf1,cf2 \n"
                   << "\n\t./rocksDBQuery -d rocksDBPath/ -f schema.fbs -k key1 \n"
                   << std::endl;
     }
@@ -105,9 +121,30 @@ private:
         return required.second;
     }
 
+    std::vector<std::string> parseColumnFamilies(const std::string& columnFamilies)
+    {
+        std::vector<std::string> result;
+
+        if (columnFamilies.empty())
+        {
+            return result;
+        }
+
+        std::stringstream ss {columnFamilies};
+        std::string token;
+
+        while (std::getline(ss, token, ','))
+        {
+            result.push_back(token);
+        }
+
+        return result;
+    }
+
     const std::string m_dbPath;
     const std::string m_fbsPath;
     const std::string m_key;
+    const std::vector<std::string> m_columnFamilies;
 };
 
 #endif // _CMD_ARGS_PARSER_HPP_

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/argsParser.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/argsParser.hpp
@@ -31,9 +31,10 @@ public:
      */
     explicit CmdLineArgs(const int argc, const char* argv[])
         : m_dbPath {paramValueOf(argc, argv, "-d")}
-        , m_fbsPath {paramValueOf(argc, argv, "-f")}
+        , m_fbsPath {paramValueOf(argc, argv, "-f", std::make_pair(false, ""))}
         , m_key {paramValueOf(argc, argv, "-k", std::make_pair(false, ""))}
         , m_columnFamilies {parseColumnFamilies(paramValueOf(argc, argv, "-c", std::make_pair(false, "")))}
+        , m_columnQuery {paramValueOf(argc, argv, "-q", std::make_pair(false, "default"))}
     {
     }
 
@@ -78,6 +79,16 @@ public:
     }
 
     /**
+     * @brief Get the requested column query.
+     *
+     * @return std::string Column query.
+     */
+    std::string getColumnQuery()
+    {
+        return m_columnQuery;
+    }
+
+    /**
      * @brief Shows the help to the user.
      */
     static void showHelp()
@@ -87,12 +98,15 @@ public:
                   << "\t-h \t\t\tShow this help message\n"
                   << "\t-d <path> \t\tPath to the rocksDB database\n"
                   << "\t-f <path> \t\tPath to the .fbs schema file\n"
-                  << "\t-c <columnFamilies> \t\tComma separated list of column families to query\n"
+                  << "\t-c <columnFamilies> \tComma separated list of column families of the DB\n"
                   << "\t-k <key> \t\tKey to query\n"
+                  << "\t-q <columnQuery> \tColumn query to filter the results\n"
                   << "\nExample:"
                   << "\n\t./rocksDBQuery -d rocksDBPath/ -f schema.fbs \n"
                   << "\n\t./rocksDBQuery -d rocksDBPath/ -f schema.fbs -c cf1,cf2 \n"
+                  << "\n\t./rocksDBQuery -d rocksDBPath/ -f schema.fbs -c cf1,cf2 -q cf1\n"
                   << "\n\t./rocksDBQuery -d rocksDBPath/ -f schema.fbs -k key1 \n"
+                  << "\n\t./rocksDBQuery -d rocksDBPath/ -q default \n"
                   << std::endl;
     }
 
@@ -145,6 +159,7 @@ private:
     const std::string m_fbsPath;
     const std::string m_key;
     const std::vector<std::string> m_columnFamilies;
+    const std::string m_columnQuery;
 };
 
 #endif // _CMD_ARGS_PARSER_HPP_

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
@@ -21,7 +21,7 @@ int main(const int argc, const char** argv)
     {
         CmdLineArgs cmdLineArgs(argc, argv);
 
-        auto rocksDB = Utils::RocksDBWrapper(cmdLineArgs.getDBPath());
+        auto rocksDB = Utils::RocksDBWrapper(cmdLineArgs.getDBPath(), cmdLineArgs.getColumnFamilies());
         auto fbs = cmdLineArgs.getFbsPath();
         auto requestedKey = cmdLineArgs.getKey();
 

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
@@ -21,6 +21,7 @@ int main(const int argc, const char** argv)
     {
         CmdLineArgs cmdLineArgs(argc, argv);
 
+        auto columQuery = cmdLineArgs.getColumnQuery();
         auto rocksDB = Utils::RocksDBWrapper(cmdLineArgs.getDBPath(), cmdLineArgs.getColumnFamilies());
         auto fbs = cmdLineArgs.getFbsPath();
         auto requestedKey = cmdLineArgs.getKey();
@@ -30,26 +31,36 @@ int main(const int argc, const char** argv)
         flatbuffers::Parser parser(options);
         std::string schemaStr;
 
-        if (!flatbuffers::LoadFile(fbs.c_str(), false, &schemaStr))
+        if (!fbs.empty())
         {
-            throw std::runtime_error("Unable to load schema file.");
-        }
-        if (!parser.Parse(schemaStr.c_str()))
-        {
-            throw std::runtime_error("Unable to parse schema file.");
+            if (!flatbuffers::LoadFile(fbs.c_str(), false, &schemaStr))
+            {
+                throw std::runtime_error("Unable to load schema file.");
+            }
+            if (!parser.Parse(schemaStr.c_str()))
+            {
+                throw std::runtime_error("Unable to parse schema file.");
+            }
         }
 
         auto printValue = [&](const std::string& key, const auto& slice)
         {
-            std::string strData;
-            flatbuffers::GenText(parser, reinterpret_cast<const uint8_t*>(slice.data()), &strData);
+            if (fbs.empty())
+            {
+                std::cout << key << " ==> " << slice.ToString() << std::endl;
+            }
+            else
+            {
+                std::string strData;
+                flatbuffers::GenText(parser, reinterpret_cast<const uint8_t*>(slice.data()), &strData);
 
-            std::cout << key << " ==> " << strData << std::endl;
+                std::cout << key << " ==> " << strData << std::endl;
+            }
         };
 
         if (requestedKey.empty())
         {
-            for (const auto& [key, value] : rocksDB.begin())
+            for (const auto& [key, value] : rocksDB.begin(columQuery))
             {
                 printValue(key, value);
             }
@@ -57,7 +68,7 @@ int main(const int argc, const char** argv)
         else
         {
             rocksdb::PinnableSlice slice;
-            if (!rocksDB.get(requestedKey, slice))
+            if (!rocksDB.get(columQuery, requestedKey, slice))
             {
                 throw std::runtime_error("Unable to find resource.");
             }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20388|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR solves a synchronization problem with the local DBs when the published documents become `REJECTED` after being `PUBLISHED`.

The descriptions and remediations have a simple design and the entries are removed directly. For candidates, it was required to write extra information in the DB (in another column family) to keep track of the entries related to a CVE and remove them later.

The `rocksdDBWrapper` was updated with all the required methods for batch and column family operations.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

To verify the changes, a single document was processed with the `databaseFeedManager` test tool

<details><summary>Details</summary>
<p>

```json
{
    "data": [
        {
            "offset": 7001,
            "type": "create",
            "version": 1,
            "context": "all_vendors_071123",
            "resource": "CVE-2003-0380",
            "payload": {
                "containers": {
                    "adp": [
                        {
                            "affected": [
                                {
                                    "platforms": [
                                        "bookworm",
                                        "bullseye",
                                        "buster",
                                        "sid",
                                        "trixie"
                                    ],
                                    "product": "atftp",
                                    "vendor": "debian",
                                    "versions": [
                                        {
                                            "lessThan": "0.6.2",
                                            "status": "affected",
                                            "version": "0",
                                            "versionType": "deb"
                                        }
                                    ]
                                },
                                {
                                    "platforms": [
                                        "bookworm",
                                        "bullseye",
                                        "buster",
                                        "sid",
                                        "trixie"
                                    ],
                                    "product": "atftpd",
                                    "vendor": "debian",
                                    "versions": [
                                        {
                                            "lessThan": "0.6.2",
                                            "status": "affected",
                                            "version": "0",
                                            "versionType": "deb"
                                        }
                                    ]
                                }
                            ],
                            "metrics": [
                                {
                                    "other": {
                                        "content": {
                                            "data": "{\"description\":\"not yet assigned\"}"
                                        },
                                        "type": "Unknown"
                                    }
                                }
                            ],
                            "providerMetadata": {
                                "orgId": "79363d38-fa19-49d1-9214-5f28da3f3ac5",
                                "shortName": "debian"
                            },
                            "references": [
                                {
                                    "url": "https://security-tracker.debian.org/tracker/CVE-2003-0380"
                                }
                            ]
                        }
                    ],
                    "cna": {
                        "affected": [
                            {
                                "cpes": [
                                    "cpe:2.3:a:atftpd:atftpd:0.6.0:*:*:*:*:*:*:*",
                                    "cpe:2.3:a:atftpd:atftpd:0.6.1.1:*:*:*:*:*:*:*"
                                ],
                                "defaultStatus": "unaffected",
                                "product": "atftpd",
                                "vendor": "atftpd",
                                "versions": [
                                    {
                                        "status": "affected",
                                        "version": "0.6.0"
                                    },
                                    {
                                        "status": "affected",
                                        "version": "0.6.1.1"
                                    }
                                ]
                            }
                        ],
                        "descriptions": [
                            {
                                "lang": "en",
                                "value": "Buffer overflow in atftp daemon (atftpd) 0.6.1 and earlier, and possibly later versions, allows remote attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long filename."
                            },
                            {
                                "lang": "es",
                                "value": "Desbordamiento de búfer en el demonio atftp (atftpd) 0.6.1 y anteriores, y posiblemente versiones posteriores, permite a atacantes remotos ejecutar código arbitrario mediante un nombre de fichero largo."
                            }
                        ],
                        "metrics": [
                            {
                                "cvssV2_0": {
                                    "accessComplexity": "LOW",
                                    "accessVector": "NETWORK",
                                    "authentication": "NONE",
                                    "availabilityImpact": "PARTIAL",
                                    "baseScore": 7.5,
                                    "confidentialityImpact": "PARTIAL",
                                    "integrityImpact": "PARTIAL",
                                    "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
                                    "version": "2.0"
                                },
                                "format": "CVSS"
                            }
                        ],
                        "problemTypes": [
                            {
                                "descriptions": [
                                    {
                                        "description": "NVD-CWE-Other",
                                        "lang": "en"
                                    }
                                ]
                            }
                        ],
                        "providerMetadata": {
                            "dateUpdated": "2008-09-05T20:34:11Z",
                            "orgId": "00000000-0000-4000-A000-000000000003",
                            "shortName": "nvd"
                        },
                        "references": [
                            {
                                "tags": [
                                    "exploit",
                                    "patch",
                                    "vendor-advisory"
                                ],
                                "url": "http://archives.neohapsis.com/archives/bugtraq/2003-06/0056.html"
                            },
                            {
                                "tags": [
                                    "patch",
                                    "vendor-advisory"
                                ],
                                "url": "http://www.debian.org/security/2003/dsa-314"
                            },
                            {
                                "tags": [
                                    "vendor-advisory"
                                ],
                                "url": "http://www.securityfocus.com/archive/82/323886/2003-06-02/2003-06-08/0"
                            }
                        ]
                    }
                },
                "cveMetadata": {
                    "assignerOrgId": "00000000-0000-4000-A000-000000000003",
                    "assignerShortName": "nvd",
                    "cveId": "CVE-2003-0380",
                    "datePublished": "2003-07-02T04:00:00Z",
                    "dateUpdated": "2008-09-05T20:34:11Z",
                    "state": "PUBLISHED"
                },
                "dataType": "CVE_RECORD",
                "dataVersion": "5.0"
            }
        }
    ]
}

```

</p>
</details> 

The DBs contain the expected entries

<details><summary>Details</summary>
<p>

```
root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# ./database_feed_manager_testtool -c config.json  -i /home/vagrant/contents/
Press enter to stop the tool...
wazuh-modulesd:vulnerability-scanner->/home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp:180 Processing message
wazuh-modulesd:vulnerability-scanner->/home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp:113 Processing file: /home/vagrant/contents/test.json
wazuh-modulesd:vulnerability-scanner->/home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp:182 Message processed

root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# ./rocks_db_query_
testtool -d queue/vd/candidates/debian -f /home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/schemas/vulnerabilityCandidat
e.fbs -c cveId
/home/vagrant/wazuh/src/external/rocksdb/include/rocksdb/slice.h:114:42: runtime error: null pointer passed as argument 2, which is declared to never be null
atftp_CVE-2003-0380 ==> {
  "candidates": [
    {
      "cveId": "CVE-2003-0380",
      "platforms": [
        "bookworm",
        "bullseye",
        "buster",
        "sid",
        "trixie"
      ],
      "versions": [
        {
          "version": "0",
          "lessThan": "0.6.2",
          "versionType": "deb"
        }
      ]
    }
  ]
}

atftpd_CVE-2003-0380 ==> {
  "candidates": [
    {
      "cveId": "CVE-2003-0380",
      "platforms": [
        "bookworm",
        "bullseye",
        "buster",
        "sid",
        "trixie"
      ],
      "versions": [
        {
          "version": "0",
          "lessThan": "0.6.2",
          "versionType": "deb"
        }
      ]
    }
  ]
}

root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# /home/vagrant/ldb
 --db=./queue/vd/candidates/debian scan --try_load_options --column_family=cveId
CVE-2003-0380_atftp : atftp_CVE-2003-0380
CVE-2003-0380_atftpd : atftpd_CVE-2003-0380

root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# ./rocks_db_query_testtool -d queue/vd/candidates/nvd -f /home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/schemas/vulnerabilityCandidate.f
bs -c cveId
/home/vagrant/wazuh/src/external/rocksdb/include/rocksdb/slice.h:114:42: runtime error: null pointer passed as argument 2, which is declared to never be null
atftpd_CVE-2003-0380 ==> {
  "candidates": [
    {
      "cveId": "CVE-2003-0380",
      "defaultStatus": "unaffected",
      "platforms": [

      ],
      "versions": [
        {
          "version": "0.6.0"
        },
        {
          "version": "0.6.1.1"
        }
      ]
    }
  ]
}

root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# /home/vagrant/ldb --db=./queue/vd/candidates/nvd scan --try_load_options --column_family=cveId
CVE-2003-0380_atftpd : atftpd_CVE-2003-0380

```

</p>
</details> 

Then, an update message was processed and the document became `REJECTED`

<details><summary>Details</summary>
<p>

```json
{
    "data": [
        {
            "offset": 7001,
            "type": "update",
            "version": 1,
            "context": "all_vendors_071123",
            "resource": "CVE-2003-0380",
            "operations": [
                {
                    "op": "replace",
                    "path": "/cveMetadata/state",
                    "value": "REJECTED"
                }
            ]
        }
    ]
}

```

</p>
</details> 

We can verify that the entries were removed

<details><summary>Details</summary>
<p>

```
root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# ./database_feed_m
anager_testtool -c config.json  -i /home/vagrant/contents/
Press enter to stop the tool...
wazuh-modulesd:vulnerability-scanner->/home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp:180 Processing message
wazuh-modulesd:vulnerability-scanner->/home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp:113 Processing file: /home/vagrant/contents/test.json
wazuh-modulesd:vulnerability-scanner->/home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp:182 Message processed

root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# ./rocks_db_query_testtool -d queue/vd/candidates/debian/ -f /home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/schemas/vulnerabilityCandida
te.fbs -c cveId
root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# ./rocks_db_query_testtool -d queue/vd/candidates/nvd -f /home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/schemas/vulnerabilityCandidate.f
bs -c cveId
root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# /home/vagrant/ldb --db=./queue/vd/candidates/nvd scan --try_load_options --column_family=cveId
root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# /home/vagrant/ldb --db=./queue/vd/candidates/debian scan --try_load_options --column_family=cveId
```

</p>
</details> 


Another test carried out consisted in removing only one entry

<details><summary>Details</summary>
<p>

```json
{
    "data": [
        {
            "offset": 7001,
            "type": "update",
            "version": 1,
            "context": "all_vendors_071123",
            "resource": "CVE-2003-0380",
            "operations": [
                {
                    "op": "remove",
                    "path": "/containers/adp/0/affected/0",
                    "value": "REJECTED"
                }
            ]
        }
    ]
}

```

</p>
</details> 

And we can verify that only the removed entry was deleted

<details><summary>Details</summary>
<p>

```
root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# ./database_feed_manager_testtool -c config.json  -i /home/vagrant/contents/
Press enter to stop the tool...
wazuh-modulesd:vulnerability-scanner->/home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp:180 Processing message
wazuh-modulesd:vulnerability-scanner->/home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp:113 Processing file: /home/vagrant/contents/test.json
wazuh-modulesd:vulnerability-scanner->/home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp:182 Message processed

root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# ./rocks_db_query_testtool -d queue/vd/candidates/debian/ -f /home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/schemas/vulnerabilityCandida
te.fbs -c cveId
/home/vagrant/wazuh/src/external/rocksdb/include/rocksdb/slice.h:114:42: runtime error: null pointer passed as argument 2, which is declared to never be null
atftpd_CVE-2003-0380 ==> {
  "candidates": [
    {
      "cveId": "CVE-2003-0380",
      "platforms": [
        "bookworm",
        "bullseye",
        "buster",
        "sid",
        "trixie"
      ],
      "versions": [
        {
          "version": "0",
          "lessThan": "0.6.2",
          "versionType": "deb"
        }
      ]
    }
  ]
}

root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# /home/vagrant/ldb --db=./queue/vd/candidates/debian scan --try_load_options --column_family=cveId
CVE-2003-0380_atftpd : atftpd_CVE-2003-0380

root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# ./rocks_db_query_testtool -d queue/vd/candidates/nvd -f /home/vagrant/wazuh/src/wazuh_modules/vulnerability_scanner/schemas/vulnerabilityCandidate.f
bs -c cveId
/home/vagrant/wazuh/src/external/rocksdb/include/rocksdb/slice.h:114:42: runtime error: null pointer passed as argument 2, which is declared to never be null
atftpd_CVE-2003-0380 ==> {
  "candidates": [
    {
      "cveId": "CVE-2003-0380",
      "defaultStatus": "unaffected",
      "platforms": [

      ],
      "versions": [
        {
          "version": "0.6.0"
        },
        {
          "version": "0.6.1.1"
        }
      ]
    }
  ]
}

root@ubuntu-jammy:/home/vagrant/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager# /home/vagrant/ldb --db=./queue/vd/candidates/nvd scan --try_load_options --column_family=cveId
CVE-2003-0380_atftpd : atftpd_CVE-2003-0380
```

</p>
</details> 




Minimum checks required
- Compilation without warnings in every supported platform
  - [x] Linux

- [x] Added unit tests (for new features)
