### PR TITLE
Bump aiohttp version

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.5
+aiohttp==3.9.1
 aiohttp-cache==2.2.0
 aiohttp-cors==0.7.0
 aiohttp-jinja2==1.5.1


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/21151 |

## Description

Bumps the `aiothttp` dependency version to `3.9.1` in the `requirements.txt` file.

## Installation from sources

<details><summary>Dependencies installation</summary>

```console
gasti@pop-os:~/work/wazuh$ docker run -it ubuntu:22.04 bash
root@044edd5de2e1:/# apt-get update
apt-get install python3 gcc g++ make libc6-dev curl policycoreutils automake autoconf libtool libssl-dev
Get:1 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
Get:2 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
Get:4 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [1046 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [109 kB]
Get:6 http://archive.ubuntu.com/ubuntu jammy/restricted amd64 Packages [164 kB]
Get:7 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages [1792 kB]
Get:8 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [44.0 kB]
Get:9 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [1572 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 Packages [266 kB]         
Get:11 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages [17.5 MB]          
Get:12 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [1326 kB]       
Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1305 kB]      
Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1599 kB]
Get:15 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 Packages [49.8 kB]                   
Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [1602 kB]                   
Get:17 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [50.4 kB]                       
Get:18 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [28.1 kB]                   
Fetched 28.9 MB in 6s (4647 kB/s)                                                                           
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  autotools-dev binutils binutils-common binutils-x86-64-linux-gnu ca-certificates cpp cpp-11 file
  fontconfig-config fonts-dejavu-core g++-11 gcc-11 gcc-11-base libasan6 libatomic1 libbinutils libbrotli1
  libbsd0 libc-dev-bin libc-devtools libcc1-0 libcrypt-dev libctf-nobfd0 libctf0 libcurl4 libdeflate0
  libexpat1 libfontconfig1 libfreetype6 libgcc-11-dev libgd3 libgdbm-compat4 libgdbm6 libgomp1 libisl23
  libitm1 libjbig0 libjpeg-turbo8 libjpeg8 libldap-2.5-0 libldap-common liblsan0 libltdl-dev libltdl7
  libmagic-mgc libmagic1 libmd0 libmpc3 libmpdec3 libmpfr6 libnghttp2-14 libnsl-dev libperl5.34 libpng16-16
  libpsl5 libpython3-stdlib libpython3.10-minimal libpython3.10-stdlib libquadmath0 libreadline8 librtmp1
  libsasl2-2 libsasl2-modules libsasl2-modules-db libsigsegv2 libsqlite3-0 libssh-4 libstdc++-11-dev
  libtiff5 libtirpc-dev libtsan0 libubsan1 libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4
  linux-libc-dev m4 manpages manpages-dev media-types netbase openssl perl perl-modules-5.34 publicsuffix
  python3-minimal python3.10 python3.10-minimal readline-common rpcsvc-proto selinux-utils ucf
Suggested packages:
  autoconf-archive gnu-standards autoconf-doc gettext binutils-doc cpp-doc gcc-11-locales g++-multilib
  g++-11-multilib gcc-11-doc gcc-multilib flex bison gdb gcc-doc gcc-11-multilib glibc-doc libgd-tools
  gdbm-l10n libtool-doc libsasl2-modules-gssapi-mit | libsasl2-modules-gssapi-heimdal libsasl2-modules-ldap
  libsasl2-modules-otp libsasl2-modules-sql libssl-doc libstdc++-11-doc gfortran | fortran95-compiler
  gcj-jdk m4-doc make-doc man-browser perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl
  libtap-harness-archive-perl python3-doc python3-tk python3-venv python3.10-venv python3.10-doc
  binfmt-support readline-doc
The following NEW packages will be installed:
  autoconf automake autotools-dev binutils binutils-common binutils-x86-64-linux-gnu ca-certificates cpp
  cpp-11 curl file fontconfig-config fonts-dejavu-core g++ g++-11 gcc gcc-11 gcc-11-base libasan6
  libatomic1 libbinutils libbrotli1 libbsd0 libc-dev-bin libc-devtools libc6-dev libcc1-0 libcrypt-dev
  libctf-nobfd0 libctf0 libcurl4 libdeflate0 libexpat1 libfontconfig1 libfreetype6 libgcc-11-dev libgd3
  libgdbm-compat4 libgdbm6 libgomp1 libisl23 libitm1 libjbig0 libjpeg-turbo8 libjpeg8 libldap-2.5-0
  libldap-common liblsan0 libltdl-dev libltdl7 libmagic-mgc libmagic1 libmd0 libmpc3 libmpdec3 libmpfr6
  libnghttp2-14 libnsl-dev libperl5.34 libpng16-16 libpsl5 libpython3-stdlib libpython3.10-minimal
  libpython3.10-stdlib libquadmath0 libreadline8 librtmp1 libsasl2-2 libsasl2-modules libsasl2-modules-db
  libsigsegv2 libsqlite3-0 libssh-4 libssl-dev libstdc++-11-dev libtiff5 libtirpc-dev libtool libtsan0
  libubsan1 libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev m4 make manpages
  manpages-dev media-types netbase openssl perl perl-modules-5.34 policycoreutils publicsuffix python3
  python3-minimal python3.10 python3.10-minimal readline-common rpcsvc-proto selinux-utils ucf
0 upgraded, 107 newly installed, 0 to remove and 0 not upgraded.
Need to get 92.6 MB of archives.
After this operation, 337 MB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libpython3.10-minimal amd64 3.10.12-1~22.04.3 [812 kB]
Get:2 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libexpat1 amd64 2.4.7-1ubuntu0.2 [91.0 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 python3.10-minimal amd64 3.10.12-1~22.04.3 [2242 kB]
...
Get:105 http://archive.ubuntu.com/ubuntu jammy/main amd64 manpages-dev all 5.10-1ubuntu1 [2309 kB]          
Get:106 http://archive.ubuntu.com/ubuntu jammy/universe amd64 selinux-utils amd64 3.3-1build2 [107 kB]      
Get:107 http://archive.ubuntu.com/ubuntu jammy/universe amd64 policycoreutils amd64 3.3-1build1 [537 kB]    
Fetched 92.6 MB in 18s (5092 kB/s)                                                                          
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package libpython3.10-minimal:amd64.
(Reading database ... 4393 files and directories currently installed.)
Preparing to unpack .../libpython3.10-minimal_3.10.12-1~22.04.3_amd64.deb ...
Unpacking libpython3.10-minimal:amd64 (3.10.12-1~22.04.3) ...
Selecting previously unselected package libexpat1:amd64.
Preparing to unpack .../libexpat1_2.4.7-1ubuntu0.2_amd64.deb ...
Unpacking libexpat1:amd64 (2.4.7-1ubuntu0.2) ...
Selecting previously unselected package python3.10-minimal.
Preparing to unpack .../python3.10-minimal_3.10.12-1~22.04.3_amd64.deb ...
Unpacking python3.10-minimal (3.10.12-1~22.04.3) ...
...
Setting up perl (5.34.0-3ubuntu1.3) ...
Setting up libgd3:amd64 (2.3.0-2ubuntu2) ...
Setting up autoconf (2.71-2) ...
Setting up libstdc++-11-dev:amd64 (11.4.0-1ubuntu1~22.04) ...
Setting up gcc-11 (11.4.0-1ubuntu1~22.04) ...
Setting up libc-devtools (2.35-0ubuntu3.5) ...
Setting up automake (1:1.16.5-1.3) ...
update-alternatives: using /usr/bin/automake-1.16 to provide /usr/bin/automake (automake) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/automake.1.gz because associated file /usr/share/man/man1/automake-1.16.1.gz (of link group automake) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/aclocal.1.gz because associated file /usr/share/man/man1/aclocal-1.16.1.gz (of link group automake) doesn't exist
Setting up libtool (2.4.6-15build2) ...
Setting up g++-11 (11.4.0-1ubuntu1~22.04) ...
Setting up gcc (4:11.2.0-1ubuntu1) ...
Setting up libltdl-dev:amd64 (2.4.6-15build2) ...
Setting up g++ (4:11.2.0-1ubuntu1) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/c++.1.gz because associated file /usr/share/man/man1/g++.1.gz (of link group c++) doesn't exist
Processing triggers for libc-bin (2.35-0ubuntu3.5) ...
Processing triggers for ca-certificates (20230311ubuntu0.22.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.

```

</details>

<details><summary>CMake installation</summary>

```console
root@044edd5de2e1:/# curl -OL https://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && ./bootstrap --no-system-curl && make -j$(nproc) && make install
cd .. && rm -rf cmake-*
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 8765k  100 8765k    0     0  2804k      0  0:00:03  0:00:03 --:--:-- 2804k
---------------------------------------------
CMake 3.18.3, Copyright 2000-2020 Kitware, Inc. and Contributors
Found GNU toolchain
C compiler on this system is: gcc   
C++ compiler on this system is: g++    
Makefile processor on this system is: gmake
g++ has setenv
g++ has unsetenv
g++ does not have environ in stdlib.h
g++ has stl wstring
g++ has <ext/stdio_filebuf.h>
...
-- Performing Test run_pic_test
-- Performing Test run_pic_test - Success
-- Performing Test run_inlines_hidden_test
-- Performing Test run_inlines_hidden_test - Success
-- Configuring done
-- Generating done
-- Build files have been written to: /cmake-3.18.3
---------------------------------------------
CMake has bootstrapped.  Now run gmake.
Scanning dependencies of target cmsys_c
Scanning dependencies of target cmsys
Scanning dependencies of target kwiml_test
Scanning dependencies of target cmstd
[  0%] Building CXX object Utilities/std/CMakeFiles/cmstd.dir/cm/bits/string_view.cxx.o
[  0%] Building C object Utilities/KWIML/test/CMakeFiles/kwiml_test.dir/test.c.o
[  0%] Building C object Source/kwsys/CMakeFiles/cmsys_c.dir/ProcessUNIX.c.o
[  0%] Building C object Source/kwsys/CMakeFiles/cmsys.dir/ProcessUNIX.c.o
[  0%] Building C object Utilities/KWIML/test/CMakeFiles/kwiml_test.dir/test_abi_C.c.o
[  0%] Building C object Utilities/KWIML/test/CMakeFiles/kwiml_test.dir/test_int_C.c.o
[  0%] Linking CXX static library libcmstd.a
[  0%] Built target cmstd
Scanning dependencies of target cmlibrhash
[  0%] Building C object Utilities/cmlibrhash/CMakeFiles/cmlibrhash.dir/librhash/algorithms.c.o
[  0%] Building C object Utilities/cmlibrhash/CMakeFiles/cmlibrhash.dir/librhash/byte_order.c.o
[  0%] Building C object Utilities/KWIML/test/CMakeFiles/kwiml_test.dir/test_include_C.c.o
[  1%] Building C object Utilities/cmlibrhash/CMakeFiles/cmlibrhash.dir/librhash/hex.c.o
[  1%] Building CXX object Utilities/KWIML/test/CMakeFiles/kwiml_test.dir/test_abi_CXX.cxx.o
[  1%] Building CXX object Utilities/KWIML/test/CMakeFiles/kwiml_test.dir/test_int_CXX.cxx.o
[  1%] Building C object Utilities/cmlibrhash/CMakeFiles/cmlibrhash.dir/librhash/md5.c.o
[  1%] Building C object Utilities/cmlibrhash/CMakeFiles/cmlibrhash.dir/librhash/rhash.c.o
[  1%] Building CXX object Utilities/KWIML/test/CMakeFiles/kwiml_test.dir/test_include_CXX.cxx.o
[  1%] Building C object Utilities/cmlibrhash/CMakeFiles/cmlibrhash.dir/librhash/sha1.c.o
[  1%] Building C object Source/kwsys/CMakeFiles/cmsys.dir/Base64.c.o
[  1%] Building C object Source/kwsys/CMakeFiles/cmsys_c.dir/Base64.c.o
[  2%] Building C object Source/kwsys/CMakeFiles/cmsys.dir/EncodingC.c.o
[  2%] Building C object Utilities/cmlibrhash/CMakeFiles/cmlibrhash.dir/librhash/sha256.c.o
[  2%] Building C object Source/kwsys/CMakeFiles/cmsys.dir/MD5.c.o
[  2%] Linking CXX executable kwiml_test
...
[100%] Building CXX object Tests/CMakeLib/CMakeFiles/CMakeLibTests.dir/testUVStreambuf.cxx.o
[100%] Building CXX object Tests/CMakeLib/CMakeFiles/CMakeLibTests.dir/testCMExtMemory.cxx.o
[100%] Building CXX object Tests/CMakeLib/CMakeFiles/CMakeLibTests.dir/testCMExtAlgorithm.cxx.o
[100%] Linking CXX executable CMakeLibTests
[100%] Built target CMakeLibTests
[  1%] Built target cmsys_c
[  2%] Built target cmsysTestSharedForward
[  4%] Built target cmsys
[  5%] Built target cmsysTestsCxx
[  5%] Built target cmsysTestProcess
[  5%] Built target cmsysTestsC
[  5%] Built target testConsoleBufChild
[  5%] Built target cmsysTestDynload
[  5%] Built target cmstd
[  5%] Built target kwiml_test
...
[ 97%] Built target pseudo_emulator_custom_command
[ 98%] Built target pseudo_emulator
[ 98%] Built target pseudo_cpplint
[ 99%] Built target pseudo_tidy
[ 99%] Built target pseudo_iwyu
[ 99%] Built target pseudo_cppcheck
[100%] Built target foo
Install the project...
-- Install configuration: "Release"
-- Installing: /usr/local/doc/cmake-3.18/cmsys/Copyright.txt
...
-- Installing: /usr/local/share/cmake-3.18/Templates/CPack.GenericDescription.txt
-- Installing: /usr/local/share/cmake-3.18/Templates/Windows
-- Installing: /usr/local/share/cmake-3.18/Templates/Windows/SmallLogo.png
-- Installing: /usr/local/share/cmake-3.18/Templates/Windows/ApplicationIcon.png
-- Installing: /usr/local/share/cmake-3.18/Templates/Windows/Logo.png
-- Installing: /usr/local/share/cmake-3.18/Templates/Windows/Windows_TemporaryKey.pfx
-- Installing: /usr/local/share/cmake-3.18/Templates/Windows/SplashScreen.png
-- Installing: /usr/local/share/cmake-3.18/Templates/Windows/SmallLogo44x44.png
-- Installing: /usr/local/share/cmake-3.18/Templates/Windows/StoreLogo.png
-- Installing: /usr/local/share/cmake-3.18/Templates/CPack.GenericWelcome.txt
-- Installing: /usr/local/share/cmake-3.18/Templates/TestDriver.cxx.in
-- Installing: /usr/local/share/cmake-3.18/Templates/CPackConfig.cmake.in
-- Installing: /usr/local/share/cmake-3.18/Templates/CPack.GenericLicense.txt
-- Installing: /usr/local/share/vim/vimfiles/indent
-- Installing: /usr/local/share/vim/vimfiles/indent/cmake.vim
-- Installing: /usr/local/share/vim/vimfiles/syntax
-- Installing: /usr/local/share/vim/vimfiles/syntax/cmake.vim
-- Installing: /usr/local/share/emacs/site-lisp/cmake-mode.el
-- Installing: /usr/local/share/aclocal/cmake.m4
-- Installing: /usr/local/share/bash-completion/completions/cmake
-- Installing: /usr/local/share/bash-completion/completions/cpack
-- Installing: /usr/local/share/bash-completion/completions/ctest
```


</details>

<details><summary>Cloning Wazuh</summary>

```console
root@044edd5de2e1:/# git clone -b fix/21151-bump-aiohttp-version --single-branch https://github.com/wazuh/wazuh
Cloning into 'wazuh'...
remote: Enumerating objects: 271090, done.
remote: Counting objects: 100% (806/806), done.
remote: Compressing objects: 100% (297/297), done.
remote: Total 271090 (delta 619), reused 585 (delta 502), pack-reused 270284
Receiving objects: 100% (271090/271090), 263.94 MiB | 5.25 MiB/s, done.
Resolving deltas: 100% (201358/201358), done.
root@044edd5de2e1:/# cd wazuh
root@044edd5de2e1:/wazuh# git branch
* fix/21151-bump-aiohttp-version
root@044edd5de2e1:/wazuh# head framework/requirements.txt -n 1
aiohttp==3.9.1
```

</details>


<details><summary>Wazuh installation</summary>

```console
root@044edd5de2e1:/wazuh# ./install.sh
 Wazuh v4.8.0 (Rev. 40801) Installation Script - https://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux 044edd5de2e1 6.2.0-76060200-generic (ubuntu 22.04)
  - User: root
  - Host: 044edd5de2e1


  -- Press ENTER to continue or Ctrl-C to abort. --


1- What kind of installation do you want (manager, agent, local, hybrid or help)? manager

  - Manager (server) installation chosen.

2- Choose where to install Wazuh [/var/ossec]: 

    - Installation will be made at  /var/ossec .

3- Configuring Wazuh.

  3.1- Do you want e-mail notification? (y/n) [n]: 

   --- Email notification disabled.

  3.2- Do you want to run the integrity check daemon? (y/n) [y]: 

   - Running syscheck (integrity check daemon).

  3.3- Do you want to run the rootkit detection engine? (y/n) [y]: 

   - Running rootcheck (rootkit detection).

  3.5- Active response allows you to execute a specific
       command based on the events received.
       By default, no active responses are defined.

   - Default white list for the active response:
      - 181.30.140.198
      - 181.30.140.133

   - Do you want to add more IPs to the white list? (y/n)? [n]: 

  3.6- Do you want to enable remote syslog (port 514 udp)? (y/n) [y]: 

   - Remote syslog enabled.

  3.7 - Do you want to run the Auth daemon? (y/n) [y]: 

   - Running Auth daemon.

  3.8- Do you want to start Wazuh after the installation? (y/n) [y]: 

   - Wazuh will start at the end of installation.

  3.9- Setting the configuration to analyze the following logs:

    -- /var/ossec/logs/active-responses.log
    -- /var/log/dpkg.log

 - If you want to monitor any other file, just change
   the ossec.conf and add a new localfile entry.
   Any questions about the configuration can be answered
   by visiting us online at https://documentation.wazuh.com/.


   --- Press ENTER to continue ---


4- Installing the system

DIR="/var/ossec"
 - Running the Makefile

...
Done building server

Wait for success...
success
Removing old SCA policies...
Installing SCA policies...
Installing additional SCA policies...
Makefile:2531: warning: overriding recipe for target 'win32/ui_resource.o'
Makefile:2471: warning: ignoring old recipe for target 'win32/ui_resource.o'
Makefile:2534: warning: overriding recipe for target 'win32/auth_resource.o'
Makefile:2474: warning: ignoring old recipe for target 'win32/auth_resource.o'
mkdir -p /var/ossec/framework/python
cp external/cpython.tar.gz /var/ossec/framework/python/cpython.tar.gz && tar -xf /var/ossec/framework/python/cpython.tar.gz -C /var/ossec/framework/python && rm -rf /var/ossec/framework/python/cpython.tar.gz
find /var/ossec/framework/python -name "*libpython3.10.so.1.0" -exec ln -f {} /var/ossec/lib/libpython3.10.so.1.0 \;
cd ../framework && /var/ossec/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/ossec/framework/python && rm -rf build/
Processing /wazuh/framework
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: wazuh
  Building wheel for wazuh (pyproject.toml) ... done
  Created wheel for wazuh: filename=wazuh-4.8.0-py3-none-any.whl size=297269 sha256=406ee52ca5626200e9d191d618e82de80a2dc11668770ede98639a263d56941d
  Stored in directory: /tmp/pip-ephem-wheel-cache-epvmphgu/wheels/fe/47/7c/2c289aea2e8a5cc5ac8936e5cecbbfc0bdd996d57bb70da19a
Successfully built wazuh
Installing collected packages: wazuh
Successfully installed wazuh-4.8.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
chown -R root:wazuh /var/ossec/framework/python
chmod -R o=- /var/ossec/framework/python
cd ../api && /var/ossec/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/ossec/framework/python && rm -rf build/
Processing /wazuh/api
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: api
  Building wheel for api (pyproject.toml) ... done
  Created wheel for api: filename=api-4.8.0-py3-none-any.whl size=159740 sha256=b38a3f0fddb918a468b4ae6f965e571dae0d9c42f46404a437540c0d9b3181f2
  Stored in directory: /tmp/pip-ephem-wheel-cache-of0bat85/wheels/2c/ed/d5/5358cdcfa6f68fc41b8ca02118521c75da82e9ec6d16f50822
Successfully built api
Installing collected packages: api
Successfully installed api-4.8.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
cd ../tools/mitre && /var/ossec/framework/python/bin/python3 mitredb.py -d /var/ossec/var/db/mitre.db
Generating self-signed certificate for wazuh-authd...


 - System is Debian (Ubuntu or derivative).
 - Init script modified to start Wazuh during boot.
Starting Wazuh...
server
Starting Wazuh v4.8.0...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2023/12/29 14:31:02 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
Started wazuh-modulesd...
Completed.

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---


 - In order to connect agent and server, you need to add each agent to the server.

   More information at: 
   https://documentation.wazuh.com/
```

</details>

<details><summary>Embedded interpreter aiohttp version</summary>

```console
root@044edd5de2e1:/wazuh# /var/ossec/framework/python/bin/python3 -m pip freeze | head -n 1
aiohttp==3.9.1
```

</details>

<details><summary>/var/ossec/bin/wazuh-control status</summary>

```console
root@044edd5de2e1:/wazuh# /var/ossec/bin/wazuh-control status
wazuh-clusterd not running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-maild not running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
wazuh-apid is running...
```

</details>


<details><summary>ossec.log</summary>

```console
root@044edd5de2e1:/wazuh# cat /var/ossec/logs/ossec.log
2023/12/29 14:31:02 wazuh-csyslogd: INFO: Remote syslog server not configured. Clean exit.
2023/12/29 14:31:02 wazuh-dbd: INFO: Database not configured. Clean exit.
2023/12/29 14:31:02 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
2023/12/29 14:31:02 wazuh-agentlessd: INFO: Not configured. Exiting.
2023/12/29 14:31:02 wazuh-authd: INFO: Started (pid: 23190).
2023/12/29 14:31:02 wazuh-authd: INFO: Accepting connections on port 1515. No password required.
2023/12/29 14:31:02 wazuh-authd: INFO: Setting network timeout to 1.000000 sec.
2023/12/29 14:31:03 wazuh-db: INFO: Started (pid: 23206).
2023/12/29 14:31:03 wazuh-db: INFO: Created Global database backup "backup/db/global.db-backup-2023-12-29-14:31:03.gz"
2023/12/29 14:31:04 wazuh-execd: INFO: Started (pid: 23239).
2023/12/29 14:31:05 wazuh-analysisd: INFO: Total rules enabled: '6785'
2023/12/29 14:31:05 wazuh-analysisd: INFO: Started (pid: 23253).
2023/12/29 14:31:05 wazuh-analysisd: INFO: (7200): Logtest started
2023/12/29 14:31:05 wazuh-analysisd: INFO: EPS limit disabled
2023/12/29 14:31:06 wazuh-syscheckd: INFO: Started (pid: 23318).
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6003): Monitoring path: '/boot', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6003): Monitoring path: '/etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6003): Monitoring path: '/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mtab'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/hosts.deny'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mail/statistics'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random-seed'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random.seed'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/adjtime'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/httpd/logs'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/utmpx'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/wtmpx'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/cups/certs'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/dumpdates'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/svc/volatile'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6207): Ignore 'file' sregex '.log$|.swp$'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6004): No diff for file: '/etc/ssl/private.key'
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6000): Starting daemon...
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2023/12/29 14:31:06 rootcheck: INFO: Starting rootcheck scan.
2023/12/29 14:31:06 wazuh-remoted: INFO: Started (pid: 23332). Listening on port 1514/TCP (secure).
2023/12/29 14:31:06 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2023/12/29 14:31:06 wazuh-syscheckd: INFO: FIM sync module started.
2023/12/29 14:31:07 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/ossec/logs/active-responses.log'.
2023/12/29 14:31:07 wazuh-monitord: INFO: Started (pid: 23356).
2023/12/29 14:31:07 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/log/dpkg.log'.
2023/12/29 14:31:07 wazuh-logcollector: INFO: Monitoring output of command(360): df -P
2023/12/29 14:31:07 wazuh-logcollector: INFO: Monitoring full output of command(360): netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
2023/12/29 14:31:07 wazuh-logcollector: INFO: Monitoring full output of command(360): last -n 20
2023/12/29 14:31:07 wazuh-logcollector: INFO: Started (pid: 23346).
2023/12/29 14:31:08 wazuh-modulesd: INFO: Started (pid: 23374).
2023/12/29 14:31:08 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2023/12/29 14:31:08 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2023/12/29 14:31:08 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2023/12/29 14:31:08 sca: INFO: Module started.
2023/12/29 14:31:08 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2023/12/29 14:31:08 wazuh-modulesd:task-manager: INFO: (8200): Module Task Manager started.
2023/12/29 14:31:08 sca: INFO: Starting Security Configuration Assessment scan.
2023/12/29 14:31:08 wazuh-modulesd:control: INFO: Starting control thread.
2023/12/29 14:31:08 wazuh-modulesd:database: INFO: Module started.
2023/12/29 14:31:08 wazuh-modulesd:download: INFO: Module started.
2023/12/29 14:31:08 wazuh-modulesd:syscollector: INFO: Module started.
2023/12/29 14:31:08 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2023/12/29 14:31:08 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2023/12/29 14:31:08 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2023/12/29 14:31:11 wazuh-remoted: INFO: (1410): Reading authentication keys file.
2023/12/29 14:31:12 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2023/12/29 14:31:12 sca: INFO: Security Configuration Assessment scan finished. Duration: 4 seconds.
2023/12/29 14:31:25 rootcheck: INFO: Ending rootcheck scan.
```

</details>

<details><summary>api.log</summary>

```console
root@044edd5de2e1:/wazuh# cat /var/ossec/logs/api.log
2023/12/29 14:39:56 INFO: HTTPS is enabled but cannot find the private key and/or certificate. Attempting to generate them
2023/12/29 14:39:56 INFO: Generated private key file in WAZUH_PATH/api/configuration/ssl/server.key
2023/12/29 14:39:56 INFO: Generated certificate file in WAZUH_PATH/api/configuration/ssl/server.crt
2023/12/29 14:39:56 INFO: Checking RBAC database integrity...
2023/12/29 14:39:56 INFO: RBAC database not found. Initializing
2023/12/29 14:39:57 INFO: /var/ossec/api/configuration/security/rbac.db database created successfully
2023/12/29 14:39:57 INFO: RBAC database integrity check finished successfully
2023/12/29 14:39:59 INFO: Listening on 0.0.0.0:55000..
```

</details>