### PR TITLE
Update number of parameters that integratord sends to the integrations

### DIFF
--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -443,7 +443,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
 
             mdebug1("Running script with args: %s", exec_full_cmd);
 
-            char **cmd = OS_StrBreak(' ', exec_full_cmd, 8);
+            char **cmd = OS_StrBreak(' ', exec_full_cmd, 9);
 
             if (cmd) {
                 wfd_t * wfd = wpopenv(integrator_config[s]->path, cmd, W_BIND_STDOUT | W_BIND_STDERR | W_CHECK_WRITE);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/20723|

## Description

This PR updates the number of parameters that `wazuh-integratord` parses and sends to the integration scripts.

This change is necessary to avoid problems when parsing the arguments in the destination script.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade