### PR TITLE
Change the object name from install_time to installed [Index states]

### DIFF
--- a/src/shared_modules/utils/tests/timeHelper_test.cpp
+++ b/src/shared_modules/utils/tests/timeHelper_test.cpp
@@ -71,9 +71,12 @@ TEST_F(TimeUtilsTest, TimestampToISO8601)
 {
     EXPECT_EQ("2020-12-28T18:00:00.000Z", Utils::timestampToISO8601("2020/12/28 15:00:00"));
     EXPECT_EQ("2020-12-29T00:00:00.000Z", Utils::timestampToISO8601("2020/12/28 21:00:00"));
+    EXPECT_EQ("", Utils::timestampToISO8601("21:00:00"));
 }
 
 TEST_F(TimeUtilsTest, RawTimestampToISO8601)
 {
     EXPECT_EQ("2020-11-13T01:54:25.000Z", Utils::rawTimestampToISO8601("1605232465"));
+    EXPECT_EQ("", Utils::rawTimestampToISO8601(""));
+    EXPECT_EQ("", Utils::rawTimestampToISO8601("abcdefg"));
 }

--- a/src/shared_modules/utils/tests/timeHelper_test.cpp
+++ b/src/shared_modules/utils/tests/timeHelper_test.cpp
@@ -9,9 +9,9 @@
  * Foundation.
  */
 
-#include <regex>
 #include "timeHelper_test.h"
 #include "timeHelper.h"
+#include <regex>
 
 void TimeUtilsTest::SetUp() {};
 
@@ -19,45 +19,56 @@ void TimeUtilsTest::TearDown() {};
 
 TEST_F(TimeUtilsTest, CheckTimestamp)
 {
-    const auto currentTimestamp { Utils::getCurrentTimestamp() };
-    const auto timestamp { Utils::getTimestamp(std::time(nullptr)) };
+    const auto currentTimestamp {Utils::getCurrentTimestamp()};
+    const auto timestamp {Utils::getTimestamp(std::time(nullptr))};
     EXPECT_FALSE(currentTimestamp.empty());
     EXPECT_FALSE(timestamp.empty());
 }
 
 TEST_F(TimeUtilsTest, CheckTimestampValidFormat)
 {
-    constexpr auto DATE_FORMAT_REGEX_STR { "[0-9]{4}/([0-9]|1[0-2]){2}/(([0-9]|1[0-2]){2}) (([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2})" };
-    const auto currentTimestamp { Utils::getCurrentTimestamp() };
-    const auto timestamp { Utils::getTimestamp(std::time(nullptr)) };
+    constexpr auto DATE_FORMAT_REGEX_STR {
+        "[0-9]{4}/([0-9]|1[0-2]){2}/(([0-9]|1[0-2]){2}) (([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2})"};
+    const auto currentTimestamp {Utils::getCurrentTimestamp()};
+    const auto timestamp {Utils::getTimestamp(std::time(nullptr))};
     EXPECT_TRUE(std::regex_match(currentTimestamp, std::regex(DATE_FORMAT_REGEX_STR)));
     EXPECT_TRUE(std::regex_match(timestamp, std::regex(DATE_FORMAT_REGEX_STR)));
 }
 
 TEST_F(TimeUtilsTest, CheckTimestampInvalidFormat)
 {
-    constexpr auto DATE_FORMAT_REGEX_STR { "[0-9]{4}/([1-9]|1[0-2])/([1-9]|[1-2][0-9]|3[0-1])(2[0-3]|1[0-9]|[0-9]):([0-9]|[1-5][0-9]):([1-5][0-9]|[0-9])" };
-    const auto currentTimestamp { Utils::getCurrentTimestamp() };
-    const auto timestamp { Utils::getTimestamp(std::time(nullptr)) };
+    constexpr auto DATE_FORMAT_REGEX_STR {
+        "[0-9]{4}/([1-9]|1[0-2])/([1-9]|[1-2][0-9]|3[0-1])(2[0-3]|1[0-9]|[0-9]):([0-9]|[1-5][0-9]):([1-5][0-9]|[0-9])"};
+    const auto currentTimestamp {Utils::getCurrentTimestamp()};
+    const auto timestamp {Utils::getTimestamp(std::time(nullptr))};
     EXPECT_FALSE(std::regex_match(currentTimestamp, std::regex(DATE_FORMAT_REGEX_STR)));
     EXPECT_FALSE(std::regex_match(timestamp, std::regex(DATE_FORMAT_REGEX_STR)));
 }
 
 TEST_F(TimeUtilsTest, CheckCompactTimestampValidFormat)
 {
-    constexpr auto DATE_FORMAT_REGEX_STR { "[0-9]{4}/([0-9]|1[0-2]){2}/(([0-9]|1[0-2]){2}) (([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2})" };
-    constexpr auto COMPACT_FORMAT_REGEX_STR { "[0-9]{4}([0-9]|1[0-2]){2}(([0-9]|1[0-2]){2})(([0-9]|1[0-2]){2})(([0-9]|1[0-2]){2})(([0-9]|1[0-2]){2})" };
-    const auto currentTimestamp { Utils::getCurrentTimestamp() };
-    const auto timestamp { Utils::getCompactTimestamp(std::time(nullptr)) };
+    constexpr auto DATE_FORMAT_REGEX_STR {
+        "[0-9]{4}/([0-9]|1[0-2]){2}/(([0-9]|1[0-2]){2}) (([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2})"};
+    constexpr auto COMPACT_FORMAT_REGEX_STR {
+        "[0-9]{4}([0-9]|1[0-2]){2}(([0-9]|1[0-2]){2})(([0-9]|1[0-2]){2})(([0-9]|1[0-2]){2})(([0-9]|1[0-2]){2})"};
+    const auto currentTimestamp {Utils::getCurrentTimestamp()};
+    const auto timestamp {Utils::getCompactTimestamp(std::time(nullptr))};
     EXPECT_TRUE(std::regex_match(currentTimestamp, std::regex(DATE_FORMAT_REGEX_STR))) << timestamp;
     EXPECT_TRUE(std::regex_match(timestamp, std::regex(COMPACT_FORMAT_REGEX_STR)));
 }
 
 TEST_F(TimeUtilsTest, CheckCompactTimestampInvalidFormat)
 {
-    constexpr auto DATE_FORMAT_REGEX_STR { "[0-9]{4}/([1-9]|1[0-2])/([1-9]|[1-2][0-9]|3[0-1])(2[0-3]|1[0-9]|[0-9]):([0-9]|[1-5][0-9]):([1-5][0-9]|[0-9])" };
-    const auto currentTimestamp { Utils::getCurrentTimestamp() };
-    const auto timestamp { Utils::getCompactTimestamp(std::time(nullptr)) };
+    constexpr auto DATE_FORMAT_REGEX_STR {
+        "[0-9]{4}/([1-9]|1[0-2])/([1-9]|[1-2][0-9]|3[0-1])(2[0-3]|1[0-9]|[0-9]):([0-9]|[1-5][0-9]):([1-5][0-9]|[0-9])"};
+    const auto currentTimestamp {Utils::getCurrentTimestamp()};
+    const auto timestamp {Utils::getCompactTimestamp(std::time(nullptr))};
     EXPECT_FALSE(std::regex_match(currentTimestamp, std::regex(DATE_FORMAT_REGEX_STR)));
     EXPECT_FALSE(std::regex_match(timestamp, std::regex(DATE_FORMAT_REGEX_STR)));
+}
+
+TEST_F(TimeUtilsTest, TimestampToISO8601)
+{
+    EXPECT_EQ("2020-12-28T18:00:00.000Z", Utils::timestampToISO8601("2020/12/28 15:00:00"));
+    EXPECT_EQ("2020-12-29T00:00:00.000Z", Utils::timestampToISO8601("2020/12/28 21:00:00"));
 }

--- a/src/shared_modules/utils/tests/timeHelper_test.cpp
+++ b/src/shared_modules/utils/tests/timeHelper_test.cpp
@@ -72,3 +72,8 @@ TEST_F(TimeUtilsTest, TimestampToISO8601)
     EXPECT_EQ("2020-12-28T18:00:00.000Z", Utils::timestampToISO8601("2020/12/28 15:00:00"));
     EXPECT_EQ("2020-12-29T00:00:00.000Z", Utils::timestampToISO8601("2020/12/28 21:00:00"));
 }
+
+TEST_F(TimeUtilsTest, RawTimestampToISO8601)
+{
+    EXPECT_EQ("2020-11-13T01:54:25.000Z", Utils::rawTimestampToISO8601("1605232465"));
+}

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -117,6 +117,24 @@ namespace Utils
         return output.str();
     }
 
+    static std::string rawTimestampToISO8601(const std::string& timestamp)
+    {
+        std::time_t time = std::stoi(timestamp);
+        auto itt = std::chrono::system_clock::from_time_t(time);
+
+        std::ostringstream output;
+        output << std::put_time(gmtime(&time), "%FT%T");
+
+        // Get milliseconds from the current time
+        auto milliseconds =
+            std::chrono::duration_cast<std::chrono::milliseconds>(itt.time_since_epoch()).count() % 1000;
+
+        // ISO 8601
+        output << '.' << std::setfill('0') << std::setw(3) << milliseconds << 'Z';
+
+        return output.str();
+    }
+
 #pragma GCC diagnostic pop
 } // namespace Utils
 

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -90,6 +90,33 @@ namespace Utils
 
         return ss.str();
     }
+
+    static std::string timestampToISO8601(const std::string& timestamp)
+    {
+        std::tm tm {};
+        std::istringstream ss(timestamp);
+        ss >> std::get_time(&tm, "%Y/%m/%d %H:%M:%S");
+        if (ss.fail())
+        {
+            return "";
+        }
+        std::time_t time = std::mktime(&tm);
+
+        auto itt = std::chrono::system_clock::from_time_t(time);
+
+        std::ostringstream output;
+        output << std::put_time(gmtime(&time), "%FT%T");
+
+        // Get milliseconds from the current time
+        auto milliseconds =
+            std::chrono::duration_cast<std::chrono::milliseconds>(itt.time_since_epoch()).count() % 1000;
+
+        // ISO 8601
+        output << '.' << std::setfill('0') << std::setw(3) << milliseconds << 'Z';
+
+        return output.str();
+    }
+
 #pragma GCC diagnostic pop
 } // namespace Utils
 

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -12,6 +12,7 @@
 #ifndef _TIME_HELPER_H
 #define _TIME_HELPER_H
 
+#include "stringHelper.h"
 #include <chrono>
 #include <ctime>
 #include <iomanip>
@@ -119,6 +120,11 @@ namespace Utils
 
     static std::string rawTimestampToISO8601(const std::string& timestamp)
     {
+        if (timestamp.empty() || !Utils::isNumber(timestamp))
+        {
+            return "";
+        }
+
         std::time_t time = std::stoi(timestamp);
         auto itt = std::chrono::system_clock::from_time_t(time);
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -52,9 +52,14 @@ public:
         package["checksum"] = "";      // TODO: Add checksum.
         package["description"] = data->packageDescription();
         package["install_scope"] = ""; // TODO: Add install scope.
+
         if (!data->packageInstallTime().empty())
         {
-            package["install_time"] = data->packageInstallTime();
+            const auto installTime {Utils::timestampToISO8601(data->packageInstallTime().data())};
+            if (!installTime.empty())
+            {
+                package["installed"] = installTime;
+            }
         }
         package["license"] = ""; // TODO: Add license.
         package["name"] = data->packageName();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -55,7 +55,7 @@ public:
 
         if (!data->packageInstallTime().empty())
         {
-            const auto installTime {Utils::timestampToISO8601(data->packageInstallTime().data())};
+            const auto installTime {Utils::rawTimestampToISO8601(data->packageInstallTime().data())};
             if (!installTime.empty())
             {
                 package["installed"] = installTime;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21037|

## Description

This pr aims to solve an invalid name definition during the population of some fields in the payload used to index data into wazuh-indexer.