### PR TITLE
Fix parsing of AWS regions argument

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3860,7 +3860,7 @@ def arg_valid_regions(arg_string):
     final_regions = []
     regions = arg_string.split(',')
     for arg_region in regions:
-        if not re.match(r'^([a-z]{2}(-gov)?)-([a-z]{4,7})-\d$', arg_region):
+        if not re.match(r'^([a-z]{2}(-gov)?)-([a-z]+)-\d$', arg_region):
             raise argparse.ArgumentTypeError(
                 f"WARNING: The region '{arg_region}' has not a valid format.'"
             )

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -105,10 +105,12 @@ RETRY_MODE_CONFIG_KEY: str = "retry_mode"
 RETRY_MODE_BOTO_KEY: str = "mode"
 
 
-ALL_REGIONS = [
-    'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2', 'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-2',
-    'ap-south-1', 'eu-central-1', 'eu-west-1'
-]
+ALL_REGIONS = (
+    'af-south-1', 'ap-east-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3', 'ap-south-1', 'ap-south-2',
+    'ap-southeast-1', 'ap-southeast-2', 'ap-southeast-3', 'ap-southeast-4', 'ca-central-1', 'eu-central-1',
+    'eu-central-2', 'eu-north-1', 'eu-south-1', 'eu-south-2', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'il-central-1',
+    'me-central-1', 'me-south-1', 'sa-east-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'
+)
 
 
 ################################################################################
@@ -174,14 +176,14 @@ def set_profile_dict_config(boto_config: dict, profile: str, profile_config: dic
 
 def remove_prefix(text: str, prefix: str) -> str:
     """Removes the prefix from the text if it exists. Otherwise, it returns the text unchanged.
-    
+
     Parameters
     ----------
     text : str
         Text to remove the prefix from.
-    prefix : str    
+    prefix : str
         Prefix to be removed.
-    
+
     Returns
     -------
     str


### PR DESCRIPTION
|Related issue|
|---|
|#20539|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #20539. Extends the list of the [AWS regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions). Also, fixes the regex used in the validation for the `--regions` parameter.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

I can't use the region from the example, `ap-south-2`, because our account didn't have it enabled

```bash
root@wazuh-master:/var/ossec# framework/python/bin/python3  wodles/aws/aws_s3.py -sr cloudwatchlogs -r ap-south-2 -g test-log-group -d 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Getting alerts from "ap-south-2" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: only logs: None
DEBUG: Getting log streams for "test-log-group" log group
DEBUG: ERROR: The "get_log_streams" request failed: An error occurred (UnrecognizedClientException) when calling the DescribeLogStreams operation: The security token included in the request is invalid.
DEBUG: committing changes and closing the DB
```

But, I tried with a new one, and it works correctly

```bash
root@wazuh-master:/var/ossec# framework/python/bin/python3  wodles/aws/aws_s3.py -sr cloudwatchlogs -r ap-northeast-3 -g test-log-group -d 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Getting alerts from "ap-northeast-3" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: only logs: None
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "test-log-group" log group
DEBUG: Found "test" log stream in test-log-group
DEBUG: Getting data from DB for log stream "test" in log group "test-log-group"
DEBUG: Token: "None", start_time: "None", end_time: "None"
DEBUG: Getting CloudWatch logs from log stream "test" in log group "test-log-group" using token "None", start_time "1701820800000" and end_time "None"
DEBUG: +++ Sending events to Analysisd...
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "Test event 1"
DEBUG: +++ Sent 1 events to Analysisd
DEBUG: Getting CloudWatch logs from log stream "test" in log group "test-log-group" using token "f/37953088820709603560681594624346263441235027635793035264/s", start_time "1701820800000" and end_time "None"
DEBUG: +++ Sending events to Analysisd...
DEBUG: +++ There are no new events in the "test-log-group" group
DEBUG: Saving data for log group "test-log-group" and log stream "test".
DEBUG: The saved values are "{'token': 'f/37953089655058534043849622461120902693561539738332004351/s', 'start_time': 1701820800000, 'end_time': 1701875362587}"
DEBUG: Purging the BD
DEBUG: Getting log streams for "test-log-group" log group
DEBUG: Found "test" log stream in test-log-group
DEBUG: committing changes and closing the DB
```

Also, the buckets run without problem

```bash
root@wazuh-master:/var/ossec# framework/python/bin/python3  wodles/aws/aws_s3.py -t cloudtrail -b wazuh-aws-wodle-cloudtrail -r ap-south-2  -d 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on xxxx - ap-south-2
DEBUG: +++ Marker: AWSLogs/xxxx/CloudTrail/ap-south-2/2023/12/06
DEBUG: +++ No logs to process in bucket: xxxx/ap-south-2
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxxx - ap-south-2
DEBUG: +++ Marker: AWSLogs/xxxx/CloudTrail/ap-south-2/2023/12/06
DEBUG: +++ No logs to process in bucket: xxxx/ap-south-2
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxxx - ap-south-2
DEBUG: +++ Marker: AWSLogs/xxxx/CloudTrail/ap-south-2/2023/12/06
DEBUG: +++ No logs to process in bucket: xxxx/ap-south-2
DEBUG: +++ DB Maintenance
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

Integration tests for the `region` parameter

```bash
root@ubuntu-jammy:/home/vagrant/wazuh-qa# pytest --disable-warnings tests/integration/test_aws/ -k region -x
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-2.0.4, html-3.1.1, testinfra-5.0.0
collected 198 items / 170 deselected / 28 selected

tests/integration/test_aws/test_parser.py ....                                                                                                                                                                [ 14%]
tests/integration/test_aws/test_regions.py ........................                                                                                                                                           [100%]

============================================================================ 28 passed, 170 deselected, 6 warnings in 606.05s (0:10:06) =============================================================================
```
