### PR TITLE
Fix/Change number of threads

### DIFF
--- a/src/shared_modules/content_manager/src/onDemandManager.hpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.hpp
@@ -12,6 +12,11 @@
 #ifndef _ONDEMAND_MANAGER_HPP
 #define _ONDEMAND_MANAGER_HPP
 
+// Define the number of threads in the thread pool for httplib.
+#ifndef CPPHTTPLIB_THREAD_POOL_COUNT
+#define CPPHTTPLIB_THREAD_POOL_COUNT 2
+#endif
+
 #include "singleton.hpp"
 #include <external/cpp-httplib/httplib.h>
 #include <functional>

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -166,6 +166,7 @@ IndexerConnector::IndexerConnector(
             }
         },
         DATABASE_BASE_PATH + indexName,
+        ELEMENTS_PER_BULK,
         DATABASE_WORKERS);
 
     m_initializeThread = std::thread(

--- a/src/shared_modules/router/src/publisher.hpp
+++ b/src/shared_modules/router/src/publisher.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include <vector>
 
-constexpr auto PUBLISHER_DISPATCH_THREAD_COUNT { 1 };
+constexpr auto PUBLISHER_DISPATCH_THREAD_COUNT {1};
 
 /**
  * @brief Publisher class.
@@ -43,7 +43,9 @@ public:
     explicit Publisher(const std::string& endpointName, const std::string& socketPath)
         : m_socketServer(std::make_unique<SocketServer<Socket<OSPrimitives>, EpollWrapper>>(socketPath + endpointName))
         , m_msgDispatcher(std::make_unique<MsgDispatcher>([this, endpointName](const std::vector<char>& data)
-                                                          { this->call(data); }, nullptr, PUBLISHER_DISPATCH_THREAD_COUNT))
+                                                          { this->call(data); },
+                                                          nullptr,
+                                                          PUBLISHER_DISPATCH_THREAD_COUNT))
     {
         m_socketServer->listen(
             [&](const int fd, const char* body, const size_t bodySize, const char* header, const size_t headerSize)

--- a/src/shared_modules/router/src/publisher.hpp
+++ b/src/shared_modules/router/src/publisher.hpp
@@ -20,6 +20,8 @@
 #include <memory>
 #include <vector>
 
+constexpr auto PUBLISHER_DISPATCH_THREAD_COUNT { 1 };
+
 /**
  * @brief Publisher class.
  *
@@ -41,7 +43,7 @@ public:
     explicit Publisher(const std::string& endpointName, const std::string& socketPath)
         : m_socketServer(std::make_unique<SocketServer<Socket<OSPrimitives>, EpollWrapper>>(socketPath + endpointName))
         , m_msgDispatcher(std::make_unique<MsgDispatcher>([this, endpointName](const std::vector<char>& data)
-                                                          { this->call(data); }))
+                                                          { this->call(data); }, nullptr, PUBLISHER_DISPATCH_THREAD_COUNT))
     {
         m_socketServer->listen(
             [&](const int fd, const char* body, const size_t bodySize, const char* header, const size_t headerSize)


### PR DESCRIPTION
|Related issue|
|---|
|Close #14153 |

## Description

This pr changes the number of threads used by the router and on-demand request and fixes a bug in the indexer connector, that uses more than 1 thread.