### PR TITLE
Fix a stack use after return at wm_database unit test setup

### DIFF
--- a/src/unit_tests/wazuh_modules/database/test_wm_database.c
+++ b/src/unit_tests/wazuh_modules/database/test_wm_database.c
@@ -63,20 +63,22 @@ int setup_keys_to_db(void **state) {
     key->ip = (os_ip *)1;
     key->raw_key = strdup("1234567890abcdef");
 
-    *state = &keys;
+    os_calloc(1, sizeof(keystore), *state);
+    memcpy(*state, &keys, sizeof(keystore));
 
     test_mode = 1;
     return OS_SUCCESS;
 }
 
 int teardown_keys_to_db(void **state) {
-    keystore keys = *((keystore *)*state);
+    keystore * keys = (keystore *)*state;
 
-    os_free(keys.keyentries[0]->id);
-    os_free(keys.keyentries[0]->name);
-    os_free(keys.keyentries[0]->raw_key);
-    os_free(keys.keyentries[0]);
-    os_free(keys.keyentries);
+    os_free(keys->keyentries[0]->id);
+    os_free(keys->keyentries[0]->name);
+    os_free(keys->keyentries[0]->raw_key);
+    os_free(keys->keyentries[0]);
+    os_free(keys->keyentries);
+    os_free(keys);
 
     test_mode = 0;
     return OS_SUCCESS;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20733|

The _wm-database_ unit tests setup was creating a status from a stack-allocated variable (`keys`). This PR aims to fix that by copying the data in the heap before returning.

## Tests

### Unit tests for server

> **100% tests passed**, 0 tests failed out of 169

<details><summary>Tests</summary>

```
        Start   1: test_analysisd_syscheck
  1/169 Test   #1: test_analysisd_syscheck .................................   Passed    0.04 sec
        Start   2: test_cleanevent
  2/169 Test   #2: test_cleanevent .........................................   Passed    0.02 sec
        Start   3: test_dbsync
  3/169 Test   #3: test_dbsync .............................................   Passed    0.03 sec
        Start   4: test_exec
  4/169 Test   #4: test_exec ...............................................   Passed    0.03 sec
        Start   5: test_log
  5/169 Test   #5: test_log ................................................   Passed    0.03 sec
        Start   6: test_labels
  6/169 Test   #6: test_labels .............................................   Passed    0.03 sec
        Start   7: test_mitre
  7/169 Test   #7: test_mitre ..............................................   Passed    0.01 sec
        Start   8: test_rules
  8/169 Test   #8: test_rules ..............................................   Passed    0.02 sec
        Start   9: test_same_different_loop
  9/169 Test   #9: test_same_different_loop ................................   Passed    0.02 sec
        Start  10: test_logtest
 10/169 Test  #10: test_logtest ............................................   Passed    0.02 sec
        Start  11: test_logtest-config
 11/169 Test  #11: test_logtest-config .....................................   Passed    0.01 sec
        Start  12: test_decoder_list
 12/169 Test  #12: test_decoder_list .......................................   Passed    0.01 sec
        Start  13: test_decode-xml
 13/169 Test  #13: test_decode-xml .........................................   Passed    0.02 sec
        Start  14: test_lists_list
 14/169 Test  #14: test_lists_list .........................................   Passed    0.01 sec
        Start  15: test_rule_list
 15/169 Test  #15: test_rule_list ..........................................   Passed    0.01 sec
        Start  16: test_eventinfo_list
 16/169 Test  #16: test_eventinfo_list .....................................   Passed    0.01 sec
        Start  17: test_logmsg
 17/169 Test  #17: test_logmsg .............................................   Passed    0.01 sec
        Start  18: test_decoder_rootcheck
 18/169 Test  #18: test_decoder_rootcheck ..................................   Passed    0.02 sec
        Start  19: test_decoder_syscollector
 19/169 Test  #19: test_decoder_syscollector ...............................   Passed    0.03 sec
        Start  20: test_decoder_winevtchannel
 20/169 Test  #20: test_decoder_winevtchannel ..............................   Passed    0.03 sec
        Start  21: test_decoder_winevtchannel_input
 21/169 Test  #21: test_decoder_winevtchannel_input ........................   Passed    0.03 sec
        Start  22: test_analysis-state
 22/169 Test  #22: test_analysis-state .....................................   Passed    0.03 sec
        Start  23: test_asyscom
 23/169 Test  #23: test_asyscom ............................................   Passed    0.02 sec
        Start  24: test_limits
 24/169 Test  #24: test_limits .............................................   Passed    0.01 sec
        Start  25: test_manager
 25/169 Test  #25: test_manager ............................................   Passed    0.03 sec
        Start  26: test_secure
 26/169 Test  #26: test_secure .............................................   Passed    0.02 sec
        Start  27: test_netbuffer
 27/169 Test  #27: test_netbuffer ..........................................   Passed    0.02 sec
        Start  28: test_sendmsg
 28/169 Test  #28: test_sendmsg ............................................   Passed    0.02 sec
        Start  29: test_remote-config
 29/169 Test  #29: test_remote-config ......................................   Passed    0.01 sec
        Start  30: test_syslogtcp
 30/169 Test  #30: test_syslogtcp ..........................................   Passed    0.02 sec
        Start  31: test_remote-state
 31/169 Test  #31: test_remote-state .......................................   Passed    0.02 sec
        Start  32: test_remcom
 32/169 Test  #32: test_remcom .............................................   Passed    0.02 sec
        Start  33: test_wdb_integrity
 33/169 Test  #33: test_wdb_integrity ......................................   Passed    0.01 sec
        Start  34: test_wdb_fim
 34/169 Test  #34: test_wdb_fim ............................................   Passed    0.01 sec
        Start  35: test_wdb_parser
 35/169 Test  #35: test_wdb_parser .........................................   Passed    0.02 sec
        Start  36: test_wdb_global_parser
 36/169 Test  #36: test_wdb_global_parser ..................................   Passed    0.02 sec
        Start  37: test_wdb_global
 37/169 Test  #37: test_wdb_global .........................................   Passed    0.17 sec
        Start  38: test_wdb_agents
 38/169 Test  #38: test_wdb_agents .........................................   Passed    0.01 sec
        Start  39: test_wdb_global_helpers
 39/169 Test  #39: test_wdb_global_helpers .................................   Passed    0.02 sec
        Start  40: test_wdb_agents_helpers
 40/169 Test  #40: test_wdb_agents_helpers .................................   Passed    0.01 sec
        Start  41: test_wdb
 41/169 Test  #41: test_wdb ................................................   Passed    0.01 sec
        Start  42: test_wdb_upgrade
 42/169 Test  #42: test_wdb_upgrade ........................................   Passed    0.01 sec
        Start  43: test_wdb_metadata
 43/169 Test  #43: test_wdb_metadata .......................................   Passed    0.01 sec
        Start  44: test_wdb_task_parser
 44/169 Test  #44: test_wdb_task_parser ....................................   Passed    0.01 sec
        Start  45: test_wdb_rootcheck
 45/169 Test  #45: test_wdb_rootcheck ......................................   Passed    0.01 sec
        Start  46: test_wdb_syscollector
 46/169 Test  #46: test_wdb_syscollector ...................................   Passed    0.01 sec
        Start  47: test_wdb_task
 47/169 Test  #47: test_wdb_task ...........................................   Passed    0.01 sec
        Start  48: test_wdb_delta_event
 48/169 Test  #48: test_wdb_delta_event ....................................   Passed    0.01 sec
        Start  49: test_wazuh_db-config
 49/169 Test  #49: test_wazuh_db-config ....................................   Passed    0.01 sec
        Start  50: test_wazuh_db_state
 50/169 Test  #50: test_wazuh_db_state .....................................   Passed    0.01 sec
        Start  51: test_wdb_com
 51/169 Test  #51: test_wdb_com ............................................   Passed    0.01 sec
        Start  52: test_auth_parse
 52/169 Test  #52: test_auth_parse .........................................   Passed    0.01 sec
        Start  53: test_auth_validate
 53/169 Test  #53: test_auth_validate ......................................   Passed    0.01 sec
        Start  54: test_auth_add
 54/169 Test  #54: test_auth_add ...........................................   Passed    0.01 sec
        Start  55: test_ssl
 55/169 Test  #55: test_ssl ................................................   Passed    0.01 sec
        Start  56: test_auth_key_request
 56/169 Test  #56: test_auth_key_request ...................................   Passed    0.01 sec
        Start  57: test_auth
 57/169 Test  #57: test_auth ...............................................   Passed    0.01 sec
        Start  58: test_generate_cert
 58/169 Test  #58: test_generate_cert ......................................   Passed    0.01 sec
        Start  59: test_authd-config
 59/169 Test  #59: test_authd-config .......................................   Passed    0.01 sec
        Start  60: test_msgs
 60/169 Test  #60: test_msgs ...............................................   Passed    0.01 sec
        Start  61: test_keys
 61/169 Test  #61: test_keys ...............................................   Passed    0.01 sec
        Start  62: test_sha1_op
 62/169 Test  #62: test_sha1_op ............................................   Passed    0.01 sec
        Start  63: test_blowfish_op
 63/169 Test  #63: test_blowfish_op ........................................   Passed    0.01 sec
        Start  64: test_md5_op
 64/169 Test  #64: test_md5_op .............................................   Passed    0.01 sec
        Start  65: test_md5_sha1_op
 65/169 Test  #65: test_md5_sha1_op ........................................   Passed    0.01 sec
        Start  66: test_md5_sha1_sha256_op
 66/169 Test  #66: test_md5_sha1_sha256_op .................................   Passed    0.01 sec
        Start  67: test_sha256_op
 67/169 Test  #67: test_sha256_op ..........................................   Passed    0.01 sec
        Start  68: test_sha512_op
 68/169 Test  #68: test_sha512_op ..........................................   Passed    0.01 sec
        Start  69: test_wm_aws
 69/169 Test  #69: test_wm_aws .............................................   Passed    0.02 sec
        Start  70: test_wm_azure
 70/169 Test  #70: test_wm_azure ...........................................   Passed    0.02 sec
        Start  71: test_wm_ciscat
 71/169 Test  #71: test_wm_ciscat ..........................................   Passed    0.02 sec
        Start  72: test_wm_command
 72/169 Test  #72: test_wm_command .........................................   Passed    0.03 sec
        Start  73: test_wm_database
 73/169 Test  #73: test_wm_database ........................................   Passed    0.01 sec
        Start  74: test_wm_docker
 74/169 Test  #74: test_wm_docker ..........................................   Passed    0.02 sec
        Start  75: test_wm_gcp
 75/169 Test  #75: test_wm_gcp .............................................   Passed    0.11 sec
        Start  76: test_wmodules_gcp
 76/169 Test  #76: test_wmodules_gcp .......................................   Passed    0.03 sec
        Start  77: test_wm_oscap
 77/169 Test  #77: test_wm_oscap ...........................................   Passed    0.02 sec
        Start  78: test_wm_sca
 78/169 Test  #78: test_wm_sca .............................................   Passed    0.02 sec
        Start  79: test_wmodules_scheduling
 79/169 Test  #79: test_wmodules_scheduling ................................   Passed    0.01 sec
        Start  80: test_wm_vuln_detector
 80/169 Test  #80: test_wm_vuln_detector ...................................   Passed    0.05 sec
        Start  81: test_wm_vuln_detector_evr
 81/169 Test  #81: test_wm_vuln_detector_evr ...............................   Passed    0.01 sec
        Start  82: test_wm_vuln_detector_nvd
 82/169 Test  #82: test_wm_vuln_detector_nvd ...............................   Passed    0.03 sec
        Start  83: test_wm_vuln_detector_run_now
 83/169 Test  #83: test_wm_vuln_detector_run_now ...........................   Passed    0.02 sec
        Start  84: test_wm_task_manager
 84/169 Test  #84: test_wm_task_manager ....................................   Passed    0.02 sec
        Start  85: test_wm_task_manager_parsing
 85/169 Test  #85: test_wm_task_manager_parsing ............................   Passed    0.01 sec
        Start  86: test_wm_task_manager_commands
 86/169 Test  #86: test_wm_task_manager_commands ...........................   Passed    0.01 sec
        Start  87: test_wm_agent_upgrade
 87/169 Test  #87: test_wm_agent_upgrade ...................................   Passed    0.01 sec
        Start  88: test_wm_agent_upgrade_manager
 88/169 Test  #88: test_wm_agent_upgrade_manager ...........................   Passed    0.02 sec
        Start  89: test_wm_agent_upgrade_parsing
 89/169 Test  #89: test_wm_agent_upgrade_parsing ...........................   Passed    0.02 sec
        Start  90: test_wm_agent_upgrade_validate
 90/169 Test  #90: test_wm_agent_upgrade_validate ..........................   Passed    0.01 sec
        Start  91: test_wm_agent_upgrade_tasks
 91/169 Test  #91: test_wm_agent_upgrade_tasks .............................   Passed    0.01 sec
        Start  92: test_wm_agent_upgrade_tasks_callbacks
 92/169 Test  #92: test_wm_agent_upgrade_tasks_callbacks ...................   Passed    0.02 sec
        Start  93: test_wm_agent_upgrade_commands
 93/169 Test  #93: test_wm_agent_upgrade_commands ..........................   Passed    0.02 sec
        Start  94: test_wm_agent_upgrade_upgrades
 94/169 Test  #94: test_wm_agent_upgrade_upgrades ..........................   Passed    0.03 sec
        Start  95: test_wmodules
 95/169 Test  #95: test_wmodules ...........................................   Passed    0.02 sec
        Start  96: test_wm_control
 96/169 Test  #96: test_wm_control .........................................   Passed    0.02 sec
        Start  97: test_wm_github
 97/169 Test  #97: test_wm_github ..........................................   Passed    0.03 sec
        Start  98: test_wm_office365
 98/169 Test  #98: test_wm_office365 .......................................   Passed    0.04 sec
        Start  99: test_wm_ms_graph
 99/169 Test  #99: test_wm_ms_graph ........................................   Passed    0.04 sec
        Start 100: test_wm_osquery_already_running
100/169 Test #100: test_wm_osquery_already_running .........................   Passed    0.02 sec
        Start 101: test_monitord
101/169 Test #101: test_monitord ...........................................   Passed    0.01 sec
        Start 102: test_monitor_actions
102/169 Test #102: test_monitor_actions ....................................   Passed    0.02 sec
        Start 103: test_logcollector
103/169 Test #103: test_logcollector .......................................   Passed    0.03 sec
        Start 104: test_read_multiline_regex
104/169 Test #104: test_read_multiline_regex ...............................   Passed    0.03 sec
        Start 105: test_localfile-config
105/169 Test #105: test_localfile-config ...................................   Passed    0.02 sec
        Start 106: test_state
106/169 Test #106: test_state ..............................................   Passed    0.01 sec
        Start 107: test_lccom
107/169 Test #107: test_lccom ..............................................   Passed    0.02 sec
        Start 108: test_macos_log
108/169 Test #108: test_macos_log ..........................................   Passed    0.01 sec
        Start 109: test_read_macos
109/169 Test #109: test_read_macos .........................................   Passed    0.03 sec
        Start 110: test_read_multiline
110/169 Test #110: test_read_multiline .....................................   Passed    0.02 sec
        Start 111: test_execd
111/169 Test #111: test_execd ..............................................   Passed    0.01 sec
        Start 112: test_get_command_by_name
112/169 Test #112: test_get_command_by_name ................................   Passed    0.01 sec
        Start 113: test_integrator
113/169 Test #113: test_integrator .........................................   Passed    0.01 sec
        Start 114: test_manage_keys
114/169 Test #114: test_manage_keys ........................................   Passed    0.01 sec
        Start 115: test_printtable
115/169 Test #115: test_printtable .........................................   Passed    0.01 sec
        Start 116: test_syscom
116/169 Test #116: test_syscom .............................................   Passed    0.01 sec
        Start 117: test_fim_diff_changes
117/169 Test #117: test_fim_diff_changes ...................................   Passed    0.03 sec
        Start 118: test_run_realtime
118/169 Test #118: test_run_realtime .......................................   Passed    0.02 sec
        Start 119: test_config
119/169 Test #119: test_config .............................................   Passed    0.03 sec
        Start 120: test_syscheck
120/169 Test #120: test_syscheck ...........................................   Passed    0.02 sec
        Start 121: test_run_check
121/169 Test #121: test_run_check ..........................................   Passed    0.02 sec
        Start 122: test_create_db
122/169 Test #122: test_create_db ..........................................   Passed    0.03 sec
        Start 123: test_audit_healthcheck
123/169 Test #123: test_audit_healthcheck ..................................   Passed    0.02 sec
        Start 124: test_audit_rule_handling
124/169 Test #124: test_audit_rule_handling ................................   Passed    0.02 sec
        Start 125: test_syscheck_audit
125/169 Test #125: test_syscheck_audit .....................................   Passed    0.11 sec
        Start 126: test_audit_parse
126/169 Test #126: test_audit_parse ........................................   Passed    0.03 sec
        Start 127: test_list_op
127/169 Test #127: test_list_op ............................................   Passed    0.02 sec
        Start 128: test_file_op
128/169 Test #128: test_file_op ............................................   Passed    0.01 sec
        Start 129: test_integrity_op
129/169 Test #129: test_integrity_op .......................................   Passed    0.01 sec
        Start 130: test_rbtree_op
130/169 Test #130: test_rbtree_op ..........................................   Passed    0.01 sec
        Start 131: test_validate_op
131/169 Test #131: test_validate_op ........................................   Passed    0.01 sec
        Start 132: test_string_op
132/169 Test #132: test_string_op ..........................................   Passed    0.01 sec
        Start 133: test_expression
133/169 Test #133: test_expression .........................................   Passed    0.01 sec
        Start 134: test_version_op
134/169 Test #134: test_version_op .........................................   Passed    0.01 sec
        Start 135: test_queue_op
135/169 Test #135: test_queue_op ...........................................   Passed    0.01 sec
        Start 136: test_queue_linked_op
136/169 Test #136: test_queue_linked_op ....................................   Passed    0.01 sec
        Start 137: test_agent_op
137/169 Test #137: test_agent_op ...........................................   Passed    0.01 sec
        Start 138: test_enrollment_op
138/169 Test #138: test_enrollment_op ......................................   Passed    0.02 sec
        Start 139: test_time_op
139/169 Test #139: test_time_op ............................................   Passed    0.01 sec
        Start 140: test_buffer_op
140/169 Test #140: test_buffer_op ..........................................   Passed    0.01 sec
        Start 141: test_utf8_op
141/169 Test #141: test_utf8_op ............................................   Passed    0.01 sec
        Start 142: test_log_builder
142/169 Test #142: test_log_builder ........................................   Passed    0.01 sec
        Start 143: test_custom_output_search_replace
143/169 Test #143: test_custom_output_search_replace .......................   Passed    0.01 sec
        Start 144: test_bzip2_op
144/169 Test #144: test_bzip2_op ...........................................   Passed    0.01 sec
        Start 145: test_schedule_scan
145/169 Test #145: test_schedule_scan ......................................   Passed    0.01 sec
        Start 146: test_rootcheck_op
146/169 Test #146: test_rootcheck_op .......................................   Passed    0.01 sec
        Start 147: test_fs_op
147/169 Test #147: test_fs_op ..............................................   Passed    0.01 sec
        Start 148: test_wazuhdb_op
148/169 Test #148: test_wazuhdb_op .........................................   Passed    0.01 sec
        Start 149: test_syscheck_op
149/169 Test #149: test_syscheck_op ........................................   Passed    0.03 sec
        Start 150: test_json_op
150/169 Test #150: test_json_op ............................................   Passed    0.01 sec
        Start 151: test_audit_op
151/169 Test #151: test_audit_op ...........................................   Passed    0.01 sec
        Start 152: test_privsep_op
152/169 Test #152: test_privsep_op .........................................   Passed    0.01 sec
        Start 153: test_mq_op
153/169 Test #153: test_mq_op ..............................................   Passed    0.01 sec
        Start 154: test_remoted_op
154/169 Test #154: test_remoted_op .........................................   Passed    0.01 sec
        Start 155: test_json-queue
155/169 Test #155: test_json-queue .........................................   Passed    0.01 sec
        Start 156: test_bqueue
156/169 Test #156: test_bqueue .............................................   Passed    0.01 sec
        Start 157: test_atomic
157/169 Test #157: test_atomic .............................................   Passed    0.01 sec
        Start 158: test_url
158/169 Test #158: test_url ................................................   Passed    0.01 sec
        Start 159: test_sysinfo_utils
159/169 Test #159: test_sysinfo_utils ......................................   Passed    0.01 sec
        Start 160: test_rwlock_op
160/169 Test #160: test_rwlock_op ..........................................   Passed    0.02 sec
        Start 161: test_os_xml
161/169 Test #161: test_os_xml .............................................   Passed    0.04 sec
        Start 162: test_os_regex
162/169 Test #162: test_os_regex ...........................................   Passed    0.01 sec
        Start 163: test_os_regex_match
163/169 Test #163: test_os_regex_match .....................................   Passed    0.01 sec
        Start 164: test_os_regex_execute
164/169 Test #164: test_os_regex_execute ...................................   Passed    0.02 sec
        Start 165: test_os_zlib
165/169 Test #165: test_os_zlib ............................................   Passed    0.01 sec
        Start 166: test_client-config_validate_ipv6_link_local_interface
166/169 Test #166: test_client-config_validate_ipv6_link_local_interface ...   Passed    0.02 sec
        Start 167: test_os_net
167/169 Test #167: test_os_net .............................................   Passed    0.01 sec
        Start 168: test_fluentd_forwarder
168/169 Test #168: test_fluentd_forwarder ..................................   Passed    0.02 sec
        Start 169: test_active-response
169/169 Test #169: test_active-response ....................................   Passed    0.01 sec
```

</details>
