### PR TITLE
Add a stop mechanism for databaseFeedManager module

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -94,10 +94,12 @@ public:
      * @param message Message received by the router.
      * @param orchestration Chain of actions to execute for each valid resource extracted from the message.
      * @param databaseCleanup Database cleanup function to execute if message type is raw.
+     * @param shouldStop Variable to control the stop of the processing operations.
      */
     void static processMessage(const std::vector<char>& message,
                                const std::function<void(const nlohmann::json&)>& orchestration,
-                               const std::function<void(void)>& databaseCleanup)
+                               const std::function<void(void)>& databaseCleanup,
+                               const std::atomic<bool>& shouldStop)
     {
         auto parsedMessage = nlohmann::json::parse(message, nullptr, false);
 
@@ -109,13 +111,17 @@ public:
         if (parsedMessage.at("type") == "offset")
         {
             auto jsonPointer {"/data"_json_pointer};
-            auto callbackSAXParser {[orchestration](nlohmann::json&& item)
+            auto callbackSAXParser {[&](nlohmann::json&& item)
                                     {
                                         orchestration(item);
-                                        return true;
+                                        return !shouldStop.load();
                                     }};
             for (const auto& path : parsedMessage.at("paths"))
             {
+                if (shouldStop.load())
+                {
+                    break;
+                }
                 logInfo(WM_VULNSCAN_LOGTAG, "Processing file: %s", path.get_ref<const std::string&>().c_str());
                 JsonArray::parse(path, callbackSAXParser, jsonPointer);
             }
@@ -141,6 +147,11 @@ public:
                 std::string line;
                 while (std::getline(file, line))
                 {
+                    if (shouldStop.load())
+                    {
+                        break;
+                    }
+
                     nlohmann::json parsedLine = nlohmann::json::parse(line, nullptr, false);
                     if (parsedLine.is_discarded() || !parsedLine.contains("name"))
                     {
@@ -180,13 +191,17 @@ public:
      * @brief Class constructor.
      *
      * @param indexerConnector Indexer connector.
+     * @param shouldStop Variable to control the graceful shutdown of the module.
      * @param isLocalSubscriber Configures the router subscription lambda execution as local or remote.
      */
     // TODO: Remove LCOV flags once the implementation of the 'Indexer Connector' module is completed
     // LCOV_EXCL_START
-    explicit TDatabaseFeedManager(std::shared_ptr<TIndexerConnector> indexerConnector, bool isLocalSubscriber = true)
+    explicit TDatabaseFeedManager(std::shared_ptr<TIndexerConnector> indexerConnector,
+                                  const std::atomic<bool>& shouldStop,
+                                  bool isLocalSubscriber = true)
         : Observer("database_feed_manager")
         , m_indexerConnector(indexerConnector)
+        , m_shouldStop(shouldStop)
     {
         const auto updaterPolicy = TPolicyManager::instance().getUpdaterConfiguration();
         const std::string topic_name = updaterPolicy.at("topicName");
@@ -236,7 +251,8 @@ public:
                 try
                 {
                     logInfo(WM_VULNSCAN_LOGTAG, "Processing message");
-                    TMessageProcessor::processMessage(message, orchestrationLambda, databaseCleanupLambda);
+                    TMessageProcessor::processMessage(
+                        message, orchestrationLambda, databaseCleanupLambda, m_shouldStop);
                     logInfo(WM_VULNSCAN_LOGTAG, "Message processed");
 
                     // Compact the database
@@ -509,6 +525,7 @@ private:
     std::unique_ptr<Utils::RocksDBWrapper> m_cvesDatabase;
     std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>> m_feedsDatabases;
     std::unique_ptr<TRouterSubscriber> m_contentUpdateSubscription;
+    const std::atomic<bool>& m_shouldStop;
 };
 
 using DatabaseFeedManager = TDatabaseFeedManager<>;

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -58,7 +58,7 @@ void VulnerabilityScannerFacade::start(
         }
 
         // Database feed manager initialization.
-        m_databaseFeedManager = std::make_shared<DatabaseFeedManager>(m_indexerConnector);
+        m_databaseFeedManager = std::make_shared<DatabaseFeedManager>(m_indexerConnector, m_shouldStop);
 
         // Socket client initialization to send vulnerability reports.
         if (configuration.contains("wm_max_eps") && configuration.at("wm_max_eps").is_number())
@@ -114,6 +114,7 @@ void VulnerabilityScannerFacade::start(
 
 void VulnerabilityScannerFacade::stop()
 {
+    m_shouldStop.store(true);
     m_indexerConnector.reset();
     m_databaseFeedManager.reset();
     m_syscollectorRsyncSubscription.reset();

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -20,6 +20,7 @@
 #include "scanOrchestrator/scanOrchestrator.hpp"
 #include "singleton.hpp"
 #include "socketClient.hpp"
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <string>
@@ -57,6 +58,7 @@ private:
     std::shared_ptr<DatabaseFeedManager> m_databaseFeedManager;
     std::shared_ptr<IndexerConnector> m_indexerConnector;
     std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> m_reportSocketClient;
+    std::atomic<bool> m_shouldStop {false};
 };
 
 #endif // _VULNERABILITY_SCANNER_FACADE_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/component/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/component/databaseFeedManager_test.cpp
@@ -22,9 +22,10 @@ TEST_F(DatabaseFeedManagerTest, TestInstantiationOfTheDatabaseFeedManagerClass)
     // TODO: Remove GTEST_SKIP and add EXPECTS once the implementation of the 'Indexer Connector' module is completed
     GTEST_SKIP();
     std::shared_ptr<IndexerConnector> indexerConnector;
+    std::atomic<bool> shouldStop {false};
 
     // Instantiation of the DatabaseFeedManager class.
-    EXPECT_NO_THROW(std::make_shared<DatabaseFeedManager>(indexerConnector));
+    EXPECT_NO_THROW(std::make_shared<DatabaseFeedManager>(indexerConnector, shouldStop));
 }
 
 /*
@@ -37,9 +38,10 @@ TEST_F(DatabaseFeedManagerTest, TestUpdateOfTheDatabaseFeedManagerClass)
     std::shared_ptr<IndexerConnector> indexerConnector;
     std::shared_ptr<DatabaseFeedManager> databaseFeedManager;
     nlohmann::json data;
+    std::atomic<bool> shouldStop {false};
 
     // Instantiation of the DatabaseFeedManager class.
-    EXPECT_NO_THROW(databaseFeedManager = std::make_shared<DatabaseFeedManager>(indexerConnector));
+    EXPECT_NO_THROW(databaseFeedManager = std::make_shared<DatabaseFeedManager>(indexerConnector, shouldStop));
 
     EXPECT_NO_THROW(databaseFeedManager->update(data));
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -934,7 +934,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidJson)
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2);
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -956,10 +956,11 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestNoType)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2);
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -981,6 +982,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidType)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
     try
     {
@@ -1243,7 +1245,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithDataSuccess)
 
 TEST_F(DatabaseFeedManagerMessageProcessorTest, TestProcessingStop)
 {
-    std::string stdMessage = R"({"paths":["file5.json"]})";
+    std::string stdMessage = R"({"paths":["file5.json"], "type" : "offset"})";
     std::vector<char> message = std::vector<char>(stdMessage.begin(), stdMessage.end());
     int totalElements {50};
     int waitTimePerElement {10};

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -22,6 +22,7 @@
 #include "flatbuffers/idl.h"
 #include "routerModule.hpp"
 #include "routerProvider.hpp"
+#include <atomic>
 #include <filesystem>
 #include <string_view>
 
@@ -181,12 +182,13 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
     }
 
     auto spTrampolineIndexerConnector = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(spTrampolineIndexerConnector)};
+                                              TrampolineRouterSubscriber>>(spTrampolineIndexerConnector, shouldStop)};
 
     FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
@@ -232,12 +234,13 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
     }
 
     auto spTrampolineIndexerConnector = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(spTrampolineIndexerConnector)};
+                                              TrampolineRouterSubscriber>>(spTrampolineIndexerConnector, shouldStop)};
 
     FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
@@ -270,12 +273,13 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
     }
 
     auto spTrampolineIndexerConnector = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(spTrampolineIndexerConnector)};
+                                              TrampolineRouterSubscriber>>(spTrampolineIndexerConnector, shouldStop)};
 
     FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
@@ -299,12 +303,13 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesSuccess)
     EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto pDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(pIndexerConnectorTrap)};
+                                              TrampolineRouterSubscriber>>(pIndexerConnectorTrap, shouldStop)};
 
     std::vector<std::string> cves;
 
@@ -340,12 +345,13 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesNoPackageName)
     EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto pDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(pIndexerConnectorTrap)};
+                                              TrampolineRouterSubscriber>>(pIndexerConnectorTrap, shouldStop)};
 
     EXPECT_ANY_THROW({
         pDatabaseFeedManager->getVulnerabilitiesCandidates(
@@ -391,12 +397,13 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_ValidData)
     }
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp)};
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp, shouldStop)};
 
     // Variables setup
     std::string cveId {"CVE-2023-2609"};
@@ -426,12 +433,13 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_DataNotFound)
     EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp)};
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp, shouldStop)};
 
     // Variables setup
     std::string cveId {"CVE-2023-5678"};
@@ -469,12 +477,13 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_InvalidData)
     }
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp)};
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp, shouldStop)};
 
     // Variables setup
     std::string cveId {"CVE-2023-2609"};
@@ -520,12 +529,13 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheMiss)
     }
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp)};
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp, shouldStop)};
 
     // Variables setup
     std::string packageName {"Apache Tomcat.GenericVersion"};
@@ -600,12 +610,13 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheHit)
     }
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp)};
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp, shouldStop)};
 
     // Variables setup
     std::string packageName {"Apache Tomcat.GenericVersion"};
@@ -707,12 +718,13 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationNoTranslationFound)
     }
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp)};
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp, shouldStop)};
 
     // Variables setup
     std::string packageName {"SQLite3"};
@@ -777,12 +789,13 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationInvalidDatabase)
     }
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
 
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
-                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp)};
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp, shouldStop)};
 
     // Variables setup
     std::string packageName {"Apache Tomcat.GenericVersion"};
@@ -888,10 +901,11 @@ void DatabaseFeedManagerTest_GracefulShutdown()
 
     const auto routerMessagePayload = routerMessageJson.dump();
     const auto routerMessage = std::vector<char>(routerMessagePayload.begin(), routerMessagePayload.end());
+    std::atomic<bool> shouldStop {false};
 
     auto spDatabaseFeedManager {std::make_shared<
         TDatabaseFeedManager<TrampolineIndexerConnector, TrampolinePolicyManager, TrampolineContentRegister>>(
-        spIndexerConnectorTramp)};
+        spIndexerConnectorTramp, shouldStop)};
 
     routerProvider->send(routerMessage);
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -916,6 +930,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidJson)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
     try
     {
@@ -969,7 +984,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidType)
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2);
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -991,10 +1006,11 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestNoPaths)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2);
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1016,10 +1032,11 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithInvalidJson)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2);
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop);
         FAIL() << "Expected parse_error exception";
     }
     catch (const nlohmann::detail::parse_error& e)
@@ -1043,10 +1060,11 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithNoData)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2);
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1070,10 +1088,11 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithDataAndExcepti
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2);
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1095,8 +1114,10 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithDataSuccess)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
-    EXPECT_NO_THROW(DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2));
+    EXPECT_NO_THROW(
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop));
 }
 
 TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithUnexistingFile)
@@ -1108,10 +1129,11 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithUnexistingFile)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2);
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1133,10 +1155,11 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithInvalidLine)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2);
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop);
         FAIL() << "Expected parse_error exception";
     }
     catch (const std::runtime_error& e)
@@ -1158,10 +1181,11 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileLineWithNoName)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2);
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1185,10 +1209,11 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithDataAndException)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2);
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1210,6 +1235,55 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithDataSuccess)
     };
     auto testingLambda2 = []() {
     };
+    std::atomic<bool> shouldStop {false};
 
-    EXPECT_NO_THROW(DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2));
+    EXPECT_NO_THROW(
+        DatabaseFeedManagerMessageProcessor::processMessage(message, testingLambda1, testingLambda2, shouldStop));
+}
+
+TEST_F(DatabaseFeedManagerMessageProcessorTest, TestProcessingStop)
+{
+    std::string stdMessage = R"({"paths":["file5.json"]})";
+    std::vector<char> message = std::vector<char>(stdMessage.begin(), stdMessage.end());
+    int totalElements {50};
+    int waitTimePerElement {10};
+
+    auto fileData = R"({"data": []})"_json;
+    for (auto i = 0; i < totalElements; i++)
+    {
+        fileData["data"].push_back("element" + std::to_string(i));
+    }
+
+    {
+        std::ofstream file5 {"file5.json"};
+        file5 << fileData.dump();
+    }
+    int counter {0};
+
+    auto testingLambda1 = [&](const nlohmann::json& obj)
+    {
+        ++counter;
+        std::this_thread::sleep_for(std::chrono::milliseconds(waitTimePerElement));
+    };
+    auto testingLambda2 = []() {
+    };
+    std::atomic<bool> shouldStop {false};
+
+    auto processingThread = std::thread {DatabaseFeedManagerMessageProcessor::processMessage,
+                                         message,
+                                         testingLambda1,
+                                         testingLambda2,
+                                         std::ref(shouldStop)};
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(waitTimePerElement * totalElements * 0.5)));
+    shouldStop.store(true);
+
+    if (processingThread.joinable())
+    {
+        processingThread.join();
+    }
+
+    std::remove("file5.json");
+
+    EXPECT_LT(counter, totalElements);
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20584 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR adds a stop mechanism to the vulnerability scanner module. More precisely, the `databaseFeedManager` has a loop that now can be stopped.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

An UT was added to confirm the feature.
The test over the environment was performed by @tsarquis88 .

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

- [x] Added unit tests (for new features)
