### PR TITLE
Add column-management capacity to the RocksDB wrapper

### DIFF
--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -349,8 +349,7 @@ namespace Utils
                                         return columnName == handle->GetName();
                                     }};
 
-            auto it {std::find_if(m_handles.begin(), m_handles.end(), columnMatch)};
-            if (it != m_handles.end())
+            if (const auto it {std::find_if(m_handles.begin(), m_handles.end(), columnMatch)}; it != m_handles.end())
             {
                 return *it;
             }

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -95,6 +95,28 @@ namespace Utils
         }
 
         /**
+         * @brief Checks whether a column exists in the database or not.
+         *
+         * @param columnName Name of the column.
+         * @return true If the column exists.
+         * @return false If the column doesn't exists.
+         */
+        bool columnExists(const std::string& columnName) const
+        {
+            if (columnName.empty())
+            {
+                throw std::invalid_argument {"Column name is empty"};
+            }
+
+            const auto columnMatch {[&columnName](const rocksdb::ColumnFamilyHandle* handle)
+                                    {
+                                        return columnName == handle->GetName();
+                                    }};
+
+            return std::find_if(m_handles.begin(), m_handles.end(), columnMatch) != m_handles.end();
+        }
+
+        /**
          * @brief Move assignment operator.
          *
          * @param other Other instance.

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -13,13 +13,13 @@
 #define _ROCKS_DB_WRAPPER_HPP
 
 #include "rocksDBIterator.hpp"
-#include <filesystem>
-#include <rocksdb/db.h>
-#include <string>
-#include <memory>
-#include <vector>
 #include <algorithm>
+#include <filesystem>
+#include <memory>
+#include <rocksdb/db.h>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace Utils
 {
@@ -61,19 +61,18 @@ namespace Utils
 
         /**
          * @brief Class destructor. Frees column family handles.
-         * 
+         *
          */
         ~RocksDBWrapper()
         {
-            std::for_each(m_handles.begin(), m_handles.end(), [this](rocksdb::ColumnFamilyHandle* handle)
-            {
-                m_db->DestroyColumnFamilyHandle(handle);
-            });
+            std::for_each(m_handles.begin(),
+                          m_handles.end(),
+                          [this](rocksdb::ColumnFamilyHandle* handle) { m_db->DestroyColumnFamilyHandle(handle); });
         }
 
         /**
          * @brief Creates a new column family in the database.
-         * 
+         *
          * @param columnName Name of the new column.
          */
         void createColumn(const std::string& columnName)
@@ -87,7 +86,7 @@ namespace Utils
             const auto status {m_db->CreateColumnFamily(rocksdb::ColumnFamilyOptions(), columnName, &pColumnFamily)};
             if (!status.ok())
             {
-                throw std::runtime_error {"Couldn't create column family: " + std::string{status.getState()}};
+                throw std::runtime_error {"Couldn't create column family: " + std::string {status.getState()}};
             }
 
             m_handles.push_back(pColumnFamily);
@@ -113,7 +112,7 @@ namespace Utils
          * @param key Key to put.
          * @param value Value to put.
          * @param columnName Column name where the put will be performed. If empty, the default column will be used.
-         * 
+         *
          * @note If the key already exists, the value will be overwritten.
          */
         void put(const std::string& key, const rocksdb::Slice& value, const std::string& columnName = "")
@@ -210,7 +209,7 @@ namespace Utils
 
         /**
          * @brief Get the last key-value pair from the database.
-         * 
+         *
          * @param columnName Column name from where to get. If empty, the default column will be used.
          *
          * @return std::pair<std::string, rocksdb::Slice> Last key-value pair.
@@ -219,7 +218,8 @@ namespace Utils
          */
         std::pair<std::string, rocksdb::Slice> getLastKeyValue(const std::string& columnName = "")
         {
-            std::unique_ptr<rocksdb::Iterator> it(m_db->NewIterator(rocksdb::ReadOptions(), getColumnFamilyHandle(columnName)));
+            std::unique_ptr<rocksdb::Iterator> it(
+                m_db->NewIterator(rocksdb::ReadOptions(), getColumnFamilyHandle(columnName)));
 
             it->SeekToLast();
             if (it->Valid())
@@ -333,7 +333,7 @@ namespace Utils
 
         /**
          * @brief Returns the column family handle identified by its name.
-         * 
+         *
          * @param columnName Name of the column family. If empty, the default handle is returned.
          * @return rocksdb::ColumnFamilyHandle* Column family handle pointer.
          */
@@ -341,21 +341,20 @@ namespace Utils
         {
             if (columnName.empty())
             {
-                return m_db->DefaultColumnFamily();  
+                return m_db->DefaultColumnFamily();
             }
 
             const auto columnMatch {[&columnName](const rocksdb::ColumnFamilyHandle* handle)
-                {
-                    return columnName == handle->GetName();      
-                }
-            };
+                                    {
+                                        return columnName == handle->GetName();
+                                    }};
 
             auto it {std::find_if(m_handles.begin(), m_handles.end(), columnMatch)};
             if (it != m_handles.end())
             {
                 return *it;
             }
-            
+
             throw std::runtime_error {"Couldn't find column family: '" + columnName + "'"};
         }
     };

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -42,8 +42,8 @@ namespace Utils
             std::filesystem::create_directories(databasePath);
 
             // Get a list of the existing columns descriptors.
-            const auto DB_FILE {databasePath / "CURRENT"};
-            if (std::filesystem::exists(DB_FILE))
+            const auto databaseFile {databasePath / "CURRENT"};
+            if (std::filesystem::exists(databaseFile))
             {
                 // Read columns names.
                 std::vector<std::string> columnsNames;

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -73,13 +73,15 @@ namespace Utils
         /**
          * @brief Creates a new column family in the database.
          *
+         * @note The column handle created is also added to the handles list to be then accessible by other methods.
+         *
          * @param columnName Name of the new column.
          */
         void createColumn(const std::string& columnName)
         {
             if (columnName.empty())
             {
-                throw std::runtime_error {"Column name is empty"};
+                throw std::invalid_argument {"Column name is empty"};
             }
 
             rocksdb::ColumnFamilyHandle* pColumnFamily;

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
@@ -338,3 +338,146 @@ TEST_F(RocksDBWrapperTest, TestCreateFolderRecursively)
     db_wrapper->deleteAll();
     std::filesystem::remove_all(DATABASE_NAME);
 }
+
+/**
+ * @brief Tests the creation of one column.
+ * 
+ */
+TEST_F(RocksDBWrapperTest, CreateColumn)
+{
+    constexpr auto COLUMN_NAME {"column_A"};
+
+    EXPECT_NO_THROW(db_wrapper->createColumn(COLUMN_NAME));
+}
+
+/**
+ * @brief Tests the creation of various columns.
+ * 
+ */
+TEST_F(RocksDBWrapperTest, CreateMultipleColumns)
+{
+    constexpr auto COLUMN_NAME_A {"column_A"};
+    constexpr auto COLUMN_NAME_B {"column_B"};
+    constexpr auto COLUMN_NAME_C {"column_C"};
+
+    EXPECT_NO_THROW(db_wrapper->createColumn(COLUMN_NAME_A));
+    EXPECT_NO_THROW(db_wrapper->createColumn(COLUMN_NAME_B));
+    EXPECT_NO_THROW(db_wrapper->createColumn(COLUMN_NAME_C));
+}
+
+/**
+ * @brief Tests the creation of a column with empty name.
+ * 
+ */
+TEST_F(RocksDBWrapperTest, CreateColumnEmptyNameThrows)
+{
+    constexpr auto COLUMN_NAME {""};
+    EXPECT_THROW(db_wrapper->createColumn(COLUMN_NAME), std::runtime_error);
+}
+
+/**
+ * @brief Test put data into a created column.
+ * 
+ */
+TEST_F(RocksDBWrapperTest, PutIntoColumn)
+{
+    constexpr auto COLUMN_NAME {"column_A"};
+    constexpr auto KEY {"key_A"};
+    constexpr auto VALUE {"value_A"};
+
+    db_wrapper->createColumn(COLUMN_NAME);
+
+    EXPECT_NO_THROW(db_wrapper->put(KEY, VALUE, COLUMN_NAME));
+}
+
+/**
+ * @brief Test put data into an inexistent column.
+ * 
+ */
+TEST_F(RocksDBWrapperTest, PutIntoInexistentColumnThrows)
+{
+    constexpr auto COLUMN_NAME {"column_A"};
+    constexpr auto KEY {"key_A"};
+    constexpr auto VALUE {"value_A"};
+
+    EXPECT_THROW(db_wrapper->put(KEY, VALUE, COLUMN_NAME), std::runtime_error);
+}
+
+/**
+ * @brief Test get data into an inexisten column.
+ * 
+ */
+TEST_F(RocksDBWrapperTest, GetFromInexistentColumnThrows)
+{
+    constexpr auto COLUMN_NAME {"column_A"};
+    constexpr auto KEY {"key_A"};
+    std::string readValue;
+
+    EXPECT_THROW(db_wrapper->get(KEY, readValue, COLUMN_NAME), std::runtime_error);
+}
+
+/**
+ * @brief Test put and get data from a created column.
+ * 
+ */
+TEST_F(RocksDBWrapperTest, PutAndGetFromColumn)
+{
+    constexpr auto COLUMN_NAME {"column_A"};
+    constexpr auto KEY {"key_A"};
+    constexpr auto VALUE {"value_A"};
+    std::string readValue;
+
+    db_wrapper->createColumn(COLUMN_NAME);
+
+    ASSERT_NO_THROW(db_wrapper->put(KEY, VALUE, COLUMN_NAME));
+    ASSERT_TRUE(db_wrapper->get(KEY, readValue, COLUMN_NAME));
+    EXPECT_EQ(readValue, VALUE);
+}
+
+/**
+ * @brief Test put and get data from various created columns.
+ * 
+ */
+TEST_F(RocksDBWrapperTest, PutAndGetFromMultipleColumns)
+{
+    constexpr auto COLUMN_NAME_A {"column_A"};
+    constexpr auto KEY_A {"key_A"};
+    constexpr auto VALUE_A {"value_A"};
+    constexpr auto COLUMN_NAME_B {"column_B"};
+    constexpr auto KEY_B {"key_B"};
+    constexpr auto VALUE_B {"value_B"};
+    std::string readValue;
+
+    db_wrapper->createColumn(COLUMN_NAME_A);
+    db_wrapper->createColumn(COLUMN_NAME_B);
+
+    ASSERT_NO_THROW(db_wrapper->put(KEY_A, VALUE_A, COLUMN_NAME_A));
+    ASSERT_NO_THROW(db_wrapper->put(KEY_B, VALUE_B, COLUMN_NAME_B));
+
+    ASSERT_TRUE(db_wrapper->get(KEY_A, readValue, COLUMN_NAME_A));
+    EXPECT_EQ(readValue, VALUE_A);
+
+    ASSERT_TRUE(db_wrapper->get(KEY_B, readValue, COLUMN_NAME_B));
+    EXPECT_EQ(readValue, VALUE_B);
+}
+
+/**
+ * @brief Test put and get last key value from a created column.
+ * 
+ */
+TEST_F(RocksDBWrapperTest, PutAndGetLastKeyValueFromColumn)
+{
+    constexpr auto COLUMN_NAME {"column_A"};
+    constexpr auto KEY_A {"key_A"};
+    constexpr auto VALUE_A {"value_A"};
+    constexpr auto KEY_B {"key_B"};
+    constexpr auto VALUE_B {"value_B"};
+
+    db_wrapper->createColumn(COLUMN_NAME);
+    db_wrapper->put(KEY_A, VALUE_A, COLUMN_NAME);
+    db_wrapper->put(KEY_B, VALUE_B, COLUMN_NAME);
+
+    const auto lastPair {db_wrapper->getLastKeyValue(COLUMN_NAME)};
+    EXPECT_EQ(lastPair.first, KEY_B);
+    EXPECT_EQ(lastPair.second, VALUE_B);
+}

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
@@ -349,6 +349,52 @@ TEST_F(RocksDBWrapperTest, CreateColumn)
 }
 
 /**
+ * @brief Tests the creation of one column twice.
+ *
+ */
+TEST_F(RocksDBWrapperTest, CreateColumnTwiceThrows)
+{
+    constexpr auto COLUMN_NAME {"column_A"};
+
+    db_wrapper->createColumn(COLUMN_NAME);
+    EXPECT_THROW(db_wrapper->createColumn(COLUMN_NAME), std::runtime_error);
+}
+
+/**
+ * @brief Tests the column existence for a column that does exist.
+ *
+ */
+TEST_F(RocksDBWrapperTest, ColumnExistPositive)
+{
+    constexpr auto COLUMN_NAME {"column_A"};
+
+    db_wrapper->createColumn(COLUMN_NAME);
+    EXPECT_TRUE(db_wrapper->columnExists(COLUMN_NAME));
+}
+
+/**
+ * @brief Tests the column existence for a column that doesn't exist.
+ *
+ */
+TEST_F(RocksDBWrapperTest, ColumnExistNegative)
+{
+    constexpr auto COLUMN_NAME {"column_A"};
+
+    EXPECT_FALSE(db_wrapper->columnExists(COLUMN_NAME));
+}
+
+/**
+ * @brief Tests the column existence for a empty column name.
+ *
+ */
+TEST_F(RocksDBWrapperTest, ColumnExistEmptyThrows)
+{
+    constexpr auto COLUMN_NAME {""};
+
+    EXPECT_THROW(db_wrapper->columnExists(COLUMN_NAME), std::invalid_argument);
+}
+
+/**
  * @brief Tests the creation of various columns.
  *
  */

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
@@ -370,7 +370,7 @@ TEST_F(RocksDBWrapperTest, CreateMultipleColumns)
 TEST_F(RocksDBWrapperTest, CreateColumnEmptyNameThrows)
 {
     constexpr auto COLUMN_NAME {""};
-    EXPECT_THROW(db_wrapper->createColumn(COLUMN_NAME), std::runtime_error);
+    EXPECT_THROW(db_wrapper->createColumn(COLUMN_NAME), std::invalid_argument);
 }
 
 /**

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
@@ -331,9 +331,7 @@ TEST_F(RocksDBWrapperTest, TestCreateFolderRecursively)
 
     std::optional<Utils::RocksDBWrapper> db_wrapper;
 
-    EXPECT_NO_THROW({
-        db_wrapper = Utils::RocksDBWrapper(DATABASE_NAME);
-    });
+    EXPECT_NO_THROW({ db_wrapper = Utils::RocksDBWrapper(DATABASE_NAME); });
 
     db_wrapper->deleteAll();
     std::filesystem::remove_all(DATABASE_NAME);
@@ -341,7 +339,7 @@ TEST_F(RocksDBWrapperTest, TestCreateFolderRecursively)
 
 /**
  * @brief Tests the creation of one column.
- * 
+ *
  */
 TEST_F(RocksDBWrapperTest, CreateColumn)
 {
@@ -352,7 +350,7 @@ TEST_F(RocksDBWrapperTest, CreateColumn)
 
 /**
  * @brief Tests the creation of various columns.
- * 
+ *
  */
 TEST_F(RocksDBWrapperTest, CreateMultipleColumns)
 {
@@ -367,7 +365,7 @@ TEST_F(RocksDBWrapperTest, CreateMultipleColumns)
 
 /**
  * @brief Tests the creation of a column with empty name.
- * 
+ *
  */
 TEST_F(RocksDBWrapperTest, CreateColumnEmptyNameThrows)
 {
@@ -377,7 +375,7 @@ TEST_F(RocksDBWrapperTest, CreateColumnEmptyNameThrows)
 
 /**
  * @brief Test put data into a created column.
- * 
+ *
  */
 TEST_F(RocksDBWrapperTest, PutIntoColumn)
 {
@@ -392,7 +390,7 @@ TEST_F(RocksDBWrapperTest, PutIntoColumn)
 
 /**
  * @brief Test put data into an inexistent column.
- * 
+ *
  */
 TEST_F(RocksDBWrapperTest, PutIntoInexistentColumnThrows)
 {
@@ -405,7 +403,7 @@ TEST_F(RocksDBWrapperTest, PutIntoInexistentColumnThrows)
 
 /**
  * @brief Test get data into an inexisten column.
- * 
+ *
  */
 TEST_F(RocksDBWrapperTest, GetFromInexistentColumnThrows)
 {
@@ -418,7 +416,7 @@ TEST_F(RocksDBWrapperTest, GetFromInexistentColumnThrows)
 
 /**
  * @brief Test put and get data from a created column.
- * 
+ *
  */
 TEST_F(RocksDBWrapperTest, PutAndGetFromColumn)
 {
@@ -436,7 +434,7 @@ TEST_F(RocksDBWrapperTest, PutAndGetFromColumn)
 
 /**
  * @brief Test put and get data from various created columns.
- * 
+ *
  */
 TEST_F(RocksDBWrapperTest, PutAndGetFromMultipleColumns)
 {
@@ -463,7 +461,7 @@ TEST_F(RocksDBWrapperTest, PutAndGetFromMultipleColumns)
 
 /**
  * @brief Test put and get last key value from a created column.
- * 
+ *
  */
 TEST_F(RocksDBWrapperTest, PutAndGetLastKeyValueFromColumn)
 {

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
@@ -328,11 +328,7 @@ TEST_F(RocksDBWrapperTest, TestRangeForLoopWithBinaryBuffers)
 TEST_F(RocksDBWrapperTest, TestCreateFolderRecursively)
 {
     const auto DATABASE_FOLDER {OUTPUT_FOLDER / "folder1" / "folder2" / "test_db"};
-    std::optional<Utils::RocksDBWrapper> wrapper;
-
-    EXPECT_NO_THROW({ wrapper = Utils::RocksDBWrapper(DATABASE_FOLDER); });
-
-    db_wrapper->deleteAll();
+    EXPECT_NO_THROW(std::make_unique<Utils::RocksDBWrapper>(DATABASE_FOLDER));
 }
 
 /**

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
@@ -327,8 +327,8 @@ TEST_F(RocksDBWrapperTest, TestRangeForLoopWithBinaryBuffers)
  */
 TEST_F(RocksDBWrapperTest, TestCreateFolderRecursively)
 {
-    const auto DATABASE_FOLDER {OUTPUT_FOLDER / "folder1" / "folder2" / "test_db"};
-    EXPECT_NO_THROW(std::make_unique<Utils::RocksDBWrapper>(DATABASE_FOLDER));
+    const auto databaseFolder {OUTPUT_FOLDER / "folder1" / "folder2" / "test_db"};
+    EXPECT_NO_THROW(std::make_unique<Utils::RocksDBWrapper>(databaseFolder));
 }
 
 /**
@@ -386,7 +386,7 @@ TEST_F(RocksDBWrapperTest, ColumnsSetup)
 
     // Reset wrapper. This will call the destructor and then the constructor again.
     db_wrapper.reset();
-    ASSERT_NO_THROW({ db_wrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_FOLDER); });
+    ASSERT_NO_THROW({ db_wrapper = std::make_unique<Utils::RocksDBWrapper>(m_databaseFolder); });
 
     EXPECT_TRUE(db_wrapper->columnExists(COLUMN_NAME_A));
     EXPECT_TRUE(db_wrapper->columnExists(COLUMN_NAME_B));

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.hpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.hpp
@@ -18,7 +18,6 @@
 #include <memory>
 
 const auto OUTPUT_FOLDER {std::filesystem::temp_directory_path() / "RocksDBWrapperTest"};
-const auto DATABASE_FOLDER {OUTPUT_FOLDER / "test_db"};
 
 /**
  * @brief Tests the RocksDBWrapper class
@@ -36,6 +35,8 @@ protected:
      */
     std::unique_ptr<Utils::RocksDBWrapper> db_wrapper;
 
+    const std::filesystem::path m_databaseFolder {OUTPUT_FOLDER / "test_db"}; ///< Database folder.
+
     /**
      * @brief Initial conditions for tests
      *
@@ -43,7 +44,7 @@ protected:
     // cppcheck-suppress unusedFunction
     void SetUp() override
     {
-        db_wrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_FOLDER);
+        db_wrapper = std::make_unique<Utils::RocksDBWrapper>(m_databaseFolder);
     }
 
     /**

--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.hpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.hpp
@@ -15,8 +15,10 @@
 #include "rocksDBWrapper.hpp"
 #include "gtest/gtest.h"
 #include <filesystem>
+#include <memory>
 
-static const std::string DATABASE_NAME {"test.db"};
+const auto OUTPUT_FOLDER {std::filesystem::temp_directory_path() / "RocksDBWrapperTest"};
+const auto DATABASE_FOLDER {OUTPUT_FOLDER / "test_db"};
 
 /**
  * @brief Tests the RocksDBWrapper class
@@ -32,7 +34,7 @@ protected:
      * @brief RocksDBWrapper object
      *
      */
-    std::optional<Utils::RocksDBWrapper> db_wrapper;
+    std::unique_ptr<Utils::RocksDBWrapper> db_wrapper;
 
     /**
      * @brief Initial conditions for tests
@@ -41,7 +43,7 @@ protected:
     // cppcheck-suppress unusedFunction
     void SetUp() override
     {
-        db_wrapper = Utils::RocksDBWrapper(DATABASE_NAME);
+        db_wrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_FOLDER);
     }
 
     /**
@@ -52,7 +54,8 @@ protected:
     void TearDown() override
     {
         db_wrapper->deleteAll();
-        std::filesystem::remove_all(DATABASE_NAME);
+        db_wrapper.reset();
+        std::filesystem::remove_all(OUTPUT_FOLDER);
     }
 };
 


### PR DESCRIPTION
|Related issue|
|---|
|#20848 |

## Description

This PR allows managing different columns using the RocksDB wrapper, allowing it to dynamically create columns and read/write from/into them.

## Results

### Unit tests

Since the UT are not executed on actions, I'm sharing the local execution of them.

:orange_circle: Tests
```bash
# ctest                    
Test project /home/wazuh-dev-xxxxx-content-manager-hash-rocksdb/src/build
      Start  1: utils_unit_test
 1/12 Test  #1: utils_unit_test .........................***Failed   87.83 sec
      Start  2: utils_benchmark_test
 2/12 Test  #2: utils_benchmark_test ....................   Passed   19.72 sec
      Start  3: router_component_tests
 3/12 Test  #3: router_component_tests ..................   Passed    0.02 sec
      Start  4: router_unit_tests
 4/12 Test  #4: router_unit_tests .......................   Passed    0.01 sec
      Start  5: content_manager_component_tests
 5/12 Test  #5: content_manager_component_tests .........   Passed   25.28 sec
      Start  6: content_manager_unit_tests
 6/12 Test  #6: content_manager_unit_tests ..............   Passed   10.97 sec
      Start  7: indexer_connector_unit_tests
 7/12 Test  #7: indexer_connector_unit_tests ............   Passed   55.08 sec
      Start  8: vulnerability_scanner_benchmark_tests
 8/12 Test  #8: vulnerability_scanner_benchmark_tests ...   Passed   20.68 sec
      Start  9: policy_manager_unit_test
 9/12 Test  #9: policy_manager_unit_test ................   Passed    0.01 sec
      Start 10: vulnerability_scanner_unit_tests
10/12 Test #10: vulnerability_scanner_unit_tests ........   Passed    6.98 sec
      Start 11: vulnerability_scanner_component_tests
11/12 Test #11: vulnerability_scanner_component_tests ...   Passed    0.05 sec
      Start 12: database_feed_manager_unit_test
12/12 Test #12: database_feed_manager_unit_test .........   Passed   48.91 sec

92% tests passed, 1 tests failed out of 12

Total Test time (real) = 275.55 sec

The following tests FAILED:
	  1 - utils_unit_test (Failed)
Errors while running CTest
```

:red_circle: Tests that are failing have nothing to do with the changes made on this PR. In fact, they're also failing on another branches.
```
[----------] Global test environment tear-down
[==========] 272 tests from 28 test suites ran. (88841 ms total)
[  PASSED  ] 270 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] TypedSocketTests/SocketTest/0.SingleDelayedClientWithReconnectionServerReset, where TypeParam = AppendHeaderProtocol
[  FAILED  ] TypedSocketTests/SocketTest/1.SingleDelayedClientWithReconnectionServerReset, where TypeParam = SizeHeaderProtocol
```

:green_circle:  RocksDB tests
```bash
# ./utils_unit_test --gtest_filter=RocksDB*            
Note: Google Test filter = RocksDB*
[==========] Running 38 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 8 tests from RocksDBSafeQueueTest
[ RUN      ] RocksDBSafeQueueTest.PopInCancelledQueue
[       OK ] RocksDBSafeQueueTest.PopInCancelledQueue (658 ms)
[ RUN      ] RocksDBSafeQueueTest.PopEmptyQueue
[       OK ] RocksDBSafeQueueTest.PopEmptyQueue (513 ms)
[ RUN      ] RocksDBSafeQueueTest.PopWithData
[       OK ] RocksDBSafeQueueTest.PopWithData (563 ms)
[ RUN      ] RocksDBSafeQueueTest.PopWithMultipleData
[       OK ] RocksDBSafeQueueTest.PopWithMultipleData (694 ms)
[ RUN      ] RocksDBSafeQueueTest.BlockingPopByRef
[       OK ] RocksDBSafeQueueTest.BlockingPopByRef (1345 ms)
[ RUN      ] RocksDBSafeQueueTest.BlockingPopBySmartPtr
[       OK ] RocksDBSafeQueueTest.BlockingPopBySmartPtr (1246 ms)
[ RUN      ] RocksDBSafeQueueTest.CancelBlockingPop
[       OK ] RocksDBSafeQueueTest.CancelBlockingPop (839 ms)
[ RUN      ] RocksDBSafeQueueTest.CreateFolderRecursively
[       OK ] RocksDBSafeQueueTest.CreateFolderRecursively (1408 ms)
[----------] 8 tests from RocksDBSafeQueueTest (7270 ms total)

[----------] 30 tests from RocksDBWrapperTest
[ RUN      ] RocksDBWrapperTest.TestPut
[       OK ] RocksDBWrapperTest.TestPut (256 ms)
[ RUN      ] RocksDBWrapperTest.TestPutEmptyKey
[       OK ] RocksDBWrapperTest.TestPutEmptyKey (525 ms)
[ RUN      ] RocksDBWrapperTest.TestPutEmptyValue
[       OK ] RocksDBWrapperTest.TestPutEmptyValue (515 ms)
[ RUN      ] RocksDBWrapperTest.TestPutExistingKey
[       OK ] RocksDBWrapperTest.TestPutExistingKey (570 ms)
[ RUN      ] RocksDBWrapperTest.TestPutExistingKeyUpdateValue
[       OK ] RocksDBWrapperTest.TestPutExistingKeyUpdateValue (535 ms)
[ RUN      ] RocksDBWrapperTest.TestGet
[       OK ] RocksDBWrapperTest.TestGet (524 ms)
[ RUN      ] RocksDBWrapperTest.TestGetPinnableSlice
[       OK ] RocksDBWrapperTest.TestGetPinnableSlice (935 ms)
[ RUN      ] RocksDBWrapperTest.TestGetNonExistentKey
[       OK ] RocksDBWrapperTest.TestGetNonExistentKey (595 ms)
[ RUN      ] RocksDBWrapperTest.TestGetEmptyKey
[       OK ] RocksDBWrapperTest.TestGetEmptyKey (553 ms)
[ RUN      ] RocksDBWrapperTest.TestGetEmptyDB
[       OK ] RocksDBWrapperTest.TestGetEmptyDB (937 ms)
[ RUN      ] RocksDBWrapperTest.TestDelete
[       OK ] RocksDBWrapperTest.TestDelete (512 ms)
[ RUN      ] RocksDBWrapperTest.TestDeleteNonExistentKey
[       OK ] RocksDBWrapperTest.TestDeleteNonExistentKey (504 ms)
[ RUN      ] RocksDBWrapperTest.TestDeleteEmptyKey
[       OK ] RocksDBWrapperTest.TestDeleteEmptyKey (527 ms)
[ RUN      ] RocksDBWrapperTest.TestDeleteEmptyDB
[       OK ] RocksDBWrapperTest.TestDeleteEmptyDB (1138 ms)
[ RUN      ] RocksDBWrapperTest.TestGetLastKeyValue
[       OK ] RocksDBWrapperTest.TestGetLastKeyValue (521 ms)
[ RUN      ] RocksDBWrapperTest.TestGetLastKeyValueEmptyDB
[       OK ] RocksDBWrapperTest.TestGetLastKeyValueEmptyDB (867 ms)
[ RUN      ] RocksDBWrapperTest.TestDeleteAll
[       OK ] RocksDBWrapperTest.TestDeleteAll (726 ms)
[ RUN      ] RocksDBWrapperTest.TestDeleteAllEmptyDB
[       OK ] RocksDBWrapperTest.TestDeleteAllEmptyDB (812 ms)
[ RUN      ] RocksDBWrapperTest.TestRangeForLoop
[       OK ] RocksDBWrapperTest.TestRangeForLoop (511 ms)
[ RUN      ] RocksDBWrapperTest.TestRangeForLoopWithBinaryBuffers
[       OK ] RocksDBWrapperTest.TestRangeForLoopWithBinaryBuffers (503 ms)
[ RUN      ] RocksDBWrapperTest.TestCreateFolderRecursively
[       OK ] RocksDBWrapperTest.TestCreateFolderRecursively (1007 ms)
[ RUN      ] RocksDBWrapperTest.CreateColumn
[       OK ] RocksDBWrapperTest.CreateColumn (663 ms)
[ RUN      ] RocksDBWrapperTest.CreateMultipleColumns
[       OK ] RocksDBWrapperTest.CreateMultipleColumns (1029 ms)
[ RUN      ] RocksDBWrapperTest.CreateColumnEmptyNameThrows
[       OK ] RocksDBWrapperTest.CreateColumnEmptyNameThrows (514 ms)
[ RUN      ] RocksDBWrapperTest.PutIntoColumn
[       OK ] RocksDBWrapperTest.PutIntoColumn (775 ms)
[ RUN      ] RocksDBWrapperTest.PutIntoInexistentColumnThrows
[       OK ] RocksDBWrapperTest.PutIntoInexistentColumnThrows (669 ms)
[ RUN      ] RocksDBWrapperTest.GetFromInexistentColumnThrows
[       OK ] RocksDBWrapperTest.GetFromInexistentColumnThrows (514 ms)
[ RUN      ] RocksDBWrapperTest.PutAndGetFromColumn
[       OK ] RocksDBWrapperTest.PutAndGetFromColumn (673 ms)
[ RUN      ] RocksDBWrapperTest.PutAndGetFromMultipleColumns
[       OK ] RocksDBWrapperTest.PutAndGetFromMultipleColumns (810 ms)
[ RUN      ] RocksDBWrapperTest.PutAndGetLastKeyValueFromColumn
[       OK ] RocksDBWrapperTest.PutAndGetLastKeyValueFromColumn (672 ms)
[----------] 30 tests from RocksDBWrapperTest (19909 ms total)

[----------] Global test environment tear-down
[==========] 38 tests from 2 test suites ran. (27180 ms total)
[  PASSED  ] 38 tests.
```

### Manager execution

:green_circle:  Manager execution

```bash
# cat /var/ossec/logs/ossec.log | grep -e content-updater -e vulnerability-scanner
2023/12/15 16:55:55 wazuh-modulesd:vulnerability-scanner[7227] wm_vulnerability_scanner.c:50 at wm_vulnerability_scanner_main(): INFO: Starting vulnerability_scanner module.
2023/12/15 16:55:55 wazuh-modulesd:vulnerability-scanner[7227] wm_vulnerability_scanner.c:42 at wm_vulnerability_scanner_log_config(): DEBUG: {"vulnerability-detection":{"enabled":"yes","index-status":"yes","feed-update-interval":"60m","cti-url":"https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0"},"wm_max_eps":100,"indexer":{"enabled":"yes","hosts":["https://0.0.0.0:9200"],"username":"admin","password":"admin","ssl":{"certificate_authorities":["/etc/filebeat/certs/root-ca.pem"],"certificate":"/etc/filebeat/certs/filebeat.pem","key":"/etc/filebeat/certs/filebeat-key.pem"}}}
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] actionOrchestrator.hpp:49 at ActionOrchestrator(): DEBUG: Creating 'vulnerability_feed_manager' Content Updater orchestration
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] executionContext.hpp:163 at handleRequest(): DEBUG: ExecutionContext - Starting process
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] executionContext.hpp:145 at createOutputFolder(): DEBUG: Creating output folders at 'queue/vd_updater/tmp'
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] factoryContentUpdater.hpp:44 at create(): DEBUG: FactoryContentUpdater - Starting process
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] factoryDownloader.hpp:46 at create(): DEBUG: Creating 'cti-offset' downloader
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] factoryDecompressor.hpp:73 at create(): DEBUG: Creating 'raw' decompressor
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] factoryVersionUpdater.hpp:41 at create(): DEBUG: Creating 'cti-api' version updater
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] factoryCleaner.hpp:41 at create(): DEBUG: Content cleaner created
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] actionOrchestrator.hpp:59 at ActionOrchestrator(): DEBUG: Content updater orchestration created
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] action.hpp:86 at operator()(): INFO: Starting on-start action for 'vulnerability_feed_manager'
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] action.hpp:203 at runAction(): INFO: Action for 'vulnerability_feed_manager' started
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] actionOrchestrator.hpp:81 at run(): DEBUG: Running 'vulnerability_feed_manager' content update
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] actionOrchestrator.hpp:140 at runFullContentDownload(): DEBUG: Performing full-content download
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] factoryContentUpdater.hpp:44 at create(): DEBUG: FactoryContentUpdater - Starting process
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] factoryDownloader.hpp:46 at create(): DEBUG: Creating 'cti-snapshot' downloader
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] factoryDecompressor.hpp:73 at create(): DEBUG: Creating 'zip' decompressor
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] factoryVersionUpdater.hpp:41 at create(): DEBUG: Creating 'cti-api' version updater
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] factoryCleaner.hpp:41 at create(): DEBUG: Content cleaner created
2023/12/15 16:55:55 wazuh-modulesd:content-updater[7227] CtiDownloader.hpp:203 at handleRequest(): DEBUG: CtiSnapshotDownloader - Starting process
2023/12/15 16:55:56 wazuh-modulesd:content-updater[7227] CtiDownloader.hpp:104 at getCtiBaseParameters(): DEBUG: CTI last offset: '281100'
2023/12/15 16:55:56 wazuh-modulesd:content-updater[7227] CtiDownloader.hpp:105 at getCtiBaseParameters(): DEBUG: CTI last snapshot link: 'https://s3.us-east-1.amazonaws.com/cti-snapshots-pro/store/contexts/vd_1.0.0/consumers/vd_4.8.0/276948_1702552338.zip'
2023/12/15 16:55:56 wazuh-modulesd:content-updater[7227] CtiDownloader.hpp:106 at getCtiBaseParameters(): DEBUG: CTI snapshot last offset: '276948'
2023/12/15 16:55:56 wazuh-modulesd:content-updater[7227] CtiSnapshotDownloader.hpp:54 at download(): DEBUG: Downloading snapshot from 'https://s3.us-east-1.amazonaws.com/cti-snapshots-pro/store/contexts/vd_1.0.0/consumers/vd_4.8.0/276948_1702552338.zip'
2023/12/15 16:58:21 wazuh-modulesd:content-updater[7227] zipDecompressor.hpp:74 at handleRequest(): DEBUG: ZipDecompressor - Starting process
2023/12/15 16:58:21 wazuh-modulesd:content-updater[7227] zipDecompressor.hpp:49 at decompress(): DEBUG: Decompressing 'queue/vd_updater/tmp/downloads/276948_1702552338.zip' into 'queue/vd_updater/tmp/contents'
2023/12/15 16:58:36 wazuh-modulesd:content-updater[7227] pubSubPublisher.hpp:61 at handleRequest(): DEBUG: PubSubPublisher - Starting process
2023/12/15 16:58:36 wazuh-modulesd:content-updater[7227] pubSubPublisher.hpp:42 at publish(): DEBUG: Data to be published: '{"paths":["queue/vd_updater/tmp/contents/vd_1.0.0_vd_4.8.0_276948_1702552338.json"],"stageStatus":[{"stage":"CtiSnapshotDownloader","status":"ok"},{"stage":"ZipDecompressor","status":"ok"}],"type":"raw"}'
2023/12/15 16:58:36 wazuh-modulesd:content-updater[7227] pubSubPublisher.hpp:45 at publish(): INFO: Data published
2023/12/15 16:58:36 wazuh-modulesd:content-updater[7227] updateCtiApiOffset.hpp:66 at handleRequest(): DEBUG: UpdateCtiApiOffset - Starting process
2023/12/15 16:58:36 wazuh-modulesd:content-updater[7227] cleanUpContent.hpp:63 at handleRequest(): DEBUG: CleanUpContent - Starting process
2023/12/15 16:58:36 wazuh-modulesd:vulnerability-scanner[7227] databaseFeedManager.hpp:238 at operator()(): INFO: Processing message
2023/12/15 16:58:36 wazuh-modulesd:vulnerability-scanner[7227] databaseFeedManager.hpp:134 at processMessage(): INFO: Processing file: queue/vd_updater/tmp/contents/vd_1.0.0_vd_4.8.0_276948_1702552338.json
2023/12/15 16:58:36 wazuh-modulesd:content-updater[7227] CtiDownloader.hpp:203 at handleRequest(): DEBUG: CtiOffsetDownloader - Starting process
2023/12/15 16:58:36 wazuh-modulesd:content-updater[7227] CtiOffsetDownloader.hpp:42 at download(): DEBUG: Initial API offset: 276948
2023/12/15 16:58:37 wazuh-modulesd:content-updater[7227] CtiDownloader.hpp:104 at getCtiBaseParameters(): DEBUG: CTI last offset: '281100'
2023/12/15 16:58:37 wazuh-modulesd:content-updater[7227] CtiDownloader.hpp:105 at getCtiBaseParameters(): DEBUG: CTI last snapshot link: 'https://s3.us-east-1.amazonaws.com/cti-snapshots-pro/store/contexts/vd_1.0.0/consumers/vd_4.8.0/276948_1702552338.zip'
2023/12/15 16:58:37 wazuh-modulesd:content-updater[7227] CtiDownloader.hpp:106 at getCtiBaseParameters(): DEBUG: CTI snapshot last offset: '276948'
2023/12/15 16:58:37 wazuh-modulesd:content-updater[7227] CtiOffsetDownloader.hpp:120 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=276948&to_offset=277948'
2023/12/15 16:58:38 wazuh-modulesd:content-updater[7227] CtiOffsetDownloader.hpp:120 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=277948&to_offset=278948'
2023/12/15 16:58:39 wazuh-modulesd:content-updater[7227] CtiOffsetDownloader.hpp:120 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=278948&to_offset=279948'
2023/12/15 16:58:40 wazuh-modulesd:content-updater[7227] CtiOffsetDownloader.hpp:120 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=279948&to_offset=280948'
2023/12/15 16:58:44 wazuh-modulesd:content-updater[7227] CtiOffsetDownloader.hpp:120 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=280948&to_offset=281100'
2023/12/15 16:58:46 wazuh-modulesd:content-updater[7227] skipStep.hpp:48 at handleRequest(): DEBUG: SkipStep - Starting process
2023/12/15 16:58:46 wazuh-modulesd:content-updater[7227] pubSubPublisher.hpp:61 at handleRequest(): DEBUG: PubSubPublisher - Starting process
2023/12/15 16:58:46 wazuh-modulesd:content-updater[7227] pubSubPublisher.hpp:42 at publish(): DEBUG: Data to be published: '{"paths":["queue/vd_updater/tmp/contents/277948-api_file.json","queue/vd_updater/tmp/contents/278948-api_file.json","queue/vd_updater/tmp/contents/279948-api_file.json","queue/vd_updater/tmp/contents/280948-api_file.json","queue/vd_updater/tmp/contents/281100-api_file.json"],"stageStatus":[{"stage":"CtiOffsetDownloader","status":"ok"}],"type":"offsets"}'
2023/12/15 16:58:46 wazuh-modulesd:content-updater[7227] pubSubPublisher.hpp:45 at publish(): INFO: Data published
2023/12/15 16:58:46 wazuh-modulesd:content-updater[7227] updateCtiApiOffset.hpp:66 at handleRequest(): DEBUG: UpdateCtiApiOffset - Starting process
2023/12/15 16:58:46 wazuh-modulesd:content-updater[7227] cleanUpContent.hpp:63 at handleRequest(): DEBUG: CleanUpContent - Starting process
2023/12/15 16:58:46 wazuh-modulesd:content-updater[7227] action.hpp:214 at runAction(): INFO: Action for 'vulnerability_feed_manager' finished
```