### PR TITLE
Ignore index-status if vulnerability scanner is disabled

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -234,6 +234,7 @@ private:
         else
         {
             if (!Utils::parseStrToBool(configuration.at("indexer").at("enabled")) &&
+                Utils::parseStrToBool(configuration.at("vulnerability-detection").at("enabled")) &&
                 Utils::parseStrToBool(configuration.at("vulnerability-detection").at("index-status")))
             {
                 throw std::runtime_error("Indexer cannot be disabled while vulnerability detection index is enabled.");

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
@@ -222,6 +222,7 @@ TEST_F(PolicyManagerTest, validConfigurationCheckParameters)
         m_policyManager->getUpdaterConfiguration().dump().c_str(),
         R"({"configData":{"apiParameters":{"itemsPerRequest":{"name":"limit","value":100},"offset":{"name":"offset","start":0,"step":100}},"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-offset","dataFormat":"json","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"queue/vd_updater/tmp","url":"https://cti-url.com","versionedContent":"cti-api"},"interval":3600,"ondemand":false,"topicName":"vulnerability_feed_manager"})");
 }
+
 TEST_F(PolicyManagerTest, validConfigurationDefaultValues)
 {
     const auto& configJson {nlohmann::json::parse(R"({
@@ -283,4 +284,34 @@ TEST_F(PolicyManagerTest, validConfigurationDefaultValuesNoIndexer)
     EXPECT_EQ(m_policyManager->getFeedUpdateTime(), 3600);
 
     EXPECT_EQ(m_policyManager->getHostList().count("http://localhost:9200"), 0);
+}
+
+TEST_F(PolicyManagerTest, validConfigurationVulnerabilityScannerIgnoreIndexStatus)
+{
+    // If the module is disable, the index-status setting should be ignored.
+    const auto& configJson {nlohmann::json::parse(R"({
+      "vulnerability-detection": {
+        "enabled": "no",
+        "index-status": "yes",
+        "feed-update-interval": "60m",
+        "offline-url": "file:///var/algo.tar.gz",
+        "cti-url": "https://cti-url.com"
+      },
+      "indexer": {
+        "enabled": "no",
+        "hosts": ["http://10.2.20.2:9200", "https://10.2.20.42:9200"],
+        "username": "ImGroot",
+        "password": "MoreSecurePassword123",
+        "api_key": "ABC123",
+        "ssl": {
+          "certificate_authorities": ["/var/ossec/"],
+          "certificate": "cert",
+          "key": "ItsASecret!"
+        }
+      }
+    })")};
+    EXPECT_NO_THROW(m_policyManager->initialize(configJson));
+
+    EXPECT_FALSE(m_policyManager->isVulnerabilityDetectionEnabled());
+    EXPECT_FALSE(m_policyManager->isIndexerEnabled());
 }


### PR DESCRIPTION
|Related issue|
|---|
|#20641|

## Description
Do not consider index-status state if the vulnerabiilty scanner is disabled. 

## Logs/Alerts example

Before 

![2023-12-05_16-17](https://github.com/wazuh/wazuh/assets/13010397/43fb8a93-a4b4-42a2-8ab3-b877358065f6)

After

![image](https://github.com/wazuh/wazuh/assets/13010397/c201157e-77e2-463e-811b-203536433ddb)

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Added unit tests (for new features)
