### PR TITLE
Set a minimum update interval for VD feeds to 1h

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -843,6 +843,10 @@ int wm_vuldet_provider_os_list(xml_node **node, vu_os_feed **feeds, char *pr_nam
                         merror("Invalid content for '%s' option at module '%s'", node[i]->attributes[j], WM_VULNDETECTOR_CONTEXT.name);
                         return OS_INVALID;
                     }
+                    if (feeds_it->interval < WM_MIN_UPDATE_INTERVAL) {
+                        mwarn("The '%s' option at module '%s' must be at least 1 hour. Automatically adjusted.", node[i]->attributes[j], WM_VULNDETECTOR_CONTEXT.name);
+                        feeds_it->interval = WM_MIN_UPDATE_INTERVAL;
+                    }
                 } else if (!strcmp(node[i]->attributes[j], XML_PATH)) {
                     free(feeds_it->path);
                     os_strdup(node[i]->values[j], feeds_it->path);
@@ -1038,6 +1042,10 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
             if (wm_vuldet_get_interval(node[i]->content, &options->update_interval)) {
                 merror("Invalid content for '%s' option at module '%s'", XML_UPDATE_INTERVAL, WM_VULNDETECTOR_CONTEXT.name);
                 return OS_INVALID;
+            }
+            if (options->update_interval < WM_MIN_UPDATE_INTERVAL) {
+                mwarn("The '%s' option at module '%s' must be at least 1 hour. Automatically adjusted.", node[i]->element, WM_VULNDETECTOR_CONTEXT.name);
+                options->update_interval = WM_MIN_UPDATE_INTERVAL;
             }
         } else if (!strcmp(node[i]->element, XML_TIMEOUT)) {
             char * end;

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -44,6 +44,7 @@
 
 #define WM_DEF_TIMEOUT      1800            // Default runtime limit (30 minutes)
 #define WM_DEF_INTERVAL     86400           // Default cycle interval (1 day)
+#define WM_MIN_UPDATE_INTERVAL 3600         // Minimum cycle update interval (1 hour)
 
 #define DAY_SEC    86400
 #define WEEK_SEC   604800


### PR DESCRIPTION
|Related issue|
|---|
|#21133|

## Description

With the changes made to the code of this PR, the 4 tasks defined in the issue are fulfilled:
- The Vulnerability Detector configuration includes a minimum time constraint for feed downloads.
- Validation logic is in place to enforce the 1-hour constraint.
- Warning log messages are generated for configurations that violate the constraint.
- Automatic adjustment of configurations to set the time to 1 hour is implemented.

## Configuration options

```xml
  <vulnerability-detector>
    <enabled>yes</enabled>
    <interval>5m</interval>
    <min_full_scan_interval>6h</min_full_scan_interval>
    <run_on_start>yes</run_on_start>

    <!-- Ubuntu OS vulnerabilities -->
    <provider name="canonical">
      <enabled>yes</enabled>
      <os>focal</os>
      <os update_interval="45m">jammy</os>
      <update_interval>59m</update_interval>
    </provider>

    <provider name="debian">
      <enabled>yes</enabled>
      <os>bookworm</os>
      <update_interval>3500s</update_interval>
    </provider>

    <!-- Windows OS vulnerabilities -->
    <provider name="msu">
      <enabled>yes</enabled>
      <update_interval>55m</update_interval>
    </provider>

    <!-- Aggregate vulnerabilities -->
    <provider name="nvd">
      <enabled>yes</enabled>
      <update_interval>1</update_interval>
    </provider>

  </vulnerability-detector>
```

## Logs/Alerts example

```
2023/12/28 17:54:29 wazuh-modulesd[65132] wmodules-vuln-detector.c:836 at wm_vuldet_provider_os_list(): WARNING: The 'update_interval' option at module 'vulnerability-detector' must be at least 1 hour. Automatically adjusted.
2023/12/28 17:54:29 wazuh-modulesd[65132] wmodules-vuln-detector.c:1036 at wm_vuldet_read_provider_content(): WARNING: The 'update_interval' option at module 'vulnerability-detector' must be at least 1 hour. Automatically adjusted.
2023/12/28 17:54:29 wazuh-modulesd[65132] wmodules-vuln-detector.c:684 at wm_vuldet_read_provider(): DEBUG: Added canonical (focal) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
2023/12/28 17:54:29 wazuh-modulesd[65132] wmodules-vuln-detector.c:684 at wm_vuldet_read_provider(): DEBUG: Added canonical (jammy) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
...
2023/12/28 17:54:29 wazuh-modulesd[65132] wmodules-vuln-detector.c:1036 at wm_vuldet_read_provider_content(): WARNING: The 'update_interval' option at module 'vulnerability-detector' must be at least 1 hour. Automatically adjusted.
2023/12/28 17:54:29 wazuh-modulesd[65132] wmodules-vuln-detector.c:742 at wm_vuldet_read_provider(): DEBUG: Added nvd feed. Interval: 3600s | Multi path: 'none' | Multi url: 'none' | Update since: 0 | Timeout: 300s
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Review logs syntax and correct language
- [ ] Added unit tests (for new features)

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

