### PR TITLE
Fix package prefix seek and populate ECS fields

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,29 @@ foreach(loop_var ${EXTERNAL_RES})
     check_and_download_dep(${loop_var} ${RESOURCES_URL})
 endforeach(loop_var)
 
+# Read VERSION and REVISION file and set variable with the content.
+file(READ ${SRC_FOLDER}/VERSION VERSION_FILE)
+string(STRIP ${VERSION_FILE} VERSION_FILE)
+add_definitions(-DVERSION="${VERSION_FILE}")
+
+file(READ ${SRC_FOLDER}/REVISION REVISION_FILE)
+string(STRIP ${REVISION_FILE} REVISION_FILE)
+add_definitions(-DREVISION="${REVISION_FILE}")
+
+## If REVISION OR FILE is empty fail
+if("${REVISION_FILE}" STREQUAL "")
+    message(FATAL_ERROR "REVISION file is empty")
+endif("${REVISION_FILE}" STREQUAL "")
+
+if("${VERSION_FILE}" STREQUAL "")
+    message(FATAL_ERROR "VERSION file is empty")
+endif("${VERSION_FILE}" STREQUAL "")
+
+message("==============================================")
+message("Wazuh version: ${VERSION_FILE}")
+message("Wazuh revision: ${REVISION_FILE}")
+message("==============================================")
+
 set(BENCHMARK_ENABLE_TESTING "OFF")
 link_directories(${SRC_FOLDER})
 link_directories(${SRC_FOLDER}/external/rocksdb/build/)

--- a/src/shared_modules/utils/cacheLRU.hpp
+++ b/src/shared_modules/utils/cacheLRU.hpp
@@ -1,3 +1,6 @@
+#ifndef _CACHELRU_HPP
+#define _CACHELRU_HPP
+
 #include <list>
 #include <map>
 #include <optional>
@@ -89,3 +92,5 @@ private:
         m_list.emplace_front(key);
     }
 };
+
+#endif // CACHELRU_HPP

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -12,21 +12,22 @@
 #ifndef _TIME_HELPER_H
 #define _TIME_HELPER_H
 
-#include <string>
+#include <chrono>
 #include <ctime>
 #include <iomanip>
 #include <sstream>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
+#include <string>
 
 namespace Utils
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
     static std::string getTimestamp(const std::time_t& time, const bool utc = true)
     {
         std::stringstream ss;
         // gmtime: result expressed as a UTC time
-        tm* localTime { utc ? gmtime(&time) : localtime(&time)};
+        tm* localTime {utc ? gmtime(&time) : localtime(&time)};
         // Final timestamp: "YYYY/MM/DD hh:mm:ss"
         // Date
         ss << std::setfill('0') << std::setw(4) << std::to_string(localTime->tm_year + 1900);
@@ -59,7 +60,7 @@ namespace Utils
     {
         std::stringstream ss;
         // gmtime: result expressed as a UTC time
-        tm const* localTime { utc ? gmtime(&time) : localtime(&time)};
+        tm const* localTime {utc ? gmtime(&time) : localtime(&time)};
         // Date
         ss << std::setfill('0') << std::setw(4) << std::to_string(localTime->tm_year + 1900);
         ss << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_mon + 1);
@@ -70,8 +71,26 @@ namespace Utils
         ss << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_sec);
         return ss.str();
     }
-}
 
+    static std::string getCurrentISO8601()
+    {
+        // Get local time in UTC
+        auto now = std::chrono::system_clock::now();
+        auto itt = std::chrono::system_clock::to_time_t(now);
+
+        std::ostringstream ss;
+        ss << std::put_time(gmtime(&itt), "%FT%T");
+
+        // Get milliseconds from the current time
+        auto milliseconds =
+            std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count() % 1000;
+
+        // ISO 8601
+        ss << '.' << std::setfill('0') << std::setw(3) << milliseconds << 'Z';
+
+        return ss.str();
+    }
 #pragma GCC diagnostic pop
+} // namespace Utils
 
 #endif // _TIME_HELPER_H

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -302,7 +302,8 @@ public:
     void getVulnerabilitiesCandidates(
         const std::string& cnaName,
         std::string_view packageName,
-        const std::function<bool(const NSVulnerabilityScanner::ScanVulnerabilityCandidate&)>& callback)
+        const std::function<bool(const std::string& cnaName,
+                                 const NSVulnerabilityScanner::ScanVulnerabilityCandidate&)>& callback)
     {
         if (packageName.empty() || cnaName.empty())
         {
@@ -310,8 +311,11 @@ public:
         }
 
         CandidatesDBHelper::findAndOpen(cnaName, m_feedsDatabases, true);
+        std::string packageNameWithSeparator;
+        packageNameWithSeparator.append(packageName);
+        packageNameWithSeparator.append("_CVE");
 
-        for (const auto& [key, value] : m_feedsDatabases.at(cnaName)->seek(packageName))
+        for (const auto& [key, value] : m_feedsDatabases.at(cnaName)->seek(packageNameWithSeparator))
         {
             auto candidatesArray = GetScanVulnerabilityCandidateArray(reinterpret_cast<const uint8_t*>(value.data()));
 
@@ -319,7 +323,7 @@ public:
             {
                 for (const auto& candidate : *candidatesArray->candidates())
                 {
-                    if (callback(*candidate))
+                    if (callback(cnaName, *candidate))
                     {
                         // If the candidate is vulnerable, we stop looking for.
                         break;
@@ -366,6 +370,33 @@ public:
 
         resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
             NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+    }
+
+    std::string getCnaName(std::string_view vendor)
+    {
+        const static std::map<std::string, std::string> vendorToCnaName = {{"Canonical", "canonical"},
+                                                                           {"Ubuntu", "canonical"},
+                                                                           {"Debian", "debian"},
+                                                                           {"Red Hat, Inc.", "redhat"},
+                                                                           {"CentOS", "redhat"},
+                                                                           {"Amazon Linux", "alas"},
+                                                                           {"Amazon.com", "alas"},
+                                                                           {"Amazon AWS", "alas"},
+                                                                           {"Arch Linux", "arch"},
+                                                                           {"suse", "suse"},
+                                                                           {"AlmaLinux", "almalinux"},
+                                                                           {"CloudLinux", "almalinux"}};
+
+        const auto it =
+            std::find_if(vendorToCnaName.begin(),
+                         vendorToCnaName.end(),
+                         [&vendor](const auto& pair) { return Utils::startsWith(vendor.data(), pair.first); });
+
+        if (it == vendorToCnaName.end())
+        {
+            return "nvd";
+        }
+        return it->second;
     }
 
 private:

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -15,6 +15,7 @@
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
 #include "scanContext.hpp"
+#include "timeHelper.h"
 
 /**
  * @brief DetailsAugmentation class.
@@ -66,12 +67,45 @@ public:
         ecs["version"] = "8.11.0";
 
         nlohmann::json agent;
-        agent["build"]["original"] = "40800"; // TODO: Remove hardcoded revision.
+        agent["build"]["original"] = REVISION;
         agent["ephemeral_id"] = data->agentNodeName();
         agent["id"] = data->agentId();
         agent["name"] = ""; // TODO: Add agent name.
         agent["type"] = "wazuh";
-        agent["version"] = "4.8.0"; // TODO: Remove hardcoded version.
+        agent["version"] = VERSION;
+
+        nlohmann::json os;
+        std::string fullName;
+        fullName.append(data->osName().data());
+        fullName.append(" ");
+        fullName.append(data->osPlatform().compare("darwin") == 0 ? data->osCodeName().data()
+                                                                  : data->osVersion().data());
+
+        std::string version = data->osMajorVersion().data();
+        if (!data->osMinorVersion().empty())
+        {
+            version += ".";
+            version += data->osMinorVersion();
+        }
+        if (!data->osPatch().empty())
+        {
+            version += ".";
+            version += data->osPatch();
+        }
+        if (!data->osBuild().empty())
+        {
+            version += ".";
+            version += data->osBuild();
+        }
+
+        os["family"] = ""; // TODO: Add family.
+        os["full"] = fullName;
+        os["kernel"] = data->osKernelRelease();
+        os["name"] = data->osName();
+        os["platform"] = Utils::toLowerCase(data->osPlatform().data());
+        os["type"] =
+            Utils::toLowerCase(data->osPlatform().compare("darwin") == 0 ? "macos" : data->osPlatform().data());
+        os["version"] = version;
 
         for (auto& [cve, json] : data->m_elements)
         {
@@ -86,6 +120,8 @@ public:
                 ecsData["ecs"] = ecs;
                 // ECS package fields.
                 ecsData["package"] = package;
+                // ECS os fields.
+                ecsData["os"] = os;
                 // ECS vulnerability fields.
                 ecsData["vulnerability"]["category"] = "Packages";
                 ecsData["vulnerability"]["classification"] = returnData.data->classification()->str();
@@ -100,6 +136,10 @@ public:
                 ecsData["vulnerability"]["score"]["temporal"] = 0.0f;      // TODO: Add temporal score.
                 ecsData["vulnerability"]["score"]["version"] = returnData.data->scoreVersion()->str();
                 ecsData["vulnerability"]["severity"] = returnData.data->severity()->str();
+                // ECS base fields.
+                ecsData["@timestamp"] = Utils::getCurrentISO8601();
+                auto labels = {"vulnerability", data->clusterName().data()};
+                ecsData["labels"];
 
                 json["operation"] = "INSERTED";
                 json["id"] = std::string(data->agentNodeName()) + "_" + std::string(data->agentId()) + "_" +

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
@@ -69,7 +69,6 @@ public:
         else if (type == ScannerType::Os)
         {
             orchestration = std::make_shared<OsScanner>();
-            std::cout << "Os scanner Init" << std::endl;
             // orchestration->setLast(std::make_shared<CheckRemediations>());
         }
         else

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -48,9 +48,8 @@ public:
     {
         const std::string packageName {Utils::toLowerCase(std::string(data->packageName()))};
 
-        logDebug1(WM_VULNSCAN_LOGTAG, "Scanning package: %s", packageName.c_str());
-
-        auto vulnerabilityScan = [&](const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
+        auto vulnerabilityScan =
+            [&](const std::string& cnaName, const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
             for (const auto& version : *callbackData.versions())
             {
@@ -151,16 +150,16 @@ public:
             }
         };
 
-        m_databaseFeedManager->getVulnerabilitiesCandidates("nvd", packageName, vulnerabilityScan);
+        const auto cnaName {m_databaseFeedManager->getCnaName(data->packageVendor())};
+        logDebug1(WM_VULNSCAN_LOGTAG, "Scanning package: %s, CNA: %s", packageName.c_str(), cnaName.c_str());
 
-        if (!data->m_elements.empty())
-        {
-            return AbstractHandler<std::shared_ptr<ScanContext>>::handleRequest(data);
-        }
-        else
+        m_databaseFeedManager->getVulnerabilitiesCandidates(cnaName, packageName, vulnerabilityScan);
+
+        if (data->m_elements.empty())
         {
             return nullptr;
         }
+        return AbstractHandler<std::shared_ptr<ScanContext>>::handleRequest(data);
     }
     // LCOV_EXCL_STOP
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/resultIndexer.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/resultIndexer.hpp
@@ -50,7 +50,7 @@ public:
         {
             for (const auto& [key, value] : data->m_elements)
             {
-                logDebug2(WM_VULNSCAN_LOGTAG, "Indexing key: %s", key.c_str());
+                logDebug2(WM_VULNSCAN_LOGTAG, "Processing key: %s", key.c_str());
                 m_indexerConnector->publish(value.dump());
             }
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -16,7 +16,9 @@
 #include "flatbuffers/include/syscollector_deltas_generated.h"
 #include "flatbuffers/include/syscollector_synchronization_generated.h"
 #include "logging_helper.h"
+#include "osDataCache.hpp"
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <variant>
@@ -117,11 +119,59 @@ public:
                                 m_type = ScannerType::PackageDelete;
                                 m_operationType = OperationType::Delete;
                             }
+                            m_osData = OsDataCache::instance().getOsData(agentId().data());
                         }
                         else if (delta->data_type() == SyscollectorDeltas::Provider_dbsync_osinfo)
                         {
                             m_type = ScannerType::Os;
                             m_operationType = OperationType::Insert;
+                            m_osData.release = delta->data_as_dbsync_osinfo()->release()
+                                                   ? delta->data_as_dbsync_osinfo()->release()->str()
+                                                   : "";
+                            m_osData.architecture = delta->data_as_dbsync_osinfo()->architecture()
+                                                        ? delta->data_as_dbsync_osinfo()->architecture()->str()
+                                                        : "";
+                            m_osData.name = delta->data_as_dbsync_osinfo()->os_name()
+                                                ? delta->data_as_dbsync_osinfo()->os_name()->str()
+                                                : "";
+                            m_osData.osVersion = delta->data_as_dbsync_osinfo()->os_version()
+                                                     ? delta->data_as_dbsync_osinfo()->os_version()->str()
+                                                     : "";
+                            m_osData.codeName = delta->data_as_dbsync_osinfo()->os_codename()
+                                                    ? delta->data_as_dbsync_osinfo()->os_codename()->str()
+                                                    : "";
+                            m_osData.majorVersion = delta->data_as_dbsync_osinfo()->os_major()
+                                                        ? delta->data_as_dbsync_osinfo()->os_major()->str()
+                                                        : "";
+                            m_osData.minorVersion = delta->data_as_dbsync_osinfo()->os_minor()
+                                                        ? delta->data_as_dbsync_osinfo()->os_minor()->str()
+                                                        : "";
+                            m_osData.patch = delta->data_as_dbsync_osinfo()->os_patch()
+                                                 ? delta->data_as_dbsync_osinfo()->os_patch()->str()
+                                                 : "";
+                            m_osData.build = delta->data_as_dbsync_osinfo()->os_build()
+                                                 ? delta->data_as_dbsync_osinfo()->os_build()->str()
+                                                 : "";
+                            m_osData.platform = delta->data_as_dbsync_osinfo()->os_platform()
+                                                    ? delta->data_as_dbsync_osinfo()->os_platform()->str()
+                                                    : "";
+                            m_osData.sysName = delta->data_as_dbsync_osinfo()->sysname()
+                                                   ? delta->data_as_dbsync_osinfo()->sysname()->str()
+                                                   : "";
+                            m_osData.release = delta->data_as_dbsync_osinfo()->release()
+                                                   ? delta->data_as_dbsync_osinfo()->release()->str()
+                                                   : "";
+                            m_osData.version = delta->data_as_dbsync_osinfo()->version()
+                                                   ? delta->data_as_dbsync_osinfo()->version()->str()
+                                                   : "";
+                            m_osData.osRelease = delta->data_as_dbsync_osinfo()->os_release()
+                                                     ? delta->data_as_dbsync_osinfo()->os_release()->str()
+                                                     : "";
+                            m_osData.osDisplayVersion =
+                                delta->data_as_dbsync_osinfo()->os_display_version()
+                                    ? delta->data_as_dbsync_osinfo()->os_display_version()->str()
+                                    : "";
+                            OsDataCache::instance().setOsData(agentId().data(), m_osData);
                         }
                         else if (delta->data_type() == SyscollectorDeltas::Provider_dbsync_hotfixes)
                         {
@@ -135,6 +185,8 @@ public:
                                 m_type = ScannerType::HotfixDelete;
                                 m_operationType = OperationType::Delete;
                             }
+
+                            m_osData = OsDataCache::instance().getOsData(agentId().data());
                         }
                     }
                     else
@@ -155,18 +207,83 @@ public:
                         {
                             m_type = ScannerType::Os;
                             m_operationType = OperationType::Insert;
+
+                            m_osData.release =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->release()
+                                    ? syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->release()->str()
+                                    : "";
+                            m_osData.architecture =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->architecture()
+                                    ? syncMsg->data_as_state()
+                                          ->attributes_as_syscollector_osinfo()
+                                          ->architecture()
+                                          ->str()
+                                    : "";
+                            m_osData.name =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_name()
+                                    ? syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_name()->str()
+                                    : "";
+                            m_osData.osVersion =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_version()
+                                    ? syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_version()->str()
+                                    : "";
+                            m_osData.codeName =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_codename()
+                                    ? syncMsg->data_as_state()
+                                          ->attributes_as_syscollector_osinfo()
+                                          ->os_codename()
+                                          ->str()
+                                    : "";
+                            m_osData.majorVersion =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_major()
+                                    ? syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_major()->str()
+                                    : "";
+                            m_osData.minorVersion =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_minor()
+                                    ? syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_minor()->str()
+                                    : "";
+                            m_osData.patch =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_patch()
+                                    ? syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_patch()->str()
+                                    : "";
+                            m_osData.build = ""; // TODO add build
+                            m_osData.platform =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->os_platform()
+                                    ? syncMsg->data_as_state()
+                                          ->attributes_as_syscollector_osinfo()
+                                          ->os_platform()
+                                          ->str()
+                                    : "";
+                            m_osData.sysName =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->sysname()
+                                    ? syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->sysname()->str()
+                                    : "";
+                            m_osData.release =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->release()
+                                    ? syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->release()->str()
+                                    : "";
+                            m_osData.version =
+                                syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->version()
+                                    ? syncMsg->data_as_state()->attributes_as_syscollector_osinfo()->version()->str()
+                                    : "";
+                            m_osData.osDisplayVersion = ""; // TODO add os_display_version
+                            OsDataCache::instance().setOsData(agentId().data(), m_osData);
                         }
                         else if (syncMsg->data_as_state()->attributes_type() ==
                                  SyscollectorSynchronization::AttributesUnion_syscollector_packages)
                         {
                             m_type = ScannerType::PackageInsert;
                             m_operationType = OperationType::Insert;
+
+                            m_osData = OsDataCache::instance().getOsData(agentId().data());
                         }
                         else if (syncMsg->data_as_state()->attributes_type() ==
                                  SyscollectorSynchronization::AttributesUnion_syscollector_hotfixes)
                         {
                             m_type = ScannerType::HotfixInsert;
                             m_operationType = OperationType::Insert;
+
+                            m_osData = OsDataCache::instance().getOsData(agentId().data());
                         }
                     }
                     else
@@ -489,6 +606,150 @@ public:
     }
 
     /**
+     * @brief Gets os hostName.
+     * @return Os hostName.
+     */
+    std::string_view osHostName() const
+    {
+        return m_osData.hostName;
+    }
+
+    /**
+     * @brief Gets os architecture.
+     * @return Os architecture.
+     */
+    std::string_view osArchitecture() const
+    {
+        return m_osData.architecture;
+    }
+
+    /**
+     * @brief Gets os name.
+     * @return Os name.
+     */
+    std::string_view osName() const
+    {
+        return m_osData.name;
+    }
+
+    /**
+     * @brief Gets os version.
+     * @return Os version.
+     */
+    std::string_view osVersion() const
+    {
+        return m_osData.osVersion;
+    }
+
+    /**
+     * @brief Gets os codeName.
+     * @return Os codeName.
+     */
+    std::string_view osCodeName() const
+    {
+        return m_osData.codeName;
+    }
+
+    /**
+     * @brief Gets os major version.
+     * @return Os major version.
+     */
+    std::string_view osMajorVersion() const
+    {
+        return m_osData.majorVersion;
+    }
+
+    /**
+     * @brief Gets os minor version.
+     * @return Os minor version.
+     */
+    std::string_view osMinorVersion() const
+    {
+        return m_osData.minorVersion;
+    }
+
+    /**
+     * @brief Gets os patch version.
+     * @return Os patch version.
+     */
+    std::string_view osPatch() const
+    {
+        return m_osData.patch;
+    }
+
+    /**
+     * @brief Gets os build number.
+     * @return Os build number.
+     */
+    std::string_view osBuild() const
+    {
+        return m_osData.build;
+    }
+
+    /**
+     * @brief Gets os platform.
+     * @return Os platform.
+     */
+    std::string_view osPlatform() const
+    {
+        return m_osData.platform;
+    }
+
+    /**
+     * @brief Gets os kernel sysName.
+     * @return Os kernel sysName.
+     */
+    std::string_view osKernelSysName() const
+    {
+        return m_osData.sysName;
+    }
+
+    /**
+     * @brief Gets os kernel release.
+     * @return Os kernel release.
+     */
+    std::string_view osKernelRelease() const
+    {
+        return m_osData.release;
+    }
+
+    /**
+     * @brief Gets os kernel version.
+     * @return Os kernel version.
+     */
+    std::string_view osKernelVersion() const
+    {
+        return m_osData.version;
+    }
+
+    /**
+     * @brief Gets os release
+     * @return Os release.
+     */
+    std::string_view osRelease() const
+    {
+        return m_osData.osRelease;
+    }
+
+    /**
+     * @brief Gets os display name.
+     * @return Os display name.
+     */
+    std::string_view osDisplayVersion() const
+    {
+        return m_osData.osDisplayVersion;
+    }
+
+    /**
+     * @brief Get cluster name.
+     * @return Cluster name.
+     */
+    std::string_view clusterName() const
+    {
+        return "";
+    }
+
+    /**
      * @brief Gets operation type.
      * @return Operation type.
      */
@@ -531,6 +792,12 @@ private:
      *
      */
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> m_data;
+
+    /**
+     * @brief Os data.
+     *
+     */
+    Os m_osData {};
 
     // LCOV_EXCL_STOP
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
@@ -50,6 +50,7 @@ void ScanOrchestrator::run(
     }
     catch (const std::exception& e)
     {
+        logError(WM_VULNSCAN_LOGTAG, "ScanOrchestrator::run::Exception: %s", e.what());
     }
 }
 // LCOV_EXCL_START

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -17,7 +17,6 @@
 #include "wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp"
 
 constexpr auto VULNERABILITY_SCANNER_TEMPLATE = "queue/indexer/vd_states_template.json";
-
 // TODO: Remove LCOV flags once the implementation of the 'Indexer Connector' module is completed
 // LCOV_EXCL_START
 void VulnerabilityScannerFacade::start(
@@ -69,6 +68,7 @@ void VulnerabilityScannerFacade::start(
         m_syscollectorDeltasSubscription->subscribe(
             [scanOrchestrator](const std::vector<char>& message)
             {
+                logDebug2(WM_VULNSCAN_LOGTAG, "Received deltas-syscollector message");
                 std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> data =
                     SyscollectorDeltas::GetDelta(message.data());
 
@@ -81,6 +81,7 @@ void VulnerabilityScannerFacade::start(
         m_syscollectorRsyncSubscription->subscribe(
             [scanOrchestrator](const std::vector<char>& message)
             {
+                logDebug2(WM_VULNSCAN_LOGTAG, "Received rsync-syscollector message");
                 std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> data =
                     SyscollectorSynchronization::GetSyncMsg(message.data());
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -318,11 +318,11 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesSuccess)
     pDatabaseFeedManager->getVulnerabilitiesCandidates(
         "cnaName",
         "libmagic-mgc",
-        [&](const NSVulnerabilityScanner::ScanVulnerabilityCandidate& candidate) -> bool
+        [&](const std::string& cnaName, const NSVulnerabilityScanner::ScanVulnerabilityCandidate& candidate) -> bool
         {
             auto cveId = candidate.cveId()->str();
             cves.push_back(cveId);
-
+            EXPECT_STREQ(cnaName.c_str(), "cnaName");
             return false;
         });
 
@@ -358,7 +358,8 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesNoPackageName)
         pDatabaseFeedManager->getVulnerabilitiesCandidates(
             "cnaName",
             "",
-            [&](const NSVulnerabilityScanner::ScanVulnerabilityCandidate& candidate) -> bool { return true; });
+            [&](const std::string& cnaName, const NSVulnerabilityScanner::ScanVulnerabilityCandidate& candidate) -> bool
+            { return true; });
     });
 }
 

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/file1.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/file1.json
@@ -7,7 +7,7 @@
   "data": {
     "architecture": "amd64",
     "checksum": "1e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
-    "description": "library for GIF images (library)",
+    "description": "Wazuh - Open Source Host and Endpoint Security",
     "format": "deb",
     "groups": "libs",
     "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53",
@@ -16,8 +16,8 @@
     "priority": "optional",
     "scan_time": "2023/08/04 19:56:11",
     "size": 72,
-    "source": "giflib",
-    "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+    "source": "wazuh",
+    "vendor": "Wazuh Inc.",
     "version": "4.2.0"
   },
   "operation": "INSERTED"


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20501 |
|Closes #20496 |


## Description

- Add OS data with LRU cache.
- Populate some ECS fields.
- Change the approach to select the ADP/CNA database.
- Fix package prefix seek.