### PR TITLE
Fix logcollector command parsing

### DIFF
--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -43,7 +43,7 @@ size_t lccom_dispatch(char * command, char ** output){
     const char *rcv_comm = command;
     char *rcv_args = NULL;
 
-    if ((rcv_args = strchr(rcv_comm, ' ')) && !strncmp(rcv_args, "next", 4)){
+    if ((rcv_args = strchr(rcv_comm, ' '))){
         *rcv_args = '\0';
         rcv_args++;
     }
@@ -58,9 +58,10 @@ size_t lccom_dispatch(char * command, char ** output){
         return lccom_getconfig(rcv_args, output);
 
     } else if (strcmp(rcv_comm, "getstate") == 0) {
+        if (rcv_args && !strncmp(rcv_args, "next", 4)){
+            return lccom_getstate(output, true);
+        }
         return lccom_getstate(output, false);
-    } else if (strcmp(rcv_comm, "getstate next") == 0) {
-        return lccom_getstate(output, true);
     } else {
         mdebug1("LCCOM Unrecognized command '%s'.", rcv_comm);
         os_strdup("err Unrecognized command", *output);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/21143|

## Description

This PR fixes the function `lccom_dispatch` to parse all commands correctly.

All cases of `getconfig` and `getstate` are now working.

This is the testing coverage of the function, all cases are contemplated and working:

<img width="681" alt="image" src="https://github.com/wazuh/wazuh/assets/11877311/75038abe-1e9c-412a-ac47-c440694515a0">

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Tests -->
- [x] Added unit tests (for new features)