### PR TITLE
Validate the format of the IP in host deny script

### DIFF
--- a/src/active-response/host-deny.c
+++ b/src/active-response/host-deny.c
@@ -65,7 +65,7 @@ int main (int argc, char **argv) {
         }
     }
 
-    if (!strstr(srcip, ".") && !strstr(srcip, ":")) {
+    if (get_ip_version(srcip) == OS_INVALID) {
         memset(log_msg, '\0', OS_MAXSTR);
         snprintf(log_msg, OS_MAXSTR -1, "Unable to run active response (invalid IP: '%s')", srcip);
         write_debug_file(argv[0], log_msg);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/internal-devel-requests/issues/535|

## Description

This PR validates the version of the IP used in the host deny AR.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade