### PR TITLE
Dev 20537 typification of downloaded content

### DIFF
--- a/src/shared_modules/content_manager/src/components/CtiApiDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiApiDownloader.hpp
@@ -71,6 +71,9 @@ private:
      */
     void download()
     {
+        // Set the type of the content.
+        m_context->data.at("type") = "offsets";
+
         logDebug2(WM_CONTENTUPDATER, "CtiApiDownloader - Starting");
         // Get the parameters needed to download the content.
         getParameters();

--- a/src/shared_modules/content_manager/src/components/updaterContext.hpp
+++ b/src/shared_modules/content_manager/src/components/updaterContext.hpp
@@ -101,6 +101,7 @@ struct UpdaterContext final : private UpdaterBaseContext
      *
      * @details JSON file structure:
      *  {
+     *      "type": "raw",
      *      "paths":
      *      [
      *          "/tmp/outputFolder/file1.json",
@@ -116,7 +117,7 @@ struct UpdaterContext final : private UpdaterBaseContext
      *  }
      *
      */
-    nlohmann::json data = R"({ "paths": [], "stageStatus": [] })"_json;
+    nlohmann::json data = R"({ "type": "raw", "paths": [], "stageStatus": [] })"_json;
 
     /**
      * @brief Represents the offset processed in the current run.

--- a/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.cpp
@@ -68,7 +68,7 @@ TEST_F(PubSubPublisherTest, TestPublishValidDataWithouStartTheRouterProvider)
     m_spUpdaterBaseContext->spChannel = std::make_shared<RouterProvider>("component-tests");
 
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
-    m_spUpdaterContext->data = R"({ "paths": ["/dummy/path"], "stageStatus": [] })"_json;
+    m_spUpdaterContext->data = R"({ "type": "raw", "paths": ["/dummy/path"], "stageStatus": [] })"_json;
 
     EXPECT_THROW(m_spPubSubPublisher->handleRequest(m_spUpdaterContext), std::runtime_error);
 

--- a/src/shared_modules/content_manager/tests/unit/APIDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/APIDownloader_test.cpp
@@ -10,10 +10,11 @@
  */
 
 #include "APIDownloader_test.hpp"
-#include "APIDownloader.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
 #include <filesystem>
+
+constexpr auto DEFAULT_TYPE {"raw"}; ///< Default content type.
 
 /**
  * @brief Tests handle a valid request with raw data.
@@ -43,6 +44,10 @@ TEST_F(APIDownloaderTest, TestHandleValidRequestWithRawData)
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
     EXPECT_EQ(stageStatus, expectedStageStatus);
+
+    const auto type = m_spUpdaterContext->data.at("type");
+
+    EXPECT_EQ(type, DEFAULT_TYPE);
 
     // It's true because the compressionType is `raw`
     EXPECT_TRUE(std::filesystem::exists(contentPath));
@@ -83,6 +88,10 @@ TEST_F(APIDownloaderTest, TestHandleValidRequestWithCompressedData)
 
     EXPECT_EQ(stageStatus, expectedStageStatus);
 
+    const auto type = m_spUpdaterContext->data.at("type");
+
+    EXPECT_EQ(type, DEFAULT_TYPE);
+
     // It's false because the compressionType isn't `raw`
     EXPECT_FALSE(std::filesystem::exists(contentPath));
 
@@ -120,6 +129,10 @@ TEST_F(APIDownloaderTest, TestHandleValidRequestWithCompressedDataAndInvalidOutp
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
     EXPECT_EQ(stageStatus, expectedStageStatus);
+
+    const auto type = m_spUpdaterContext->data.at("type");
+
+    EXPECT_EQ(type, DEFAULT_TYPE);
 }
 
 /**
@@ -152,6 +165,10 @@ TEST_F(APIDownloaderTest, TestHandleAnEmptyUrl)
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
     EXPECT_EQ(stageStatus, expectedStageStatus);
+
+    const auto type = m_spUpdaterContext->data.at("type");
+
+    EXPECT_EQ(type, DEFAULT_TYPE);
 }
 
 /**
@@ -184,4 +201,8 @@ TEST_F(APIDownloaderTest, TestHandleAnInvalidUrl)
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
     EXPECT_EQ(stageStatus, expectedStageStatus);
+
+    const auto type = m_spUpdaterContext->data.at("type");
+
+    EXPECT_EQ(type, DEFAULT_TYPE);
 }

--- a/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiApiDownloader_test.cpp
@@ -17,6 +17,8 @@
 const auto OK_STATUS = R"([{"stage":"CtiApiDownloader","status":"ok"}])"_json;
 const auto FAIL_STATUS = R"([{"stage":"CtiApiDownloader","status":"fail"}])"_json;
 
+constexpr auto DEFAULT_TYPE {"offsets"}; ///< Default content type.
+
 /**
  * @brief Tests handle a valid request with raw data.
  */
@@ -34,6 +36,10 @@ TEST_F(CtiApiDownloaderTest, TestHandleValidRequestWithRawData)
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
     EXPECT_EQ(stageStatus, OK_STATUS);
+
+    const auto type = m_spUpdaterContext->data.at("type");
+
+    EXPECT_EQ(type, DEFAULT_TYPE);
 
     // It's true because the compressionType is `raw`
     EXPECT_TRUE(std::filesystem::exists(contentPath));
@@ -63,6 +69,10 @@ TEST_F(CtiApiDownloaderTest, TestHandleValidRequestWithCompressedData)
 
     EXPECT_EQ(stageStatus, OK_STATUS);
 
+    const auto type = m_spUpdaterContext->data.at("type");
+
+    EXPECT_EQ(type, DEFAULT_TYPE);
+
     // It's false because the compressionType isn't `raw`
     EXPECT_FALSE(std::filesystem::exists(contentPath));
 
@@ -89,6 +99,10 @@ TEST_F(CtiApiDownloaderTest, TestHandleValidRequestWithCompressedDataAndInvalidO
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
     EXPECT_EQ(stageStatus, FAIL_STATUS);
+
+    const auto type = m_spUpdaterContext->data.at("type");
+
+    EXPECT_EQ(type, DEFAULT_TYPE);
 }
 
 /**
@@ -110,6 +124,10 @@ TEST_F(CtiApiDownloaderTest, TestHandleAnEmptyUrl)
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
     EXPECT_EQ(stageStatus, FAIL_STATUS);
+
+    const auto type = m_spUpdaterContext->data.at("type");
+
+    EXPECT_EQ(type, DEFAULT_TYPE);
 }
 
 /**
@@ -131,6 +149,10 @@ TEST_F(CtiApiDownloaderTest, TestHandleAnInvalidUrl)
     const auto stageStatus = m_spUpdaterContext->data.at("stageStatus");
 
     EXPECT_EQ(stageStatus, FAIL_STATUS);
+
+    const auto type = m_spUpdaterContext->data.at("type");
+
+    EXPECT_EQ(type, DEFAULT_TYPE);
 }
 
 /**
@@ -150,6 +172,7 @@ TEST_F(CtiApiDownloaderTest, DownloadServerErrorWithRetry)
     nlohmann::json expectedData;
     expectedData["paths"].push_back(contentPath);
     expectedData["stageStatus"] = OK_STATUS;
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_NO_THROW(m_spCtiApiDownloader->handleRequest(m_spUpdaterContext));
 
@@ -170,6 +193,7 @@ TEST_F(CtiApiDownloaderTest, DownloadClientErrorNoRetry)
     nlohmann::json expectedData;
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = FAIL_STATUS;
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_THROW(m_spCtiApiDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -189,6 +213,7 @@ TEST_F(CtiApiDownloaderTest, DownloadClientAndServerErrorsRetryAndFail)
     nlohmann::json expectedData;
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = FAIL_STATUS;
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_THROW(m_spCtiApiDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);

--- a/src/shared_modules/content_manager/tests/unit/fileDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/fileDownloader_test.cpp
@@ -25,6 +25,8 @@ const auto CONTENT_FILENAME_RAW = "raw";
 const auto CONTENT_FILENAME_XZ = "xz";
 const std::string BASE_URL = "localhost:4444/";
 
+constexpr auto DEFAULT_TYPE {"raw"}; ///< Default content type.
+
 void FileDownloaderTest::SetUpTestSuite()
 {
     if (!m_spFakeServer)
@@ -78,6 +80,7 @@ TEST_F(FileDownloaderTest, DownloadBadURL)
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(FAIL_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Set invalid config data. This will make the downloader to download from 'localhost:4444/invalid_file'.
     m_spUpdaterBaseContext->configData["compressionType"] = "raw";
@@ -104,6 +107,7 @@ TEST_F(FileDownloaderTest, DownloadRawFile)
     expectedData["paths"].push_back(expectedFilepath.string());
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Set config data. This will make the downloader to download from 'localhost:4444/raw'.
     m_spUpdaterBaseContext->configData["compressionType"] = "raw";
@@ -133,6 +137,7 @@ TEST_F(FileDownloaderTest, DownloadCompressedFile)
     expectedData["paths"].push_back(expectedFilepath.string());
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Set config data. This will make the downloader to download from 'localhost:4444/xz'.
     m_spUpdaterBaseContext->configData["compressionType"] = "xz";
@@ -163,6 +168,7 @@ TEST_F(FileDownloaderTest, DownloadSameFileTwice)
     expectedData["paths"].push_back(expectedFilepath.string());
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Set config data. This will make the downloader to download from 'localhost:4444/xz'.
     m_spUpdaterBaseContext->configData["compressionType"] = "xz";
@@ -200,6 +206,7 @@ TEST_F(FileDownloaderTest, DownloadSameFileTwiceAndThenADifferentOne)
     expectedData["paths"].push_back(compressedExpectedFilepath.string());
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Set config data. This will make the downloader to download from 'localhost:4444/xz'.
     m_spUpdaterBaseContext->configData["compressionType"] = "xz";
@@ -250,6 +257,7 @@ TEST_F(FileDownloaderTest, DownloadURLWithoutFilename)
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(FAIL_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Set invalid config data. This will make the downloader to download from 'localhost:4444/'.
     m_spUpdaterBaseContext->configData["url"] = BASE_URL;

--- a/src/shared_modules/content_manager/tests/unit/gzipDecompressor_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/gzipDecompressor_test.cpp
@@ -23,6 +23,8 @@ const auto INPUT_INEXISTANT_FILE_PATH {INPUT_FILES_DIR / "inexistant.xml.gz"};
 const auto OK_STATUS = R"({"stage":"GzipDecompressor","status":"ok"})"_json;
 const auto FAIL_STATUS = R"({"stage":"GzipDecompressor","status":"fail"})"_json;
 
+constexpr auto DEFAULT_TYPE {"raw"}; ///< Default content type.
+
 /**
  * @brief Test the correct instantiation of the class.
  *
@@ -44,6 +46,7 @@ TEST_F(GzipDecompressorTest, DecompressNoFile)
     expectedData["paths"] = m_spContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Run decompression.
     ASSERT_NO_THROW(GzipDecompressor().handleRequest(m_spContext));
@@ -66,6 +69,7 @@ TEST_F(GzipDecompressorTest, DecompressOneFile)
     expectedData["paths"].push_back(OUTPUT_SAMPLE_A_FILE_PATH.string());
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Run decompression.
     ASSERT_NO_THROW(GzipDecompressor().handleRequest(m_spContext));
@@ -93,6 +97,7 @@ TEST_F(GzipDecompressorTest, DecompressTwoFiles)
     expectedData["paths"].push_back(OUTPUT_SAMPLE_B_FILE_PATH.string());
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Run decompression.
     ASSERT_NO_THROW(GzipDecompressor().handleRequest(m_spContext));
@@ -119,6 +124,7 @@ TEST_F(GzipDecompressorTest, DecompressInexistantFile)
     expectedData["paths"] = m_spContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(FAIL_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Run decompression.
     ASSERT_THROW(GzipDecompressor().handleRequest(m_spContext), std::runtime_error);
@@ -143,6 +149,7 @@ TEST_F(GzipDecompressorTest, DecompressTwoFilesOneInexistant)
     expectedData["paths"].push_back(INPUT_INEXISTANT_FILE_PATH);
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(FAIL_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Run decompression.
     ASSERT_THROW(GzipDecompressor().handleRequest(m_spContext), std::runtime_error);

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
@@ -29,6 +29,8 @@ const auto CONTENT_FILENAME_RAW = "raw";
 const auto CONTENT_FILENAME_XZ = "xz";
 const std::string BASE_URL = "localhost:4444/";
 
+constexpr auto DEFAULT_TYPE {"raw"}; ///< Default content type.
+
 /**
  * @brief Tests the correct instantiation of the class.
  *
@@ -53,6 +55,7 @@ TEST_F(OfflineDownloaderTest, RawFileDownload)
                                     m_inputFilePathRaw.filename().string());
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -73,6 +76,7 @@ TEST_F(OfflineDownloaderTest, CompressedFileDownload)
                                     m_inputFilePathCompressed.filename().string());
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -93,6 +97,7 @@ TEST_F(OfflineDownloaderTest, InexistantFileDownload)
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -113,6 +118,7 @@ TEST_F(OfflineDownloaderTest, SkipFileProcessing)
                                     m_inputFilePathRaw.filename().string());
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -145,6 +151,7 @@ TEST_F(OfflineDownloaderTest, TwoFileDownloadsOverrideOutput)
                                     m_inputFilePathRaw.filename().string());
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Trigger first download.
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
@@ -180,6 +187,7 @@ TEST_F(OfflineDownloaderTest, InexistantContentFolder)
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(FAIL_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext), std::runtime_error);
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -200,6 +208,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadRawFile)
     expectedData["paths"].push_back(expectedOutputFile);
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -221,6 +230,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadCompressedFile)
     expectedData["paths"].push_back(expectedOutputFile);
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -240,6 +250,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadFileWithoutFilename)
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(FAIL_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext), std::runtime_error);
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -258,6 +269,7 @@ TEST_F(OfflineDownloaderTest, DownloadUnknownPrefixedFile)
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(FAIL_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext), std::runtime_error);
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -278,6 +290,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadRawFileOverride)
     expectedData["paths"].push_back(expectedOutputFile);
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Create dummy file in the expected output path.
     std::ofstream testFileStream {expectedOutputFile};
@@ -302,6 +315,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadInvalidURL)
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -322,6 +336,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadFileTwice)
     expectedData["paths"].push_back(expectedOutputFile);
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -354,6 +369,7 @@ TEST_F(OfflineDownloaderTest, HttpAndLocalDownloadFileTwice)
     expectedData["paths"].push_back(expectedOutputFile);
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);

--- a/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.cpp
@@ -43,6 +43,8 @@ const auto ZIP_EMPTY {INPUT_FILES_DIR / "empty.zip"};
 const auto OK_STATUS = R"({"stage":"ZipDecompressor","status":"ok"})"_json;
 const auto FAIL_STATUS = R"({"stage":"ZipDecompressor","status":"fail"})"_json;
 
+constexpr auto DEFAULT_TYPE {"raw"}; ///< Default content type.
+
 /**
  * @brief Tests the correct class instantiation.
  *
@@ -64,6 +66,7 @@ TEST_F(ZipDecompressorTest, DecompressNoFile)
     expectedData["paths"] = m_spContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Run decompression.
     ASSERT_NO_THROW(ZipDecompressor().handleRequest(m_spContext));
@@ -83,6 +86,7 @@ TEST_F(ZipDecompressorTest, DecompressOneZipOneFile)
     expectedData["paths"] = ZIP_CONTENT_A_EXPECTED_FILES;
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Set input files.
     m_spContext->data.at("paths").push_back(ZIP_CONTENT_A);
@@ -111,6 +115,7 @@ TEST_F(ZipDecompressorTest, DecompressOneZipTwoFiles)
     expectedData["paths"] = ZIP_CONTENT_B_EXPECTED_FILES;
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Set input files.
     m_spContext->data.at("paths").push_back(ZIP_CONTENT_B);
@@ -143,6 +148,7 @@ TEST_F(ZipDecompressorTest, DecompressTwoZips)
     expectedData["paths"] = expectedPaths;
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(OK_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Set input files.
     m_spContext->data.at("paths").push_back(ZIP_CONTENT_A);
@@ -175,6 +181,7 @@ TEST_F(ZipDecompressorTest, DecompressInexistantFile)
     expectedData["paths"] = m_spContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(FAIL_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Run decompression.
     EXPECT_THROW(ZipDecompressor().handleRequest(m_spContext), std::runtime_error);
@@ -197,6 +204,7 @@ TEST_F(ZipDecompressorTest, DecompressEmptyZip)
     expectedData["paths"] = m_spContext->data.at("paths");
     expectedData["stageStatus"] = nlohmann::json::array();
     expectedData["stageStatus"].push_back(FAIL_STATUS);
+    expectedData["type"] = DEFAULT_TYPE;
 
     // Run decompression.
     EXPECT_THROW(ZipDecompressor().handleRequest(m_spContext), std::runtime_error);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/20537|

## Description

The following changes are introduced in this PR:
- A new field representing the type of the published content is added.
- The file type is initialized with the value "raw".
- The specific type `offsets` is set in the CtiApiDownloader class.
- The tests are updated

## Test

<details>
<summary>CtiApiDownloader</summary>

```json
{
    "paths":
    [
        "/tmp/testProvider/contents/221000-example.json",
        "/tmp/testProvider/contents/222000-example.json",
        "/tmp/testProvider/contents/223000-example.json",
        "/tmp/testProvider/contents/224000-example.json",
        "/tmp/testProvider/contents/225000-example.json",
        "/tmp/testProvider/contents/226000-example.json",
        "/tmp/testProvider/contents/227000-example.json",
        "/tmp/testProvider/contents/228000-example.json",
        "/tmp/testProvider/contents/229000-example.json",
        "/tmp/testProvider/contents/230000-example.json",
        "/tmp/testProvider/contents/230577-example.json"
    ],
    "stageStatus":
    [
        {
            "stage": "CtiApiDownloader",
            "status": "ok"
        }
    ],
    "type": "offsets"
}
```
</details>

<details>
<summary>APIDownloader</summary>

```json
{
    "paths":
    [
        "/tmp/testProvider/contents/example.json"
    ],
    "stageStatus":
    [
        {
            "stage": "APIDownloader",
            "status": "ok"
        }
    ],
    "type": "raw"
}
```
</details>

<details>
<summary>OfflineDownloader</summary>

```json
{
    "paths":
    [
        "/tmp/testProvider/contents/metadataFile.json"
    ],
    "stageStatus":
    [
        {
            "stage": "OfflineDownloader",
            "status": "ok"
        }
    ],
    "type": "raw"
}
```
</details>

<details>
<summary>FileDownloader</summary>

```json
{
    "paths":
    [
        "/tmp/testProvider/contents/metadataFile.json"
    ],
    "stageStatus":
    [
        {
            "stage": "FileDownloader",
            "status": "ok"
        }
    ],
    "type": "raw"
}
```
</details>
