### PR TITLE
Update mappings for 'wazuh-states-vulnerabilities' index

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
@@ -18,9 +18,6 @@
           "base.tags",
           "agent.id",
           "ecs.version",
-          "event.id",
-          "event.module",
-          "event.severity",
           "host.os.family",
           "host.os.full.text",
           "host.os.version",
@@ -28,7 +25,8 @@
           "package.version",
           "vulnerability.id",
           "vulnerability.description.text",
-          "vulnerability.severity"
+          "vulnerability.severity",
+          "wazuh.cluster.name"
         ],
         "refresh_interval": "2s"
       }
@@ -85,106 +83,6 @@
         "ecs": {
           "properties": {
             "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "event": {
-          "properties": {
-            "action": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "agent_id_status": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "category": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "code": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "created": {
-              "type": "date"
-            },
-            "dataset": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "duration": {
-              "type": "long"
-            },
-            "end": {
-              "type": "date"
-            },
-            "hash": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "ingested": {
-              "type": "date"
-            },
-            "kind": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "module": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "original": {
-              "doc_values": false,
-              "index": false,
-              "type": "keyword"
-            },
-            "outcome": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "provider": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "reason": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "reference": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "risk_score": {
-              "type": "float"
-            },
-            "risk_score_norm": {
-              "type": "float"
-            },
-            "sequence": {
-              "type": "long"
-            },
-            "severity": {
-              "type": "long"
-            },
-            "start": {
-              "type": "date"
-            },
-            "timezone": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "url": {
               "ignore_above": 1024,
               "type": "keyword"
             }
@@ -363,6 +261,18 @@
             "severity": {
               "ignore_above": 1024,
               "type": "keyword"
+            }
+          }
+        },
+        "wazuh": {
+          "properties": {
+            "cluster": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
|Related issue|
|---|
| #14153, https://github.com/wazuh/wazuh-indexer/issues/73|

## Description

This PR updates the mappings of the vulnerability detector index (`wazuh-states-vulnerability`) to:

* Remove `events` ECS field.
* Create `wazuh` custom field, with `cluster.name` keyword property. 

Use this command to upload the template (change the name of the template as desired):

```bash
curl -u admin:admin -k -X PUT "https://localhost:9200/_index_template/wazuh-vulnerability-detector" -H "Content-Type: application/json" -d @legacy-template.json
```


![image](https://github.com/wazuh/wazuh-indexer/assets/15186973/34626be4-deeb-4637-a8d4-ffabdb54df4a)

