### PR TITLE
Fixing types for network interface messages

### DIFF
--- a/src/shared_modules/utils/flatbuffers/schemas/syscollectorDeltas/syscollector_deltas.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/syscollectorDeltas/syscollector_deltas.fbs
@@ -35,16 +35,16 @@ table dbsync_network_iface {
     adapter:string;
     type:string;
     state:string;
-    mtu:int;
+    mtu:uint32;
     mac:string;
-    tx_packets:int;
-    rx_packets:int;
-    tx_bytes:int;
-    rx_bytes:int;
-    tx_errors:int;
-    rx_errors:int;
-    tx_dropped:int;
-    rx_dropped:int;
+    tx_packets:uint;
+    rx_packets:uint;
+    tx_bytes:uint;
+    rx_bytes:uint;
+    tx_errors:uint;
+    rx_errors:uint;
+    tx_dropped:uint;
+    rx_dropped:uint;
     checksum:string;
     item_id:string;
 }

--- a/src/shared_modules/utils/flatbuffers/schemas/syscollectorRsync/syscollector_synchronization.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/syscollectorRsync/syscollector_synchronization.fbs
@@ -41,18 +41,18 @@ table syscollector_network_iface {
     checksum:string;
     item_id:string;
     mac:string;
-    mtu:int;
+    mtu:uint32;
     name:string;
-    rx_bytes:int;
-    rx_dropped:int;
-    rx_errors:int;
-    rx_packets:int;
+    rx_bytes:uint;
+    rx_dropped:uint;
+    rx_errors:uint;
+    rx_packets:uint;
     scan_time:string;
     state:string;
-    tx_bytes:int;
-    tx_dropped:int;
-    tx_errors:int;
-    tx_packets:int;
+    tx_bytes:uint;
+    tx_dropped:uint;
+    tx_errors:uint;
+    tx_packets:uint;
     type:string;
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20793 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR sets the correct type for me fields of the `dbsync_network_iface` and `syscollector_network_iface` tables.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
 
