### PR TITLE
Adding ingest node pipeline geoip support for Wazuh active response alert field "data.parameters.alert.data.srcip"

### DIFF
--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -82,6 +82,15 @@
       }
     },
     {
+      "geoip": {
+        "field": "data.parameters.alert.data.srcip",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
       "date": {
         "field": "timestamp",
         "target_field": "@timestamp",

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -82,6 +82,15 @@
       }
     },
     {
+      "geoip": {
+        "field": "data.parameters.alert.data.srcip",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
       "date": {
         "field": "timestamp",
         "target_field": "@timestamp",


### PR DESCRIPTION
## Description

There is no geoip processor for the Wazuh active response alert field "data.parameters.alert.data.srcip" presently provided in the existing pipeline.json files distributed as part of the Wazuh filebeat module.  This PR just adds that support using the same pattern as is used in the existing geoip sections.

## Tests

Create an active response setup that would trigger a firewall-drop or firewalld-drop active response action.  Then actually generate an event to trigger it in which the source IP is publicly routable and confirmed to be present in the Maxmind database GeoIP (https://www.maxmind.com/en/geoip-demo/).  Then in Wazuh Dashboard, search for

`decoder.name:"ar_log_json"`

In the recent results, find the Wazuh alert accounting for the active response action that was just triggered, and expand the alert record.  You should now see geoip fields populated there.
