### PR TITLE
Match support for Amazon versioning

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/iVersionObjectInterface.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/iVersionObjectInterface.hpp
@@ -20,7 +20,8 @@ enum class VersionObjectType : int
     MajorMinor = 3,
     SemVer = 4,
     DPKG = 5,
-    RPM = 6
+    RPM = 6,
+    AMZN = 7
 };
 
 /**

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
@@ -14,6 +14,7 @@
 
 #include "iVersionObjectInterface.hpp"
 #include "loggerHelper.h"
+#include "versionObjectAmzn.hpp"
 #include "versionObjectCalVer.hpp"
 #include "versionObjectDpkg.hpp"
 #include "versionObjectMajorMinor.hpp"
@@ -50,6 +51,7 @@ private:
         SemVer semVer {};
         Dpkg dpkgVer {};
         Rpm rpmVer {};
+        Amzn amznVer {};
         switch (type)
         {
             default: logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject. Invalid type"); return nullptr;
@@ -77,6 +79,10 @@ private:
                 else if (VersionObjectSemVer::match(version, semVer))
                 {
                     return std::make_shared<VersionObjectSemVer>(semVer);
+                }
+                else if (VersionObjectAmzn::match(version, amznVer))
+                {
+                    return std::make_shared<VersionObjectAmzn>(amznVer);
                 }
                 else
                 {
@@ -169,6 +175,20 @@ private:
                 {
                     logDebug2(WM_VULNSCAN_LOGTAG,
                               "Error creating VersionObject (RPMver). The version string doesn't match the "
+                              "specified type. Version string: %s",
+                              version.c_str());
+                    return nullptr;
+                }
+                break;
+            case VersionObjectType::AMZN:
+                if (VersionObjectAmzn::match(version, amznVer))
+                {
+                    return std::make_shared<VersionObjectAmzn>(amznVer);
+                }
+                else
+                {
+                    logDebug2(WM_VULNSCAN_LOGTAG,
+                              "Error creating VersionObject (AMZNVer). The version string doesn't match the "
                               "specified type. Version string: %s",
                               version.c_str());
                     return nullptr;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.cpp
@@ -1,0 +1,14 @@
+/*
+ * Wazuh Vulnerability scanner - Database Feed Manager
+ * Copyright (C) 2015, Wazuh Inc.
+ * December 28, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "versionObjectAmzn.hpp"
+
+std::regex VersionObjectAmzn::m_parserRegex(R"((\d+:)?(\d+)\.?(\d+)?\.?(\d+)?-(\d+)?)");

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.hpp
@@ -24,11 +24,11 @@
  */
 struct Amzn
 {
-    uint32_t epoch;    ///< Year.
-    uint32_t major;    ///< Month.
-    uint32_t minor;    ///< Day.
-    uint32_t patch;    ///< Microseconds.
-    uint32_t release;    ///< Microseconds.
+    uint32_t epoch;   ///< Year.
+    uint32_t major;   ///< Month.
+    uint32_t minor;   ///< Day.
+    uint32_t patch;   ///< Microseconds.
+    uint32_t release; ///< Microseconds.
 };
 
 /**
@@ -39,10 +39,10 @@ class VersionObjectAmzn final : public IVersionObject
 {
 private:
     static std::regex m_parserRegex;
-    uint32_t m_epoch;  
-    uint32_t m_major;  
-    uint32_t m_minor;  
-    uint32_t m_patch;  
+    uint32_t m_epoch;
+    uint32_t m_major;
+    uint32_t m_minor;
+    uint32_t m_patch;
     uint32_t m_release;
 
 public:
@@ -109,7 +109,8 @@ public:
         {
             throw std::runtime_error {"Error casting VersionObject type"};
         }
-        return (m_epoch == pB->m_epoch && m_major == pB->m_major && m_minor == pB->m_minor && m_patch == pB->m_patch && m_release == pB->m_release);
+        return (m_epoch == pB->m_epoch && m_major == pB->m_major && m_minor == pB->m_minor && m_patch == pB->m_patch &&
+                m_release == pB->m_release);
     }
 
     /**
@@ -126,24 +127,27 @@ public:
             throw std::runtime_error {"Error casting VersionObject type"};
         }
 
-        if (m_epoch != pB->m_epoch) {
+        if (m_epoch != pB->m_epoch)
+        {
             return m_epoch < pB->m_epoch;
         }
 
-        else if (m_major != pB->m_major) {
+        else if (m_major != pB->m_major)
+        {
             return m_major < pB->m_major;
         }
 
-        else if (m_minor != pB->m_minor) {
+        else if (m_minor != pB->m_minor)
+        {
             return m_minor < pB->m_minor;
         }
 
-        else if (m_patch != pB->m_patch) {
+        else if (m_patch != pB->m_patch)
+        {
             return m_patch < pB->m_patch;
         }
 
         return m_release < pB->m_release;
-
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.hpp
@@ -1,7 +1,7 @@
 /*
  * Wazuh Vulnerability scanner - Database Feed Manager
  * Copyright (C) 2015, Wazuh Inc.
- * December 14, 2023.
+ * December 28, 2023.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
@@ -27,8 +27,8 @@ struct Amzn
     uint32_t epoch;   ///< Year.
     uint32_t major;   ///< Month.
     uint32_t minor;   ///< Day.
-    uint32_t patch;   ///< Microseconds.
-    uint32_t release; ///< Microseconds.
+    uint32_t patch;   ///< Patch.
+    uint32_t release; ///< Release.
 };
 
 /**

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.hpp
@@ -1,0 +1,150 @@
+/*
+ * Wazuh Vulnerability scanner - Database Feed Manager
+ * Copyright (C) 2015, Wazuh Inc.
+ * December 14, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _VERSION_OBJECT_AMZN_HPP
+#define _VERSION_OBJECT_AMZN_HPP
+
+#include "iVersionObjectInterface.hpp"
+#include <iostream>
+#include <memory>
+#include <regex>
+#include <string>
+
+/**
+ * @brief Amzn data struct.
+ *
+ */
+struct Amzn
+{
+    uint32_t epoch;    ///< Year.
+    uint32_t major;    ///< Month.
+    uint32_t minor;    ///< Day.
+    uint32_t patch;    ///< Microseconds.
+    uint32_t release;    ///< Microseconds.
+};
+
+/**
+ * @brief VersionObjectAmzn class.
+ *
+ */
+class VersionObjectAmzn final : public IVersionObject
+{
+private:
+    static std::regex m_parserRegex;
+    uint32_t m_epoch;  
+    uint32_t m_major;  
+    uint32_t m_minor;  
+    uint32_t m_patch;  
+    uint32_t m_release;
+
+public:
+    /**
+     * @brief Static method to match a version string to a Amzn object.
+     *
+     * @param version version string to match.
+     * @param output Amzn object to store the result.
+     * @return true/false according to match condition.
+     */
+    static bool match(const std::string& version, Amzn& output)
+    {
+        std::smatch parserMatches;
+        if ((std::regex_search(version, parserMatches, m_parserRegex) == false) || (parserMatches.size() != 5))
+        {
+
+            output.epoch = parserMatches.str(1).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(1)));
+            output.major = parserMatches.str(2).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(2)));
+            output.minor = parserMatches.str(3).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(3)));
+            output.patch = parserMatches.str(4).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(4)));
+            output.release = parserMatches.str(5).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(5)));
+            return true;
+        }
+
+        return false;
+    }
+    /**
+     * @brief Constructor.
+     *
+     * @param version version SemVer object.
+     */
+    explicit VersionObjectAmzn(const Amzn& version)
+        : m_epoch {version.epoch}
+        , m_major {version.major}
+        , m_minor {version.minor}
+        , m_patch {version.patch}
+        , m_release {version.release}
+    {
+    }
+    // LCOV_EXCL_START
+    ~VersionObjectAmzn() override = default;
+    // LCOV_EXCL_STOP
+
+    /**
+     * @brief Returns the VersionObjectType of this class.
+     *
+     * @return VersionObjectType.
+     */
+    VersionObjectType getType() override
+    {
+        return VersionObjectType::AMZN;
+    }
+
+    /**
+     * @brief Comparison operator ==.
+     *
+     * @param b comparison rhs object.
+     * @return true/false according to equality condition.
+     */
+    bool operator==(const IVersionObject& b) const override
+    {
+        const auto* pB = dynamic_cast<const VersionObjectAmzn*>(&b);
+        if (pB == nullptr)
+        {
+            throw std::runtime_error {"Error casting VersionObject type"};
+        }
+        return (m_epoch == pB->m_epoch && m_major == pB->m_major && m_minor == pB->m_minor && m_patch == pB->m_patch && m_release == pB->m_release);
+    }
+
+    /**
+     * @brief Comparison operator <.
+     *
+     * @param b comparison rhs object.
+     * @return true/false according to less than condition.
+     */
+    bool operator<(const IVersionObject& b) const override
+    {
+        const auto* pB = dynamic_cast<const VersionObjectAmzn*>(&b);
+        if (pB == nullptr)
+        {
+            throw std::runtime_error {"Error casting VersionObject type"};
+        }
+
+        if (m_epoch != pB->m_epoch) {
+            return m_epoch < pB->m_epoch;
+        }
+
+        else if (m_major != pB->m_major) {
+            return m_major < pB->m_major;
+        }
+
+        else if (m_minor != pB->m_minor) {
+            return m_minor < pB->m_minor;
+        }
+
+        else if (m_patch != pB->m_patch) {
+            return m_patch < pB->m_patch;
+        }
+
+        return m_release < pB->m_release;
+
+    }
+};
+
+#endif // _VERSION_OBJECT_AMZN_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
@@ -528,3 +528,16 @@ TEST_F(VersionMatcherTest, compareAmznLinux_casesGretter)
     EXPECT_EQ(VersionMatcher::compare("2:9.1.2120-1.amzn2023", "2:9.0.2120-1.amzn2023", VersionObjectType::AMZN), 1);
     EXPECT_EQ(VersionMatcher::compare("2.21-29.amzn2023.0.2", "2.21-26.amzn2023.0.2", VersionObjectType::AMZN), 1);
 }
+
+TEST_F(VersionMatcherTest, compareAmznLinux_casesRealScan)
+{
+    EXPECT_EQ(
+        VersionMatcher::compare("1.15.1-6.amzn2023.0.3", "gpgme-1.4.3-5.15.amzn1.x86_64.rpm", VersionObjectType::AMZN),
+        1);
+    EXPECT_EQ(VersionMatcher::compare(
+                  "1.57.0-1.amzn2023.0.1", "libnghttp2-1.41.0-1.amzn2.0.4.aarch64.rpm", VersionObjectType::AMZN),
+              -1);
+    EXPECT_EQ(VersionMatcher::compare(
+                  "5.4.4-3.amzn2023.0.2", "lua-libs-5.4.4-3.amzn2022.x86_64.rpm", VersionObjectType::AMZN),
+              0);
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
@@ -492,3 +492,36 @@ TEST_F(VersionMatcherTest, compareRpmVer_rmpPackages)
               0);                                                                                           // Alma
     EXPECT_EQ(VersionMatcher::compare("2.2.20-2.el8", "2.2.20-2.el8.aarch64", VersionObjectType::RPM), -1); // CentOS
 }
+
+TEST_F(VersionMatcherTest, compareAmznLinux_casesEqual)
+{
+    EXPECT_EQ(VersionMatcher::compare("1:4.8.0-2.amzn2023.0.2", "1:4.8.0-2.amzn2023.0.2", VersionObjectType::AMZN), 0);
+    EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::AMZN), 0);
+    EXPECT_EQ(VersionMatcher::compare("3.14-5.amzn2023.0.3", "3.14-5.amzn2023.0.3", VersionObjectType::RPM), 0);
+    EXPECT_EQ(VersionMatcher::compare("1:2.0.5-12.amzn2023.0.2", "1:2.0.5-12.amzn2023.0.2", VersionObjectType::AMZN), 0);
+    EXPECT_EQ(VersionMatcher::compare("2.37.4-1.amzn2023.0.3", "2.37.4-1.amzn2023.0.3", VersionObjectType::AMZN), 0);
+    EXPECT_EQ(VersionMatcher::compare("2:9.0.2120-1.amzn2023", "2:9.0.2120-1.amzn2023", VersionObjectType::AMZN), 0);
+    EXPECT_EQ(VersionMatcher::compare("2.21-26.amzn2023.0.2", "2.21-26.amzn2023.0.2", VersionObjectType::AMZN), 0);
+}
+
+TEST_F(VersionMatcherTest, compareAmznLinux_casesLess)
+{
+    EXPECT_EQ(VersionMatcher::compare("1:4.8.0-2.amzn2023.0.2", "2:4.8.0-2.amzn2023.0.2", VersionObjectType::AMZN), -1);
+    EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "6-4.amzn2023.0.5", VersionObjectType::AMZN), -1);
+    EXPECT_EQ(VersionMatcher::compare("3.14-5.amzn2023.0.3", "3.15-5.amzn2023.0.3", VersionObjectType::RPM), -1);
+    EXPECT_EQ(VersionMatcher::compare("1:2.0.5-12.amzn2023.0.2", "1:2.0.6-12.amzn2023.0.2", VersionObjectType::AMZN), -1);
+    EXPECT_EQ(VersionMatcher::compare("2.37.4-1.amzn2023.0.3", "2.37.4-2.amzn2023.0.3", VersionObjectType::AMZN), -1);
+    EXPECT_EQ(VersionMatcher::compare("2:9.0.2120-1.amzn2023", "2:9.0.2120-2.amzn2023", VersionObjectType::AMZN), -1);
+    EXPECT_EQ(VersionMatcher::compare("2.21-26.amzn2023.0.2", "2.22-26.amzn2023.0.2", VersionObjectType::AMZN), -1);
+}
+
+TEST_F(VersionMatcherTest, compareAmznLinux_casesGretter)
+{
+    EXPECT_EQ(VersionMatcher::compare("2:4.8.0-2.amzn2023.0.2", "1:4.8.0-2.amzn2023.0.2", VersionObjectType::AMZN), 1);
+    EXPECT_EQ(VersionMatcher::compare("6-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::AMZN), 1);
+    EXPECT_EQ(VersionMatcher::compare("3.15-5.amzn2023.0.3", "3.14-5.amzn2023.0.3", VersionObjectType::RPM), 1);
+    EXPECT_EQ(VersionMatcher::compare("1:2.0.5-13.amzn2023.0.2", "1:2.0.5-12.amzn2023.0.2", VersionObjectType::AMZN), 1);
+    EXPECT_EQ(VersionMatcher::compare("3.37.4-1.amzn2023.0.3", "2.37.4-1.amzn2023.0.3", VersionObjectType::AMZN), 1);
+    EXPECT_EQ(VersionMatcher::compare("2:9.1.2120-1.amzn2023", "2:9.0.2120-1.amzn2023", VersionObjectType::AMZN), 1);
+    EXPECT_EQ(VersionMatcher::compare("2.21-29.amzn2023.0.2", "2.21-26.amzn2023.0.2", VersionObjectType::AMZN), 1);
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
@@ -498,7 +498,8 @@ TEST_F(VersionMatcherTest, compareAmznLinux_casesEqual)
     EXPECT_EQ(VersionMatcher::compare("1:4.8.0-2.amzn2023.0.2", "1:4.8.0-2.amzn2023.0.2", VersionObjectType::AMZN), 0);
     EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::AMZN), 0);
     EXPECT_EQ(VersionMatcher::compare("3.14-5.amzn2023.0.3", "3.14-5.amzn2023.0.3", VersionObjectType::RPM), 0);
-    EXPECT_EQ(VersionMatcher::compare("1:2.0.5-12.amzn2023.0.2", "1:2.0.5-12.amzn2023.0.2", VersionObjectType::AMZN), 0);
+    EXPECT_EQ(VersionMatcher::compare("1:2.0.5-12.amzn2023.0.2", "1:2.0.5-12.amzn2023.0.2", VersionObjectType::AMZN),
+              0);
     EXPECT_EQ(VersionMatcher::compare("2.37.4-1.amzn2023.0.3", "2.37.4-1.amzn2023.0.3", VersionObjectType::AMZN), 0);
     EXPECT_EQ(VersionMatcher::compare("2:9.0.2120-1.amzn2023", "2:9.0.2120-1.amzn2023", VersionObjectType::AMZN), 0);
     EXPECT_EQ(VersionMatcher::compare("2.21-26.amzn2023.0.2", "2.21-26.amzn2023.0.2", VersionObjectType::AMZN), 0);
@@ -509,7 +510,8 @@ TEST_F(VersionMatcherTest, compareAmznLinux_casesLess)
     EXPECT_EQ(VersionMatcher::compare("1:4.8.0-2.amzn2023.0.2", "2:4.8.0-2.amzn2023.0.2", VersionObjectType::AMZN), -1);
     EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "6-4.amzn2023.0.5", VersionObjectType::AMZN), -1);
     EXPECT_EQ(VersionMatcher::compare("3.14-5.amzn2023.0.3", "3.15-5.amzn2023.0.3", VersionObjectType::RPM), -1);
-    EXPECT_EQ(VersionMatcher::compare("1:2.0.5-12.amzn2023.0.2", "1:2.0.6-12.amzn2023.0.2", VersionObjectType::AMZN), -1);
+    EXPECT_EQ(VersionMatcher::compare("1:2.0.5-12.amzn2023.0.2", "1:2.0.6-12.amzn2023.0.2", VersionObjectType::AMZN),
+              -1);
     EXPECT_EQ(VersionMatcher::compare("2.37.4-1.amzn2023.0.3", "2.37.4-2.amzn2023.0.3", VersionObjectType::AMZN), -1);
     EXPECT_EQ(VersionMatcher::compare("2:9.0.2120-1.amzn2023", "2:9.0.2120-2.amzn2023", VersionObjectType::AMZN), -1);
     EXPECT_EQ(VersionMatcher::compare("2.21-26.amzn2023.0.2", "2.22-26.amzn2023.0.2", VersionObjectType::AMZN), -1);
@@ -520,7 +522,8 @@ TEST_F(VersionMatcherTest, compareAmznLinux_casesGretter)
     EXPECT_EQ(VersionMatcher::compare("2:4.8.0-2.amzn2023.0.2", "1:4.8.0-2.amzn2023.0.2", VersionObjectType::AMZN), 1);
     EXPECT_EQ(VersionMatcher::compare("6-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::AMZN), 1);
     EXPECT_EQ(VersionMatcher::compare("3.15-5.amzn2023.0.3", "3.14-5.amzn2023.0.3", VersionObjectType::RPM), 1);
-    EXPECT_EQ(VersionMatcher::compare("1:2.0.5-13.amzn2023.0.2", "1:2.0.5-12.amzn2023.0.2", VersionObjectType::AMZN), 1);
+    EXPECT_EQ(VersionMatcher::compare("1:2.0.5-13.amzn2023.0.2", "1:2.0.5-12.amzn2023.0.2", VersionObjectType::AMZN),
+              1);
     EXPECT_EQ(VersionMatcher::compare("3.37.4-1.amzn2023.0.3", "2.37.4-1.amzn2023.0.3", VersionObjectType::AMZN), 1);
     EXPECT_EQ(VersionMatcher::compare("2:9.1.2120-1.amzn2023", "2:9.0.2120-1.amzn2023", VersionObjectType::AMZN), 1);
     EXPECT_EQ(VersionMatcher::compare("2.21-29.amzn2023.0.2", "2.21-26.amzn2023.0.2", VersionObjectType::AMZN), 1);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21032 |

## Objective
This pull request aims to improve version extraction and vulnerability database comparison for Amazon packages. The primary objective is to introduce a regular expression (`regex`) `(\d+:)?(\d+)\.?(\d+)?\.?(\d+)?-(\d+)?` that accurately captures the version information from Amazon packages. Additionally, minor changes are proposed for the `syscollector` module to ensure correct extraction of version details from Amazon packages, facilitating more accurate and reliable version-based vulnerability checks.


## Description
- Introduces the following regex for Amazon versioning:

```bash
(\d+:)?(\d+)\.?(\d+)?\.?(\d+)?-(\d+)?
```

This regex is designed to extract version components from Amazon packages. It accounts for various version formats commonly found in Amazon package versions, ensuring comprehensive coverage. Let's break down the components of this regular expression:

- `(\d+:)?`: This part handles the optional epoch component in the version. An epoch is a single non-negative integer followed by a colon. This entire part is optional, as indicated by the ?.

- `(\d+)`: This captures the main version number, which is a required non-negative integer.
 
- `\.?`: This accounts for an optional dot (.) that may separate the main version number from the subversion.

- `(\d+)?`: This captures the subversion, which is an optional non-negative integer. The entire subversion part is also optional due to the ?.

- ` \.?`: This accounts for another optional dot (.) that may separate the subversion from the patch version.

- ` (\d+)?`: This captures the patch version, which is another optional non-negative integer. The entire patch version part is optional due to the ?.

- `-(\d+)`: This captures the release version, which is a non-negative integer preceded by a hyphen. This part is required.

## Quality Assurance
New tests have been added to validate the quality of this implementation

```bash
./build/wazuh_modules/vulnerability_scanner/tests/unit/vulnerability_scanner_unit_tests
```

```bash
[----------] 34 tests from VersionMatcherTest
[ RUN      ] VersionMatcherTest.compareCalVer_OkEqual
[       OK ] VersionMatcherTest.compareCalVer_OkEqual (0 ms)
[ RUN      ] VersionMatcherTest.compareCalVer_OkLess
[       OK ] VersionMatcherTest.compareCalVer_OkLess (0 ms)
[ RUN      ] VersionMatcherTest.compareCalVer_OkGreater
[       OK ] VersionMatcherTest.compareCalVer_OkGreater (0 ms)
[ RUN      ] VersionMatcherTest.compareCalVer_ErrorInvalidVersion
[       OK ] VersionMatcherTest.compareCalVer_ErrorInvalidVersion (0 ms)
[ RUN      ] VersionMatcherTest.comparePEP440_OkEqual
[       OK ] VersionMatcherTest.comparePEP440_OkEqual (1 ms)
[ RUN      ] VersionMatcherTest.comparePEP440_OkLess
[       OK ] VersionMatcherTest.comparePEP440_OkLess (3 ms)
[ RUN      ] VersionMatcherTest.comparePEP440_OkGreater
[       OK ] VersionMatcherTest.comparePEP440_OkGreater (3 ms)
[ RUN      ] VersionMatcherTest.comparePEP440_ErrorInvalidVersion
[       OK ] VersionMatcherTest.comparePEP440_ErrorInvalidVersion (0 ms)
[ RUN      ] VersionMatcherTest.compareMajorMinor_OkEqual
[       OK ] VersionMatcherTest.compareMajorMinor_OkEqual (0 ms)
[ RUN      ] VersionMatcherTest.compareMajorMinor_OkLess
[       OK ] VersionMatcherTest.compareMajorMinor_OkLess (0 ms)
[ RUN      ] VersionMatcherTest.compareMajorMinor_OkGreater
[       OK ] VersionMatcherTest.compareMajorMinor_OkGreater (0 ms)
[ RUN      ] VersionMatcherTest.compareMajorMinor_ErrorInvalidVersion
[       OK ] VersionMatcherTest.compareMajorMinor_ErrorInvalidVersion (0 ms)
[ RUN      ] VersionMatcherTest.compareSemVer_OkEqual
[       OK ] VersionMatcherTest.compareSemVer_OkEqual (0 ms)
[ RUN      ] VersionMatcherTest.compareSemVer_OkLess
[       OK ] VersionMatcherTest.compareSemVer_OkLess (0 ms)
[ RUN      ] VersionMatcherTest.compareSemVer_OkGreater
[       OK ] VersionMatcherTest.compareSemVer_OkGreater (0 ms)
[ RUN      ] VersionMatcherTest.compareSemVer_ErrorInvalidVersion
[       OK ] VersionMatcherTest.compareSemVer_ErrorInvalidVersion (0 ms)
[ RUN      ] VersionMatcherTest.compareUnspecified_OkCalVer
[       OK ] VersionMatcherTest.compareUnspecified_OkCalVer (0 ms)
[ RUN      ] VersionMatcherTest.compareUnspecified_OkPEP440
[       OK ] VersionMatcherTest.compareUnspecified_OkPEP440 (0 ms)
[ RUN      ] VersionMatcherTest.compareUnspecified_OkMajorMinor
[       OK ] VersionMatcherTest.compareUnspecified_OkMajorMinor (0 ms)
[ RUN      ] VersionMatcherTest.compareUnspecified_OkSemVer
[       OK ] VersionMatcherTest.compareUnspecified_OkSemVer (0 ms)
[ RUN      ] VersionMatcherTest.compareUnspecified_ErrorInvalidFormat
[       OK ] VersionMatcherTest.compareUnspecified_ErrorInvalidFormat (0 ms)
[ RUN      ] VersionMatcherTest.compareUnspecified_ErrorDifferentFormats
[       OK ] VersionMatcherTest.compareUnspecified_ErrorDifferentFormats (0 ms)
[ RUN      ] VersionMatcherTest.compareUnexistingVersionObjectType
[       OK ] VersionMatcherTest.compareUnexistingVersionObjectType (0 ms)
[ RUN      ] VersionMatcherTest.compareDpkgVer_OkEqual
[       OK ] VersionMatcherTest.compareDpkgVer_OkEqual (0 ms)
[ RUN      ] VersionMatcherTest.compareDpkgVer_OkLess
[       OK ] VersionMatcherTest.compareDpkgVer_OkLess (0 ms)
[ RUN      ] VersionMatcherTest.compareDpkgVer_OkGreater
[       OK ] VersionMatcherTest.compareDpkgVer_OkGreater (0 ms)
[ RUN      ] VersionMatcherTest.compareDpkgVer_ErrorInvalidVersion
[       OK ] VersionMatcherTest.compareDpkgVer_ErrorInvalidVersion (0 ms)
[ RUN      ] VersionMatcherTest.compareDpkgVer_dpkgLib
[       OK ] VersionMatcherTest.compareDpkgVer_dpkgLib (0 ms)
[ RUN      ] VersionMatcherTest.compareRpmVer_rmpLib
[       OK ] VersionMatcherTest.compareRpmVer_rmpLib (2 ms)
[ RUN      ] VersionMatcherTest.compareRpmVer_rmpPackages
[       OK ] VersionMatcherTest.compareRpmVer_rmpPackages (0 ms)
[ RUN      ] VersionMatcherTest.compareAmznLinux_casesEqual
[       OK ] VersionMatcherTest.compareAmznLinux_casesEqual (0 ms)
[ RUN      ] VersionMatcherTest.compareAmznLinux_casesLess
[       OK ] VersionMatcherTest.compareAmznLinux_casesLess (0 ms)
[ RUN      ] VersionMatcherTest.compareAmznLinux_casesGretter
[       OK ] VersionMatcherTest.compareAmznLinux_casesGretter (0 ms)
[ RUN      ] VersionMatcherTest.compareAmznLinux_casesRealScan
[       OK ] VersionMatcherTest.compareAmznLinux_casesRealScan (0 ms)
[----------] 34 tests from VersionMatcherTest (17 ms total)
```


<details><summary>ScanBuild report</summary>

Command:

```bash
scan-build-15 -enable-checker alpha.core.CastSize -enable-checker alpha.core.CastToStruct -enable-checker alpha.core.Conversion -enable-checker alpha.core.IdenticalExpr -enable-checker alpha.core.SizeofPtr -enable-checker alpha.core.TestAfterDivZero --exclude external make TARGET=server DEBUG=1 -j$(nproc)
```

```bash

Done building server

scan-build: No bugs found.

```

</details>

<details><summary>Clang-Format</summary>

```bash
---------------------------------
PASSED: Clang-format check passed
---------------------------------
```
</details>


## Exploratory tests

### Setup
- Clone this branch 
- Compile with `TARGET=server`
- Install manager
- Set `wazuh_modules.debug=2` and restart manager
- Optional: Install indexer
- Connect an agent to the manager
- Wait until scan ends

<details><summary>Show log</summary>

```text
2023/12/29 15:35:56 wazuh-modulesd:vulnerability-scanner[48980] packageScanner.hpp:62 at operator()(): DEBUG: SCAN -> Package: lua-libs, Version: 5.4.4-3.amzn2023.0.2, CVE: CVE-2022-33099, Ver: 0, RLT: lua-libs-5.4.4-3.amzn2022.x86_64.rpm, RLTE: 
2023/12/29 15:35:56 wazuh-modulesd:vulnerability-scanner[48980] packageScanner.hpp:62 at operator()(): DEBUG: SCAN -> Package: gpgme, Version: 1.15.1-6.amzn2023.0.3, CVE: CVE-2014-3564, Ver: 0, RLT: gpgme-1.4.3-5.15.amzn1.x86_64.rpm, RLTE: 
2023/12/29 15:35:56 wazuh-modulesd:vulnerability-scanner[48980] packageScanner.hpp:62 at operator()(): DEBUG: SCAN -> Package: libnghttp2, Version: 1.57.0-1.amzn2023.0.1, CVE: CVE-2023-44487, Ver: 0, RLT: libnghttp2-1.41.0-1.amzn2.0.4.x86_64.rpm, RLTE:
[...]
2023/12/29 15:35:46 wazuh-modulesd:vulnerability-scanner[48980] packageScanner.hpp:107 at operator()(): DEBUG: MATCH Package: requests, Version: 2.25.1, CVE: CVE-2023-32681, Ver: 2.3.0, RLT: 2.31.0, RLTE: 
2023/12/29 15:35:49 wazuh-modulesd:vulnerability-scanner[48980] packageScanner.hpp:107 at operator()(): DEBUG: MATCH Package: urllib3, Version: 1.25.10, CVE: CVE-2021-33503, Ver: 1.25.4, RLT: 1.26.5, RLTE: 
2023/12/29 15:35:49 wazuh-modulesd:vulnerability-scanner[48980] packageScanner.hpp:107 at operator()(): DEBUG: MATCH Package: urllib3, Version: 1.25.10, CVE: CVE-2023-43804, Ver: 0, RLT: 1.26.17, RLTE: 
2023/12/29 15:35:49 wazuh-modulesd:vulnerability-scanner[48980] packageScanner.hpp:107 at operator()(): DEBUG: MATCH Package: urllib3, Version: 1.25.10, CVE: CVE-2023-45803, Ver: 0, RLT: 1.26.18, RLTE: 
2023/12/29 15:35:53 wazuh-modulesd:vulnerability-scanner[48980] packageScanner.hpp:107 at operator()(): DEBUG: MATCH Package: rpm, Version: 4.16.1.3, CVE: CVE-2021-3521, Ver: 0, RLT: 4.17.1, RLTE: 
2023/12/29 15:35:53 wazuh-modulesd:vulnerability-scanner[48980] packageScanner.hpp:107 at operator()(): DEBUG: MATCH Package: rpm, Version: 4.16.1.3, CVE: CVE-2021-35937, Ver: 0, RLT: 4.18.0, RLTE: 
2023/12/29 15:35:53 wazuh-modulesd:vulnerability-scanner[48980] packageScanner.hpp:107 at operator()(): DEBUG: MATCH Package: rpm, Version: 4.16.1.3, CVE: CVE-2021-35938, Ver: 0, RLT: 4.18.0, RLTE: 
2023/12/29 15:35:53 wazuh-modulesd:vulnerability-scanner[48980] packageScanner.hpp:107 at operator()(): DEBUG: MATCH Package: rpm, Version: 4.16.1.3, CVE: CVE-2021-35939, Ver: 0, RLT: 4.18, RLTE:
[...]
root@pr-test:/var/ossec# grep "Error" logs/ossec.log | wc -l
0
[...]
bash-5.2# dnf list | grep "1.57.0-1.amzn2023.0.1"
libnghttp2.x86_64                                                 1.57.0-1.amzn2023.0.1                       @System      
libnghttp2-devel.x86_64                                           1.57.0-1.amzn2023.0.1                       amazonlinux  
nghttp2.x86_64 
```

</details>



### Check summary
- [x] Style and quality of SCA.
- [x] Documentation clear.
- [x] Functionality optimizated.
