### PR TITLE
Fix missing include at windowsHelper.h

### DIFF
--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -17,6 +17,7 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include <array>
 #include <system_error>
 #include <winsock2.h>
 #include <windows.h>


### PR DESCRIPTION
That was preventing the Windows agent from building on Ubuntu 23.04.

|Related issue|
|---|
|Closes #20738|

This PR aims to add a missing `#include` directive that prevented the Windows agent from being compiled on Ubuntu 23.04 (MinGW 12).

## Tests

### Build

> Done building winagent

<details><summary>Settings</summary>

```
General settings:
    TARGET:             winagent
    V:
    DEBUG:
    DEBUGAD
    INSTALLDIR:
    DATABASE:
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/23
    EXTERNAL_SRC_ONLY:
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        yes
    USE_AUDIT:          no
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:
    libs:
Pgsql settings:
    includes:
    libs:
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_CISCAT
Compiler:
    CFLAGS            -Wl,-L,win32/ -Wl,-Bstatic,--whole-archive -lwinpthreadpatched -Wl,--no-whole-archive -Wl,-Bdynamic -ldelayimp -pthread -DBUILDING_LIBCURL= -DPCRE2_EXP_DECL= -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_CISCAT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -Isyscheckd/include
    LDFLAGS           -Wl,-L,win32/ -Wl,-Bstatic,--whole-archive -lwinpthreadpatched -Wl,--no-whole-archive -Wl,-Bdynamic -ldelayimp -pthread -DBUILDING_LIBCURL= -DPCRE2_EXP_DECL= -O2 -Lshared_modules/dbsync/build/bin -Lshared_modules/rsync/build/bin  -Lwazuh_modules/syscollector/build/bin -Ldata_provider/build/bin -Lsyscheckd/build/lib -Lsyscheckd/build/bin
    LIBS
    CC                gcc
    MAKE              make
```

</details>