### PR TITLE
Update 0810-sysmon_id_3.xml

### DIFF
--- a/ruleset/rules/0810-sysmon_id_3.xml
+++ b/ruleset/rules/0810-sysmon_id_3.xml
@@ -82,7 +82,7 @@
 
   <rule id="92108" level="0">
     <if_group>sysmon_event3</if_group>
-    <field name="win.eventdata.destinationPort" type="pcre2">3389</field>
+    <field name="win.eventdata.destinationPort">^3389$</field>
     <options>no_full_log</options>
     <description>Detected RDP port network activity from $(win.eventdata.sourceIp) to $(win.eventdata.destinationIp)</description>
     <mitre>


### PR DESCRIPTION
|Related issue|
|---|
|#21321|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Fixing false-positive prone 92108 that matches destination port with substring 3389 rather than absolute string 3389.
We are seeing hits on the original 92108 rule where the destination port is something like 23389 or 33891 which is clearly not the intent of the rule.
<!--
Add a clear description of how the problem has been solved.
-->

<!--
When proceed, this section should include new configuration parameters.
-->
<!--
Paste here related logs and alerts
-->

## Tests
<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors