### PR TITLE
updateRemediation method modified to support correct handling of JSON…

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -73,10 +73,11 @@ public:
         }
 
         std::string key {data->cveMetadata()->cveId()->str()};
-
+        flatbuffers::FlatBufferBuilder builder;
+        std::vector<flatbuffers::Offset<flatbuffers::String>> updatesVec;
         std::for_each(remediations->begin(),
                       remediations->end(),
-                      [&key, &remediationsDatabase](const cve_v5::Remediation* remediation)
+                      [&key, &builder, &updatesVec, &remediationsDatabase](const cve_v5::Remediation* remediation)
                       {
                           auto updatesCve5 = remediation->anyOf();
                           if (!updatesCve5)
@@ -84,23 +85,22 @@ public:
                               logError(WM_VULNSCAN_LOGTAG, "No updates available.");
                               return;
                           }
-                          flatbuffers::FlatBufferBuilder builder;
-
-                          std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
 
                           for (size_t idxUpdate = 0; idxUpdate < updatesCve5->size(); idxUpdate++)
                           {
-                              updates_vec.emplace_back(builder.CreateString(updatesCve5->Get(idxUpdate)->c_str()));
+                              updatesVec.emplace_back(builder.CreateString(updatesCve5->Get(idxUpdate)->c_str()));
                           }
-
-                          auto updates = builder.CreateVector(updates_vec);
-                          auto fbbRemediation = CreateRemediationInfo(builder, updates);
-                          builder.Finish(fbbRemediation);
-
-                          rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()),
-                                               builder.GetSize());
-                          remediationsDatabase.put(key, value);
                       });
+
+        if (!updatesVec.empty())
+        {
+            auto updates = builder.CreateVector(updatesVec);
+            auto fbbRemediation = CreateRemediationInfo(builder, updates);
+            builder.Finish(fbbRemediation);
+
+            rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()), builder.GetSize());
+            remediationsDatabase.put(key, value);
+        }
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
@@ -18,7 +18,7 @@ constexpr auto COMMON_DATABASE_DIR {"queue/vd"}; //<<Used for all databases
 const std::string FLATBUFFER_SCHEMA {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
 const char* FB_INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
 
-auto JSON_CVE5_VALID = R"(
+auto JSON_CVE5_VALID_ONE_BLOCK = R"(
     {
         "dataType": "CVE_RECORD",
         "dataVersion": "5.0",
@@ -72,6 +72,85 @@ auto JSON_CVE5_VALID = R"(
                     "windows": [
                         {
                             "anyOf":["KBT-800","KBT-1000","KBT-3000"],
+                            "products": ["Windows 10 - HastaLaVistaBaby", "Windows 11 - RiseOfTheMachines", "Windows 12 - Genisys"],
+                            "type": "update"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+)";
+
+auto JSON_CVE5_VALID_MULTIPLE_BLOCKS = R"(
+    {
+        "dataType": "CVE_RECORD",
+        "dataVersion": "5.0",
+        "cveMetadata": {
+            "cveId": "CVE-1337-1234",
+            "assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+            "state": "PUBLISHED"
+        },
+        "containers": {
+            "cna": {
+                "providerMetadata": {
+                    "orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6"
+                },
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "lang": "en",
+                                "description": "CWE-78 OS Command Injection"
+                            }
+                        ]
+                    }
+                ],
+                "affected": [
+                    {
+                        "vendor": "Example.org",
+                        "product": "Example Enterprise",
+                        "versions": [
+                            {
+                                "version": "1.0.0",
+                                "status": "affected",
+                                "lessThan": "1.0.6",
+                                "versionType": "semver"
+                            }
+                        ],
+                        "defaultStatus": "unaffected"
+                    }
+                ],
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "OS Command Injection vulnerability parseFilename function of example.php in the Web Management Interface of Example.org Example Enterprise on Windows, MacOS and XT-4500 allows remote unauthenticated attackers to escalate privileges.\n\nThis issue affects:\n  *  1.0 versions before 1.0.6\n  *  2.1 versions from 2.16 until 2.1.9."
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://example.org/ESA-22-11-CVE-1337-1234"
+                    }
+                ],
+                "x_remediations": {
+                    "windows": [
+                        {
+                            "anyOf":["KBT-800","KBT-1000","KBT-3000"],
+                            "products": ["Windows 10 - HastaLaVistaBaby", "Windows 11 - RiseOfTheMachines", "Windows 12 - Genisys"],
+                            "type": "update"
+                        },
+                        {
+                            "anyOf":["KBT-4000"],
+                            "products": ["Windows 10 - HastaLaVistaBaby", "Windows 11 - RiseOfTheMachines", "Windows 12 - Genisys"],
+                            "type": "update"
+                        },
+                        {
+                            "anyOf":["KBT-5000","KBT-6000"],
+                            "products": ["Windows 10 - HastaLaVistaBaby", "Windows 11 - RiseOfTheMachines", "Windows 12 - Genisys"],
+                            "type": "update"
+                        },
+                        {
+                            "anyOf":["KBT-7000","KBT-8000","KBT-9000"],
                             "products": ["Windows 10 - HastaLaVistaBaby", "Windows 11 - RiseOfTheMachines", "Windows 12 - Genisys"],
                             "type": "update"
                         }
@@ -274,7 +353,7 @@ void StoreRemediationsModelTest::TearDown()
     std::filesystem::remove_all(COMMON_DATABASE_DIR);
 };
 
-TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediation)
+TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediationOneBlock)
 {
     // Define schema variable and parse JSON object.
     std::string schemaStr;
@@ -285,7 +364,7 @@ TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediation)
 
     // Parse schema.
     flatbuffers::Parser parser;
-    valid = parser.Parse(schemaStr.c_str(), FB_INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_VALID);
+    valid = parser.Parse(schemaStr.c_str(), FB_INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_VALID_ONE_BLOCK);
     EXPECT_TRUE(valid);
 
     // Create a test Entry object with Windows remediations
@@ -309,9 +388,57 @@ TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediation)
     dtoVulnRemediation.data = const_cast<NSVulnerabilityScanner::RemediationInfo*>(
         NSVulnerabilityScanner::GetRemediationInfo(dtoVulnRemediation.slice.data()));
 
+    ASSERT_EQ(dtoVulnRemediation.data->updates()->size(), 3);
     EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(0)->str().c_str(), "KBT-800");
     EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(1)->str().c_str(), "KBT-1000");
     EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(2)->str().c_str(), "KBT-3000");
+}
+
+TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediationMultipleBlocks)
+{
+    // Define schema variable and parse JSON object.
+    std::string schemaStr;
+
+    // Load file with schema.
+    bool valid = flatbuffers::LoadFile(FLATBUFFER_SCHEMA.c_str(), false, &schemaStr);
+    EXPECT_TRUE(valid);
+
+    // Parse schema.
+    flatbuffers::Parser parser;
+    valid = parser.Parse(schemaStr.c_str(), FB_INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_VALID_MULTIPLE_BLOCKS);
+    EXPECT_TRUE(valid);
+
+    // Create a test Entry object with Windows remediations
+    auto jbuf = parser.builder_.GetBufferPointer();
+    flatbuffers::Verifier jverifier(jbuf, parser.builder_.GetSize());
+    EXPECT_TRUE(cve_v5::VerifyEntryBuffer(jverifier));
+    auto entry = cve_v5::GetEntry(jbuf);
+
+    // Create a mock RocksDBWrapper object
+    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+
+    // Call the updateRemediation function with the test data
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+
+    // Assert result.
+    std::string cveId {"CVE-1337-1234"};
+    FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
+
+    // Asserts
+    EXPECT_NO_THROW(rocksDBWrapper.get(cveId, dtoVulnRemediation.slice));
+    dtoVulnRemediation.data = const_cast<NSVulnerabilityScanner::RemediationInfo*>(
+        NSVulnerabilityScanner::GetRemediationInfo(dtoVulnRemediation.slice.data()));
+
+    ASSERT_EQ(dtoVulnRemediation.data->updates()->size(), 9);
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(0)->str().c_str(), "KBT-800");
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(1)->str().c_str(), "KBT-1000");
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(2)->str().c_str(), "KBT-3000");
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(3)->str().c_str(), "KBT-4000");
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(4)->str().c_str(), "KBT-5000");
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(5)->str().c_str(), "KBT-6000");
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(6)->str().c_str(), "KBT-7000");
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(7)->str().c_str(), "KBT-8000");
+    EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(8)->str().c_str(), "KBT-9000");
 }
 
 TEST_F(StoreRemediationsModelTest, SkipsEmptyRemediations)


### PR DESCRIPTION
… multiple blocks in key containers.cna.x_remediations.windows

|Related issue|
|---|
|Closes #20500 |

## Description

This PR fixes method updateRemediation to support correct handling of JSON multiple blocks in key containers.cna.x_remediations.windows

## Logs/Alerts example

New UT added to verify correct JSON multiple blocks parsing.
![image](https://github.com/wazuh/wazuh/assets/101227434/b3cee953-58fe-42e3-be9a-97ec93b6d611)

## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] UT runs ok