### PR TITLE
Reporting agent version in vulnerabilities

### DIFF
--- a/src/headers/hash_op.h
+++ b/src/headers/hash_op.h
@@ -74,6 +74,7 @@ void *OSHash_Delete_ins(OSHash *self, const char *key) __attribute__((nonnull));
 void *OSHash_Get(const OSHash *self, const char *key) __attribute__((nonnull));
 void *OSHash_Numeric_Get_ex(const OSHash *self, int key) __attribute__((nonnull(1)));
 void *OSHash_Get_ex(const OSHash *self, const char *key) __attribute__((nonnull));
+void *OSHash_Get_ex_dup(const OSHash *self, const char *key, void*(*duplicator)(void*)) __attribute__((nonnull));
 void *OSHash_Get_ins(const OSHash *self, const char *key) __attribute__((nonnull));
 
 unsigned int OSHash_Get_Elem_ex(OSHash *self) __attribute__((nonnull));

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -228,6 +228,9 @@ static int poll_interval_time = 0;
 /* This variable is used to prevent flooding when group files exceed the maximum size */
 static int reported_path_size_exceeded = 0;
 
+/* Hash table for agent data */
+OSHash *agent_data_hash;
+
 // Frees data in m_hash table
 void cleaner(void* data) {
     os_free(data);
@@ -302,6 +305,8 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
             if (agent_info = cJSON_Parse(strchr(r_msg, '{')), agent_info) {
                 cJSON *version = NULL;
                 if (version = cJSON_GetObjectItem(agent_info, "version"), cJSON_IsString(version)) {
+                    // Update agent data to keep context of events to forward
+                    OSHash_Set_ex(agent_data_hash, key->id, cJSON_Duplicate(agent_info, true));
                     if (!logr.allow_higher_versions &&
                         compare_wazuh_versions(__ossec_version, version->valuestring, false) < 0) {
 
@@ -327,6 +332,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
             mdebug1("Agent %s sent HC_SHUTDOWN from '%s'", key->name, aux_ip);
             is_shutdown = 1;
             rem_inc_recv_ctrl_shutdown(key->id);
+            cJSON_Delete(OSHash_Delete_ex(agent_data_hash, key->id));
         }
     } else {
         /* Clean msg and shared files (remove random string) */
@@ -1762,6 +1768,8 @@ void manager_init()
     groups = OSHash_Create();
     multi_groups = OSHash_Create();
 
+    agent_data_hash = OSHash_Create();
+
     disk_storage = getDefine_Int("remoted", "disk_storage", 0, 1);
 
     /* Run initial groups and multigroups scan */
@@ -1779,6 +1787,16 @@ void manager_init()
     OSHash_SetFreeDataPointer(pending_data, (void (*)(void *))free_pending_data);
 }
 
+/**
+ * @brief Custom deleter to clean the entries of the hash table without compilation warnings.
+ *
+ * @param data The cJSON pointer to remove.
+ */
+void agent_data_hash_cleaner(void *data) {
+    cJSON_Delete((cJSON*)data);
+}
+
 void manager_free() {
     linked_queue_free(pending_queue);
+    OSHash_Clean(agent_data_hash, agent_data_hash_cleaner);
 }

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -26,6 +26,9 @@
 #define AG_STOP_MSG REMOTED_MSG_HEADER OS_AG_STOPPED
 #define MAX_SHARED_PATH 200
 
+/* Hash table for agent data */
+extern OSHash *agent_data_hash;
+
 /* Pending data structure */
 
 typedef struct pending_data_t {

--- a/src/shared/hash_op.c
+++ b/src/shared/hash_op.c
@@ -431,6 +431,21 @@ void *OSHash_Get_ex(const OSHash *self, const char *key)
     return result;
 }
 
+/** void *OSHash_Get_ex(OSHash *self, char *key, void(*duplicator)(void*))
+ * Returns NULL on error (key not found).
+ * Returns a copy of the data otherwise.
+ * Key must not be NULL.
+ */
+void *OSHash_Get_ex_dup(const OSHash *self, const char *key, void*(*duplicator)(void*))
+{
+    void *result;
+    w_rwlock_rdlock((pthread_rwlock_t *)&self->mutex);
+    result = duplicator(OSHash_Get(self, key));
+    w_rwlock_unlock((pthread_rwlock_t *)&self->mutex);
+
+    return result;
+}
+
 /** void *OSHash_Get_ins(OSHash *self, char *key)
  * Returns NULL on error (key not found).
  * Returns the key otherwise.

--- a/src/shared/hash_op.c
+++ b/src/shared/hash_op.c
@@ -431,9 +431,9 @@ void *OSHash_Get_ex(const OSHash *self, const char *key)
     return result;
 }
 
-/** void *OSHash_Get_ex(OSHash *self, char *key, void(*duplicator)(void*))
+/** void *OSHash_Get_ex_dup(OSHash *self, char *key, void(*duplicator)(void*))
  * Returns NULL on error (key not found).
- * Returns a copy of the data otherwise.
+ * Returns a copy of the data otherwise. Must be freed by the caller.
  * Key must not be NULL.
  */
 void *OSHash_Get_ex_dup(const OSHash *self, const char *key, void*(*duplicator)(void*))

--- a/src/shared_modules/utils/flatbuffers/schemas/syscollectorDeltas/syscollector_deltas.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/syscollectorDeltas/syscollector_deltas.fbs
@@ -165,6 +165,7 @@ table AgentInfo {
     agent_id:string;
     agent_ip:string;
     agent_name:string;
+    agent_version:string;
     node_name:string;
 }
 

--- a/src/shared_modules/utils/flatbuffers/schemas/syscollectorRsync/syscollector_synchronization.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/syscollectorRsync/syscollector_synchronization.fbs
@@ -4,6 +4,7 @@ table AgentInfo {
     agent_id:string;
     agent_ip:string;
     agent_name:string;
+    agent_version:string;
     node_name:string;
 }
 

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -73,7 +73,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accep
                             -Wl,--wrap,w_mutex_lock -Wl,--wrap,w_mutex_unlock \
                             -Wl,--wrap,wnotify_add -Wl,--wrap,SendMSG -Wl,--wrap,rem_inc_recv_evt \
                             -Wl,--wrap,OS_DupKeyEntry -Wl,--wrap,OS_FreeKey ${DEBUG_OP_WRAPPERS} \
-                            -Wl,--wrap,router_provider_send_fb")
+                            -Wl,--wrap,router_provider_send_fb ${HASH_OP_WRAPPERS}")
 
 list(APPEND remoted_names "test_netbuffer")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,wnet_order -Wl,--wrap,wnotify_modify \

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -34,6 +34,7 @@
 #include "../wrappers/wazuh/os_crypto/msgs_wrappers.h"
 #include "../wrappers/wazuh/remoted/state_wrappers.h"
 #include "../wrappers/wazuh/shared_modules/router_wrappers.h"
+#include "../wrappers/wazuh/shared/hash_op_wrappers.h"
 #include "../../remoted/secure.c"
 
 typedef struct test_agent_info {
@@ -46,6 +47,7 @@ extern keystore keys;
 extern remoted logr;
 extern wnotify_t * notify;
 extern char *str_family_address[FAMILY_ADDRESS_SIZE];
+extern OSHash *agent_data_hash;
 
 void tmp_HandleSecureMessage_invalid_family_address(sa_family_t sin_family);
 
@@ -84,6 +86,7 @@ static int teardown_new_tcp(void **state) {
 static int setup_remoted_configuration(void **state) {
     test_mode = 1;
     node_name = "test_node_name";
+    agent_data_hash = (OSHash*)1;
 
     test_agent_info* agent;
     os_calloc(1, sizeof(test_agent_info), agent);
@@ -925,6 +928,7 @@ void test_HandleSecureMessage_close_idle_sock(void **state)
     key->keyid = 1;
     key->rcvd = 0;
     key->ip->ip = "127.0.0.1";
+    key->name = strdup("name");
 
     keys.keyentries[1] = key;
 
@@ -976,7 +980,7 @@ void test_HandleSecureMessage_close_idle_sock(void **state)
 
     // SendMSG
     expect_string(__wrap_SendMSG, message, "12!");
-    expect_string(__wrap_SendMSG, locmsg, "[001] ((null)) 127.0.0.1");
+    expect_string(__wrap_SendMSG, locmsg, "[001] (name) 127.0.0.1");
     expect_any(__wrap_SendMSG, loc);
     will_return(__wrap_SendMSG, 0);
 
@@ -985,6 +989,7 @@ void test_HandleSecureMessage_close_idle_sock(void **state)
     HandleSecureMessage(&message, &wdb_sock);
 
     os_free(key->id);
+    os_free(key->name);
     os_free(key->ip);
     os_free(key);
     os_free(keyentries);
@@ -1015,6 +1020,7 @@ void test_HandleSecureMessage_close_idle_sock_2(void **state)
     key->keyid = 1;
     key->rcvd = 0;
     key->ip->ip = "127.0.0.1";
+    key->name = strdup("name");
 
     keys.keyentries[1] = key;
 
@@ -1066,7 +1072,7 @@ void test_HandleSecureMessage_close_idle_sock_2(void **state)
 
     // SendMSG
     expect_string(__wrap_SendMSG, message, "AAA");
-    expect_string(__wrap_SendMSG, locmsg, "[001] ((null)) 127.0.0.1");
+    expect_string(__wrap_SendMSG, locmsg, "[001] (name) 127.0.0.1");
     expect_any(__wrap_SendMSG, loc);
     will_return(__wrap_SendMSG, 0);
 
@@ -1076,6 +1082,7 @@ void test_HandleSecureMessage_close_idle_sock_2(void **state)
 
     os_free(key->id);
     os_free(key->ip);
+    os_free(key->name);
     os_free(key);
     os_free(keyentries);
 }
@@ -1102,6 +1109,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled(void **state)
     key->sock = 4;
     key->keyid = 1;
     key->rcvd = 0;
+    key->name = strdup("name");
 
     keys.keyentries[1] = key;
 
@@ -1147,6 +1155,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled(void **state)
     HandleSecureMessage(&message, &wdb_sock);
 
     os_free(key->id);
+    os_free(key->name);
     os_free(key);
     os_free(keyentries);
 }
@@ -1173,6 +1182,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled_2(void **state)
     key->sock = 4;
     key->keyid = 1;
     key->rcvd = 0;
+    key->name = strdup("name");
 
     keys.keyentries[1] = key;
 
@@ -1219,6 +1229,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled_2(void **state)
     HandleSecureMessage(&message, &wdb_sock);
 
     os_free(key->id);
+    os_free(key->name);
     os_free(key);
     os_free(keyentries);
 }
@@ -1565,7 +1576,7 @@ void test_HandleSecureMessage_close_same_sock(void **state)
     key->keyid = 1;
     key->rcvd = 0;
     key->ip->ip = "127.0.0.1";
-
+    key->name = strdup("name");
 
     keys.keyentries[1] = key;
 
@@ -1594,7 +1605,7 @@ void test_HandleSecureMessage_close_same_sock(void **state)
 
     // SendMSG
     expect_string(__wrap_SendMSG, message, "12!");
-    expect_string(__wrap_SendMSG, locmsg, "[001] ((null)) 127.0.0.1");
+    expect_string(__wrap_SendMSG, locmsg, "[001] (name) 127.0.0.1");
     expect_any(__wrap_SendMSG, loc);
     will_return(__wrap_SendMSG, 0);
 
@@ -1604,6 +1615,7 @@ void test_HandleSecureMessage_close_same_sock(void **state)
 
     os_free(key->id);
     os_free(key->ip);
+    os_free(key->name);
     os_free(key);
     os_free(keyentries);
 }
@@ -1633,7 +1645,7 @@ void test_HandleSecureMessage_close_same_sock_2(void **state)
     key->keyid = 1;
     key->rcvd = 0;
     key->ip->ip = "127.0.0.1";
-
+    key->name = strdup("name");
 
     keys.keyentries[1] = key;
 
@@ -1663,7 +1675,7 @@ void test_HandleSecureMessage_close_same_sock_2(void **state)
 
     // SendMSG
     expect_string(__wrap_SendMSG, message, "AAA");
-    expect_string(__wrap_SendMSG, locmsg, "[001] ((null)) 127.0.0.1");
+    expect_string(__wrap_SendMSG, locmsg, "[001] (name) 127.0.0.1");
     expect_any(__wrap_SendMSG, loc);
     will_return(__wrap_SendMSG, 0);
 
@@ -1673,6 +1685,7 @@ void test_HandleSecureMessage_close_same_sock_2(void **state)
 
     os_free(key->id);
     os_free(key->ip);
+    os_free(key->name);
     os_free(key);
     os_free(keyentries);
 }
@@ -2048,6 +2061,10 @@ void test_router_message_forward_invalid_sync_json_message(void **state)
 
     expect_string(__wrap__mdebug2, formatted_msg, "Unable to forward message for agent 001");
 
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
+
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
 
@@ -2064,6 +2081,10 @@ void test_router_message_forward_valid_integrity_check_global(void **state)
     expect_string(__wrap_router_provider_send_fb, msg, expected_message);
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_synchronization_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
+
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
 
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
@@ -2082,6 +2103,10 @@ void test_router_message_forward_valid_integrity_check_left(void **state)
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_synchronization_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
 
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
+
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
 
@@ -2099,6 +2124,10 @@ void test_router_message_forward_valid_integrity_check_right(void **state)
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_synchronization_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
 
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
+
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
 
@@ -2114,6 +2143,10 @@ void test_router_message_forward_valid_integrity_clear(void **state)
     expect_string(__wrap_router_provider_send_fb, msg, expected_message);
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_synchronization_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
+
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
 
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
@@ -2153,6 +2186,10 @@ void test_router_message_forward_invalid_delta_json_message(void **state)
 
     expect_string(__wrap__mdebug2, formatted_msg, "Unable to forward message for agent 001");
 
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
+
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
 
@@ -2173,6 +2210,10 @@ void test_router_message_forward_valid_delta_packages_json_message(void **state)
     expect_string(__wrap_router_provider_send_fb, msg, expected_message);
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
+
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
 
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
@@ -2195,6 +2236,10 @@ void test_router_message_forward_valid_delta_os_json_message(void **state)
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
 
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
+
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
 
@@ -2216,6 +2261,10 @@ void test_router_message_forward_valid_delta_netiface_json_message(void **state)
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
 
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
+
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
 
@@ -2235,6 +2284,10 @@ void test_router_message_forward_valid_delta_netproto_json_message(void **state)
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
 
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
+
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
 
@@ -2253,6 +2306,10 @@ void test_router_message_forward_valid_delta_netaddr_json_message(void **state)
     expect_string(__wrap_router_provider_send_fb, msg, expected_message);
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
+
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
 
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
@@ -2274,6 +2331,10 @@ void test_router_message_forward_valid_delta_hardware_json_message(void **state)
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
 
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
+
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
 
@@ -2292,6 +2353,10 @@ void test_router_message_forward_valid_delta_ports_json_message(void **state)
     expect_string(__wrap_router_provider_send_fb, msg, expected_message);
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
+
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
 
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
@@ -2312,6 +2377,10 @@ void test_router_message_forward_valid_delta_processes_json_message(void **state
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
 
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
+
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
 
@@ -2328,6 +2397,10 @@ void test_router_message_forward_valid_delta_hotfixes_json_message(void **state)
     expect_string(__wrap_router_provider_send_fb, msg, expected_message);
     expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
     will_return(__wrap_router_provider_send_fb, 0);
+
+    will_return(__wrap_OSHash_Get_ex_dup, NULL);
+    expect_value(__wrap_OSHash_Get_ex_dup, self, (OSHash*)1);
+    expect_string(__wrap_OSHash_Get_ex_dup, key, data->agent_id);
 
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
@@ -146,6 +146,12 @@ void *__wrap_OSHash_Get_ex(const OSHash *self, const char *key) {
     return mock_type(void*);
 }
 
+void *__wrap_OSHash_Get_ex_dup(const OSHash *self, const char *key, __attribute__((unused)) void*(*duplicator)(void*)) {
+    check_expected(self);
+    check_expected(key);
+    return mock_type(void*);
+}
+
 void *__wrap_OSHash_Numeric_Get_ex(const OSHash *self, int key) {
     check_expected(self);
     check_expected(key);

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
@@ -44,6 +44,8 @@ void *__real_OSHash_Get(const OSHash *self, const char *key);
 void *__real_OSHash_Get_ex(const OSHash *self, const char *key);
 void *__wrap_OSHash_Get_ex(const OSHash *self, const char *key);
 
+void *__wrap_OSHash_Get_ex_dup(const OSHash *self, const char *key, void*(*duplicator)(void*));
+
 void *__real_OSHash_Numeric_Get_ex(const OSHash *self, int key);
 void *__wrap_OSHash_Numeric_Get_ex(const OSHash *self, int key);
 

--- a/src/unit_tests/wrappers/wazuh/shared/shared.cmake
+++ b/src/unit_tests/wrappers/wazuh/shared/shared.cmake
@@ -7,6 +7,7 @@ set(HASH_OP_WRAPPERS "-Wl,--wrap,OSHash_Add \
                       -Wl,--wrap,OSHash_Delete \
                       -Wl,--wrap,OSHash_Get \
                       -Wl,--wrap,OSHash_Get_ex \
+                      -Wl,--wrap,OSHash_Get_ex_dup \
                       -Wl,--wrap,OSHash_Next \
                       -Wl,--wrap,OSHash_SetFreeDataPointer \
                       -Wl,--wrap,OSHash_setSize \

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -68,12 +68,12 @@ public:
         ecs["version"] = "8.11.0";
 
         nlohmann::json agent;
-        agent["build"]["original"] = REVISION; // TODO The revision is from the agent.
+        agent["build"]["original"] = ""; // The revision isn't reported by the agents.
         agent["ephemeral_id"] = data->agentNodeName();
         agent["id"] = data->agentId();
         agent["name"] = data->agentName();
         agent["type"] = "wazuh";
-        agent["version"] = VERSION; // TODO The version is from the agent.
+        agent["version"] = data->agentVersion();
 
         nlohmann::json os;
         std::string fullName;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -151,7 +151,13 @@ public:
         };
 
         const auto cnaName {m_databaseFeedManager->getCnaName(data->packageVendor())};
-        logDebug1(WM_VULNSCAN_LOGTAG, "Scanning package: %s, CNA: %s", packageName.c_str(), cnaName.c_str());
+        logDebug1(WM_VULNSCAN_LOGTAG,
+                  "Scanning package: '%s', CNA: '%s'. From agent ID: '%s', name: '%s', version: '%s'",
+                  packageName.c_str(),
+                  cnaName.c_str(),
+                  data->agentId().data(),
+                  data->agentName().data(),
+                  data->agentVersion().data());
 
         m_databaseFeedManager->getVulnerabilitiesCandidates(cnaName, packageName, vulnerabilityScan);
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -611,6 +611,20 @@ public:
     }
 
     /**
+     * @brief Gets agent version.
+     *
+     * @return Agent version.
+     */
+    std::string_view agentVersion() const
+    {
+        return extractData<std::string_view>(
+            [](const SyscollectorDeltas::Delta* delta)
+            { return delta->agent_info()->agent_version() ? delta->agent_info()->agent_version()->c_str() : ""; },
+            [](const SyscollectorSynchronization::SyncMsg* syncMsg)
+            { return syncMsg->agent_info()->agent_version() ? syncMsg->agent_info()->agent_version()->c_str() : ""; });
+    }
+
+    /**
      * @brief Gets agent node name.
      * @return Agent node name.
      */


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21013|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR creates a cache in **remoted** to store the agent version and adds this information to the forwarded messages.
Also, the new field is added in the flatbuffer schemas to report it in the vulnerabilities inventory. 

The revision field was omitted as it's explained in the issue.  

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

The debugging log shows that the agent version is available during the scan

![2023-12-27_02-16](https://github.com/wazuh/wazuh/assets/65046601/2765dd42-ebcf-4915-8420-52527d834792)

Also, a temporal message was added to print the vulnerability that will be indexed and the version is present

![2023-12-28_18-34](https://github.com/wazuh/wazuh/assets/65046601/1c88b0a1-bdee-4547-b619-45156eaa4281)


<!-- Minimum checks required -->
- [x] Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- [x] Added unit tests (for new features)

