### PR TITLE
Added missing fields to syscollector sync flatbuffer schema

### DIFF
--- a/src/shared_modules/utils/flatbuffers/schemas/syscollectorRsync/syscollector_synchronization.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/syscollectorRsync/syscollector_synchronization.fbs
@@ -1,107 +1,103 @@
 namespace SyscollectorSynchronization;
 
-table AgentInfo
-{
+table AgentInfo {
     agent_id:string;
     agent_ip:string;
     agent_name:string;
     node_name:string;
 }
 
-table syscollector_hotfixes
-{
+table syscollector_hotfixes {
     checksum:string;
     hotfix:string;
     scan_time:string;
 }
 
-table syscollector_hwinfo
-{
-    board_serial: string;
-    checksum: string;
-    cpu_cores: int;
-    cpu_mhz: float;
-    cpu_name: string;
-    ram_free: int;
-    ram_total: int;
-    ram_usage: int;
-    scan_time: string;
+table syscollector_hwinfo {
+    board_serial:string;
+    checksum:string;
+    cpu_cores:int;
+    cpu_mhz:double;
+    cpu_name:string;
+    ram_free:int;
+    ram_total:int;
+    ram_usage:int;
+    scan_time:string;
 }
 
-table syscollector_network_address
-{
-    address: string;
-    broadcast: string;
-    checksum: string;
-    iface: string;
-    item_id: string;
-    netmask: string;
-    proto: int;
-    scan_time: string;
+table syscollector_network_address {
+    address:string;
+    broadcast:string;
+    checksum:string;
+    iface:string;
+    item_id:string;
+    netmask:string;
+    proto:int;
+    scan_time:string;
 }
 
-table syscollector_network_iface
-{
-    adapter: string;
-    checksum: string;
-    item_id: string;
-    mac: string;
-    mtu: int;
-    name: string;
-    rx_bytes: int;
-    rx_dropped: int;
-    rx_errors: int;
-    rx_packets: int;
-    scan_time: string;
-    state: string;
-    tx_bytes: int;
-    tx_dropped: int;
-    tx_errors: int;
-    tx_packets: int;
-    type: string;
+table syscollector_network_iface {
+    adapter:string;
+    checksum:string;
+    item_id:string;
+    mac:string;
+    mtu:int;
+    name:string;
+    rx_bytes:int;
+    rx_dropped:int;
+    rx_errors:int;
+    rx_packets:int;
+    scan_time:string;
+    state:string;
+    tx_bytes:int;
+    tx_dropped:int;
+    tx_errors:int;
+    tx_packets:int;
+    type:string;
 }
 
 table syscollector_network_protocol {
-    scan_time:string;
-    iface:string;
-    type:string;
-    gateway:string;
-    dhcp:string;
-    metric:string;
     checksum:string;
+    dhcp:string;
+    gateway:string;
+    iface:string;
     item_id:string;
+    metric:string;
+    scan_time:string;
+    type:string;
 }
 
-table syscollector_osinfo
-{
-    architecture: string;
-    checksum: string;
-    hostname: string;
-    os_codename: string;
-    os_major: string;
-    os_minor: string;
-    os_name: string;
-    os_patch: string;
-    os_platform: string;
-    os_version: string;
-    release: string;
-    scan_time: string;
-    sysname: string;
-    version: string;
+table syscollector_osinfo {
+    architecture:string;
+    checksum:string;
+    hostname:string;
+    os_build:string;
+    os_codename:string;
+    os_display_version:string;
+    os_major:string;
+    os_minor:string;
+    os_name:string;
+    os_patch:string;
+    os_platform:string;
+    os_release:string;
+    os_version:string;
+    release:string;
+    scan_time:string;
+    sysname:string;
+    version:string;
 }
 
-table syscollector_packages
-{
+table syscollector_packages {
     architecture:string;
     checksum:string;
     description:string;
     format:string;
-    install_time: string;
     groups:string;
+    install_time:string;
     item_id:string;
+    location:string;
     multiarch:string;
     name:string;
-    location: string;
     priority:string;
     scan_time:string;
     size:int;
@@ -110,62 +106,57 @@ table syscollector_packages
     version:string;
 }
 
-table syscollector_ports
-{
-    checksum: string;
-    inode: int;
-    item_id: string;
-    local_ip: string;
-    local_port: int;
-    pid: int;
-    process: string;
-    protocol: string;
-    remote_ip: string;
-    remote_port: int;
-    rx_queue: int;
-    scan_time: string;
-    state: string;
-    tx_queue: int;
+table syscollector_ports {
+    checksum:string;
+    inode:long;
+    item_id:string;
+    local_ip:string;
+    local_port:long;
+    pid:long;
+    process:string;
+    protocol:string;
+    remote_ip:string;
+    remote_port:long;
+    rx_queue:long;
+    scan_time:string;
+    state:string;
+    tx_queue:long;
 }
 
-table syscollector_processes
-{
-    argvs: string;
-    checksum: string;
-    cmd: string;
-    egroup: string;
-    euser: string;
-    fgroup: string;
-    name: string;
-    nice: int;
-    nlwp: int;
-    pgrp: int;
-    pid: string;
-    ppid: int;
-    priority: int;
-    processor: int;
-    resident: int;
-    rgroup: string;
-    ruser: string;
-    rx_queue: int;
-    scan_time: string;
-    tx_queue: int;
-    session: int;
-    sgroup: string;
-    share: int;
-    size: int;
-    start_time: int;
-    state: string;
-    stime: int;
-    suser: string;
-    tgid: int;
-    tty: int;
-    utime: int;
-    vm_size: int;
+table syscollector_processes {
+    argvs:string;
+    checksum:string;
+    cmd:string;
+    egroup:string;
+    euser:string;
+    fgroup:string;
+    name:string;
+    nice:long;
+    nlwp:long;
+    pgrp:long;
+    pid:string;
+    ppid:long;
+    priority:long;
+    processor:long;
+    resident:long;
+    rgroup:string;
+    ruser:string;
+    scan_time:string;
+    session:long;
+    sgroup:string;
+    share:long;
+    size:long;
+    start_time:long;
+    state:string;
+    stime:long;
+    suser:string;
+    tgid:long;
+    tty:long;
+    utime:long;
+    vm_size:long;
 }
 
-union AttributesUnion
-{
+union AttributesUnion {
     syscollector_hotfixes,
     syscollector_hwinfo,
     syscollector_network_address,
@@ -177,15 +168,13 @@ union AttributesUnion
     syscollector_processes
 }
 
-table state
-{
+table state {
   attributes: AttributesUnion;
   index: string;
   timestamp: string;
 }
 
-table integrity_check_global
-{
+table integrity_check_global {
   attributes_type:string;
   id: int;
   begin: string;
@@ -193,8 +182,7 @@ table integrity_check_global
   checksum: string;
 }
 
-table integrity_check_right
-{
+table integrity_check_right {
   attributes_type:string;
   id: int;
   begin: string;
@@ -202,8 +190,7 @@ table integrity_check_right
   checksum: string;
 }
 
-table integrity_check_left
-{
+table integrity_check_left {
   attributes_type:string;
   id: int;
   begin: string;
@@ -212,14 +199,12 @@ table integrity_check_left
   checksum: string;
 }
 
-table integrity_clear
-{
+table integrity_clear {
   attributes_type:string;
   id: int;
 }
 
-union DataUnion
-{
+union DataUnion {
     state,
     integrity_check_global,
     integrity_check_left,
@@ -227,8 +212,7 @@ union DataUnion
     integrity_clear
 }
 
-table SyncMsg
-{
+table SyncMsg {
     agent_info: AgentInfo;
     data: DataUnion;
 }

--- a/src/wazuh_modules/syscollector/tests/sysCollectorFlatbuffers/syscollectorFb_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorFlatbuffers/syscollectorFb_test.cpp
@@ -48,7 +48,7 @@ TEST(SyscollectorFbTest, JSONParsePackageUnix)
 TEST(SyscollectorFbTest, JSONParsePackageWin)
 {
     const std::string alert_json =
-        "{\n  agent_info: {\n    agent_id: \"001\",\n    node_name: \"node01\"\n  },\n  data_type: \"state\",\n  data: {\n    attributes_type: \"syscollector_packages\",\n    attributes: {\n      checksum: \"9141d4744f95aad5db1cf8cf17c33c2f7dffed40\",\n      format: \"win\",\n      install_time: \"20230804\",\n      item_id: \"e8cc756531b3adaae0e8a51c6800a681f4e903aa\",\n      name: \"Microsoft Application Amazing Runtime\",\n      location: \"C:\\\\Users\\\\winuser\\\\AppData\\\\Local\\\\Microsoft\\\\Amazing\\\\Application\",\n      scan_time: \"0000/00/00 00:00:00\",\n      vendor: \"Microsoft Application Amazing\",\n      version: \"110.110.110.10.10\"\n    },\n    index: \"e8cc756531b3adaae0e8a51c6800a681f4e903aa\",\n    timestamp: \"\"\n  }\n}\n";
+        "{\n  agent_info: {\n    agent_id: \"001\",\n    node_name: \"node01\"\n  },\n  data_type: \"state\",\n  data: {\n    attributes_type: \"syscollector_packages\",\n    attributes: {\n      checksum: \"9141d4744f95aad5db1cf8cf17c33c2f7dffed40\",\n      format: \"win\",\n      install_time: \"20230804\",\n      item_id: \"e8cc756531b3adaae0e8a51c6800a681f4e903aa\",\n      location: \"C:\\\\Users\\\\winuser\\\\AppData\\\\Local\\\\Microsoft\\\\Amazing\\\\Application\",\n      name: \"Microsoft Application Amazing Runtime\",\n      scan_time: \"0000/00/00 00:00:00\",\n      vendor: \"Microsoft Application Amazing\",\n      version: \"110.110.110.10.10\"\n    },\n    index: \"e8cc756531b3adaae0e8a51c6800a681f4e903aa\",\n    timestamp: \"\"\n  }\n}\n";
 
     flatbuffers::Parser parser;
     std::string schemaFile;


### PR DESCRIPTION
|Related issue|
|---|
|#20794|

## Description

This PR adds some missing fields in the syscollector synchronization schema for the operating system. 
- os_build
- os_display_version 

Syscollector sync schema was unified with syscollector deltas (after a verification the second one respects the syscollector implementation databases).

## Logs

![image](https://github.com/wazuh/wazuh/assets/13010397/d2ad80cb-1c86-4320-a208-deab5d095753)
