### PR TITLE
Check for input data sanitization at Eventchannel decoder

### DIFF
--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -143,22 +143,19 @@ int DecodeWinevt(Eventinfo *lf){
             }
         } else {
             node = OS_GetElementsbyNode(&xml, NULL);
-            int i = 0, l = 0;
-            if (node && node[i] && (child = OS_GetElementsbyNode(&xml, node[i]))) {
-                int j = 0;
 
-                while (child && child[j]){
+            if (node && node[0] && (child = OS_GetElementsbyNode(&xml, node[0]))) {
+                for (int j = 0; child && child[j]; j++){
 
                     XML_NODE child_attr = NULL;
                     child_attr = OS_GetElementsbyNode(&xml, child[j]);
-                    int p = 0;
 
-                    while (child_attr && child_attr[p]){
+                    for (int p = 0; child_attr && child_attr[p]; p++) {
 
                         if(child[j]->element && !strcmp(child[j]->element, "System") && child_attr[p]->element){
 
                             if (!strcmp(child_attr[p]->element, "Provider")) {
-                                while(child_attr[p]->attributes[l]){
+                                for (int l = 0; child_attr[p]->attributes[l]; l++) {
                                     if (!strcmp(child_attr[p]->attributes[l], "Name")){
                                         cJSON_AddStringToObject(json_system_in, "providerName", child_attr[p]->values[l]);
                                     } else if (!strcmp(child_attr[p]->attributes[l], "Guid")){
@@ -166,7 +163,6 @@ int DecodeWinevt(Eventinfo *lf){
                                     } else if (!strcmp(child_attr[p]->attributes[l], "EventSourceName")){
                                         cJSON_AddStringToObject(json_system_in, "eventSourceName", child_attr[p]->values[l]);
                                     }
-                                    l++;
                                 }
                             } else if (!strcmp(child_attr[p]->element, "TimeCreated")) {
                                 if(!strcmp(child_attr[p]->attributes[0], "SystemTime")){
@@ -209,7 +205,7 @@ int DecodeWinevt(Eventinfo *lf){
                             }
                         } else if (child[j]->element && !strcmp(child[j]->element, "EventData") && child_attr[p]->element){
                             if (!strcmp(child_attr[p]->element, "Data") && child_attr[p]->values && strlen(child_attr[p]->content) > 0){
-                                for (l = 0; child_attr[p]->attributes[l]; l++) {
+                                for (int l = 0; child_attr[p]->attributes[l]; l++) {
                                     if (!strcmp(child_attr[p]->attributes[l], "Name") && strcmp(child_attr[p]->content, "(NULL)") != 0
                                             && strcmp(child_attr[p]->content, "-") != 0) {
                                         filtered_string = replace_win_format(child_attr[p]->content, 0);
@@ -302,12 +298,9 @@ int DecodeWinevt(Eventinfo *lf){
                             }
                             OS_ClearNode(extra_data_child);
                         }
-                        p++;
                     }
 
                     OS_ClearNode(child_attr);
-
-                    j++;
                 }
 
                 OS_ClearNode(child);
@@ -628,14 +621,13 @@ int DecodeWinevt(Eventinfo *lf){
                 char **audit_split;
                 char *audit_pol_changes = NULL;
                 char *audit_final_field = NULL;
-                int i = 0;
 
                 char * filtered_changes = wstr_replace(auditPolicyChangesId, "%%", "");
                 os_free(auditPolicyChangesId);
 
                 audit_split = OS_StrBreak(',', filtered_changes, 4);
 
-                while (audit_split[i]) {
+                for (int i = 0; audit_split[i]; i++) {
                     audit_split_n = strtol(audit_split[i], NULL, 10);
 
                     switch (audit_split_n) {
@@ -654,8 +646,6 @@ int DecodeWinevt(Eventinfo *lf){
                         default:
                             break;
                     }
-
-                    i++;
                 }
                 audit_final_field = wstr_replace(audit_pol_changes, ",", ", ");
                 cJSON_AddStringToObject(json_eventdata_in, "auditPolicyChanges", audit_final_field);

--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -168,12 +168,14 @@ int DecodeWinevt(Eventinfo *lf){
                                 if(!strcmp(child_attr[p]->attributes[0], "SystemTime")){
                                     cJSON_AddStringToObject(json_system_in, "systemTime", child_attr[p]->values[0]);
                                 }
-                            } else if (!strcmp(child_attr[p]->element, "Execution")) {
-                                if(!strcmp(child_attr[p]->attributes[0], "ProcessID")){
-                                    cJSON_AddStringToObject(json_system_in, "processID", child_attr[p]->values[0]);
-                                }
-                                if(!strcmp(child_attr[p]->attributes[1], "ThreadID")){
-                                    cJSON_AddStringToObject(json_system_in, "threadID", child_attr[p]->values[1]);
+                            } else if (!strcmp(child_attr[p]->element, "Execution") && child_attr[p]->attributes != NULL) {
+                                for (int l = 0; child_attr[p]->attributes[l]; l++) {
+                                    if (!strcmp(child_attr[p]->attributes[l], "ProcessID")){
+                                        cJSON_AddStringToObject(json_system_in, "processID", child_attr[p]->values[l]);
+                                    }
+                                    if (!strcmp(child_attr[p]->attributes[l], "ThreadID")){
+                                        cJSON_AddStringToObject(json_system_in, "threadID", child_attr[p]->values[l]);
+                                    }
                                 }
                             } else if (!strcmp(child_attr[p]->element, "Channel")) {
                                 cJSON_AddStringToObject(json_system_in, "channel", child_attr[p]->content);

--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -154,7 +154,7 @@ int DecodeWinevt(Eventinfo *lf){
 
                         if(child[j]->element && !strcmp(child[j]->element, "System") && child_attr[p]->element){
 
-                            if (!strcmp(child_attr[p]->element, "Provider")) {
+                            if (!strcmp(child_attr[p]->element, "Provider") && child_attr[p]->attributes != NULL) {
                                 for (int l = 0; child_attr[p]->attributes[l]; l++) {
                                     if (!strcmp(child_attr[p]->attributes[l], "Name")){
                                         cJSON_AddStringToObject(json_system_in, "providerName", child_attr[p]->values[l]);

--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -173,7 +173,7 @@ int DecodeWinevt(Eventinfo *lf){
                                     if (!strcmp(child_attr[p]->attributes[l], "ProcessID")){
                                         cJSON_AddStringToObject(json_system_in, "processID", child_attr[p]->values[l]);
                                     }
-                                    if (!strcmp(child_attr[p]->attributes[l], "ThreadID")){
+                                    else if (!strcmp(child_attr[p]->attributes[l], "ThreadID")){
                                         cJSON_AddStringToObject(json_system_in, "threadID", child_attr[p]->values[l]);
                                     }
                                 }
@@ -188,14 +188,14 @@ int DecodeWinevt(Eventinfo *lf){
                                 }
                             } else if (!strcmp(child_attr[p]->element, "Level")) {
                                 if (level){
-                                    os_free(level);
+                                    free(level);
                                 }
                                 os_strdup(child_attr[p]->content, level);
                                 *child_attr[p]->element = tolower(*child_attr[p]->element);
                                 cJSON_AddStringToObject(json_system_in, child_attr[p]->element, child_attr[p]->content);
                             } else if (!strcmp(child_attr[p]->element, "Keywords")) {
                                 if (keywords){
-                                    os_free(keywords);
+                                    free(keywords);
                                 }
                                 os_strdup(child_attr[p]->content, keywords);
                                 *child_attr[p]->element = tolower(*child_attr[p]->element);
@@ -216,14 +216,14 @@ int DecodeWinevt(Eventinfo *lf){
                                         // Save category ID
                                         if (!strcmp(child_attr[p]->values[l], "categoryId")){
                                             if (categoryId){
-                                                os_free(categoryId);
+                                                free(categoryId);
                                             }
                                             os_strdup(filtered_string, categoryId);
 
                                         // Save subcategory ID
                                         } else if (!strcmp(child_attr[p]->values[l], "subcategoryId")){
                                             if (subcategoryId){
-                                                os_free(subcategoryId);
+                                                free(subcategoryId);
                                             }
                                             os_strdup(filtered_string, subcategoryId);
                                         }
@@ -231,7 +231,7 @@ int DecodeWinevt(Eventinfo *lf){
                                         // Save Audit Policy Changes
                                         if (!strcmp(child_attr[p]->values[l], "auditPolicyChanges")){
                                             if (auditPolicyChangesId){
-                                                os_free(auditPolicyChangesId);
+                                                free(auditPolicyChangesId);
                                             }
                                             os_strdup(filtered_string, auditPolicyChangesId);
                                             cJSON_AddStringToObject(json_eventdata_in, "auditPolicyChangesId", filtered_string);
@@ -262,7 +262,7 @@ int DecodeWinevt(Eventinfo *lf){
                                         snprintf(join_data, strlen(filtered_string) + 1, "%s", filtered_string);
                                     }
                                     if (join_data2){
-                                        os_free(join_data2);
+                                        free(join_data2);
                                     }
                                     os_strdup(join_data,join_data2);
                                 } else if (strcmp(child_attr[p]->element, "Data")){

--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -164,7 +164,7 @@ int DecodeWinevt(Eventinfo *lf){
                                         cJSON_AddStringToObject(json_system_in, "eventSourceName", child_attr[p]->values[l]);
                                     }
                                 }
-                            } else if (!strcmp(child_attr[p]->element, "TimeCreated")) {
+                            } else if (!strcmp(child_attr[p]->element, "TimeCreated") && child_attr[p]->attributes != NULL) {
                                 if(!strcmp(child_attr[p]->attributes[0], "SystemTime")){
                                     cJSON_AddStringToObject(json_system_in, "systemTime", child_attr[p]->values[0]);
                                 }

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -151,6 +151,9 @@ LIST(APPEND analysisd_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,cJSON_ParseWithOpts
                               -Wl,--wrap,OS_ReadXMLString -Wl,--wrap,OS_GetElementsbyNode -Wl,--wrap,OS_ClearXML       \
                               -Wl,--wrap,w_get_attr_val_by_name")
 
+LIST(APPEND analysisd_names "test_decoder_winevtchannel_input")
+LIST(APPEND analysisd_flags "${DEBUG_OP_WRAPPERS}")
+
 
 list(APPEND analysisd_names "test_analysis-state")
 list(APPEND analysisd_flags "-Wl,--wrap,time -Wl,--wrap,rem_get_qsize -Wl,--wrap,rem_get_tsize \

--- a/src/unit_tests/analysisd/test_decoder_winevtchannel_input.c
+++ b/src/unit_tests/analysisd/test_decoder_winevtchannel_input.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <string.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../config/global-config.h"
+#include "../../analysisd/eventinfo.h"
+
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+#define TEST_AGENT_ID   "005"
+#define TEST_TIME       10005
+
+#define FAIL_DECODE    1
+#define SUCCESS_DECODE 0
+
+extern int DecodeWinevt(Eventinfo * lf);
+extern void w_free_event_info(Eventinfo * lf);
+extern _Config Config;
+
+int test_setup_global(void ** state) {
+    expect_string(__wrap__mdebug1, formatted_msg, "WinevtInit completed.");
+    Config.decoder_order_size = 32;
+    WinevtInit();
+    return 0;
+}
+
+int test_setup(void ** state) {
+    Eventinfo * lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
+    Zero_Eventinfo(lf);
+    os_strdup(TEST_AGENT_ID, lf->agent_id);
+    lf->time.tv_sec = (time_t) TEST_TIME;
+
+    *state = lf;
+
+    // lf->log and lf->full_log are null
+
+    return 0;
+}
+
+int test_cleanup(void ** state) {
+    Eventinfo * lf = *state;
+
+    w_free_event_info(lf);
+    return 0;
+}
+
+void test_winevt_dec_time_created_no_attributes(void ** state) {
+    const char * TEST_LOG_STRING = "{\"Event\":\"<Event><System><TimeCreated></TimeCreated></System></Event>\"}";
+
+    Eventinfo * lf = *state;
+    lf->log = lf->full_log = strdup(TEST_LOG_STRING);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Decoding JSON: '{\"win\":{\"system\":{}}}'");
+
+    int ret = DecodeWinevt(lf);
+    assert_int_equal(ret, SUCCESS_DECODE);
+}
+
+void test_winevt_dec_execution_no_attributes(void ** state) {
+    const char * TEST_LOG_STRING = "{\"Event\":\"<Event><System><Execution></Execution></System></Event>\"}";
+
+    Eventinfo * lf = *state;
+    lf->log = lf->full_log = strdup(TEST_LOG_STRING);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Decoding JSON: '{\"win\":{\"system\":{}}}'");
+
+    int ret = DecodeWinevt(lf);
+    assert_int_equal(ret, SUCCESS_DECODE);
+}
+
+void test_winevt_dec_execution_one_attribute(void ** state) {
+    const char * TEST_LOG_STRING = "{\"Event\":\"<Event><System><Execution ProcessID='1'></Execution></System></Event>\"}";
+
+    Eventinfo * lf = *state;
+    lf->log = lf->full_log = strdup(TEST_LOG_STRING);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Decoding JSON: '{\"win\":{\"system\":{\"processID\":\"1'");
+
+    int ret = DecodeWinevt(lf);
+    assert_int_equal(ret, SUCCESS_DECODE);
+}
+
+void test_winevt_dec_provider_no_attributes(void ** state) {
+    const char * TEST_LOG_STRING = "{\"Event\":\"<Event><System><Provider></Provider></System></Event>\"}";
+
+    Eventinfo * lf = *state;
+    lf->log = lf->full_log = strdup(TEST_LOG_STRING);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Decoding JSON: '{\"win\":{\"system\":{}}}'");
+
+    int ret = DecodeWinevt(lf);
+    assert_int_equal(ret, SUCCESS_DECODE);
+}
+
+void test_winevt_dec_provider(void ** state) {
+    const char * TEST_LOG_STRING = "{\"Event\":\"<Event><System><Provider First='1' Second='2' Third='3'></Provider><Provider Fourth='4'></Provider></System></Event>\"}";
+
+    Eventinfo * lf = *state;
+    lf->log = lf->full_log = strdup(TEST_LOG_STRING);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Decoding JSON: '{\"win\":{\"system\":{}}}'");
+
+    int ret = DecodeWinevt(lf);
+    assert_int_equal(ret, SUCCESS_DECODE);
+}
+
+int main() {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_winevt_dec_time_created_no_attributes, test_setup, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_winevt_dec_execution_no_attributes, test_setup, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_winevt_dec_execution_one_attribute, test_setup, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_winevt_dec_provider_no_attributes, test_setup, test_cleanup),
+        cmocka_unit_test_setup_teardown(test_winevt_dec_provider, test_setup, test_cleanup),
+    };
+    return cmocka_run_group_tests(tests, test_setup_global, NULL);
+}


### PR DESCRIPTION
|Related issue|
|---|
|#20734|

This PR aims to fix the input data sanitization in the Eventchannel decoder at _wazuh-analysisd_:

- Normalize loops (assure that variable `l` is resetted).
- Check that `<Provider>` contains some attributes.
- Check that `<TimeCreated>` contains some attributes.
- Check that `<Execution>` contains some attributes.

## Tests

- [x] Unit tests have been added for the cases above.