### PR TITLE
Replace eval calls

### DIFF
--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import re
 import subprocess
@@ -233,7 +234,7 @@ def test_validate_data_dict_field(response, fields_dict):
 
         for element in field_list:
             try:
-                assert (isinstance(element[key], eval(value)) for key, value in dikt.items())
+                assert (isinstance(element[key], ast.literal_eval(value)) for key, value in dikt.items())
             except KeyError:
                 assert len(element) == 1
                 assert isinstance(element['count'], int)
@@ -481,7 +482,7 @@ def check_agent_active_status(agents_list):
             raise subprocess.SubprocessError("Error while trying to get agents") from exc
 
         # Transform string representation of list to list and save agents id
-        id_active_agents = [agent['id'] for agent in eval(output)]
+        id_active_agents = [agent['id'] for agent in ast.literal_eval(output)]
 
         if all(a in id_active_agents for a in agents_list):
             break

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1,6 +1,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import ast
 import asyncio
 import base64
 import contextlib
@@ -1794,7 +1795,7 @@ def as_wazuh_object(dct: Dict):
             return datetime.datetime.fromisoformat(dct['__wazuh_datetime__'])
         elif '__unhandled_exc__' in dct:
             exc_data = dct['__unhandled_exc__']
-            return eval(exc_data['__class__'])(*exc_data['__args__'])
+            return ast.literal_eval(exc_data['__class__'])(*exc_data['__args__'])
         return dct
 
     except (KeyError, AttributeError):


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/20604 |

## Description

Replaces `eval()` with `ast.literal_eval()`.

Differences between `eval()` and `ast.literal_eval()`: https://stackoverflow.com/questions/15197673/using-pythons-eval-vs-ast-literal-eval

"Eval really dangerous" article: https://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html

> Pointed to the next patch `4.7.2`.

## Logs/Alerts example

<details><summary>cluster.log</summary>

```console
root@wazuh-master:/# cat /var/ossec/logs/cluster.log
2023/12/05 18:05:34 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2023/12/05 18:05:34 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2023/12/05 18:05:34 INFO: [Master] [Local integrity] Starting.
2023/12/05 18:05:34 INFO: [Master] [Local agent-groups] Sleeping 30s before starting the agent-groups task, waiting for the workers connection.
2023/12/05 18:05:34 INFO: [Master] [Local integrity] Finished in 0.107s. Calculated metadata of 34 files.
2023/12/05 18:05:35 INFO: [Worker] [Main] Connection from ('172.19.0.5', 43112)
2023/12/05 18:05:42 INFO: [Master] [Local integrity] Starting.
2023/12/05 18:05:42 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 34 files.
2023/12/05 18:05:44 INFO: [Worker worker] [Integrity check] Starting.
2023/12/05 18:05:44 INFO: [Worker worker] [Integrity check] Finished in 0.003s. Received metadata of 33 files. Sync required.
2023/12/05 18:05:44 INFO: [Worker worker] [Integrity sync] Starting.
2023/12/05 18:05:44 INFO: [Worker worker] [Integrity sync] Files to create in worker: 1 | Files to update in worker: 1 | Files to delete in worker: 0
2023/12/05 18:05:44 INFO: [Worker worker] [Integrity sync] Finished in 0.014s.
2023/12/05 18:05:50 INFO: [Master] [Local integrity] Starting.
2023/12/05 18:05:50 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 34 files.
```

</details>

## Tests

<details><summary>Framework core unit tests</summary>

```console

(venv) gasti@pop-os:~/work/wazuh$ python3 -m pytest framework/wazuh/core --disable-warnings
===================================================================== test session starts ======================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/gasti/work/wazuh/framework
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0, cov-4.1.0
asyncio: mode=auto
collected 1207 items                                                                                                                                           

framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                    [  2%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                       [  3%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                   [  6%]
framework/wazuh/core/cluster/tests/test_common.py ....................................................................................                   [ 13%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                [ 14%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............                                                                                   [ 15%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                         [ 17%]
framework/wazuh/core/cluster/tests/test_master.py ...............................................                                                        [ 21%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                          [ 23%]
framework/wazuh/core/cluster/tests/test_utils.py ............                                                                                            [ 24%]
framework/wazuh/core/cluster/tests/test_worker.py ..................................                                                                     [ 27%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                        [ 28%]
framework/wazuh/core/tests/test_agent.py ............................................................................................................... [ 37%]
......................................                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                       [ 44%]
framework/wazuh/core/tests/test_common.py .........                                                                                                      [ 44%]
framework/wazuh/core/tests/test_configuration.py .......................................................................                                 [ 50%]
framework/wazuh/core/tests/test_database.py .............                                                                                                [ 51%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                              [ 53%]
framework/wazuh/core/tests/test_exception.py ..........                                                                                                  [ 54%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                   [ 54%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                            [ 54%]
framework/wazuh/core/tests/test_manager.py ................                                                                                              [ 55%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                   [ 56%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                  [ 57%]
framework/wazuh/core/tests/test_results.py ........................................                                                                      [ 60%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                               [ 61%]
framework/wazuh/core/tests/test_rule.py .......................                                                                                          [ 63%]
framework/wazuh/core/tests/test_sca.py .............................                                                                                     [ 66%]
framework/wazuh/core/tests/test_security.py .............                                                                                                [ 67%]
framework/wazuh/core/tests/test_stats.py .................                                                                                               [ 68%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                      [ 69%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                      [ 69%]
framework/wazuh/core/tests/test_task.py ........                                                                                                         [ 70%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................... [ 79%]
........................................................................................................................................................ [ 91%]
...........                                                                                                                                              [ 92%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                      [ 92%]
framework/wazuh/core/tests/test_wazuh_queue.py .......................                                                                                   [ 94%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                     [ 96%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                   [ 99%]
framework/wazuh/core/tests/test_wlogging.py ............                                                                                                 [100%]

========================================================= 1207 passed, 47 warnings in 13.00s =========================================================
```

</details>

<details><summary>test_default_endpoints.tavern.yaml</summary>

Executed to test `tavern_utils.py` changes

```console
(venv) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_default_endpoints.tavern.yaml
===================================================================== test session starts ======================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-0.13.1 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '0.13.1'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.7.0', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0', 'cov': '4.1.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0, cov-4.1.0
asyncio: mode=auto
collected 1 item                                                                                                                                               

test_default_endpoints.tavern.yaml::GET / PASSED                                                                                                          [100%]

================================================================= 1 passed in 64.07s (0:01:04) =================================================================
```

</details>