### PR TITLE
Fix agent stats processing

### DIFF
--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1226,7 +1226,7 @@ def test_agent_get_config_ko(socket_mock, send_mock, mock_wazuh_socket):
 def test_agent_get_stats(socket_mock, send_mock, mock_wazuh_socket):
     """Test get_stats method returns expected message."""
     agent = Agent('001')
-    mock_wazuh_socket.return_value.receive.return_value = b'{"error":0, "data":{"test":0}}'
+    mock_wazuh_socket.return_value.receive.return_value = b'{"error":0, "data":{"global":{}, "interval":{}}}'
     result = agent.get_stats('logcollector')
     assert result == {'global': {}, 'interval': {}}, 'Result message is not as expected.'
 

--- a/framework/wazuh/core/tests/test_stats.py
+++ b/framework/wazuh/core/tests/test_stats.py
@@ -239,35 +239,43 @@ def test_get_daemons_stats_from_socket(agent_id, daemon, response):
             mock_send.assert_called_once_with(f"{str(agent_id).zfill(3)} {daemon} getstate".encode())
 
 
-@pytest.mark.parametrize("agent_id, daemon, responses ,expected, expected_socket_calls, expected_arg_calls", [
+@pytest.mark.parametrize("agent_id, daemon, responses, expected, expected_socket_calls, expected_arg_calls", [
     ('000', 'logcollector', [
-        '{"error":0, "remaining": true, "data":{"global": {"start": "2023-11-27 19:51:54", "end": "2023-11-27 19:52:54", "files": [1, 2]}}}'.encode(),
-        '{"error":0, "remaining": false, "data":{"global": {"start": "2023-11-27 19:52:54", "end": "2023-11-27 19:53:54", "files": [3, 4]}}}'.encode()],
+        '{"error":0, "remaining": true, "data":{"global": {"start": "2023-11-27 19:51:54", '
+        '"end": "2023-11-27 19:52:54", "files": [1, 2]}, "interval": {}}}'.encode(),
+        '{"error":0, "remaining": false, "data":{"global": {"start": "2023-11-27 19:52:54", '
+        '"end": "2023-11-27 19:53:54", "files": [3, 4]}, "interval": {}}}'.encode()],
      {"global": {"start": "2023-11-27T19:51:54Z", "end": "2023-11-27T19:53:54Z", "files": [1, 2, 3, 4]},
       "interval": {}},
      2,
      [call('getstate'.encode()), call('getstate next'.encode())]),
-    ('001', 'agent', [
-        '{"error":0, "remaining": true, "data":{"global": {"start": "2023-11-27 19:51:54", "end": "2023-11-27 19:52:54", "files": [1, 2]}}}'.encode(),
-        '{"error":0, "remaining": true, "data":{"global": {"start": "2023-11-27 19:52:54", "end": "2023-11-27 19:53:54", "files": [3, 4]}}}'.encode(),
-        '{"error":0, "remaining": false, "data":{"global": {"start": "2023-11-27 19:53:54", "end": "2023-11-27 19:54:54", "files": [5, 6]}}}'.encode()],
+    ('001', 'logcollector', [
+        '{"error":0, "remaining": true, "data":{"global": {"start": "2023-11-27 19:51:54", '
+        '"end": "2023-11-27 19:52:54", "files": [1, 2]}, "interval": {}}}'.encode(),
+        '{"error":0, "remaining": true, "data":{"global": {"start": "2023-11-27 19:52:54", '
+        '"end": "2023-11-27 19:53:54", "files": [3, 4]}, "interval": {}}}'.encode(),
+        '{"error":0, "remaining": false, "data":{"global": {"start": "2023-11-27 19:53:54", '
+        '"end": "2023-11-27 19:54:54", "files": [5, 6]}, "interval": {}}}'.encode()],
      {"global": {"start": "2023-11-27T19:51:54Z", "end": "2023-11-27T19:54:54Z", "files": [1, 2, 3, 4, 5, 6]},
       "interval": {}},
      3,
      [
-         call('001 agent getstate'.encode()),
-         call('001 agent getstate next'.encode()),
-         call('001 agent getstate next'.encode())]),
-    ('001', 'agent', [
-        '{"error":0, "json_updated": false, "remaining": true, "data":{"global": {"start": "2023-11-27 19:51:54", "end": "2023-11-27 19:52:54", "files": [1, 2]}}}'.encode(),
-        '{"error":0, "json_updated": true, "remaining": true, "data":{"global": {"start": "2023-11-27 19:52:54", "end": "2023-11-27 19:53:54", "files": [3, 4]}}}'.encode(),
-        '{"error":0, "json_updated": false, "remaining": false, "data":{"global": {"start": "2023-11-27 19:53:54", "end": "2023-11-27 19:54:54", "files": [5, 6]}}}'.encode()],
+         call('001 logcollector getstate'.encode()),
+         call('001 logcollector getstate next'.encode()),
+         call('001 logcollector getstate next'.encode())]),
+    ('001', 'logcollector', [
+        '{"error":0, "json_updated": false, "remaining": true, "data":{"global": {"start": "2023-11-27 19:51:54", '
+        '"end": "2023-11-27 19:52:54", "files": [1, 2]}, "interval": {}}}'.encode(),
+        '{"error":0, "json_updated": true, "remaining": true, "data":{"global": {"start": "2023-11-27 19:52:54", '
+        '"end": "2023-11-27 19:53:54", "files": [3, 4]}, "interval": {}}}'.encode(),
+        '{"error":0, "json_updated": false, "remaining": false, "data":{"global": {"start": "2023-11-27 19:53:54", '
+        '"end": "2023-11-27 19:54:54", "files": [5, 6]}, "interval": {}}}'.encode()],
      {"global": {"start": "2023-11-27T19:53:54Z", "end": "2023-11-27T19:54:54Z", "files": [5, 6]}, "interval": {}},
      3,
      [
-         call('001 agent getstate'.encode()),
-         call('001 agent getstate next'.encode()),
-         call('001 agent getstate'.encode())]),
+         call('001 logcollector getstate'.encode()),
+         call('001 logcollector getstate next'.encode()),
+         call('001 logcollector getstate'.encode())]),
 ])
 def test_get_daemons_stats_from_socket(agent_id, daemon, responses, expected, expected_socket_calls,
                                        expected_arg_calls):


### PR DESCRIPTION
|Related issue|
|---|
| #21021 |



## Description

Fixes how `get_daemons_stats_from_socket` handles the response from `WazuhSocket`. This was the origin of one of the errors found in #21021 related to the `test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component}` test. The other errors in the AITs were fixed in #21145.

## API Integration tests

<details><summary>test_agent_GET_endpoints</summary>

```console
$ pytest -vv test_agent_GET_endpoints.tavern.yaml
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-0.13.1 -- /home/fdalmau/venv/integrationtest-env-3.10/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.13', 'Platform': 'Linux-5.15.0-91-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '7.3.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '1.0.4', 'trio': '0.7.0', 'metadata': '2.0.2', 'tavern': '1.23.5', 'asyncio': '0.18.1', 'html': '2.1.1'}}
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 96 items                                                                                                                                                                                        

test_agent_GET_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                            [  1%]
test_agent_GET_endpoints.tavern.yaml::GET /agents with single agent id PASSED                                                                                                                       [  2%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                              [  3%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} (only cluster configuration) PASSED                                                                 [  4%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                                   [  5%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                             [  6%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                                                                                                   [  7%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                                                                               [  8%]
test_agent_GET_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                            [  9%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED                                                                                                                           [ 10%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED                                                                                                                          [ 11%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED                                                                                                                        [ 12%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED                                                                                                                        [ 13%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED                                                                                                                        [ 14%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED                                                                                                                        [ 15%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED                                                                                                                       [ 16%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED                                                                                                                       [ 17%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED                                                                                                                      [ 18%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED                                                                                                                      [ 19%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED                                                                                                                      [ 20%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED                                                                                                                      [ 21%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                          [ 22%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED                                                                                                 [ 23%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED                                                                                                   [ 25%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED                                                                                                     [ 26%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED                                                                                                        [ 27%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED                                                                                                        [ 28%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED                                                                                             [ 29%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED                                                                                                   [ 30%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED                                                                                                 [ 31%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED                                                                                                      [ 32%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED                                                                                                 [ 33%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED                                                                                                   [ 34%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED                                                                                                  [ 35%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED                                                                                               [ 36%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED                                                                                                  [ 37%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED                                                                                                  [ 38%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED                                                                                                   [ 39%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED                                                                                               [ 40%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED                                                                                                  [ 41%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED                                                                                                [ 42%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED                                                                                                [ 43%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED                                                                                                    [ 44%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED                                                                                                   [ 45%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status_code] PASSED                                                                                               [ 46%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                                   [ 47%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                           [ 48%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED                                                                                                          [ 50%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED                                                                                                         [ 51%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED                                                                                                       [ 52%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED                                                                                                       [ 53%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED                                                                                                       [ 54%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED                                                                                                       [ 55%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED                                                                                                      [ 56%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED                                                                                                      [ 57%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED                                                                                                     [ 58%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED                                                                                                     [ 59%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED                                                                                                     [ 60%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED                                                                                                     [ 61%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                                           [ 62%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                                            [ 63%]
test_agent_GET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                            [ 64%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                                   [ 65%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED                                                                                                            [ 66%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED                                                                                                                 [ 67%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED                                                                                                                 [ 68%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED                                                                                                               [ 69%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED                                                                                                          [ 70%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED                                                                                                         [ 71%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED                                                                                                             [ 72%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status_code] PASSED                                                                                                        [ 73%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                                   [ 75%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                             [ 76%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED                                                                                                           [ 77%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED                                                                                                                [ 78%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED                                                                                                                [ 79%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED                                                                                                     [ 80%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED                                                                                                           [ 81%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED                                                                                                              [ 82%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED                                                                                                         [ 83%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED                                                                                                           [ 84%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED                                                                                                          [ 85%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED                                                                                                       [ 86%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED                                                                                                          [ 87%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED                                                                                                          [ 88%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED                                                                                                           [ 89%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED                                                                                                       [ 90%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED                                                                                                          [ 91%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED                                                                                                        [ 92%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED                                                                                                        [ 93%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED                                                                                                            [ 94%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED                                                                                                           [ 95%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status_code] PASSED                                                                                                       [ 96%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                             [ 97%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                                 [ 98%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                                             [100%]

============================================================================================ warnings summary =============================================================================================
../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_agent_GET_endpoints.tavern.yaml: 96 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================== 96 passed, 97 warnings in 849.66s (0:14:09) ===============================================================================
```

</details>


<details><summary>test_cluster_endpoints</summary>

```console
$ pytest -vv --nobuild test_cluster_endpoints.tavern.yaml
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-0.13.1 -- /home/fdalmau/venv/integrationtest-env-3.10/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.13', 'Platform': 'Linux-5.15.0-91-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '7.3.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '1.0.4', 'trio': '0.7.0', 'metadata': '2.0.2', 'tavern': '1.23.5', 'asyncio': '0.18.1', 'html': '2.1.1'}}
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 49 items                                                                                                                                                                                        

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                                                                [  2%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                                                 [  4%]
test_cluster_endpoints.tavern.yaml::GET /cluster/ruleset/synchronization PASSED                                                                                                                     [  6%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                                                  [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                                                       [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                                                                          [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                                                                              [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                                                                              [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                                                                            [ 18%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                                                                          [ 20%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                                                                          [ 22%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                                                                       [ 24%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                                                      [ 26%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                                                     [ 28%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                                                    [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                                                  [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                                                         [ 34%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                                                                                 [ 36%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                                                                     [ 38%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                                                                     [ 40%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                                                                                 [ 42%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                                                                     [ 44%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                                                                     [ 46%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                                                                             [ 48%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                                                                             [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[master-node] PASSED                                                                                                        [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker1] PASSED                                                                                                            [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker2] PASSED                                                                                                            [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                                                                                [ 59%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                                                                                    [ 61%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                                                                                    [ 63%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                                                                            [ 65%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                                                                                                      [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                                                                                          [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                                                                                          [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                                                                         [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                                                                             [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                                                                             [ 77%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                                                                        [ 79%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                                                                            [ 81%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                                                                            [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                                                                         [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                                                                             [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                                                                             [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                                                                               [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                                                                                   [ 93%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                                                                                   [ 95%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                                                     [ 97%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                                                                     [100%]

============================================================================================ warnings summary =============================================================================================
../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_cluster_endpoints.tavern.yaml: 49 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================== 49 passed, 50 warnings in 479.32s (0:07:59) ===============================================================================
```

</details>


<details><summary>test_manager_endpoints</summary>

```console
$ pytest -vv --nobuild test_manager_endpoints.tavern.yaml
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-0.13.1 -- /home/fdalmau/venv/integrationtest-env-3.10/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.13', 'Platform': 'Linux-5.15.0-91-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '7.3.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '1.0.4', 'trio': '0.7.0', 'metadata': '2.0.2', 'tavern': '1.23.5', 'asyncio': '0.18.1', 'html': '2.1.1'}}
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 32 items                                                                                                                                                                                        

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                                      [  3%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                        [  6%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                                                                                             [  9%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                                                                                               [ 12%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                                                                                            [ 15%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                                                                                            [ 18%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                                                                                            [ 21%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                                                                                             [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                                                                                          [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                                                                                            [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                                                                                             [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                                                                                          [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                                                                                            [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                                                                                                [ 43%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                                                                                           [ 46%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                                                                                                       [ 50%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED                                                                                             [ 53%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                               [ 56%]
test_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                                                                                               [ 59%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                                       [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                                [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                                [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                             [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                               [ 75%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                        [ 78%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                                [ 81%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                                  [ 84%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                                                                                               [ 87%]
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED                                                                                                                             [ 90%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                                   [ 93%]
test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                                                                                               [ 96%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                                     [100%]

============================================================================================ warnings summary =============================================================================================
../../../../../venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/fdalmau/venv/integrationtest-env-3.10/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_manager_endpoints.tavern.yaml: 32 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================== 32 passed, 33 warnings in 98.67s (0:01:38) ================================================================================
```

</details>
