### PR TITLE
Fixed AWS module to be compatible with the minimum Python version

### DIFF
--- a/wodles/aws/subscribers/sqs_message_processor.py
+++ b/wodles/aws/subscribers/sqs_message_processor.py
@@ -5,6 +5,7 @@
 import json
 import sys
 from os import path
+from typing import List
 
 sys.path.insert(0, path.dirname(path.dirname(path.abspath(__file__))))
 import aws_tools
@@ -13,7 +14,7 @@ import aws_tools
 class AWSQueueMessageProcessor:
     """Class in charge of processing the messages retrieved from an AWS SQS queue."""
 
-    def extract_message_info(self, sqs_messages: list[dict]) -> list:
+    def extract_message_info(self, sqs_messages: List[dict]) -> List[dict]:
         messages = []
         for mesg in sqs_messages:
             body = mesg['Body']


### PR DESCRIPTION
|Related issue|
|---|
| #19039  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR closes #19039 , fixing the TypeError that was occurring at https://github.com/wazuh/wazuh/issues/20722#issuecomment-1854410413

The error was reproduced with Python 3.7 :
```console

root@217337b8dbc3:/var/ossec# python3.7 --version
Python 3.7.5
root@217337b8dbc3:/var/ossec# which python3.7
/usr/bin/python3.7
root@217337b8dbc3:/var/ossec# head -1 wodles/aws/aws-s3
#!/usr/bin/env python3.7

```
The issue was verified:
```console

root@217337b8dbc3:/var/ossec# wodles/aws/aws-s3 --bucket wazuh-aws-wodle-cloudtrail --aws_profile dev --only_logs_after 2022-JAN-01 --type cloudtrail --debug 2
Traceback (most recent call last):
  File "wodles/aws/aws-s3", line 40, in <module>
    import subscribers
  File "/var/ossec/wodles/aws/subscribers/__init__.py", line 1, in <module>
    from subscribers import sqs_queue
  File "/var/ossec/wodles/aws/subscribers/sqs_queue.py", line 11, in <module>
    import sqs_message_processor
  File "/var/ossec/wodles/aws/subscribers/../subscribers/sqs_message_processor.py", line 12, in <module>
    class AWSQueueMessageProcessor:
  File "/var/ossec/wodles/aws/subscribers/../subscribers/sqs_message_processor.py", line 15, in AWSQueueMessageProcessor
    def extract_message_info(self, sqs_messages: List[dict]) -> list:
TypeError: 'type' object is not subscriptable

```


After the changes were made:
```console

root@217337b8dbc3:/var/ossec# wodles/aws/aws-s3 --bucket wazuh-aws-wodle-cloudtrail --aws_profile dev --only_logs_after 2022-JAN-01 --type cloudtrail --debug 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'dev' configuration
DEBUG: +++ Working on xxxxxxxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxxxxx/CloudTrail/us-west-1/2023/09/06/xxxxx_CloudTrail_us-west-1_20230906T1755Z_2CqtXDyI0zFiYm1J.json
DEBUG: +++ No logs to process in bucket: 166157441623/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxxxxxxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxxxxxxxxxx/CloudTrail/us-west-1/2022/01/01
DEBUG: +++ No logs to process in bucket: 166157449999/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxxxxxxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxxxxxxx/CloudTrail/us-west-1/2023/01/25/xxxxxx3_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxxxxxxxxx.json.gz
DEBUG: +++ No logs to process in bucket: xxxxxxxxxxx/us-west-1
DEBUG: +++ DB Maintenance

```

## Logs/Alerts example
<details><summary>Custom logs buckets</summary>

```console

root@217337b8dbc3:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 --subscriber buckets --queue 13577-expand-aws-support --aws_profile dev --debug 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: The SQS queue is: https://sqs.us-east-1.amazonaws.com/xxxxxxxxxxxx/13577-expand-aws-support
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: Retrieving messages from: 13577-expand-aws-support
DEBUG: The message is: {'Records': [{'eventVersion': '2.1', 'eventSource': 'aws:s3', 'awsRegion': 'us-east-1', 'eventTime': '2023-12-14T19:40:30.547Z', 'eventName': 'ObjectCreated:Put', 'userIdentity': {'principalId': 'AWS:AIDAYIPNU4FPETHSEMJAB'}, 'requestParameters': {'sourceIPAddress': '81.34.152.140'}, 'responseElements': {'x-amz-request-id': 'SSJ797QDPKANCR9H', 'x-amz-id-2': 'QpJ3SHY+rBbH5AX5ICO+DenDT05tzi2dhjglePKesexP+0OyQk+/7CveczNpdVqE14kYu2jg6WogIZs7lITeJ1ciSHvEcKiv'}, 's3': {'s3SchemaVersion': '1.0', 'configurationId': 'Log collection', 'bucket': {'name': '13577-expand-aws-support', 'ownerIdentity': {'principalId': 'A3QSZTCUMLI4LE'}, 'arn': 'arn:aws:s3:::13577-expand-aws-support'}, 'object': {'key': 'guardduty-firehose-test-long-log-2', 'size': 512814, 'eTag': 'fef6ba9d4c9b714d81c9d73b6f754d8c', 'sequencer': '00657B5A2E5EBE9691'}}}]}
DEBUG: Message deleted from queue: 13577-expand-aws-support
DEBUG: Retrieving messages from: 13577-expand-aws-support


```

</details>

<details><summary>Security Lake</summary>

```console

root@217337b8dbc3:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3  --subscriber security_lake --queue AmazonSecurityLake-f38b8aff-fec5-4705-a05a-3d62abdfc439-Main-Queue --external_id wazuh-external-id --iam_role_arn arn:aws:iam::xxxxxxx:role/AmazonSecurityLake-f38b8aff-fec5-4705-a05a-3d62abdfc439 --debug 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'default' configuration
DEBUG: The SQS queue is: https://sqs.us-east-1.amazonaws.com/xxxxxxxx/AmazonSecurityLake-f38b8aff-fec5-4705-a05a-3d62abdfc439-Main-Queue
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'default' configuration
DEBUG: Retrieving messages from: AmazonSecurityLake-f38b8aff-fec5-4705-a05a-3d62abdfc439-Main-Queue
DEBUG: Found 399 events in file aws/S3_DATA/1.0/region=us-east-1/accountId=xxxxxxxxxxx/eventDay=20231213/acc632ab812b3ca47f118e5645ae74a1.gz.parquet
DEBUG: 399 events sent to Analysisd
DEBUG: Message deleted from queue: AmazonSecurityLake-f38b8aff-fec5-4705-a05a-3d62abdfc439-Main-Queue
DEBUG: Processing file aws/ROUTE53/1.0/region=us-east-1/accountId=xxxxxxxxxxxx/eventDay=20231213/7cc632add1bf866085818fd5ed308195.gz.parquet in aws-security-data-lake-us-east-1-gbxqof17tcdrj8qkkk1rbchg3rhig0
########################################33333


```

</details>

<details><summary>Cloudtrail</summary>

```console

root@217337b8dbc3:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2022-JAN-01 -p default -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'default' configuration
DEBUG: +++ Working on xxxxxxxxxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxxxxxxxxxxxx/CloudTrail/us-west-1/2023/09/06/xxxxxxxxx_CloudTrail_us-west-1_20230906T1755Z_2CqtXDyI0zFiYm1J.json
DEBUG: +++ No logs to process in bucket: xxxxxxxxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxxxxxxxxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxxxxxxxxxxx/CloudTrail/us-west-1/2022/01/01
DEBUG: +++ No logs to process in bucket: xxxxxxxxxxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxxxxxxxxxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxxxxxxxx/CloudTrail/us-west-1/2023/01/25/xxxxxxxxxx_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxxxxxxxxx.json.gz
DEBUG: +++ No logs to process in bucket: xxxxxxxxxxx/us-west-1
DEBUG: +++ DB Maintenance


```

</details>

<details><summary>Cloudwatchlogs</summary>

```console

root@217337b8dbc3:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -g 4_5_test -d 2 -s 2022-JUL-29 -p dev -r us-east-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'dev' configuration
DEBUG: only logs: 1659052800000
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: Getting data from DB for log stream "test_stream" in log group "4_5_test"
DEBUG: Token: "f/37645185496176941583196752952502274031084618732661604351/s", start_time: "1659052800000", end_time: "1688068270000"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_5_test" using token "f/37645185496176941583196752952502274031084618732661604351/s", start_time "1688068270001" and end_time "None"
DEBUG: +++ There are no new events in the "4_5_test" group
DEBUG: Saving data for log group "4_5_test" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/37645185496176941583196752952502274031084618732661604351/s', 'start_time': 1659052800000, 'end_time': 1688068270001}"
DEBUG: Some data already exists on DB for that key. Updating their values...
DEBUG: Purging the BD
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: committing changes and closing the DB


```

</details>
