### PR TITLE
mplement remove the vulnerabilities in the inventory when integrity_clear message is sent.

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -282,7 +282,9 @@ public:
                             m_osData = OsDataCache::instance().getOsData(agentId().data());
                         }
                     }
-                    else if (syncMsg->data_type() == SyscollectorSynchronization::DataUnion_integrity_clear)
+                    else if (syncMsg->data_type() == SyscollectorSynchronization::DataUnion_integrity_clear &&
+                             syncMsg->data_as_state()->attributes_type() ==
+                                 SyscollectorSynchronization::AttributesUnion_syscollector_packages)
                     {
                         m_type = ScannerType::IntegrityClear;
                         m_operationType = OperationType::DeleteAll;


### PR DESCRIPTION
|Related issue|
|---|
|#20963|

(Re open - See #21118)

## Objective
The purpose of this pull request is to implement a solution within the factory orchestrator design pattern that, upon receiving an `integrity_clear` message from an agent, removes all vulnerabilities associated with that agent from the inventory database. This functionality is particularly important when the `syscollector` is disabled on the agent, ensuring accurate and up-to-date vulnerability information within the system.

## Description
- Introduce an orchestration mechanism within the factory orchestrator design pattern. This orchestration is triggered specifically when an agent sends an `integrity_clear` message due to the syscollector being disabled on the agent's system.
- Upon receiving the `integrity_clear` message, the orchestrator orchestrates the removal of all vulnerabilities associated with the corresponding agent from the `inventory` database. This ensures that outdated or irrelevant vulnerability data is promptly cleared, maintaining the integrity of vulnerability information in the system.
- New test cases have been added to the `scanner testtool` to validate the behavior of the orchestrator when processing `integrity_clear` messages. These test cases cover various scenarios, including different syscollector statuses, multiple agents, and various vulnerability profiles.


## Quality Assurance
No test has been added to this PR, only `TC-003`

```bash
#This TC-003 requires an indexer installed and the config.json set with the correct values of address and certificates

BINARY="/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_scanner_testtool"
CONFIG="/wazuh/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.json"
TEMPLATE="/wazuh/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json"
INPUT="/wazuh/src/wazuh_modules/vulnerability_scanner/testtool/scanner/TC-003/step_0.json,/wazuh/src/wazuh_modules/vulnerability_scanner/testtool/scanner/TC-003/step_1.json"

$BINARY -c $CONFIG -t $TEMPLATE -i $INPUT
```

```bash
indexer-connnector:indexerConnector.cpp:250 initialize : IndexerConnector initialized.
wazuh-modulesd:content-updater:actionOrchestrator.hpp:50 ActionOrchestrator : Creating 'vulnerability_feed_manager' Content Updater orchestration
wazuh-modulesd:content-updater:executionContext.hpp:202 handleRequest : ExecutionContext - Starting process
wazuh-modulesd:content-updater:executionContext.hpp:179 createOutputFolder : Removing previous output folder 'queue/vd_updater/tmp'
wazuh-modulesd:content-updater:executionContext.hpp:184 createOutputFolder : Creating output folders at 'queue/vd_updater/tmp'
wazuh-modulesd:content-updater:factoryContentUpdater.hpp:44 create : FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:factoryDownloader.hpp:46 create : Creating 'cti-offset' downloader
wazuh-modulesd:content-updater:factoryDecompressor.hpp:73 create : Creating 'raw' decompressor
wazuh-modulesd:content-updater:factoryVersionUpdater.hpp:41 create : Creating 'cti-api' version updater
wazuh-modulesd:content-updater:factoryCleaner.hpp:41 create : Content cleaner created
wazuh-modulesd:content-updater:actionOrchestrator.hpp:60 ActionOrchestrator : Content updater orchestration created
wazuh-modulesd:content-updater:action.hpp:125 runActionScheduled : Starting scheduled action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:215 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:82 run : Running 'vulnerability_feed_manager' content update
wazuh-modulesd:content-updater:CtiDownloader.hpp:204 handleRequest : CtiOffsetDownloader - Starting process
wazuh-modulesd:content-updater:CtiOffsetDownloader.hpp:42 download : Initial API offset: 281100
Integrity clear scanner Init
Processing file: /wazuh/src/wazuh_modules/vulnerability_scanner/testtool/scanner/TC-003/step_0.json
Syscollector delta parsed successfully
size: 484
Failed to send message: Error sending data to socket: 107 Transport endpoint is not connected
Error modifying FD from interface.
wazuh-modulesd:content-updater:CtiDownloader.hpp:104 getCtiBaseParameters : CTI last offset: '281100'
wazuh-modulesd:content-updater:CtiDownloader.hpp:105 getCtiBaseParameters : CTI last snapshot link: 'https://s3.us-east-1.amazonaws.com/cti-snapshots-pro/store/contexts/vd_1.0.0/consumers/vd_4.8.0/281100_1703273628.zip'
wazuh-modulesd:content-updater:CtiDownloader.hpp:106 getCtiBaseParameters : CTI snapshot last offset: '281100'
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest : SkipStep - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:61 handleRequest : PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:49 publish : No data to publish
wazuh-modulesd:content-updater:updateCtiApiOffset.hpp:68 handleRequest : UpdateCtiApiOffset - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest : CleanUpContent - Starting process
wazuh-modulesd:content-updater:action.hpp:226 runAction : Action for 'vulnerability_feed_manager' finished
wazuh-modulesd:vulnerability-scanner:osDataCache.hpp:129 getOsData : Error quering Wazuh-DB: Timeout waiting for DB response
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:154 handleRequest : Scanning package: wazuh, CNA: nvd
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:62 operator() : SCAN -> Package: wazuh, Version: 4.2.0, CVE: CVE-2018-19666, Ver: 1.0.0, RLT: , RLTE: 2.1.1
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:62 operator() : SCAN -> Package: wazuh, Version: 4.2.0, CVE: CVE-2021-26814, Ver: 4.0.0, RLT: , RLTE: 4.0.3
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:62 operator() : SCAN -> Package: wazuh, Version: 4.2.0, CVE: CVE-2021-41821, Ver: 0, RLT: , RLTE: 4.1.5
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:62 operator() : SCAN -> Package: wazuh, Version: 4.2.0, CVE: CVE-2021-44079, Ver: 4.2.0, RLT: 4.2.5, RLTE: 
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:107 operator() : MATCH Package: wazuh, Version: 4.2.0, CVE: CVE-2021-44079, Ver: 4.2.0, RLT: 4.2.5, RLTE: 
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:62 operator() : SCAN -> Package: wazuh, Version: 4.2.0, CVE: CVE-2022-40497, Ver: 3.6.1, RLT: , RLTE: 3.13.5
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:62 operator() : SCAN -> Package: wazuh, Version: 4.2.0, CVE: CVE-2022-40497, Ver: 4.0.0, RLT: , RLTE: 4.2.7
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:107 operator() : MATCH Package: wazuh, Version: 4.2.0, CVE: CVE-2022-40497, Ver: 4.0.0, RLT: , RLTE: 4.2.7
wazuh-modulesd:vulnerability-scanner:sendReport.hpp:66 handleRequest : REPORT: 1:[001] () ->vulnerability-scanner:{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2022-40497","description":"Wazuh v3.6.1 - v3.13.5, v4.0.0 - v4.2.7, and v4.3.0 - v4.3.7 were discovered to contain an authenticated remote code execution (RCE) vulnerability via the Active Response endpoint.","enumeration":"CVE","package":{"architecture":"amd64","build_version":"","checksum":"","description":"Wazuh - Open Source Host and Endpoint Security","install_scope":"","license":"","name":"wazuh","path":"","reference":"","size":72,"type":"deb","version":"4.2.0"},"reference":"https://github.com/wazuh/wazuh/pull/14801","report_id":"","scanner":{"vendor":"Wazuh"},"score":{"base":8.8,"environmental":0.0,"temporal":0.0,"version":"3.1"},"severity":"High","status":"Active"}}
Failed to send message: Error sending data to socket: 107 Transport endpoint is not connected
Error modifying FD from interface.
wazuh-modulesd:vulnerability-scanner:sendReport.hpp:66 handleRequest : REPORT: 1:[001] () ->vulnerability-scanner:{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2021-44079","description":"In the wazuh-slack active response script in Wazuh 4.2.x before 4.2.5, untrusted user agents are passed to a curl command line, potentially resulting in remote code execution.","enumeration":"CVE","package":{"architecture":"amd64","build_version":"","checksum":"","description":"Wazuh - Open Source Host and Endpoint Security","install_scope":"","license":"","name":"wazuh","path":"","reference":"","size":72,"type":"deb","version":"4.2.0"},"reference":"https://github.com/wazuh/wazuh/issues/10858, https://github.com/wazuh/wazuh/issues/10858#issuecomment-991118254, https://github.com/wazuh/wazuh/pull/10809","report_id":"","scanner":{"vendor":"Wazuh"},"score":{"base":7.5,"environmental":0.0,"temporal":0.0,"version":"2.0"},"severity":"High","status":"Active"}}
wazuh-modulesd:vulnerability-scanner:resultIndexer.hpp:53 handleRequest : Processing key: CVE-2022-40497
wazuh-modulesd:vulnerability-scanner:resultIndexer.hpp:53 handleRequest : Processing key: CVE-2021-44079
Processing file: /wazuh/src/wazuh_modules/vulnerability_scanner/testtool/scanner/TC-003/step_1.json
Syscollector synchronization parsed successfully
size: 132
wazuh-modulesd:vulnerability-scanner:inventorySync.hpp:72 handleRequest : Generate JSON: {"id":"test_node_name_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2022-40497","operation":"DELETED"}
wazuh-modulesd:vulnerability-scanner:inventorySync.hpp:72 handleRequest : Generate JSON: {"id":"test_node_name_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2021-44079","operation":"DELETED"}
wazuh-modulesd:vulnerability-scanner:inventorySync.hpp:74 handleRequest : Deleting all agent package key: test_node_name_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53
wazuh-modulesd:vulnerability-scanner:sendReport.hpp:73 handleRequest : Couldn't send vulnerability JSON report
wazuh-modulesd:vulnerability-scanner:sendReport.hpp:73 handleRequest : Couldn't send vulnerability JSON report
wazuh-modulesd:vulnerability-scanner:resultIndexer.hpp:53 handleRequest : Processing key: test_node_name_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2021-44079
wazuh-modulesd:vulnerability-scanner:resultIndexer.hpp:53 handleRequest : Processing key: test_node_name_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2022-40497
Press enter to stop the scanner...
indexer-connnector:indexerConnector.cpp:153 operator() : Response: {"took":73,"errors":false,"items":[{"index":{"_index":"wazuh-states-vulnerabilities","_id":"test_node_name_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2022-40497","_version":19,"result":"updated","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":54,"_primary_term":1,"status":200}},{"index":{"_index":"wazuh-states-vulnerabilities","_id":"test_node_name_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2021-44079","_version":19,"result":"updated","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":55,"_primary_term":1,"status":200}},{"delete":{"_index":"wazuh-states-vulnerabilities","_id":"test_node_name_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2021-44079","_version":20,"result":"deleted","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":56,"_primary_term":1,"status":200}},{"delete":{"_index":"wazuh-states-vulnerabilities","_id":"test_node_name_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2022-40497","_version":20,"result":"deleted","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":57,"_primary_term":1,"status":200}}]}
wazuh-modulesd:content-updater:onDemandManager.cpp:93 stopServer : Server stopped
wazuh-modulesd:content-updater:action.hpp:145 stopActionScheduler : Scheduler stopped for 'vulnerability_feed_manager'
```

```bash
# We can validate the correct behavior using rocksdbquery tool
/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/rocks_db_query_testtool -d queue/vd/inventory/ | wc -l
0
```

> [!IMPORTANT]  
> The testtool rocksdbquery should have the following commit to execute it: c18c6ee821f1ab1bc2258d62c6c4e4ede214535a 

<details><summary>ScanBuild report</summary>

Command:

```bash
scan-build-15 -enable-checker alpha.core.CastSize -enable-checker alpha.core.CastToStruct -enable-checker alpha.core.Conversion -enable-checker alpha.core.IdenticalExpr -enable-checker alpha.core.SizeofPtr -enable-checker alpha.core.TestAfterDivZero --exclude external make TARGET=server DEBUG=1 -j$(nproc)
```

```bash

Done building server

scan-build: No bugs found.

```

</details>

<details><summary>Clang-Format</summary>

```bash
---------------------------------
PASSED: Clang-format check passed
---------------------------------
```
</details>


### Check summary
- [x] Style and quality of SCA.
- [x] Documentation clear.
- [x] Functionality optimizated.
