### PR TITLE
Content Manager - Fix on-demand execution launched in parallel

### DIFF
--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -68,6 +68,24 @@ public:
     }
 
     /**
+     * @brief Action execution with exclusivity: The action is only executed if there isn't another action in progress.
+     *
+     * @param id Action ID.
+     * @param offset Manually set current offset to process.
+     *
+     * @return True if the execution was made, false otherwise.
+     */
+    bool runActionWithExclusivity(const ActionID id, const int offset = -1)
+    {
+        auto expectedValue {false};
+        if (m_actionInProgress.compare_exchange_strong(expectedValue, true))
+        {
+            runAction(id, offset);
+        }
+        return !expectedValue;
+    }
+
+    /**
      * @brief Action scheduler start.
      *
      * @param interval Scheduler interval.
@@ -83,30 +101,30 @@ public:
                 std::unique_lock<std::mutex> lock(m_mutex);
 
                 // Run action on start, independently of the interval time.
-                runActionOnDemand();
+                runActionScheduled();
 
                 while (m_schedulerRunning)
                 {
                     m_cv.wait_for(lock, std::chrono::seconds(this->m_interval));
                     if (m_schedulerRunning)
                     {
-                        bool expected = false;
-                        if (m_actionInProgress.compare_exchange_strong(expected, true))
-                        {
-                            logInfo(WM_CONTENTUPDATER, "Starting scheduled action for '%s'", m_topicName.c_str());
-                            runAction(ActionID::SCHEDULED);
-                        }
-                        else
-                        {
-                            // LCOV_EXCL_START
-                            logInfo(WM_CONTENTUPDATER,
-                                    "Action in progress for '%s', scheduled request ignored",
-                                    m_topicName.c_str());
-                            // LCOV_EXCL_STOP
-                        }
+                        runActionScheduled();
                     }
                 }
             });
+    }
+
+    /**
+     * @brief Runs scheduled action. Wrapper of runActionWithExclusivity().
+     *
+     */
+    void runActionScheduled()
+    {
+        logInfo(WM_CONTENTUPDATER, "Starting scheduled action for '%s'", m_topicName.c_str());
+        if (!runActionWithExclusivity(ActionID::SCHEDULED))
+        {
+            logInfo(WM_CONTENTUPDATER, "Action in progress for '%s', scheduled request ignored", m_topicName.c_str());
+        }
     }
 
     /**
@@ -153,23 +171,16 @@ public:
     }
 
     /**
-     * @brief Runs ondemand action.
+     * @brief Runs ondemand action. Wrapper of runActionWithExclusivity().
      *
      * @param offset Manually set current offset to process. Default -1
      */
     void runActionOnDemand(const int offset = -1)
     {
-        auto expected = false;
-        if (m_actionInProgress.compare_exchange_strong(expected, true))
+        logInfo(WM_CONTENTUPDATER, "Starting on-demand action for '%s'", m_topicName.c_str());
+        if (!runActionWithExclusivity(ActionID::ON_DEMAND, offset))
         {
-            logInfo(WM_CONTENTUPDATER, "Starting on-demand action for '%s'", m_topicName.c_str());
-            runAction(ActionID::ON_DEMAND, offset);
-        }
-        else
-        {
-            // LCOV_EXCL_START
             logInfo(WM_CONTENTUPDATER, "Action in progress for '%s', on-demand request ignored", m_topicName.c_str());
-            // LCOV_EXCL_STOP
         }
     }
 

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -75,7 +75,7 @@ public:
      *
      * @return True if the execution was made, false otherwise.
      */
-    bool runActionWithExclusivity(const ActionID id, const int offset = -1)
+    bool runActionExclusively(const ActionID id, const int offset = -1)
     {
         auto expectedValue {false};
         if (m_actionInProgress.compare_exchange_strong(expectedValue, true))
@@ -115,13 +115,13 @@ public:
     }
 
     /**
-     * @brief Runs scheduled action. Wrapper of runActionWithExclusivity().
+     * @brief Runs scheduled action. Wrapper of runActionExclusively().
      *
      */
     void runActionScheduled()
     {
         logInfo(WM_CONTENTUPDATER, "Starting scheduled action for '%s'", m_topicName.c_str());
-        if (!runActionWithExclusivity(ActionID::SCHEDULED))
+        if (!runActionExclusively(ActionID::SCHEDULED))
         {
             logInfo(WM_CONTENTUPDATER, "Action in progress for '%s', scheduled request ignored", m_topicName.c_str());
         }
@@ -171,14 +171,14 @@ public:
     }
 
     /**
-     * @brief Runs ondemand action. Wrapper of runActionWithExclusivity().
+     * @brief Runs ondemand action. Wrapper of runActionExclusively().
      *
      * @param offset Manually set current offset to process. Default -1
      */
     void runActionOnDemand(const int offset = -1)
     {
         logInfo(WM_CONTENTUPDATER, "Starting on-demand action for '%s'", m_topicName.c_str());
-        if (!runActionWithExclusivity(ActionID::ON_DEMAND, offset))
+        if (!runActionExclusively(ActionID::ON_DEMAND, offset))
         {
             logInfo(WM_CONTENTUPDATER, "Action in progress for '%s', on-demand request ignored", m_topicName.c_str());
         }

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -83,8 +83,7 @@ public:
                 std::unique_lock<std::mutex> lock(m_mutex);
 
                 // Run action on start, independently of the interval time.
-                logInfo(WM_CONTENTUPDATER, "Starting on-start action for '%s'", m_topicName.c_str());
-                runAction(ActionID::SCHEDULED);
+                runActionOnDemand();
 
                 while (m_schedulerRunning)
                 {


### PR DESCRIPTION
|Related issue|
|---|
|#20920 |

## Description

This PR fixes the on-start action trigger, where the in-progress flag was not being well set.

## Results

### Test tool

- Config
```json
{
    "topicName": "test",
    "interval": 10,
    "ondemand": true,
    "configData":
    {
        "contentSource": "cti-snapshot",
        "compressionType": "zip",
        "versionedContent": "false",
        "deleteDownloadedContent": true,
        "url": "https://cti-dev.wazuh.com/api/v1/catalog/contexts/vdp_all_vendors/consumers/vdp_all_vendors_consumer",
        "outputFolder": "/tmp/testProvider",
        "dataFormat": "json",
        "contentFileName": "example.json",
        "databasePath": "/tmp/content_updater/rocksdb",
        "offset": 0
    }
}
```

- Execution log. Some empty lines were added to highlight pieces of logs::
```bash
# ./content_manager_test_tool 
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:50 ActionOrchestrator: Creating 'test' Content Updater orchestration
wazuh-modulesd:content-updater:[DEBUG]:executionContext.hpp:202 handleRequest: ExecutionContext - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:executionContext.hpp:179 createOutputFolder: Removing previous output folder '/tmp/testProvider'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:executionContext.hpp:184 createOutputFolder: Creating output folders at '/tmp/testProvider'
wazuh-modulesd:content-updater:[DEBUG]:factoryContentUpdater.hpp:44 create: FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:[DEBUG]:factoryDownloader.hpp:46 create: Creating 'cti-snapshot' downloader
wazuh-modulesd:content-updater:[DEBUG]:factoryDecompressor.hpp:73 create: Creating 'zip' decompressor
wazuh-modulesd:content-updater:[DEBUG]:factoryVersionUpdater.hpp:41 create: Creating 'false' version updater
wazuh-modulesd:content-updater:[DEBUG]:factoryCleaner.hpp:41 create: Content cleaner created
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:60 ActionOrchestrator: Content updater orchestration created
wazuh-modulesd:content-updater:[INFO]: Starting scheduled action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action for 'test' started
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:actionOrchestrator.hpp:82 run: Running 'test' content update
wazuh-modulesd:content-updater:[DEBUG]:CtiDownloader.hpp:203 handleRequest: CtiSnapshotDownloader - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiDownloader.hpp:104 getCtiBaseParameters: CTI last offset: '255909'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiDownloader.hpp:105 getCtiBaseParameters: CTI last snapshot link: 'https://s3.us-east-1.amazonaws.com/cti-snapshots/store/contexts/vdp_all_vendors/consumers/vdp_all_vendors_consumer/255909_1702998513.zip'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiDownloader.hpp:106 getCtiBaseParameters: CTI snapshot last offset: '255909'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiSnapshotDownloader.hpp:54 download: Downloading snapshot from 'https://s3.us-east-1.amazonaws.com/cti-snapshots/store/contexts/vdp_all_vendors/consumers/vdp_all_vendors_consumer/255909_1702998513.zip'

wazuh-modulesd:content-updater:[INFO]: Starting on-demand action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action in progress for 'test', on-demand request ignored

wazuh-modulesd:content-updater:[DEBUG]:zipDecompressor.hpp:74 handleRequest: ZipDecompressor - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:zipDecompressor.hpp:49 decompress: Decompressing '/tmp/testProvider/downloads/255909_1702998513.zip' into '/tmp/testProvider/contents'
wazuh-modulesd:content-updater:[DEBUG]:pubSubPublisher.hpp:61 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:pubSubPublisher.hpp:42 publish: Data to be published: '{"paths":["/tmp/testProvider/contents/vdp_all_vendors_vdp_all_vendors_consumer_255909_1702998513.json"],"stageStatus":[{"stage":"CtiSnapshotDownloader","status":"ok"},{"stage":"ZipDecompressor","status":"ok"}],"type":"raw"}'
wazuh-modulesd:content-updater:[INFO]: Data published
wazuh-modulesd:content-updater:[DEBUG]:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:[DEBUG]:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater:[INFO]: Action for 'test' finished
wazuh-modulesd:content-updater:[INFO]: Starting scheduled action for 'test'
```

- Test tool modified to make multiple on-demand requests. Some empty lines were added to highlight pieces of logs:
```bash
# ./content_manager_test_tool 
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:50 ActionOrchestrator: Creating 'test' Content Updater orchestration
wazuh-modulesd:content-updater:[DEBUG]:executionContext.hpp:202 handleRequest: ExecutionContext - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:executionContext.hpp:179 createOutputFolder: Removing previous output folder '/tmp/testProvider'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:executionContext.hpp:184 createOutputFolder: Creating output folders at '/tmp/testProvider'
wazuh-modulesd:content-updater:[DEBUG]:factoryContentUpdater.hpp:44 create: FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:[DEBUG]:factoryDownloader.hpp:46 create: Creating 'cti-snapshot' downloader
wazuh-modulesd:content-updater:[DEBUG]:factoryDecompressor.hpp:73 create: Creating 'zip' decompressor
wazuh-modulesd:content-updater:[DEBUG]:factoryVersionUpdater.hpp:41 create: Creating 'false' version updater
wazuh-modulesd:content-updater:[DEBUG]:factoryCleaner.hpp:41 create: Content cleaner created
wazuh-modulesd:content-updater:[DEBUG]:actionOrchestrator.hpp:60 ActionOrchestrator: Content updater orchestration created
wazuh-modulesd:content-updater:[INFO]: Starting scheduled action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action for 'test' started
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:actionOrchestrator.hpp:82 run: Running 'test' content update
wazuh-modulesd:content-updater:[DEBUG]:CtiDownloader.hpp:203 handleRequest: CtiSnapshotDownloader - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiDownloader.hpp:104 getCtiBaseParameters: CTI last offset: '255909'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiDownloader.hpp:105 getCtiBaseParameters: CTI last snapshot link: 'https://s3.us-east-1.amazonaws.com/cti-snapshots/store/contexts/vdp_all_vendors/consumers/vdp_all_vendors_consumer/255909_1702998513.zip'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiDownloader.hpp:106 getCtiBaseParameters: CTI snapshot last offset: '255909'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiSnapshotDownloader.hpp:54 download: Downloading snapshot from 'https://s3.us-east-1.amazonaws.com/cti-snapshots/store/contexts/vdp_all_vendors/consumers/vdp_all_vendors_consumer/255909_1702998513.zip'

wazuh-modulesd:content-updater:[INFO]: Starting on-demand action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action in progress for 'test', on-demand request ignored
wazuh-modulesd:content-updater:[INFO]: Starting on-demand action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action in progress for 'test', on-demand request ignored
wazuh-modulesd:content-updater:[INFO]: Starting on-demand action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action in progress for 'test', on-demand request ignored
wazuh-modulesd:content-updater:[INFO]: Starting on-demand action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action in progress for 'test', on-demand request ignored

wazuh-modulesd:content-updater:[DEBUG]:zipDecompressor.hpp:74 handleRequest: ZipDecompressor - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:zipDecompressor.hpp:49 decompress: Decompressing '/tmp/testProvider/downloads/255909_1702998513.zip' into '/tmp/testProvider/contents'
wazuh-modulesd:content-updater:[DEBUG]:pubSubPublisher.hpp:61 handleRequest: PubSubPublisher - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:pubSubPublisher.hpp:42 publish: Data to be published: '{"paths":["/tmp/testProvider/contents/vdp_all_vendors_vdp_all_vendors_consumer_255909_1702998513.json"],"stageStatus":[{"stage":"CtiSnapshotDownloader","status":"ok"},{"stage":"ZipDecompressor","status":"ok"}],"type":"raw"}'
wazuh-modulesd:content-updater:[INFO]: Data published
wazuh-modulesd:content-updater:[DEBUG]:skipStep.hpp:48 handleRequest: SkipStep - Starting process
wazuh-modulesd:content-updater:[DEBUG]:cleanUpContent.hpp:63 handleRequest: CleanUpContent - Starting process
wazuh-modulesd:content-updater:[INFO]: Action for 'test' finished

wazuh-modulesd:content-updater:[INFO]: Starting on-demand action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action for 'test' started
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:actionOrchestrator.hpp:82 run: Running 'test' content update
wazuh-modulesd:content-updater:[DEBUG]:CtiDownloader.hpp:203 handleRequest: CtiSnapshotDownloader - Starting process
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiDownloader.hpp:104 getCtiBaseParameters: CTI last offset: '255909'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiDownloader.hpp:105 getCtiBaseParameters: CTI last snapshot link: 'https://s3.us-east-1.amazonaws.com/cti-snapshots/store/contexts/vdp_all_vendors/consumers/vdp_all_vendors_consumer/255909_1702998513.zip'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiDownloader.hpp:106 getCtiBaseParameters: CTI snapshot last offset: '255909'
wazuh-modulesd:content-updater:[DEBUG_VERBOSE]:CtiSnapshotDownloader.hpp:54 download: Downloading snapshot from 'https://s3.us-east-1.amazonaws.com/cti-snapshots/store/contexts/vdp_all_vendors/consumers/vdp_all_vendors_consumer/255909_1702998513.zip'

wazuh-modulesd:content-updater:[INFO]: Starting scheduled action for 'test'
wazuh-modulesd:content-updater:[INFO]: Action in progress for 'test', scheduled request ignored

[truncated]
```