### PR TITLE
Query Wazuh-DB to fill OS cache

### DIFF
--- a/src/shared_modules/utils/socketDBWrapper.hpp
+++ b/src/shared_modules/utils/socketDBWrapper.hpp
@@ -39,7 +39,7 @@ private:
 public:
     explicit SocketDBWrapper(const std::string& socketPath)
         : m_dbSocket {
-              std::make_shared<SocketClient<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>>(socketPath, true)}
+              std::make_shared<SocketClient<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>>(socketPath, false)}
     {
         m_dbSocket->connect(
             [&](const char* body, uint32_t bodySize, const char* header, uint32_t headerSize)

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
@@ -13,9 +13,15 @@
 #define _OS_DATA_CACHE_HPP
 
 #include "cacheLRU.hpp"
+#include "loggerHelper.h"
 #include "singleton.hpp"
+#include "socketDBWrapper.hpp"
+#include "vulnerabilityScannerDefs.hpp"
+#include "wazuhDBQueryBuilder.hpp"
 #include <shared_mutex>
 #include <string>
+
+auto constexpr OS_CACHE_WDB_SOCKET {"queue/db/wdb"};
 
 /**
  * @brief Os structure.
@@ -48,8 +54,54 @@ class OsDataCache final : public Singleton<OsDataCache>
 private:
     LRUCache<std::string, Os> m_osData {1000};
     std::shared_mutex m_mutex;
+    std::optional<SocketDBWrapper> m_wdbSocketWrapper {std::nullopt};
+
+    Os getOsDataFromWdb(const std::string& agentId)
+    {
+
+        nlohmann::json response;
+        m_wdbSocketWrapper->query(WazuhDBQueryBuilder::builder().agentGetOsInfoCommand(agentId).build(), response);
+
+        if (response.empty())
+        {
+            throw std::runtime_error("Empty response from Wazuh-DB");
+        }
+
+        Os osData;
+        auto& data = response.at(0);
+
+        osData.hostName = data.value("hostname", "");
+        osData.architecture = data.value("architecture", "");
+        osData.name = data.value("os_name", "");
+        osData.codeName = data.value("os_codename", "");
+        osData.majorVersion = data.value("os_major", "");
+        osData.minorVersion = data.value("os_minor", "");
+        osData.patch = data.value("os_patch", "");
+        osData.build = data.value("os_build", "");
+        osData.platform = data.value("os_platform", "");
+        osData.version = data.value("os_version", "");
+        osData.release = data.value("os_release", "");
+        osData.displayVersion = data.value("os_display_version", "");
+        osData.sysName = data.value("sysname", "");
+        osData.kernelVersion = data.value("version", "");
+        osData.kernelRelease = data.value("release", "");
+
+        return osData;
+    }
 
 public:
+    OsDataCache()
+    {
+        try
+        {
+            m_wdbSocketWrapper.emplace(OS_CACHE_WDB_SOCKET);
+        }
+        catch (const std::exception& e)
+        {
+            logDebug2(WM_VULNSCAN_LOGTAG, "Error creating socketDBWrapper: %s", e.what());
+        }
+    }
+
     /**
      * @brief This method returns the os data.
      * @param agentId agent id.
@@ -60,7 +112,27 @@ public:
     {
         std::shared_lock<std::shared_mutex> lock(m_mutex);
         auto value = m_osData.getValue(agentId);
-        return value ? *value : Os();
+
+        if (value)
+        {
+            return *value;
+        }
+
+        if (m_wdbSocketWrapper)
+        {
+            try
+            {
+                auto osData = getOsDataFromWdb(agentId);
+                m_osData.insertKey(agentId, osData);
+                return osData;
+            }
+            catch (const std::exception& e)
+            {
+                logDebug2(WM_VULNSCAN_LOGTAG, "Error quering Wazuh-DB: %s", e.what());
+            }
+        }
+
+        return Os();
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
@@ -58,7 +58,6 @@ private:
 
     Os getOsDataFromWdb(const std::string& agentId)
     {
-
         nlohmann::json response;
         m_wdbSocketWrapper->query(WazuhDBQueryBuilder::builder().agentGetOsInfoCommand(agentId).build(), response);
 
@@ -90,18 +89,6 @@ private:
     }
 
 public:
-    OsDataCache()
-    {
-        try
-        {
-            m_wdbSocketWrapper.emplace(OS_CACHE_WDB_SOCKET);
-        }
-        catch (const std::exception& e)
-        {
-            logDebug2(WM_VULNSCAN_LOGTAG, "Error creating socketDBWrapper: %s", e.what());
-        }
-    }
-
     /**
      * @brief This method returns the os data.
      * @param agentId agent id.
@@ -118,18 +105,27 @@ public:
             return *value;
         }
 
-        if (m_wdbSocketWrapper)
+        if (!m_wdbSocketWrapper)
         {
             try
             {
-                auto osData = getOsDataFromWdb(agentId);
-                m_osData.insertKey(agentId, osData);
-                return osData;
+                m_wdbSocketWrapper.emplace(OS_CACHE_WDB_SOCKET);
             }
             catch (const std::exception& e)
             {
-                logDebug2(WM_VULNSCAN_LOGTAG, "Error quering Wazuh-DB: %s", e.what());
+                logDebug2(WM_VULNSCAN_LOGTAG, "Error creating socketDBWrapper: %s", e.what());
             }
+        }
+
+        try
+        {
+            auto osData = getOsDataFromWdb(agentId);
+            m_osData.insertKey(agentId, osData);
+            return osData;
+        }
+        catch (const std::exception& e)
+        {
+            logDebug2(WM_VULNSCAN_LOGTAG, "Error quering Wazuh-DB: %s", e.what());
         }
 
         return Os();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
@@ -128,7 +128,7 @@ public:
             logDebug2(WM_VULNSCAN_LOGTAG, "Error quering Wazuh-DB: %s", e.what());
         }
 
-        return Os();
+        return {};
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.cpp
@@ -1,0 +1,150 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * December 13, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "osDataCache_test.hpp"
+
+TEST_F(OsDataCacheTest, TestSetAndGetSuccess)
+{
+    // Start fake server
+    m_socketServer->listen(
+        [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
+        {
+            std::ignore = fd;
+            std::ignore = dataHeader;
+            std::ignore = sizeHeader;
+            std::ignore = size;
+            std::ignore = data;
+
+            m_socketServer->send(fd, "err ", 4);
+        });
+
+    OsDataCache cache;
+    std::string agentId {"1"};
+
+    // Try to get value from empty cache
+    auto osDataRetrieved = cache.getOsData(agentId);
+
+    // Verify that the returned value is empty
+    ASSERT_TRUE(osDataRetrieved.hostName.empty());
+    ASSERT_TRUE(osDataRetrieved.architecture.empty());
+    ASSERT_TRUE(osDataRetrieved.name.empty());
+    ASSERT_TRUE(osDataRetrieved.codeName.empty());
+    ASSERT_TRUE(osDataRetrieved.majorVersion.empty());
+    ASSERT_TRUE(osDataRetrieved.minorVersion.empty());
+    ASSERT_TRUE(osDataRetrieved.patch.empty());
+    ASSERT_TRUE(osDataRetrieved.build.empty());
+    ASSERT_TRUE(osDataRetrieved.platform.empty());
+    ASSERT_TRUE(osDataRetrieved.version.empty());
+    ASSERT_TRUE(osDataRetrieved.release.empty());
+    ASSERT_TRUE(osDataRetrieved.displayVersion.empty());
+    ASSERT_TRUE(osDataRetrieved.sysName.empty());
+    ASSERT_TRUE(osDataRetrieved.kernelVersion.empty());
+    ASSERT_TRUE(osDataRetrieved.kernelRelease.empty());
+
+    // Set value in cache
+    Os osData {.hostName = "hostName",
+               .architecture = "architecture",
+               .name = "name",
+               .codeName = "codeName",
+               .majorVersion = "majorVersion",
+               .minorVersion = "minorVersion",
+               .patch = "patch",
+               .build = "build",
+               .platform = "platform",
+               .version = "version",
+               .release = "release",
+               .displayVersion = "displayVersion",
+               .sysName = "sysName",
+               .kernelVersion = "kernelVersion",
+               .kernelRelease = "kernelRelease"};
+
+    cache.setOsData(agentId, osData);
+
+    // Get value from cache
+    osDataRetrieved = cache.getOsData(agentId);
+
+    // Verify that the returned value is the same as the one set
+    ASSERT_EQ(osDataRetrieved.hostName, osData.hostName);
+    ASSERT_EQ(osDataRetrieved.architecture, osData.architecture);
+    ASSERT_EQ(osDataRetrieved.name, osData.name);
+    ASSERT_EQ(osDataRetrieved.codeName, osData.codeName);
+    ASSERT_EQ(osDataRetrieved.majorVersion, osData.majorVersion);
+    ASSERT_EQ(osDataRetrieved.minorVersion, osData.minorVersion);
+    ASSERT_EQ(osDataRetrieved.patch, osData.patch);
+    ASSERT_EQ(osDataRetrieved.build, osData.build);
+    ASSERT_EQ(osDataRetrieved.platform, osData.platform);
+    ASSERT_EQ(osDataRetrieved.version, osData.version);
+    ASSERT_EQ(osDataRetrieved.release, osData.release);
+    ASSERT_EQ(osDataRetrieved.displayVersion, osData.displayVersion);
+    ASSERT_EQ(osDataRetrieved.sysName, osData.sysName);
+    ASSERT_EQ(osDataRetrieved.kernelVersion, osData.kernelVersion);
+    ASSERT_EQ(osDataRetrieved.kernelRelease, osData.kernelRelease);
+}
+
+TEST_F(OsDataCacheTest, TestDbQuery)
+{
+    // Create fake response
+    nlohmann::json response;
+    response["hostname"] = "hostName";
+    response["architecture"] = "architecture";
+    response["os_name"] = "name";
+    response["os_codename"] = "codeName";
+    response["os_major"] = "majorVersion";
+    response["os_minor"] = "minorVersion";
+    response["os_patch"] = "patch";
+    response["os_build"] = "build";
+    response["os_platform"] = "platform";
+    response["os_version"] = "version";
+    response["os_release"] = "release";
+    response["os_display_version"] = "displayVersion";
+    response["sysname"] = "sysName";
+    response["version"] = "kernelVersion";
+    response["release"] = "kernelRelease";
+
+    std::string responseString = response.dump();
+    std::string finalResponse = "ok ";
+    finalResponse.append(responseString);
+
+    // Start fake server
+    m_socketServer->listen(
+        [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
+        {
+            std::ignore = dataHeader;
+            std::ignore = sizeHeader;
+            std::ignore = size;
+            std::ignore = data;
+
+            m_socketServer->send(fd, finalResponse.c_str(), finalResponse.size());
+        });
+
+    OsDataCache cache;
+    std::string agentId {"1"};
+
+    // Get value from cache
+    auto osDataRetrieved = cache.getOsData(agentId);
+
+    // Verify that the returned value is the one returned by the server
+    ASSERT_EQ(osDataRetrieved.hostName, "hostName");
+    ASSERT_EQ(osDataRetrieved.architecture, "architecture");
+    ASSERT_EQ(osDataRetrieved.name, "name");
+    ASSERT_EQ(osDataRetrieved.codeName, "codeName");
+    ASSERT_EQ(osDataRetrieved.majorVersion, "majorVersion");
+    ASSERT_EQ(osDataRetrieved.minorVersion, "minorVersion");
+    ASSERT_EQ(osDataRetrieved.patch, "patch");
+    ASSERT_EQ(osDataRetrieved.build, "build");
+    ASSERT_EQ(osDataRetrieved.platform, "platform");
+    ASSERT_EQ(osDataRetrieved.version, "version");
+    ASSERT_EQ(osDataRetrieved.release, "release");
+    ASSERT_EQ(osDataRetrieved.displayVersion, "displayVersion");
+    ASSERT_EQ(osDataRetrieved.sysName, "sysName");
+    ASSERT_EQ(osDataRetrieved.kernelVersion, "kernelVersion");
+    ASSERT_EQ(osDataRetrieved.kernelRelease, "kernelRelease");
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.hpp
@@ -1,0 +1,60 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * December 13, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _OS_DATA_CACHE_TEST_HPP
+#define _OS_DATA_CACHE_TEST_HPP
+
+#include "osDataCache.hpp"
+#include "socketServer.hpp"
+#include "gtest/gtest.h"
+#include <filesystem>
+
+/**
+ * @brief Runs unit tests for osDataCache
+ */
+class OsDataCacheTest : public ::testing::Test
+{
+protected:
+    // LCOV_EXCL_START
+    OsDataCacheTest() = default;
+    ~OsDataCacheTest() override = default;
+    // LCOV_EXCL_STOP
+    /**
+     * @brief Fake socket server to test the DB query.
+     *
+     */
+    std::shared_ptr<SocketServer<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>> m_socketServer;
+
+    /**
+     * @brief Set the Up every test case.
+     *
+     */
+    void SetUp() override
+    {
+        std::filesystem::create_directories("queue/db");
+        // Create the socket server
+        m_socketServer =
+            std::make_shared<SocketServer<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>>(OS_CACHE_WDB_SOCKET);
+    }
+
+    /**
+     * @brief Clean up method after every test execution.
+     *
+     */
+    void TearDown() override
+    {
+        // Stop the socket server
+        m_socketServer->stop();
+        std::filesystem::remove_all("queue/db");
+    }
+};
+
+#endif // _OS_DATA_CACHE_TEST_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.hpp
@@ -12,7 +12,9 @@
 #ifndef _SEND_REPORT_TEST_HPP
 #define _SEND_REPORT_TEST_HPP
 
+#include "socketServer.hpp"
 #include "gtest/gtest.h"
+#include <filesystem>
 
 /**
  * @brief SendReport test class.
@@ -24,6 +26,44 @@ class SendReportTest : public ::testing::Test
 protected:
     SendReportTest() = default;
     ~SendReportTest() override = default;
+
+    /**
+     * @brief Fake server to receive Wazuh-DB queries.
+     *
+     */
+    std::shared_ptr<SocketServer<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>> m_fakeWdb;
+
+    /**
+     * @brief Set the environment for testing.
+     *
+     */
+    void SetUp() override
+    {
+        std::filesystem::create_directories("queue/db");
+
+        m_fakeWdb =
+            std::make_shared<SocketServer<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>>("queue/db/wdb");
+
+        m_fakeWdb->listen(
+            [&](const int fd, const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader)
+            {
+                std::ignore = fd;
+                std::ignore = dataHeader;
+                std::ignore = sizeHeader;
+                std::ignore = size;
+                std::ignore = data;
+            });
+    }
+
+    /**
+     * @brief Clean the environment after testing.
+     *
+     */
+    void TearDown() override
+    {
+        m_fakeWdb->stop();
+        std::filesystem::remove_all("queue/db");
+    }
 };
 
 #endif // _SEND_REPORT_TEST_HPP


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20761 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR queries the Wazuh-DB when the OS cache of vulnerability detector doesn't contain data for an agent.
The item is added to the cache also.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->
UT tests were added.

Also, a manual test was carried out. Some temporary debug messages were added to confirm the DB was queried successfully just once

```
2023/12/14 03:48:03 wazuh-modulesd:vulnerability-scanner[86147] databaseFeedManager.hpp:134 at processMessage(): INFO: Processing file: queue/vd_updater/tmp/contents/vd_1.0.0_vd_4.8.0_230577_1700904966.json

2023/12/14 03:48:05 wazuh-modulesd:vulnerability-scanner[86147] osDataCache.hpp:128 at getOsData(): WARNING: Os data retrieved from DB for agentId: 004

2023/12/14 03:48:05 wazuh-modulesd:vulnerability-scanner[86147] packageScanner.hpp:154 at handleRequest(): DEBUG: Scanning package: libc-dev-bin, CNA: canonical

2023/12/14 03:48:06 wazuh-modulesd:vulnerability-scanner[86147] osDataCache.hpp:118 at getOsData(): WARNING: Os data found in cache for agentId: 004
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Source installation

- [x] Added unit tests (for new features)
