### PR TITLE
Flatbuffers verifiers added

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -432,6 +432,13 @@ public:
 
         for (const auto& [key, value] : m_feedsDatabases.at(cnaName)->seek(packageNameWithSeparator))
         {
+            flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(value.data()), value.size());
+            if (!NSVulnerabilityScanner::VerifyScanVulnerabilityCandidateArrayBuffer(verifier))
+            {
+                throw std::runtime_error(
+                    "Error getting ScanVulnerabilityCandidateArray object from rocksdb. FlatBuffers verifier failed");
+            }
+
             auto candidatesArray = GetScanVulnerabilityCandidateArray(reinterpret_cast<const uint8_t*>(value.data()));
 
             if (candidatesArray)

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
@@ -85,6 +85,28 @@ private:
                     throw std::runtime_error("Unable to find resource.");
                 }
 
+                flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
+                switch (data->resourceType)
+                {
+                    default: throw std::runtime_error("Invalid resource type.");
+
+                    case ResourceType::CVE:
+                        if (!cve_v5::VerifyEntryBuffer(verifier))
+                        {
+                            throw std::runtime_error(
+                                "Error getting CVEv5 Entry object from rocksdb. FlatBuffers verifier failed");
+                        }
+                        break;
+
+                    case ResourceType::TRANSLATION:
+                        if (!NSVulnerabilityScanner::VerifyTranslationEntryBuffer(verifier))
+                        {
+                            throw std::runtime_error(
+                                "Error getting TranslationEntry object from rocksdb. FlatBuffers verifier failed");
+                        }
+                        break;
+                }
+
                 flatbuffers::IDLOptions options;
                 options.output_default_scalars_in_json = true;
                 options.strict_json = true;

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -101,7 +101,9 @@ const std::string VULNERABILITY_CANDIDATE_EXAMPLE = R"(
 ]
 )";
 
+const std::string CNA_NAME {"cnaName"};
 const std::string PACKAGE_NAME {"libmagic-mgc"};
+const std::string CORRUPTED_PACKAGE_NAME {"libcorrupted"};
 
 // External shared pointers definitions
 std::shared_ptr<MockIndexerConnector> spIndexerConnectorMock;
@@ -124,7 +126,7 @@ void DatabaseFeedManagerTest::SetUp()
     valid = parser.Parse(schemaStr.c_str());
     assert(valid == true);
 
-    Utils::RocksDBWrapper rocksDBWrapper(CANDIDATES_DATABASE_PATH + std::string("/") + "cnaName");
+    Utils::RocksDBWrapper rocksDBWrapper(CANDIDATES_DATABASE_PATH + std::string("/") + CNA_NAME);
 
     for (const auto& item : jsonExample)
     {
@@ -319,19 +321,65 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesSuccess)
     std::vector<std::string> cves;
 
     pDatabaseFeedManager->getVulnerabilitiesCandidates(
-        "cnaName",
-        "libmagic-mgc",
+        CNA_NAME,
+        PACKAGE_NAME,
         [&](const std::string& cnaName, const NSVulnerabilityScanner::ScanVulnerabilityCandidate& candidate) -> bool
         {
             auto cveId = candidate.cveId()->str();
             cves.push_back(cveId);
-            EXPECT_STREQ(cnaName.c_str(), "cnaName");
+            EXPECT_STREQ(cnaName.c_str(), CNA_NAME.c_str());
             return false;
         });
 
     EXPECT_EQ(cves.size(), 2);
     EXPECT_EQ(cves[0], "CVE-1999-1234");
     EXPECT_EQ(cves[1], "CVE-1999-1235");
+}
+
+TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesCorrupted)
+{
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+
+    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
+    spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
+        configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
+    spContentRegisterMock = std::make_shared<MockContentRegister>(
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
+
+    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
+
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+
+    auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
+
+    auto pDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              TrampolineRouterSubscriber>>(pIndexerConnectorTrap, shouldStop)};
+
+    // Simulate corrupted data stored
+    {
+        uint8_t corruptedData[] = {
+            0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
+        auto dbWrapper =
+            std::make_unique<Utils::RocksDBWrapper>(CANDIDATES_DATABASE_PATH + std::string("/") + CNA_NAME);
+        rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
+        dbWrapper->put(std::string(CORRUPTED_PACKAGE_NAME) + "_CVE-2023-7845", dbValue);
+    }
+
+    EXPECT_THROW(
+        {
+            pDatabaseFeedManager->getVulnerabilitiesCandidates(
+                CNA_NAME,
+                CORRUPTED_PACKAGE_NAME,
+                [&](const std::string& cnaName,
+                    const NSVulnerabilityScanner::ScanVulnerabilityCandidate& candidate) -> bool { return true; });
+        },
+        std::runtime_error);
 }
 
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesNoPackageName)
@@ -361,7 +409,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesNoPackageName)
 
     EXPECT_ANY_THROW({
         pDatabaseFeedManager->getVulnerabilitiesCandidates(
-            "cnaName",
+            CNA_NAME,
             "",
             [&](const std::string& cnaName, const NSVulnerabilityScanner::ScanVulnerabilityCandidate& candidate) -> bool
             { return true; });

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
@@ -575,6 +575,36 @@ TEST_F(EventDecoderTest, TestUpdatedResource)
 }
 
 /*
+ * @brief Test an update for a resource with corrupted data in rocksdb.
+ */
+TEST_F(EventDecoderTest, TestUpdatedResourceCorrupted)
+{
+    std::vector<char> message {};
+
+    // Simulate corrupted data stored
+    {
+        uint8_t corruptedData[] = {
+            0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
+        rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
+        m_cvesDb->put("CVE-2010-0002", dbValue);
+    }
+
+    std::shared_ptr<EventDecoder> eventDecoder;
+
+    // Instantiation of the EventDecoder class.
+    EXPECT_NO_THROW(eventDecoder = std::make_shared<EventDecoder>());
+
+    // Apply update
+    auto updatedJsonResource = nlohmann::json::parse(UPDATED_RESOURCE);
+    auto updatedEventContext = std::make_shared<EventContext>(EventContext {.message = message,
+                                                                            .resource = updatedJsonResource,
+                                                                            .cvesDatabase = m_cvesDb,
+                                                                            .translationsDatabase = m_translationsDb});
+
+    EXPECT_THROW(eventDecoder->handleRequest(updatedEventContext), std::runtime_error);
+}
+
+/*
  * @brief Test an update for a translation resource.
  */
 TEST_F(EventDecoderTest, TestUpdatedTranslationResource)
@@ -619,6 +649,36 @@ TEST_F(EventDecoderTest, TestUpdatedTranslationResource)
     std::string jsongen;
     flatbuffers::GenText(parser, reinterpret_cast<const uint8_t*>(slice.data()), &jsongen);
     EXPECT_EQ(nlohmann::json::parse(jsongen), nlohmann::json::parse(UPDATED_TRANSLATION_DATA));
+}
+
+/*
+ * @brief Test an update for a translation resource with corrupted data in rocksdb.
+ */
+TEST_F(EventDecoderTest, TestUpdatedTranslationResourceCorrupted)
+{
+    std::vector<char> message {};
+
+    // Simulate corrupted data stored
+    {
+        uint8_t corruptedData[] = {
+            0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
+        rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
+        m_translationsDb->put("TID-0001", dbValue);
+    }
+
+    std::shared_ptr<EventDecoder> eventDecoder;
+
+    // Instantiation of the EventDecoder class.
+    EXPECT_NO_THROW(eventDecoder = std::make_shared<EventDecoder>());
+
+    // Apply update
+    auto updatedJsonResource = nlohmann::json::parse(UPDATE_TRANSLATION);
+    auto updatedEventContext = std::make_shared<EventContext>(EventContext {.message = message,
+                                                                            .resource = updatedJsonResource,
+                                                                            .cvesDatabase = m_cvesDb,
+                                                                            .translationsDatabase = m_translationsDb});
+
+    EXPECT_THROW(eventDecoder->handleRequest(updatedEventContext), std::runtime_error);
 }
 
 /*


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21017 |

## Description

This PR adds flatbuffers verifiers to data read from rocksdb previous to be used to avoid errors related to data corruption.

## Tests

Tests "DatabaseFeedManagerTest.GetVulnerabilityCandidatesCorrupted", "EventDecoderTest.TestUpdatedResourceCorrupted" and "EventDecoderTest.TestUpdatedTranslationResourceCorrupted" were added.

- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Manual tests running ok
- [ ] UT running ok
