### PR TITLE
Content manager - Use condition_variable in retry wait loop

### DIFF
--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -33,16 +33,16 @@ public:
      *
      * @param channel Channel where the orchestration will publish the data.
      * @param parameters Parameters used to create the orchestration.
-     * @param shouldRun Flag used to interrupt the orchestration stages.
+     * @param stopActionCondition Condition wrapper used to interrupt the orchestration stages.
      */
     explicit ActionOrchestrator(const std::shared_ptr<IRouterProvider> channel,
                                 const nlohmann::json& parameters,
-                                const std::atomic<bool>& shouldRun)
+                                std::shared_ptr<ConditionSync> stopActionCondition)
     {
         try
         {
             // Create a context
-            m_spBaseContext = std::make_shared<UpdaterBaseContext>(shouldRun);
+            m_spBaseContext = std::make_shared<UpdaterBaseContext>(stopActionCondition);
             m_spBaseContext->topicName = parameters.at("topicName");
             m_spBaseContext->configData = parameters.at("configData");
             m_spBaseContext->spChannel = channel;

--- a/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
@@ -48,9 +48,10 @@ private:
 
         // Iterate until the current offset is equal to the consumer offset.
         auto pathsArray = nlohmann::json::array();
+        auto& stopCondition {m_spUpdaterContext->spUpdaterBaseContext->spStopCondition};
         while (context.currentOffset < consumerLastOffset)
         {
-            if (!context.spUpdaterBaseContext->shouldRun.load())
+            if (stopCondition->check())
             {
                 logWarn(WM_CONTENTUPDATER, "The offsets download has been interrupted");
                 return;

--- a/src/shared_modules/content_manager/src/components/conditionSync.hpp
+++ b/src/shared_modules/content_manager/src/components/conditionSync.hpp
@@ -30,7 +30,7 @@ public:
      *
      * @param initialState The initial value of the condition.
      */
-    ConditionSync(bool initialState)
+    explicit ConditionSync(bool initialState)
         : m_condition(initialState) {};
 
     /**

--- a/src/shared_modules/content_manager/src/components/conditionSync.hpp
+++ b/src/shared_modules/content_manager/src/components/conditionSync.hpp
@@ -55,11 +55,9 @@ public:
     }
 
     /**
-     * @brief Sets the value of the condition to the specified value.
+     * @brief Sets the value of the condition to the specified value and notifies the waiting threads.
      * @param value The new value of the condition.
      *
-     * Sets the value of the condition to the specified value and notifies
-     * all waiting threads.
      */
     void set(bool value)
     {

--- a/src/shared_modules/content_manager/src/components/conditionSync.hpp
+++ b/src/shared_modules/content_manager/src/components/conditionSync.hpp
@@ -1,0 +1,77 @@
+/*
+ * Wazuh content manager
+ * Copyright (C) 2015, Wazuh Inc.
+ * December 22, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _CONDITION_SYNC_HPP
+#define _CONDITION_SYNC_HPP
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+/**
+ * @brief Synchronization class based on a condition variable.
+ *
+ * Simple synchronization mechanism for coordinating threads based on a boolean condition.
+ */
+class ConditionSync
+{
+public:
+    /**
+     * @brief Construct a new Condition Sync object
+     *
+     * @param initialState The initial value of the condition.
+     */
+    ConditionSync(bool initialState)
+        : m_condition(initialState) {};
+
+    /**
+     * @brief Waits for the condition to become true or until a timeout occurs.
+     *
+     * @param timeout Maximum duration to wait for the condition.
+     * @return True if the condition becomes true, false if a timeout occurs.
+     */
+    bool waitFor(std::chrono::milliseconds timeout)
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_cv.wait_for(lock, timeout, [this] { return m_condition.load(); });
+    }
+
+    /**
+     * @brief Checks the current value of the condition.
+     * @return The current value of the condition.
+     */
+    bool check()
+    {
+        return m_condition.load();
+    }
+
+    /**
+     * @brief Sets the value of the condition to the specified value.
+     * @param value The new value of the condition.
+     *
+     * Sets the value of the condition to the specified value and notifies
+     * all waiting threads.
+     */
+    void set(bool value)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_condition = value;
+        m_cv.notify_all();
+    }
+
+private:
+    std::atomic<bool> m_condition; ///< The shared boolean condition.
+    std::mutex m_mutex;            ///< Mutex for synchronization.
+    std::condition_variable m_cv;  ///< Condition variable for signaling.
+};
+
+#endif // _CONDITION_SYNC_HPP

--- a/src/shared_modules/content_manager/src/components/updaterContext.hpp
+++ b/src/shared_modules/content_manager/src/components/updaterContext.hpp
@@ -12,11 +12,13 @@
 #ifndef _UPDATER_CONTEXT_HPP
 #define _UPDATER_CONTEXT_HPP
 
+#include "conditionSync.hpp"
 #include "iRouterProvider.hpp"
+#include "json.hpp"
 #include "utils/rocksDBWrapper.hpp"
-#include <atomic>
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
+#include <memory>
 #include <string>
 
 constexpr auto DOWNLOAD_FOLDER = "downloads";
@@ -80,15 +82,15 @@ struct UpdaterBaseContext
      * @brief Variable to control the graceful shutdown of the orchestration.
      *
      */
-    const std::atomic<bool>& shouldRun;
+    std::shared_ptr<ConditionSync> spStopCondition;
 
     /**
      * @brief Struct constructor.
      *
-     * @param shouldRun Reference to an interruption flag.
+     * @param spStopCondition Pointer to a stop condition wrapper.
      */
-    explicit UpdaterBaseContext(const std::atomic<bool>& shouldRun)
-        : shouldRun(shouldRun)
+    explicit UpdaterBaseContext(std::shared_ptr<ConditionSync> spStopCondition)
+        : spStopCondition(spStopCondition)
     {
     }
 };

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.hpp
@@ -12,10 +12,10 @@
 #ifndef _ACTION_ORCHESTRATOR_TEST_HPP
 #define _ACTION_ORCHESTRATOR_TEST_HPP
 
+#include "conditionSync.hpp"
 #include "fakes/fakeServer.hpp"
 #include "mocks/mockRouterProvider.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
 #include <memory>
@@ -33,7 +33,9 @@ protected:
     nlohmann::json m_parameters; ///< Parameters used to create the ActionOrchestrator
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Pointer to FakeServer class
-    const std::atomic<bool> m_shouldRun {true};               ///< Interruption flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
+
     const std::filesystem::path DATABASE_PATH {std::filesystem::temp_directory_path() /
                                                "ActionOrchestratorTest"}; ///< Path used to store the RocksDB database.
     const unsigned int INITIAL_OFFSET {1}; ///< Initial offset to be inserted on the database.

--- a/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/pubSubPublisher_test.hpp
@@ -12,10 +12,10 @@
 #ifndef _PUB_SUB_PUBLISHER_TEST_HPP
 #define _PUB_SUB_PUBLISHER_TEST_HPP
 
+#include "conditionSync.hpp"
 #include "pubSubPublisher.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <memory>
 
 /**
@@ -32,7 +32,8 @@ protected:
     std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on the merge pipeline.
 
     std::shared_ptr<PubSubPublisher> m_spPubSubPublisher; ///< PubSubPublisher used to publish the content data.
-    const std::atomic<bool> m_shouldRun {true};           ///< Interruption flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -44,7 +45,7 @@ protected:
         m_spPubSubPublisher = std::make_shared<PubSubPublisher>();
         // Create a updater context
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_spStopActionCondition);
     }
 };
 

--- a/src/shared_modules/content_manager/tests/unit/APIDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/APIDownloader_test.hpp
@@ -14,10 +14,10 @@
 
 #include "APIDownloader.hpp"
 #include "HTTPRequest.hpp"
+#include "conditionSync.hpp"
 #include "fakes/fakeServer.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <memory>
 
 /**
@@ -37,7 +37,8 @@ protected:
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< pointer to FakeServer class
 
-    const std::atomic<bool> m_shouldRun {true}; ///< Interruption flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -48,7 +49,7 @@ protected:
     {
         m_spAPIDownloader = std::make_shared<APIDownloader>(HTTPRequest::instance());
         // Create a updater base context
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_spStopActionCondition);
         m_spUpdaterBaseContext->outputFolder = "/tmp/api-downloader-tests";
         m_spUpdaterBaseContext->downloadsFolder = m_spUpdaterBaseContext->outputFolder / DOWNLOAD_FOLDER;
         m_spUpdaterBaseContext->contentsFolder = m_spUpdaterBaseContext->outputFolder / CONTENTS_FOLDER;

--- a/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
@@ -98,10 +98,8 @@ public:
 
 void CtiDownloaderTest::SetUp()
 {
-    m_shouldRun = true;
-
     // Create base context.
-    auto spBaseContext {std::make_shared<UpdaterBaseContext>(m_shouldRun)};
+    auto spBaseContext {std::make_shared<UpdaterBaseContext>(m_spStopActionCondition)};
     spBaseContext->configData["url"] = FAKE_CTI_URL;
 
     // Create updater context.
@@ -236,7 +234,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadInterrupted)
 {
     auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
 
-    m_shouldRun = false;
+    m_spStopActionCondition->set(true);
     ASSERT_NO_THROW(downloader.handleRequest(m_spUpdaterContext));
 
     // Check expected data.

--- a/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.hpp
@@ -12,10 +12,10 @@
 #ifndef _CTI_DOWNLOADER_TEST_HPP
 #define _CTI_DOWNLOADER_TEST_HPP
 
+#include "conditionSync.hpp"
 #include "fakes/fakeServer.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <memory>
 
 /**
@@ -30,7 +30,8 @@ protected:
 
     std::shared_ptr<UpdaterContext> m_spUpdaterContext;       ///< UpdaterContext used on the update orchestration.
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< FakeServer used for tests.
-    std::atomic<bool> m_shouldRun;                            ///< Run flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Setup routine for each test fixture.

--- a/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.cpp
@@ -226,7 +226,7 @@ TEST_F(CtiOffsetDownloaderTest, DownloadClientAndServerErrorsRetryAndFail)
 TEST_F(CtiOffsetDownloaderTest, DownloadInterrupted)
 {
     // Set interruption flag.
-    m_shouldRun = false;
+    m_spStopActionCondition->set(true);
 
     ASSERT_NO_THROW(m_spCtiOffsetDownloader->handleRequest(m_spUpdaterContext));
 

--- a/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.hpp
@@ -14,10 +14,10 @@
 
 #include "CtiOffsetDownloader.hpp"
 #include "HTTPRequest.hpp"
+#include "conditionSync.hpp"
 #include "fakes/fakeServer.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <memory>
 
 /**
@@ -37,7 +37,8 @@ protected:
     std::shared_ptr<CtiOffsetDownloader> m_spCtiOffsetDownloader; ///< CtiOffsetDownloader used to download the content.
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Pointer to FakeServer class
-    std::atomic<bool> m_shouldRun;                            ///< Run flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -46,10 +47,9 @@ protected:
     // cppcheck-suppress unusedFunction
     void SetUp() override
     {
-        m_shouldRun = true;
         m_spCtiOffsetDownloader = std::make_shared<CtiOffsetDownloader>(HTTPRequest::instance());
         // Create a updater base context
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_spStopActionCondition);
         m_spUpdaterBaseContext->outputFolder = "/tmp/api-downloader-tests";
         m_spUpdaterBaseContext->downloadsFolder = m_spUpdaterBaseContext->outputFolder / DOWNLOAD_FOLDER;
         m_spUpdaterBaseContext->contentsFolder = m_spUpdaterBaseContext->outputFolder / CONTENTS_FOLDER;

--- a/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.cpp
@@ -29,7 +29,7 @@ const auto OUTPUT_DIR {std::filesystem::temp_directory_path() / "CtiSnapshotDown
 void CtiSnapshotDownloaderTest::SetUp()
 {
     // Create base context.
-    auto spBaseContext {std::make_shared<UpdaterBaseContext>(m_shouldRun)};
+    auto spBaseContext {std::make_shared<UpdaterBaseContext>(m_spStopActionCondition)};
     spBaseContext->downloadsFolder = OUTPUT_DIR;
     spBaseContext->configData["url"] = FAKE_CTI_URL;
 

--- a/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.hpp
@@ -12,10 +12,10 @@
 #ifndef _CTI_SNAPSHOT_DOWNLOADER_TEST_HPP
 #define _CTI_SNAPSHOT_DOWNLOADER_TEST_HPP
 
+#include "conditionSync.hpp"
 #include "fakes/fakeServer.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <memory>
 
 /**
@@ -30,7 +30,8 @@ protected:
 
     std::shared_ptr<UpdaterContext> m_spUpdaterContext;       ///< UpdaterContext used on the update orchestration.
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< FakeServer used for tests.
-    const std::atomic<bool> m_shouldRun {true};               ///< Run flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Setup routine for each test fixture.

--- a/src/shared_modules/content_manager/tests/unit/cleanUpContent_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/cleanUpContent_test.hpp
@@ -13,8 +13,8 @@
 #define _CLEAN_UP_CONTENT_TEST_HPP
 
 #include "cleanUpContent.hpp"
+#include "conditionSync.hpp"
 #include "updaterContext.hpp"
-#include <atomic>
 #include <gtest/gtest.h>
 
 const std::string TEST_DIR {"/tmp/test"};
@@ -45,15 +45,15 @@ protected:
      */
     std::shared_ptr<CleanUpContent> m_spCleanUpContent;
 
-    const std::atomic<bool> m_shouldRun {true}; ///< Interruption flag.
-
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
     /**
      * @brief Sets up the test fixture.
      */
     void SetUp() override
     {
         // Initialize contexts
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_spStopActionCondition);
 
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
         m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;

--- a/src/shared_modules/content_manager/tests/unit/conditionSync_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/conditionSync_test.cpp
@@ -1,0 +1,194 @@
+/*
+ * Wazuh content manager - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * Dec 22, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "conditionSync_test.hpp"
+#include "conditionSync.hpp"
+#include "gtest/gtest.h"
+#include <chrono>
+#include <thread>
+
+/**
+ * @brief Tests initial value of the condition
+ */
+TEST_F(ConditionSyncTest, TestInitialValue)
+{
+    {
+        ConditionSync conditionSync(false);
+        EXPECT_FALSE(conditionSync.check());
+    }
+
+    {
+        ConditionSync conditionSync(true);
+        EXPECT_TRUE(conditionSync.check());
+    }
+}
+
+/**
+ * @brief Tests that the value of the condition changes
+ */
+TEST_F(ConditionSyncTest, TestChangingTheValue)
+{
+    {
+        ConditionSync conditionSync(false);
+        conditionSync.set(true);
+        EXPECT_TRUE(conditionSync.check());
+    }
+
+    {
+        ConditionSync conditionSync(true);
+        conditionSync.set(false);
+        EXPECT_FALSE(conditionSync.check());
+    }
+}
+
+/**
+ * @brief Tests waiting for the value to change within the wait period
+ */
+TEST_F(ConditionSyncTest, TestWaitingForValueChange)
+{
+
+    ConditionSync conditionSync(false);
+    std::thread t1(
+        [&conditionSync]()
+        {
+            const auto maxWaitTime {std::chrono::seconds(2)};
+            auto start {std::chrono::high_resolution_clock::now()};
+
+            // The condition must be true when the function returns
+            EXPECT_TRUE(conditionSync.waitFor(maxWaitTime));
+            auto end {std::chrono::high_resolution_clock::now()};
+
+            // The waited time must be less than the max wait time
+            EXPECT_TRUE(end - start < maxWaitTime);
+        });
+
+    // Wait for some time
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    // Set condition to true
+    conditionSync.set(true);
+
+    t1.join();
+}
+
+/**
+ * @brief Tests waiting for the value to change, exit on timeout
+ */
+TEST_F(ConditionSyncTest, TestWaitingForWithTimeout)
+{
+
+    ConditionSync conditionSync(false);
+    std::thread t1(
+        [&conditionSync]()
+        {
+            const auto maxWaitTime {std::chrono::milliseconds(100)};
+
+            auto start {std::chrono::high_resolution_clock::now()};
+
+            // The condition must be false when the function returns because it exits on timeout
+            EXPECT_FALSE(conditionSync.waitFor(maxWaitTime));
+            auto end {std::chrono::high_resolution_clock::now()};
+
+            // The waited time must be greater than or equal to the max wait time
+            EXPECT_TRUE(end - start >= maxWaitTime);
+        });
+
+    // The condition value does not change, waitFor will exit on timeout
+
+    t1.join();
+}
+
+/**
+ * @brief Tests waiting for the value to change within the wait period, two threads
+ */
+TEST_F(ConditionSyncTest, TestWaitingForTwoThreads)
+{
+
+    ConditionSync conditionSync(false);
+    std::thread t1(
+        [&conditionSync]()
+        {
+            const auto maxWaitTime {std::chrono::seconds(2)};
+            auto start {std::chrono::high_resolution_clock::now()};
+
+            // The condition must be true when the function returns
+            EXPECT_TRUE(conditionSync.waitFor(maxWaitTime));
+            auto end {std::chrono::high_resolution_clock::now()};
+
+            // The waited time must be less than the max wait time
+            EXPECT_TRUE(end - start < maxWaitTime);
+        });
+    std::thread t2(
+        [&conditionSync]()
+        {
+            const auto maxWaitTime {std::chrono::seconds(1)};
+            auto start {std::chrono::high_resolution_clock::now()};
+
+            // The condition must be true when the function returns
+            EXPECT_TRUE(conditionSync.waitFor(maxWaitTime));
+            auto end {std::chrono::high_resolution_clock::now()};
+
+            // The waited time must be less than the max wait time
+            EXPECT_TRUE(end - start < maxWaitTime);
+        });
+
+    // Wait for some time
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+
+    // Set condition to true
+    conditionSync.set(true);
+
+    t1.join();
+    t2.join();
+}
+
+/**
+ * @brief Tests waiting for the value to change, exit on timeout
+ */
+TEST_F(ConditionSyncTest, TestWaitingForWithTimeoutTwoThreads)
+{
+
+    ConditionSync conditionSync(false);
+
+    std::thread t1(
+        [&conditionSync]()
+        {
+            const auto maxWaitTime {std::chrono::milliseconds(50)};
+
+            auto start {std::chrono::high_resolution_clock::now()};
+
+            // The condition must be false when the function returns because it exits on timeout
+            EXPECT_FALSE(conditionSync.waitFor(maxWaitTime));
+            auto end {std::chrono::high_resolution_clock::now()};
+
+            // The waited time must be greater than or equal to the max wait time
+            EXPECT_TRUE(end - start >= maxWaitTime);
+        });
+    std::thread t2(
+        [&conditionSync]()
+        {
+            const auto maxWaitTime {std::chrono::milliseconds(40)};
+
+            auto start {std::chrono::high_resolution_clock::now()};
+
+            // The condition must be false when the function returns because it exits on timeout
+            EXPECT_FALSE(conditionSync.waitFor(maxWaitTime));
+            auto end {std::chrono::high_resolution_clock::now()};
+
+            // The waited time must be greater than or equal to the max wait time
+            EXPECT_TRUE(end - start >= maxWaitTime);
+        });
+
+    // The condition value does not change, waitFor will exit on timeout.
+
+    t1.join();
+    t2.join();
+}

--- a/src/shared_modules/content_manager/tests/unit/conditionSync_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/conditionSync_test.hpp
@@ -1,0 +1,27 @@
+/*
+ * Wazuh content manager - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * Dec 22, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _CONDITION_SYNC_TEST_HPP
+#define _CONDITION_SYNC_TEST_HPP
+
+#include "gtest/gtest.h"
+
+/**
+ * @brief Runs unit tests for ConditionSync
+ */
+class ConditionSyncTest : public ::testing::Test
+{
+protected:
+    ConditionSyncTest() = default;
+    ~ConditionSyncTest() override = default;
+};
+
+#endif //_CONDITION_SYNC_TEST_HPP

--- a/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/executionContext_test.hpp
@@ -12,10 +12,10 @@
 #ifndef _EXECUTION_CONTEXT_TEST_HPP
 #define _EXECUTION_CONTEXT_TEST_HPP
 
+#include "conditionSync.hpp"
 #include "executionContext.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <filesystem>
 #include <memory>
 
@@ -36,7 +36,8 @@ protected:
 
     const std::filesystem::path m_databasePath {"/tmp/database"};        ///< Path used to store the database files.
     const std::filesystem::path m_outputFolder {"/tmp/content_manager"}; ///< Path used to store the output files.
-    const std::atomic<bool> m_shouldRun {true};                          ///< Interruption flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -48,7 +49,7 @@ protected:
         m_spExecutionContext = std::make_shared<ExecutionContext>();
         // Create a updater context
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_spStopActionCondition);
         m_spUpdaterBaseContext->configData["outputFolder"] = m_outputFolder.string();
     }
 

--- a/src/shared_modules/content_manager/tests/unit/fileDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/fileDownloader_test.cpp
@@ -42,7 +42,7 @@ void FileDownloaderTest::TearDownTestSuite()
 
 void FileDownloaderTest::SetUp()
 {
-    m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
+    m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_spStopActionCondition);
     m_spUpdaterBaseContext->downloadsFolder = (m_outputFolder / "downloads").string();
     m_spUpdaterBaseContext->contentsFolder = (m_outputFolder / "contents").string();
 

--- a/src/shared_modules/content_manager/tests/unit/fileDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/fileDownloader_test.hpp
@@ -12,10 +12,10 @@
 #ifndef _FILE_DOWNLOADER_TEST_HPP
 #define _FILE_DOWNLOADER_TEST_HPP
 
+#include "conditionSync.hpp"
 #include "fakes/fakeServer.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <filesystem>
 #include <memory>
 
@@ -34,7 +34,8 @@ protected:
     const std::filesystem::path m_outputFolder {std::filesystem::temp_directory_path() /
                                                 "FileDownloaderTest"}; ///< Output folder for tests.
     inline static std::unique_ptr<FakeServer> m_spFakeServer;          ///< Fake HTTP server used in tests.
-    const std::atomic<bool> m_shouldRun {true};                        ///< Interruption flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Setup routine for the test suite.

--- a/src/shared_modules/content_manager/tests/unit/gzipDecompressor_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/gzipDecompressor_test.hpp
@@ -12,9 +12,9 @@
 #ifndef _GZIP_DECOMPRESSOR_TEST_HPP
 #define _GZIP_DECOMPRESSOR_TEST_HPP
 
+#include "conditionSync.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <filesystem>
 #include <memory>
 
@@ -35,7 +35,8 @@ protected:
     ~GzipDecompressorTest() override = default;
 
     std::shared_ptr<UpdaterContext> m_spContext; ///< Context used on tests.
-    const std::atomic<bool> m_shouldRun {true};  ///< Interruption flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Setup routine for each test fixture. Context initialization.
@@ -44,7 +45,7 @@ protected:
     void SetUp() override
     {
         m_spContext = std::make_shared<UpdaterContext>();
-        m_spContext->spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
+        m_spContext->spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_spStopActionCondition);
         m_spContext->spUpdaterBaseContext->outputFolder = WORKING_DIR;
     }
 

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
@@ -12,11 +12,11 @@
 #ifndef _OFFLINE_DOWNLOADER_TEST
 #define _OFFLINE_DOWNLOADER_TEST
 
+#include "conditionSync.hpp"
 #include "fakes/fakeServer.hpp"
 #include "offlineDownloader.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -40,7 +40,8 @@ protected:
     std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on tests.
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Fake HTTP server used in tests.
-    const std::atomic<bool> m_shouldRun {true};               ///< Interruption flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Set up routine for each test fixture.
@@ -61,7 +62,7 @@ protected:
         testFileStream.close();
 
         // Updater base context.
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_spStopActionCondition);
         m_spUpdaterBaseContext->outputFolder = m_outputFolder;
         m_spUpdaterBaseContext->downloadsFolder = m_outputFolder / DOWNLOAD_FOLDER;
         m_spUpdaterBaseContext->contentsFolder = m_outputFolder / CONTENTS_FOLDER;

--- a/src/shared_modules/content_manager/tests/unit/pubSubPublisher_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/pubSubPublisher_test.hpp
@@ -12,10 +12,10 @@
 #ifndef _PUB_SUB_PUBLISHER_TEST_HPP
 #define _PUB_SUB_PUBLISHER_TEST_HPP
 
+#include "conditionSync.hpp"
 #include "pubSubPublisher.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 
 /**
  * @brief Runs unit tests for PubSubPublisher
@@ -31,7 +31,8 @@ protected:
     std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on the merge pipeline.
 
     std::shared_ptr<PubSubPublisher> m_spPubSubPublisher; ///< PubSubPublisher used to publish the content data.
-    const std::atomic<bool> m_shouldRun {true};           ///< Interruption flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Sets initial conditions for each test case.
@@ -43,7 +44,7 @@ protected:
         m_spPubSubPublisher = std::make_shared<PubSubPublisher>();
         // Create a updater context
         m_spUpdaterContext = std::make_shared<UpdaterContext>();
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_spStopActionCondition);
     }
 };
 

--- a/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/updateCtiApiOffset_test.hpp
@@ -12,12 +12,12 @@
 #ifndef _UPDATE_CTI_API_OFFSET_TEST_HPP
 #define _UPDATE_CTI_API_OFFSET_TEST_HPP
 
+#include "conditionSync.hpp"
 #include "updateCtiApiOffset.hpp"
 #include "updaterContext.hpp"
 #include "utils/rocksDBWrapper.hpp"
 #include "utils/timeHelper.h"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <filesystem>
 
 const auto DATABASE_FOLDER {std::filesystem::temp_directory_path() / "test_db"};
@@ -46,7 +46,8 @@ protected:
      */
     std::shared_ptr<UpdateCtiApiOffset> m_spUpdateCtiApiOffset;
 
-    const std::atomic<bool> m_shouldRun {true}; ///< Interruption flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Sets up the test fixture.
@@ -54,7 +55,7 @@ protected:
     void SetUp() override
     {
         // Initialize contexts
-        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
+        m_spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_spStopActionCondition);
         m_spUpdaterBaseContext->spRocksDB = std::make_unique<Utils::RocksDBWrapper>(DATABASE_FOLDER);
         m_spUpdaterBaseContext->spRocksDB->createColumn(Components::Columns::CURRENT_OFFSET);
         m_spUpdaterBaseContext->spRocksDB->put(

--- a/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.hpp
@@ -12,9 +12,9 @@
 #ifndef _ZIP_DECOMPRESSOR_TEST_HPP
 #define _ZIP_DECOMPRESSOR_TEST_HPP
 
+#include "conditionSync.hpp"
 #include "updaterContext.hpp"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <filesystem>
 #include <memory>
 
@@ -33,7 +33,8 @@ protected:
     ~ZipDecompressorTest() override = default;
 
     std::shared_ptr<UpdaterContext> m_spContext; ///< Context used on tests.
-    const std::atomic<bool> m_shouldRun {true};  ///< Interruption flag.
+    std::shared_ptr<ConditionSync> m_spStopActionCondition {
+        std::make_shared<ConditionSync>(false)}; ///< Stop condition wrapper
 
     /**
      * @brief Setup routine for each test fixture. Context initialization and output directories creation.
@@ -42,7 +43,7 @@ protected:
     void SetUp() override
     {
         m_spContext = std::make_shared<UpdaterContext>();
-        m_spContext->spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_shouldRun);
+        m_spContext->spUpdaterBaseContext = std::make_shared<UpdaterBaseContext>(m_spStopActionCondition);
         m_spContext->spUpdaterBaseContext->outputFolder = OUTPUT_FOLDER;
 
         std::filesystem::create_directory(OUTPUT_FOLDER);


### PR DESCRIPTION
|Related issue|
|---|
| Closes #20987|

## Description

This PR adds the class `ConditionSync`, a wrapper around a `std::condition_variable` that can be used to synchronize threads according to a boolean value.
This class is used in the Action Orchestration to signal when the action must be stopped. Using a condition_variable allows the different steps of the orchestration to respond immediately to the stop condition.


## Results

A fake server that always responds with a 505 error was used to force the retry mechanism.
<details><summary>Server script</summary>

```
from flask import Flask, request, jsonify

app = Flask(__name__)

@app.route('/endpoint', methods=['GET'])
def emulate_server():
    return jsonify({'error': 'Server Error'}), 505

if __name__ == '__main__':
    app.run(debug=True)
```

</details>

In the image, the retry mechanism was activated, prompting the content updater to attempt the download every 30 seconds. However, at 17:46:42, a stop request was issued, leading the content updater to promptly cancel its task and exit gracefully within a second, bypassing the usual 30-second waiting interval.
![image](https://github.com/wazuh/wazuh/assets/7939712/08574f5a-d5dc-4c4c-842e-e2d182165908)



