### PR TITLE
Vulnerability scan field score.base fixed

### DIFF
--- a/src/shared_modules/utils/numericHelper.h
+++ b/src/shared_modules/utils/numericHelper.h
@@ -1,0 +1,34 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * December 22, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _NUMERIC_HELPER_H
+#define _NUMERIC_HELPER_H
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+namespace Utils
+{
+    static double floatToDoubleRound(float number, size_t precision)
+    {
+        std::stringstream ssAux;
+        ssAux << std::fixed << std::setprecision(precision) << number;
+        return std::stod(ssAux.str());
+    }
+} // namespace Utils
+
+#pragma GCC diagnostic pop
+
+#endif // _NUMERIC_HELPER_H

--- a/src/shared_modules/utils/numericHelper.h
+++ b/src/shared_modules/utils/numericHelper.h
@@ -21,7 +21,7 @@
 
 namespace Utils
 {
-    static double floatToDoubleRound(float number, size_t precision)
+    static double floatToDoubleRound(const float number, const int precision)
     {
         std::stringstream ssAux;
         ssAux << std::fixed << std::setprecision(precision) << number;

--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ file(GLOB UTIL_CXX_UNITTEST_COMMON_SRC
     "msgDispatcher_test.cpp"
     "pipelineNodes_test.cpp"
     "stringHelper_test.cpp"
+    "numericHelper_test.cpp"
     "threadDispatcher_test.cpp"
     "threadSafeQueue_test.cpp"
     "timeHelper_test.cpp"

--- a/src/shared_modules/utils/tests/numericHelper_test.cpp
+++ b/src/shared_modules/utils/tests/numericHelper_test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * December 22, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "numericHelper_test.h"
+#include "numericHelper.h"
+
+void NumericUtilsTest::SetUp() {};
+
+void NumericUtilsTest::TearDown() {};
+
+TEST_F(NumericUtilsTest, floatToDoubleRound)
+{
+    EXPECT_DOUBLE_EQ(0.0, Utils::floatToDoubleRound(0.0f, 1));
+    EXPECT_DOUBLE_EQ(0.0, Utils::floatToDoubleRound(0.0f, 2));
+    EXPECT_DOUBLE_EQ(1.0, Utils::floatToDoubleRound(1.0f, 1));
+    EXPECT_DOUBLE_EQ(1.0, Utils::floatToDoubleRound(1.0f, 2));
+    EXPECT_DOUBLE_EQ(1.1, Utils::floatToDoubleRound(1.1f, 1));
+    EXPECT_DOUBLE_EQ(1.1, Utils::floatToDoubleRound(1.1f, 2));
+    EXPECT_DOUBLE_EQ(4.3, Utils::floatToDoubleRound(4.3f, 1));
+    EXPECT_DOUBLE_EQ(4.3, Utils::floatToDoubleRound(4.3f, 2));
+    EXPECT_DOUBLE_EQ(7.9, Utils::floatToDoubleRound(7.9f, 2));
+    EXPECT_DOUBLE_EQ(7.99, Utils::floatToDoubleRound(7.99f, 2));
+    EXPECT_DOUBLE_EQ(8.0, Utils::floatToDoubleRound(7.999f, 2));
+    EXPECT_DOUBLE_EQ(7.0, Utils::floatToDoubleRound(7.001f, 2));
+}

--- a/src/shared_modules/utils/tests/numericHelper_test.h
+++ b/src/shared_modules/utils/tests/numericHelper_test.h
@@ -1,0 +1,43 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * December 22, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef NUMERIC_HELPER_TESTS_H
+#define NUMERIC_HELPER_TESTS_H
+#include "gtest/gtest.h"
+
+class NumericUtilsTest : public ::testing::Test
+{
+protected:
+    /**
+     * @brief Construct a new NumericUtilsTest object
+     *
+     */
+    NumericUtilsTest() = default;
+
+    /**
+     * @brief Destroy the NumericUtilsTest object
+     *
+     */
+    virtual ~NumericUtilsTest() = default;
+
+    /**
+     * @brief SetUp.
+     *
+     */
+    void SetUp() override;
+
+    /**
+     * @brief TearDown.
+     *
+     */
+    void TearDown() override;
+};
+#endif //NUMERIC_HELPER_TESTS_H

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -12,8 +12,11 @@
 #ifndef _DETAILS_AUGMENTATION_HPP
 #define _DETAILS_AUGMENTATION_HPP
 
+#include <cmath>
+
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
+#include "numericHelper.h"
 #include "scanContext.hpp"
 #include "timeHelper.h"
 
@@ -131,7 +134,7 @@ public:
                 ecsData["vulnerability"]["reference"] = returnData.data->reference()->str();
                 ecsData["vulnerability"]["report_id"] = ""; // TODO: Add report id.
                 ecsData["vulnerability"]["scanner"]["vendor"] = "Wazuh";
-                ecsData["vulnerability"]["score"]["base"] = returnData.data->scoreBase();
+                ecsData["vulnerability"]["score"]["base"] = Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
                 ecsData["vulnerability"]["score"]["environmental"] = 0.0f; // TODO: Add environmental score.
                 ecsData["vulnerability"]["score"]["temporal"] = 0.0f;      // TODO: Add temporal score.
                 ecsData["vulnerability"]["score"]["version"] = returnData.data->scoreVersion()->str();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -12,8 +12,6 @@
 #ifndef _DETAILS_AUGMENTATION_HPP
 #define _DETAILS_AUGMENTATION_HPP
 
-#include <cmath>
-
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
 #include "numericHelper.h"


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20955 |

## Description

This PR fixes the field score.base in vulnerability scan items.
Helper Utils::floatToDoubleRound was created.
UT was created.

## Logs/Alerts example

Previous the change:

```
2023/12/20 12:33:28 wazuh-modulesd:vulnerability-scanner: INFO: REPORT: 1:[001] (ca1c20830bc3) any->vulnerability-scanner:{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2023-3446","description":"Issue summary: Checking excessively long DH keys or parameters may be very slow.  Impact summary: Applications that use the functions DH_check(), DH_check_ex() or EVP_PKEY_param_check() to check a DH key or DH parameters may experience long delays. Where the key or parameters that are being checked have been obtained from an untrusted source this may lead to a Denial of Service.  The function DH_check() performs various checks on DH parameters. One of those checks confirms that the modulus ('p' parameter) is not too large. Trying to use a very large modulus is slow and OpenSSL will not normally use a modulus which is over 10,000 bits in length.  However the DH_check() function checks numerous aspects of the key or parameters that have been supplied. Some of those checks use the supplied modulus value even if it has already been found to be too large.  An application that calls DH_check() and supplies a key or parameters obtained from an untrusted source could be vulernable to a Denial of Service attack.  The function DH_check() is itself called by a number of other OpenSSL functions. An application calling any of those other functions may similarly be affected. The other functions affected by this are DH_check_ex() and EVP_PKEY_param_check().  Also vulnerable are the OpenSSL dhparam and pkeyparam command line applications when using the '-check' option.  The OpenSSL SSL/TLS implementation is not affected by this issue. The OpenSSL 3.0 and 3.1 FIPS providers are not affected by this issue.","enumeration":"CVE","package":{"architecture":"amd64","build_version":"","checksum":"","description":"Secure Sockets Layer toolkit - cryptographic utility","install_scope":"","install_time":" ","license":"","name":"openssl","path":" ","reference":"","size":2053,"type":"deb","version":"3.0.2-0ubuntu1.12"},"reference":"https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9a0a4d3c1e7138915563c0df4fe6a3f9377b839c, https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=1fa20cf2f506113c761777127a38bce5068740eb, https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8780a896543a654e757db1b9396383f9d8095528, https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=fc9867c1e03c22ebf56943be205202e576aabf23, http://www.openwall.com/lists/oss-security/2023/07/19/4, http://www.openwall.com/lists/oss-security/2023/07/19/5, http://www.openwall.com/lists/oss-security/2023/07/19/6, http://www.openwall.com/lists/oss-security/2023/07/31/1, https://lists.debian.org/debian-lts-announce/2023/08/msg00019.html, https://security.netapp.com/advisory/ntap-20230803-0011/, https://www.openssl.org/news/secadv/20230719.txt","report_id":"","scanner":{"vendor":"Wazuh"},"score":{"base":5.300000190734863,"environmental":0.0,"temporal":0.0,"version":"3.1"},"severity":"Medium","status":"Active"}}

2023/12/20 12:33:28 wazuh-modulesd:vulnerability-scanner: INFO: REPORT: 1:[001] (ca1c20830bc3) any->vulnerability-scanner:{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2022-1434","description":"The OpenSSL 3.0 implementation of the RC4-MD5 ciphersuite incorrectly uses the AAD data as the MAC key. This makes the MAC key trivially predictable. An attacker could exploit this issue by performing a man-in-the-middle attack to modify data being sent from one endpoint to an OpenSSL 3.0 recipient such that the modified data would still pass the MAC integrity check. Note that data sent from an OpenSSL 3.0 endpoint to a non-OpenSSL 3.0 endpoint will always be rejected by the recipient and the connection will fail at that point. Many application protocols require data to be sent from the client to the server first. Therefore, in such a case, only an OpenSSL 3.0 server would be impacted when talking to a non-OpenSSL 3.0 client. If both endpoints are OpenSSL 3.0 then the attacker could modify data being sent in both directions. In this case both clients and servers could be affected, regardless of the application protocol. Note that in the absence of an attacker this bug means that an OpenSSL 3.0 endpoint communicating with a non-OpenSSL 3.0 endpoint will fail to complete the handshake when using this ciphersuite. The confidentiality of data is not impacted by this issue, i.e. an attacker cannot decrypt data that has been encrypted using this ciphersuite - they can only modify it. In order for this attack to work both endpoints must legitimately negotiate the RC4-MD5 ciphersuite. This ciphersuite is not compiled by default in OpenSSL 3.0, and is not available within the default provider or the default ciphersuite list. This ciphersuite will never be used if TLSv1.3 has been negotiated. In order for an OpenSSL 3.0 endpoint to use this ciphersuite the following must have occurred: 1) OpenSSL must have been compiled with the (non-default) compile time option enable-weak-ssl-ciphers 2) OpenSSL must have had the legacy provider explicitly loaded (either through application code or via configuration) 3) The ciphersuite must have been explicitly added to the ciphersuite list 4) The libssl security level must have been set to 0 (default is 1) 5) A version of SSL/TLS below TLSv1.3 must have been negotiated 6) Both endpoints must negotiate the RC4-MD5 ciphersuite in preference to any others that both endpoints have in common Fixed in OpenSSL 3.0.3 (Affected 3.0.0,3.0.1,3.0.2).","enumeration":"CVE","package":{"architecture":"amd64","build_version":"","checksum":"","description":"Secure Sockets Layer toolkit - cryptographic utility","install_scope":"","install_time":" ","license":"","name":"openssl","path":" ","reference":"","size":2053,"type":"deb","version":"3.0.2-0ubuntu1.12"},"reference":"https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=7d56a74a96828985db7354a55227a511615f732b, https://security.netapp.com/advisory/ntap-20220602-0009/, https://www.openssl.org/news/secadv/20220503.txt, https://cert-portal.siemens.com/productcert/pdf/ssa-953464.pdf","report_id":"","scanner":{"vendor":"Wazuh"},"score":{"base":4.300000190734863,"environmental":0.0,"temporal":0.0,"version":"2.0"},"severity":"Medium","status":"Active"}}
```

After the change:
```
2023/12/20 16:48:31 wazuh-modulesd:vulnerability-scanner: INFO: REPORT: 1:[001] (ca1c20830bc3) any->vulnerability-scanner:{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2023-3446","description":"Issue summary: Checking excessively long DH keys or parameters may be very slow.  Impact summary: Applications that use the functions DH_check(), DH_check_ex() or EVP_PKEY_param_check() to check a DH key or DH parameters may experience long delays. Where the key or parameters that are being checked have been obtained from an untrusted source this may lead to a Denial of Service.  The function DH_check() performs various checks on DH parameters. One of those checks confirms that the modulus ('p' parameter) is not too large. Trying to use a very large modulus is slow and OpenSSL will not normally use a modulus which is over 10,000 bits in length.  However the DH_check() function checks numerous aspects of the key or parameters that have been supplied. Some of those checks use the supplied modulus value even if it has already been found to be too large.  An application that calls DH_check() and supplies a key or parameters obtained from an untrusted source could be vulernable to a Denial of Service attack.  The function DH_check() is itself called by a number of other OpenSSL functions. An application calling any of those other functions may similarly be affected. The other functions affected by this are DH_check_ex() and EVP_PKEY_param_check().  Also vulnerable are the OpenSSL dhparam and pkeyparam command line applications when using the '-check' option.  The OpenSSL SSL/TLS implementation is not affected by this issue. The OpenSSL 3.0 and 3.1 FIPS providers are not affected by this issue.","enumeration":"CVE","package":{"architecture":"amd64","build_version":"","checksum":"","description":"Secure Sockets Layer toolkit - cryptographic utility","install_scope":"","install_time":" ","license":"","name":"openssl","path":" ","reference":"","size":2053,"type":"deb","version":"3.0.2-0ubuntu1.12"},"reference":"https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9a0a4d3c1e7138915563c0df4fe6a3f9377b839c, https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=1fa20cf2f506113c761777127a38bce5068740eb, https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8780a896543a654e757db1b9396383f9d8095528, https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=fc9867c1e03c22ebf56943be205202e576aabf23, http://www.openwall.com/lists/oss-security/2023/07/19/4, http://www.openwall.com/lists/oss-security/2023/07/19/5, http://www.openwall.com/lists/oss-security/2023/07/19/6, http://www.openwall.com/lists/oss-security/2023/07/31/1, https://lists.debian.org/debian-lts-announce/2023/08/msg00019.html, https://security.netapp.com/advisory/ntap-20230803-0011/, https://www.openssl.org/news/secadv/20230719.txt","report_id":"","scanner":{"vendor":"Wazuh"},"score":{"base":5.3,"environmental":0.0,"temporal":0.0,"version":"3.1"},"severity":"Medium","status":"Active"}}

2023/12/20 16:48:31 wazuh-modulesd:vulnerability-scanner: INFO: REPORT: 1:[001] (ca1c20830bc3) any->vulnerability-scanner:{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2022-1434","description":"The OpenSSL 3.0 implementation of the RC4-MD5 ciphersuite incorrectly uses the AAD data as the MAC key. This makes the MAC key trivially predictable. An attacker could exploit this issue by performing a man-in-the-middle attack to modify data being sent from one endpoint to an OpenSSL 3.0 recipient such that the modified data would still pass the MAC integrity check. Note that data sent from an OpenSSL 3.0 endpoint to a non-OpenSSL 3.0 endpoint will always be rejected by the recipient and the connection will fail at that point. Many application protocols require data to be sent from the client to the server first. Therefore, in such a case, only an OpenSSL 3.0 server would be impacted when talking to a non-OpenSSL 3.0 client. If both endpoints are OpenSSL 3.0 then the attacker could modify data being sent in both directions. In this case both clients and servers could be affected, regardless of the application protocol. Note that in the absence of an attacker this bug means that an OpenSSL 3.0 endpoint communicating with a non-OpenSSL 3.0 endpoint will fail to complete the handshake when using this ciphersuite. The confidentiality of data is not impacted by this issue, i.e. an attacker cannot decrypt data that has been encrypted using this ciphersuite - they can only modify it. In order for this attack to work both endpoints must legitimately negotiate the RC4-MD5 ciphersuite. This ciphersuite is not compiled by default in OpenSSL 3.0, and is not available within the default provider or the default ciphersuite list. This ciphersuite will never be used if TLSv1.3 has been negotiated. In order for an OpenSSL 3.0 endpoint to use this ciphersuite the following must have occurred: 1) OpenSSL must have been compiled with the (non-default) compile time option enable-weak-ssl-ciphers 2) OpenSSL must have had the legacy provider explicitly loaded (either through application code or via configuration) 3) The ciphersuite must have been explicitly added to the ciphersuite list 4) The libssl security level must have been set to 0 (default is 1) 5) A version of SSL/TLS below TLSv1.3 must have been negotiated 6) Both endpoints must negotiate the RC4-MD5 ciphersuite in preference to any others that both endpoints have in common Fixed in OpenSSL 3.0.3 (Affected 3.0.0,3.0.1,3.0.2).","enumeration":"CVE","package":{"architecture":"amd64","build_version":"","checksum":"","description":"Secure Sockets Layer toolkit - cryptographic utility","install_scope":"","install_time":" ","license":"","name":"openssl","path":" ","reference":"","size":2053,"type":"deb","version":"3.0.2-0ubuntu1.12"},"reference":"https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=7d56a74a96828985db7354a55227a511615f732b, https://security.netapp.com/advisory/ntap-20220602-0009/, https://www.openssl.org/news/secadv/20220503.txt, https://cert-portal.siemens.com/productcert/pdf/ssa-953464.pdf","report_id":"","scanner":{"vendor":"Wazuh"},"score":{"base":4.3,"environmental":0.0,"temporal":0.0,"version":"2.0"},"severity":"Medium","status":"Active"}}
```

## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Vulnerability scan test with field score.base as expected
