### PR TITLE
Upgrade aiohttp version to 3.9.1

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.1
+aiohttp==3.9.1
 aiohttp-cache==2.2.0
 aiohttp-cors==0.7.0
 aiohttp-jinja2==1.4.2


### PR DESCRIPTION
|Related issue|
|---|
| #20586 |

## Description

Upgrades the `aiohttp` to version `3.9.1` which fixes a found security vulnerability.

## Tests

Unit tests can be found [here](https://github.com/wazuh/wazuh/issues/20586#issuecomment-1852752929).
API Integration tests can be found [here](https://github.com/wazuh/wazuh/issues/20586#issuecomment-1854627044).