### PR TITLE
Pass variable "topic_name" by value

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -189,7 +189,7 @@ public:
         , m_indexerConnector(indexerConnector)
     {
         const auto updaterPolicy = TPolicyManager::instance().getUpdaterConfiguration();
-        const std::string topic_name = updaterPolicy.at("topicName");
+        const std::string topicName = updaterPolicy.at("topicName");
 
         m_descriptionsDatabase = std::make_unique<Utils::RocksDBWrapper>(DESCRIPTION_DATABASE_PATH);
         m_remediationsDatabase = std::make_unique<Utils::RocksDBWrapper>(REMEDIATIONS_DATABASE_PATH);
@@ -200,10 +200,10 @@ public:
 
         // Subscription to vulnerability detector content update events.
         m_contentUpdateSubscription =
-            std::make_unique<TRouterSubscriber>(topic_name, "vulnerability_feed_manager", isLocalSubscriber);
+            std::make_unique<TRouterSubscriber>(topicName, "vulnerability_feed_manager", isLocalSubscriber);
 
         m_contentUpdateSubscription->subscribe(
-            [&, topic_name](const std::vector<char>& message)
+            [&, topicName](const std::vector<char>& message)
             {
                 auto eventDecoder = std::make_shared<EventDecoder>();
                 eventDecoder->setLast(std::make_shared<StoreModel>(
@@ -263,7 +263,7 @@ public:
                         database->deleteAll();
                     }
 
-                    const std::string url = "http://localhost/ondemand/" + topic_name + "?offset=0";
+                    const std::string url = "http://localhost/ondemand/" + topicName + "?offset=0";
                     UNIXSocketRequest::instance().get(
                         HttpUnixSocketURL(ONDEMAND_SOCK, url),
                         [](const std::string& msg) { std::cout << msg << std::endl; },
@@ -277,7 +277,7 @@ public:
 
         // Vulnerability content updater initialization.
         m_contentRegistration =
-            std::make_unique<TContentRegister>(topic_name, TPolicyManager::instance().getUpdaterConfiguration());
+            std::make_unique<TContentRegister>(topicName, TPolicyManager::instance().getUpdaterConfiguration());
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -203,7 +203,7 @@ public:
             std::make_unique<TRouterSubscriber>(topic_name, "vulnerability_feed_manager", isLocalSubscriber);
 
         m_contentUpdateSubscription->subscribe(
-            [&](const std::vector<char>& message)
+            [&, topic_name](const std::vector<char>& message)
             {
                 auto eventDecoder = std::make_shared<EventDecoder>();
                 eventDecoder->setLast(std::make_shared<StoreModel>(


### PR DESCRIPTION
|Related issue|
|---|
|#20948|

## Description

The variable `topic_name` was passed by reference in the lambda, and when the function finished executing, it was deleted, leaving garbage in the variable. So when I made the call to `UNIXSocketRequest`, I couldn't make it.