### PR TITLE
Fix segfault in `integrity_clear` orchestration

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -283,8 +283,8 @@ public:
                         }
                     }
                     else if (syncMsg->data_type() == SyscollectorSynchronization::DataUnion_integrity_clear &&
-                             syncMsg->data_as_state()->attributes_type() ==
-                                 SyscollectorSynchronization::AttributesUnion_syscollector_packages)
+                             syncMsg->data_as_integrity_clear()->attributes_type()->str().compare(
+                                 "syscollector_packages") == 0)
                     {
                         m_type = ScannerType::IntegrityClear;
                         m_operationType = OperationType::DeleteAll;


### PR DESCRIPTION
|Related issue|
|---|
|#20963|

This PR aims to fix a segmentation fault error when an `integrity_clear` message is received and the instruction flow tries to check if a `syscollector_packages`