### PR TITLE
Add AWS WAF Geolocation

### DIFF
--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -65,6 +65,15 @@
     },
     {
       "geoip": {
+        "field": "data.aws.httpRequest.clientIp",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
+      "geoip": {
         "field": "data.gcp.jsonPayload.sourceIP",
         "target_field": "GeoLocation",
         "properties": ["city_name", "country_name", "region_name", "location"],

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -65,6 +65,15 @@
     },
     {
       "geoip": {
+        "field": "data.aws.httpRequest.clientIp",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
+      "geoip": {
         "field": "data.gcp.jsonPayload.sourceIP",
         "target_field": "GeoLocation",
         "properties": ["city_name", "country_name", "region_name", "location"],


### PR DESCRIPTION
|Related issue|
|---|
|#20426 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #20426. Adds geolocation mapping for the AWS WAF events. 

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

To test the functionality apply the changes to the `pipeline.json` and refresh `filebeat setup --pipelines`.


## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

After call the AWS module 

```bash
wodles/aws/aws-s3 -t waf -b wazuh-aws-wodle-waf --debug 2
```

Can see the events geolocated

![image](https://github.com/wazuh/wazuh/assets/7127104/11445782-a31f-4c2b-a0ed-6f404703d218)

![image](https://github.com/wazuh/wazuh/assets/7127104/e8147b0d-be8e-4f9c-8520-451de7b0486f)
