### PR TITLE
Fix build flatbuffer schema target

### DIFF
--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -80,15 +80,16 @@ if (NOT ${TARGET} STREQUAL "")
     list(APPEND Schemas
                 syscollector_synchronization
     )
-    message("Compile schemas")
-    message("${SRC_FOLDER}/external/flatbuffers/build/flatc")
+
     add_custom_target(compile_schemas)
     foreach(schema IN LISTS Schemas)
       set(FILE "${FLATBUFFERS_FOLDER}/syscollectorRsync/${schema}.fbs")
-      message("Analizing file ${FILE}")
+      set(RSYNC_OUTPUT_HEADER_GENERATED "${FLATBUFFERS_FOLDER}/../include/${schema}_generated.h")
+      set(RSYNC_OUTPUT_HEADER "${FLATBUFFERS_FOLDER}/../include/${schema}_schema.h")
+
       add_custom_command(
-          TARGET compile_schemas
-          COMMAND ${SRC_FOLDER}/external/flatbuffers/build/flatc
+          OUTPUT "${RSYNC_OUTPUT_HEADER_GENERATED}"
+          COMMAND ${FLATC_PATH}/flatc
           ARGS --cpp
           ARGS -o "${FLATBUFFERS_FOLDER}/../include" "${FILE}"
           ARGS --no-warnings
@@ -97,13 +98,15 @@ if (NOT ${TARGET} STREQUAL "")
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
       add_custom_command(
-          TARGET compile_schemas
+          OUTPUT "${RSYNC_OUTPUT_HEADER}"
           COMMAND bash -c "echo -e '// This file was generated from ${FILE} , do not modify \\n#ifndef ${schema}_HEADER\\n#define ${schema}_HEADER\\nauto constexpr ${schema}_SCHEMA = R\"('`cat ${FILE}`')\" ;\\n#endif // ${schema}_HEADER\\n ' > ${FLATBUFFERS_FOLDER}/../include/${schema}_schema.h"
           COMMENT "Creating header from schema file: '${schema}'"
-          DEPENDS ${FILE}
+          DEPENDS "${RSYNC_OUTPUT_HEADER_GENERATED}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
           VERBATIM)
 
+      add_custom_target(${schema}_schema_target DEPENDS ${RSYNC_OUTPUT_HEADER})
+      add_dependencies(compile_schemas ${schema}_schema_target)
     endforeach()
   endif()
 endif()

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -180,7 +180,7 @@ if (NOT ${TARGET} STREQUAL "")
       add_dependencies(compile_schemas_deltas ${schema}_schema_deltas_target)
     endforeach()
 
-    add_dependencies(${PROJECT_NAME} compile_schemas_deltas)
+    add_dependencies(syscollector compile_schemas_deltas)
   endif()
 endif()
 

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -153,23 +153,34 @@ if (NOT ${TARGET} STREQUAL "")
                 syscollector_deltas
     )
 
+    add_custom_target(compile_schemas_deltas)
     foreach(schema IN LISTS DeltaSchemas)
       set(FBS_FILE "${FLATBUFFERS_FOLDER}/syscollectorDeltas/${schema}.fbs")
-      add_custom_target(${schema}_target
-        COMMAND ${FLATC_PATH}/flatc -c -o ${FLATBUFFERS_FOLDER}/../include/ --no-warnings ${FBS_FILE}
+      set(RSYNC_OUTPUT_HEADER_GENERATED "${FLATBUFFERS_FOLDER}/../include/${schema}_generated.h")
+      set(RSYNC_OUTPUT_HEADER "${FLATBUFFERS_FOLDER}/../include/${schema}_schema.h")
+
+      add_custom_command(
+        OUTPUT "${RSYNC_OUTPUT_HEADER_GENERATED}"
+        COMMAND ${FLATC_PATH}/flatc
+        ARGS -c
+        ARGS -o "${FLATBUFFERS_FOLDER}/../include" "${FBS_FILE}"
+        ARGS --no-warnings
         COMMENT "Executing flatc to generate ${schema} header file."
       )
 
       add_custom_command(
-          TARGET compile_schemas
+          OUTPUT "${RSYNC_OUTPUT_HEADER}"
           COMMAND bash -c "echo -e '// This file was generated from ${FBS_FILE} , do not modify \\n#ifndef ${schema}_HEADER\\n#define ${schema}_HEADER\\nauto constexpr ${schema}_SCHEMA = R\"('`cat ${FBS_FILE}`')\" ;\\n#endif // ${schema}_HEADER\\n ' > ${FLATBUFFERS_FOLDER}/../include/${schema}_schema.h"
           COMMENT "Creating header from schema file: '${schema}'"
-          DEPENDS ${FBS_FILE}
+          DEPENDS "${RSYNC_OUTPUT_HEADER_GENERATED}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
           VERBATIM)
 
-      add_dependencies(${PROJECT_NAME} ${schema}_target)
+      add_custom_target(${schema}_schema_deltas_target DEPENDS ${RSYNC_OUTPUT_HEADER})
+      add_dependencies(compile_schemas_deltas ${schema}_schema_deltas_target)
     endforeach()
+
+    add_dependencies(${PROJECT_NAME} compile_schemas_deltas)
   endif()
 endif()
 

--- a/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
@@ -51,12 +51,16 @@ list(APPEND Schemas
             vulnerabilityRemediations
             vulnerabilityTranslationPackages
 )
+
 message("Compiling schemas")
 add_custom_target(compile_schemas)
 foreach(schema IN LISTS Schemas)
   set(FILE "./schemas/${schema}.fbs")
+  set(FBS_OUTPUT_HEADER_GENERATED "${CMAKE_CURRENT_SOURCE_DIR}/include/${schema}_generated.h")
+  set(FBS_OUTPUT_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/include/${schema}_schema.h")
+
   add_custom_command(
-      TARGET compile_schemas
+      OUTPUT "${FBS_OUTPUT_HEADER_GENERATED}"
       COMMAND ${SRC_FOLDER}/external/flatbuffers/build/flatc
       ARGS --cpp
       ARGS -o "${CMAKE_CURRENT_SOURCE_DIR}/include" "${FILE}"
@@ -66,12 +70,15 @@ foreach(schema IN LISTS Schemas)
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_custom_command(
-      TARGET compile_schemas
+      OUTPUT "${FBS_OUTPUT_HEADER}"
       COMMAND bash -c "echo -e '// This file was generated from ${FILE} , do not modify \\n#ifndef ${schema}_HEADER\\n#define ${schema}_HEADER\\nauto constexpr ${schema}_SCHEMA = R\"('`cat ${FILE}`')\" ;\\n#endif // ${schema}_HEADER\\n ' > ./include/${schema}_schema.h"
       COMMENT "Creating header from schema file: '${schema}'"
-      DEPENDS ${FILE}
+      DEPENDS ${FBS_OUTPUT_HEADER_GENERATED}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       VERBATIM)
+
+  add_custom_target(${schema}_schema_target DEPENDS ${FBS_OUTPUT_HEADER})
+  add_dependencies(compile_schemas ${schema}_schema_target)
 endforeach()
 
 add_subdirectory("src/scanOrchestrator")

--- a/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
@@ -92,7 +92,7 @@ add_library(vulnerability_scanner SHARED
     ${VULNERABILITY_SCANNER_SRC}
     )
 
-add_dependencies(database_feed compile_schemas) #Add a dependency between top-level targets.
+add_dependencies(vulnerability_scanner compile_schemas) #Add a dependency between top-level targets.
 
 target_link_libraries(vulnerability_scanner scan_orchestrator database_feed router content_manager indexer_connector router gcc_s flatbuffers)
 

--- a/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
@@ -92,7 +92,7 @@ add_library(vulnerability_scanner SHARED
     ${VULNERABILITY_SCANNER_SRC}
     )
 
-add_dependencies(vulnerability_scanner compile_schemas) #Add a dependency between top-level targets.
+add_dependencies(database_feed compile_schemas) #Add a dependency between top-level targets.
 
 target_link_libraries(vulnerability_scanner scan_orchestrator database_feed router content_manager indexer_connector router gcc_s flatbuffers)
 

--- a/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
@@ -56,11 +56,11 @@ message("Compiling schemas")
 add_custom_target(compile_schemas)
 foreach(schema IN LISTS Schemas)
   set(FILE "./schemas/${schema}.fbs")
-  set(FBS_OUTPUT_HEADER_GENERATED "${CMAKE_CURRENT_SOURCE_DIR}/include/${schema}_generated.h")
-  set(FBS_OUTPUT_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/include/${schema}_schema.h")
+  set(VULNERABILITY_OUTPUT_HEADER_GENERATED "${CMAKE_CURRENT_SOURCE_DIR}/include/${schema}_generated.h")
+  set(VULNERABILITY_OUTPUT_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/include/${schema}_schema.h")
 
   add_custom_command(
-      OUTPUT "${FBS_OUTPUT_HEADER_GENERATED}"
+      OUTPUT "${VULNERABILITY_OUTPUT_HEADER_GENERATED}"
       COMMAND ${SRC_FOLDER}/external/flatbuffers/build/flatc
       ARGS --cpp
       ARGS -o "${CMAKE_CURRENT_SOURCE_DIR}/include" "${FILE}"
@@ -70,14 +70,14 @@ foreach(schema IN LISTS Schemas)
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_custom_command(
-      OUTPUT "${FBS_OUTPUT_HEADER}"
+      OUTPUT "${VULNERABILITY_OUTPUT_HEADER}"
       COMMAND bash -c "echo -e '// This file was generated from ${FILE} , do not modify \\n#ifndef ${schema}_HEADER\\n#define ${schema}_HEADER\\nauto constexpr ${schema}_SCHEMA = R\"('`cat ${FILE}`')\" ;\\n#endif // ${schema}_HEADER\\n ' > ./include/${schema}_schema.h"
       COMMENT "Creating header from schema file: '${schema}'"
-      DEPENDS ${FBS_OUTPUT_HEADER_GENERATED}
+      DEPENDS ${VULNERABILITY_OUTPUT_HEADER_GENERATED}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       VERBATIM)
 
-  add_custom_target(${schema}_schema_target DEPENDS ${FBS_OUTPUT_HEADER})
+  add_custom_target(${schema}_schema_target DEPENDS ${VULNERABILITY_OUTPUT_HEADER})
   add_dependencies(compile_schemas ${schema}_schema_target)
 endforeach()
 


### PR DESCRIPTION
|Related issue|
|---|
|#20189|

## Description
Now when compiling flatbuffer schemes, it validates whether the files exist or have been modified, to avoid compiling unnecessarily.

Changes were applied to SysCollector and Vulnerability_scanner


<!--
Add a clear description of how the problem has been solved.
-->


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
