### PR TITLE
Implement solved vulnerability alerts

### DIFF
--- a/ruleset/rules/0520-vulnerability-detector_rules.xml
+++ b/ruleset/rules/0520-vulnerability-detector_rules.xml
@@ -52,4 +52,11 @@
       <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
+  <rule id="23507" level="3">
+    <decoded_as>json</decoded_as>
+    <options>no_full_log</options>
+    <field name="vulnerability.status">Clear</field>
+    <description>Vulnerabilities cleared</description>
+  </rule>
+
 </group>

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -25,6 +25,8 @@
 class DetailsAugmentation final : public AbstractHandler<std::shared_ptr<ScanContext>>
 {
 private:
+    // TODO: Add UTs for this class.
+    // LCOV_EXCL_START
     std::shared_ptr<DatabaseFeedManager> m_databaseFeedManager;
     void indexedDataAugmentation(std::shared_ptr<ScanContext> data)
     {
@@ -191,6 +193,7 @@ private:
             data->m_alerts.emplace(std::make_pair("clear", report));
         }
     }
+    // LCOV_EXCL_STOP
 
 public:
     // LCOV_EXCL_START

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -28,7 +28,7 @@ private:
     std::shared_ptr<DatabaseFeedManager> m_databaseFeedManager;
     void indexedDataAugmentation(std::shared_ptr<ScanContext> data)
     {
-        if (data->getType() == ScannerType::PackageDelete)
+        if (data->getType() == ScannerType::PackageDelete || data->getType() == ScannerType::PackagesClear)
         {
             return;
         }
@@ -142,41 +142,53 @@ private:
 
     void alertedDataAugmentation(std::shared_ptr<ScanContext> data)
     {
-        nlohmann::json package;
-        package["architecture"] = data->packageArchitecture();
-        package["name"] = data->packageName();
-        package["version"] = data->packageVersion();
-
-        if (data->getType() == ScannerType::PackageInsert)
+        if (data->getType() != ScannerType::PackagesClear)
         {
-            package["description"] = data->packageDescription();
-            if (!data->packageInstallTime().empty())
+            nlohmann::json package;
+            package["architecture"] = data->packageArchitecture();
+            package["name"] = data->packageName();
+            package["version"] = data->packageVersion();
+
+            if (data->getType() == ScannerType::PackageInsert)
             {
-                package["install_time"] = data->packageInstallTime();
+                package["description"] = data->packageDescription();
+                if (!data->packageInstallTime().empty())
+                {
+                    package["install_time"] = data->packageInstallTime();
+                }
+                package["path"] = data->packageLocation();
+                package["size"] = data->packageSize();
+                package["type"] = data->packageFormat();
             }
-            package["path"] = data->packageLocation();
-            package["size"] = data->packageSize();
-            package["type"] = data->packageFormat();
+
+            for (auto& [cve, json] : data->m_alerts)
+            {
+                FlatbufferDataPair<VulnerabilityDescription> returnData;
+                m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, returnData);
+                if (returnData.data)
+                {
+                    json["vulnerability"]["package"] = package;
+                    json["vulnerability"]["category"] = "Packages";
+                    json["vulnerability"]["classification"] = returnData.data->classification()->str();
+                    json["vulnerability"]["description"] = returnData.data->description()->str();
+                    json["vulnerability"]["enumeration"] = "CVE";
+                    json["vulnerability"]["cve"] = cve;
+                    json["vulnerability"]["reference"] = returnData.data->reference()->str();
+                    json["vulnerability"]["severity"] = Utils::toSentenceCase(returnData.data->severity()->str());
+                    json["vulnerability"]["score"]["base"] = Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
+                    json["vulnerability"]["score"]["version"] = returnData.data->scoreVersion()->str();
+                    json["vulnerability"]["status"] =
+                        data->getType() == ScannerType::PackageInsert ? "Active" : "Solved";
+                }
+            }
         }
-
-        for (auto& [cve, json] : data->m_alerts)
+        else
         {
-            FlatbufferDataPair<VulnerabilityDescription> returnData;
-            m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, returnData);
-            if (returnData.data)
-            {
-                json["vulnerability"]["package"] = package;
-                json["vulnerability"]["category"] = "Packages";
-                json["vulnerability"]["classification"] = returnData.data->classification()->str();
-                json["vulnerability"]["description"] = returnData.data->description()->str();
-                json["vulnerability"]["enumeration"] = "CVE";
-                json["vulnerability"]["cve"] = cve;
-                json["vulnerability"]["reference"] = returnData.data->reference()->str();
-                json["vulnerability"]["severity"] = Utils::toSentenceCase(returnData.data->severity()->str());
-                json["vulnerability"]["score"]["base"] = Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
-                json["vulnerability"]["score"]["version"] = returnData.data->scoreVersion()->str();
-                json["vulnerability"]["status"] = data->getType() == ScannerType::PackageInsert ? "Active" : "Solved";
-            }
+            nlohmann::json report;
+            report["vulnerability"]["category"] = "Packages";
+            report["vulnerability"]["status"] = "Clear";
+
+            data->m_alerts.emplace(std::make_pair("clear", report));
         }
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -26,26 +26,13 @@ class DetailsAugmentation final : public AbstractHandler<std::shared_ptr<ScanCon
 {
 private:
     std::shared_ptr<DatabaseFeedManager> m_databaseFeedManager;
+    void indexedDataAugmentation(std::shared_ptr<ScanContext> data)
+    {
+        if (data->getType() == ScannerType::PackageDelete)
+        {
+            return;
+        }
 
-public:
-    // LCOV_EXCL_START
-    /**
-     * @brief DetailsAugmentation constructor.
-     *
-     * @param databaseFeedManager Database feed manager.
-     */
-    explicit DetailsAugmentation(std::shared_ptr<DatabaseFeedManager>& databaseFeedManager)
-        : m_databaseFeedManager(databaseFeedManager)
-    {
-    }
-    /**
-     * @brief Handles request and passes control to the next step of the chain.
-     *
-     * @param data Scan context.
-     * @return std::shared_ptr<ScanContext> Abstract handler.
-     */
-    std::shared_ptr<ScanContext> handleRequest(std::shared_ptr<ScanContext> data) override
-    {
         nlohmann::json package;
         package["architecture"] = data->packageArchitecture();
         package["build_version"] = ""; // TODO: Add build version.
@@ -151,6 +138,69 @@ public:
                 json["data"] = ecsData;
             }
         }
+    }
+
+    void alertedDataAugmentation(std::shared_ptr<ScanContext> data)
+    {
+        nlohmann::json package;
+        package["architecture"] = data->packageArchitecture();
+        package["name"] = data->packageName();
+        package["version"] = data->packageVersion();
+
+        if (data->getType() == ScannerType::PackageInsert)
+        {
+            package["description"] = data->packageDescription();
+            if (!data->packageInstallTime().empty())
+            {
+                package["install_time"] = data->packageInstallTime();
+            }
+            package["path"] = data->packageLocation();
+            package["size"] = data->packageSize();
+            package["type"] = data->packageFormat();
+        }
+
+        for (auto& [cve, json] : data->m_alerts)
+        {
+            FlatbufferDataPair<VulnerabilityDescription> returnData;
+            m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, returnData);
+            if (returnData.data)
+            {
+                json["vulnerability"]["package"] = package;
+                json["vulnerability"]["category"] = "Packages";
+                json["vulnerability"]["classification"] = returnData.data->classification()->str();
+                json["vulnerability"]["description"] = returnData.data->description()->str();
+                json["vulnerability"]["enumeration"] = "CVE";
+                json["vulnerability"]["cve"] = cve;
+                json["vulnerability"]["reference"] = returnData.data->reference()->str();
+                json["vulnerability"]["severity"] = Utils::toSentenceCase(returnData.data->severity()->str());
+                json["vulnerability"]["score"]["base"] = Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
+                json["vulnerability"]["score"]["version"] = returnData.data->scoreVersion()->str();
+                json["vulnerability"]["status"] = data->getType() == ScannerType::PackageInsert ? "Active" : "Solved";
+            }
+        }
+    }
+
+public:
+    // LCOV_EXCL_START
+    /**
+     * @brief DetailsAugmentation constructor.
+     *
+     * @param databaseFeedManager Database feed manager.
+     */
+    explicit DetailsAugmentation(std::shared_ptr<DatabaseFeedManager>& databaseFeedManager)
+        : m_databaseFeedManager(databaseFeedManager)
+    {
+    }
+    /**
+     * @brief Handles request and passes control to the next step of the chain.
+     *
+     * @param data Scan context.
+     * @return std::shared_ptr<ScanContext> Abstract handler.
+     */
+    std::shared_ptr<ScanContext> handleRequest(std::shared_ptr<ScanContext> data) override
+    {
+        indexedDataAugmentation(data);
+        alertedDataAugmentation(data);
 
         return AbstractHandler<std::shared_ptr<ScanContext>>::handleRequest(data);
     }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -30,7 +30,7 @@ private:
     std::shared_ptr<DatabaseFeedManager> m_databaseFeedManager;
     void indexedDataAugmentation(std::shared_ptr<ScanContext> data)
     {
-        if (data->getType() == ScannerType::PackageDelete || data->getType() == ScannerType::PackagesClear)
+        if (data->getType() == ScannerType::PackageDelete || data->getType() == ScannerType::IntegrityClear)
         {
             return;
         }
@@ -144,7 +144,7 @@ private:
 
     void alertedDataAugmentation(std::shared_ptr<ScanContext> data)
     {
-        if (data->getType() != ScannerType::PackagesClear)
+        if (data->getType() != ScannerType::IntegrityClear)
         {
             nlohmann::json package;
             package["architecture"] = data->packageArchitecture();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
@@ -59,6 +59,8 @@ public:
         }
         else if (type == ScannerType::PackageDelete)
         {
+            orchestration = std::make_shared<PackageScanner>(databaseFeedManager);
+            orchestration->setLast(std::make_shared<DetailsAugmentation>(databaseFeedManager));
         }
         else if (type == ScannerType::HotfixInsert)
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
@@ -62,7 +62,7 @@ public:
             orchestration = std::make_shared<PackageScanner>(databaseFeedManager);
             orchestration->setLast(std::make_shared<DetailsAugmentation>(databaseFeedManager));
         }
-        else if (type == ScannerType::PackagesClear)
+        else if (type == ScannerType::IntegrityClear)
         {
             orchestration = std::make_shared<DetailsAugmentation>(databaseFeedManager);
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
@@ -62,6 +62,10 @@ public:
             orchestration = std::make_shared<PackageScanner>(databaseFeedManager);
             orchestration->setLast(std::make_shared<DetailsAugmentation>(databaseFeedManager));
         }
+        else if (type == ScannerType::PackagesClear)
+        {
+            orchestration = std::make_shared<DetailsAugmentation>(databaseFeedManager);
+        }
         else if (type == ScannerType::HotfixInsert)
         {
             std::cout << "Hotfix insert scanner Init" << std::endl;
@@ -98,6 +102,7 @@ public:
 
         orchestration->setLast(std::make_shared<SendReport>(reportSocketClient));
         orchestration->setLast(std::make_shared<ResultIndexer>(indexerConnector));
+
         return orchestration;
     }
     // LCOV_EXCL_STOP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
@@ -46,6 +46,11 @@ public:
      */
     std::shared_ptr<ScanContext> handleRequest(std::shared_ptr<ScanContext> data) override
     {
+        if (data->operationType() == OperationType::Clear)
+        {
+            return AbstractHandler<std::shared_ptr<ScanContext>>::handleRequest(data);
+        }
+
         std::string agentPackageKey;
         agentPackageKey.append(data->agentNodeName());
         agentPackageKey.append("_");

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
@@ -46,7 +46,7 @@ public:
      */
     std::shared_ptr<ScanContext> handleRequest(std::shared_ptr<ScanContext> data) override
     {
-        if (data->operationType() == OperationType::Clear)
+        if (data->operationType() == OperationType::DeleteAll)
         {
             return AbstractHandler<std::shared_ptr<ScanContext>>::handleRequest(data);
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
@@ -46,11 +46,6 @@ public:
      */
     std::shared_ptr<ScanContext> handleRequest(std::shared_ptr<ScanContext> data) override
     {
-        if (data->operationType() == OperationType::DeleteAll)
-        {
-            return AbstractHandler<std::shared_ptr<ScanContext>>::handleRequest(data);
-        }
-
         std::string agentPackageKey;
         agentPackageKey.append(data->agentNodeName());
         agentPackageKey.append("_");

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -84,6 +84,7 @@ public:
                                       versionStringLessThanOrEqual.c_str());
 
                             data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
+                            data->m_alerts[callbackData.cveId()->str()] = nlohmann::json::object();
                             return true;
                         }
                         else
@@ -114,6 +115,7 @@ public:
                                           versionStringLessThanOrEqual.c_str());
 
                                 data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
+                                data->m_alerts[callbackData.cveId()->str()] = nlohmann::json::object();
                                 return true;
                             }
                             else
@@ -142,6 +144,7 @@ public:
                           callbackData.cveId()->str().c_str());
 
                 data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
+                data->m_alerts[callbackData.cveId()->str()] = nlohmann::json::object();
                 return true;
             }
             else
@@ -172,7 +175,7 @@ public:
                     e.what());
         }
 
-        if (data->m_elements.empty())
+        if (data->m_alerts.empty())
         {
             return nullptr;
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -809,6 +809,12 @@ public:
      * @brief Elements to process.
      */
     std::unordered_map<std::string, nlohmann::json> m_elements;
+
+    /**
+     * @brief Elements for alerts.
+     *
+     */
+    std::unordered_map<std::string, nlohmann::json> m_alerts;
     // LCOV_EXCL_STOP
 private:
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
@@ -32,6 +32,10 @@ void ScanOrchestrator::run(
         {
             m_packageDeleteOrchestration->handleRequest(context);
         }
+        else if (type == ScannerType::PackagesClear)
+        {
+            m_packagesClearOrchestration->handleRequest(context);
+        }
         else if (type == ScannerType::HotfixInsert)
         {
             std::cout << "ScanOrchestrator::run::HotfixInserted" << std::endl;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.cpp
@@ -32,7 +32,7 @@ void ScanOrchestrator::run(
         {
             m_packageDeleteOrchestration->handleRequest(context);
         }
-        else if (type == ScannerType::PackagesClear)
+        else if (type == ScannerType::IntegrityClear)
         {
             m_packagesClearOrchestration->handleRequest(context);
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -79,6 +79,7 @@ private:
     std::shared_ptr<AbstractHandler<std::shared_ptr<ScanContext>>> m_osOrchestration;
     std::shared_ptr<AbstractHandler<std::shared_ptr<ScanContext>>> m_packageInsertOrchestration;
     std::shared_ptr<AbstractHandler<std::shared_ptr<ScanContext>>> m_packageDeleteOrchestration;
+    std::shared_ptr<AbstractHandler<std::shared_ptr<ScanContext>>> m_packagesClearOrchestration;
     std::shared_ptr<AbstractHandler<std::shared_ptr<ScanContext>>> m_hotfixInsertOrchestration;
     std::shared_ptr<AbstractHandler<std::shared_ptr<ScanContext>>> m_hotfixDeleteOrchestration;
     std::shared_ptr<AbstractHandler<std::shared_ptr<ScanContext>>> m_integrityClearOrchestration;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/sendReport.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/sendReport.hpp
@@ -57,7 +57,9 @@ public:
                 const std::string message = oss.str();
                 logDebug2(WM_VULNSCAN_LOGTAG,
                           "Vulnerability %s report: %s",
-                          data->getType() == ScannerType::PackageInsert ? "detected" : "solved",
+                          data->getType() == ScannerType::PackageInsert   ? "detected"
+                          : data->getType() == ScannerType::PackageDelete ? "solved"
+                                                                          : "clear",
                           message.c_str());
                 m_reportSocketClient->send(message.c_str(), message.size());
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/sendReport.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/sendReport.hpp
@@ -40,39 +40,40 @@ public:
      */
     std::shared_ptr<ScanContext> handleRequest(std::shared_ptr<ScanContext> data) override
     {
-        for (const auto& [key, value] : data->m_elements)
+        for (const auto& [key, value] : data->m_alerts)
         {
             try
             {
                 std::ostringstream oss;
-                nlohmann::json vulnerabilityReport;
-
-                vulnerabilityReport["vulnerability"] = value.at("data").at("vulnerability");
-                vulnerabilityReport["vulnerability"]["cve"] = value.at("data").at("vulnerability").at("id");
-                vulnerabilityReport["vulnerability"].erase("id");
-                vulnerabilityReport["vulnerability"]["status"] = "Active";
-                vulnerabilityReport["vulnerability"]["package"] = value.at("data").at("package");
 
                 // 1:[001] (agent_name) ip->location:
                 oss << LOCALFILE_MQ << ":"
-                    << "[" << value.at("data").at("agent").at("id").get_ref<const std::string&>() << "] ("
-                    << value.at("data").at("agent").at("name").get_ref<const std::string&>() << ") "
+                    << "[" << std::string(data->agentId()) << "] (" << std::string(data->agentName()) << ") "
                     << std::string(data->agentIp()) << "->" << VS_WM_NAME
                     << ":"
                     // Vulnerability report.
-                    << vulnerabilityReport.dump();
+                    << value.dump().c_str();
 
                 const std::string message = oss.str();
-                logDebug2(WM_VULNSCAN_LOGTAG, "REPORT: %s", message.c_str());
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Vulnerability %s report: %s",
+                          data->getType() == ScannerType::PackageInsert ? "detected" : "solved",
+                          message.c_str());
                 m_reportSocketClient->send(message.c_str(), message.size());
 
                 std::this_thread::sleep_for(std::chrono::microseconds(SOCKET_WAIT));
             }
             catch (...)
             {
-                logWarn(WM_VULNSCAN_LOGTAG, "Couldn't send vulnerability JSON report");
+                logWarn(WM_VULNSCAN_LOGTAG, "Couldn't send vulnerability JSON report for %s:", key.c_str());
             }
         }
+
+        if (data->m_elements.empty())
+        {
+            return nullptr;
+        }
+
         return AbstractHandler<std::shared_ptr<ScanContext>>::handleRequest(data);
     }
     // LCOV_EXCL_STOP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
@@ -10,6 +10,8 @@
  */
 
 #include "sendReport_test.hpp"
+#include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_generated.h"
+#include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_schema.h"
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_synchronization_generated.h"
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_synchronization_schema.h"
 #include "../scanOrchestrator/sendReport.hpp"
@@ -22,7 +24,7 @@
 const std::string TEST_PATH {"/tmp/socket"};
 const size_t MAX_RETRIES {10};
 
-const std::string SYNC_MSG =
+const std::string SYNC_STATE_MSG {
     R"(
             {
                 "agent_info": {
@@ -55,8 +57,9 @@ const std::string SYNC_MSG =
                     "timestamp": ""
                 }
             }
-        )";
-const std::string DETECTION_STR =
+        )"};
+
+const std::string SYNC_STATE_ALERT {
     R"(
         {
             "vulnerability": {
@@ -91,7 +94,89 @@ const std::string DETECTION_STR =
                 "status": "Active"
             }
         }
-    )";
+    )"};
+
+const std::string INTEGRITY_CLEAR_MSG {
+    R"(
+            {
+                "agent_info": {
+                    "agent_id": "001",
+                    "agent_ip": "192.168.33.20",
+                    "agent_name": "focal",
+                    "node_name": "node01"
+                },
+                "data_type": "integrity_clear",
+                "data": {
+                    "attributes_type": "syscollector_packages",
+                    "id": 1700236640
+                }
+            }
+        )"};
+
+const std::string INTEGRITY_CLEAR_ALERT {
+    R"(
+        {
+            "vulnerability": {
+                "category": "Packages",
+                "status": "Clear"
+            }
+        }
+    )"};
+
+const std::string DELTA_DELETE_MSG {
+    R"(
+            {
+                "agent_info": {
+                    "agent_id": "001",
+                    "agent_ip": "192.168.33.20",
+                    "agent_name": "focal",
+                    "node_name": "node01"
+                },
+                "data_type": "dbsync_packages",
+                "data": {
+                    "architecture": "amd64",
+                    "checksum": "dfc12dd72d4b32c6b2c6b598c1999f8578c2ee89",
+                    "description": "Text editor",
+                    "format": "deb",
+                    "groups": "editors",
+                    "item_id": "772cafce68754b17864ade66be2d66730b5706e4",
+                    "multiarch": "foreign",
+                    "name": "vim",
+                    "priority": "important",
+                    "scan_time": "2023/08/04 20:03:45",
+                    "size": 205,
+                    "source": "vim",
+                    "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+                    "version": "2:8.1.2269-1ubuntu5.21"
+                },
+                "operation": "DELETED"
+            }
+    )"};
+
+const std::string DELTA_DELETE_ALERT {
+    R"(
+            {
+                "vulnerability": {
+                    "category": "Packages",
+                    "classification": "CVSS",
+                    "cve": "CVE-2023-5441",
+                    "description": "NULL Pointer Dereference in GitHub repository vim/vim prior to 20d161ace307e28690229b68584f2d84556f8960.",
+                    "enumeration": "CVE",
+                    "package": {
+                        "architecture": "amd64",
+                        "name": "vim",
+                        "version": "2:8.1.2269-1ubuntu5.21"
+                    },
+                    "reference": "https://huntr.dev/bounties/b54cbdf5-3e85-458d-bb38-9ea2c0b669f2, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VDDWD25AZIHBAA44HQT75OWLQ5UMDKU3/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VGTVLUV7UCXXCZAIQIUCLG6JXAVYT3HE/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XPT7NMYJRLBPIALGSE24UWTY6F774GZW/, https://github.com/vim/vim/commit/20d161ace307e28690229b68584f2d84556f8960",
+                    "score": {
+                    "base": "6.200000",
+                    "version": "3.0"
+                    },
+                    "severity": "Medium",
+                    "status": "Solved"
+                }
+            }
+        )"};
 
 TEST_F(SendReportTest, SendFormattedMsg)
 {
@@ -161,12 +246,12 @@ TEST_F(SendReportTest, SendFormattedMsg)
     // Mock scanContext.
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
-    ASSERT_TRUE(parser.Parse(SYNC_MSG.c_str()));
+    ASSERT_TRUE(parser.Parse(SYNC_STATE_MSG.c_str()));
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorSync =
         SyscollectorSynchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
     auto scanContext = std::make_shared<ScanContext>(syscollectorSync);
-    nlohmann::json detectionJson = nlohmann::json::parse(DETECTION_STR);
+    nlohmann::json detectionJson = nlohmann::json::parse(SYNC_STATE_ALERT);
     scanContext->m_alerts["CVE-2020-14343"] = detectionJson;
 
     // Send report.
@@ -246,12 +331,12 @@ TEST_F(SendReportTest, InvalidEncodingValue)
     // Mock scanContext.
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
-    ASSERT_TRUE(parser.Parse(SYNC_MSG.c_str()));
+    ASSERT_TRUE(parser.Parse(SYNC_STATE_MSG.c_str()));
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorSync =
         SyscollectorSynchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
     auto scanContext = std::make_shared<ScanContext>(syscollectorSync);
-    nlohmann::json detectionJson = nlohmann::json::parse(DETECTION_STR);
+    nlohmann::json detectionJson = nlohmann::json::parse(SYNC_STATE_ALERT);
     detectionJson["data"]["package"]["name"] = "\xAA";
     scanContext->m_alerts["CVE-2020-14343"] = detectionJson;
 
@@ -260,6 +345,169 @@ TEST_F(SendReportTest, InvalidEncodingValue)
 
     // The report was not sent. A dummy message is sent to close the server socket.
     send(socketClient->getSocketDescriptor(), expectedString.c_str(), expectedString.size(), 0);
+
+    thread.join();
+}
+
+TEST_F(SendReportTest, SendFormattedClearMsg)
+{
+    const std::string report = R"({"vulnerability":{"category":"Packages","status":"Clear"}})";
+    std::string expectedStr = "1:[001] (focal) 192.168.33.20->vulnerability-scanner:" + report;
+
+    // Fake socket server
+    auto thread = std::thread(
+        [&]()
+        {
+            struct sockaddr_un serverAddr
+            {
+            };
+            struct sockaddr_un clientAddr
+            {
+            };
+
+            int socketServer = socket(AF_UNIX, SOCK_DGRAM, 0);
+            ASSERT_NE(socketServer, -1);
+
+            serverAddr.sun_family = AF_UNIX;
+            std::strcpy(serverAddr.sun_path, TEST_PATH.c_str());
+
+            ASSERT_NE(bind(socketServer, (struct sockaddr*)&serverAddr, sizeof(serverAddr)), -1);
+
+            char buffer[65536];
+            size_t bytesReceived;
+            socklen_t clientSize = sizeof(clientAddr);
+
+            bytesReceived =
+                recvfrom(socketServer, buffer, sizeof(buffer), 0, (struct sockaddr*)&clientAddr, &clientSize);
+
+            ASSERT_NE(bytesReceived, -1);
+            buffer[bytesReceived] = '\0';
+
+            EXPECT_STREQ(buffer, expectedStr.c_str());
+
+            close(socketServer);
+            std::filesystem::remove(TEST_PATH);
+        });
+
+    // Socket client instance.
+    std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> socketClient =
+        std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(TEST_PATH);
+
+    // Wait for server.
+    struct stat fileStat
+    {
+    };
+    int statRet;
+    size_t retries = 0;
+    do
+    {
+        ++retries;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100 * retries));
+        statRet = stat(TEST_PATH.c_str(), &fileStat);
+    } while (statRet != 0 && retries < MAX_RETRIES);
+
+    // Connect to server.
+    socketClient->connect(
+        [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader) {}, []() {}, SOCK_DGRAM);
+
+    // Send report instance.
+    SendReport sendReport(socketClient);
+
+    // Mock scanContext.
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
+    ASSERT_TRUE(parser.Parse(INTEGRITY_CLEAR_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorSync =
+        SyscollectorSynchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
+    auto scanContext = std::make_shared<ScanContext>(syscollectorSync);
+    nlohmann::json detectionJson = nlohmann::json::parse(INTEGRITY_CLEAR_ALERT);
+    scanContext->m_alerts["CVE-2020-14343"] = detectionJson;
+
+    // Send report.
+    sendReport.handleRequest(scanContext);
+
+    thread.join();
+}
+
+TEST_F(SendReportTest, SendFormattedDeltaMsg)
+{
+    const std::string report =
+        R"({"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2023-5441","description":"NULL Pointer Dereference in GitHub repository vim/vim prior to 20d161ace307e28690229b68584f2d84556f8960.","enumeration":"CVE","package":{"architecture":"amd64","name":"vim","version":"2:8.1.2269-1ubuntu5.21"},"reference":"https://huntr.dev/bounties/b54cbdf5-3e85-458d-bb38-9ea2c0b669f2, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VDDWD25AZIHBAA44HQT75OWLQ5UMDKU3/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VGTVLUV7UCXXCZAIQIUCLG6JXAVYT3HE/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XPT7NMYJRLBPIALGSE24UWTY6F774GZW/, https://github.com/vim/vim/commit/20d161ace307e28690229b68584f2d84556f8960","score":{"base":"6.200000","version":"3.0"},"severity":"Medium","status":"Solved"}})";
+    std::string expectedStr = "1:[001] (focal) 192.168.33.20->vulnerability-scanner:" + report;
+
+    // Fake socket server
+    auto thread = std::thread(
+        [&]()
+        {
+            struct sockaddr_un serverAddr
+            {
+            };
+            struct sockaddr_un clientAddr
+            {
+            };
+
+            int socketServer = socket(AF_UNIX, SOCK_DGRAM, 0);
+            ASSERT_NE(socketServer, -1);
+
+            serverAddr.sun_family = AF_UNIX;
+            std::strcpy(serverAddr.sun_path, TEST_PATH.c_str());
+
+            ASSERT_NE(bind(socketServer, (struct sockaddr*)&serverAddr, sizeof(serverAddr)), -1);
+
+            char buffer[65536];
+            size_t bytesReceived;
+            socklen_t clientSize = sizeof(clientAddr);
+
+            bytesReceived =
+                recvfrom(socketServer, buffer, sizeof(buffer), 0, (struct sockaddr*)&clientAddr, &clientSize);
+
+            ASSERT_NE(bytesReceived, -1);
+            buffer[bytesReceived] = '\0';
+
+            EXPECT_STREQ(buffer, expectedStr.c_str());
+
+            close(socketServer);
+            std::filesystem::remove(TEST_PATH);
+        });
+
+    // Socket client instance.
+    std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> socketClient =
+        std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(TEST_PATH);
+
+    // Wait for server.
+    struct stat fileStat
+    {
+    };
+    int statRet;
+    size_t retries = 0;
+    do
+    {
+        ++retries;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100 * retries));
+        statRet = stat(TEST_PATH.c_str(), &fileStat);
+    } while (statRet != 0 && retries < MAX_RETRIES);
+
+    // Connect to server.
+    socketClient->connect(
+        [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader) {}, []() {}, SOCK_DGRAM);
+
+    // Send report instance.
+    SendReport sendReport(socketClient);
+
+    // Mock scanContext.
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_DELETE_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorDelta =
+        SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+    auto scanContext = std::make_shared<ScanContext>(syscollectorDelta);
+    nlohmann::json detectionJson = nlohmann::json::parse(DELTA_DELETE_ALERT);
+    scanContext->m_alerts["CVE-2023-5441"] = detectionJson;
+
+    // Send report.
+    sendReport.handleRequest(scanContext);
 
     thread.join();
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
@@ -20,7 +20,7 @@
 #include "socketServer.hpp"
 
 const std::string TEST_PATH {"/tmp/socket"};
-const size_t MAX_RETRIES {1000};
+const size_t MAX_RETRIES {10};
 
 const std::string SYNC_MSG =
     R"(
@@ -56,68 +56,47 @@ const std::string SYNC_MSG =
                 }
             }
         )";
-
 const std::string DETECTION_STR =
     R"(
         {
-            "data": {
-                "agent": {
-                "build": {
-                    "original": "40800"
-                },
-                "ephemeral_id": "node01",
-                "id": "001",
-                "name": "focal",
-                "type": "wazuh",
-                "version": "4.8.0"
-                },
-                "ecs": {
-                "version": "8.11.0"
-                },
-                "package": {
-                "architecture": " ",
-                "build_version": "",
-                "checksum": "",
-                "description": " ",
-                "install_scope": "",
-                "install_time": " ",
-                "license": "",
-                "name": "PyYAML",
-                "path": "/usr/lib/python3/dist-packages/PyYAML-5.3.1.egg-info",
-                "reference": "",
-                "size": 0,
-                "type": "pypi",
-                "version": "5.3.1"
-                },
-                "vulnerability": {
+            "vulnerability": {
                 "category": "Packages",
                 "classification": "CVSS",
+                "cve": "CVE-2020-14343",
                 "description": "A vulnerability was discovered in the PyYAML library in versions before 5.4, where it is susceptible to arbitrary code execution when it processes untrusted YAML files through the full_load method or with the FullLoader loader. Applications that use the library to process untrusted input may be vulnerable to this flaw. This flaw allows an attacker to execute arbitrary code on the system by abusing the python/object/new constructor. This flaw is due to an incomplete fix for CVE-2020-1747.",
                 "enumeration": "CVE",
-                "id": "CVE-2020-14343",
-                "reference": "https://bugzilla.redhat.com/show_bug.cgi?id=1860466, https://github.com/SeldonIO/seldon-core/issues/2252, https://github.com/yaml/pyyaml/issues/420, https://www.oracle.com/security-alerts/cpuapr2022.html, https://www.oracle.com/security-alerts/cpujul2022.html",
-                "report_id": "",
-                "scanner": {
-                    "vendor": "Wazuh"
+                "package": {
+                    "architecture": " ",
+                    "build_version": "",
+                    "checksum": "",
+                    "description": " ",
+                    "install_scope": "",
+                    "install_time": " ",
+                    "license": "",
+                    "name": "PyYAML",
+                    "path": "/usr/lib/python3/dist-packages/PyYAML-5.3.1.egg-info",
+                    "reference": "",
+                    "size": 0,
+                    "type": "pypi",
+                    "version": "5.3.1"
                 },
+                "reference": "https://bugzilla.redhat.com/show_bug.cgi?id=1860466, https://github.com/SeldonIO/seldon-core/issues/2252, https://github.com/yaml/pyyaml/issues/420, https://www.oracle.com/security-alerts/cpuapr2022.html, https://www.oracle.com/security-alerts/cpujul2022.html",
                 "score": {
                     "base": 9.800000190734863,
                     "environmental": 0.0,
                     "temporal": 0.0,
                     "version": "3.1"
                 },
-                "severity": "CRITICAL"
-                }
-            },
-            "id": "node01_001_e793091be00d470d63406011b00de081543a28bc_CVE-2020-14343",
-            "operation": "INSERTED"
-    }
-)";
+                "severity": "Critical",
+                "status": "Active"
+            }
+        }
+    )";
 
 TEST_F(SendReportTest, SendFormattedMsg)
 {
     const std::string report =
-        R"({"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2020-14343","description":"A vulnerability was discovered in the PyYAML library in versions before 5.4, where it is susceptible to arbitrary code execution when it processes untrusted YAML files through the full_load method or with the FullLoader loader. Applications that use the library to process untrusted input may be vulnerable to this flaw. This flaw allows an attacker to execute arbitrary code on the system by abusing the python/object/new constructor. This flaw is due to an incomplete fix for CVE-2020-1747.","enumeration":"CVE","package":{"architecture":" ","build_version":"","checksum":"","description":" ","install_scope":"","install_time":" ","license":"","name":"PyYAML","path":"/usr/lib/python3/dist-packages/PyYAML-5.3.1.egg-info","reference":"","size":0,"type":"pypi","version":"5.3.1"},"reference":"https://bugzilla.redhat.com/show_bug.cgi?id=1860466, https://github.com/SeldonIO/seldon-core/issues/2252, https://github.com/yaml/pyyaml/issues/420, https://www.oracle.com/security-alerts/cpuapr2022.html, https://www.oracle.com/security-alerts/cpujul2022.html","report_id":"","scanner":{"vendor":"Wazuh"},"score":{"base":9.800000190734863,"environmental":0.0,"temporal":0.0,"version":"3.1"},"severity":"CRITICAL","status":"Active"}})";
+        R"({"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2020-14343","description":"A vulnerability was discovered in the PyYAML library in versions before 5.4, where it is susceptible to arbitrary code execution when it processes untrusted YAML files through the full_load method or with the FullLoader loader. Applications that use the library to process untrusted input may be vulnerable to this flaw. This flaw allows an attacker to execute arbitrary code on the system by abusing the python/object/new constructor. This flaw is due to an incomplete fix for CVE-2020-1747.","enumeration":"CVE","package":{"architecture":" ","build_version":"","checksum":"","description":" ","install_scope":"","install_time":" ","license":"","name":"PyYAML","path":"/usr/lib/python3/dist-packages/PyYAML-5.3.1.egg-info","reference":"","size":0,"type":"pypi","version":"5.3.1"},"reference":"https://bugzilla.redhat.com/show_bug.cgi?id=1860466, https://github.com/SeldonIO/seldon-core/issues/2252, https://github.com/yaml/pyyaml/issues/420, https://www.oracle.com/security-alerts/cpuapr2022.html, https://www.oracle.com/security-alerts/cpujul2022.html","score":{"base":9.800000190734863,"environmental":0.0,"temporal":0.0,"version":"3.1"},"severity":"Critical","status":"Active"}})";
     std::string expectedStr = "1:[001] (focal) 192.168.33.20->vulnerability-scanner:" + report;
 
     // Fake socket server
@@ -164,12 +143,13 @@ TEST_F(SendReportTest, SendFormattedMsg)
     {
     };
     int statRet;
-    size_t attemps = -1;
+    size_t retries = 0;
     do
     {
-        ++attemps;
+        ++retries;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100 * retries));
         statRet = stat(TEST_PATH.c_str(), &fileStat);
-    } while (statRet != 0 && attemps < MAX_RETRIES);
+    } while (statRet != 0 && retries < MAX_RETRIES);
 
     // Connect to server.
     socketClient->connect(
@@ -187,7 +167,7 @@ TEST_F(SendReportTest, SendFormattedMsg)
         SyscollectorSynchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
     auto scanContext = std::make_shared<ScanContext>(syscollectorSync);
     nlohmann::json detectionJson = nlohmann::json::parse(DETECTION_STR);
-    scanContext->m_elements["CVE-2020-14343"] = detectionJson;
+    scanContext->m_alerts["CVE-2020-14343"] = detectionJson;
 
     // Send report.
     sendReport.handleRequest(scanContext);
@@ -248,12 +228,13 @@ TEST_F(SendReportTest, InvalidEncodingValue)
     {
     };
     int statRet;
-    size_t attemps = -1;
+    size_t retries = 0;
     do
     {
-        ++attemps;
+        ++retries;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100 * retries));
         statRet = stat(TEST_PATH.c_str(), &fileStat);
-    } while (statRet != 0 || attemps < MAX_RETRIES);
+    } while (statRet != 0 && retries < MAX_RETRIES);
 
     // Connect to server.
     socketClient->connect(
@@ -271,7 +252,8 @@ TEST_F(SendReportTest, InvalidEncodingValue)
         SyscollectorSynchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
     auto scanContext = std::make_shared<ScanContext>(syscollectorSync);
     nlohmann::json detectionJson = nlohmann::json::parse(DETECTION_STR);
-    detectionJson["data"]["package"]["name"] = "\xAA", scanContext->m_elements["CVE-2020-14343"] = detectionJson;
+    detectionJson["data"]["package"]["name"] = "\xAA";
+    scanContext->m_alerts["CVE-2020-14343"] = detectionJson;
 
     // Send report.
     sendReport.handleRequest(scanContext);


### PR DESCRIPTION
|Related issue|
|---|
|#20965|

## Description 

This PR implements the required changes to alert solved vulnerabilities by package removal

## Logs/Alerts example

### Solved vulnerabilities

Logs 
![image](https://github.com/wazuh/wazuh/assets/13010397/07a6ca6d-9b41-40bc-9346-7417be7af272)

Alerts
![image](https://github.com/wazuh/wazuh/assets/13010397/1519c825-002e-4062-ac67-c94680cd672d)

```json
{"timestamp":"2023-12-26T17:18:50.745-0300","rule":{"level":10,"description":"CVE-2023-1170 affects vim","id":"23505","firedtimes":48,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"001","name":"focal","ip":"192.168.33.20"},"manager":{"name":"jammy"},"id":"1703621930.1059644","decoder":{"name":"json"},"data":{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2023-1170","description":"Heap-based Buffer Overflow in GitHub repository vim/vim prior to 9.0.1376.","enumeration":"CVE","package":{"architecture":"amd64","description":"Vi IMproved - enhanced vi editor","install_time":" ","name":"vim","path":" ","size":"3048","type":"deb","version":"2:8.1.2269-1ubuntu5.21"},"reference":"https://huntr.dev/bounties/286e0090-e654-46d2-ac60-29f81799d0a4, https://github.com/vim/vim/commit/1c73b65229c25e3c1fd8824ba958f7cc4d604f9c, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DIAKPMKJ4OZ6NYRZJO7YWMNQL2BICLYV/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/IE44W6WMMREYCW3GJHPSYP7NK2VT5NY6/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/X4KDAU76Z7QNSPKZX2JAJ6O7KIEOXWTL/","score":{"base":"7.300000","version":"3.0"},"severity":"High","status":"Active"}},"location":"vulnerability-scanner"}
``` 

```json
{"timestamp":"2023-12-26T17:21:01.291-0300","rule":{"level":3,"description":"The CVE-2023-1170 that affected vim was solved due to a package removal/update or a system upgrade","id":"23502","firedtimes":153,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"001","name":"focal","ip":"192.168.33.20"},"manager":{"name":"jammy"},"id":"1703622061.1423515","decoder":{"name":"json"},"data":{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2023-1170","description":"Heap-based Buffer Overflow in GitHub repository vim/vim prior to 9.0.1376.","enumeration":"CVE","package":{"architecture":"amd64","name":"vim","version":"2:8.1.2269-1ubuntu5.21"},"reference":"https://huntr.dev/bounties/286e0090-e654-46d2-ac60-29f81799d0a4, https://github.com/vim/vim/commit/1c73b65229c25e3c1fd8824ba958f7cc4d604f9c, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DIAKPMKJ4OZ6NYRZJO7YWMNQL2BICLYV/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/IE44W6WMMREYCW3GJHPSYP7NK2VT5NY6/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/X4KDAU76Z7QNSPKZX2JAJ6O7KIEOXWTL/","score":{"base":"7.300000","version":"3.0"},"severity":"High","status":"Solved"}},"location":"vulnerability-scanner"}
```

### Update 12/27/23 integrity_clear alert

![image](https://github.com/wazuh/wazuh/assets/13010397/dbe6d4c2-e8ec-48b2-a57d-cad96ba613f2)
![image](https://github.com/wazuh/wazuh/assets/13010397/03085fb7-784f-48a8-a6ad-03e8258a3cb9)

```json
{"timestamp":"2023-12-27T15:08:52.607-0300","rule":{"level":3,"description":"Vulnerabilities cleared","id":"23507","firedtimes":1,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"001","name":"focal","ip":"192.168.33.20"},"manager":{"name":"jammy"},"id":"1703700532.3195050","decoder":{"name":"json"},"data":{"vulnerability":{"category":"Packages","status":"Clear"}},"location":"vulnerability-scanner"}
```

### Update 01/03/24 

After the fix https://github.com/wazuh/wazuh/pull/21174 was merged, and some rebase commits added. 

After re-sync all detected vulnerabilities are reported.
![image](https://github.com/wazuh/wazuh/assets/13010397/64f35741-2bc7-4d7f-ba2b-5445ee1f5a8d)

After removing the Vim package and its dependencies.
![image](https://github.com/wazuh/wazuh/assets/13010397/7f8542d0-ac61-4dd8-8a87-4bfbdba379e6)
![image](https://github.com/wazuh/wazuh/assets/13010397/faf13486-a359-45cf-97c6-96bea61647f2)

Solved alert example 

```json
{"timestamp":"2024-01-03T12:13:59.009-0300","rule":{"level":3,"description":"The CVE-2023-0054 that affected vim was solved due to a package removal/update or a system upgrade","id":"23502","firedtimes":158,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"001","name":"focal","ip":"192.168.33.20"},"manager":{"name":"jammy"},"id":"1704294839.9023696","decoder":{"name":"json"},"data":{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2023-0054","description":"Out-of-bounds Write in GitHub repository vim/vim prior to 9.0.1145.","enumeration":"CVE","package":{"architecture":"amd64","name":"vim","version":"2:8.1.2269-1ubuntu5.21"},"reference":"https://huntr.dev/bounties/b289ee0f-fd16-4147-bd01-c6289c45e49d, https://github.com/vim/vim/commit/3ac1d97a1d9353490493d30088256360435f7731, http://seclists.org/fulldisclosure/2023/Mar/17, https://lists.debian.org/debian-lts-announce/2023/06/msg00015.html, https://security.gentoo.org/glsa/202305-16, https://support.apple.com/kb/HT213670","score":{"base":"7.300000","version":"3.0"},"severity":"High","status":"Solved"}},"location":"vulnerability-scanner"}
```

```json
{"timestamp":"2024-01-03T12:13:59.022-0300","rule":{"level":3,"description":"The CVE-2022-4292 that affected vim was solved due to a package removal/update or a system upgrade","id":"23502","firedtimes":159,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"001","name":"focal","ip":"192.168.33.20"},"manager":{"name":"jammy"},"id":"1704294839.9025545","decoder":{"name":"json"},"data":{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2022-4292","description":"Use After Free in GitHub repository vim/vim prior to 9.0.0882.","enumeration":"CVE","package":{"architecture":"amd64","name":"vim","version":"2:8.1.2269-1ubuntu5.21"},"reference":"https://huntr.dev/bounties/da3d4c47-e57a-451e-993d-9df0ed31f57b, https://github.com/vim/vim/commit/c3d27ada14acd02db357f2d16347acc22cb17e93, https://security.netapp.com/advisory/ntap-20230113-0005/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WYC22GGZ6QA66HLNLHCTAJU265TT3O33/, https://security.gentoo.org/glsa/202305-16","score":{"base":"7.800000","version":"3.0"},"severity":"High","status":"Solved"}},"location":"vulnerability-scanner"}
```

```json
{"timestamp":"2024-01-03T12:13:59.034-0300","rule":{"level":3,"description":"The CVE-2022-4293 that affected vim was solved due to a package removal/update or a system upgrade","id":"23502","firedtimes":160,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"001","name":"focal","ip":"192.168.33.20"},"manager":{"name":"jammy"},"id":"1704294839.9027450","decoder":{"name":"json"},"data":{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2022-4293","description":"Floating Point Comparison with Incorrect Operator in GitHub repository vim/vim prior to 9.0.0804.","enumeration":"CVE","package":{"architecture":"amd64","name":"vim","version":"2:8.1.2269-1ubuntu5.21"},"reference":"https://huntr.dev/bounties/385a835f-6e33-4d00-acce-ac99f3939143, https://github.com/vim/vim/commit/cdef1cefa2a440911c727558562f83ed9b00e16b, https://security.gentoo.org/glsa/202305-16, https://security.netapp.com/advisory/ntap-20230203-0007/","score":{"base":"6.800000","version":"3.0"},"severity":"Medium","status":"Solved"}},"location":"vulnerability-scanner"}
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Added unit tests (for new features)