### PR TITLE
Restore version field to item id calculation for syscollector packages

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -333,7 +333,7 @@ constexpr auto PACKAGES_SQL_STATEMENT
     item_id TEXT,
     PRIMARY KEY (name,version,architecture,format,location)) WITHOUT ROWID;)"
 };
-static const std::vector<std::string> PACKAGES_ITEM_ID_FIELDS{"name", "architecture", "format", "location"};
+static const std::vector<std::string> PACKAGES_ITEM_ID_FIELDS{"name", "version", "architecture", "format", "location"};
 
 constexpr auto PACKAGES_SYNC_CONFIG_STATEMENT
 {

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -151,7 +151,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -183,7 +183,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -407,7 +407,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -435,7 +435,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -580,7 +580,7 @@ TEST_F(SyscollectorImpTest, noOs)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult11
     {
@@ -608,7 +608,7 @@ TEST_F(SyscollectorImpTest, noOs)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -740,7 +740,7 @@ TEST_F(SyscollectorImpTest, noNetwork)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -760,7 +760,7 @@ TEST_F(SyscollectorImpTest, noNetwork)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -1075,7 +1075,7 @@ TEST_F(SyscollectorImpTest, noPorts)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1103,7 +1103,7 @@ TEST_F(SyscollectorImpTest, noPorts)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -1252,7 +1252,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1284,7 +1284,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -1428,7 +1428,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1456,7 +1456,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -1606,7 +1606,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1638,7 +1638,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     };
     const auto expectedResult17
     {
-        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
     };
     const auto expectedResult18
     {
@@ -1809,7 +1809,7 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
     };
     const auto expectedResult5
     {
-        R"({"component":"syscollector_packages","data":{"begin":"285901cb705fc0883ff04197e730c429dcc77e99","end":"285901cb705fc0883ff04197e730c429dcc77e99"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
     };
     const auto expectedResult6
     {
@@ -1853,7 +1853,7 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
     };
     const auto expectedResult17
     {
-        R"({"data":{"architecture":"amd64","checksum":"c1a125f40a70bab20a252f42ea4ec0dcf90733e8","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","os_patch":null,"priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"c1a125f40a70bab20a252f42ea4ec0dcf90733e8","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","os_patch":null,"priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult18
     {
@@ -2300,7 +2300,7 @@ TEST_F(SyscollectorImpTest, PackagesDuplicated)
 
     const auto expectedResult1
     {
-        R"({"data":{"architecture":"amd64","format":"deb","group":"x11","item_id":"285901cb705fc0883ff04197e730c429dcc77e99","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
 
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20499|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR restores the `version` field to the `itemId` list for the programs table of **syscollector**.
The UT were also updated.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

It was manually confirmed that both RSync and DBSync mechanisms work for the packages synchronization. 

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Source installation
