### PR TITLE
Add requests timeouts

### DIFF
--- a/integrations/pagerduty.py
+++ b/integrations/pagerduty.py
@@ -198,7 +198,7 @@ def send_msg(msg: any) -> None:
 
     headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
     url     = 'https://events.pagerduty.com/v2/enqueue'
-    res     = requests.post(url, data=msg, headers=headers)
+    res     = requests.post(url, data=msg, headers=headers, timeout=10)
     debug("# Response received: %s" % res.json)
 
 def get_json_alert(file_location: str) -> any:

--- a/integrations/slack.py
+++ b/integrations/slack.py
@@ -208,7 +208,7 @@ def send_msg(msg: str, url: str) -> None:
             URL of the API.
     """
     headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
-    res     = requests.post(url, data=msg, headers=headers)
+    res     = requests.post(url, data=msg, headers=headers, timeout=10)
     debug("# Response received: %s" % res.json)
 
 def get_json_alert(file_location: str) -> any:

--- a/integrations/tests/test_pagerduty.py
+++ b/integrations/tests/test_pagerduty.py
@@ -156,4 +156,4 @@ def test_send_msg():
    with patch('requests.post', return_value=requests.Response) as request_post:
        pagerduty.send_msg(msg_template)
        url                = 'https://events.pagerduty.com/v2/enqueue'
-       request_post.assert_called_once_with(url, data=msg_template, headers=headers)
+       request_post.assert_called_once_with(url, data=msg_template, headers=headers, timeout=10)

--- a/integrations/tests/test_slack.py
+++ b/integrations/tests/test_slack.py
@@ -150,4 +150,4 @@ def test_send_msg():
     headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
     with patch('requests.post', return_value=requests.Response) as request_post:
         slack.send_msg(msg_template, sys_args_template[3])
-        request_post.assert_called_once_with(sys_args_template[3], data=msg_template, headers=headers)
+        request_post.assert_called_once_with(sys_args_template[3], data=msg_template, headers=headers, timeout=10)

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -391,7 +391,7 @@ def get_log_analytics_events(url: str, body: dict, headers: dict, md5_hash: str)
         If the response for the request is not 200 OK.
     """
     logging.info("Log Analytics: Sending a request to the Log Analytics API.")
-    response = get(url, params=body, headers=headers)
+    response = get(url, params=body, headers=headers, timeout=10)
     if response.status_code == 200:
         try:
             columns = response.json()['tables'][0]['columns']
@@ -563,7 +563,7 @@ def get_graph_events(url: str, headers: dict, md5_hash: str):
     HTTPError
         If the response for the request is not 200 OK.
     """
-    response = get(url=url, headers=headers)
+    response = get(url=url, headers=headers, timeout=10)
 
     if response.status_code == 200:
         response_json = response.json()
@@ -803,7 +803,7 @@ def get_token(client_id: str, secret: str, domain: str, scope: str):
     }
     auth_url = f'{URL_LOGGING}/{domain}/oauth2/v2.0/token'
     try:
-        token_response = post(auth_url, data=body).json()
+        token_response = post(auth_url, data=body, timeout=10).json()
         return token_response['access_token']
     except (ValueError, KeyError):
         if token_response['error'] == 'unauthorized_client':

--- a/wodles/azure/tests/test_azure.py
+++ b/wodles/azure/tests/test_azure.py
@@ -358,7 +358,7 @@ def test_get_log_analytics_events(mock_get, mock_position, mock_iter, mock_updat
     body = "body"
     headers = "headers"
     azure.get_log_analytics_events(url=url, body=body, headers=headers, md5_hash="")
-    mock_get.assert_called_with(url, params=body, headers=headers)
+    mock_get.assert_called_with(url, params=body, headers=headers, timeout=10)
     if rows is None or (len(rows) > 0 and time_position is None):
         mock_logging.assert_called_once()
     elif len(rows) == 0:
@@ -541,7 +541,7 @@ def test_get_graph_events(mock_get, mock_update, mock_send):
 
     headers = "headers"
     azure.get_graph_events(url=url, headers=headers, md5_hash="")
-    mock_get.assert_called_with(url=url, headers=headers)
+    mock_get.assert_called_with(url=url, headers=headers, timeout=10)
     assert mock_update.call_count == num_events
     assert mock_send.call_count == num_events
 
@@ -855,7 +855,7 @@ def test_get_token(mock_post):
     mock_post.return_value = m
     token = azure.get_token(client_id, secret, domain, scope)
     auth_url = f'{azure.URL_LOGGING}/{domain}/oauth2/v2.0/token'
-    mock_post.assert_called_with(auth_url, data=body)
+    mock_post.assert_called_with(auth_url, data=body, timeout=10)
     assert token == expected_token
 
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/20603 |

## Description

Adds timeouts to multiple requests to avoid indefinite hangouts while awaiting a response. 

Tested the slack integration to demonstrate that the changes do not break the functionality of the request calls.

> Pointed to the next patch `4.7.2`.

## Configuration options

```xml
<integration>
  <name>slack</name>
  <hook_url>https://hooks.slack.com/services/XXXX/XXXX/XXXX</hook_url>
  <alert_format>json</alert_format>
</integration>
```

And `integrator.debug=2`  in `/var/ossec/etc/internal_options.conf`.

## Logs/Alerts example

<details><summary>integrations.log</summary>

```console
root@wazuh-master:/# cat /var/ossec/logs/integrations.log
/tmp/slack-xxx--xxx.alert  https://hooks.slack.com/services/XXX/XXX/XXX debug 
# Running Slack script
# JSON file for options  doesn't exist
# Opening options file at '' with 'None'
# Opening alert file at '/tmp/slack-1701797665--1186643439.alert' with '{'timestamp': '2023-12-05T17:34:25.342+0000', 'rule': {'level': 7, 'description': 'Host-based anomaly detection event (rootcheck).', 'id': '510', 'firedtimes': 1, 'mail': False, 'groups': ['ossec', 'rootcheck'], 'pci_dss': ['10.6.1'], 'gdpr': ['IV_35.7.d']}, 'agent': {'id': '000', 'name': 'wazuh-master'}, 'manager': {'name': 'wazuh-master'}, 'id': '1701797665.5141', 'cluster': {'name': 'wazuh', 'node': 'master-node'}, 'full_log': "Trojaned version of file '/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", 'decoder': {'name': 'rootcheck'}, 'data': {'title': 'Trojaned version of file detected.', 'file': '/bin/diff'}, 'location': 'rootcheck'}'
# Generating message
# Sending message {"attachments": [{"color": "warning", "pretext": "WAZUH Alert", "title": "Host-based anomaly detection event (rootcheck).", "text": "Trojaned version of file '/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", "fields": [{"title": "Agent", "value": "(000) - wazuh-master"}, {"title": "Location", "value": "rootcheck"}, {"title": "Rule ID", "value": "510 _(Level 7)_"}], "ts": "1701797665.5141"}]} to Slack server
# Response received: <bound method Response.json of <Response [200]>>/tmp/slack-1701797666-1190480985.alert  https://hooks.slack.com/services/XXX/XXX/XXX debug 

# Running Slack script
# JSON file for options  doesn't exist
# Opening options file at '' with 'None'
# Opening alert file at '/tmp/slack-1701797666-1190480985.alert' with '{'timestamp': '2023-12-05T17:34:25.354+0000', 'rule': {'level': 7, 'description': 'Host-based anomaly detection event (rootcheck).', 'id': '510', 'firedtimes': 2, 'mail': False, 'groups': ['ossec', 'rootcheck'], 'pci_dss': ['10.6.1'], 'gdpr': ['IV_35.7.d']}, 'agent': {'id': '000', 'name': 'wazuh-master'}, 'manager': {'name': 'wazuh-master'}, 'id': '1701797665.5520', 'cluster': {'name': 'wazuh', 'node': 'master-node'}, 'full_log': "Trojaned version of file '/usr/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", 'decoder': {'name': 'rootcheck'}, 'data': {'title': 'Trojaned version of file detected.', 'file': '/usr/bin/diff'}, 'location': 'rootcheck'}'
# Generating message
# Sending message {"attachments": [{"color": "warning", "pretext": "WAZUH Alert", "title": "Host-based anomaly detection event (rootcheck).", "text": "Trojaned version of file '/usr/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\\.h|proc\\.h|/dev/[^n]|^/bin/.*sh' (Generic).", "fields": [{"title": "Agent", "value": "(000) - wazuh-master"}, {"title": "Location", "value": "rootcheck"}, {"title": "Rule ID", "value": "510 _(Level 7)_"}], "ts": "1701797665.5520"}]} to Slack server
# Response received: <bound method Response.json of <Response [200]>>/tmp/slack-1701797677--238681625.alert  https://hooks.slack.com/services/XXX/XXX/XXX debug 

# Running Slack script
# JSON file for options  doesn't exist
# Opening options file at '' with 'None'
# Opening alert file at '/tmp/slack-1701797677--238681625.alert' with '{'timestamp': '2023-12-05T17:34:37.089+0000', 'rule': {'level': 3, 'description': 'Wazuh server started.', 'id': '502', 'firedtimes': 1, 'mail': False, 'groups': ['ossec'], 'pci_dss': ['10.6.1'], 'gpg13': ['10.1'], 'gdpr': ['IV_35.7.d'], 'hipaa': ['164.312.b'], 'nist_800_53': ['AU.6'], 'tsc': ['CC7.2', 'CC7.3']}, 'agent': {'id': '000', 'name': 'wazuh-master'}, 'manager': {'name': 'wazuh-master'}, 'id': '1701797677.5907', 'cluster': {'name': 'wazuh', 'node': 'master-node'}, 'full_log': 'ossec: Manager started.', 'decoder': {'name': 'ossec'}, 'location': 'wazuh-monitord'}'
# Generating message
# Sending message {"attachments": [{"color": "good", "pretext": "WAZUH Alert", "title": "Wazuh server started.", "text": "ossec: Manager started.", "fields": [{"title": "Agent", "value": "(000) - wazuh-master"}, {"title": "Location", "value": "wazuh-monitord"}, {"title": "Rule ID", "value": "502 _(Level 3)_"}], "ts": "1701797677.5907"}]} to Slack server
# Response received: <bound method Response.json of <Response [200]>>
```

</details>

### Tests

Uploading unit tests since they weren't launched right after opening the pull request.

<details><summary>wodles</summary>

```console
(venv) gasti@pop-os:~/work/wazuh$ python3 -m pytest wodles/ --disable-warnings
===================================================================== test session starts ======================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/gasti/work/wazuh
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0, cov-4.1.0
asyncio: mode=auto
collected 278 items                                                                                                                                            

wodles/aws/tests/test_aws.py .......................................                                                                                     [ 14%]
wodles/azure/tests/test_azure.py .....................................................................................................................   [ 56%]
wodles/azure/tests/test_orm.py ...............................                                                                                           [ 67%]
wodles/docker-listener/tests/test_docker_listener.py ...................                                                                                 [ 74%]
wodles/gcloud/tests/test_bucket.py .................................                                                                                     [ 85%]
wodles/gcloud/tests/test_gcloud.py .........                                                                                                             [ 89%]
wodles/gcloud/tests/test_integration.py ........                                                                                                         [ 92%]
wodles/gcloud/tests/test_subscriber.py ..............                                                                                                    [ 97%]
wodles/gcloud/tests/test_tools.py ........                                                                                                               [100%]

=============================================================== 278 passed, 3 warnings in 1.42s ================================================================
```

</details>

<details><summary>integrations</summary>

```console
(venv) gasti@pop-os:~/work/wazuh$ python3 -m pytest integrations/ --disable-warnings
===================================================================== test session starts ======================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/gasti/work/wazuh
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0, cov-4.1.0
asyncio: mode=auto
collected 103 items                                                                                                                                            

integrations/tests/test_maltiverse.py ..............................................                                                                     [ 44%]
integrations/tests/test_pagerduty.py ..........                                                                                                          [ 54%]
integrations/tests/test_shuffle.py ..................                                                                                                    [ 71%]
integrations/tests/test_slack.py ..........                                                                                                              [ 81%]
integrations/tests/test_virustotal.py ...................                                                                                                [100%]

================================================================ 103 passed, 1 warning in 0.24s ================================================================
```

</details>