### PR TITLE
Configuration for vulnerability detector LRU caches size added

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -424,8 +424,8 @@ auth.timeout_seconds=1
 auth.timeout_microseconds=0
 
 # Vulnerability detector LRUs size
-vulnerability-detector.translation_lru_size=2048
-vulnerability-detector.osdata_lru_size=1000
+vulnerability-detection.translation_lru_size=2048
+vulnerability-detection.osdata_lru_size=1000
 
 # Debug options.
 # Debug 0 -> no debug

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -423,6 +423,9 @@ sca.commands_timeout=30
 auth.timeout_seconds=1
 auth.timeout_microseconds=0
 
+# Vulnerability detector LRUs size
+vulnerability-detector.translation_lru_size=2048
+vulnerability-detector.osdata_lru_size=1000
 
 # Debug options.
 # Debug 0 -> no debug

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -47,8 +47,6 @@ constexpr auto REMEDIATIONS_DATABASE_PATH {"queue/vd/remediations"};
 constexpr auto TRANSLATIONS_DATABASE_PATH {"queue/vd/translations"};
 constexpr auto CVES_DATABASE_PATH {"queue/vd/cves"};
 
-constexpr auto CACHE_SIZE {2048};
-
 using namespace NSVulnerabilityScanner;
 
 /**
@@ -195,7 +193,8 @@ public:
         m_remediationsDatabase = std::make_unique<Utils::RocksDBWrapper>(REMEDIATIONS_DATABASE_PATH);
         m_translationsDatabase = std::make_unique<Utils::RocksDBWrapper>(TRANSLATIONS_DATABASE_PATH);
 
-        m_translationsCache = std::make_unique<LRUCache<std::string, std::string>>(CACHE_SIZE);
+        m_translationsCache =
+            std::make_unique<LRUCache<std::string, std::string>>(TPolicyManager::instance().getTranslationLRUSize());
         m_cvesDatabase = std::make_unique<Utils::RocksDBWrapper>(CVES_DATABASE_PATH);
 
         // Subscription to vulnerability detector content update events.

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -27,6 +27,8 @@
 
 constexpr auto UNKNOWN_VALUE {" "};
 constexpr auto STATES_VD_INDEX_NAME {"wazuh-states-vulnerabilities"};
+constexpr auto DEFAULT_TRANSLATION_LRU_SIZE {2048};
+constexpr auto DEFAULT_OSDATA_LRU_SIZE {1000};
 
 /**
  * @brief PolicyManager class.
@@ -155,14 +157,14 @@ private:
             }
         }
 
-        if (!newPolicy.contains("translation_lru_size"))
+        if (!newPolicy.contains("translationLRUSize"))
         {
-            newPolicy["translation_lru_size"] = 2048;
+            newPolicy["translationLRUSize"] = DEFAULT_TRANSLATION_LRU_SIZE;
         }
 
-        if (!newPolicy.contains("osdata_lru_size"))
+        if (!newPolicy.contains("osdataLRUSize"))
         {
-            newPolicy["osdata_lru_size"] = 1000;
+            newPolicy["osdataLRUSize"] = DEFAULT_OSDATA_LRU_SIZE;
         }
 
         return newPolicy;
@@ -533,7 +535,7 @@ public:
      */
     uint32_t getTranslationLRUSize() const
     {
-        return m_configuration.at("translation_lru_size").get<uint32_t>();
+        return m_configuration.at("translationLRUSize").get<uint32_t>();
     }
 
     /**
@@ -541,9 +543,9 @@ public:
      *
      * @return uint32_t osdata LRU size.
      */
-    uint32_t getOsDataLRUSize() const
+    uint32_t getOsdataLRUSize() const
     {
-        return m_configuration.at("osdata_lru_size").get<uint32_t>();
+        return m_configuration.at("osdataLRUSize").get<uint32_t>();
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -155,6 +155,16 @@ private:
             }
         }
 
+        if (!newPolicy.contains("translation_lru_size"))
+        {
+            newPolicy["translation_lru_size"] = 2048;
+        }
+
+        if (!newPolicy.contains("osdata_lru_size"))
+        {
+            newPolicy["osdata_lru_size"] = 1000;
+        }
+
         return newPolicy;
     }
 
@@ -514,6 +524,26 @@ public:
     std::string getCTIUrl() const
     {
         return m_configuration.at("vulnerability-detection").at("cti-url").get_ref<const std::string&>();
+    }
+
+    /**
+     * @brief Get translation LRU size.
+     *
+     * @return uint32_t translation LRU size.
+     */
+    uint32_t getTranslationLRUSize() const
+    {
+        return m_configuration.at("translation_lru_size").get<uint32_t>();
+    }
+
+    /**
+     * @brief Get osdata LRU size.
+     *
+     * @return uint32_t osdata LRU size.
+     */
+    uint32_t getOsDataLRUSize() const
+    {
+        return m_configuration.at("osdata_lru_size").get<uint32_t>();
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
@@ -12,6 +12,7 @@
 #ifndef _OS_DATA_CACHE_HPP
 #define _OS_DATA_CACHE_HPP
 
+#include "../policyManager/policyManager.hpp"
 #include "cacheLRU.hpp"
 #include "loggerHelper.h"
 #include "singleton.hpp"
@@ -52,7 +53,7 @@ struct Os final
 class OsDataCache final : public Singleton<OsDataCache>
 {
 private:
-    LRUCache<std::string, Os> m_osData {1000};
+    std::unique_ptr<LRUCache<std::string, Os>> m_osDataCache;
     std::shared_mutex m_mutex;
     std::optional<SocketDBWrapper> m_wdbSocketWrapper {std::nullopt};
 
@@ -89,6 +90,14 @@ private:
     }
 
 public:
+    /**
+     * @brief Class constructor.
+     */
+    explicit OsDataCache()
+    {
+        m_osDataCache = std::make_unique<LRUCache<std::string, Os>>(PolicyManager::instance().getOsDataLRUSize());
+    }
+
     /**
      * @brief This method returns the os data.
      * @param agentId agent id.
@@ -140,7 +149,7 @@ public:
     void setOsData(const std::string& agentId, const Os& osData)
     {
         std::lock_guard<std::shared_mutex> lock(m_mutex);
-        m_osData.insertKey(agentId, osData);
+        m_osDataCache->insertKey(agentId, osData);
     }
 };
 // LCOV_EXCL_STOP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
@@ -53,7 +53,7 @@ struct Os final
 class OsDataCache final : public Singleton<OsDataCache>
 {
 private:
-    std::unique_ptr<LRUCache<std::string, Os>> m_osDataCache;
+    LRUCache<std::string, Os> m_osData {PolicyManager::instance().getOsdataLRUSize()};
     std::shared_mutex m_mutex;
     std::optional<SocketDBWrapper> m_wdbSocketWrapper {std::nullopt};
 
@@ -90,14 +90,6 @@ private:
     }
 
 public:
-    /**
-     * @brief Class constructor.
-     */
-    explicit OsDataCache()
-    {
-        m_osDataCache = std::make_unique<LRUCache<std::string, Os>>(PolicyManager::instance().getOsDataLRUSize());
-    }
-
     /**
      * @brief This method returns the os data.
      * @param agentId agent id.
@@ -149,7 +141,7 @@ public:
     void setOsData(const std::string& agentId, const Os& osData)
     {
         std::lock_guard<std::shared_mutex> lock(m_mutex);
-        m_osDataCache->insertKey(agentId, osData);
+        m_osData.insertKey(agentId, osData);
     }
 };
 // LCOV_EXCL_STOP

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -61,9 +61,9 @@ void VulnerabilityScannerFacade::start(
         m_databaseFeedManager = std::make_shared<DatabaseFeedManager>(m_indexerConnector);
 
         // Socket client initialization to send vulnerability reports.
-        if (configuration.contains("wm_max_eps") && configuration.at("wm_max_eps").is_number())
+        if (configuration.contains("wmMaxEps") && configuration.at("wmMaxEps").is_number())
         {
-            SOCKET_WAIT = MICROSEC_FACTOR / configuration.at("wm_max_eps").get<int>();
+            SOCKET_WAIT = MICROSEC_FACTOR / configuration.at("wmMaxEps").get<int>();
         }
         m_reportSocketClient =
             std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(DEFAULT_QUEUE_PATH);

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -156,6 +156,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -207,6 +208,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -253,6 +255,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -295,6 +298,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesSuccess)
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
 
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
 
@@ -336,6 +340,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesNoPackageName)
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
 
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
 
@@ -366,6 +371,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_ValidData)
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -417,6 +423,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_DataNotFound)
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -451,6 +458,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_InvalidData)
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -494,6 +502,7 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheMiss)
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -574,6 +583,7 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationCacheHit)
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -681,6 +691,7 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationNoTranslationFound)
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -759,6 +770,7 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationInvalidDatabase)
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
@@ -859,6 +871,7 @@ void DatabaseFeedManagerTest_GracefulShutdown()
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters);

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockPolicyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockPolicyManager.hpp
@@ -186,6 +186,27 @@ public:
      * @note This method is intended for testing purposes and does not perform any real action.
      */
     MOCK_METHOD(std::string, getKey, (), (const));
+
+    /**
+     * @brief Mock method for getCTIUrl.
+     *
+     * @note This method is intended for testing purposes and does not perform any real action.
+     */
+    MOCK_METHOD(std::string, getCTIUrl, (), (const));
+
+    /**
+     * @brief Mock method for getTranslationLRUSize.
+     *
+     * @note This method is intended for testing purposes and does not perform any real action.
+     */
+    MOCK_METHOD(uint32_t, getTranslationLRUSize, (), (const));
+
+    /**
+     * @brief Mock method for getOsDataLRUSize.
+     *
+     * @note This method is intended for testing purposes and does not perform any real action.
+     */
+    MOCK_METHOD(uint32_t, getOsDataLRUSize, (), (const));
 };
 
 #endif // _MOCK_POLICYMANAGER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockPolicyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockPolicyManager.hpp
@@ -202,11 +202,11 @@ public:
     MOCK_METHOD(uint32_t, getTranslationLRUSize, (), (const));
 
     /**
-     * @brief Mock method for getOsDataLRUSize.
+     * @brief Mock method for getOsdataLRUSize.
      *
      * @note This method is intended for testing purposes and does not perform any real action.
      */
-    MOCK_METHOD(uint32_t, getOsDataLRUSize, (), (const));
+    MOCK_METHOD(uint32_t, getOsdataLRUSize, (), (const));
 };
 
 #endif // _MOCK_POLICYMANAGER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolinePolicyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolinePolicyManager.hpp
@@ -295,9 +295,9 @@ public:
      *
      * @return uint32_t osdata LRU size.
      */
-    uint32_t getOsDataLRUSize() const
+    uint32_t getOsdataLRUSize() const
     {
-        return spPolicyManagerMock->getOsDataLRUSize();
+        return spPolicyManagerMock->getOsdataLRUSize();
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolinePolicyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolinePolicyManager.hpp
@@ -270,6 +270,35 @@ public:
     {
         return spPolicyManagerMock->getKey();
     }
+
+    /**
+     * @brief Get CTI url.
+     * @return std::string CTI-Server url.
+     */
+    std::string getCTIUrl() const
+    {
+        return spPolicyManagerMock->getCTIUrl();
+    }
+
+    /**
+     * @brief Get translation LRU size.
+     *
+     * @return uint32_t translation LRU size.
+     */
+    uint32_t getTranslationLRUSize() const
+    {
+        return spPolicyManagerMock->getTranslationLRUSize();
+    }
+
+    /**
+     * @brief Get osdata LRU size.
+     *
+     * @return uint32_t osdata LRU size.
+     */
+    uint32_t getOsDataLRUSize() const
+    {
+        return spPolicyManagerMock->getOsDataLRUSize();
+    }
 };
 
 #endif //_TRAMPOLINE_POLICYMANAGER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
@@ -180,7 +180,9 @@ TEST_F(PolicyManagerTest, validConfigurationCheckParameters)
           "certificate": "cert",
           "key": "ItsASecret!"
         }
-      }
+      },
+      "translation_lru_size": 5000,
+      "osdata_lru_size": 6000
     })")};
     EXPECT_NO_THROW(m_policyManager->initialize(configJson));
 
@@ -204,6 +206,8 @@ TEST_F(PolicyManagerTest, validConfigurationCheckParameters)
     EXPECT_STREQ(
         m_policyManager->getUpdaterConfiguration().dump().c_str(),
         R"({"configData":{"apiParameters":{"itemsPerRequest":{"name":"limit","value":100},"offset":{"name":"offset","start":0,"step":100}},"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-offset","dataFormat":"json","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"queue/vd_updater/tmp","url":"https://cti-url.com","versionedContent":"cti-api"},"interval":3600,"ondemand":true,"topicName":"vulnerability_feed_manager"})");
+    EXPECT_EQ(m_policyManager->getTranslationLRUSize(), 5000);
+    EXPECT_EQ(m_policyManager->getOsDataLRUSize(), 6000);
 }
 
 TEST_F(PolicyManagerTest, validConfigurationCheckParametersOffline)
@@ -257,6 +261,8 @@ TEST_F(PolicyManagerTest, validConfigurationDefaultValues)
     EXPECT_STREQ(m_policyManager->getKey().c_str(), "");
     EXPECT_EQ(m_policyManager->getCAList().size(), 0);
     EXPECT_EQ(m_policyManager->getCTIUrl(), "cti-url.com");
+    EXPECT_EQ(m_policyManager->getTranslationLRUSize(), 2048);
+    EXPECT_EQ(m_policyManager->getOsDataLRUSize(), 1000);
 }
 
 TEST_F(PolicyManagerTest, invalidConfigurationNoCTIUrl)
@@ -289,6 +295,9 @@ TEST_F(PolicyManagerTest, validConfigurationDefaultValuesNoIndexer)
     EXPECT_EQ(m_policyManager->getFeedUpdateTime(), 3600);
 
     EXPECT_EQ(m_policyManager->getHostList().count("http://localhost:9200"), 0);
+
+    EXPECT_EQ(m_policyManager->getTranslationLRUSize(), 2048);
+    EXPECT_EQ(m_policyManager->getOsDataLRUSize(), 1000);
 }
 
 TEST_F(PolicyManagerTest, validConfigurationVulnerabilityScannerIgnoreIndexStatus)

--- a/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/policyManager/policyManager_test.cpp
@@ -181,8 +181,8 @@ TEST_F(PolicyManagerTest, validConfigurationCheckParameters)
           "key": "ItsASecret!"
         }
       },
-      "translation_lru_size": 5000,
-      "osdata_lru_size": 6000
+      "translationLRUSize": 5000,
+      "osdataLRUSize": 6000
     })")};
     EXPECT_NO_THROW(m_policyManager->initialize(configJson));
 
@@ -207,7 +207,7 @@ TEST_F(PolicyManagerTest, validConfigurationCheckParameters)
         m_policyManager->getUpdaterConfiguration().dump().c_str(),
         R"({"configData":{"apiParameters":{"itemsPerRequest":{"name":"limit","value":100},"offset":{"name":"offset","start":0,"step":100}},"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-offset","dataFormat":"json","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"queue/vd_updater/tmp","url":"https://cti-url.com","versionedContent":"cti-api"},"interval":3600,"ondemand":true,"topicName":"vulnerability_feed_manager"})");
     EXPECT_EQ(m_policyManager->getTranslationLRUSize(), 5000);
-    EXPECT_EQ(m_policyManager->getOsDataLRUSize(), 6000);
+    EXPECT_EQ(m_policyManager->getOsdataLRUSize(), 6000);
 }
 
 TEST_F(PolicyManagerTest, validConfigurationCheckParametersOffline)
@@ -262,7 +262,7 @@ TEST_F(PolicyManagerTest, validConfigurationDefaultValues)
     EXPECT_EQ(m_policyManager->getCAList().size(), 0);
     EXPECT_EQ(m_policyManager->getCTIUrl(), "cti-url.com");
     EXPECT_EQ(m_policyManager->getTranslationLRUSize(), 2048);
-    EXPECT_EQ(m_policyManager->getOsDataLRUSize(), 1000);
+    EXPECT_EQ(m_policyManager->getOsdataLRUSize(), 1000);
 }
 
 TEST_F(PolicyManagerTest, invalidConfigurationNoCTIUrl)
@@ -297,7 +297,7 @@ TEST_F(PolicyManagerTest, validConfigurationDefaultValuesNoIndexer)
     EXPECT_EQ(m_policyManager->getHostList().count("http://localhost:9200"), 0);
 
     EXPECT_EQ(m_policyManager->getTranslationLRUSize(), 2048);
-    EXPECT_EQ(m_policyManager->getOsDataLRUSize(), 1000);
+    EXPECT_EQ(m_policyManager->getOsdataLRUSize(), 1000);
 }
 
 TEST_F(PolicyManagerTest, validConfigurationVulnerabilityScannerIgnoreIndexStatus)

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.hpp
@@ -13,6 +13,7 @@
 #define _OS_DATA_CACHE_TEST_HPP
 
 #include "osDataCache.hpp"
+#include "policyManager.hpp"
 #include "socketServer.hpp"
 #include "gtest/gtest.h"
 #include <filesystem>
@@ -43,6 +44,17 @@ protected:
         // Create the socket server
         m_socketServer =
             std::make_shared<SocketServer<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>>(OS_CACHE_WDB_SOCKET);
+
+        // Policy manager initialization.
+        const auto& configJson {nlohmann::json::parse(R"({
+        "vulnerability-detection": {
+            "enabled": "yes",
+            "index-status": "yes",
+            "cti-url": "cti-url.com"
+        },
+        "osdataLRUSize":1000
+        })")};
+        PolicyManager::instance().initialize(configJson);
     }
 
     /**
@@ -51,6 +63,7 @@ protected:
      */
     void TearDown() override
     {
+        PolicyManager::instance().teardown();
         // Stop the socket server
         m_socketServer->stop();
         std::filesystem::remove_all("queue/db");

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
@@ -16,7 +16,6 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
-#include "policyManager.hpp"
 #include "socketClient.hpp"
 #include "socketServer.hpp"
 
@@ -114,25 +113,6 @@ const std::string detectionStr =
             "operation": "INSERTED"
     }
 )";
-
-void SendReportTest::SetUp()
-{
-    // Policy manager initialization.
-    const auto& configJson {nlohmann::json::parse(R"({
-      "vulnerability-detection": {
-        "enabled": "yes",
-        "index-status": "yes",
-        "cti-url": "cti-url.com"
-      },
-      "osdataLRUSize":1000
-    })")};
-    PolicyManager::instance().initialize(configJson);
-};
-
-void SendReportTest::TearDown()
-{
-    PolicyManager::instance().teardown();
-};
 
 TEST_F(SendReportTest, SendFormattedMsg)
 {

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
@@ -16,6 +16,7 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
+#include "policyManager.hpp"
 #include "socketClient.hpp"
 #include "socketServer.hpp"
 
@@ -113,6 +114,25 @@ const std::string detectionStr =
             "operation": "INSERTED"
     }
 )";
+
+void SendReportTest::SetUp()
+{
+    // Policy manager initialization.
+    const auto& configJson {nlohmann::json::parse(R"({
+      "vulnerability-detection": {
+        "enabled": "yes",
+        "index-status": "yes",
+        "cti-url": "cti-url.com"
+      },
+      "osdataLRUSize":1000
+    })")};
+    PolicyManager::instance().initialize(configJson);
+};
+
+void SendReportTest::TearDown()
+{
+    PolicyManager::instance().teardown();
+};
 
 TEST_F(SendReportTest, SendFormattedMsg)
 {

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.hpp
@@ -24,7 +24,16 @@ class SendReportTest : public ::testing::Test
 {
 
 protected:
+    /**
+     * @brief Construct a new SendReportTest object
+     *
+     */
     SendReportTest() = default;
+
+    /**
+     * @brief Destroy the SendReportTest object
+     *
+     */
     ~SendReportTest() override = default;
 
     /**
@@ -53,6 +62,17 @@ protected:
                 std::ignore = size;
                 std::ignore = data;
             });
+
+        // Policy manager initialization.
+        const auto& configJson {nlohmann::json::parse(R"({
+        "vulnerability-detection": {
+            "enabled": "yes",
+            "index-status": "yes",
+            "cti-url": "cti-url.com"
+        },
+        "osdataLRUSize":1000
+        })")};
+        PolicyManager::instance().initialize(configJson);
     }
 
     /**
@@ -61,6 +81,7 @@ protected:
      */
     void TearDown() override
     {
+        PolicyManager::instance().teardown();
         m_fakeWdb->stop();
         std::filesystem::remove_all("queue/db");
     }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.hpp
@@ -12,6 +12,7 @@
 #ifndef _SEND_REPORT_TEST_HPP
 #define _SEND_REPORT_TEST_HPP
 
+#include "policyManager.hpp"
 #include "socketServer.hpp"
 #include "gtest/gtest.h"
 #include <filesystem>

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
@@ -63,6 +63,26 @@ public:
         return updaterConfiguration;
     }
 
+    /**
+     * @brief Get translation LRU size.
+     *
+     * @return uint32_t translation LRU size.
+     */
+    uint32_t getTranslationLRUSize() const
+    {
+        return 2048;
+    }
+
+    /**
+     * @brief Get osdata LRU size.
+     *
+     * @return uint32_t osdata LRU size.
+     */
+    uint32_t getOsDataLRUSize() const
+    {
+        return 1000;
+    }
+
 private:
     std::string m_topic;
 };

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
@@ -78,7 +78,7 @@ public:
      *
      * @return uint32_t osdata LRU size.
      */
-    uint32_t getOsDataLRUSize() const
+    uint32_t getOsdataLRUSize() const
     {
         return 1000;
     }

--- a/src/wazuh_modules/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/wm_vulnerability_scanner.c
@@ -60,6 +60,8 @@ void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t * data)
             cJSON *config_json = cJSON_CreateObject();
             cJSON_AddItemToObject(config_json, "vulnerability-detection", cJSON_Duplicate(data->vulnerability_detection, TRUE));
             cJSON_AddNumberToObject(config_json, "wm_max_eps", wm_max_eps);
+            cJSON_AddNumberToObject(config_json, "translation_lru_size", getDefine_Int("vulnerability-detector", "translation_lru_size", 1, 100000));
+            cJSON_AddNumberToObject(config_json, "osdata_lru_size", getDefine_Int("vulnerability-detector", "osdata_lru_size", 1, 100000));
 
             if(indexer_config == NULL)
             {

--- a/src/wazuh_modules/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/wm_vulnerability_scanner.c
@@ -60,8 +60,8 @@ void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t * data)
             cJSON *config_json = cJSON_CreateObject();
             cJSON_AddItemToObject(config_json, "vulnerability-detection", cJSON_Duplicate(data->vulnerability_detection, TRUE));
             cJSON_AddNumberToObject(config_json, "wmMaxEps", wm_max_eps);
-            cJSON_AddNumberToObject(config_json, "translationLRUSize", getDefine_Int("vulnerability-detector", "translation_lru_size", 1, 100000));
-            cJSON_AddNumberToObject(config_json, "osdataLRUSize", getDefine_Int("vulnerability-detector", "osdata_lru_size", 1, 100000));
+            cJSON_AddNumberToObject(config_json, "translationLRUSize", getDefine_Int("vulnerability-detection", "translation_lru_size", 1, 100000));
+            cJSON_AddNumberToObject(config_json, "osdataLRUSize", getDefine_Int("vulnerability-detection", "osdata_lru_size", 1, 100000));
 
             if(indexer_config == NULL)
             {

--- a/src/wazuh_modules/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/wm_vulnerability_scanner.c
@@ -59,9 +59,9 @@ void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t * data)
         {
             cJSON *config_json = cJSON_CreateObject();
             cJSON_AddItemToObject(config_json, "vulnerability-detection", cJSON_Duplicate(data->vulnerability_detection, TRUE));
-            cJSON_AddNumberToObject(config_json, "wm_max_eps", wm_max_eps);
-            cJSON_AddNumberToObject(config_json, "translation_lru_size", getDefine_Int("vulnerability-detector", "translation_lru_size", 1, 100000));
-            cJSON_AddNumberToObject(config_json, "osdata_lru_size", getDefine_Int("vulnerability-detector", "osdata_lru_size", 1, 100000));
+            cJSON_AddNumberToObject(config_json, "wmMaxEps", wm_max_eps);
+            cJSON_AddNumberToObject(config_json, "translationLRUSize", getDefine_Int("vulnerability-detector", "translation_lru_size", 1, 100000));
+            cJSON_AddNumberToObject(config_json, "osdataLRUSize", getDefine_Int("vulnerability-detector", "osdata_lru_size", 1, 100000));
 
             if(indexer_config == NULL)
             {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20783 |

## Description

This PR adds vulnerability detector LRU cache size configuration values in the internal configuration file.
Some UTs were modified to support new values.

## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Check some different configuration values
