### PR TITLE
Update 0380-windows_decoders.xml

### DIFF
--- a/ruleset/decoders/0380-windows_decoders.xml
+++ b/ruleset/decoders/0380-windows_decoders.xml
@@ -72,8 +72,8 @@
   <use_own_name>true</use_own_name>
   <prematch offset="after_parent">^W3SVC\d+ \S+ \S+ \S+ </prematch>
   <regex offset="after_prematch">^(\S+ \S+) \d+ \S+ (\S+) </regex>
-  <regex>\S+ \S+ \S+ \S+ \S+ (\d+) </regex>
-  <order>url, srcip, id</order>
+  <regex>\S+ \S+ \S+ \S+ (\S+) (\d+) </regex>
+  <order>url, srcip, hostname, id</order>
 </decoder>
 
 <!--


### PR DESCRIPTION
Add hostname order to the iis6 decoder so you can create better alert descriptions, which is useful for those who have integrations with Telegram or Slack. Example of how I use it in my environments:

```xml
<description>SQL injection from ip: $(srcip) in the $(hostname).</description>
````