### PR TITLE
Content Manager - Implement interruption mechanism

### DIFF
--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -145,21 +145,17 @@ public:
      */
     void runActionOnDemand()
     {
-        if (m_schedulerRunning.load())
+        auto expected = false;
+        if (m_actionInProgress.compare_exchange_strong(expected, true))
         {
-            auto expected = false;
-            if (m_actionInProgress.compare_exchange_strong(expected, true))
-            {
-                logInfo(WM_CONTENTUPDATER, "Starting on-demand action for '%s'", m_topicName.c_str());
-                runAction(ActionID::ON_DEMAND);
-            }
-            else
-            {
-                // LCOV_EXCL_START
-                logInfo(
-                    WM_CONTENTUPDATER, "Action in progress for '%s', on-demand request ignored", m_topicName.c_str());
-                // LCOV_EXCL_STOP
-            }
+            logInfo(WM_CONTENTUPDATER, "Starting on-demand action for '%s'", m_topicName.c_str());
+            runAction(ActionID::ON_DEMAND);
+        }
+        else
+        {
+            // LCOV_EXCL_START
+            logInfo(WM_CONTENTUPDATER, "Action in progress for '%s', on-demand request ignored", m_topicName.c_str());
+            // LCOV_EXCL_STOP
         }
     }
 

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -48,9 +48,23 @@ public:
         , m_cv {}
         , m_topicName {std::move(topicName)}
         , m_interval {0}
-        , m_orchestration {std::make_unique<ActionOrchestrator>(channel, parameters, m_schedulerRunning)}
+        , m_shouldRun {true}
+        , m_orchestration {std::make_unique<ActionOrchestrator>(channel, parameters, m_shouldRun)}
     {
         m_parameters = std::move(parameters);
+    }
+
+    /**
+     * @brief Class destructor. Stops the action execution if it's in progress.
+     *
+     */
+    ~Action()
+    {
+        // Stop running action, if any.
+        m_shouldRun = false;
+
+        unregisterActionOnDemand();
+        stopActionScheduler();
     }
 
     /**
@@ -173,7 +187,7 @@ public:
 private:
     std::shared_ptr<RouterProvider> m_channel;
     std::thread m_schedulerThread;
-    std::atomic<bool> m_schedulerRunning = false;
+    bool m_schedulerRunning = false;
     std::atomic<bool> m_actionInProgress;
     std::atomic<size_t> m_interval;
     std::mutex m_mutex;
@@ -181,6 +195,7 @@ private:
     std::string m_topicName;
     nlohmann::json m_parameters;
     std::unique_ptr<ActionOrchestrator> m_orchestration;
+    std::atomic<bool> m_shouldRun;
 
     void runAction(const ActionID id)
     {

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -31,7 +31,7 @@ public:
      *
      * @param channel Channel where the orchestration will publish the data.
      * @param parameters Parameters used to create the orchestration.
-     * @param shouldRun ADD DOCU.
+     * @param shouldRun Flag used to interrupt the orchestration stages.
      */
     explicit ActionOrchestrator(const std::shared_ptr<RouterProvider> channel,
                                 const nlohmann::json& parameters,

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -31,13 +31,16 @@ public:
      *
      * @param channel Channel where the orchestration will publish the data.
      * @param parameters Parameters used to create the orchestration.
+     * @param shouldRun ADD DOCU.
      */
-    explicit ActionOrchestrator(const std::shared_ptr<RouterProvider> channel, const nlohmann::json& parameters)
+    explicit ActionOrchestrator(const std::shared_ptr<RouterProvider> channel,
+                                const nlohmann::json& parameters,
+                                const std::atomic<bool>& shouldRun)
     {
         try
         {
             // Create a context
-            m_spBaseContext = std::make_shared<UpdaterBaseContext>();
+            m_spBaseContext = std::make_shared<UpdaterBaseContext>(shouldRun);
             m_spBaseContext->topicName = parameters.at("topicName");
             m_spBaseContext->configData = parameters.at("configData");
             m_spBaseContext->spChannel = channel;

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -35,7 +35,7 @@ public:
      */
     explicit ActionOrchestrator(const std::shared_ptr<RouterProvider> channel,
                                 const nlohmann::json& parameters,
-                                const std::atomic<bool>& shouldRun)
+                                const std::atomic<bool>& shouldRun = std::atomic<bool>(true))
     {
         try
         {

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -35,7 +35,7 @@ public:
      */
     explicit ActionOrchestrator(const std::shared_ptr<RouterProvider> channel,
                                 const nlohmann::json& parameters,
-                                const std::atomic<bool>& shouldRun = std::atomic<bool>(true))
+                                const std::atomic<bool>& shouldRun)
     {
         try
         {

--- a/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
@@ -137,7 +137,7 @@ protected:
         auto sleepTime {INITIAL_SLEEP_TIME};
         auto retryAttempt {1};
         auto retry {true};
-        while (retry)
+        while (retry && m_spUpdaterContext->spUpdaterBaseContext->shouldRun.load())
         {
             try
             {
@@ -168,8 +168,9 @@ protected:
      */
     virtual void download(UpdaterContext& context) = 0;
 
-    IURLRequest& m_urlRequest;         ///< Interface to perform HTTP requests.
-    const std::string m_componentName; ///< Stage name.
+    IURLRequest& m_urlRequest;                          ///< Interface to perform HTTP requests.
+    const std::string m_componentName;                  ///< Stage name.
+    std::shared_ptr<UpdaterContext> m_spUpdaterContext; ///< Updater context.
 
 public:
     // LCOV_EXCL_START
@@ -197,6 +198,8 @@ public:
     std::shared_ptr<UpdaterContext> handleRequest(std::shared_ptr<UpdaterContext> context) override
     {
         logDebug1(WM_CONTENTUPDATER, "%s - Starting process", m_componentName.c_str());
+
+        m_spUpdaterContext = context;
 
         try
         {

--- a/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
@@ -106,8 +106,8 @@ protected:
     }
 
     /**
-     * @brief Loop for retrying the downloads from the server until the download is successful or there is an HTTP error
-     * different from 5xx.
+     * @brief Loop for retrying the downloads from the server until the download is successful, there is an HTTP error
+     * different from 5xx, or in case of an interruption.
      *
      * @param URL URL to download from.
      * @param onSuccess Callback on success download.

--- a/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
@@ -52,7 +52,7 @@ private:
         {
             if (!context.spUpdaterBaseContext->shouldRun.load())
             {
-                logWarn(WM_CONTENTUPDATER, "Download has been interrupted");
+                logWarn(WM_CONTENTUPDATER, "The offsets download has been interrupted");
                 return;
             }
 

--- a/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
@@ -47,8 +47,15 @@ private:
         const auto consumerLastOffset {getCtiBaseParameters(m_url).lastOffset};
 
         // Iterate until the current offset is equal to the consumer offset.
+        auto pathsArray = nlohmann::json::array();
         while (context.currentOffset < consumerLastOffset)
         {
+            if (!context.spUpdaterBaseContext->shouldRun.load())
+            {
+                logWarn(WM_CONTENTUPDATER, "Download has been interrupted");
+                return;
+            }
+
             // Amount of offsets to download on each query.
             constexpr auto OFFSETS_DELTA {1000};
 
@@ -66,9 +73,12 @@ private:
             // Update the current offset.
             context.currentOffset = toOffset;
 
-            // Save the path of the downloaded content in the context.
-            context.data.at("paths").push_back(fullFilePath);
+            // Save the path of the downloaded content in a temporary variable.
+            pathsArray.push_back(fullFilePath);
         }
+
+        // Commit changes.
+        context.data.at("paths") = std::move(pathsArray);
     }
 
     /**

--- a/src/shared_modules/content_manager/src/components/updaterContext.hpp
+++ b/src/shared_modules/content_manager/src/components/updaterContext.hpp
@@ -14,6 +14,7 @@
 
 #include "iRouterProvider.hpp"
 #include "utils/rocksDBWrapper.hpp"
+#include <atomic>
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
 #include <string>
@@ -76,6 +77,12 @@ struct UpdaterBaseContext
     std::string downloadedFileHash;
 
     /**
+     * @brief Variable to control the graceful shutdown of the orchestration.
+     *
+     */
+    const std::atomic<bool>& shouldRun;
+
+    /**
      * @brief For testing purposes. Delete it.
      */
     uint8_t download {1};      ///< download
@@ -83,6 +90,11 @@ struct UpdaterBaseContext
     uint8_t publish {0};       ///< publish
     uint8_t updateVersion {0}; ///< updateVersion
     uint8_t clean {0};         ///< clean
+
+    UpdaterBaseContext(const std::atomic<bool>& shouldRun = std::atomic<bool>(true))
+        : shouldRun(shouldRun)
+    {
+    }
 };
 
 /**

--- a/src/shared_modules/content_manager/src/components/updaterContext.hpp
+++ b/src/shared_modules/content_manager/src/components/updaterContext.hpp
@@ -91,6 +91,11 @@ struct UpdaterBaseContext
     uint8_t updateVersion {0}; ///< updateVersion
     uint8_t clean {0};         ///< clean
 
+    /**
+     * @brief Struct constructor.
+     *
+     * @param shouldRun Reference to an interruption flag.
+     */
     UpdaterBaseContext(const std::atomic<bool>& shouldRun = std::atomic<bool>(true))
         : shouldRun(shouldRun)
     {

--- a/src/shared_modules/content_manager/src/components/updaterContext.hpp
+++ b/src/shared_modules/content_manager/src/components/updaterContext.hpp
@@ -83,15 +83,6 @@ struct UpdaterBaseContext
     const std::atomic<bool>& shouldRun;
 
     /**
-     * @brief For testing purposes. Delete it.
-     */
-    uint8_t download {1};      ///< download
-    uint8_t decompress {0};    ///< decompress
-    uint8_t publish {0};       ///< publish
-    uint8_t updateVersion {0}; ///< updateVersion
-    uint8_t clean {0};         ///< clean
-
-    /**
      * @brief Struct constructor.
      *
      * @param shouldRun Reference to an interruption flag.

--- a/src/shared_modules/content_manager/src/components/updaterContext.hpp
+++ b/src/shared_modules/content_manager/src/components/updaterContext.hpp
@@ -87,7 +87,7 @@ struct UpdaterBaseContext
      *
      * @param shouldRun Reference to an interruption flag.
      */
-    UpdaterBaseContext(const std::atomic<bool>& shouldRun = std::atomic<bool>(true))
+    explicit UpdaterBaseContext(const std::atomic<bool>& shouldRun)
         : shouldRun(shouldRun)
     {
     }
@@ -97,7 +97,7 @@ struct UpdaterBaseContext
  * @brief Object created and handled on every execution of the updater chain.
  *
  */
-struct UpdaterContext final : private UpdaterBaseContext
+struct UpdaterContext
 {
     /**
      * @brief Pointer to the Updater context.

--- a/src/shared_modules/content_manager/src/contentProvider.hpp
+++ b/src/shared_modules/content_manager/src/contentProvider.hpp
@@ -47,8 +47,7 @@ public:
 
     ~ContentProvider()
     {
-        m_action->unregisterActionOnDemand();
-        m_action->stopActionScheduler();
+        m_action.reset();
         m_routerProvider.reset();
     }
 

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -36,7 +36,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiation)
 
     EXPECT_NO_THROW(routerProvider->start());
 
-    EXPECT_NO_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun));
+    EXPECT_NO_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -59,7 +59,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitoutConfigData)
 
     parameters.erase("configData");
 
-    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, parameters, m_shouldRun), std::invalid_argument);
+    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, parameters), std::invalid_argument);
 
     EXPECT_NO_THROW(routerProvider->stop());
 }
@@ -78,8 +78,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitoutContentSourceInConfigData
 
     m_parameters.at("configData").erase("contentSource");
 
-    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun),
-                 std::invalid_argument);
+    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters), std::invalid_argument);
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -100,8 +99,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitoutCompressionTypeInConfigDa
 
     m_parameters.at("configData").erase("compressionType");
 
-    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun),
-                 std::invalid_argument);
+    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters), std::invalid_argument);
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -122,7 +120,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitXZCompressionType)
 
     m_parameters["configData"]["compressionType"] = "xz";
 
-    EXPECT_NO_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun));
+    EXPECT_NO_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -143,8 +141,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitoutVersionedContentInConfigD
 
     m_parameters.at("configData").erase("versionedContent");
 
-    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun),
-                 std::invalid_argument);
+    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters), std::invalid_argument);
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -165,8 +162,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitoutDeleteDownloadedContentIn
 
     m_parameters.at("configData").erase("deleteDownloadedContent");
 
-    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun),
-                 std::invalid_argument);
+    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters), std::invalid_argument);
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -188,7 +184,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationAndExecutionWhitRawCompressionTy
 
     EXPECT_NO_THROW(routerProvider->start());
 
-    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun)};
+    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -223,7 +219,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationAndExecutionWhitXZCompressionTyp
 
     EXPECT_NO_THROW(routerProvider->start());
 
-    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun)};
+    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -259,7 +255,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationAndExecutionWhitXZCompressionTyp
 
     EXPECT_NO_THROW(routerProvider->start());
 
-    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun)};
+    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -36,7 +36,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiation)
 
     EXPECT_NO_THROW(routerProvider->start());
 
-    EXPECT_NO_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters));
+    EXPECT_NO_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -59,7 +59,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitoutConfigData)
 
     parameters.erase("configData");
 
-    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, parameters), std::invalid_argument);
+    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, parameters, m_shouldRun), std::invalid_argument);
 
     EXPECT_NO_THROW(routerProvider->stop());
 }
@@ -78,7 +78,8 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitoutContentSourceInConfigData
 
     m_parameters.at("configData").erase("contentSource");
 
-    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters), std::invalid_argument);
+    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun),
+                 std::invalid_argument);
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -99,7 +100,8 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitoutCompressionTypeInConfigDa
 
     m_parameters.at("configData").erase("compressionType");
 
-    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters), std::invalid_argument);
+    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun),
+                 std::invalid_argument);
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -120,7 +122,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitXZCompressionType)
 
     m_parameters["configData"]["compressionType"] = "xz";
 
-    EXPECT_NO_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters));
+    EXPECT_NO_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -141,7 +143,8 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitoutVersionedContentInConfigD
 
     m_parameters.at("configData").erase("versionedContent");
 
-    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters), std::invalid_argument);
+    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun),
+                 std::invalid_argument);
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -162,7 +165,8 @@ TEST_F(ActionOrchestratorTest, TestInstantiationWhitoutDeleteDownloadedContentIn
 
     m_parameters.at("configData").erase("deleteDownloadedContent");
 
-    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters), std::invalid_argument);
+    EXPECT_THROW(std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun),
+                 std::invalid_argument);
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -184,7 +188,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationAndExecutionWhitRawCompressionTy
 
     EXPECT_NO_THROW(routerProvider->start());
 
-    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters)};
+    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -219,7 +223,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationAndExecutionWhitXZCompressionTyp
 
     EXPECT_NO_THROW(routerProvider->start());
 
-    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters)};
+    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 
@@ -255,7 +259,7 @@ TEST_F(ActionOrchestratorTest, TestInstantiationAndExecutionWhitXZCompressionTyp
 
     EXPECT_NO_THROW(routerProvider->start());
 
-    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters)};
+    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_shouldRun)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
@@ -14,6 +14,7 @@
 
 #include "fakes/fakeServer.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
 #include <memory>
@@ -31,6 +32,7 @@ protected:
     nlohmann::json m_parameters; ///< Parameters used to create the ActionOrchestrator
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Pointer to FakeServer class
+    const std::atomic<bool> m_shouldRun {true};               ///< Interruption flag.
 
     /**
      * @brief Sets initial conditions for each test case.

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
@@ -14,7 +14,6 @@
 
 #include "fakes/fakeServer.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
 #include <memory>
@@ -29,8 +28,7 @@ protected:
     ActionOrchestratorTest() = default;
     ~ActionOrchestratorTest() override = default;
 
-    nlohmann::json m_parameters;                ///< Parameters used to create the ActionOrchestrator
-    const std::atomic<bool> m_shouldRun {true}; ///< Run flag.
+    nlohmann::json m_parameters; ///< Parameters used to create the ActionOrchestrator
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Pointer to FakeServer class
 

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
@@ -14,6 +14,7 @@
 
 #include "fakes/fakeServer.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
 #include <memory>
@@ -28,7 +29,8 @@ protected:
     ActionOrchestratorTest() = default;
     ~ActionOrchestratorTest() override = default;
 
-    nlohmann::json m_parameters; ///< Parameters used to create the ActionOrchestrator
+    nlohmann::json m_parameters;                ///< Parameters used to create the ActionOrchestrator
+    const std::atomic<bool> m_shouldRun {true}; ///< Run flag.
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Pointer to FakeServer class
 

--- a/src/shared_modules/content_manager/tests/component/action_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.cpp
@@ -196,7 +196,7 @@ TEST_F(ActionTest, TestInstantiationOfTwoActionsWithTheSameTopicName)
 /*
  * @brief Tests the instantiation of the Action class and runActionOnDemand
  */
-TEST_F(ActionTest, DISABLED_TestInstantiationAndRunActionOnDemand)
+TEST_F(ActionTest, TestInstantiationAndRunActionOnDemand)
 {
     m_parameters["ondemand"] = true;
 
@@ -205,10 +205,18 @@ TEST_F(ActionTest, DISABLED_TestInstantiationAndRunActionOnDemand)
     const auto& fileName {m_parameters.at("configData").at("contentFileName").get_ref<const std::string&>()};
     const auto contentPath {outputFolder + "/" + CONTENTS_FOLDER + "/3-" + fileName};
     const auto downloadPath {outputFolder + "/" + DOWNLOAD_FOLDER + "/3-" + fileName};
+    const auto& interval {m_parameters.at("interval").get_ref<const size_t&>()};
 
     auto action {std::make_shared<Action>(m_spRouterProvider, topicName, m_parameters)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
+
+    // Start scheduler and wait for on-start execution to finish.
+    action->startActionScheduler(interval);
+    std::this_thread::sleep_for(std::chrono::seconds(interval + 1));
+
+    // Remove results from on-start action.
+    std::filesystem::remove(contentPath);
 
     EXPECT_NO_THROW(action->registerActionOnDemand());
 
@@ -218,6 +226,8 @@ TEST_F(ActionTest, DISABLED_TestInstantiationAndRunActionOnDemand)
 
     EXPECT_NO_THROW(action->unregisterActionOnDemand());
     EXPECT_NO_THROW(action->clearEndpoints());
+
+    action->stopActionScheduler();
 
     // This file shouldn't exist because it's a test for raw data
     EXPECT_FALSE(std::filesystem::exists(downloadPath));

--- a/src/shared_modules/content_manager/tests/component/action_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.cpp
@@ -205,18 +205,10 @@ TEST_F(ActionTest, TestInstantiationAndRunActionOnDemand)
     const auto& fileName {m_parameters.at("configData").at("contentFileName").get_ref<const std::string&>()};
     const auto contentPath {outputFolder + "/" + CONTENTS_FOLDER + "/3-" + fileName};
     const auto downloadPath {outputFolder + "/" + DOWNLOAD_FOLDER + "/3-" + fileName};
-    const auto& interval {m_parameters.at("interval").get_ref<const size_t&>()};
 
     auto action {std::make_shared<Action>(m_spRouterProvider, topicName, m_parameters)};
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
-
-    // Start scheduler and wait for on-start execution to finish.
-    action->startActionScheduler(interval);
-    std::this_thread::sleep_for(std::chrono::seconds(interval + 1));
-
-    // Remove results from on-start action.
-    std::filesystem::remove(contentPath);
 
     EXPECT_NO_THROW(action->registerActionOnDemand());
 
@@ -226,8 +218,6 @@ TEST_F(ActionTest, TestInstantiationAndRunActionOnDemand)
 
     EXPECT_NO_THROW(action->unregisterActionOnDemand());
     EXPECT_NO_THROW(action->clearEndpoints());
-
-    action->stopActionScheduler();
 
     // This file shouldn't exist because it's a test for raw data
     EXPECT_FALSE(std::filesystem::exists(downloadPath));

--- a/src/shared_modules/content_manager/tests/component/action_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.cpp
@@ -196,7 +196,7 @@ TEST_F(ActionTest, TestInstantiationOfTwoActionsWithTheSameTopicName)
 /*
  * @brief Tests the instantiation of the Action class and runActionOnDemand
  */
-TEST_F(ActionTest, TestInstantiationAndRunActionOnDemand)
+TEST_F(ActionTest, DISABLED_TestInstantiationAndRunActionOnDemand)
 {
     m_parameters["ondemand"] = true;
 

--- a/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.hpp
@@ -15,6 +15,7 @@
 #include "pubSubPublisher.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <memory>
 
 /**
@@ -31,6 +32,7 @@ protected:
     std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on the merge pipeline.
 
     std::shared_ptr<PubSubPublisher> m_spPubSubPublisher; ///< PubSubPublisher used to publish the content data.
+    const std::atomic<bool> m_shouldRun {true};           ///< Interruption flag.
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -42,7 +44,7 @@ protected:
         m_spPubSubPublisher = std::make_shared<PubSubPublisher>();
         // Create a updater context
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
     }
 };
 

--- a/src/shared_modules/content_manager/tests/unit/APIDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/APIDownloader_test.hpp
@@ -17,6 +17,7 @@
 #include "fakes/fakeServer.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <memory>
 
 /**
@@ -36,6 +37,8 @@ protected:
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< pointer to FakeServer class
 
+    const std::atomic<bool> m_shouldRun {true}; ///< Interruption flag.
+
     /**
      * @brief Sets initial conditions for each test case.
      *
@@ -45,7 +48,7 @@ protected:
     {
         m_spAPIDownloader = std::make_shared<APIDownloader>(HTTPRequest::instance());
         // Create a updater base context
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
         m_spUpdaterBaseContext->outputFolder = "/tmp/api-downloader-tests";
         m_spUpdaterBaseContext->downloadsFolder = m_spUpdaterBaseContext->outputFolder / DOWNLOAD_FOLDER;
         m_spUpdaterBaseContext->contentsFolder = m_spUpdaterBaseContext->outputFolder / CONTENTS_FOLDER;

--- a/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
@@ -24,6 +24,9 @@ constexpr auto CONTENT_TYPE {"raw"};
 constexpr auto FAKE_CTI_URL {"http://localhost:4444/snapshot/consumers"};
 constexpr auto RAW_URL {"http://localhost:4444/raw"};
 
+constexpr auto DEFAULT_LAST_OFFSET {0};
+constexpr auto DEFAULT_LAST_SNAPSHOT_LINK {""};
+
 /**
  * @class CtiDummyDownloader
  *
@@ -46,8 +49,8 @@ private:
         m_lastSnapshotLink = parameters.lastSnapshotLink;
     }
 
-    int m_lastOffset {};               ///< Last offset downloaded from CTI.
-    std::string m_lastSnapshotLink {}; ///< Last snapshot link downloaded from CTI.
+    int m_lastOffset {DEFAULT_LAST_OFFSET};                      ///< Last offset downloaded from CTI.
+    std::string m_lastSnapshotLink {DEFAULT_LAST_SNAPSHOT_LINK}; ///< Last snapshot link downloaded from CTI.
 
 public:
     /**
@@ -209,4 +212,27 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadClientError)
     expectedData["type"] = CONTENT_TYPE;
 
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}
+
+/**
+ * @brief Tests the interruption of the download of the base parameters.
+ *
+ */
+TEST_F(CtiDownloaderTest, BaseParametersDownloadInterrupted)
+{
+    auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
+
+    m_shouldRun = false;
+    ASSERT_NO_THROW(downloader.handleRequest(m_spUpdaterContext));
+
+    // Check expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = OK_STATUS;
+    expectedData["type"] = CONTENT_TYPE;
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+
+    // Check expected base parameters.
+    EXPECT_EQ(downloader.getLastOffset(), DEFAULT_LAST_OFFSET);
+    EXPECT_EQ(downloader.getLastSnapshotLink(), DEFAULT_LAST_SNAPSHOT_LINK);
 }

--- a/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
@@ -83,8 +83,10 @@ public:
 
 void CtiDownloaderTest::SetUp()
 {
+    m_shouldRun = true;
+
     // Create base context.
-    auto spBaseContext {std::make_shared<UpdaterBaseContext>()};
+    auto spBaseContext {std::make_shared<UpdaterBaseContext>(m_shouldRun)};
     spBaseContext->configData["url"] = FAKE_CTI_URL;
 
     // Create updater context.

--- a/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.hpp
@@ -15,6 +15,7 @@
 #include "fakes/fakeServer.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <memory>
 
 /**
@@ -29,6 +30,7 @@ protected:
 
     std::shared_ptr<UpdaterContext> m_spUpdaterContext;       ///< UpdaterContext used on the update orchestration.
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< FakeServer used for tests.
+    std::atomic<bool> m_shouldRun;                            ///< Run flag.
 
     /**
      * @brief Setup routine for each test fixture.

--- a/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.cpp
@@ -218,3 +218,22 @@ TEST_F(CtiOffsetDownloaderTest, DownloadClientAndServerErrorsRetryAndFail)
     ASSERT_THROW(m_spCtiOffsetDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
 }
+
+/**
+ * @brief Test the download interruption.
+ *
+ */
+TEST_F(CtiOffsetDownloaderTest, DownloadInterrupted)
+{
+    // Set interruption flag.
+    m_shouldRun = false;
+
+    ASSERT_NO_THROW(m_spCtiOffsetDownloader->handleRequest(m_spUpdaterContext));
+
+    // Set expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = OK_STATUS;
+    expectedData["type"] = DEFAULT_TYPE;
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}

--- a/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.hpp
@@ -17,6 +17,7 @@
 #include "fakes/fakeServer.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <memory>
 
 /**
@@ -36,6 +37,7 @@ protected:
     std::shared_ptr<CtiOffsetDownloader> m_spCtiOffsetDownloader; ///< CtiOffsetDownloader used to download the content.
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Pointer to FakeServer class
+    const std::atomic<bool> m_shouldRun {true};               ///< Run flag.
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -46,7 +48,7 @@ protected:
     {
         m_spCtiOffsetDownloader = std::make_shared<CtiOffsetDownloader>(HTTPRequest::instance());
         // Create a updater base context
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
         m_spUpdaterBaseContext->outputFolder = "/tmp/api-downloader-tests";
         m_spUpdaterBaseContext->downloadsFolder = m_spUpdaterBaseContext->outputFolder / DOWNLOAD_FOLDER;
         m_spUpdaterBaseContext->contentsFolder = m_spUpdaterBaseContext->outputFolder / CONTENTS_FOLDER;

--- a/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.hpp
@@ -37,7 +37,7 @@ protected:
     std::shared_ptr<CtiOffsetDownloader> m_spCtiOffsetDownloader; ///< CtiOffsetDownloader used to download the content.
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Pointer to FakeServer class
-    const std::atomic<bool> m_shouldRun {true};               ///< Run flag.
+    std::atomic<bool> m_shouldRun;                            ///< Run flag.
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -46,6 +46,7 @@ protected:
     // cppcheck-suppress unusedFunction
     void SetUp() override
     {
+        m_shouldRun = true;
         m_spCtiOffsetDownloader = std::make_shared<CtiOffsetDownloader>(HTTPRequest::instance());
         // Create a updater base context
         m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);

--- a/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.cpp
@@ -29,7 +29,7 @@ const auto OUTPUT_DIR {std::filesystem::temp_directory_path() / "CtiSnapshotDown
 void CtiSnapshotDownloaderTest::SetUp()
 {
     // Create base context.
-    auto spBaseContext {std::make_shared<UpdaterBaseContext>()};
+    auto spBaseContext {std::make_shared<UpdaterBaseContext>(m_shouldRun)};
     spBaseContext->downloadsFolder = OUTPUT_DIR;
     spBaseContext->configData["url"] = FAKE_CTI_URL;
 

--- a/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.hpp
@@ -15,6 +15,7 @@
 #include "fakes/fakeServer.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <memory>
 
 /**
@@ -29,6 +30,7 @@ protected:
 
     std::shared_ptr<UpdaterContext> m_spUpdaterContext;       ///< UpdaterContext used on the update orchestration.
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< FakeServer used for tests.
+    const std::atomic<bool> m_shouldRun {true};               ///< Run flag.
 
     /**
      * @brief Setup routine for each test fixture.

--- a/src/shared_modules/content_manager/tests/unit/cleanUpContent_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/cleanUpContent_test.hpp
@@ -14,6 +14,7 @@
 
 #include "cleanUpContent.hpp"
 #include "updaterContext.hpp"
+#include <atomic>
 #include <gtest/gtest.h>
 
 const std::string TEST_DIR {"/tmp/test"};
@@ -44,13 +45,15 @@ protected:
      */
     std::shared_ptr<CleanUpContent> m_spCleanUpContent;
 
+    const std::atomic<bool> m_shouldRun {true}; ///< Interruption flag.
+
     /**
      * @brief Sets up the test fixture.
      */
     void SetUp() override
     {
         // Initialize contexts
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
 
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
         m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;

--- a/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
@@ -15,6 +15,7 @@
 #include "executionContext.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <filesystem>
 #include <memory>
 
@@ -35,6 +36,7 @@ protected:
 
     const std::filesystem::path m_databasePath {"/tmp/database"};        ///< Path used to store the database files.
     const std::filesystem::path m_outputFolder {"/tmp/content_manager"}; ///< Path used to store the output files.
+    const std::atomic<bool> m_shouldRun {true};                          ///< Interruption flag.
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -46,7 +48,7 @@ protected:
         m_spExecutionContext = std::make_shared<ExecutionContext>();
         // Create a updater context
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
         m_spUpdaterBaseContext->configData["outputFolder"] = m_outputFolder.string();
     }
 

--- a/src/shared_modules/content_manager/tests/unit/fileDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/fileDownloader_test.cpp
@@ -42,7 +42,7 @@ void FileDownloaderTest::TearDownTestSuite()
 
 void FileDownloaderTest::SetUp()
 {
-    m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+    m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
     m_spUpdaterBaseContext->downloadsFolder = (m_outputFolder / "downloads").string();
     m_spUpdaterBaseContext->contentsFolder = (m_outputFolder / "contents").string();
 

--- a/src/shared_modules/content_manager/tests/unit/fileDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/fileDownloader_test.hpp
@@ -15,6 +15,7 @@
 #include "fakes/fakeServer.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <filesystem>
 #include <memory>
 
@@ -33,6 +34,7 @@ protected:
     const std::filesystem::path m_outputFolder {std::filesystem::temp_directory_path() /
                                                 "FileDownloaderTest"}; ///< Output folder for tests.
     inline static std::unique_ptr<FakeServer> m_spFakeServer;          ///< Fake HTTP server used in tests.
+    const std::atomic<bool> m_shouldRun {true};                        ///< Interruption flag.
 
     /**
      * @brief Setup routine for the test suite.

--- a/src/shared_modules/content_manager/tests/unit/gzipDecompressor_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/gzipDecompressor_test.hpp
@@ -14,6 +14,7 @@
 
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <filesystem>
 #include <memory>
 
@@ -34,6 +35,7 @@ protected:
     ~GzipDecompressorTest() override = default;
 
     std::shared_ptr<UpdaterContext> m_spContext; ///< Context used on tests.
+    const std::atomic<bool> m_shouldRun {true};  ///< Interruption flag.
 
     /**
      * @brief Setup routine for each test fixture. Context initialization.
@@ -42,7 +44,7 @@ protected:
     void SetUp() override
     {
         m_spContext = std::make_shared<UpdaterContext>();
-        m_spContext->spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spContext->spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
         m_spContext->spUpdaterBaseContext->outputFolder = WORKING_DIR;
     }
 

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
@@ -16,6 +16,7 @@
 #include "offlineDownloader.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -39,6 +40,7 @@ protected:
     std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on tests.
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Fake HTTP server used in tests.
+    const std::atomic<bool> m_shouldRun {true};               ///< Interruption flag.
 
     /**
      * @brief Set up routine for each test fixture.
@@ -59,7 +61,7 @@ protected:
         testFileStream.close();
 
         // Updater base context.
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
         m_spUpdaterBaseContext->outputFolder = m_outputFolder;
         m_spUpdaterBaseContext->downloadsFolder = m_outputFolder / DOWNLOAD_FOLDER;
         m_spUpdaterBaseContext->contentsFolder = m_outputFolder / CONTENTS_FOLDER;

--- a/src/shared_modules/content_manager/tests/unit/pubSubPublisher_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/pubSubPublisher_test.hpp
@@ -15,6 +15,7 @@
 #include "pubSubPublisher.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 
 /**
  * @brief Runs unit tests for PubSubPublisher
@@ -30,6 +31,7 @@ protected:
     std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on the merge pipeline.
 
     std::shared_ptr<PubSubPublisher> m_spPubSubPublisher; ///< PubSubPublisher used to publish the content data.
+    const std::atomic<bool> m_shouldRun {true};           ///< Interruption flag.
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -41,7 +43,7 @@ protected:
         m_spPubSubPublisher = std::make_shared<PubSubPublisher>();
         // Create a updater context
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
     }
 };
 

--- a/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.hpp
@@ -17,6 +17,7 @@
 #include "utils/rocksDBWrapper.hpp"
 #include "utils/timeHelper.h"
 #include "gtest/gtest.h"
+#include <atomic>
 
 static const std::string DATABASE_NAME {"test.db"};
 
@@ -44,13 +45,15 @@ protected:
      */
     std::shared_ptr<UpdateCtiApiOffset> m_spUpdateCtiApiOffset;
 
+    const std::atomic<bool> m_shouldRun {true}; ///< Interruption flag.
+
     /**
      * @brief Sets up the test fixture.
      */
     void SetUp() override
     {
         // Initialize contexts
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
         m_spUpdaterBaseContext->spRocksDB = std::make_unique<Utils::RocksDBWrapper>(DATABASE_NAME);
         m_spUpdaterBaseContext->spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)), "0");
 

--- a/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.hpp
@@ -14,6 +14,7 @@
 
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <filesystem>
 #include <memory>
 
@@ -32,6 +33,7 @@ protected:
     ~ZipDecompressorTest() override = default;
 
     std::shared_ptr<UpdaterContext> m_spContext; ///< Context used on tests.
+    const std::atomic<bool> m_shouldRun {true};  ///< Interruption flag.
 
     /**
      * @brief Setup routine for each test fixture. Context initialization and output directories creation.
@@ -40,7 +42,7 @@ protected:
     void SetUp() override
     {
         m_spContext = std::make_shared<UpdaterContext>();
-        m_spContext->spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>();
+        m_spContext->spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
         m_spContext->spUpdaterBaseContext->outputFolder = OUTPUT_FOLDER;
 
         std::filesystem::create_directory(OUTPUT_FOLDER);


### PR DESCRIPTION
|Related issue|
|---|
|#20633 #20584 |

## Description

This PR implements a mechanism to interrupt the components under the Content Manager orchestration. Although the mechanism is generated, each stage has to implement a specific routine to finish what they are doing. This routine has been implemented for the `CtiApiDownloader`.

The mechanism consists of a flag passed to the `UpdaterBaseContext` that will be raised if no interruptions are present. Each component should read this flag and, if not raised, perform some abort routine.

## Results

### Manager stop

- Start Wazuh manager compiled from this PR's branch
```bash
# /var/ossec/bin/wazuh-control start
2023/12/05 18:08:05 wazuh-modulesd:router: INFO: Loaded router module.
2023/12/05 18:08:05 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Starting Wazuh v4.8.0...
/var/ossec/api/scripts/wazuh-apid.py:306: DeprecationWarning: ssl.PROTOCOL_TLSv1_2 is deprecated
  ssl_context = ssl.SSLContext(protocol=ssl_protocol)
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2023/12/05 18:08:06 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
2023/12/05 18:08:15 wazuh-modulesd:router: INFO: Loaded router module.
2023/12/05 18:08:15 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Started wazuh-modulesd...
Completed.
```

- Wait some seconds and stop it
```bash
# /var/ossec/bin/wazuh-control stop
wazuh-clusterd not running...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
wazuh-maild not running...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
Killing wazuh-apid...
Wazuh v4.8.0 Stopped
```

- Check log
```bash
# cat /var/ossec/logs/ossec.log | grep content-updater
2023/12/05 18:08:18 wazuh-modulesd:content-updater: INFO: Starting on-start action for 'vulnerability_feed_manager'
2023/12/05 18:08:18 wazuh-modulesd:content-updater: INFO: Action for 'vulnerability_feed_manager' started
2023/12/05 18:08:30 wazuh-modulesd:content-updater: WARNING: The offsets download has been interrupted
2023/12/05 18:08:30 wazuh-modulesd:content-updater: INFO: Action for 'vulnerability_feed_manager' finished
2023/12/05 18:08:30 wazuh-modulesd:content-updater: INFO: Scheduler stopped for 'vulnerability_feed_manager'
```

### Manager restart

- Restart Wazuh manager compiled from this PR's branch
```bash
# /var/ossec/bin/wazuh-control restart
2023/12/06 13:47:49 wazuh-modulesd:router: INFO: Loaded router module.
2023/12/06 13:47:49 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
wazuh-clusterd not running...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
wazuh-maild not running...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
Killing wazuh-apid...
Wazuh v4.8.0 Stopped
Starting Wazuh v4.8.0...
/var/ossec/api/scripts/wazuh-apid.py:306: DeprecationWarning: ssl.PROTOCOL_TLSv1_2 is deprecated
  ssl_context = ssl.SSLContext(protocol=ssl_protocol)
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2023/12/06 13:48:06 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
2023/12/06 13:48:15 wazuh-modulesd:router: INFO: Loaded router module.
2023/12/06 13:48:15 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Started wazuh-modulesd...
Completed.
```

- Check log:
```bash
# cat /var/ossec/logs/ossec.log | grep content-updater
2023/12/06 13:47:23 wazuh-modulesd:content-updater: INFO: Starting on-start action for 'vulnerability_feed_manager'
2023/12/06 13:47:23 wazuh-modulesd:content-updater: INFO: Action for 'vulnerability_feed_manager' started
2023/12/06 13:48:02 wazuh-modulesd:content-updater: WARNING: The offsets download has been interrupted
2023/12/06 13:48:02 wazuh-modulesd:content-updater: INFO: Action for 'vulnerability_feed_manager' finished
2023/12/06 13:48:02 wazuh-modulesd:content-updater: INFO: Scheduler stopped for 'vulnerability_feed_manager'
2023/12/06 13:48:17 wazuh-modulesd:content-updater: INFO: Starting on-start action for 'vulnerability_feed_manager'
2023/12/06 13:48:17 wazuh-modulesd:content-updater: INFO: Action for 'vulnerability_feed_manager' started
```