### PR TITLE
Improving the WPK upgrade script

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -239,9 +239,10 @@ status="pending"
 COUNTER=30
 while [ "$status" != "connected" -a $COUNTER -gt 0 ]; do
     . ./var/run/wazuh-agentd.state >> ./logs/upgrade.log 2>&1
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Waiting connection... Remaining attempts: ${COUNTER}." >> ./logs/upgrade.log
     sleep 1
     COUNTER=$[COUNTER - 1]
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Waiting connection... Status = "${status}". Remaining attempts: ${COUNTER}." >> ./logs/upgrade.log
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Status = "${status}". " >> ./logs/upgrade.log
 done
 
 # Check connection

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -12,7 +12,7 @@ TMP_DIR_BACKUP=./tmp_bkp
 
 # Check if there is an upgrade in progress
 declare -a BACKUP_FOLDERS
-[ -d "./tmp_bkp" ] && BACKUP_FOLDERS+=("./tmp_bkp")
+[ -d "${TMP_DIR_BACKUP}" ] && BACKUP_FOLDERS+=("${TMP_DIR_BACKUP}")
 [ -d "./backup" ] && BACKUP_FOLDERS+=("./backup")
 for dir in "${BACKUP_FOLDERS[@]}"; do
     ATTEMPTS=5
@@ -27,7 +27,7 @@ for dir in "${BACKUP_FOLDERS[@]}"; do
 done
 
 # Clean before backup
-rm -rf "${TMP_DIR_BACKUP}/"
+rm -rf ${TMP_DIR_BACKUP}/
 
 WAZUH_REVISION=0
 OSSEC_LIST_FILES=""
@@ -284,6 +284,12 @@ else
     # Restore backup
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Restoring backup...." >> ./logs/upgrade.log
     tar xzf ./backup/backup_[${BDATE}].tar.gz -C / >> ./logs/upgrade.log 2>&1
+    RESULT=$?
+
+    if [ $RESULT -ne 0 ]; then
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Error uncompressing the Backup, it has not been possible to restore the installation." >> ./logs/upgrade.log
+        exit 1
+    fi
 
     # Assign the ossec ownership, if appropriate
     if [ $RESTORE_OSSEC_OWN -eq 1 ]; then

--- a/src/init/pkg_installer_mac.sh
+++ b/src/init/pkg_installer_mac.sh
@@ -4,7 +4,7 @@
 
 # Generating Backup
 CURRENT_DIR=`pwd`
-if [ "${CURRENT_DIR}" -eq "/" ]; then
+if [ "${CURRENT_DIR}" = "/" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Execution path is wrong, interrupting upgrade." >> ./logs/upgrade.log
     exit 1
 fi

--- a/src/init/pkg_installer_mac.sh
+++ b/src/init/pkg_installer_mac.sh
@@ -105,9 +105,10 @@ status="pending"
 COUNTER=30
 while [ "$status" != "connected" -a $COUNTER -gt 0 ]; do
     . ./var/run/wazuh-agentd.state >> ./logs/upgrade.log 2>&1
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Waiting connection... Remaining attempts: ${COUNTER}." >> ./logs/upgrade.log
     sleep 1
     COUNTER=$[COUNTER - 1]
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Waiting connection... Status = "${status}". Remaining attempts: ${COUNTER}." >> ./logs/upgrade.log
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Status = "${status}". " >> ./logs/upgrade.log
 done
 
 # Check connection

--- a/src/init/pkg_installer_mac.sh
+++ b/src/init/pkg_installer_mac.sh
@@ -12,7 +12,7 @@ TMP_DIR_BACKUP=./tmp_bkp
 
 # Check if there is an upgrade in progress
 declare -a BACKUP_FOLDERS
-[ -d "./tmp_bkp" ] && BACKUP_FOLDERS+=("./tmp_bkp")
+[ -d "${TMP_DIR_BACKUP}" ] && BACKUP_FOLDERS+=("${TMP_DIR_BACKUP}")
 [ -d "./backup" ] && BACKUP_FOLDERS+=("./backup")
 for dir in "${BACKUP_FOLDERS[@]}"; do
     ATTEMPTS=5
@@ -149,6 +149,8 @@ else
         done
     else
         echo "$(date +"%Y/%m/%d %H:%M:%S") - Error uncompressing the Backup, it has not been possible to restore the installation." >> ./logs/upgrade.log
+        rm -rf ./backup/restore
+        exit 1
     fi
 
     rm -rf ./backup/restore


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/20490|


## Description

This PR includes some improvements in the WPK upgrade scripts so that in certain circumstances they do not generate any problems. 
The scripts are intended to stop their execution if something goes wrong or if it is not possible to generate the corresponding backups.


## Logs/Alerts example

If there is a problem generating the backup, the script will warn and terminate execution:
`2023/12/04 13:01:33 - Error creating the Backup, interrupting the upgrade.`
If there is any problem decompressing the backup, same situation:
`2023/12/04 13:03:48 - Error uncompressing the Backup, it has not been possible to restore the installation.`
