### PR TITLE
Refactor Azure logs to use common cloud logger

### DIFF
--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -40,7 +40,7 @@ from shared.wazuh_cloud_logger import WazuhCloudLogger
 
 
 # URLs
-URL_azure_logger = 'https://login.microsoftonline.com'
+URL_LOGGING = 'https://login.microsoftonline.com'
 URL_ANALYTICS = 'https://api.loganalytics.io'
 URL_GRAPH = 'https://graph.microsoft.com'
 SOCKET_HEADER = '1:Azure:'
@@ -327,8 +327,8 @@ def build_log_analytics_query(offset: str, md5_hash: str) -> dict:
         if item is None:
             item = create_new_row(table=orm.LogAnalytics, query=args.la_query, md5_hash=md5_hash, offset=offset)
     except orm.AzureORMError as e:
-        azure_logger.error(f"Error trying to obtain row object from '{orm.LogAnalytics.__tablename__}' using md5='{md5}': "
-                      f"{e}")
+        azure_logger.error(f"Error trying to obtain row object from '{orm.LogAnalytics.__tablename__}' "
+                           f"using md5='{md5}': {e}")
         sys.exit(1)
 
     min_str = item.min_processed_date
@@ -786,7 +786,7 @@ def get_token(client_id: str, secret: str, domain: str, scope: str):
         'scope': scope,
         'grant_type': 'client_credentials'
     }
-    auth_url = f'{URL_azure_logger}/{domain}/oauth2/v2.0/token'
+    auth_url = f'{URL_LOGGING}/{domain}/oauth2/v2.0/token'
     try:
         token_response = post(auth_url, data=body).json()
         return token_response['access_token']

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -871,6 +871,14 @@ def offset_to_datetime(offset: str):
 if __name__ == "__main__":
     args = get_script_arguments()
 
+    # Get log level
+    log_level = args.debug_level
+
+    # Set log level
+    azure_logger.set_level(
+        log_level=log_level
+    )
+
     if not orm.check_database_integrity():
         sys.exit(1)
 

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -38,7 +38,6 @@ sys.path.insert(0, dirname(dirname(abspath(__file__))))
 from utils import ANALYSISD, MAX_EVENT_SIZE
 from shared.wazuh_cloud_logger import WazuhCloudLogger
 
-
 # URLs
 URL_LOGGING = 'https://login.microsoftonline.com'
 URL_ANALYTICS = 'https://api.loganalytics.io'
@@ -48,7 +47,6 @@ DATETIME_MASK = '%Y-%m-%dT%H:%M:%S.%fZ'
 CREDENTIALS_URL = 'https://documentation.wazuh.com/current/azure/activity-services/prerequisites/credentials.html'
 DEPRECATED_MESSAGE = 'The {name} authentication parameter was deprecated in {release}. ' \
                      'Please use another authentication method instead. Check {url} for more information.'
-
 
 # Set Azure logger
 azure_logger = WazuhCloudLogger(
@@ -183,13 +181,13 @@ def read_auth_file(auth_path: str, fields: tuple):
                     continue
                 credentials[key] = value.replace("\n", "")
         if fields[0] not in credentials or fields[1] not in credentials:
-            azure_logger.error(f"Error: The authentication file does not contains the expected '{fields[0]}' "
-                          f"and '{fields[1]}' fields.")
+            azure_logger.error(f"Error: The authentication file does not contain the expected '{fields[0]}' "
+                               f"and '{fields[1]}' fields.")
             sys.exit(1)
         return credentials[fields[0]], credentials[fields[1]]
     except ValueError:
         azure_logger.error("Error: The authentication file format is not valid. "
-                      "Make sure that it is composed of only 2 lines with 'field = value' format.")
+                           "Make sure that it is composed of only 2 lines with 'field = value' format.")
         sys.exit(1)
     except OSError as e:
         azure_logger.error(f"Error: The authentication file could not be opened: {e}")
@@ -229,11 +227,11 @@ def update_row_object(table: orm.Base, md5_hash: str, new_min: str, new_max: str
         min_ = new_min if new_min_date < old_min_date else old_min_str
         max_ = new_max if new_max_date > old_max_date else old_max_str
         azure_logger.debug(f"Attempting to update a {table.__tablename__} row object. "
-                      f"MD5: '{md5_hash}', min_date: '{min_}', max_date: '{max_}'")
+                           f"MD5: '{md5_hash}', min_date: '{min_}', max_date: '{max_}'")
         try:
             orm.update_row(table=table, md5=md5_hash, min_date=min_, max_date=max_, query=query)
         except orm.AzureORMError as e:
-            azure_logger.error(f"Error updating row object from {table.__tablename__}: {e}")
+            azure_logger.error(f"Error updating row object from {table.__tablename__}: {e}.")
             sys.exit(1)
 
 
@@ -262,11 +260,11 @@ def create_new_row(table: orm.Base, md5_hash: str, query: str, offset: str) -> o
     desired_str = desired_datetime.strftime(DATETIME_MASK)
     item = table(md5=md5_hash, query=query, min_processed_date=desired_str, max_processed_date=desired_str)
     azure_logger.debug(f"Attempting to insert row object into {table.__tablename__} with md5='{md5_hash}', "
-                  f"min_date='{desired_str}', max_date='{desired_str}'")
+                       f"min_date='{desired_str}', max_date='{desired_str}'")
     try:
         orm.add_row(row=item)
     except orm.AzureORMError as e:
-        azure_logger.error(f"Error inserting row object into {table.__tablename__}: {e}")
+        azure_logger.error(f"Error inserting row object into {table.__tablename__}: {e}.")
         sys.exit(1)
     return item
 
@@ -303,7 +301,7 @@ def start_log_analytics():
     try:
         get_log_analytics_events(url=url, body=body, headers=headers, md5_hash=md5_hash)
     except HTTPError as e:
-        azure_logger.error(f"Log Analytics: {e}")
+        azure_logger.error(f"Log Analytics: {e}.")
     azure_logger.info("Azure Log Analytics ending.")
 
 
@@ -328,7 +326,7 @@ def build_log_analytics_query(offset: str, md5_hash: str) -> dict:
             item = create_new_row(table=orm.LogAnalytics, query=args.la_query, md5_hash=md5_hash, offset=offset)
     except orm.AzureORMError as e:
         azure_logger.error(f"Error trying to obtain row object from '{orm.LogAnalytics.__tablename__}' "
-                           f"using md5='{md5}': {e}")
+                           f"using md5='{md5}': {e}.")
         sys.exit(1)
 
     min_str = item.min_processed_date
@@ -355,7 +353,7 @@ def build_log_analytics_query(offset: str, md5_hash: str) -> dict:
             filter_value = f"TimeGenerated > {max_str}"
 
     query = f"{args.la_query} | order by TimeGenerated asc | where {filter_value} "
-    azure_logger.info(f"Log Analytics: The search starts for query: '{query}'")
+    azure_logger.info(f"Log Analytics: The search starts for query: '{query}'.")
     return {"query": query}
 
 
@@ -385,7 +383,7 @@ def get_log_analytics_events(url: str, body: dict, headers: dict, md5_hash: str)
             columns = response.json()['tables'][0]['columns']
             rows = response.json()['tables'][0]['rows']
             if len(rows) == 0:
-                azure_logger.info("Log Analytics: There are no new results")
+                azure_logger.info("Log Analytics: There are no new results.")
             else:
                 time_position = get_time_position(columns)
                 if time_position is not None:
@@ -393,7 +391,7 @@ def get_log_analytics_events(url: str, body: dict, headers: dict, md5_hash: str)
                     update_row_object(table=orm.LogAnalytics, md5_hash=md5_hash, new_min=rows[0][time_position],
                                       new_max=rows[len(rows) - 1][time_position], query=args.la_query)
                 else:
-                    azure_logger.error("Error: No TimeGenerated field was found")
+                    azure_logger.error("Error: No TimeGenerated field was found.")
 
         except KeyError as e:
             azure_logger.error(f"Error: It was not possible to obtain the columns and rows from the event: '{e}'.")
@@ -459,7 +457,8 @@ def start_graph():
     if args.graph_auth_path and args.graph_tenant_domain:
         client, secret = read_auth_file(auth_path=args.graph_auth_path, fields=("application_id", "application_key"))
     elif args.graph_id and args.graph_key and args.graph_tenant_domain:
-        azure_logger.warning(DEPRECATED_MESSAGE.format(name="graph_id and graph_key", release="4.4", url=CREDENTIALS_URL))
+        azure_logger.warning(
+            DEPRECATED_MESSAGE.format(name="graph_id and graph_key", release="4.4", url=CREDENTIALS_URL))
         client = args.graph_id
         secret = args.graph_key
     else:
@@ -475,15 +474,15 @@ def start_graph():
     azure_logger.info(f"Graph: Building the url.")
     md5_hash = md5(args.graph_query.encode()).hexdigest()
     url = build_graph_url(offset=args.graph_time_offset, md5_hash=md5_hash)
-    azure_logger.info(f"Graph: The URL is '{url}'")
+    azure_logger.info(f"Graph: The URL is '{url}'.")
 
     # Get events
-    azure_logger.info("Graph: Pagination starts")
+    azure_logger.info("Graph: Pagination starts.")
     try:
         get_graph_events(url=url, headers=headers, md5_hash=md5_hash)
     except HTTPError as e:
         azure_logger.error(f"Graph: {e}")
-    azure_logger.info("Graph: End")
+    azure_logger.info("Graph: End.")
 
 
 def build_graph_url(offset: str, md5_hash: str):
@@ -506,7 +505,8 @@ def build_graph_url(offset: str, md5_hash: str):
         if item is None:
             item = create_new_row(table=orm.Graph, query=args.graph_query, md5_hash=md5_hash, offset=offset)
     except orm.AzureORMError as e:
-        azure_logger.error(f"Error trying to obtain row object from '{orm.Graph.__tablename__}' using md5='{md5}': {e}")
+        azure_logger.error(f"Error trying to obtain row object from '{orm.Graph.__tablename__}' "
+                           f"using md5='{md5}': {e}.")
         sys.exit(1)
 
     min_str = item.min_processed_date
@@ -530,7 +530,7 @@ def build_graph_url(offset: str, md5_hash: str):
         else:
             filter_value = f"{filtering_condition}+gt+{max_str}"
 
-    azure_logger.info(f"Graph: The search starts for query: '{args.graph_query}' using {filter_value}")
+    azure_logger.info(f"Graph: The search starts for query: '{args.graph_query}' using {filter_value}.")
     return f"{URL_GRAPH}/v1.0/{args.graph_query}{'?' if '?' not in args.graph_query else ''}&$filter={filter_value}"
 
 
@@ -570,7 +570,7 @@ def get_graph_events(url: str, headers: dict, md5_hash: str):
             send_message(json_result)
 
         if len(values_json) == 0:
-            azure_logger.info("Graph: There are no new results")
+            azure_logger.info("Graph: There are no new results.")
         next_url = response_json.get('@odata.nextLink')
 
         if next_url:
@@ -593,7 +593,8 @@ def start_storage():
     if args.storage_auth_path:
         name, key = read_auth_file(auth_path=args.storage_auth_path, fields=("account_name", "account_key"))
     elif args.account_name and args.account_key:
-        azure_logger.warning(DEPRECATED_MESSAGE.format(name="account_name and account_key", release="4.4", url=CREDENTIALS_URL))
+        azure_logger.warning(
+            DEPRECATED_MESSAGE.format(name="account_name and account_key", release="4.4", url=CREDENTIALS_URL))
         name = args.account_name
         key = args.account_key
     else:
@@ -640,7 +641,8 @@ def start_storage():
             if item is None:
                 item = create_new_row(table=orm.Storage, query=name, md5_hash=md5_hash, offset=offset)
         except orm.AzureORMError as e:
-            azure_logger.error(f"Error trying to obtain row object from '{orm.Storage.__tablename__}' using md5='{md5}': {e}")
+            azure_logger.error(f"Error trying to obtain row object from '{orm.Storage.__tablename__}' "
+                               f"using md5='{md5}': {e}.")
             sys.exit(1)
 
         min_datetime = parse(item.min_processed_date, fuzzy=True)
@@ -648,12 +650,13 @@ def start_storage():
         desired_datetime = offset_to_datetime(offset) if offset else max_datetime
         get_blobs(container_name=container, prefix=args.prefix, blob_service=block_blob_service, md5_hash=md5_hash,
                   min_datetime=min_datetime, max_datetime=max_datetime, desired_datetime=desired_datetime)
-    azure_logger.info("Storage: End")
+    azure_logger.info("Storage: End.")
 
 
 def get_blobs(
-    container_name: str, blob_service: BlockBlobService, md5_hash: str, min_datetime: datetime, max_datetime: datetime,
-    desired_datetime: datetime, next_marker: str = None, prefix: str = None
+        container_name: str, blob_service: BlockBlobService, md5_hash: str, min_datetime: datetime,
+        max_datetime: datetime,
+        desired_datetime: datetime, next_marker: str = None, prefix: str = None
 ):
     """Get the blobs from a container and send their content.
 
@@ -691,7 +694,7 @@ def get_blobs(
     else:
 
         azure_logger.info(f"Storage: The search starts from the date: {desired_datetime} for blobs in "
-                     f"container: '{container_name}' and prefix: '/{prefix if prefix is not None else ''}'")
+                          f"container: '{container_name}' and prefix: '/{prefix if prefix is not None else ''}'")
         for blob in blobs:
             # Skip if the blob is empty
             if blob.properties.content_length == 0:
@@ -799,10 +802,10 @@ def get_token(client_id: str, secret: str, domain: str, scope: str):
             err_msg = f"The '{domain}' tenant domain was not found."
         else:
             err_msg = "Couldn't get the token for authentication."
-        azure_logger.error(f"Error: {err_msg}")
+        azure_logger.error(f"Error: {err_msg}.")
 
     except RequestException as e:
-        azure_logger.error(f"Error: An error occurred while trying to obtain the authentication token: {e}")
+        azure_logger.error(f"Error: An error occurred while trying to obtain the authentication token: {e}.")
 
     sys.exit(1)
 
@@ -833,7 +836,7 @@ def send_message(message: str):
         elif e.errno == 90:
             azure_logger.error("ERROR: Message too long to send to Wazuh.  Skipping message...")
         else:
-            azure_logger.error(f"ERROR: Error sending message to wazuh: {e}")
+            azure_logger.error(f"ERROR: Error sending message to wazuh: {e}.")
             sys.exit(1)
     finally:
         s.close()

--- a/wodles/azure/tests/test_azure.py
+++ b/wodles/azure/tests/test_azure.py
@@ -1,7 +1,6 @@
 import importlib
 import json
-import logging
-import os
+from os.path import join, dirname, realpath
 import socket
 import sys
 from datetime import datetime
@@ -14,15 +13,13 @@ import pytz
 from dateutil.parser import parse
 from requests import HTTPError
 
-from wodles.shared.wazuh_cloud_logger import WazuhCloudLogger
-
-sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))  # noqa: E501
+sys.path.append(join(dirname(realpath(__file__)), '..'))  # noqa: E501
 
 with patch('azure-logs.orm'):
     azure = importlib.import_module("azure-logs")
 
-TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-TEST_AUTHENTICATION_PATH = os.path.join(TEST_DATA_PATH, 'authentication_files')
+TEST_DATA_PATH = join(dirname(realpath(__file__)), 'data')
+TEST_AUTHENTICATION_PATH = join(TEST_DATA_PATH, 'authentication_files')
 
 PAST_DATE = "2022-01-01T12:00:00.000000Z"
 PRESENT_DATE = "2022-06-15T12:00:00.000000Z"
@@ -125,7 +122,7 @@ def test_arg_valid_blob_extension(arg_string):
 ])
 def test_read_auth_file(file_name, fields):
     """Test read_auth_file correctly handles valid authentication files."""
-    credentials = azure.read_auth_file(auth_path=os.path.join(TEST_AUTHENTICATION_PATH, file_name), fields=fields)
+    credentials = azure.read_auth_file(auth_path=join(TEST_AUTHENTICATION_PATH, file_name), fields=fields)
     assert isinstance(credentials, tuple)
     for i in range(len(fields)):
         assert credentials[i] == f"{fields[i]}_value"
@@ -142,7 +139,7 @@ def test_read_auth_file(file_name, fields):
 def test_read_auth_file_ko(mock_logging, file_name):
     """Test read_auth_file correctly handles invalid authentication files."""
     with pytest.raises(SystemExit) as err:
-        azure.read_auth_file(auth_path=os.path.join(TEST_AUTHENTICATION_PATH, file_name), fields=("field", "field"))
+        azure.read_auth_file(auth_path=join(TEST_AUTHENTICATION_PATH, file_name), fields=("field", "field"))
     assert err.value.code == 1
     mock_logging.assert_called_once()
 
@@ -330,7 +327,7 @@ def test_get_log_analytics_events(mock_get, mock_position, mock_iter, mock_updat
     field was present."""
     azure.args = MagicMock(la_query="test_query")
     m = MagicMock(status_code=200)
-    with open(os.path.join(TEST_DATA_PATH, file)) as f:
+    with open(join(TEST_DATA_PATH, file)) as f:
         try:
             events = json.loads(f.read())
             m.json.return_value = events
@@ -386,7 +383,7 @@ def test_iter_log_analytics_events(mock_send):
     """Test iter_log_analytics_events iterates through the columns and rows to build the events and send them to the
     socket."""
     azure.args = MagicMock(la_tag="tag")
-    with open(os.path.join(TEST_DATA_PATH, "log_analytics_events")) as f:
+    with open(join(TEST_DATA_PATH, "log_analytics_events")) as f:
         events = json.loads(f.read())
         columns = events['tables'][0]['columns']
         rows = events['tables'][0]['rows']
@@ -510,7 +507,7 @@ def test_get_graph_events(mock_get, mock_update, mock_send):
     """Test get_graph_events recursively request the data using the specified url and process the values present in the
     response."""
     def load_events(path):
-        with open(os.path.join(TEST_DATA_PATH, path)) as f:
+        with open(join(TEST_DATA_PATH, path)) as f:
             return json.loads(f.read())
 
     azure.args = MagicMock(graph_query="test_query", graph_tag="tag")
@@ -671,7 +668,7 @@ def test_get_blobs(mock_send, mock_update, blob_date, min_date, max_date, desire
     else:
         test_file = "storage_events_plain"
 
-    with open(os.path.join(TEST_DATA_PATH, test_file)) as f:
+    with open(join(TEST_DATA_PATH, test_file)) as f:
         contents = f.read()
         blob_service.get_blob_to_text.return_value = MagicMock(content=contents)
 

--- a/wodles/azure/tests/test_azure.py
+++ b/wodles/azure/tests/test_azure.py
@@ -14,6 +14,8 @@ import pytz
 from dateutil.parser import parse
 from requests import HTTPError
 
+from wodles.shared.wazuh_cloud_logger import WazuhCloudLogger
+
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))  # noqa: E501
 
 with patch('azure-logs.orm'):
@@ -53,19 +55,6 @@ def create_mocked_blob(blob_name: str, last_modified: datetime = None, content_l
         blob.properties.content_length = content_length
 
     return blob
-
-
-@pytest.mark.parametrize('debug_level', [0, 1, 2, 3])
-@patch('azure-logs.logging.basicConfig')
-def test_set_logger(mock_logging, debug_level):
-    """Test set_logger sets the expected logging verbosity level."""
-    azure.args = MagicMock(debug_level=debug_level)
-    azure.set_logger()
-    mock_logging.assert_called_with(level=azure.LOG_LEVELS.get(debug_level, logging.INFO),
-                                    format=azure.LOGGING_MSG_FORMAT,
-                                    datefmt=azure.LOGGING_DATE_FORMAT)
-    assert logging.getLogger('azure').level == azure.LOG_LEVELS.get(debug_level, logging.WARNING).real
-    assert logging.getLogger("urllib3").level == logging.ERROR.real
 
 
 def test_get_script_arguments(capsys):
@@ -149,7 +138,7 @@ def test_read_auth_file(file_name, fields):
     "invalid_authentication_file_2",
     "invalid_authentication_file_3"
 ])
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 def test_read_auth_file_ko(mock_logging, file_name):
     """Test read_auth_file correctly handles invalid authentication files."""
     with pytest.raises(SystemExit) as err:
@@ -180,7 +169,7 @@ def test_update_row_object(mock_get, mock_update, min_date, max_date):
         mock_update.assert_not_called()
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.orm.get_row', side_effect=AttributeError)
 def test_update_row_object_ko(mock_get, mock_logging):
     """Test update_row_object handles ORM errors as expected."""
@@ -190,7 +179,7 @@ def test_update_row_object_ko(mock_get, mock_logging):
     mock_logging.assert_called_once()
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.orm.update_row', side_effect=azure.orm.AzureORMError)
 @patch('azure-logs.orm.get_row', return_value=MagicMock(min_processed_date=PRESENT_DATE,
                                                         max_processed_date=PRESENT_DATE))
@@ -214,7 +203,7 @@ def test_create_new_row(mock_orm):
     mock_orm.add_row.assert_called_with(row=item)
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.orm.add_row', side_effect=azure.orm.AzureORMError)
 def test_create_new_row_ko(mock_add_row, mock_logging):
     """Test create_new_row raises an error if when attempting to add a invalid row object."""
@@ -259,7 +248,7 @@ def test_start_log_analytics(mock_auth, mock_token, mock_build, mock_get_logs, a
                                      headers={"Authorization": f"Bearer {token}"}, md5_hash=md5_hash)
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.get_log_analytics_events', side_effect=HTTPError)
 @patch('azure-logs.build_log_analytics_query')
 @patch('azure-logs.get_token')
@@ -272,7 +261,7 @@ def test_start_log_analytics_ko(mock_auth, mock_token, mock_build, mock_get_logs
     mock_logging.assert_called_once()
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 def test_start_log_analytics_ko_credentials(mock_logging):
     """Test start_log_analytics stops its execution if no valid credentials are provided."""
     azure.args = MagicMock(la_tenant_domain=None)
@@ -315,7 +304,7 @@ def test_build_log_analytics_query(mock_get, mock_create, mock_datetime, min_dat
     assert expected_str in result["query"]
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.orm.get_row', side_effect=azure.orm.AzureORMError)
 def test_build_log_analytics_query_ko(mock_get, mock_logging):
     """Test build_log_analytics_query handles ORM exceptions."""
@@ -331,7 +320,7 @@ def test_build_log_analytics_query_ko(mock_get, mock_logging):
     ("log_analytics_events_no_results", None),
     ("log_analytics_events_empty", None)
 ])
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.update_row_object')
 @patch('azure-logs.iter_log_analytics_events')
 @patch('azure-logs.get_time_position')
@@ -440,7 +429,7 @@ def test_start_graph(mock_auth, mock_token, mock_build, mock_graph, auth_path, g
     mock_graph.assert_called_with(url=url, headers={'Authorization': f'Bearer {token}'}, md5_hash=md5_hash)
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.get_graph_events', side_effect=HTTPError)
 @patch('azure-logs.build_graph_url')
 @patch('azure-logs.get_token')
@@ -452,7 +441,7 @@ def test_start_graph_ko(mock_auth, mock_token, mock_build, mock_get, mock_loggin
     mock_logging.assert_called_once()
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 def test_start_graph_ko_credentials(mock_logging):
     """Test start_graph stops its execution if no valid credentials are provided."""
     azure.args = MagicMock(graph_tenant_domain=None)
@@ -468,7 +457,7 @@ def test_start_graph_ko_credentials(mock_logging):
     (PAST_DATE, FUTURE_DATE, PRESENT_DATE, False),
     (PAST_DATE, PAST_DATE, PRESENT_DATE, True),
 ])
-@patch('azure-logs.logging.info')
+@patch('azure-logs.azure_logger.info')
 @patch('azure-logs.offset_to_datetime')
 @patch('azure-logs.create_new_row')
 @patch('azure-logs.orm.get_row', return_value=None)
@@ -504,7 +493,7 @@ def test_build_graph_url(mock_get, mock_create, mock_datetime, mock_logging, min
     assert expected_str in result
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.orm.get_row', side_effect=azure.orm.AzureORMError)
 def test_build_graph_url_ko(mock_get, mock_logging):
     """Test build_log_analytics_query handles ORM exceptions."""
@@ -547,7 +536,7 @@ def test_get_graph_events(mock_get, mock_update, mock_send):
 
 
 @pytest.mark.parametrize('status_code', [400, 500])
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.get')
 def test_get_graph_events_error_responses(mock_get, mock_logging, status_code):
     """Test get_graph_events handles invalid responses from the request module."""
@@ -602,7 +591,7 @@ def test_start_storage(mock_auth, mock_blob, mock_get_row, mock_create, mock_get
     ("*", azure.AzureException),
     ("*", None)
 ])
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.create_new_row', side_effect=azure.orm.AzureORMError)
 @patch('azure-logs.orm.get_row', return_value=None)
 @patch('azure-logs.BlockBlobService')
@@ -625,7 +614,7 @@ def test_start_storage_ko(mock_blob, mock_get, mock_create, mock_logging, contai
     mock_logging.assert_called_once()
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 def test_start_storage_ko_credentials(mock_logging):
     """Test start_storage stops its execution if no valid credentials are provided."""
     azure.args = MagicMock(storage_auth_path=None, account_name=None, account_key=None)
@@ -780,7 +769,7 @@ def test_get_blobs_only_with_prefix(mock_send, mock_update):
     )
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 def test_get_blobs_list_blobs_ko(mock_logging):
     """Test get_blobs_list_blobs handles exceptions from 'list_blobs'."""
     m = MagicMock()
@@ -793,7 +782,7 @@ def test_get_blobs_list_blobs_ko(mock_logging):
 
 
 @pytest.mark.parametrize('exception', [ValueError, azure.AzureException, azure.AzureHttpError(message="", status_code="")])
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.update_row_object')
 def test_get_blobs_blob_data_ko(mock_update, mock_logging, exception):
     """Test get_blobs_list_blobs handles exceptions from 'get_blob_to_text'."""
@@ -814,7 +803,7 @@ def test_get_blobs_blob_data_ko(mock_update, mock_logging, exception):
 
 
 @pytest.mark.parametrize('exception', [json.JSONDecodeError, TypeError, KeyError])
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.loads')
 @patch('azure-logs.update_row_object')
 def test_get_blobs_json_ko(mock_update, mock_loads, mock_logging, exception):
@@ -869,7 +858,7 @@ def test_get_token(mock_post):
     (None, '', []),
     (None, None, [])
 ])
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.post')
 def test_get_token_ko(mock_post, mock_logging, exception, error_msg, error_codes):
     """Test get_token handles exceptions when the 'access_token' field is not present in the response."""
@@ -896,7 +885,7 @@ def test_send_message(mock_connect, mock_send, mock_close):
 
 
 @pytest.mark.parametrize('error_code', [111, 90, 1])
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.socket.close')
 @patch('azure-logs.socket.send')
 @patch('azure-logs.socket.connect')
@@ -929,7 +918,7 @@ def test_offset_to_datetime(mock_time, offset, expected_date):
     assert result == parse(expected_date)
 
 
-@patch('azure-logs.logging.error')
+@patch('azure-logs.azure_logger.error')
 @patch('azure-logs.datetime')
 def test_offset_to_datetime_ko(mock_time, mock_logging):
     """Test offset_to_datetime handles the exception when an invalid offset format was provided."""


### PR DESCRIPTION
|Related issue|
|---|
| Closes #16739 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

As explained in #16739, The Azure wodle has been updated to include the modularized cloud logger.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

All test related to the wodle has been performed [here](https://github.com/wazuh/wazuh/issues/16739#issuecomment-1864846884).

```python
(unit-test) eduardoleon@pop-os:~/git/wazuh(16739-refactor-azure-logs)$ pytest wodles/
=========================== test session starts ===========================
platform linux -- Python 3.9.16, pytest-7.4.2, pluggy-0.13.1
rootdir: /home/eduardoleon/git/wazuh
plugins: anyio-3.6.2, aiohttp-1.0.4, trio-0.7.0, html-3.0.0, asyncio-0.18.1, cov-3.0.0, metadata-2.0.2
asyncio: mode=auto
collected 852 items

wodles/aws/tests/test_aws_bucket.py ............................... [  3%]
................................................................... [ 11%]
................................................................... [ 19%]
............................................                        [ 24%]
wodles/aws/tests/test_aws_s3.py ..................                  [ 26%]
wodles/aws/tests/test_aws_service.py ....                           [ 27%]
wodles/aws/tests/test_cloudtrail.py ..                              [ 27%]
wodles/aws/tests/test_cloudwatchlogs.py ........................... [ 30%]
..........................                                          [ 33%]
wodles/aws/tests/test_config.py ................................... [ 37%]
...........................................                         [ 42%]
wodles/aws/tests/test_guardduty.py .................                [ 44%]
wodles/aws/tests/test_inspector.py ......                           [ 45%]
wodles/aws/tests/test_load_balancers.py ............                [ 46%]
wodles/aws/tests/test_s3_log_handler.py ....                        [ 47%]
wodles/aws/tests/test_server_access.py ............................ [ 50%]
.....                                                               [ 51%]
wodles/aws/tests/test_sqs_queue.py .......                          [ 51%]
wodles/aws/tests/test_tools.py ...............................      [ 55%]
wodles/aws/tests/test_umbrella.py ......                            [ 56%]
wodles/aws/tests/test_vpcflow.py ............................       [ 59%]
wodles/aws/tests/test_waf.py .......                                [ 60%]
wodles/aws/tests/test_wazuh_integration.py ........................ [ 63%]
................................................................... [ 71%]
...........                                                         [ 72%]
wodles/azure/tests/test_azure.py .................................. [ 76%]
................................................................... [ 84%]
............                                                        [ 85%]
wodles/azure/tests/test_orm.py ...............................      [ 89%]
wodles/docker-listener/tests/test_docker_listener.py .............. [ 90%]
.....                                                               [ 91%]
wodles/gcloud/tests/test_bucket.py ................................ [ 95%]
.                                                                   [ 95%]
wodles/gcloud/tests/test_gcloud.py .........                        [ 96%]
wodles/gcloud/tests/test_integration.py ........                    [ 97%]
wodles/gcloud/tests/test_subscriber.py ..............               [ 99%]
wodles/gcloud/tests/test_tools.py ........                          [100%]

============================ warnings summary =============================
../../.pyenv/versions/3.9.16/envs/unit-test/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28
  /home/eduardoleon/.pyenv/versions/3.9.16/envs/unit-test/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================== 852 passed, 1 warning in 3.08s ======================

```