### PR TITLE
Deprecate syscollector and syscheck endpoints

### DIFF
--- a/api/api/controllers/experimental_controller.py
+++ b/api/api/controllers/experimental_controller.py
@@ -13,7 +13,7 @@ import wazuh.syscheck as syscheck
 import wazuh.syscollector as syscollector
 from api import configuration
 from api.encoder import dumps, prettify
-from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
+from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deprecate_endpoint
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.exception import WazuhResourceNotFound
 
@@ -73,6 +73,7 @@ async def clear_rootcheck_database(request, pretty: bool = False, wait_for_compl
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 @check_experimental_feature_value
 async def clear_syscheck_database(request, pretty: bool = False, wait_for_complete: bool = False,
                                   agents_list: list = None) -> web.Response:
@@ -193,6 +194,7 @@ async def get_cis_cat_results(request, pretty: bool = False, wait_for_complete: 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_hardware_info(request, pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                             offset: int = 0, limit: int = None, select: str = None, sort: str = None,
@@ -258,6 +260,7 @@ async def get_hardware_info(request, pretty: bool = False, wait_for_complete: bo
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_network_address_info(request, pretty: bool = False, wait_for_complete: bool = False,
                                    agents_list: str = '*', offset: int = 0, limit: str = None, select: str = None,
@@ -331,6 +334,7 @@ async def get_network_address_info(request, pretty: bool = False, wait_for_compl
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_network_interface_info(request, pretty: bool = False, wait_for_complete: bool = False,
                                      agents_list: str = '*', offset: int = 0, limit: int = None, select: str = None,
@@ -405,6 +409,7 @@ async def get_network_interface_info(request, pretty: bool = False, wait_for_com
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_network_protocol_info(request, pretty: bool = False, wait_for_complete: bool = False,
                                     agents_list: str = '*', offset: int = 0, limit: int = None, select: str = None,
@@ -473,6 +478,7 @@ async def get_network_protocol_info(request, pretty: bool = False, wait_for_comp
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_os_info(request, pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                       offset: int = 0, limit: int = None, select: str = None, sort: str = None, search: str = None,
@@ -546,6 +552,7 @@ async def get_os_info(request, pretty: bool = False, wait_for_complete: bool = F
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_packages_info(request, pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                             offset: int = 0, limit: int = None, select: str = None, sort: str = None,
@@ -617,6 +624,7 @@ async def get_packages_info(request, pretty: bool = False, wait_for_complete: bo
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_ports_info(request, pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                          offset: int = 0, limit: int = None, select: str = None, sort: str = None, search: str = None,
@@ -696,6 +704,7 @@ async def get_ports_info(request, pretty: bool = False, wait_for_complete: bool 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_processes_info(request, pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                              offset: int = 0, limit: int = None, select: str = None, sort: str = None,
@@ -798,6 +807,7 @@ async def get_processes_info(request, pretty: bool = False, wait_for_complete: b
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_hotfixes_info(request, pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                             offset: int = 0, limit: int = None, sort: str = None, search: str = None,

--- a/api/api/controllers/syscheck_controller.py
+++ b/api/api/controllers/syscheck_controller.py
@@ -7,7 +7,7 @@ import logging
 from aiohttp import web
 
 from api.encoder import dumps, prettify
-from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
+from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deprecate_endpoint
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.syscheck import run, clear, files, last_scan
 
@@ -49,6 +49,7 @@ async def put_syscheck(request, agents_list: str = '*', pretty: bool = False,
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 async def get_syscheck_agent(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                              offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                              search: str = None, distinct: bool = False, summary: bool = False, md5: str = None,
@@ -123,6 +124,7 @@ async def get_syscheck_agent(request, agent_id: str, pretty: bool = False, wait_
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 async def delete_syscheck_agent(request, agent_id: str = '*', pretty: bool = False,
                                 wait_for_complete: bool = False) -> web.Response:
     """Clear file integrity monitoring scan results for a specified agent.

--- a/api/api/controllers/syscollector_controller.py
+++ b/api/api/controllers/syscollector_controller.py
@@ -8,12 +8,13 @@ from aiohttp import web
 
 import wazuh.syscollector as syscollector
 from api.encoder import dumps, prettify
-from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
+from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deprecate_endpoint
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
 logger = logging.getLogger('wazuh-api')
 
 
+@deprecate_endpoint()
 async def get_hardware_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                             select: str = None) -> web.Response:
     """Get hardware info of an agent.
@@ -51,6 +52,7 @@ async def get_hardware_info(request, agent_id: str, pretty: bool = False, wait_f
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 async def get_hotfix_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                           offset: int = 0, limit: int = None, sort: str = None, search: str = None, select: str = None,
                           hotfix: str = None, q: str = None, distinct: bool = False) -> web.Response:
@@ -115,6 +117,7 @@ async def get_hotfix_info(request, agent_id: str, pretty: bool = False, wait_for
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 async def get_network_address_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                                    offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                                    search: str = None, iface: str = None, proto: str = None, address: str = None,
@@ -192,6 +195,7 @@ async def get_network_address_info(request, agent_id: str, pretty: bool = False,
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 async def get_network_interface_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                                      offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                                      search: str = None, name: str = None, adapter: str = None, state: str = None,
@@ -270,6 +274,7 @@ async def get_network_interface_info(request, agent_id: str, pretty: bool = Fals
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 async def get_network_protocol_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                                     offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                                     search: str = None, iface: str = None, gateway: str = None, dhcp: str = None,
@@ -341,6 +346,7 @@ async def get_network_protocol_info(request, agent_id: str, pretty: bool = False
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 async def get_os_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                       select: str = None) -> web.Response:
     """Get OS info of an agent.
@@ -379,6 +385,7 @@ async def get_os_info(request, agent_id: str, pretty: bool = False, wait_for_com
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 async def get_packages_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                             offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                             search: str = None, vendor: str = None, name: str = None, architecture: str = None,
@@ -453,6 +460,7 @@ async def get_packages_info(request, agent_id: str, pretty: bool = False, wait_f
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 async def get_ports_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
                          limit: int = None, select: str = None, sort: str = None, search: str = None, pid: str = None,
                          protocol: str = None, tx_queue: str = None, state: str = None, process: str = None,
@@ -533,6 +541,7 @@ async def get_ports_info(request, agent_id: str, pretty: bool = False, wait_for_
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@deprecate_endpoint()
 async def get_processes_info(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                              offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                              search: str = None, pid: str = None, state: str = None, ppid: str = None,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -14519,6 +14519,7 @@ paths:
     get:
       tags:
       - Syscheck
+      deprecated: true
       summary: "Get results"
       description: "Return FIM findings in the specified agent"
       operationId: api.controllers.syscheck_controller.get_syscheck_agent
@@ -14609,6 +14610,7 @@ paths:
     delete:
       tags:
         - Syscheck
+      deprecated: true
       summary: "Clear results"
       description: "Clear file integrity monitoring scan results for a specified agent. Only available for agents < 3.12.0, it doesn't apply for more recent ones"
       operationId: api.controllers.syscheck_controller.delete_syscheck_agent
@@ -15202,6 +15204,7 @@ paths:
     delete:
       tags:
         - Experimental
+      deprecated: true
       summary: "Clear agents FIM results"
       description: "Clear the syscheck database for all agents or a list of them"
       operationId: api.controllers.experimental_controller.clear_syscheck_database
@@ -15352,6 +15355,7 @@ paths:
     get:
       tags:
         - Experimental
+      deprecated: true
       summary: "Get agents hardware"
       description: "Return all agents (or a list of them) hardware info. This information include cpu, ram, scan info
       among others of all agents"
@@ -15447,6 +15451,7 @@ paths:
     get:
       tags:
         - Experimental
+      deprecated: true
       summary: "Get agents netaddr"
       description: "Return all agents (or a list of them) IPv4 and IPv6 addresses associated to their network
       interfaces. This information include used IP protocol, interface, and IP address among others"
@@ -15525,6 +15530,7 @@ paths:
     get:
       tags:
         - Experimental
+      deprecated: true
       summary: "Get agents netiface"
       description: "Return all agents (or a list of them) network interfaces. This information includes rx, scan, tx
       info and some network information among other"
@@ -15645,6 +15651,7 @@ paths:
     get:
       tags:
         - Experimental
+      deprecated: true
       summary: "Get agents netproto"
       description: "Return all agents (or a list of them) routing configuration for each network interface. This
       information includes interface, type protocol information among other"
@@ -15720,6 +15727,7 @@ paths:
     get:
       tags:
         - Experimental
+      deprecated: true
       summary: "Get agents OS"
       description: "Return all agents (or a list of them) OS info. This information includes os information,
       architecture information among other"
@@ -15823,6 +15831,7 @@ paths:
     get:
       tags:
         - Experimental
+      deprecated: true
       summary: "Get agents packages"
       description: "Return all agents (or a list of them) packages info. This information includes name, section, size,
       and priority information of all packages among other"
@@ -15923,6 +15932,7 @@ paths:
     get:
       tags:
         - Experimental
+      deprecated: true
       summary: "Get agents ports"
       description: "Return all agents (or a list of them) ports info. This information includes local IP, Remote IP,
       protocol information among other"
@@ -16026,6 +16036,7 @@ paths:
     get:
       tags:
         - Experimental
+      deprecated: true
       summary: "Get agents processes"
       description: "Return all agents (or a list of them) processes info"
       operationId: api.controllers.experimental_controller.get_processes_info
@@ -16153,6 +16164,7 @@ paths:
     get:
       tags:
         - Experimental
+      deprecated: true
       summary: "Get agents hotfixes"
       description: "Return all agents (or a list of them) hotfixes info"
       operationId: api.controllers.experimental_controller.get_hotfixes_info
@@ -16211,6 +16223,7 @@ paths:
     get:
       tags:
         - Syscollector
+      deprecated: true
       summary: "Get agent hardware"
       description: "Return the agent's hardware info. This information include cpu, ram, scan info among others"
       operationId: api.controllers.syscollector_controller.get_hardware_info
@@ -16269,6 +16282,7 @@ paths:
     get:
       tags:
         - Syscollector
+      deprecated: true
       summary: "Get agent hotfixes"
       description: "Return all hotfixes installed by Microsoft(R) in Windows(R) systems (KB... fixes)"
       operationId: api.controllers.syscollector_controller.get_hotfix_info
@@ -16325,6 +16339,7 @@ paths:
     get:
       tags:
         - Syscollector
+      deprecated: true
       summary: "Get agent netaddr"
       description: "Return the agent's network address info. This information include used IP protocol, interface, IP
       address  among others"
@@ -16388,6 +16403,7 @@ paths:
     get:
       tags:
         - Syscollector
+      deprecated: true
       summary: "Get agent netiface"
       description: "Return the agent's network interface info. This information include rx, scan, tx info and some
       network information among others"
@@ -16472,6 +16488,7 @@ paths:
     get:
       tags:
         - Syscollector
+      deprecated: true
       summary: "Get agent netproto"
       description: "Return the agent's routing configuration for each network interface"
       operationId: api.controllers.syscollector_controller.get_network_protocol_info
@@ -16534,6 +16551,7 @@ paths:
     get:
       tags:
         - Syscollector
+      deprecated: true
       summary: "Get agent OS"
       description: "Return the agent's OS info. This information include os information, architecture information among
       others of all agents"
@@ -16596,6 +16614,7 @@ paths:
     get:
       tags:
         - Syscollector
+      deprecated: true
       summary: "Get agent packages"
       description: "Return the agent's packages info. This information include name, section, size, priority
       information of all packages among others"
@@ -16697,6 +16716,7 @@ paths:
     get:
       tags:
         - Syscollector
+      deprecated: true
       summary: "Get agent ports"
       description: "Return the agent's ports info. This information include local IP, Remote IP, protocol information
       among others"
@@ -16803,6 +16823,7 @@ paths:
     get:
       tags:
         - Syscollector
+      deprecated: true
       summary: "Get agent processes"
       description: "Return the agent's processes info"
       operationId: api.controllers.syscollector_controller.get_processes_info


### PR DESCRIPTION
|Related issue|
|---|
| #20792 |


## Description

Adds deprecation marks to the `/experimental/syscheck`, `/experimental/syscollector`, `/syscheck/{agent_id}` and `/syscollector/{agent_id}/*` endpoints.

## Endpoint use example
<details><summary>GET /syscheck/{agent_id} response headers example</summary>

```console
$ curl --location -k 'https://localhost:55555/syscheck/001' --header 'Accept: application/json' --header "Authorization: Bearer $TOKEN" -v | jq | grep Deprecated
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:55555...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 55555 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
} [5 bytes data]
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
} [512 bytes data]
* TLSv1.3 (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
{ [6 bytes data]
* TLSv1.3 (IN), TLS handshake, Certificate (11):
{ [883 bytes data]
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* TLSv1.3 (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.3 (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  start date: Dec 14 13:15:34 2023 GMT
*  expire date: Dec 13 13:15:34 2024 GMT
*  issuer: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
} [5 bytes data]
> GET /syscheck/001 HTTP/1.1
> Host: localhost:55555
> User-Agent: curl/7.68.0
> Accept: application/json
> Authorization: Bearer TOKEN
> 
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
{ [233 bytes data]
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
{ [233 bytes data]
* old SSL session ID is stale, removing
{ [5 bytes data]
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Deprecated: true
< Strict-Transport-Security: max-age=63072000; includeSubdomains
< X-Frame-Options: DENY
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< Content-Security-Policy: none
< Referrer-Policy: no-referrer, strict-origin-when-cross-origin
< Pragma: no-cache
< Expires: 0
< Cache-control: no-cache, no-store, must-revalidate, max-age=0
< Content-Length: 220684
< Date: Thu, 14 Dec 2023 14:02:25 GMT
< 
{ [5 bytes data]
100  215k  100  215k    0     0  1841k      0 --:--:-- --:--:-- --:--:-- 1841k

```

</details>

## API Integration Tests
<details><summary>test_syscheck_endpoints.tavern.yaml</summary>

```console
$ pytest test_syscheck_endpoints.tavern.yaml
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 34 items                                                                                                                                              

test_syscheck_endpoints.tavern.yaml ..................................                                                                                    [100%]

======================================================================= warnings summary ========================================================================
../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_syscheck_endpoints.tavern.yaml: 34 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 34 passed, 35 warnings in 1340.33s (0:22:20) ==========================================================
```

</details>

<details><summary>test_syscollector_endpoints.tavern.yaml</summary>

```console
$ pytest test_syscollector_endpoints.tavern.yaml
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 159 items                                                                                                                                             

test_syscollector_endpoints.tavern.yaml ................................................................................................................. [ 66%]
..............................................

======================================================================= warnings summary ========================================================================
../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_syscollector_endpoints.tavern.yaml: 159 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================== 159 passed, 160 warnings in 1236.41s (0:20:36) =========================================================
```

</details>

<details><summary>test_experimental_endpoints.tavern.yaml</summary>

```console
$ pytest test_experimental_endpoints.tavern.yaml
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 12 items                                                                                                                                              

test_experimental_endpoints.tavern.yaml ............                                                                                                      [100%]

======================================================================= warnings summary ========================================================================
../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_experimental_endpoints.tavern.yaml: 12 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 12 passed, 13 warnings in 971.05s (0:16:11) ==========================================================
```

</details>

> [!NOTE]
> The check [Integration tests for API - Tier 0 and 1](https://github.com/wazuh/wazuh/actions/runs/7210835498/job/19644862112?pr=20853) is failing because the vulnerability detector key has been changed in https://github.com/wazuh/qa-integration-framework/pull/51 and needs the [refactor from Core](https://github.com/wazuh/wazuh/issues/14153) to be fully merged.