### PR TITLE
Vulnerability severity field content changed to sentence case format

### DIFF
--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -255,14 +255,11 @@ namespace Utils
 
     static std::string toSentenceCase(const std::string& str)
     {
-        std::string temp {str};
-        if(!str.empty())
+        std::string temp;
+        if (!str.empty())
         {
-            temp[0] = std::toupper(temp[0]);
-            std::transform(std::begin(temp) + 1,
-                        std::end(temp),
-                        std::begin(temp) + 1,
-                        [](std::string::value_type character) { return std::tolower(character); });
+            temp = toLowerCase(str);
+            *temp.begin() = static_cast<char>(std::toupper(*str.begin()));
         }
         return temp;
     }

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -253,6 +253,20 @@ namespace Utils
         return temp;
     }
 
+    static std::string toSentenceCase(const std::string& str)
+    {
+        std::string temp {str};
+        if(!str.empty())
+        {
+            temp[0] = std::toupper(temp[0]);
+            std::transform(std::begin(temp) + 1,
+                        std::end(temp),
+                        std::begin(temp) + 1,
+                        [](std::string::value_type character) { return std::tolower(character); });
+        }
+        return temp;
+    }
+
     static bool startsWith(const std::string& str, const std::string& start)
     {
         if (!str.empty() && str.length() >= start.length())

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -124,18 +124,28 @@ TEST_F(StringUtilsTest, Trim)
     EXPECT_EQ("Hello", Utils::trim(" \t\nHello\t\n ", " \t\n"));
 }
 
-TEST_F(StringUtilsTest, ToUpper)
+TEST_F(StringUtilsTest, ToUpperCase)
 {
     EXPECT_EQ("", Utils::toUpperCase(""));
     EXPECT_EQ("HELLO WORLD", Utils::toUpperCase("HeLlO WoRlD"));
     EXPECT_EQ("123", Utils::toUpperCase("123"));
 }
 
-TEST_F(StringUtilsTest, ToLower)
+TEST_F(StringUtilsTest, ToLowerCase)
 {
     EXPECT_EQ("", Utils::toLowerCase(""));
     EXPECT_EQ("hello world", Utils::toLowerCase("HeLlO WoRlD"));
     EXPECT_EQ("123", Utils::toLowerCase("123"));
+}
+
+TEST_F(StringUtilsTest, ToSentenceCase)
+{
+    EXPECT_EQ("", Utils::toSentenceCase(""));
+    EXPECT_EQ("H", Utils::toSentenceCase("h"));
+    EXPECT_EQ("Hello", Utils::toSentenceCase("hello"));
+    EXPECT_EQ("Hello", Utils::toSentenceCase("HELLO"));
+    EXPECT_EQ("Hello world", Utils::toSentenceCase("HeLlO WoRlD"));
+    EXPECT_EQ("123", Utils::toSentenceCase("123"));
 }
 
 TEST_F(StringUtilsTest, StartsWith)

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -135,7 +135,7 @@ public:
                 ecsData["vulnerability"]["score"]["environmental"] = 0.0f; // TODO: Add environmental score.
                 ecsData["vulnerability"]["score"]["temporal"] = 0.0f;      // TODO: Add temporal score.
                 ecsData["vulnerability"]["score"]["version"] = returnData.data->scoreVersion()->str();
-                ecsData["vulnerability"]["severity"] = returnData.data->severity()->str();
+                ecsData["vulnerability"]["severity"] = Utils::toSentenceCase(returnData.data->severity()->str());
                 // ECS base fields.
                 ecsData["@timestamp"] = Utils::getCurrentISO8601();
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20796 |

## Description

This PR changes the severity field content to sentence case format.
A new string helper method "toSentenceCase" was created.
UTs added.

## Tests

Here are some extracts from the alerts.json file showing the severity field:
![image](https://github.com/wazuh/wazuh/assets/101227434/b4de0981-5b04-4b29-a5d1-a0a7ae62f581)

- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Check the severity field on alerts is sentence case formated.