### PR TITLE
Deprecate indexer api_key setting

### DIFF
--- a/src/shared_modules/indexer_connector/testtool/input/config.json
+++ b/src/shared_modules/indexer_connector/testtool/input/config.json
@@ -4,7 +4,6 @@
   "hosts": ["https://0.0.0.0:9200"],
   "username": "admin",
   "password": "admin",
-  "api_key": "",
   "ssl": {
     "certificate_authorities": ["~/root-ca.pem"],
     "certificate": "~/indexer.pem",

--- a/src/unit_tests/config/test_indexer.c
+++ b/src/unit_tests/config/test_indexer.c
@@ -58,7 +58,6 @@ void test_read_full_configuration(void **state) {
         "</hosts>"
         "<username>user</username>"
         "<password>pwd</password>"
-        "<api_key></api_key>"
         "<ssl>"
         "<certificate_authorities>"
             "<ca>/var/ossec/</ca>"
@@ -72,7 +71,7 @@ void test_read_full_configuration(void **state) {
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"api_key\":\"\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
     cJSON_free(json_result);
 }
 
@@ -95,7 +94,6 @@ void test_read_empty_field_configuration(void **state) {
         "</hosts>"
         "<username>user</username>"
         "<password>pwd</password>"
-        "<api_key></api_key>"
         "<ssl>"
         "<certificate_authorities>"
             "<ca>/var/ossec/</ca>"
@@ -109,7 +107,7 @@ void test_read_empty_field_configuration(void **state) {
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"api_key\":\"\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"\"}}");
     cJSON_free(json_result);
 }
 
@@ -120,7 +118,6 @@ void test_read_field_host_0_entries_configuration(void **state) {
         "</hosts>"
         "<username>user</username>"
         "<password>pwd</password>"
-        "<api_key></api_key>"
         "<ssl>"
         "<certificate_authorities>"
             "<ca>/var/ossec/</ca>"
@@ -134,7 +131,7 @@ void test_read_field_host_0_entries_configuration(void **state) {
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[],\"username\":\"user\",\"password\":\"pwd\",\"api_key\":\"\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
     cJSON_free(json_result);
 }
 
@@ -146,7 +143,6 @@ void test_read_field_host_1_entries_configuration(void **state) {
         "</hosts>"
         "<username>user</username>"
         "<password>pwd</password>"
-        "<api_key></api_key>"
         "<ssl>"
         "<certificate_authorities>"
             "<ca>/var/ossec/</ca>"
@@ -160,7 +156,7 @@ void test_read_field_host_1_entries_configuration(void **state) {
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"api_key\":\"\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
     cJSON_free(json_result);
 }
 
@@ -173,7 +169,6 @@ void test_read_field_certificate_authorities_0_entries_configuration(void **stat
         "</hosts>"
         "<username>user</username>"
         "<password>pwd</password>"
-        "<api_key></api_key>"
         "<ssl>"
         "<certificate_authorities>"
         "</certificate_authorities>"
@@ -185,7 +180,7 @@ void test_read_field_certificate_authorities_0_entries_configuration(void **stat
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"api_key\":\"\",\"ssl\":{\"certificate_authorities\":[],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
     cJSON_free(json_result);
 }
 
@@ -198,7 +193,6 @@ void test_read_field_certificate_authorities_1_entries_configuration(void **stat
         "</hosts>"
         "<username>user</username>"
         "<password>pwd</password>"
-        "<api_key></api_key>"
         "<ssl>"
         "<certificate_authorities>"
             "<ca>/var/ossec/</ca>"
@@ -211,7 +205,7 @@ void test_read_field_certificate_authorities_1_entries_configuration(void **stat
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"api_key\":\"\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
     cJSON_free(json_result);
 }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -69,11 +69,6 @@ private:
                 newPolicy["indexer"]["password"] = "";
             }
 
-            if (!newPolicy.at("indexer").contains("api_key"))
-            {
-                newPolicy["indexer"]["api_key"] = "";
-            }
-
             if (!newPolicy.at("indexer").contains("ssl"))
             {
                 newPolicy["indexer"]["ssl"] = nlohmann::json::object();
@@ -106,7 +101,6 @@ private:
             newPolicy["indexer"]["hosts"] = nlohmann::json::array();
             newPolicy["indexer"]["username"] = "";
             newPolicy["indexer"]["password"] = "";
-            newPolicy["indexer"]["api_key"] = "";
             newPolicy["indexer"]["ssl"] = nlohmann::json::object();
             newPolicy["indexer"]["ssl"]["certificate_authorities"] = nlohmann::json::array();
             newPolicy["indexer"]["ssl"]["certificate"] = "";
@@ -497,16 +491,6 @@ public:
     std::string getKey() const
     {
         return m_configuration.at("indexer").at("ssl").at("key").get<std::string>();
-    }
-
-    /**
-     * @brief Get apikey.
-     *
-     * @return std::string apikey.
-     */
-    std::string getApikey() const
-    {
-        return m_configuration.at("indexer").at("api_key").get<std::string>();
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockPolicyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockPolicyManager.hpp
@@ -186,13 +186,6 @@ public:
      * @note This method is intended for testing purposes and does not perform any real action.
      */
     MOCK_METHOD(std::string, getKey, (), (const));
-
-    /**
-     * @brief Mock method for getApikey.
-     *
-     * @note This method is intended for testing purposes and does not perform any real action.
-     */
-    MOCK_METHOD(std::string, getApikey, (), (const));
 };
 
 #endif // _MOCK_POLICYMANAGER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolinePolicyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolinePolicyManager.hpp
@@ -270,16 +270,6 @@ public:
     {
         return spPolicyManagerMock->getKey();
     }
-
-    /**
-     * @brief Get apikey.
-     *
-     * @return std::string apikey.
-     */
-    std::string getApikey() const
-    {
-        return spPolicyManagerMock->getApikey();
-    }
 };
 
 #endif //_TRAMPOLINE_POLICYMANAGER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
@@ -38,7 +38,6 @@ TEST_F(PolicyManagerTest, invalidConfigurationIDWithVD)
         "hosts": ["http://10.2.20.2:9200", "https://10.2.20.42:9200"],
         "username": "user",
         "password": "pwd",
-        "api_key": "",
         "ssl": {
           "certificate_authorities": ["/var/ossec/"],
           "certificate": "cert",
@@ -63,7 +62,6 @@ TEST_F(PolicyManagerTest, invalidConfigurationURLFeed)
         "hosts": ["http://10.2.20.2:9200", "https://10.2.20.42:9200"],
         "username": "user",
         "password": "pwd",
-        "api_key": "",
         "ssl": {
           "certificate_authorities": ["/var/ossec/"],
           "certificate": "cert",
@@ -88,7 +86,6 @@ TEST_F(PolicyManagerTest, invalidConfigurationNegativeTime)
         "hosts": ["http://10.2.20.2:9200", "https://10.2.20.42:9200"],
         "username": "user",
         "password": "pwd",
-        "api_key": "",
         "ssl": {
           "certificate_authorities": ["/var/ossec/"],
           "certificate": "cert",
@@ -113,7 +110,6 @@ TEST_F(PolicyManagerTest, invalidConfigurationIDWithTypo)
         "hosts": ["http://10.2.20.2:9200", "https://10.2.20.42:9200"],
         "username": "user",
         "password": "pwd",
-        "api_key": "",
         "ssl": {
           "certificate_authorities": ["/var/ossec/"],
           "certificate": "cert",
@@ -138,7 +134,6 @@ TEST_F(PolicyManagerTest, invalidConfigurationVDWithTypo)
         "hosts": ["http://10.2.20.2:9200", "https://10.2.20.42:9200"],
         "username": "user",
         "password": "pwd",
-        "api_key": "",
         "ssl": {
           "certificate_authorities": ["/var/ossec/"],
           "certificate": "cert",
@@ -163,7 +158,6 @@ TEST_F(PolicyManagerTest, invalidConfigurationVDWithoutIDStatus)
         "hosts": ["http://10.2.20.2:9200", "https://10.2.20.42:9200"],
         "username": "user",
         "password": "pwd",
-        "api_key": "",
         "ssl": {
           "certificate_authorities": ["/var/ossec/"],
           "certificate": "cert",
@@ -189,7 +183,6 @@ TEST_F(PolicyManagerTest, validConfigurationCheckParameters)
         "hosts": ["http://10.2.20.2:9200", "https://10.2.20.42:9200"],
         "username": "ImGroot",
         "password": "MoreSecurePassword123",
-        "api_key": "ABC123",
         "ssl": {
           "certificate_authorities": ["/var/ossec/"],
           "certificate": "cert",
@@ -210,7 +203,6 @@ TEST_F(PolicyManagerTest, validConfigurationCheckParameters)
 
     EXPECT_STREQ(m_policyManager->getUsername().c_str(), "ImGroot");
     EXPECT_STREQ(m_policyManager->getPassword().c_str(), "MoreSecurePassword123");
-    EXPECT_STREQ(m_policyManager->getApikey().c_str(), "ABC123");
 
     EXPECT_EQ(m_policyManager->getCAList().count("/var/ossec/"), 1);
 
@@ -246,7 +238,6 @@ TEST_F(PolicyManagerTest, validConfigurationDefaultValues)
 
     EXPECT_STREQ(m_policyManager->getUsername().c_str(), "");
     EXPECT_STREQ(m_policyManager->getPassword().c_str(), "");
-    EXPECT_STREQ(m_policyManager->getApikey().c_str(), "");
     EXPECT_STREQ(m_policyManager->getCertificate().c_str(), "");
     EXPECT_STREQ(m_policyManager->getKey().c_str(), "");
     EXPECT_EQ(m_policyManager->getCAList().size(), 0);


### PR DESCRIPTION
|Related issue|
|---|
|#20642|

## Description

This PR deprecates the `api_key` option for indexer configuration.

## Indexer config tests 

![2023-12-06_16-09](https://github.com/wazuh/wazuh/assets/13010397/251f51a6-db34-4a08-8e33-36f10da3a24f)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux