### PR TITLE
Fix bus error and segfault on content manager UTs

### DIFF
--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -188,7 +188,7 @@ public:
 private:
     std::shared_ptr<RouterProvider> m_channel;
     std::thread m_schedulerThread;
-    bool m_schedulerRunning = false;
+    std::atomic<bool> m_schedulerRunning = false;
     std::atomic<bool> m_actionInProgress;
     std::atomic<size_t> m_interval;
     std::mutex m_mutex;

--- a/src/shared_modules/content_manager/src/onDemandManager.cpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.cpp
@@ -20,7 +20,6 @@
  */
 void OnDemandManager::startServer()
 {
-    std::atomic<bool> runningTrigger {true};
     m_serverThread = std::thread(
         [&]()
         {
@@ -70,11 +69,11 @@ void OnDemandManager::startServer()
             std::filesystem::path path {ONDEMAND_SOCK};
             std::filesystem::create_directories(path.parent_path());
 
-            runningTrigger = m_server.listen(ONDEMAND_SOCK, true);
+            m_runningTrigger = m_server.listen(ONDEMAND_SOCK, true);
         });
 
     // Spin lock until server is ready
-    while (!m_server.is_running() && runningTrigger)
+    while (!m_server.is_running() && m_runningTrigger)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }

--- a/src/shared_modules/content_manager/src/onDemandManager.hpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.hpp
@@ -28,6 +28,7 @@ private:
     std::map<std::string, std::function<void(int)>> m_endpoints {};
     std::shared_mutex m_mutex {};
     std::thread m_serverThread {};
+    std::atomic<bool> m_runningTrigger {true};
     void startServer();
     void stopServer();
 

--- a/src/shared_modules/content_manager/tests/component/contentModuleFacade_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/contentModuleFacade_test.cpp
@@ -179,7 +179,7 @@ TEST_F(ContentModuleFacadeTest, TestSingletonAndChangeSchedulerIntervalWithoutPr
 /*
  * @brief Tests singleton of the ContentModuleFacade class and start on demand for raw data
  */
-TEST_F(ContentModuleFacadeTest, DISABLED_TestSingletonAndStartOnDemandForRawData)
+TEST_F(ContentModuleFacadeTest, TestSingletonAndStartOnDemandForRawData)
 {
     const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
     const auto& outputFolder {m_parameters.at("configData").at("outputFolder").get_ref<const std::string&>()};

--- a/src/shared_modules/content_manager/tests/component/contentRegister_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/contentRegister_test.cpp
@@ -34,7 +34,7 @@ TEST_F(ContentRegisterTest, TestInstantiation)
 /*
  * @brief Tests instantiation of the ContentRegister class with ondemand enabled
  */
-TEST_F(ContentRegisterTest, DISABLED_TestInstantiationWithOnDemandEnabled)
+TEST_F(ContentRegisterTest, TestInstantiationWithOnDemandEnabled)
 {
     const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
 


### PR DESCRIPTION
|Related issue|
|---|
|#20746|

## Description

This PR fixes two separate issues with Content Manager UTs. 

Segfault the first test, and bus error the second one

![2023-12-12_16-21](https://github.com/wazuh/wazuh/assets/13010397/3bad4729-f13e-40f5-aa53-76403f96727f)

More info

https://github.com/wazuh/wazuh/issues/20746#issuecomment-1852714458

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer