### PR TITLE
adds a flag that allows to correctly convert binary data (FlatBuffers) to text

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -191,10 +191,6 @@ public:
         const auto updaterPolicy = TPolicyManager::instance().getUpdaterConfiguration();
         const std::string topic_name = updaterPolicy.at("topicName");
 
-        // Vulnerability content updater initialization.
-        m_contentRegistration =
-            std::make_unique<TContentRegister>(topic_name, TPolicyManager::instance().getUpdaterConfiguration());
-
         m_descriptionsDatabase = std::make_unique<Utils::RocksDBWrapper>(DESCRIPTION_DATABASE_PATH);
         m_remediationsDatabase = std::make_unique<Utils::RocksDBWrapper>(REMEDIATIONS_DATABASE_PATH);
         m_translationsDatabase = std::make_unique<Utils::RocksDBWrapper>(TRANSLATIONS_DATABASE_PATH);
@@ -278,6 +274,10 @@ public:
                         });
                 }
             });
+
+        // Vulnerability content updater initialization.
+        m_contentRegistration =
+            std::make_unique<TContentRegister>(topic_name, TPolicyManager::instance().getUpdaterConfiguration());
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
@@ -59,6 +59,7 @@ public:
             }
 
             flatbuffers::IDLOptions options;
+            options.output_default_scalars_in_json = true;
             options.strict_json = true;
             flatbuffers::Parser parser(options);
             parser.Parse(cve5_SCHEMA);

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
@@ -35,6 +35,25 @@ auto constexpr CREATED_RESOURCE {R"(
             "containers": {
                 "adp": [
                     {
+                        "metrics": [
+                            {
+                                "cvssV3_1":
+                                {
+                                    "scope": "UNCHANGED",
+                                    "version": "3.1",
+                                    "baseScore": 0.0,
+                                    "attackVector": "LOCAL",
+                                    "baseSeverity": "NONE",
+                                    "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:N",
+                                    "integrityImpact": "NONE",
+                                    "userInteraction": "NONE",
+                                    "attackComplexity": "LOW",
+                                    "availabilityImpact": "NONE",
+                                    "privilegesRequired": "LOW",
+                                    "confidentialityImpact": "NONE"
+                                }
+                            }
+                        ],
                         "affected": [
                             {
                                 "defaultStatus": "unaffected",
@@ -136,6 +155,7 @@ auto constexpr CREATED_RESOURCE {R"(
                 "cveId": "CVE-2010-0002",
                 "datePublished": "2010-01-14T18:30:00.000Z",
                 "dateUpdated": "2011-08-08T04:00:00.000Z",
+                "serial": 0,
                 "state": "PUBLISHED"
             },
             "dataType": "CVE_RECORD",
@@ -166,6 +186,11 @@ auto constexpr UPDATED_RESOURCE {R"(
                 {
                     "op": "remove",
                     "path": "/containers/cna/problemTypes"
+                },
+                {
+                    "op": "replace",
+                    "path": "/containers/adp/0/metrics/0/cvssV3_1/baseScore",
+                    "value": 7.8
                 }
             ]
     }
@@ -176,6 +201,25 @@ auto constexpr UPDATED_DATA {R"(
         "containers": {
             "adp": [
                 {
+                    "metrics": [
+                        {
+                            "cvssV3_1":
+                            {
+                                "scope": "UNCHANGED",
+                                "version": "3.1",
+                                "baseScore": 7.8,
+                                "attackVector": "LOCAL",
+                                "baseSeverity": "NONE",
+                                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:N",
+                                "integrityImpact": "NONE",
+                                "userInteraction": "NONE",
+                                "attackComplexity": "LOW",
+                                "availabilityImpact": "NONE",
+                                "privilegesRequired": "LOW",
+                                "confidentialityImpact": "NONE"
+                            }
+                        }
+                    ],
                     "affected": [
                         {
                             "defaultStatus": "unknown",
@@ -268,6 +312,7 @@ auto constexpr UPDATED_DATA {R"(
             "cveId": "CVE-2010-0002",
             "datePublished": "2010-01-14T18:30:00.000Z",
             "dateUpdated": "2011-08-08T04:00:00.000Z",
+            "serial": 0,
             "state": "PUBLISHED"
         },
         "dataType": "CVE_RECORD",
@@ -322,6 +367,7 @@ TEST_F(EventDecoderTest, TestCreatedResource)
 
     // Verify data
     flatbuffers::IDLOptions options;
+    options.output_default_scalars_in_json = true;
     options.strict_json = true;
 
     flatbuffers::Parser parser(options);
@@ -365,6 +411,7 @@ TEST_F(EventDecoderTest, TestUpdatedResource)
 
     // Verify data
     flatbuffers::IDLOptions options;
+    options.output_default_scalars_in_json = true;
     options.strict_json = true;
 
     flatbuffers::Parser parser(options);


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/20926|

## Description

This issue adds a flag that allows to correctly convert binary data (FlatBuffers) to text.

During the analysis of this issue, an error was found when the databaseFeedManager should process a message.

```
damangold@damangold:~/Wazuh/dev/wazuh/src$ ./build/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_scanner_testtool -c wazuh_modules/vulnerability_scanner/testtool/scanner/config.json -t wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json -i wazuh_modules/vulnerability_scanner/testtool/scanner/file1.json 
wazuh-modulesd:content-updater:actionOrchestrator.hpp:49 ActionOrchestrator : Creating 'vulnerability_feed_manager' Content Updater orchestration
wazuh-modulesd:content-updater:executionContext.hpp:163 handleRequest : ExecutionContext - Starting process
wazuh-modulesd:content-updater:executionContext.hpp:140 createOutputFolder : Removing previous output folder 'queue/vd_updater/tmp'
wazuh-modulesd:content-updater:executionContext.hpp:145 createOutputFolder : Creating output folders at 'queue/vd_updater/tmp'
wazuh-modulesd:content-updater:factoryContentUpdater.hpp:44 create : FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:factoryDownloader.hpp:46 create : Creating 'offline' downloader
wazuh-modulesd:content-updater:factoryDecompressor.hpp:73 create : Creating 'raw' decompressor
wazuh-modulesd:content-updater:factoryVersionUpdater.hpp:41 create : Creating 'false' version updater
wazuh-modulesd:content-updater:factoryCleaner.hpp:41 create : Content cleaner created
wazuh-modulesd:content-updater:actionOrchestrator.hpp:59 ActionOrchestrator : Content updater orchestration created
wazuh-modulesd:content-updater:action.hpp:86 operator() : Starting on-start action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:203 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:81 run : Running 'vulnerability_feed_manager' content update
wazuh-modulesd:content-updater:offlineDownloader.hpp:184 handleRequest : OfflineDownloader - Starting process
wazuh-modulesd:content-updater:offlineDownloader.hpp:66 copyFile : Copying file from 'file:///home/damangold/Wazuh/dev/wazuh/src/queue/example.json' into 'queue/vd_updater/tmp/contents/example.json'
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest : SkipStep - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:61 handleRequest : PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:42 publish : Data to be published: '{"paths":["queue/vd_updater/tmp/contents/example.json"],"stageStatus":[{"stage":"OfflineDownloader","status":"ok"}],"type":"offsets"}'
wazuh-modulesd:content-updater:pubSubPublisher.hpp:45 publish : Data published
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest : SkipStep - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest : CleanUpContent - Starting process
wazuh-modulesd:content-updater:action.hpp:214 runAction : Action for 'vulnerability_feed_manager' finished
```
As can be seen in the log, a new message was published but the databaseFeedManager did not process it. 
This bug was related to the time at which the modules were registered. To fix the bug, we changed the order in which the content updater is initialized, moving it to the end.



## Tests

[execution_log.txt](https://github.com/wazuh/wazuh/files/13709301/execution_log.txt)
