### PR TITLE
Update cryptography dependency to version `41.0.7`

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.4
 click==8.1.3
 clickclick==20.10.2
 connexion==2.14.2
-cryptography==41.0.4
+cryptography==41.0.7
 Cython==0.29.21
 defusedxml==0.6.0
 docker==6.0.0

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.5
+aiohttp==3.9.1
 aiohttp-cache==2.2.0
 aiohttp-cors==0.7.0
 aiohttp-jinja2==1.5.1


### PR DESCRIPTION
|Related issue|
|---|
| #20601 |

## Description

Closes #20601. Updates the `cryptography` dependency to the latest `41.0.7` that addresses several security vulnerabilities.


## Tests

Unit Tests can be found [here](https://github.com/wazuh/wazuh/issues/20601#issuecomment-1867945582).
API Integration Tests can be found [here](https://github.com/wazuh/wazuh/issues/20601#issuecomment-1867935692).

> [!NOTE]
> The changes added with the [Modify DEPS_VERSION to 26-20601 for testing](https://github.com/wazuh/wazuh/pull/21055/commits/619f560a88ffab6672d617db7908208af1a23a08) commit will be rolled back once the packages are added to the `DEPS_VERSION=26` and the `aiohttp==3.9.1` dependency is part of the `4.8.1` branch.

> [!NOTE]
> The checks for `Integration tests for Analisysd - Tier 0 and 1`, `Integration tests for API - Tier 0 and 1`, and `Integration tests for Vulnerability Detector - Tier 0 and 1` are failing due to the reasons exposed [here](https://github.com/wazuh/wazuh/pull/21005#issuecomment-1866970871).