### PR TITLE
Remove profile prefixes

### DIFF
--- a/wodles/aws/aws_tools.py
+++ b/wodles/aws/aws_tools.py
@@ -37,13 +37,13 @@ RETRY_MODE_BOTO_KEY: str = "mode"
 debug_level = 0
 
 
-def set_profile_dict_config(boto_config: dict, profile: str, profile_config: dict):
-    """Create a botocore.config.Config object with the specified profile and profile_config.
+def set_profile_dict_config(boto_config: dict, profile_config: dict):
+    """Create a botocore.config.Config object with the specified profile_config.
 
     This function reads the profile configuration from the provided profile_config object and extracts the necessary
     parameters to create a botocore.config.Config object.
-    It handles the signature version, s3, proxies, and proxies_config settings found in the .aws/config file for the
-    specified profile. If a setting is not found, a default value is used based on the boto3 documentation and config is
+    It handles the signature version, s3, proxies, and proxies_config settings found in the .aws/config file.
+    If a setting is not found, a default value is used based on the boto3 documentation and config is
     set into the boto_config.
 
     Parameters
@@ -51,44 +51,41 @@ def set_profile_dict_config(boto_config: dict, profile: str, profile_config: dic
     boto_config: dict
         The config dictionary where the Boto Config will be set.
 
-    profile : str
-        The AWS profile name to use for the configuration.
-
     profile_config : dict
         The user config dict containing the profile configuration.
     """
     profile = remove_prefix(profile, 'profile ')
 
     # Set s3 config
-    if f'{profile}.s3' in str(profile_config):
+    if 's3' in str(profile_config):
         s3_config = {
-            "max_concurrent_requests": int(profile_config.get(f'{profile}.s3.max_concurrent_requests', 10)),
-            "max_queue_size": int(profile_config.get(f'{profile}.s3.max_queue_size', 10)),
-            "multipart_threshold": profile_config.get(f'{profile}.s3.multipart_threshold', '8MB'),
-            "multipart_chunksize": profile_config.get(f'{profile}.s3.multipart_chunksize', '8MB'),
-            "max_bandwidth": profile_config.get(f'{profile}.s3.max_bandwidth'),
+            "max_concurrent_requests": int(profile_config.get('s3.max_concurrent_requests', 10)),
+            "max_queue_size": int(profile_config.get('s3.max_queue_size', 10)),
+            "multipart_threshold": profile_config.get('s3.multipart_threshold', '8MB'),
+            "multipart_chunksize": profile_config.get('s3.multipart_chunksize', '8MB'),
+            "max_bandwidth": profile_config.get('s3.max_bandwidth'),
             "use_accelerate_endpoint": (
-                True if profile_config.get(f'{profile}.s3.use_accelerate_endpoint') == 'true' else False
+                True if profile_config.get('s3.use_accelerate_endpoint') == 'true' else False
             ),
-            "addressing_style": profile_config.get(f'{profile}.s3.addressing_style', 'auto'),
+            "addressing_style": profile_config.get('s3.addressing_style', 'auto'),
         }
         boto_config['config'].s3 = s3_config
 
     # Set Proxies configuration
-    if f'{profile}.proxy' in str(profile_config):
+    if 'proxy' in str(profile_config):
         proxy_config = {
-            "host": profile_config.get(f'{profile}.proxy.host'),
-            "port": int(profile_config.get(f'{profile}.proxy.port')),
-            "username": profile_config.get(f'{profile}.proxy.username'),
-            "password": profile_config.get(f'{profile}.proxy.password'),
+            "host": profile_config.get('proxy.host'),
+            "port": int(profile_config.get('proxy.port')),
+            "username": profile_config.get('proxy.username'),
+            "password": profile_config.get('proxy.password'),
         }
         boto_config['config'].proxies = proxy_config
 
         proxies_config = {
-            "ca_bundle": profile_config.get(f'{profile}.proxy.ca_bundle'),
-            "client_cert": profile_config.get(f'{profile}.proxy.client_cert'),
+            "ca_bundle": profile_config.get('proxy.ca_bundle'),
+            "client_cert": profile_config.get('proxy.client_cert'),
             "use_forwarding_for_https": (
-                True if profile_config.get(f'{profile}.proxy.use_forwarding_for_https') == 'true' else False
+                True if profile_config.get('proxy.use_forwarding_for_https') == 'true' else False
             )
         }
         boto_config['config'].proxies_config = proxies_config

--- a/wodles/aws/aws_tools.py
+++ b/wodles/aws/aws_tools.py
@@ -51,7 +51,7 @@ def set_profile_dict_config(boto_config: dict, profile: str, profile_config: dic
     ----------
     boto_config: dict
         The config dictionary where the Boto Config will be set.
-    
+
     profile : str
         The AWS profile name to use for the configuration.
 

--- a/wodles/aws/wazuh_integration.py
+++ b/wodles/aws/wazuh_integration.py
@@ -120,7 +120,11 @@ class WazuhIntegration:
             aws_config = aws_tools.get_aws_config_params()
 
             # Set profile
-            profile = f"profile {profile}" if profile is not None else 'default'
+            if profile is not None and profile != 'default':
+                if profile not in aws_config.sections():
+                    profile = f"profile {profile}"
+            else:
+                profile = 'default'
 
             try:
                 # Get profile config dictionary

--- a/wodles/aws/wazuh_integration.py
+++ b/wodles/aws/wazuh_integration.py
@@ -123,11 +123,7 @@ class WazuhIntegration:
             aws_config = aws_tools.get_aws_config_params()
 
             # Set profile
-            if profile is not None:
-                if profile not in aws_config.sections():
-                    profile = f"profile {profile}"
-            else:
-                profile = 'default'
+            profile = f"profile {profile}" if profile is not None else 'default'
 
             try:
                 # Get profile config dictionary
@@ -166,7 +162,6 @@ class WazuhIntegration:
 
                 # Set profile dictionaries configuration
                 aws_tools.set_profile_dict_config(boto_config=args,
-                                                  profile=profile,
                                                   profile_config=profile_config)
 
             except (KeyError, ValueError) as e:


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/20752 |


## Description

Removes the profile prefixes from the AWS configuration values.

## Configuration options

<details><summary>Credentials</summary>

```console
root@wazuh-master:/# cat /root/.aws/credentials
[default]
aws_access_key_id=foo
aws_secret_access_key=bar
region=us-east-1

[dev]
aws_access_key_id=foo
aws_secret_access_key=bar
region=us-east-1

[test]
aws_access_key_id=foo
aws_secret_access_key=bar
region=us-east-1
```

</details>

<details><summary>Configuration</summary>

```console
root@wazuh-master:/# cat /root/.aws/config
[default]
region=us-east-1
max_attempts=10
retry_mode=standard
s3.max_concurrent_requests = 20
s3.max_queue_size = 500
proxy.host = localhost
proxy.port = 8080
signature_version = s3v4

[profile dev]
region=us-east-1
max_attempts=5
retry_mode=standard
s3.max_concurrent_requests = 10
s3.max_queue_size = 1000
proxy.host = localhost
proxy.port = 8080
signature_version = s3v4

[profile test]
region=us-east-1
max_attempts=7
retry_mode=standard
s3.max_concurrent_requests = 15
s3.max_queue_size = 1200
proxy.host = localhost
proxy.port = 8080
signature_version = s3v4
```

</details>

## Logs/Alerts example

<details><summary>Profile 'default'</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/wodles/aws/aws-s3.py -b wazuh-xxx-cloudtrail -t cloudtrail -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Retries parameters found in user profile. Using profile 'default' retries configuration
DEBUG: Created Config object using profile: 'default' configuration
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/12/22
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/12/22
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/12/22
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
```

Configuration used

```console
DEBUG: {"region": "us-east-1", "max_attempts": "10", "retry_mode": "standard", "s3.max_concurrent_requests": "20", "s3.max_queue_size": "500", "proxy.host": "localhost", "proxy.port": "8080", "signature_version": "s3v4"}
```

</details>

<details><summary>Profile 'dev'</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/wodles/aws/aws-s3.py --aws_profile dev -b wazuh-xxx-cloudtrail -t cloudtrail -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Retries parameters found in user profile. Using profile 'profile dev' retries configuration
DEBUG: Created Config object using profile: 'profile dev' configuration
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/12/22
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/12/22
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/12/22
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
```

Configuration used

```console
DEBUG: {"region": "us-east-1", "max_attempts": "5", "retry_mode": "standard", "s3.max_concurrent_requests": "10", "s3.max_queue_size": "1000", "proxy.host": "localhost", "proxy.port": "8080", "signature_version": "s3v4"}
```

</details>

<details><summary>Profile 'test'</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/wodles/aws/aws-s3.py --aws_profile test -b wazuh-xxx-cloudtrail -t cloudtrail -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Retries parameters found in user profile. Using profile 'profile test' retries configuration
DEBUG: Created Config object using profile: 'profile test' configuration
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/12/22
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxx/CloudTrail/us-west-1/2023/12/22
DEBUG: +++ No logs to process in bucket: xxx/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on xxxx - us-west-1
DEBUG: +++ Marker: AWSLogs/xxxx/CloudTrail/us-west-1/2023/12/22
DEBUG: +++ No logs to process in bucket: xxxx/us-west-1
DEBUG: +++ DB Maintenance
```

Configuration used

```console
DEBUG: {"region": "us-east-1", "max_attempts": "7", "retry_mode": "standard", "s3.max_concurrent_requests": "15", "s3.max_queue_size": "1200", "proxy.host": "localhost", "proxy.port": "8080", "signature_version": "s3v4"}
```

</details>

## Tests

<details><summary>AWS unit tests</summary>

```console
(venv10) gasti@pop-os:~/work/wazuh$ python3 -m pytest wodles/aws --disable-warnings
================================================= test session starts =================================================
platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-1.3.0
rootdir: /home/gasti/work/wazuh/wodles
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 639 items                                                                                                   

wodles/aws/tests/test_aws_bucket.py ........................................................................... [ 11%]
............................................................................................................... [ 29%]
.......................                                                                                         [ 32%]
wodles/aws/tests/test_aws_s3.py ..................                                                              [ 35%]
wodles/aws/tests/test_aws_service.py ....                                                                       [ 36%]
wodles/aws/tests/test_cloudtrail.py ..                                                                          [ 36%]
wodles/aws/tests/test_cloudwatchlogs.py .....................................................                   [ 44%]
wodles/aws/tests/test_config.py ..............................................................................  [ 56%]
wodles/aws/tests/test_guardduty.py .................                                                            [ 59%]
wodles/aws/tests/test_inspector.py ......                                                                       [ 60%]
wodles/aws/tests/test_load_balancers.py ............                                                            [ 62%]
wodles/aws/tests/test_s3_log_handler.py ................                                                        [ 64%]
wodles/aws/tests/test_server_access.py .................................                                        [ 70%]
wodles/aws/tests/test_sqs_message_processor.py ........                                                         [ 71%]
wodles/aws/tests/test_sqs_queue.py .......                                                                      [ 72%]
wodles/aws/tests/test_tools.py ..................................                                               [ 77%]
wodles/aws/tests/test_umbrella.py ......                                                                        [ 78%]
wodles/aws/tests/test_vpcflow.py ...........................                                                    [ 82%]
wodles/aws/tests/test_waf.py .......                                                                            [ 84%]
wodles/aws/tests/test_wazuh_integration.py .................................................................... [ 94%]
..................................                                                                              [100%]

================================================= 639 passed in 2.39s =================================================
```

</details>