### PR TITLE
Update deprecated ssl protocol message

### DIFF
--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -14,9 +14,7 @@ from api.constants import API_LOG_PATH
 from wazuh.core.wlogging import TimeBasedFileRotatingHandler, SizeBasedFileRotatingHandler
 from wazuh.core import pyDaemonModule
 
-SSL_DEPRECATED_MESSAGE = 'The `{ssl_protocol}` SSL protocol option was deprecated in {release} and will be removed ' \
-                         'in the next minor in favor of the `auto` option and the manual setting of the minimum and ' \
-                         'maximum TLS supported versions.'
+SSL_DEPRECATED_MESSAGE = 'The `{ssl_protocol}` SSL protocol is deprecated.'
 
 API_MAIN_PROCESS = 'wazuh-apid'
 API_LOCAL_REQUEST_PROCESS = 'wazuh-apid_exec'
@@ -312,8 +310,8 @@ if __name__ == '__main__':
 
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=DeprecationWarning)
-                if ssl_protocol is not ssl.PROTOCOL_TLS_SERVER:
-                    logger.warning(SSL_DEPRECATED_MESSAGE.format(ssl_protocol=config_ssl_protocol, release="4.8"))
+                if ssl_protocol in (ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1_1):
+                    logger.warning(SSL_DEPRECATED_MESSAGE.format(ssl_protocol=config_ssl_protocol))
                 ssl_context = ssl.SSLContext(protocol=ssl_protocol)
 
             if api_conf['https']['use_ca']:


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/20484 |

## Description

Updates the deprecated SSL protocol message to show it only when `tlsv1` or `tlsv1.1` are used.

## Logs/Alerts example

### Deprecated SSL protocol configurations

<details><summary>tlsv1</summary>

```console
2023/11/30 16:05:07 WARNING: The `tlsv1` SSL protocol is deprecated.
2023/11/30 16:05:07 INFO: Checking RBAC database integrity...
2023/11/30 16:05:07 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2023/11/30 16:05:07 INFO: RBAC database integrity check finished successfully
2023/11/30 16:05:09 INFO: Listening on 0.0.0.0:55000..
```

</details>


<details><summary>tlsv1.1</summary>

```console
2023/11/30 15:14:35 WARNING: The `tlsv1.1` SSL protocol is deprecated.
2023/11/30 15:14:35 INFO: Checking RBAC database integrity...
2023/11/30 15:14:35 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2023/11/30 15:14:35 INFO: RBAC database integrity check finished successfully
2023/11/30 15:14:36 INFO: Listening on 0.0.0.0:55000..
```

</details>


### Supported SSL protocol configurations



<details><summary>tlsv1.2</summary>

```console
2023/11/30 16:07:48 INFO: Checking RBAC database integrity...
2023/11/30 16:07:48 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2023/11/30 16:07:48 INFO: RBAC database integrity check finished successfully
2023/11/30 16:07:50 INFO: Listening on 0.0.0.0:55000..
```

</details>

> `auto` and `tls` have the same behavior

<details><summary>auto</summary>

```console
2023/11/30 15:15:50 INFO: Checking RBAC database integrity...
2023/11/30 15:15:50 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2023/11/30 15:15:50 INFO: RBAC database integrity check finished successfully
2023/11/30 15:15:51 INFO: Listening on 0.0.0.0:55000..
```

</details>

<details><summary>tls</summary>

```console
2023/11/30 16:08:45 INFO: Checking RBAC database integrity...
2023/11/30 16:08:45 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2023/11/30 16:08:45 INFO: RBAC database integrity check finished successfully
2023/11/30 16:08:47 INFO: Listening on 0.0.0.0:55000..
```

</details>

### Client requests to a `auto` (TLS 1.3) server

<details><summary>TLS 1.0/1.1 request</summary>

As expected, the client can't send TLS 1.0/1.1 requests to the server because those versions don't not support TLS 1.3 ciphers.

```console
gasti@pop-os:~/work/wazuh$ curl -u wazuh:wazuh -X POST -vk https://0.0.0.0:55050/security/user/authenticate --tls-max 1.0
*   Trying 0.0.0.0:55050...
* Connected to 0.0.0.0 (127.0.0.1) port 55050 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* TLSv1.2 (OUT), TLS header, Unknown (21):
* TLSv1.3 (OUT), TLS alert, protocol version (582):
* error:0A0000BF:SSL routines::no protocols available
* Closing connection 0
curl: (35) error:0A0000BF:SSL routines::no protocols available
gasti@pop-os:~/work/wazuh$ curl -u wazuh:wazuh -X POST -vk https://0.0.0.0:55050/security/user/authenticate --tls-max 1.1
*   Trying 0.0.0.0:55050...
* Connected to 0.0.0.0 (127.0.0.1) port 55050 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* TLSv1.2 (OUT), TLS header, Unknown (21):
* TLSv1.3 (OUT), TLS alert, protocol version (582):
* error:0A0000BF:SSL routines::no protocols available
* Closing connection 0
curl: (35) error:0A0000BF:SSL routines::no protocols available
```

</details>


<details><summary>TLS 1.2 request</summary>

```console
gasti@pop-os:~/work/wazuh$ curl -u wazuh:wazuh -X POST -vk https://0.0.0.0:55050/security/user/authenticate --tlsv1.2 --tls-max 1.2
*   Trying 0.0.0.0:55050...
* Connected to 0.0.0.0 (127.0.0.1) port 55050 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* TLSv1.0 (OUT), TLS header, Certificate Status (22):
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS header, Certificate Status (22):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS header, Certificate Status (22):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS header, Certificate Status (22):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS header, Certificate Status (22):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS header, Certificate Status (22):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS header, Finished (20):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS header, Certificate Status (22):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS header, Finished (20):
* TLSv1.2 (IN), TLS header, Certificate Status (22):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  start date: Nov 30 14:36:09 2023 GMT
*  expire date: Nov 29 14:36:09 2024 GMT
*  issuer: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  SSL certificate verify result: self-signed certificate (18), continuing anyway.
* Server auth using Basic with user 'wazuh'
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
> POST /security/user/authenticate HTTP/1.1
> Host: 0.0.0.0:55050
> Authorization: Basic d2F6dWg6d2F6dWg=
> User-Agent: curl/7.81.0
> Accept: */*
> 
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Strict-Transport-Security: max-age=63072000; includeSubdomains
< X-Frame-Options: DENY
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< Content-Security-Policy: none
< Referrer-Policy: no-referrer, strict-origin-when-cross-origin
< Pragma: no-cache
< Expires: 0
< Cache-control: no-cache, no-store, must-revalidate, max-age=0
< Content-Length: 433
< Date: Thu, 30 Nov 2023 14:51:23 GMT
< 
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* Connection #0 to host 0.0.0.0 left intact
{"data": {"token": "eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzAxMzU1ODgzLCJleHAiOjE3MDEzNTY3ODMsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.ALCioGXmnr5cAa-A69zyf4bcssuFa5sShlxqNizCRomB_OTOshx-3wDIB8X1VnyfC2EZDhDKAAqZ02RiApc_GoPyALLxLHf2LVVPVQrmgpOSWJed7u1n7FbJQ9mbzNwHQr31JknQfjAdLFtwCuV4Ysjnowd7dwogLT1ZlkRGVTM4iZKb"}, "error": 0}
```

</details>

<details><summary>TLS 1.3 request</summary>

```console
gasti@pop-os:~/work/wazuh$ curl -u wazuh:wazuh -k -X POST -v https://0.0.0.0:55050/security/user/authenticate --tlsv1.3
*   Trying 0.0.0.0:55050...
* Connected to 0.0.0.0 (127.0.0.1) port 55050 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* TLSv1.0 (OUT), TLS header, Certificate Status (22):
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS header, Certificate Status (22):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS header, Finished (20):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.2 (OUT), TLS header, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  start date: Nov 30 14:36:09 2023 GMT
*  expire date: Nov 29 14:36:09 2024 GMT
*  issuer: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  SSL certificate verify result: self-signed certificate (18), continuing anyway.
* Server auth using Basic with user 'wazuh'
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
> POST /security/user/authenticate HTTP/1.1
> Host: 0.0.0.0:55050
> Authorization: Basic d2F6dWg6d2F6dWg=
> User-Agent: curl/7.81.0
> Accept: */*
> 
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Strict-Transport-Security: max-age=63072000; includeSubdomains
< X-Frame-Options: DENY
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< Content-Security-Policy: none
< Referrer-Policy: no-referrer, strict-origin-when-cross-origin
< Pragma: no-cache
< Expires: 0
< Cache-control: no-cache, no-store, must-revalidate, max-age=0
< Content-Length: 433
< Date: Thu, 30 Nov 2023 14:46:05 GMT
< 
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* Connection #0 to host 0.0.0.0 left intact
{"data": {"token": "eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzAxMzU1NTY1LCJleHAiOjE3MDEzNTY0NjUsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AfXI9ZOhEUvyhHDyx6gpjcA0F6CHOODSrf174-gvOFqg36LKJFuQ2nLFUbjzLfyeM7iyAV27SiqIWwud5wB2y4_dANIc4DxAghqrKk6aUhV71qG9xI97vJaKpG7tirlhl7OstpTGcIyiIyANh6rT-NLlZLU9FShTC5haO38MTUoMxszP"}, "error": 0}
```

</details>
