### PR TITLE
Content Manager - Store offset and file hash on different RocksDB columns

### DIFF
--- a/src/shared_modules/content_manager/doc/components/EXECUTION_CONTEXT.md
+++ b/src/shared_modules/content_manager/doc/components/EXECUTION_CONTEXT.md
@@ -6,7 +6,7 @@ The [execution context](../../src/components/executionContext.hpp) stage is part
 
 The tasks that this stage performs are:
 - **Set up context**: Configure some of the fields present on the Updater Context.
-- **Database initialization**: Initializes the RocksDB database, retrieving the API offset stored in it. It also defines which offset will be considered as the current one between the offset in the database and the offset in the input configuration.
+- **Database initialization**: Initializes the RocksDB database, creating the necessary columns, and retrieving the API offset stored in it as well as the last downloaded file hash. It also defines which offset will be considered as the current one between the offset in the database and the offset in the input configuration.
 - **Output folders creation**: It creates the folders needed to store the execution files, such as downloaded and uncompressed files. If the output folder already exists, it gets deleted and re-created.
 
 It is important to note that this stage is only called once for each Content Manager execution.
@@ -22,3 +22,4 @@ The context fields related to this stage are:
 - `topicName`: Used to compose the name of the database.
 - `spRocksDB`: Used to initialize the database connector.
 - `outputFolder`: Used to create the output files location.
+- `downloadedFileHash`: Used to store the file hash from the database.

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -84,9 +84,8 @@ public:
             // If the database exists, get the last offset
             if (m_spBaseContext->spRocksDB)
             {
-                spUpdaterContext->currentOffset =
-                    std::stoi(m_spBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET)
-                                  .second.ToString());
+                spUpdaterContext->currentOffset = std::stoi(
+                    m_spBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString());
             }
 
             if (offset == 0)
@@ -113,7 +112,7 @@ public:
             {
                 m_spBaseContext->spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)),
                                                 m_spBaseContext->downloadedFileHash,
-                                                Components::COLUMN_NAME_FILE_HASH);
+                                                Components::Columns::DOWNLOADED_FILE_HASH);
             }
         }
         catch (const std::exception& e)

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -15,6 +15,7 @@
 #include "components/executionContext.hpp"
 #include "components/factoryContentUpdater.hpp"
 #include "components/updaterContext.hpp"
+#include "componentsHelper.hpp"
 #include "routerProvider.hpp"
 #include "utils/rocksDBWrapper.hpp"
 #include <memory>
@@ -80,7 +81,7 @@ public:
 
             logDebug2(WM_CONTENTUPDATER, "Running '%s' content update", m_spBaseContext->topicName.c_str());
 
-            // If the database exists, get the last offset and file hash.
+            // If the database exists, get the last offset
             if (m_spBaseContext->spRocksDB)
             {
                 spUpdaterContext->currentOffset =
@@ -107,7 +108,7 @@ public:
             // Run the updater chain
             m_spUpdaterOrchestration->handleRequest(spUpdaterContext);
 
-            // Update filehash.
+            // Update filehash if it has changed.
             if (m_spBaseContext->spRocksDB && m_spBaseContext->downloadedFileHash != lastDownloadedFileHash)
             {
                 m_spBaseContext->spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)),

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -16,7 +16,7 @@
 #include "components/factoryContentUpdater.hpp"
 #include "components/updaterContext.hpp"
 #include "componentsHelper.hpp"
-#include "routerProvider.hpp"
+#include "iRouterProvider.hpp"
 #include "utils/rocksDBWrapper.hpp"
 #include <memory>
 #include <utility>
@@ -35,7 +35,7 @@ public:
      * @param parameters Parameters used to create the orchestration.
      * @param shouldRun Flag used to interrupt the orchestration stages.
      */
-    explicit ActionOrchestrator(const std::shared_ptr<RouterProvider> channel,
+    explicit ActionOrchestrator(const std::shared_ptr<IRouterProvider> channel,
                                 const nlohmann::json& parameters,
                                 const std::atomic<bool>& shouldRun)
     {

--- a/src/shared_modules/content_manager/src/components/componentsHelper.hpp
+++ b/src/shared_modules/content_manager/src/components/componentsHelper.hpp
@@ -30,8 +30,11 @@ namespace Components
         STATUS_FAIL
     };
 
-    static const std::string COLUMN_NAME_CURRENT_OFFSET {"current_offset"}; ///< Database column name for offsets.
-    static const std::string COLUMN_NAME_FILE_HASH {"file_hash"};           ///< Database column name for hashes.
+    namespace Columns
+    {
+        static const std::string CURRENT_OFFSET {"current_offset"};             ///< Database column name for offsets.
+        static const std::string DOWNLOADED_FILE_HASH {"downloaded_file_hash"}; ///< Database column name for hashes.
+    }                                                                           // namespace Columns
 
     /**
      * @brief Pushes the state of the current component into the data field of the context.

--- a/src/shared_modules/content_manager/src/components/componentsHelper.hpp
+++ b/src/shared_modules/content_manager/src/components/componentsHelper.hpp
@@ -30,6 +30,9 @@ namespace Components
         STATUS_FAIL
     };
 
+    static const std::string COLUMN_NAME_CURRENT_OFFSET {"current_offset"}; ///< Database column name for offsets.
+    static const std::string COLUMN_NAME_FILE_HASH {"file_hash"};           ///< Database column name for hashes.
+
     /**
      * @brief Pushes the state of the current component into the data field of the context.
      *

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -48,14 +48,14 @@ private:
         try
         {
             databaseOffset =
-                std::stoi(context.spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString());
+                std::stoi(context.spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString());
         }
         catch (const std::runtime_error&)
         {
             // First execution. Set offset to zero.
             databaseOffset = 0;
             context.spRocksDB->put(
-                Utils::getCompactTimestamp(std::time(nullptr)), "0", Components::COLUMN_NAME_CURRENT_OFFSET);
+                Utils::getCompactTimestamp(std::time(nullptr)), "0", Components::Columns::CURRENT_OFFSET);
         }
 
         return databaseOffset;
@@ -71,7 +71,7 @@ private:
     {
         try
         {
-            return context.spRocksDB->getLastKeyValue(Components::COLUMN_NAME_FILE_HASH).second.ToString();
+            return context.spRocksDB->getLastKeyValue(Components::Columns::DOWNLOADED_FILE_HASH).second.ToString();
         }
         catch (const std::runtime_error& e)
         {
@@ -119,8 +119,8 @@ private:
         context.spRocksDB = std::make_unique<Utils::RocksDBWrapper>(databasePath + databaseName);
 
         // Create database columns if necessary.
-        const std::vector<std::string> COLUMNS {Components::COLUMN_NAME_CURRENT_OFFSET,
-                                                Components::COLUMN_NAME_FILE_HASH};
+        const std::vector<std::string> COLUMNS {Components::Columns::CURRENT_OFFSET,
+                                                Components::Columns::DOWNLOADED_FILE_HASH};
         for (const auto& columnName : COLUMNS)
         {
             if (!context.spRocksDB->columnExists(columnName))
@@ -145,7 +145,7 @@ private:
             // Put the current offset in the database.
             context.spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)),
                                    std::to_string(currentOffset),
-                                   Components::COLUMN_NAME_CURRENT_OFFSET);
+                                   Components::Columns::CURRENT_OFFSET);
         }
     }
 

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -14,6 +14,7 @@
 
 #include "../sharedDefs.hpp"
 #include "chainOfResponsability.hpp"
+#include "componentsHelper.hpp"
 #include "json.hpp"
 #include "stringHelper.h"
 #include "updaterContext.hpp"
@@ -46,16 +47,37 @@ private:
         unsigned int databaseOffset;
         try
         {
-            databaseOffset = std::stoi(context.spRocksDB->getLastKeyValue().second.ToString());
+            databaseOffset =
+                std::stoi(context.spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString());
         }
         catch (const std::runtime_error&)
         {
             // First execution. Set offset to zero.
             databaseOffset = 0;
-            context.spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)), "0");
+            context.spRocksDB->put(
+                Utils::getCompactTimestamp(std::time(nullptr)), "0", Components::COLUMN_NAME_CURRENT_OFFSET);
         }
 
         return databaseOffset;
+    }
+
+    /**
+     * @brief Reads and returns the file hash from the database.
+     *
+     * @param context Updater context configured with the database driver.
+     * @return unsigned int Last file hash from the database.
+     */
+    std::string getDatabaseFileHash(const UpdaterBaseContext& context) const
+    {
+        try
+        {
+            return context.spRocksDB->getLastKeyValue(Components::COLUMN_NAME_FILE_HASH).second.ToString();
+        }
+        catch (const std::runtime_error& e)
+        {
+            // First execution. Return empty hash.
+            return "";
+        }
     }
 
     /**
@@ -96,6 +118,21 @@ private:
         // Initialize RocksDB driver instance.
         context.spRocksDB = std::make_unique<Utils::RocksDBWrapper>(databasePath + databaseName);
 
+        // Create database columns if necessary.
+        const std::vector<std::string> COLUMNS {Components::COLUMN_NAME_CURRENT_OFFSET,
+                                                Components::COLUMN_NAME_FILE_HASH};
+        for (const auto& columnName : COLUMNS)
+        {
+            if (!context.spRocksDB->columnExists(columnName))
+            {
+                logDebug1(WM_CONTENTUPDATER, "Column '%s' doesn't exist so it will be created", columnName.c_str());
+                context.spRocksDB->createColumn(columnName);
+            }
+        }
+
+        // Set last downloaded hash.
+        context.downloadedFileHash = getDatabaseFileHash(context);
+
         // Read input offsets.
         const auto databaseOffset {getDatabaseOffset(context)};
         const auto configOffset {getConfigOffset(context.configData)};
@@ -106,7 +143,9 @@ private:
         if (currentOffset > databaseOffset)
         {
             // Put the current offset in the database.
-            context.spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)), std::to_string(currentOffset));
+            context.spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)),
+                                   std::to_string(currentOffset),
+                                   Components::COLUMN_NAME_CURRENT_OFFSET);
         }
     }
 

--- a/src/shared_modules/content_manager/src/components/executionContext.hpp
+++ b/src/shared_modules/content_manager/src/components/executionContext.hpp
@@ -40,7 +40,7 @@ private:
      * @brief Reads and returns the last offset from the database.
      *
      * @param context Updater context configured with the database driver.
-     * @return unsigned int Last offset from the database.
+     * @return unsigned int Last offset from the database. If there is no available data, cero is returned.
      */
     unsigned int getDatabaseOffset(const UpdaterBaseContext& context) const
     {
@@ -65,7 +65,7 @@ private:
      * @brief Reads and returns the file hash from the database.
      *
      * @param context Updater context configured with the database driver.
-     * @return unsigned int Last file hash from the database.
+     * @return std::string Last file hash from the database. If there is no available data, an empty string is returned.
      */
     std::string getDatabaseFileHash(const UpdaterBaseContext& context) const
     {

--- a/src/shared_modules/content_manager/src/components/updateCtiApiOffset.hpp
+++ b/src/shared_modules/content_manager/src/components/updateCtiApiOffset.hpp
@@ -13,6 +13,7 @@
 #define _UPDATE_CTI_API_OFFSET_HPP
 
 #include "../sharedDefs.hpp"
+#include "componentsHelper.hpp"
 #include "updaterContext.hpp"
 #include "utils/chainOfResponsability.hpp"
 #include "utils/timeHelper.h"
@@ -39,7 +40,8 @@ private:
             if (context.spUpdaterBaseContext->spRocksDB)
             {
                 context.spUpdaterBaseContext->spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)),
-                                                             std::to_string(context.currentOffset));
+                                                             std::to_string(context.currentOffset),
+                                                             Components::COLUMN_NAME_CURRENT_OFFSET);
             }
             else
             {

--- a/src/shared_modules/content_manager/src/components/updateCtiApiOffset.hpp
+++ b/src/shared_modules/content_manager/src/components/updateCtiApiOffset.hpp
@@ -41,7 +41,7 @@ private:
             {
                 context.spUpdaterBaseContext->spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)),
                                                              std::to_string(context.currentOffset),
-                                                             Components::COLUMN_NAME_CURRENT_OFFSET);
+                                                             Components::Columns::CURRENT_OFFSET);
             }
             else
             {

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -342,8 +342,6 @@ TEST_F(ActionOrchestratorTest, OfflineDownloadDownloadedFileHashStore)
  */
 TEST_F(ActionOrchestratorTest, OfflineDownloadSameAndModifiedFileDifferentInstances)
 {
-    const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
-
     // Create temp test file with dummy data.
     const auto testName {::testing::UnitTest::GetInstance()->current_test_info()->name()};
     const auto inputFilePath {std::filesystem::current_path() / testName};
@@ -361,14 +359,14 @@ TEST_F(ActionOrchestratorTest, OfflineDownloadSameAndModifiedFileDifferentInstan
 
     {
         // Run first orchestration. File should be published.
-        auto mockRouterProvider {std::make_shared<MockRouterProvider>(topicName)};
+        auto mockRouterProvider {std::make_shared<MockRouterProvider>()};
         EXPECT_CALL(*mockRouterProvider, send(::testing::_)).Times(1);
         ASSERT_NO_THROW(std::make_shared<ActionOrchestrator>(mockRouterProvider, m_parameters, m_shouldRun)->run());
     }
 
     {
         // Run second orchestration. File should not be published since it didn't change.
-        auto mockRouterProvider {std::make_shared<MockRouterProvider>(topicName)};
+        auto mockRouterProvider {std::make_shared<MockRouterProvider>()};
         EXPECT_CALL(*mockRouterProvider, send(::testing::_)).Times(0);
         ASSERT_NO_THROW(std::make_shared<ActionOrchestrator>(mockRouterProvider, m_parameters, m_shouldRun)->run());
     }
@@ -380,7 +378,7 @@ TEST_F(ActionOrchestratorTest, OfflineDownloadSameAndModifiedFileDifferentInstan
 
     {
         // Run third orchestration. File should be published since it has changed.
-        auto mockRouterProvider {std::make_shared<MockRouterProvider>(topicName)};
+        auto mockRouterProvider {std::make_shared<MockRouterProvider>()};
         EXPECT_CALL(*mockRouterProvider, send(::testing::_)).Times(1);
         ASSERT_NO_THROW(std::make_shared<ActionOrchestrator>(mockRouterProvider, m_parameters, m_shouldRun)->run());
     }

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -332,7 +332,7 @@ TEST_F(ActionOrchestratorTest, OfflineDownloadDownloadedFileHashStore)
     const auto EXPECTED_DB_PATH {DATABASE_PATH / ("updater_" + topicName + "_metadata")};
     constexpr auto EXPECTED_HASH {"83f5b8992df285cdd0235bb0304e236047614d60"};
     auto wrapper {Utils::RocksDBWrapper(EXPECTED_DB_PATH)};
-    EXPECT_EQ(wrapper.getLastKeyValue(Components::COLUMN_NAME_FILE_HASH).second.ToString(), EXPECTED_HASH);
+    EXPECT_EQ(wrapper.getLastKeyValue(Components::Columns::DOWNLOADED_FILE_HASH).second.ToString(), EXPECTED_HASH);
 }
 
 /**

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
@@ -36,7 +36,8 @@ protected:
     const std::filesystem::path DATABASE_PATH {std::filesystem::temp_directory_path() /
                                                "ActionOrchestratorTest"}; ///< Path used to store the RocksDB database.
     const unsigned int INITIAL_OFFSET {1}; ///< Initial offset to be inserted on the database.
-    const std::filesystem::path m_inputFilesDir {std::filesystem::current_path() / "input_files"};
+    const std::filesystem::path m_inputFilesDir {std::filesystem::current_path() /
+                                                 "input_files"}; ///< Input files folder.
 
     /**
      * @brief Sets initial conditions for each test case.

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
@@ -36,6 +36,7 @@ protected:
     const std::filesystem::path DATABASE_PATH {std::filesystem::temp_directory_path() /
                                                "ActionOrchestratorTest"}; ///< Path used to store the RocksDB database.
     const unsigned int INITIAL_OFFSET {1}; ///< Initial offset to be inserted on the database.
+    const std::filesystem::path m_inputFilesDir {std::filesystem::current_path() / "input_files"};
 
     /**
      * @brief Sets initial conditions for each test case.

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
@@ -13,6 +13,7 @@
 #define _ACTION_ORCHESTRATOR_TEST_HPP
 
 #include "fakes/fakeServer.hpp"
+#include "mocks/mockRouterProvider.hpp"
 #include "gtest/gtest.h"
 #include <atomic>
 #include <external/nlohmann/json.hpp>
@@ -38,6 +39,7 @@ protected:
     const unsigned int INITIAL_OFFSET {1}; ///< Initial offset to be inserted on the database.
     const std::filesystem::path m_inputFilesDir {std::filesystem::current_path() /
                                                  "input_files"}; ///< Input files folder.
+    std::shared_ptr<MockRouterProvider> m_spMockRouterProvider;  ///< Router provider used on tests.
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -66,6 +68,8 @@ protected:
         // An initial offset different from zero is inserted in order to avoid the snapshot download.
         m_parameters.at("configData")["databasePath"] = DATABASE_PATH;
         m_parameters.at("configData")["offset"] = INITIAL_OFFSET;
+
+        m_spMockRouterProvider = std::make_shared<MockRouterProvider>();
     }
     /**
      * @brief Tear down routine for tests

--- a/src/shared_modules/content_manager/tests/component/mocks/mockRouterProvider.hpp
+++ b/src/shared_modules/content_manager/tests/component/mocks/mockRouterProvider.hpp
@@ -1,0 +1,51 @@
+/*
+ * Wazuh Content Manager - Component Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * Dec 18, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _MOCK_ROUTER_PROVIDER_H
+#define _MOCK_ROUTER_PROVIDER_H
+
+#include "iRouterProvider.hpp"
+#include <gmock/gmock.h>
+#include <string>
+#include <vector>
+
+/**
+ * @class MockRouterProvider
+ *
+ * @brief Mock implementation of IRouterProvider.
+ *
+ */
+class MockRouterProvider : public IRouterProvider
+{
+public:
+    explicit MockRouterProvider(const std::string&) {};
+    virtual ~MockRouterProvider() = default;
+
+    /**
+     * @brief Mock implementation of function IRouterProvider::stop.
+     *
+     */
+    MOCK_METHOD(void, stop, ());
+
+    /**
+     * @brief Mock implementation of function IRouterProvider::start.
+     *
+     */
+    MOCK_METHOD(void, start, ());
+
+    /**
+     * @brief Mock implementation of function IRouterProvider::send.
+     *
+     */
+    MOCK_METHOD(void, send, (const std::vector<char>& data));
+};
+
+#endif //_MOCK_ROUTER_PROVIDER_H

--- a/src/shared_modules/content_manager/tests/component/mocks/mockRouterProvider.hpp
+++ b/src/shared_modules/content_manager/tests/component/mocks/mockRouterProvider.hpp
@@ -26,7 +26,16 @@
 class MockRouterProvider : public IRouterProvider
 {
 public:
+    /**
+     * @brief Mock class constructor.
+     *
+     */
     explicit MockRouterProvider(const std::string&) {};
+
+    /**
+     * @brief Mock class destructor.
+     *
+     */
     virtual ~MockRouterProvider() = default;
 
     /**

--- a/src/shared_modules/content_manager/tests/component/mocks/mockRouterProvider.hpp
+++ b/src/shared_modules/content_manager/tests/component/mocks/mockRouterProvider.hpp
@@ -30,10 +30,10 @@ public:
      * @brief Mock class constructor.
      *
      */
-    explicit MockRouterProvider(const std::string&) {};
+    MockRouterProvider() = default;
 
     /**
-     * @brief Mock class destructor.
+     * @brief Destroy the Mock Router Provider object
      *
      */
     virtual ~MockRouterProvider() = default;

--- a/src/shared_modules/content_manager/tests/unit/executionContext_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/executionContext_test.cpp
@@ -125,9 +125,8 @@ TEST_F(ExecutionContextTest, DatabaseGeneration)
 
     EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
     EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString(),
-        std::to_string(OFFSET));
+    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString(),
+              std::to_string(OFFSET));
 }
 
 /**
@@ -158,9 +157,8 @@ TEST_F(ExecutionContextTest, DatabaseGenerationPositiveOffset)
 
     EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
     EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString(),
-        std::to_string(OFFSET));
+    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString(),
+              std::to_string(OFFSET));
 }
 
 /**
@@ -179,9 +177,8 @@ TEST_F(ExecutionContextTest, DatabaseGenerationConfigOffsetLessThanDatabaseOffse
     m_spUpdaterBaseContext->configData["offset"] = FIRST_OFFSET;
     EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
     EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString(),
-        std::to_string(FIRST_OFFSET));
+    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString(),
+              std::to_string(FIRST_OFFSET));
 
     // Call RocksDBWrapper destructor.
     m_spUpdaterBaseContext->spRocksDB.reset();
@@ -190,9 +187,8 @@ TEST_F(ExecutionContextTest, DatabaseGenerationConfigOffsetLessThanDatabaseOffse
     m_spUpdaterBaseContext->configData["offset"] = SECOND_OFFSET;
     EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
     EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString(),
-        std::to_string(FIRST_OFFSET));
+    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString(),
+              std::to_string(FIRST_OFFSET));
 }
 
 /**
@@ -211,9 +207,8 @@ TEST_F(ExecutionContextTest, DatabaseGenerationConfigOffsetGreaterThanDatabaseOf
     m_spUpdaterBaseContext->configData["offset"] = FIRST_OFFSET;
     EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
     EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString(),
-        std::to_string(FIRST_OFFSET));
+    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString(),
+              std::to_string(FIRST_OFFSET));
 
     // Call RocksDBWrapper destructor.
     m_spUpdaterBaseContext->spRocksDB.reset();
@@ -222,9 +217,8 @@ TEST_F(ExecutionContextTest, DatabaseGenerationConfigOffsetGreaterThanDatabaseOf
     m_spUpdaterBaseContext->configData["offset"] = SECOND_OFFSET;
     EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
     EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString(),
-        std::to_string(SECOND_OFFSET));
+    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString(),
+              std::to_string(SECOND_OFFSET));
 }
 
 /**
@@ -241,9 +235,8 @@ TEST_F(ExecutionContextTest, DatabaseGenerationConfigOffsetEqualToDatabaseOffset
     m_spUpdaterBaseContext->configData["offset"] = OFFSET;
     EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
     EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString(),
-        std::to_string(OFFSET));
+    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString(),
+              std::to_string(OFFSET));
 
     // Call RocksDBWrapper destructor.
     m_spUpdaterBaseContext->spRocksDB.reset();
@@ -251,9 +244,8 @@ TEST_F(ExecutionContextTest, DatabaseGenerationConfigOffsetEqualToDatabaseOffset
     // Second execution.
     EXPECT_NO_THROW(m_spExecutionContext->handleRequest(m_spUpdaterBaseContext));
     EXPECT_TRUE(std::filesystem::exists(m_databasePath));
-    EXPECT_EQ(
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString(),
-        std::to_string(OFFSET));
+    EXPECT_EQ(m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString(),
+              std::to_string(OFFSET));
 }
 
 /**
@@ -286,8 +278,8 @@ TEST_F(ExecutionContextTest, ReadLastDownloadedFileHash)
     {
         const auto EXPECTED_DB_PATH {m_databasePath / (std::string("updater_") + TOPIC_NAME + "_metadata")};
         auto wrapper {Utils::RocksDBWrapper(EXPECTED_DB_PATH)};
-        wrapper.createColumn(Components::COLUMN_NAME_FILE_HASH);
-        wrapper.put("test_key", FILE_HASH, Components::COLUMN_NAME_FILE_HASH);
+        wrapper.createColumn(Components::Columns::DOWNLOADED_FILE_HASH);
+        wrapper.put("test_key", FILE_HASH, Components::Columns::DOWNLOADED_FILE_HASH);
     }
 
     m_spExecutionContext->handleRequest(m_spUpdaterBaseContext);

--- a/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
@@ -58,6 +58,12 @@ protected:
      */
     void TearDown() override
     {
+        // Destruct RocksDB wrapper.
+        if (m_spUpdaterBaseContext->spRocksDB)
+        {
+            m_spUpdaterBaseContext->spRocksDB.reset();
+        }
+
         std::filesystem::remove_all(m_outputFolder);
         std::filesystem::remove_all(m_databasePath);
     }

--- a/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.cpp
@@ -19,7 +19,7 @@ TEST_F(UpdateCtiApiOffsetTest, updateOffset)
 {
     // Get the last offset in the database.
     const auto lastOffset =
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString();
+        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString();
 
     // Set the current offset to a value different from the last offset.
     m_spUpdaterContext->currentOffset = 10;
@@ -29,7 +29,7 @@ TEST_F(UpdateCtiApiOffsetTest, updateOffset)
 
     // Get the new last offset in the database.
     const auto newLastOffset =
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString();
+        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString();
 
     // Check that the last offset has been updated.
     EXPECT_NE(lastOffset, newLastOffset);
@@ -43,7 +43,7 @@ TEST_F(UpdateCtiApiOffsetTest, notUpdateOffset)
 {
     // Get the last offset in the database.
     const auto lastOffset =
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString();
+        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString();
 
     // Set the current offset to a value equal to the last offset.
     m_spUpdaterContext->currentOffset = std::stoi(lastOffset);
@@ -53,7 +53,7 @@ TEST_F(UpdateCtiApiOffsetTest, notUpdateOffset)
 
     // Get the new last offset in the database.
     const auto newLastOffset =
-        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString();
+        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::Columns::CURRENT_OFFSET).second.ToString();
 
     // Check that the last offset has not been updated.
     EXPECT_EQ(lastOffset, newLastOffset);

--- a/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.cpp
@@ -18,7 +18,8 @@
 TEST_F(UpdateCtiApiOffsetTest, updateOffset)
 {
     // Get the last offset in the database.
-    const auto lastOffset = m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString();
+    const auto lastOffset =
+        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString();
 
     // Set the current offset to a value different from the last offset.
     m_spUpdaterContext->currentOffset = 10;
@@ -27,7 +28,8 @@ TEST_F(UpdateCtiApiOffsetTest, updateOffset)
     EXPECT_NO_THROW(m_spUpdateCtiApiOffset->handleRequest(m_spUpdaterContext));
 
     // Get the new last offset in the database.
-    const auto newLastOffset = m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString();
+    const auto newLastOffset =
+        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString();
 
     // Check that the last offset has been updated.
     EXPECT_NE(lastOffset, newLastOffset);
@@ -40,7 +42,8 @@ TEST_F(UpdateCtiApiOffsetTest, updateOffset)
 TEST_F(UpdateCtiApiOffsetTest, notUpdateOffset)
 {
     // Get the last offset in the database.
-    const auto lastOffset = m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString();
+    const auto lastOffset =
+        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString();
 
     // Set the current offset to a value equal to the last offset.
     m_spUpdaterContext->currentOffset = std::stoi(lastOffset);
@@ -49,7 +52,8 @@ TEST_F(UpdateCtiApiOffsetTest, notUpdateOffset)
     EXPECT_NO_THROW(m_spUpdateCtiApiOffset->handleRequest(m_spUpdaterContext));
 
     // Get the new last offset in the database.
-    const auto newLastOffset = m_spUpdaterBaseContext->spRocksDB->getLastKeyValue().second.ToString();
+    const auto newLastOffset =
+        m_spUpdaterBaseContext->spRocksDB->getLastKeyValue(Components::COLUMN_NAME_CURRENT_OFFSET).second.ToString();
 
     // Check that the last offset has not been updated.
     EXPECT_EQ(lastOffset, newLastOffset);

--- a/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.hpp
@@ -18,8 +18,9 @@
 #include "utils/timeHelper.h"
 #include "gtest/gtest.h"
 #include <atomic>
+#include <filesystem>
 
-static const std::string DATABASE_NAME {"test.db"};
+const auto DATABASE_FOLDER {std::filesystem::temp_directory_path() / "test_db"};
 
 /**
  * @brief Runs unit tests for UpdateCtiApiOffset
@@ -54,8 +55,10 @@ protected:
     {
         // Initialize contexts
         m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
-        m_spUpdaterBaseContext->spRocksDB = std::make_unique<Utils::RocksDBWrapper>(DATABASE_NAME);
-        m_spUpdaterBaseContext->spRocksDB->put(Utils::getCompactTimestamp(std::time(nullptr)), "0");
+        m_spUpdaterBaseContext->spRocksDB = std::make_unique<Utils::RocksDBWrapper>(DATABASE_FOLDER);
+        m_spUpdaterBaseContext->spRocksDB->createColumn(Components::COLUMN_NAME_CURRENT_OFFSET);
+        m_spUpdaterBaseContext->spRocksDB->put(
+            Utils::getCompactTimestamp(std::time(nullptr)), "0", Components::COLUMN_NAME_CURRENT_OFFSET);
 
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
         m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
@@ -74,7 +77,7 @@ protected:
             m_spUpdaterBaseContext->spRocksDB->deleteAll();
         }
 
-        std::filesystem::remove_all(DATABASE_NAME);
+        std::filesystem::remove_all(DATABASE_FOLDER);
     }
 };
 

--- a/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.hpp
@@ -56,9 +56,9 @@ protected:
         // Initialize contexts
         m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
         m_spUpdaterBaseContext->spRocksDB = std::make_unique<Utils::RocksDBWrapper>(DATABASE_FOLDER);
-        m_spUpdaterBaseContext->spRocksDB->createColumn(Components::COLUMN_NAME_CURRENT_OFFSET);
+        m_spUpdaterBaseContext->spRocksDB->createColumn(Components::Columns::CURRENT_OFFSET);
         m_spUpdaterBaseContext->spRocksDB->put(
-            Utils::getCompactTimestamp(std::time(nullptr)), "0", Components::COLUMN_NAME_CURRENT_OFFSET);
+            Utils::getCompactTimestamp(std::time(nullptr)), "0", Components::Columns::CURRENT_OFFSET);
 
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
         m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;


### PR DESCRIPTION
|Related issue|
|---|
|#20849 |

## Description

This PR makes the Content Manager to:
- Store the `offset` in a different RocksDB column than the default one.
- Store the `downloadedFileHash` in RocksDB.

## Results

### Test tool

#### Offline downloader :green_circle:

- Config
```json
{
    "topicName": "test",
    "interval": 10,
    "ondemand": true,
    "configData":
    {
        "contentSource": "offline",
        "compressionType": "raw",
        "versionedContent": "false",
        "deleteDownloadedContent": true,
        "url": "file:///home/content.json",
        "outputFolder": "/tmp/testProvider",
        "dataFormat": "json",
        "contentFileName": "example.json",
        "databasePath": "/tmp/content_updater/rocksdb",
        "offset": 0
    }
}
```

- Execution
```bash
# ./content_manager_test_tool 
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:49 ActionOrchestrator: Creating 'test' Content Updater orchestration
wazuh-modulesd:content-updater:[DEBUG]:executionContext.hpp:202 handleRequest: ExecutionContext - Starting process
wazuh-modulesd:content-updater:[DEBUG]:executionContext.hpp:128 createRocksDB: Column 'current_offset' doesn't exist so it will be created
wazuh-modulesd:content-updater:[DEBUG]:executionContext.hpp:128 createRocksDB: Column 'file_hash' doesn't exist so it will be created
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:executionContext.hpp:184 createOutputFolder: Creating output folders at '/tmp/testProvider'
wazuh-modulesd:content-updater:[DEBUG]:factoryContentUpdater.hpp:44 create: FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:[DEBUG]:factoryDownloader.hpp:46 create: Creating 'offline' downloader
wazuh-modulesd:content-updater:[DEBUG]:factoryDecompressor.hpp:73 create: Creating 'raw' decompressor
wazuh-modulesd:content-updater:[DEBUG]:factoryVersionUpdater.hpp:41 create: Creating 'false' version updater
wazuh-modulesd:content-updater:[DEBUG]:factoryCleaner.hpp:41 create: Content cleaner created
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:59 ActionOrchestrator: Content updater orchestration created
wazuh-modulesd:content-updater:[INFO]: Starting on-start action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action for 'test' started
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:actionOrchestrator.hpp:81 run: Running 'test' content update
wazuh-modulesd:content-updater:[DEBUG]:offlineDownloader.hpp:183 handleRequest: OfflineDownloader - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:offlineDownloader.hpp:66 copyFile: Copying file from 'file:///home/content.json' into '/tmp/testProvider/contents/content.json'
wazuh-modulesd:content-updater:[DEBUG]:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:[DEBUG]:pubSubPublisher.hpp:61 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:pubSubPublisher.hpp:42 publish: Data to be published: '{"paths":["/tmp/testProvider/contents/content.json"],"stageStatus":[{"stage":"OfflineDownloader","status":"ok"}],"type":"raw"}'
wazuh-modulesd:content-updater:[INFO]: Data published
wazuh-modulesd:content-updater:[DEBUG]:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:[DEBUG]:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater:[INFO]: Action for 'test' finished

[first execution manually interrupted]

# ./content_manager_test_tool 
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:49 ActionOrchestrator: Creating 'test' Content Updater orchestration
wazuh-modulesd:content-updater:[DEBUG]:executionContext.hpp:202 handleRequest: ExecutionContext - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:executionContext.hpp:179 createOutputFolder: Removing previous output folder '/tmp/testProvider'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:executionContext.hpp:184 createOutputFolder: Creating output folders at '/tmp/testProvider'
wazuh-modulesd:content-updater:[DEBUG]:factoryContentUpdater.hpp:44 create: FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:[DEBUG]:factoryDownloader.hpp:46 create: Creating 'offline' downloader
wazuh-modulesd:content-updater:[DEBUG]:factoryDecompressor.hpp:73 create: Creating 'raw' decompressor
wazuh-modulesd:content-updater:[DEBUG]:factoryVersionUpdater.hpp:41 create: Creating 'false' version updater
wazuh-modulesd:content-updater:[DEBUG]:factoryCleaner.hpp:41 create: Content cleaner created
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:59 ActionOrchestrator: Content updater orchestration created
wazuh-modulesd:content-updater:[INFO]: Starting on-start action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action for 'test' started
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:actionOrchestrator.hpp:81 run: Running 'test' content update
wazuh-modulesd:content-updater:[DEBUG]:offlineDownloader.hpp:183 handleRequest: OfflineDownloader - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:offlineDownloader.hpp:66 copyFile: Copying file from 'file:///home/content.json' into '/tmp/testProvider/contents/content.json'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:offlineDownloader.hpp:160 download: File '/tmp/testProvider/contents/content.json' didn't change from last download so it won't be published
wazuh-modulesd:content-updater:[DEBUG]:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:[DEBUG]:pubSubPublisher.hpp:61 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:pubSubPublisher.hpp:49 publish: No data to publish
wazuh-modulesd:content-updater:[DEBUG]:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:[DEBUG]:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater:[INFO]: Action for 'test' finished
```

#### HTTP file download :green_circle:

- Config
```json
{
    "topicName": "test",
    "interval": 10,
    "ondemand": true,
    "configData":
    {
        "contentSource": "file",
        "compressionType": "raw",
        "versionedContent": "false",
        "deleteDownloadedContent": true,
        "url": "https://raw.githubusercontent.com/wazuh/wazuh/master/README.md",
        "outputFolder": "/tmp/testProvider",
        "dataFormat": "json",
        "contentFileName": "example.json",
        "databasePath": "/tmp/content_updater/rocksdb",
        "offset": 0
    }
}
```

- Execution
```bash
# ./content_manager_test_tool 
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:49 ActionOrchestrator: Creating 'test' Content Updater orchestration
wazuh-modulesd:content-updater:[DEBUG]:executionContext.hpp:202 handleRequest: ExecutionContext - Starting process
wazuh-modulesd:content-updater:[DEBUG]:executionContext.hpp:128 createRocksDB: Column 'current_offset' doesn't exist so it will be created
wazuh-modulesd:content-updater:[DEBUG]:executionContext.hpp:128 createRocksDB: Column 'file_hash' doesn't exist so it will be created
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:executionContext.hpp:184 createOutputFolder: Creating output folders at '/tmp/testProvider'
wazuh-modulesd:content-updater:[DEBUG]:factoryContentUpdater.hpp:44 create: FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:[DEBUG]:factoryDownloader.hpp:46 create: Creating 'file' downloader
wazuh-modulesd:content-updater:[DEBUG]:factoryDecompressor.hpp:73 create: Creating 'raw' decompressor
wazuh-modulesd:content-updater:[DEBUG]:factoryVersionUpdater.hpp:41 create: Creating 'false' version updater
wazuh-modulesd:content-updater:[DEBUG]:factoryCleaner.hpp:41 create: Content cleaner created
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:59 ActionOrchestrator: Content updater orchestration created
wazuh-modulesd:content-updater:[INFO]: Starting on-start action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action for 'test' started
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:actionOrchestrator.hpp:81 run: Running 'test' content update
wazuh-modulesd:content-updater:[DEBUG]:fileDownloader.hpp:101 handleRequest: FileDownloader - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:fileDownloader.hpp:72 download: Downloading file from 'https://raw.githubusercontent.com/wazuh/wazuh/master/README.md'
wazuh-modulesd:content-updater:[DEBUG]:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:[DEBUG]:pubSubPublisher.hpp:61 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:pubSubPublisher.hpp:42 publish: Data to be published: '{"paths":["/tmp/testProvider/contents/README.md"],"stageStatus":[{"stage":"FileDownloader","status":"ok"}],"type":"raw"}'
wazuh-modulesd:content-updater:[INFO]: Data published
wazuh-modulesd:content-updater:[DEBUG]:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:[DEBUG]:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater:[INFO]: Action for 'test' finished

[first execution manually interrupted]

# ./content_manager_test_tool 
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:49 ActionOrchestrator: Creating 'test' Content Updater orchestration
wazuh-modulesd:content-updater:[DEBUG]:executionContext.hpp:202 handleRequest: ExecutionContext - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:executionContext.hpp:179 createOutputFolder: Removing previous output folder '/tmp/testProvider'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:executionContext.hpp:184 createOutputFolder: Creating output folders at '/tmp/testProvider'
wazuh-modulesd:content-updater:[DEBUG]:factoryContentUpdater.hpp:44 create: FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:[DEBUG]:factoryDownloader.hpp:46 create: Creating 'file' downloader
wazuh-modulesd:content-updater:[DEBUG]:factoryDecompressor.hpp:73 create: Creating 'raw' decompressor
wazuh-modulesd:content-updater:[DEBUG]:factoryVersionUpdater.hpp:41 create: Creating 'false' version updater
wazuh-modulesd:content-updater:[DEBUG]:factoryCleaner.hpp:41 create: Content cleaner created
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:59 ActionOrchestrator: Content updater orchestration created
wazuh-modulesd:content-updater:[INFO]: Starting on-start action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action for 'test' started
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:actionOrchestrator.hpp:81 run: Running 'test' content update
wazuh-modulesd:content-updater:[DEBUG]:fileDownloader.hpp:101 handleRequest: FileDownloader - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:fileDownloader.hpp:72 download: Downloading file from 'https://raw.githubusercontent.com/wazuh/wazuh/master/README.md'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:fileDownloader.hpp:79 download: File '/tmp/testProvider/contents/README.md' didn't change from last download so it won't be published
wazuh-modulesd:content-updater:[DEBUG]:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:[DEBUG]:pubSubPublisher.hpp:61 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:pubSubPublisher.hpp:49 publish: No data to publish
wazuh-modulesd:content-updater:[DEBUG]:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:[DEBUG]:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater:[INFO]: Action for 'test' finished
```