### PR TITLE
Refactor to use column families and set offset after update one file during the offset update.

### DIFF
--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -17,24 +17,46 @@
 #include <filesystem>
 #include <memory>
 #include <rocksdb/db.h>
+#include <rocksdb/utilities/transaction.h>
+#include <rocksdb/utilities/transaction_db.h>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace Utils
 {
+    class RocksDBTransaction;
+    class IRocksDBWrapper
+    {
+    public:
+        virtual void put(const std::string& key, const rocksdb::Slice& value, const std::string& columnName) = 0;
+        virtual void put(const std::string& key, const rocksdb::Slice& value) = 0;
+        virtual void delete_(const std::string& key, const std::string& columnName) = 0; // NOLINT
+        virtual void delete_(const std::string& key) = 0;                                // NOLINT
+        virtual void commit() = 0;
+        virtual bool get(const std::string& key, rocksdb::PinnableSlice& value, const std::string& columnName) = 0;
+        virtual bool get(const std::string& key, rocksdb::PinnableSlice& value) = 0;
+        virtual void createColumn(const std::string& columnName) = 0;
+        virtual bool columnExists(const std::string& columnName) const = 0;
+        virtual void deleteAll() = 0;
+
+        virtual ~IRocksDBWrapper() = default;
+    };
+
     /**
      * @brief Wrapper class for RocksDB.
      *
      */
-    class RocksDBWrapper
+    class RocksDBWrapper : public IRocksDBWrapper
     {
     public:
         explicit RocksDBWrapper(const std::string& dbPath)
         {
             rocksdb::Options options;
             options.create_if_missing = true;
-            rocksdb::DB* dbRawPtr;
+            // Disable wal
+            options.wal_bytes_per_sync = 0;
+            rocksdb::TransactionDB* dbRawPtr;
             std::vector<rocksdb::ColumnFamilyDescriptor> columnsDescriptors;
             const std::filesystem::path databasePath {dbPath};
 
@@ -47,7 +69,7 @@ namespace Utils
             {
                 // Read columns names.
                 std::vector<std::string> columnsNames;
-                const auto listStatus {rocksdb::DB::ListColumnFamilies(options, dbPath, &columnsNames)};
+                const auto listStatus {rocksdb::TransactionDB::ListColumnFamilies(options, dbPath, &columnsNames)};
                 if (!listStatus.ok())
                 {
                     throw std::runtime_error("Failed to list columns: " + std::string {listStatus.getState()});
@@ -56,19 +78,18 @@ namespace Utils
                 // Create a set of column descriptors. This includes the default column.
                 for (auto& columnName : columnsNames)
                 {
-                    columnsDescriptors.push_back(
-                        rocksdb::ColumnFamilyDescriptor(std::move(columnName), rocksdb::ColumnFamilyOptions()));
+                    columnsDescriptors.emplace_back(columnName, rocksdb::ColumnFamilyOptions());
                 }
             }
             else
             {
                 // Database doesn't exist: Set just the default column descriptor.
-                columnsDescriptors.push_back(
-                    rocksdb::ColumnFamilyDescriptor(rocksdb::kDefaultColumnFamilyName, rocksdb::ColumnFamilyOptions()));
+                columnsDescriptors.emplace_back(rocksdb::kDefaultColumnFamilyName, rocksdb::ColumnFamilyOptions());
             }
 
             // Open database with a list of columns descriptors.
-            const auto status {rocksdb::DB::Open(options, dbPath, columnsDescriptors, &m_columnsHandles, &dbRawPtr)};
+            const auto status {rocksdb::TransactionDB::Open(
+                options, rocksdb::TransactionDBOptions(), dbPath, columnsDescriptors, &m_columnsHandles, &dbRawPtr)};
             if (!status.ok())
             {
                 throw std::runtime_error("Failed to open RocksDB database. Reason: " + std::string {status.getState()});
@@ -79,23 +100,13 @@ namespace Utils
         }
 
         /**
-         * @brief Move constructor.
-         *
-         * @param other Other instance.
-         */
-        RocksDBWrapper(RocksDBWrapper&& other) noexcept
-            : m_db {std::move(other.m_db)}
-        {
-        }
-
-        /**
          * @brief Class destructor. Frees column family handles.
          *
          * @note The documentation of the lib clearly states that we should not free the default column family handler
          * but not freeing it ends up on memory leaks and ASAN errors. OTOH, no problems seem to appear freeing it.
          *
          */
-        ~RocksDBWrapper()
+        ~RocksDBWrapper() override
         {
             std::for_each(m_columnsHandles.begin(),
                           m_columnsHandles.end(),
@@ -108,69 +119,7 @@ namespace Utils
                                                             std::string {status.getState()}};
                               }
                           });
-        }
-
-        /**
-         * @brief Creates a new column family in the database.
-         *
-         * @note The column handle created is also added to the handles list to be then accessible by other methods.
-         *
-         * @param columnName Name of the new column.
-         */
-        void createColumn(const std::string& columnName)
-        {
-            if (columnName.empty())
-            {
-                throw std::invalid_argument {"Column name is empty"};
-            }
-
-            rocksdb::ColumnFamilyHandle* pColumnFamily;
-            const auto status {m_db->CreateColumnFamily(rocksdb::ColumnFamilyOptions(), columnName, &pColumnFamily)};
-            if (!status.ok())
-            {
-                throw std::runtime_error {"Couldn't create column family: " + std::string {status.getState()}};
-            }
-
-            m_columnsHandles.push_back(pColumnFamily);
-        }
-
-        /**
-         * @brief Checks whether a column exists in the database or not.
-         *
-         * @param columnName Name of the column.
-         * @return true If the column exists.
-         * @return false If the column doesn't exists.
-         */
-        bool columnExists(const std::string& columnName) const
-        {
-            if (columnName.empty())
-            {
-                throw std::invalid_argument {"Column name is empty"};
-            }
-
-            const auto columnMatch {[&columnName](const rocksdb::ColumnFamilyHandle* handle)
-                                    {
-                                        return columnName == handle->GetName();
-                                    }};
-
-            return std::find_if(m_columnsHandles.begin(), m_columnsHandles.end(), columnMatch) !=
-                   m_columnsHandles.end();
-        }
-
-        /**
-         * @brief Move assignment operator.
-         *
-         * @param other Other instance.
-         * @return RocksDBWrapper&
-         */
-        RocksDBWrapper& operator=(RocksDBWrapper&& other) noexcept
-        {
-            if (this != &other)
-            {
-                m_db = std::move(other.m_db);
-            }
-            return *this;
-        }
+        };
 
         /**
          * @brief Put a key-value pair in the database.
@@ -180,18 +129,33 @@ namespace Utils
          *
          * @note If the key already exists, the value will be overwritten.
          */
-        void put(const std::string& key, const rocksdb::Slice& value, const std::string& columnName = "")
+        void put(const std::string& key, const rocksdb::Slice& value, const std::string& columnName) override
         {
             if (key.empty())
             {
                 throw std::invalid_argument("Key is empty");
             }
 
-            const auto status {m_db->Put(rocksdb::WriteOptions(), getColumnFamilyHandle(columnName), key, value)};
+            rocksdb::WriteOptions writeOptions;
+            writeOptions.disableWAL = true;
+
+            const auto status {m_db->Put(writeOptions, getColumnFamilyHandle(columnName), key, value)};
             if (!status.ok())
             {
                 throw std::runtime_error("Error putting data: " + status.ToString());
             }
+        }
+
+        /**
+         * @brief Put a key-value pair in the database.
+         * @param key Key to put.
+         * @param value Value to put.
+         *
+         * @note If the key already exists, the value will be overwritten.
+         */
+        void put(const std::string& key, const rocksdb::Slice& value) override
+        {
+            put(key, value, "");
         }
 
         /**
@@ -229,19 +193,20 @@ namespace Utils
          *
          * @param key Key to get.
          * @param value Value to get (rocksdb::PinnableSlice).
+         * @param columnName Column name from where to get. If empty, the default column will be used.
          *
          * @return bool True if the operation was successful.
          * @return bool False if the key was not found.
          */
 
-        bool get(const std::string& key, rocksdb::PinnableSlice& value)
+        bool get(const std::string& key, rocksdb::PinnableSlice& value, const std::string& columnName) override
         {
             if (key.empty())
             {
                 throw std::invalid_argument("Key is empty");
             }
 
-            const auto status {m_db->Get(rocksdb::ReadOptions(), m_db->DefaultColumnFamily(), key, &value)};
+            const auto status {m_db->Get(rocksdb::ReadOptions(), getColumnFamilyHandle(columnName), key, &value)};
             if (status.IsNotFound())
             {
                 return false;
@@ -254,22 +219,50 @@ namespace Utils
         }
 
         /**
+         * @brief Get a value from the database.
+         *
+         * @param key Key to get.
+         * @param value Value to get (rocksdb::PinnableSlice).
+         *
+         * @return bool True if the operation was successful.
+         * @return bool False if the key was not found.
+         */
+
+        bool get(const std::string& key, rocksdb::PinnableSlice& value) override
+        {
+            return get(key, value, "");
+        }
+
+        /**
          * @brief Delete a key-value pair from the database.
          *
          * @param key Key to delete.
+         * @param columnName Column name from where to delete. If empty, the default column will be used.
          */
-        void delete_(const std::string& key) // NOLINT
+        void delete_(const std::string& key, const std::string& columnName) override // NOLINT
         {
             if (key.empty())
             {
                 throw std::invalid_argument("Key is empty");
             }
+            rocksdb::WriteOptions writeOptions;
+            writeOptions.disableWAL = true;
 
-            const auto status {m_db->Delete(rocksdb::WriteOptions(), key)};
+            const auto status {m_db->Delete(writeOptions, getColumnFamilyHandle(columnName), key)};
             if (!status.ok())
             {
                 throw std::runtime_error("Error deleting data: " + status.ToString());
             }
+        }
+
+        /**
+         * @brief Delete a key-value pair from the database.
+         *
+         * @param key Key to delete.
+         */
+        void delete_(const std::string& key) override // NOLINT
+        {
+            delete_(key, "");
         }
 
         /**
@@ -296,41 +289,25 @@ namespace Utils
         }
 
         /**
-         * @brief Delete all key-value pairs from the database.
-         */
-        void deleteAll()
-        {
-            rocksdb::WriteBatch batch;
-            std::unique_ptr<rocksdb::Iterator> it(m_db->NewIterator(rocksdb::ReadOptions()));
-            for (it->SeekToFirst(); it->Valid(); it->Next())
-            {
-                batch.Delete(it->key());
-            }
-
-            const auto status {m_db->Write(rocksdb::WriteOptions(), &batch)};
-            if (!status.ok())
-            {
-                throw std::runtime_error("Error deleting data: " + status.ToString());
-            }
-        }
-
-        /**
          * @brief Seek to specific key.
          * @param key Key to seek.
          * @return RocksDBIterator Iterator to the database.
          */
-        RocksDBIterator seek(std::string_view key)
+        RocksDBIterator seek(std::string_view key, const std::string& columnName = "")
         {
-            return {std::shared_ptr<rocksdb::Iterator>(m_db->NewIterator(rocksdb::ReadOptions())), key};
+            return {std::shared_ptr<rocksdb::Iterator>(
+                        m_db->NewIterator(rocksdb::ReadOptions(), getColumnFamilyHandle(columnName))),
+                    key};
         }
 
         /**
          * @brief Get an iterator to the database.
          * @return RocksDBIterator Iterator to the database.
          */
-        RocksDBIterator begin()
+        RocksDBIterator begin(const std::string& columnName = "")
         {
-            return RocksDBIterator {std::shared_ptr<rocksdb::Iterator>(m_db->NewIterator(rocksdb::ReadOptions()))};
+            return RocksDBIterator {std::shared_ptr<rocksdb::Iterator>(
+                m_db->NewIterator(rocksdb::ReadOptions(), getColumnFamilyHandle(columnName)))};
         }
 
         /**
@@ -392,9 +369,96 @@ namespace Utils
             m_db->CompactRange(compactOptions, nullptr, nullptr);
         }
 
+        /**
+         * @brief Initialize transaction.
+         * @return RocksDBTransaction Transaction object.
+         */
+        std::unique_ptr<RocksDBTransaction> createTransaction()
+        {
+            return std::make_unique<RocksDBTransaction>(this);
+        }
+
+        void commit() override
+        {
+            throw std::runtime_error("Not implemented");
+        }
+
+        /**
+         * @brief Creates a new column family in the database.
+         *
+         * @note The column handle created is also added to the handles list to be then accessible by other methods.
+         *
+         * @param columnName Name of the new column.
+         */
+        void createColumn(const std::string& columnName) override
+        {
+            if (columnName.empty())
+            {
+                throw std::invalid_argument {"Column name is empty"};
+            }
+
+            rocksdb::ColumnFamilyHandle* pColumnFamily;
+            rocksdb::ColumnFamilyOptions columnFamilyOptions;
+            const auto status {m_db->CreateColumnFamily(columnFamilyOptions, columnName, &pColumnFamily)};
+            if (!status.ok())
+            {
+                throw std::runtime_error {"Couldn't create column family: " + std::string {status.getState()}};
+            }
+            m_columnsHandles.push_back(pColumnFamily);
+        }
+
+        /**
+         * @brief Checks whether a column exists in the database or not.
+         *
+         * @param columnName Name of the column.
+         * @return true If the column exists.
+         * @return false If the column doesn't exists.
+         */
+        bool columnExists(const std::string& columnName) const override
+        {
+            if (columnName.empty())
+            {
+                throw std::invalid_argument {"Column name is empty"};
+            }
+
+            const auto columnMatch {[&columnName](const rocksdb::ColumnFamilyHandle* handle)
+                                    {
+                                        return columnName == handle->GetName();
+                                    }};
+
+            return std::find_if(m_columnsHandles.begin(), m_columnsHandles.end(), columnMatch) !=
+                   m_columnsHandles.end();
+        }
+
+        /**
+         * @brief Delete all key-value pairs from the database.
+         */
+        void deleteAll() override
+        {
+            // Delete from all family columns
+            for (const auto& columnHandle : m_columnsHandles)
+            {
+                rocksdb::WriteBatch batch;
+                std::unique_ptr<rocksdb::Iterator> it(m_db->NewIterator(rocksdb::ReadOptions(), columnHandle));
+                for (it->SeekToFirst(); it->Valid(); it->Next())
+                {
+                    batch.Delete(it->key());
+                }
+
+                rocksdb::WriteOptions writeOptions;
+                writeOptions.disableWAL = true;
+
+                const auto status {m_db->Write(writeOptions, &batch)};
+                if (!status.ok())
+                {
+                    throw std::runtime_error("Error deleting data: " + status.ToString());
+                }
+            }
+        }
+
     private:
-        std::unique_ptr<rocksdb::DB> m_db {};
-        std::vector<rocksdb::ColumnFamilyHandle*> m_columnsHandles {}; ///< List of column handles.
+        std::unique_ptr<rocksdb::TransactionDB> m_db;               ///< RocksDB instance.
+        std::vector<rocksdb::ColumnFamilyHandle*> m_columnsHandles; ///< List of column family handles.
 
         /**
          * @brief Returns the column family handle identified by its name.
@@ -422,7 +486,203 @@ namespace Utils
 
             throw std::runtime_error {"Couldn't find column family: '" + columnName + "'"};
         }
+        friend class RocksDBTransaction;
+    };
+
+    /**
+     * @brief Wrapper class for RocksDB transactions.
+     *
+     */
+    class RocksDBTransaction final : public IRocksDBWrapper
+    {
+    public:
+        /**
+         * @brief Constructor.
+         *
+         * @param db RocksDB instance.
+         */
+        explicit RocksDBTransaction(RocksDBWrapper* dbWrapper)
+            : m_dbWrapper {dbWrapper}
+        {
+            if (!m_dbWrapper)
+            {
+                throw std::runtime_error {"RocksDB instance is null"};
+            }
+
+            rocksdb::WriteOptions writeOptions;
+            writeOptions.disableWAL = true;
+
+            m_txn = std::unique_ptr<rocksdb::Transaction>(m_dbWrapper->m_db->BeginTransaction(writeOptions));
+            if (!m_txn)
+            {
+                throw std::runtime_error {"Failed to begin transaction"};
+            }
+        }
+
+        /**
+         * @brief Destructor.
+         * @note If the transaction has not been committed, it will be aborted.
+         */
+        ~RocksDBTransaction() override
+        {
+            if (!m_committed)
+            {
+                m_txn->Rollback();
+            }
+        }
+
+        /**
+         * @brief Put a key-value pair in the database.
+         * @param key Key to put.
+         * @param value Value to put.
+         * @param columnName Column name where the put will be performed. If empty, the default column will be used.
+         *
+         * @note If the key already exists, the value will be overwritten.
+         */
+        void put(const std::string& key, const rocksdb::Slice& value, const std::string& columnName) override
+        {
+            const auto status {m_txn->Put(m_dbWrapper->getColumnFamilyHandle(columnName), key, value)};
+            if (!status.ok())
+            {
+                throw std::runtime_error {"Failed to put key: " + std::string {status.getState()}};
+            }
+        }
+
+        /**
+         * @brief Put a key-value pair in the database.
+         * @param key Key to put.
+         * @param value Value to put.
+         *
+         * @note If the key already exists, the value will be overwritten.
+         */
+        void put(const std::string& key, const rocksdb::Slice& value) override
+        {
+            put(key, value, "");
+        }
+
+        /**
+         * @brief Delete a key-value pair from the database.
+         *
+         * @param key Key to delete.
+         * @param columnName Column name from where to delete. If empty, the default column will be used.
+         */
+        void delete_(const std::string& key, const std::string& columnName) override
+        {
+            const auto status {m_txn->Delete(m_dbWrapper->getColumnFamilyHandle(columnName), key)};
+            if (!status.ok())
+            {
+                throw std::runtime_error {"Failed to delete key: " + std::string {status.getState()}};
+            }
+        }
+
+        /**
+         * @brief Delete a key-value pair from the database.
+         *
+         * @param key Key to delete.
+         * @param columnName Column name from where to delete. If empty, the default column will be used.
+         */
+        void delete_(const std::string& key) override
+        {
+            delete_(key, "");
+        }
+
+        /**
+         * @brief Get a value from the database.
+         *
+         * @param key Key to get.
+         * @param value Value to get (rocksdb::PinnableSlice).
+         * @param columnName Column name from where to get. If empty, the default column will be used.
+         *
+         * @return bool True if the operation was successful.
+         * @return bool False if the key was not found.
+         */
+
+        bool get(const std::string& key, rocksdb::PinnableSlice& value, const std::string& columnName) override
+        {
+            if (key.empty())
+            {
+                throw std::invalid_argument("Key is empty");
+            }
+
+            const auto status {
+                m_txn->Get(rocksdb::ReadOptions(), m_dbWrapper->getColumnFamilyHandle(columnName), key, &value)};
+            if (status.IsNotFound())
+            {
+                return false;
+            }
+            else if (!status.ok())
+            {
+                throw std::runtime_error("Error getting data: " + status.ToString());
+            }
+            return true;
+        }
+
+        /**
+         * @brief Get a value from the database.
+         *
+         * @param key Key to get.
+         * @param value Value to get (rocksdb::PinnableSlice).
+         *
+         * @return bool True if the operation was successful.
+         * @return bool False if the key was not found.
+         */
+
+        bool get(const std::string& key, rocksdb::PinnableSlice& value) override
+        {
+            return get(key, value, "");
+        }
+
+        /**
+         * @brief Commit the transaction.
+         */
+        void commit() override
+        {
+            const auto status {m_txn->Commit()};
+            if (!status.ok())
+            {
+                throw std::runtime_error {"Failed to commit transaction: " + std::string {status.getState()}};
+            }
+            m_committed = true;
+        }
+
+        /**
+         * @brief Delete all key-value pairs from the database.
+         */
+        void deleteAll() override
+        {
+            m_dbWrapper->deleteAll();
+        }
+
+        /**
+         * @brief Creates a new column family in the database.
+         *
+         * @note The column handle created is also added to the handles list to be then accessible by other methods.
+         *
+         * @param columnName Name of the new column.
+         */
+        void createColumn(const std::string& columnName) override
+        {
+            m_dbWrapper->createColumn(columnName);
+        }
+
+        /**
+         * @brief Checks whether a column exists in the database or not.
+         *
+         * @param columnName Name of the column.
+         * @return true If the column exists.
+         * @return false If the column doesn't exists.
+         */
+        bool columnExists(const std::string& columnName) const override
+        {
+            return m_dbWrapper->columnExists(columnName);
+        }
+
+    private:
+        RocksDBWrapper* m_dbWrapper;                 ///< RocksDB instance.
+        std::unique_ptr<rocksdb::Transaction> m_txn; ///< RocksDB transaction.
+        bool m_committed {false};                    ///< Whether the transaction has been committed or not.
     };
 } // namespace Utils
 
 #endif // _ROCKS_DB_WRAPPER_HPP
+

--- a/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScanner.hpp
@@ -27,6 +27,10 @@
 #include <string>
 #include <vector>
 
+constexpr auto REMEDIATIONS_COLUMN {"remediations"};
+constexpr auto TRANSLATIONS_COLUMN {"translations"};
+constexpr auto DESCRIPTIONS_COLUMN {"descriptions"};
+
 /**
  * @brief VulnerabilityScanner class.
  *

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -42,11 +42,8 @@
 #include <string>
 #include <vector>
 
-constexpr auto REMEDIATIONS_DATABASE_PATH {"queue/vd/remediations"};
-constexpr auto TRANSLATIONS_DATABASE_PATH {"queue/vd/translations"};
-constexpr auto CVES_DATABASE_PATH {"queue/vd/cves"};
-
 using namespace NSVulnerabilityScanner;
+constexpr auto DATABASE_PATH {"queue/vd/feed"};
 
 /**
  * @brief A struct for storing a pair of FlatBuffers data.
@@ -85,21 +82,36 @@ struct FlatbufferDataPair final
 class DatabaseFeedManagerMessageProcessor final
 {
 public:
+};
+
+/**
+ * @brief DatabaseFeedManager class.
+ *
+ * @tparam TIndexerConnector Indexer connector type.
+ * @tparam TPolicyManager Policy manager type.
+ * @tparam TContentRegister Content register type.
+ * @tparam TRouterSubscriber Router subscriber type.
+ */
+template<typename TIndexerConnector = IndexerConnector,
+         typename TPolicyManager = PolicyManager,
+         typename TContentRegister = ContentRegister,
+         typename TRouterSubscriber = RouterSubscriber,
+         typename TUNIXSocketRequest = UNIXSocketRequest,
+         typename TRocksDBWrapper = Utils::RocksDBWrapper>
+class TDatabaseFeedManager final : public Observer<nlohmann::json&>
+{
+public:
     /**
      * @brief Process and validated the message received by the router.
      *
      * @param message Message received by the router.
      * @param topicName Topic name.
      * @param orchestration Chain of actions to execute for each valid resource extracted from the message.
-     * @param databaseCleanup Database cleanup function to execute if message type is raw.
-     * @param shouldStop Variable to control the stop of the processing operations.
      */
-    template<typename TUNIXSocketRequest = UNIXSocketRequest>
-    void static processMessage(const std::vector<char>& message,
-                               const std::string& topicName,
-                               const std::function<void(const nlohmann::json&)>& orchestration,
-                               const std::function<void(void)>& databaseCleanup,
-                               const std::atomic<bool>& shouldStop)
+
+    void processMessage(const std::vector<char>& message,
+                        const std::string& topicName,
+                        const std::function<void(const nlohmann::json&)>& orchestration)
     {
         auto parsedMessage = nlohmann::json::parse(message, nullptr, false);
 
@@ -112,29 +124,65 @@ public:
         if (parsedMessage.at("type") == "offsets")
         {
             auto jsonPointer {"/data"_json_pointer};
-            auto callbackSAXParser {[&](nlohmann::json&& item)
-                                    {
-                                        orchestration(item);
-                                        return !shouldStop.load();
-                                    }};
             for (const auto& path : parsedMessage.at("paths"))
             {
-                if (shouldStop.load())
+                // Create a transaction for each file.
+                auto feedTransaction {m_feedDatabase->createTransaction()};
+                // Set the current database to the transaction, this is used by each element of the chain/orchestration.
+                m_currentDatabase = feedTransaction.get();
+                // The offset is 0 by default, and it will be updated with the last processed offset.
+                auto currentOffset = 0LL;
+                logInfo(WM_VULNSCAN_LOGTAG, "Processing file: %s", path.get_ref<const std::string&>().c_str());
+
+                // Parse the file and execute the chain/orchestration for each valid resource.
+                // The lambda function returns false if the module is stopped.
+                // This uses the json sax api, so it is faster than the json tree api and it consumes less memory.
+                JsonArray::parse(
+                    path,
+                    [&](nlohmann::json&& item)
+                    {
+                        orchestration(item);
+                        currentOffset = item.at("offset");
+                        return !m_shouldStop.load();
+                    },
+                    jsonPointer);
+
+                // If the module is stopped, we do not commit the transaction and update the offset,
+                // so that the next time the module is started, it will start from the last offset committed.
+                if (m_shouldStop.load())
                 {
                     break;
                 }
-                logInfo(WM_VULNSCAN_LOGTAG, "Processing file: %s", path.get_ref<const std::string&>().c_str());
-                JsonArray::parse(path, callbackSAXParser, jsonPointer);
+                // Commit the transaction.
+                feedTransaction->commit();
+
+                // If some data was processed, update the offset.
+                if (currentOffset != 0LL)
+                {
+                    nlohmann::json data;
+                    data["offset"] = currentOffset;
+                    data["topicName"] = topicName;
+
+                    TUNIXSocketRequest::instance().put(
+                        HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/offset"),
+                        data,
+                        [](const std::string& msg) {},
+                        [](const std::string& msg, const long responseCode)
+                        { throw std::runtime_error("Error updating offset: " + msg); });
+                }
             }
         }
         else if (parsedMessage.at("type") == "raw")
         {
+            // The message contains a list of files to process.
+            // For the case of the raw message, the list of files is always one, because it uses the consolidated file.
             if (parsedMessage.at("paths").size() != 1)
             {
                 throw std::runtime_error("Invalid message");
             }
 
-            databaseCleanup();
+            // Delete all the data in the database, because the raw message contains all and latest data.
+            m_feedDatabase->deleteAll();
 
             for (const auto& path : parsedMessage.at("paths"))
             {
@@ -147,9 +195,11 @@ public:
 
                 std::string line;
                 int32_t step = 0;
+                // Parse the file and execute the chain/orchestration for each valid resource.
+                // It orchestrate line by line.
                 while (std::getline(file, line))
                 {
-                    if (shouldStop.load())
+                    if (m_shouldStop.load())
                     {
                         break;
                     }
@@ -167,48 +217,36 @@ public:
 
                     parsedLine["resource"] = parsedLine["name"];
                     parsedLine["type"] = "create";
+
+                    // This not uses a transaction, because rocksdb uses memory for each transaction.
+                    // for this case, we use atomic operations.
+                    m_currentDatabase = m_feedDatabase.get();
                     orchestration(parsedLine);
                 }
+            }
+
+            // If the module is stopped, we do not update the offset.
+            // So that the next time the module is started, it will start from zero.
+            if (!m_shouldStop.load())
+            {
+                nlohmann::json data;
+                data["offset"] = parsedMessage.at("offset");
+                data["topicName"] = topicName;
+
+                TUNIXSocketRequest::instance().put(
+                    HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/offset"),
+                    data,
+                    [](const std::string& msg) {},
+                    [](const std::string& msg, const long responseCode)
+                    { throw std::runtime_error("Error updating offset: " + msg); });
             }
         }
         else
         {
             throw std::runtime_error("Invalid message");
         }
-
-        if (!shouldStop.load())
-        {
-            nlohmann::json data;
-            data["offset"] = parsedMessage.at("offset");
-            data["topicName"] = topicName;
-
-            TUNIXSocketRequest::instance().put(
-                HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/offset"),
-                data,
-                [](const std::string& msg) {},
-                [](const std::string& msg, const long responseCode)
-                { throw std::runtime_error("Error updating offset: " + msg); });
-        }
     }
-};
 
-/**
- * @brief DatabaseFeedManager class.
- *
- * @tparam TIndexerConnector Indexer connector type.
- * @tparam TPolicyManager Policy manager type.
- * @tparam TContentRegister Content register type.
- * @tparam TRouterSubscriber Router subscriber type.
- */
-template<typename TIndexerConnector = IndexerConnector,
-         typename TPolicyManager = PolicyManager,
-         typename TContentRegister = ContentRegister,
-         typename TRouterSubscriber = RouterSubscriber,
-         typename TMessageProcessor = DatabaseFeedManagerMessageProcessor,
-         typename TUNIXSocketRequest = UNIXSocketRequest>
-class TDatabaseFeedManager final : public Observer<nlohmann::json&>
-{
-public:
     /**
      * @brief Class constructor.
      *
@@ -228,13 +266,10 @@ public:
         const auto updaterPolicy = TPolicyManager::instance().getUpdaterConfiguration();
         const std::string topicName = updaterPolicy.at("topicName");
 
-        m_descriptionsDatabase = std::make_unique<Utils::RocksDBWrapper>(DESCRIPTION_DATABASE_PATH);
-        m_remediationsDatabase = std::make_unique<Utils::RocksDBWrapper>(REMEDIATIONS_DATABASE_PATH);
-        m_translationsDatabase = std::make_unique<Utils::RocksDBWrapper>(TRANSLATIONS_DATABASE_PATH);
+        m_feedDatabase = std::make_unique<TRocksDBWrapper>(DATABASE_PATH);
 
         m_translationsCache =
             std::make_unique<LRUCache<std::string, std::string>>(TPolicyManager::instance().getTranslationLRUSize());
-        m_cvesDatabase = std::make_unique<Utils::RocksDBWrapper>(CVES_DATABASE_PATH);
 
         // Subscription to vulnerability detector content update events.
         m_contentUpdateSubscription =
@@ -244,38 +279,23 @@ public:
             [&, topicName](const std::vector<char>& message)
             {
                 auto eventDecoder = std::make_shared<EventDecoder>();
-                eventDecoder->setLast(std::make_shared<StoreModel>(
-                    m_feedsDatabases, m_descriptionsDatabase.get(), m_remediationsDatabase.get()));
+                eventDecoder->setLast(std::make_shared<StoreModel>());
                 eventDecoder->setLast(std::make_shared<FeedIndexer<TIndexerConnector>>(m_indexerConnector));
                 eventDecoder->setLast(std::make_shared<ScanDispatcher>());
 
                 auto orchestrationLambda = [&](const nlohmann::json& resource)
                 {
-                    auto eventContext =
-                        std::make_shared<EventContext>(EventContext {.message = message,
-                                                                     .resource = resource,
-                                                                     .cvesDatabase = m_cvesDatabase,
-                                                                     .translationsDatabase = m_translationsDatabase,
-                                                                     .resourceType = ResourceType::UNKNOWN});
+                    auto eventContext = std::make_shared<EventContext>(
+                        EventContext {.message = message,
+                                      .resource = resource,
+                                      .feedDatabase = !m_currentDatabase ? m_feedDatabase.get() : m_currentDatabase,
+                                      .resourceType = ResourceType::UNKNOWN});
                     eventDecoder->handleRequest(eventContext);
-                };
-                auto databaseCleanupLambda = [&]()
-                {
-                    m_descriptionsDatabase->deleteAll();
-                    m_remediationsDatabase->deleteAll();
-                    m_translationsDatabase->deleteAll();
-                    m_cvesDatabase->deleteAll();
-
-                    for (auto& [name, database] : m_feedsDatabases)
-                    {
-                        database->deleteAll();
-                    }
                 };
                 try
                 {
                     logInfo(WM_VULNSCAN_LOGTAG, "Processing message");
-                    TMessageProcessor::template processMessage<TUNIXSocketRequest>(
-                        message, topicName, orchestrationLambda, databaseCleanupLambda, m_shouldStop);
+                    processMessage(message, topicName, orchestrationLambda);
                     logInfo(WM_VULNSCAN_LOGTAG, "Message processed");
 
                     // TODO: If the databases are compressed, they weigh 2GB,
@@ -293,7 +313,7 @@ public:
                     // logInfo(WM_VULNSCAN_LOGTAG, "Compacting description, remediation, translation
                     // and feed databases"); m_descriptionsDatabase->compactDatabase();
                     // m_remediationsDatabase->compactDatabase();
-                    // m_translationsDatabase->compactDatabase();
+                    // m_feedDatabase->compactDatabase();
                     // for (const auto& [key, db] : m_feedsDatabases)
                     // {
                     //     db->compactDatabase();
@@ -336,7 +356,7 @@ public:
      */
     void getVulnerabilityRemediation(const std::string& cveId, FlatbufferDataPair<RemediationInfo>& dtoVulnRemediation)
     {
-        auto result = m_remediationsDatabase->get(cveId, dtoVulnRemediation.slice);
+        auto result = m_feedDatabase->get(cveId, dtoVulnRemediation.slice, REMEDIATIONS_COLUMN);
 
         if (!result)
         {
@@ -380,7 +400,7 @@ public:
         {
             FlatbufferDataPair<TranslationEntry> dtoVulnTranslation;
 
-            auto resultQuery = m_translationsDatabase->get(resultCache.value(), dtoVulnTranslation.slice);
+            auto resultQuery = m_feedDatabase->get(resultCache.value(), dtoVulnTranslation.slice, TRANSLATIONS_COLUMN);
             if (!resultQuery)
             {
                 throw std::runtime_error("Value for key " + resultCache.value() + " does not exist in database.");
@@ -401,7 +421,7 @@ public:
 
         // If the translation is not in the cache, iterate over all the translations in the database and look for
         // a match.
-        for (const auto& [key, value] : m_translationsDatabase->begin())
+        for (const auto& [key, value] : m_feedDatabase->begin(TRANSLATIONS_COLUMN))
         {
             flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(value.data()), value.size());
             if (!VerifyTranslationEntryBuffer(verifier))
@@ -439,12 +459,11 @@ public:
             throw std::runtime_error("Invalid package/cna name.");
         }
 
-        CandidatesDBHelper::findAndOpen(cnaName, m_feedsDatabases, true);
         std::string packageNameWithSeparator;
         packageNameWithSeparator.append(packageName);
         packageNameWithSeparator.append("_CVE");
 
-        for (const auto& [key, value] : m_feedsDatabases.at(cnaName)->seek(packageNameWithSeparator))
+        for (const auto& [key, value] : m_feedDatabase->seek(packageNameWithSeparator, cnaName))
         {
             flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(value.data()), value.size());
             if (!NSVulnerabilityScanner::VerifyScanVulnerabilityCandidateArrayBuffer(verifier))
@@ -475,11 +494,11 @@ public:
      * This function provides access to the Common Vulnerabilities and Exposures (CVE) database
      * represented by a reference to a RocksDBWrapper object.
      *
-     * @return A reference to the CVE database represented by Utils::RocksDBWrapper.
+     * @return A reference to the CVE database represented by TRocksDBWrapper.
      */
-    Utils::RocksDBWrapper& getCVEDatabase()
+    TRocksDBWrapper& getCVEDatabase()
     {
-        return *m_cvesDatabase;
+        return *m_feedDatabase;
     }
 
     /**
@@ -502,7 +521,7 @@ public:
     void getVulnerabiltyDescriptiveInformation(const std::string_view cveId,
                                                FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
     {
-        if (m_descriptionsDatabase->get(std::string(cveId), resultContainer.slice) == false)
+        if (m_feedDatabase->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN) == false)
         {
             throw std::runtime_error(
                 "Error getting VulnerabilityDescription object from rocksdb. Object not found for cveId: " +
@@ -560,13 +579,10 @@ private:
      */
     std::shared_ptr<TIndexerConnector> m_indexerConnector;
     std::unique_ptr<TContentRegister> m_contentRegistration;
-    std::unique_ptr<Utils::RocksDBWrapper> m_descriptionsDatabase;
-    std::unique_ptr<Utils::RocksDBWrapper> m_remediationsDatabase;
-    std::unique_ptr<Utils::RocksDBWrapper> m_translationsDatabase;
+    std::unique_ptr<TRocksDBWrapper> m_feedDatabase;
     std::unique_ptr<LRUCache<std::string, std::string>> m_translationsCache;
-    std::unique_ptr<Utils::RocksDBWrapper> m_cvesDatabase;
-    std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>> m_feedsDatabases;
     std::unique_ptr<TRouterSubscriber> m_contentUpdateSubscription;
+    Utils::IRocksDBWrapper* m_currentDatabase {nullptr};
     const std::atomic<bool>& m_shouldStop;
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -163,12 +163,14 @@ public:
                     data["offset"] = currentOffset;
                     data["topicName"] = topicName;
 
+                    // LCOV_EXCL_START
                     TUNIXSocketRequest::instance().put(
                         HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/offset"),
                         data,
                         [](const std::string& msg) {},
                         [](const std::string& msg, const long responseCode)
                         { throw std::runtime_error("Error updating offset: " + msg); });
+                    // LCOV_EXCL_STOP
                 }
             }
         }
@@ -233,12 +235,14 @@ public:
                 data["offset"] = parsedMessage.at("offset");
                 data["topicName"] = topicName;
 
+                // LCOV_EXCL_START
                 TUNIXSocketRequest::instance().put(
                     HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/offset"),
                     data,
                     [](const std::string& msg) {},
                     [](const std::string& msg, const long responseCode)
                     { throw std::runtime_error("Error updating offset: " + msg); });
+                // LCOV_EXCL_STOP
             }
         }
         else

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -137,6 +137,7 @@ public:
                 // Parse the file and execute the chain/orchestration for each valid resource.
                 // The lambda function returns false if the module is stopped.
                 // This uses the json sax api, so it is faster than the json tree api and it consumes less memory.
+                // LCOV_EXCL_START
                 JsonArray::parse(
                     path,
                     [&](nlohmann::json&& item)
@@ -146,6 +147,7 @@ public:
                         return !m_shouldStop.load();
                     },
                     jsonPointer);
+                // LCOV_EXCL_STOP
 
                 // If the module is stopped, we do not commit the transaction and update the offset,
                 // so that the next time the module is started, it will start from the last offset committed.
@@ -565,9 +567,11 @@ public:
                                                                            {"cloudlinux", "almalinux"}};
 
         const auto vendorLowerCase = Utils::toLowerCase(vendor.data());
+        // LCOV_EXCL_START
         const auto it = std::find_if(vendorToCnaName.begin(),
                                      vendorToCnaName.end(),
                                      [&](const auto& pair) { return Utils::startsWith(vendorLowerCase, pair.first); });
+        // LCOV_EXCL_STOP
 
         if (it == vendorToCnaName.end())
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventContext.hpp
@@ -34,27 +34,11 @@ enum class ResourceType
  */
 struct EventContext final
 {
-    const std::vector<char>& message;                                   ///< Message.
-    const nlohmann::json& resource;                                     ///< Modified/created resource.
-    flatbuffers::DetachedBuffer cve5Buffer;                             ///< CVE data.
-    const std::unique_ptr<Utils::RocksDBWrapper>& cvesDatabase;         ///< CVEs database.
-    const std::unique_ptr<Utils::RocksDBWrapper>& translationsDatabase; ///< CVEs database.
-    ResourceType resourceType;                                          ///< Resource type.
-
-    /**
-     * @brief This function returns the database associated to the resource type.
-     *
-     * @return Utils::RocksDBWrapper* Database.
-     */
-    Utils::RocksDBWrapper* getDatabaseByResourceType()
-    {
-        switch (resourceType)
-        {
-            case ResourceType::CVE: return cvesDatabase.get();
-            case ResourceType::TRANSLATION: return translationsDatabase.get();
-            default: throw std::runtime_error("Invalid resource type.");
-        }
-    }
+    const std::vector<char>& message;       ///< Message.
+    const nlohmann::json& resource;         ///< Modified/created resource.
+    flatbuffers::DetachedBuffer cve5Buffer; ///< CVE data.
+    Utils::IRocksDBWrapper* feedDatabase;   ///< CVEs database.
+    ResourceType resourceType;              ///< Resource type.
 };
 
 #endif // _EVENT_CONTEXT_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
@@ -26,6 +26,11 @@ const static std::map<ResourceType, const char*> SCHEMA = {
     {ResourceType::TRANSLATION, packageTranslation_SCHEMA},
 };
 
+const static std::map<ResourceType, const char*> COLUMNS = {
+    {ResourceType::CVE, "cve5"},
+    {ResourceType::TRANSLATION, "translation"},
+};
+
 /**
  * @brief EventDecoder class.
  *
@@ -56,7 +61,15 @@ private:
             }
 
             auto schema = SCHEMA.at(data->resourceType);
-            auto database = data->getDatabaseByResourceType();
+            auto column = COLUMNS.at(data->resourceType);
+
+            for (auto& element : COLUMNS)
+            {
+                if (!data->feedDatabase->columnExists(element.second))
+                {
+                    data->feedDatabase->createColumn(element.second);
+                }
+            }
 
             if ("create" == data->resource.at("type"))
             {
@@ -69,7 +82,7 @@ private:
 
                 rocksdb::Slice flatbufferResource(reinterpret_cast<const char*>(parser.builder_.GetBufferPointer()),
                                                   parser.builder_.GetSize());
-                database->put(data->resource.at("resource"), flatbufferResource);
+                data->feedDatabase->put(data->resource.at("resource"), flatbufferResource, column);
                 if (data->resourceType == ResourceType::CVE)
                 {
                     flatbuffers::FlatBufferBuilder& builder = parser.builder_;
@@ -80,7 +93,7 @@ private:
             else if ("update" == data->resource.at("type"))
             {
                 rocksdb::PinnableSlice slice;
-                if (!database->get(data->resource.at("resource"), slice))
+                if (!data->feedDatabase->get(data->resource.at("resource"), slice, column))
                 {
                     throw std::runtime_error("Unable to find resource.");
                 }
@@ -126,7 +139,7 @@ private:
                 rocksdb::Slice flatbufferResource(reinterpret_cast<const char*>(parser.builder_.GetBufferPointer()),
                                                   parser.builder_.GetSize());
 
-                database->put(data->resource.at("resource"), flatbufferResource);
+                data->feedDatabase->put(data->resource.at("resource"), flatbufferResource, column);
 
                 if (data->resourceType == ResourceType::CVE)
                 {
@@ -139,7 +152,7 @@ private:
             {
                 if (data->resourceType == ResourceType::TRANSLATION)
                 {
-                    database->delete_(data->resource.at("resource"));
+                    data->feedDatabase->delete_(data->resource.at("resource"), column);
                 }
             }
             else

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
@@ -42,44 +42,14 @@ public:
             auto cveMetadata = cve5Entry->cveMetadata();
             if (cveMetadata->state() && cveMetadata->state()->str().compare("REJECTED") != 0)
             {
-                StoreRemediationsModel::updateRemediation(cve5Entry, m_remediationsDatabase);
-                UpdateCVECandidates::storeVulnerabilityCandidate(cve5Entry, m_feedsDatabases);
-                UpdateCVEDescription::storeVulnerabilityDescription(cve5Entry, m_descriptionsDatabase);
+                StoreRemediationsModel::updateRemediation(cve5Entry, data->feedDatabase);
+                UpdateCVECandidates::storeVulnerabilityCandidate(cve5Entry, data->feedDatabase);
+                UpdateCVEDescription::storeVulnerabilityDescription(cve5Entry, data->feedDatabase);
             }
         }
 
         return AbstractHandler<std::shared_ptr<EventContext>>::handleRequest(data);
     }
-
-    /**
-     * @brief Constructor.
-     *
-     * @param vulnerabilitiesCandidates A map of vulnerability candidates databases.
-     * @param vulnerabilityDescription A vulnerability description database.
-     * @param vulnerabilityRemediations A remediations database.
-     */
-    explicit StoreModel(std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>>& vulnerabilitiesCandidates,
-                        Utils::RocksDBWrapper* vulnerabilityDescription,
-                        Utils::RocksDBWrapper* vulnerabilityRemediations)
-        : m_feedsDatabases(vulnerabilitiesCandidates)
-        , m_descriptionsDatabase(*vulnerabilityDescription)
-        , m_remediationsDatabase(*vulnerabilityRemediations)
-    {
-        if (!vulnerabilityDescription)
-        {
-            throw std::runtime_error("Vulnerability description database is null");
-        }
-
-        if (!vulnerabilityRemediations)
-        {
-            throw std::runtime_error("Vulnerability remediations database is null");
-        }
-    }
-
-private:
-    Utils::RocksDBWrapper& m_descriptionsDatabase;
-    Utils::RocksDBWrapper& m_remediationsDatabase;
-    std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>>& m_feedsDatabases;
 };
 
 #endif // _STORE_MODEL_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -57,7 +57,7 @@ public:
      * @see Entry - The data structure containing CVE and remediation information.
      * @see RocksDBWrapper - The utility class for interacting with RocksDB databases.
      */
-    static void updateRemediation(const cve_v5::Entry* data, Utils::RocksDBWrapper& remediationsDatabase)
+    static void updateRemediation(const cve_v5::Entry* data, Utils::IRocksDBWrapper* feedDatabase)
     {
         if (!(data->containers()->cna() && data->containers()->cna()->x_remediations()))
         {
@@ -98,7 +98,13 @@ public:
             builder.Finish(fbbRemediation);
 
             rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()), builder.GetSize());
-            remediationsDatabase.put(data->cveMetadata()->cveId()->c_str(), value);
+
+            if (!feedDatabase->columnExists(REMEDIATIONS_COLUMN))
+            {
+                feedDatabase->createColumn(REMEDIATIONS_COLUMN);
+            }
+
+            feedDatabase->put(data->cveMetadata()->cveId()->c_str(), value, REMEDIATIONS_COLUMN);
         }
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -36,7 +36,7 @@ public:
      * If no remediation data is available or an error occurs during the update process, it provides error messages.
      *
      * @param data Pointer to the 'Entry' object containing vulnerability and remediation information.
-     * @param remediationsDatabase Reference to the RocksDBWrapper object representing the database.
+     * @param feedDatabase Pointer to the 'RocksDB' object for interacting with the database.
      *
      * @note The 'Entry' object should conform to the specified cve5 schema, including nested structures.
      * @note The 'RocksDBWrapper' object should be properly initialized and connected to the target database.

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
@@ -33,7 +33,7 @@ public:
      * @brief Inserts the candidate data into the corresponding database.
      *
      * @param cve5Flatbuffer CVE5 Flatbuffer.
-     * @param dbMap map with rocksDB instances.
+     * @param feedDatabase rocksDB wrapper instance.
      */
     static void storeVulnerabilityCandidate(const cve_v5::Entry* cve5Flatbuffer, Utils::IRocksDBWrapper* feedDatabase)
     {

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
@@ -22,44 +22,6 @@ const std::unordered_map<std::string, NSVulnerabilityScanner::Status> VERSION_ST
     {"affected", NSVulnerabilityScanner::Status::Status_affected},
     {"unknown", NSVulnerabilityScanner::Status::Status_unknown}};
 
-constexpr auto CANDIDATES_DATABASE_PATH {"queue/vd/candidates"};
-
-/**
- * @brief Helper class to centralize the map lookup and dynamic fill.
- *
- */
-class CandidatesDBHelper final
-{
-public:
-    /**
-     * @brief Looks for the database in the map and adds it if it does not exist. In case of failIfNotExists, it throws
-     * an exception if the database does not exist.
-     *
-     * @param shortName Name of the database.
-     * @param map Candidates database map.
-     * @param failIfNotExists Flag to indicate if it should throw an exception when the database does not exist.
-     */
-    void static findAndOpen(const std::string& shortName,
-                            std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>>& map,
-                            bool failIfNotExists = false)
-    {
-        if (map.find(shortName) == map.end())
-        {
-            std::string dbPath {CANDIDATES_DATABASE_PATH + std::string("/") + shortName};
-
-            if (failIfNotExists)
-            {
-                if (!std::filesystem::exists(std::filesystem::path(dbPath)))
-                {
-                    throw std::runtime_error("Database " + dbPath + " does not exist");
-                }
-            }
-
-            map.emplace(shortName, std::make_unique<Utils::RocksDBWrapper>(dbPath));
-        }
-    }
-};
-
 /**
  * @brief UpdateCVECandidates class.
  *
@@ -73,8 +35,7 @@ public:
      * @param cve5Flatbuffer CVE5 Flatbuffer.
      * @param dbMap map with rocksDB instances.
      */
-    static void storeVulnerabilityCandidate(const cve_v5::Entry* cve5Flatbuffer,
-                                            std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>>& dbMap)
+    static void storeVulnerabilityCandidate(const cve_v5::Entry* cve5Flatbuffer, Utils::IRocksDBWrapper* feedDatabase)
     {
         if (!cve5Flatbuffer || !cve5Flatbuffer->containers())
         {
@@ -173,7 +134,7 @@ public:
                 const rocksdb::Slice slice(reinterpret_cast<const char*>(buffer), flatbufferSize);
                 const auto finalKey = key + "_" + cveId->str();
 
-                dbMap.at(shortName)->put(finalKey, slice);
+                feedDatabase->put(finalKey, slice, shortName);
             }
         };
 
@@ -188,7 +149,11 @@ public:
                 }
 
                 auto shortName = adp->providerMetadata()->shortName()->str();
-                CandidatesDBHelper::findAndOpen(shortName, dbMap);
+
+                if (!feedDatabase->columnExists(shortName))
+                {
+                    feedDatabase->createColumn(shortName);
+                }
 
                 candidateLambda(adp->affected(), shortName);
             }
@@ -210,7 +175,11 @@ public:
             }
 
             auto shortName = cna->providerMetadata()->shortName()->str();
-            CandidatesDBHelper::findAndOpen(shortName, dbMap);
+
+            if (!feedDatabase->columnExists(shortName))
+            {
+                feedDatabase->createColumn(shortName);
+            }
 
             candidateLambda(cna->affected(), shortName);
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -18,9 +18,7 @@
 #include "flatbuffers/flatbuffers.h"
 #include "rocksDBWrapper.hpp"
 #include "vulnerabilityDescription_generated.h"
-
-constexpr auto DESCRIPTION_DATABASE_PATH {"queue/vd/descriptions"};
-constexpr auto CVE5_DATABASE_PATH {"queue/vd/cve5"};
+#include "vulnerabilityScanner.hpp"
 
 /**
  * @brief UpdateCVEDescription class.
@@ -36,8 +34,7 @@ public:
      * @param cve5Flatbuffer CVE5 Flatbuffer.
      * @param rocksDBWrapper rocksDB wrapper instance.
      */
-    static void storeVulnerabilityDescription(const cve_v5::Entry* cve5Flatbuffer,
-                                              Utils::RocksDBWrapper& rocksDBWrapper)
+    static void storeVulnerabilityDescription(const cve_v5::Entry* cve5Flatbuffer, Utils::IRocksDBWrapper* feedDatabase)
     {
         if (cve5Flatbuffer->containers() && cve5Flatbuffer->containers()->cna())
         {
@@ -146,7 +143,13 @@ public:
                 std::string key {cve5Flatbuffer->cveMetadata()->cveId()->str()};
                 const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer),
                                                                    flatbufferSize);
-                rocksDBWrapper.put(key, VulnerabilityDescriptionSlice);
+
+                if (!feedDatabase->columnExists(DESCRIPTIONS_COLUMN))
+                {
+                    feedDatabase->createColumn(DESCRIPTIONS_COLUMN);
+                }
+
+                feedDatabase->put(key, VulnerabilityDescriptionSlice, DESCRIPTIONS_COLUMN);
             }
         }
     }

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -32,7 +32,7 @@ public:
      * database.
      *
      * @param cve5Flatbuffer CVE5 Flatbuffer.
-     * @param rocksDBWrapper rocksDB wrapper instance.
+     * @param feedDatabase rocksDB wrapper instance.
      */
     static void storeVulnerabilityDescription(const cve_v5::Entry* cve5Flatbuffer, Utils::IRocksDBWrapper* feedDatabase)
     {

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -1048,6 +1048,9 @@ TEST_F(DatabaseFeedManagerTest, GetCNAName)
 
     // For centos use mantainer name.
     EXPECT_STREQ(spDatabaseFeedManager->getCnaName("CentOS <lorem@ipsum.com>").c_str(), "redhat");
+
+    // By default use NVD
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("loremIpsum").c_str(), "nvd");
 }
 
 /* DatabaseFeedManagerMessageProcessor tests */

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -126,7 +126,7 @@ void DatabaseFeedManagerTest::SetUp()
     valid = parser.Parse(schemaStr.c_str());
     assert(valid == true);
 
-    Utils::RocksDBWrapper rocksDBWrapper(CANDIDATES_DATABASE_PATH + std::string("/") + CNA_NAME);
+    Utils::RocksDBWrapper rocksDBWrapper(DATABASE_PATH);
 
     for (const auto& item : jsonExample)
     {
@@ -137,8 +137,14 @@ void DatabaseFeedManagerTest::SetUp()
         const size_t flatbufferSize = parser.builder_.GetSize();
 
         const rocksdb::Slice vulnerabilityCandidate(reinterpret_cast<const char*>(buf), flatbufferSize);
+
+        if (!rocksDBWrapper.columnExists(CNA_NAME))
+        {
+            rocksDBWrapper.createColumn(CNA_NAME);
+        }
         rocksDBWrapper.put(PACKAGE_NAME + "_" + item.at("candidates").at(0).at("cveId").get<std::string>(),
-                           vulnerabilityCandidate);
+                           vulnerabilityCandidate,
+                           CNA_NAME);
     }
 };
 
@@ -180,7 +186,7 @@ TEST_F(DatabaseFeedManagerTest, DISABLED_getVulnerabiltyDescriptiveInformation_O
     fbBuilder.Finish(vdOriginalData);
 
     {
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DESCRIPTION_DATABASE_PATH);
+        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
         rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
         dbWrapper->put(CVEID_TEST_OK, dbValue);
     }
@@ -233,7 +239,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
     fbBuilder.Finish(vdOriginalData);
 
     {
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DESCRIPTION_DATABASE_PATH);
+        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
         rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
         dbWrapper->put(CVEID_TEST_NOT_FOUND, dbValue);
     }
@@ -273,7 +279,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
     {
         uint8_t corruptedData[] = {
             0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DESCRIPTION_DATABASE_PATH);
+        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
         rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
         dbWrapper->put(CVEID_TEST_CORRUPTED, dbValue);
     }
@@ -355,21 +361,20 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesCorrupted)
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
     std::atomic<bool> shouldStop {false};
 
+    // Simulate corrupted data stored
+    {
+        uint8_t corruptedData[] = {
+            0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
+        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+        rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
+        dbWrapper->put(std::string(CORRUPTED_PACKAGE_NAME) + "_CVE-2023-7845", dbValue, CNA_NAME);
+    }
+
     auto pDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
                                               TrampolineRouterSubscriber>>(pIndexerConnectorTrap, shouldStop)};
-
-    // Simulate corrupted data stored
-    {
-        uint8_t corruptedData[] = {
-            0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
-        auto dbWrapper =
-            std::make_unique<Utils::RocksDBWrapper>(CANDIDATES_DATABASE_PATH + std::string("/") + CNA_NAME);
-        rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
-        dbWrapper->put(std::string(CORRUPTED_PACKAGE_NAME) + "_CVE-2023-7845", dbValue);
-    }
 
     EXPECT_THROW(
         {
@@ -439,7 +444,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_ValidData)
     {
         std::string key_dummy {"CVE-2023-2609"};
         flatbuffers::FlatBufferBuilder builder;
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(REMEDIATIONS_DATABASE_PATH);
+        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
 
         std::vector<flatbuffers::Offset<flatbuffers::String>> updates_vec;
         updates_vec.push_back(builder.CreateString("KB2023"));
@@ -448,7 +453,12 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_ValidData)
         builder.Finish(dummy);
 
         rocksdb::Slice value(reinterpret_cast<const char*>(builder.GetBufferPointer()), builder.GetSize());
-        dbWrapper->put(key_dummy, value);
+
+        if (!dbWrapper->columnExists(REMEDIATIONS_COLUMN))
+        {
+            dbWrapper->createColumn(REMEDIATIONS_COLUMN);
+        }
+        dbWrapper->put(key_dummy, value, REMEDIATIONS_COLUMN);
     }
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
@@ -528,7 +538,7 @@ TEST_F(DatabaseFeedManagerTest, GetVulnerabilityRemediation_InvalidData)
     {
         uint8_t corruptedData[] = {
             0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(REMEDIATIONS_DATABASE_PATH);
+        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
         rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
         dbWrapper->put("CVE-2023-2609", dbValue);
     }
@@ -573,7 +583,7 @@ TEST_F(DatabaseFeedManagerTest, DISABLED_PackageTranslationCacheMiss)
     {
         std::string idDummy {"WT_001"};
         flatbuffers::FlatBufferBuilder builder;
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TRANSLATIONS_DATABASE_PATH);
+        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
         auto source = CreateSourceFieldsDirect(builder, "^The Apache Software", "^Apache Tomcat.*", "");
         auto translation = CreateTranslationFieldsDirect(builder, "apache", "tomcat", "");
         std::vector<flatbuffers::Offset<TranslationFields>> translations_vector;
@@ -655,7 +665,7 @@ TEST_F(DatabaseFeedManagerTest, DISABLED_PackageTranslationCacheHit)
     {
         std::string idDummy {"WT_001"};
         flatbuffers::FlatBufferBuilder builder;
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TRANSLATIONS_DATABASE_PATH);
+        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
         auto source = CreateSourceFieldsDirect(builder, "^The Apache Software", "^Apache Tomcat.*", "");
         auto translation = CreateTranslationFieldsDirect(builder, "apache", "tomcat", "");
         std::vector<flatbuffers::Offset<TranslationFields>> translations_vector;
@@ -764,7 +774,7 @@ TEST_F(DatabaseFeedManagerTest, DISABLED_PackageTranslationNoTranslationFound)
     {
         std::string idDummy {"WT_001"};
         flatbuffers::FlatBufferBuilder builder;
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TRANSLATIONS_DATABASE_PATH);
+        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
         auto source = CreateSourceFieldsDirect(builder, "^The Apache Software", "^Apache Tomcat.*", "");
         auto translation = CreateTranslationFieldsDirect(builder, "apache", "tomcat", "");
         std::vector<flatbuffers::Offset<TranslationFields>> translations_vector;
@@ -844,7 +854,7 @@ TEST_F(DatabaseFeedManagerTest, DISABLED_PackageTranslationInvalidDatabase)
     {
         uint8_t corruptedData[] = {
             0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TRANSLATIONS_DATABASE_PATH);
+        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
         rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
         dbWrapper->put("WT_001", dbValue);
     }
@@ -871,7 +881,7 @@ TEST_F(DatabaseFeedManagerTest, PackageTranslationInvalidCache)
     // ToDo It's necessary the write function to store a value corrupted and run this test.
 }
 
-void DatabaseFeedManagerTest_GracefulShutdown()
+void databaseFeedManagerTestGracefulShutdown()
 {
     // Test setup
     nlohmann::json jsonFileContent;
@@ -973,7 +983,6 @@ void DatabaseFeedManagerTest_GracefulShutdown()
                                               TrampolinePolicyManager,
                                               TrampolineContentRegister,
                                               RouterSubscriber,
-                                              DatabaseFeedManagerMessageProcessor,
                                               MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
 
     routerProvider->send(routerMessage);
@@ -985,10 +994,52 @@ void DatabaseFeedManagerTest_GracefulShutdown()
 
 TEST_F(DatabaseFeedManagerTest, GracefulShutdown)
 {
-    EXPECT_NO_THROW(DatabaseFeedManagerTest_GracefulShutdown());
+    EXPECT_NO_THROW(databaseFeedManagerTestGracefulShutdown());
 }
 
 /* DatabaseFeedManagerMessageProcessor tests */
+/**
+ * @brief SetUp.
+ *
+ */
+void DatabaseFeedManagerMessageProcessorTest::SetUp()
+{
+    std::ofstream file1 {"file1.json"};
+    file1 << R"({invalid:json})";
+
+    std::ofstream file2 {"file2.json"};
+    file2 << R"({"field":"value"})";
+
+    std::ofstream file3 {"file3.json"};
+    file3 << R"({"data": [{"element1":"element1","offset":1}]})";
+
+    std::ofstream file4 {"file4.json"};
+    file4 << R"({"name": "name_string"})";
+
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
+    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
+};
+
+/**
+ * @brief TearDown.
+ *
+ */
+void DatabaseFeedManagerMessageProcessorTest::TearDown()
+{
+    std::remove("file1.json");
+    std::remove("file2.json");
+    std::remove("file3.json");
+    std::remove("file4.json");
+
+    // Reset shared_ptr owner
+    spIndexerConnectorMock.reset();
+    spPolicyManagerMock.reset();
+    spContentRegisterMock.reset();
+    spRouterSubscriberMock.reset();
+    std::filesystem::remove_all(COMMON_DATABASE_DIR);
+};
 
 TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidJson)
 {
@@ -997,14 +1048,19 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidJson)
 
     auto testingLambda1 = [](const nlohmann::json& obj) {
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(
-            message, "topicName", testingLambda1, testingLambda2, shouldStop);
+        auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+        auto spDatabaseFeedManager {
+            std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                  TrampolinePolicyManager,
+                                                  TrampolineContentRegister,
+                                                  RouterSubscriber,
+                                                  MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+        spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1024,14 +1080,19 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestNoType)
 
     auto testingLambda1 = [](const nlohmann::json& obj) {
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(
-            message, "topicName", testingLambda1, testingLambda2, shouldStop);
+        auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+        auto spDatabaseFeedManager {
+            std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                  TrampolinePolicyManager,
+                                                  TrampolineContentRegister,
+                                                  RouterSubscriber,
+                                                  MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+        spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1051,14 +1112,19 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidType)
 
     auto testingLambda1 = [](const nlohmann::json& obj) {
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(
-            message, "topicName", testingLambda1, testingLambda2, shouldStop);
+        auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+        auto spDatabaseFeedManager {
+            std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                  TrampolinePolicyManager,
+                                                  TrampolineContentRegister,
+                                                  RouterSubscriber,
+                                                  MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+        spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1078,14 +1144,20 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestNoPaths)
 
     auto testingLambda1 = [](const nlohmann::json& obj) {
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(
-            message, "topicName", testingLambda1, testingLambda2, shouldStop);
+        auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+        auto spDatabaseFeedManager {
+            std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                  TrampolinePolicyManager,
+                                                  TrampolineContentRegister,
+                                                  RouterSubscriber,
+                                                  MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+        spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
+
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1105,14 +1177,20 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithInvalidJson)
 
     auto testingLambda1 = [](const nlohmann::json& obj) {
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(
-            message, "topicName", testingLambda1, testingLambda2, shouldStop);
+        auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+        auto spDatabaseFeedManager {
+            std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                  TrampolinePolicyManager,
+                                                  TrampolineContentRegister,
+                                                  RouterSubscriber,
+                                                  MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+        spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
+
         FAIL() << "Expected parse_error exception";
     }
     catch (const nlohmann::detail::parse_error& e)
@@ -1134,14 +1212,19 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithNoData)
 
     auto testingLambda1 = [](const nlohmann::json& obj) {
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(
-            message, "topicName", testingLambda1, testingLambda2, shouldStop);
+        auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+        auto spDatabaseFeedManager {
+            std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                  TrampolinePolicyManager,
+                                                  TrampolineContentRegister,
+                                                  RouterSubscriber,
+                                                  MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+        spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1163,14 +1246,19 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithDataAndExcepti
     {
         throw std::runtime_error {"Error"};
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(
-            message, "topicName", testingLambda1, testingLambda2, shouldStop);
+        auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+        auto spDatabaseFeedManager {
+            std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                  TrampolinePolicyManager,
+                                                  TrampolineContentRegister,
+                                                  RouterSubscriber,
+                                                  MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+        spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1190,16 +1278,21 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithDataSuccess)
 
     auto testingLambda1 = [](const nlohmann::json& obj) {
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _, _))
         .Times(1)
         .WillOnce(::testing::InvokeArgument<2>(std::string {"ok"}));
 
-    EXPECT_NO_THROW(DatabaseFeedManagerMessageProcessor::processMessage<MockUnixSocketRequest>(
-        message, "topicName", testingLambda1, testingLambda2, shouldStop));
+    auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              RouterSubscriber,
+                                              MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+    EXPECT_NO_THROW(spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1));
 }
 
 TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithDataSuccessButOffsetError)
@@ -1209,16 +1302,21 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithDataSuccessBut
 
     auto testingLambda1 = [](const nlohmann::json& obj) {
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _, _))
         .Times(1)
         .WillOnce(::testing::InvokeArgument<3>(std::string {"Error"}, 400));
 
-    EXPECT_ANY_THROW(DatabaseFeedManagerMessageProcessor::processMessage<MockUnixSocketRequest>(
-        message, "topicName", testingLambda1, testingLambda2, shouldStop));
+    auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              RouterSubscriber,
+                                              MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+    EXPECT_ANY_THROW(spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1));
 }
 
 TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithUnexistingFile)
@@ -1228,14 +1326,19 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithUnexistingFile)
 
     auto testingLambda1 = [](const nlohmann::json& obj) {
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(
-            message, "topicName", testingLambda1, testingLambda2, shouldStop);
+        auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+        auto spDatabaseFeedManager {
+            std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                  TrampolinePolicyManager,
+                                                  TrampolineContentRegister,
+                                                  RouterSubscriber,
+                                                  MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+        spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1255,14 +1358,19 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithInvalidLine)
 
     auto testingLambda1 = [](const nlohmann::json& obj) {
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(
-            message, "topicName", testingLambda1, testingLambda2, shouldStop);
+        auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+        auto spDatabaseFeedManager {
+            std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                  TrampolinePolicyManager,
+                                                  TrampolineContentRegister,
+                                                  RouterSubscriber,
+                                                  MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+        spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
         FAIL() << "Expected parse_error exception";
     }
     catch (const std::runtime_error& e)
@@ -1282,14 +1390,19 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileLineWithNoName)
 
     auto testingLambda1 = [](const nlohmann::json& obj) {
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(
-            message, "topicName", testingLambda1, testingLambda2, shouldStop);
+        auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+        auto spDatabaseFeedManager {
+            std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                  TrampolinePolicyManager,
+                                                  TrampolineContentRegister,
+                                                  RouterSubscriber,
+                                                  MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+        spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1317,8 +1430,15 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithDataAndException)
 
     try
     {
-        DatabaseFeedManagerMessageProcessor::processMessage(
-            message, "topicName", testingLambda1, testingLambda2, shouldStop);
+        auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+        auto spDatabaseFeedManager {
+            std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                  TrampolinePolicyManager,
+                                                  TrampolineContentRegister,
+                                                  RouterSubscriber,
+                                                  MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+        spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
         FAIL() << "Expected std::runtime_error";
     }
     catch (const std::runtime_error& e)
@@ -1343,8 +1463,16 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithDataSuccess)
     std::atomic<bool> shouldStop {false};
 
     EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _, _)).Times(1);
-    EXPECT_NO_THROW(DatabaseFeedManagerMessageProcessor::processMessage<MockUnixSocketRequest>(
-        message, "topicName", testingLambda1, testingLambda2, shouldStop));
+
+    auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              RouterSubscriber,
+                                              MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
+
+    EXPECT_NO_THROW(spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1));
 }
 
 TEST_F(DatabaseFeedManagerMessageProcessorTest, DISABLED_TestProcessingStop)
@@ -1371,16 +1499,20 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, DISABLED_TestProcessingStop)
         ++counter;
         std::this_thread::sleep_for(std::chrono::milliseconds(waitTimePerElement));
     };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
+    auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              RouterSubscriber,
+                                              MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop)};
 
-    auto processingThread = std::thread {DatabaseFeedManagerMessageProcessor::processMessage<MockUnixSocketRequest>,
-                                         message,
-                                         "topicName",
-                                         testingLambda1,
-                                         testingLambda2,
-                                         std::ref(shouldStop)};
+    auto processingThread =
+        std::thread {[&]()
+                     {
+                         spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1);
+                     }};
 
     std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(waitTimePerElement * totalElements * 0.5)));
     shouldStop.store(true);

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.cpp
@@ -158,7 +158,7 @@ void DatabaseFeedManagerTest::TearDown()
     std::filesystem::remove_all(COMMON_DATABASE_DIR);
 };
 
-TEST_F(DatabaseFeedManagerTest, DISABLED_getVulnerabiltyDescriptiveInformation_Ok)
+TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
 {
     const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
 
@@ -188,7 +188,11 @@ TEST_F(DatabaseFeedManagerTest, DISABLED_getVulnerabiltyDescriptiveInformation_O
     {
         auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
         rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-        dbWrapper->put(CVEID_TEST_OK, dbValue);
+        if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN))
+        {
+            dbWrapper->createColumn(DESCRIPTIONS_COLUMN);
+        }
+        dbWrapper->put(CVEID_TEST_OK, dbValue, DESCRIPTIONS_COLUMN);
     }
 
     auto spTrampolineIndexerConnector = std::make_shared<TrampolineIndexerConnector>();
@@ -241,7 +245,11 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
     {
         auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
         rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-        dbWrapper->put(CVEID_TEST_NOT_FOUND, dbValue);
+        if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN))
+        {
+            dbWrapper->createColumn(DESCRIPTIONS_COLUMN);
+        }
+        dbWrapper->put(CVEID_TEST_NOT_FOUND, dbValue, DESCRIPTIONS_COLUMN);
     }
 
     auto spTrampolineIndexerConnector = std::make_shared<TrampolineIndexerConnector>();
@@ -281,7 +289,11 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
             0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
         auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
         rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
-        dbWrapper->put(CVEID_TEST_CORRUPTED, dbValue);
+        if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN))
+        {
+            dbWrapper->createColumn(DESCRIPTIONS_COLUMN);
+        }
+        dbWrapper->put(CVEID_TEST_CORRUPTED, dbValue, DESCRIPTIONS_COLUMN);
     }
 
     auto spTrampolineIndexerConnector = std::make_shared<TrampolineIndexerConnector>();
@@ -995,6 +1007,47 @@ void databaseFeedManagerTestGracefulShutdown()
 TEST_F(DatabaseFeedManagerTest, GracefulShutdown)
 {
     EXPECT_NO_THROW(databaseFeedManagerTestGracefulShutdown());
+}
+
+TEST_F(DatabaseFeedManagerTest, GetCNAName)
+{
+    // Test setup
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+    std::shared_ptr<MockIndexerConnector> pIndexerConnectorMock;
+
+    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+
+    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
+    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
+
+    spContentRegisterMock = std::make_shared<MockContentRegister>(
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
+
+    spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
+        configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+
+    auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTramp, shouldStop)};
+
+    // For ubuntu use mantainer name.
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>").c_str(),
+                 "canonical");
+    // For debian use mantainer name.
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Debian GCC Maintainers <debian-gcc@lists.debian.org>").c_str(),
+                 "debian");
+
+    // For redhat use mantainer name.
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Red Hat, Inc. <loren@ipsum.com>").c_str(), "redhat");
+
+    // For centos use mantainer name.
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("CentOS <lorem@ipsum.com>").c_str(), "redhat");
 }
 
 /* DatabaseFeedManagerMessageProcessor tests */

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.h
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/databaseFeedManager_test.h
@@ -68,32 +68,13 @@ protected:
      * @brief SetUp.
      *
      */
-    void SetUp() override
-    {
-        std::ofstream file1 {"file1.json"};
-        file1 << R"({invalid:json})";
-
-        std::ofstream file2 {"file2.json"};
-        file2 << R"({"field":"value"})";
-
-        std::ofstream file3 {"file3.json"};
-        file3 << R"({"data": ["element1"]})";
-
-        std::ofstream file4 {"file4.json"};
-        file4 << R"({"name": "name_string"})";
-    };
+    void SetUp() override;
 
     /**
      * @brief TearDown.
      *
      */
-    void TearDown() override
-    {
-        std::remove("file1.json");
-        std::remove("file2.json");
-        std::remove("file3.json");
-        std::remove("file4.json");
-    };
+    void TearDown() override;
 };
 
 #endif //_DATABASE_FEED_MANAGER_TEST_H

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/storeRemediationsModel_test.cpp
@@ -13,6 +13,7 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
+#include <memory>
 
 constexpr auto COMMON_DATABASE_DIR {"queue/vd"}; //<<Used for all databases
 const std::string FLATBUFFER_SCHEMA {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
@@ -452,17 +453,17 @@ TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediationOneBlock)
     auto entry = cve_v5::GetEntry(jbuf);
 
     // Create a mock RocksDBWrapper object
-    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+    std::unique_ptr<Utils::IRocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
 
     // Call the updateRemediation function with the test data
-    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper.get()));
 
     // Assert result.
     std::string cveId {"CVE-1337-1234"};
     FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
 
     // Asserts
-    EXPECT_NO_THROW(rocksDBWrapper.get(cveId, dtoVulnRemediation.slice));
+    EXPECT_NO_THROW(rocksDBWrapper->get(cveId, dtoVulnRemediation.slice, REMEDIATIONS_COLUMN));
     dtoVulnRemediation.data = const_cast<NSVulnerabilityScanner::RemediationInfo*>(
         NSVulnerabilityScanner::GetRemediationInfo(dtoVulnRemediation.slice.data()));
 
@@ -493,17 +494,17 @@ TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediationMultipleBlocks)
     auto entry = cve_v5::GetEntry(jbuf);
 
     // Create a mock RocksDBWrapper object
-    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+    std::unique_ptr<Utils::IRocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
 
     // Call the updateRemediation function with the test data
-    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper.get()));
 
     // Assert result.
     std::string cveId {"CVE-1337-1234"};
     FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
 
     // Asserts
-    EXPECT_NO_THROW(rocksDBWrapper.get(cveId, dtoVulnRemediation.slice));
+    EXPECT_NO_THROW(rocksDBWrapper->get(cveId, dtoVulnRemediation.slice, REMEDIATIONS_COLUMN));
     dtoVulnRemediation.data = const_cast<NSVulnerabilityScanner::RemediationInfo*>(
         NSVulnerabilityScanner::GetRemediationInfo(dtoVulnRemediation.slice.data()));
 
@@ -541,17 +542,17 @@ TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediationMultipleBlocksSomeWi
     auto entry = cve_v5::GetEntry(jbuf);
 
     // Create a mock RocksDBWrapper object
-    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+    std::unique_ptr<Utils::IRocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
 
     // Call the updateRemediation function with the test data
-    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper.get()));
 
     // Assert result.
     std::string cveId {"CVE-1337-1234"};
     FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
 
     // Asserts
-    EXPECT_NO_THROW(rocksDBWrapper.get(cveId, dtoVulnRemediation.slice));
+    EXPECT_NO_THROW(rocksDBWrapper->get(cveId, dtoVulnRemediation.slice, REMEDIATIONS_COLUMN));
     dtoVulnRemediation.data = const_cast<NSVulnerabilityScanner::RemediationInfo*>(
         NSVulnerabilityScanner::GetRemediationInfo(dtoVulnRemediation.slice.data()));
 
@@ -586,13 +587,18 @@ TEST_F(StoreRemediationsModelTest, SkipsEmptyRemediations)
     auto entry = cve_v5::GetEntry(jbuf);
 
     // Create a mock RocksDBWrapper object
-    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+    std::unique_ptr<Utils::IRocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+
+    if (!rocksDBWrapper->columnExists(REMEDIATIONS_COLUMN))
+    {
+        rocksDBWrapper->createColumn(REMEDIATIONS_COLUMN);
+    }
 
     // Asserts there's no element with the key provided.
-    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper.get()));
     std::string key {entry->cveMetadata()->cveId()->str()};
-    std::string response;
-    EXPECT_EQ(false, rocksDBWrapper.get(key, response));
+    FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
+    EXPECT_EQ(false, rocksDBWrapper->get(key, dtoVulnRemediation.slice, REMEDIATIONS_COLUMN));
 }
 
 TEST_F(StoreRemediationsModelTest, SkipsEmptyUpdates)
@@ -616,13 +622,18 @@ TEST_F(StoreRemediationsModelTest, SkipsEmptyUpdates)
     auto entry = cve_v5::GetEntry(jbuf);
 
     // Create a mock RocksDBWrapper object
-    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+    std::unique_ptr<Utils::IRocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+
+    if (!rocksDBWrapper->columnExists(REMEDIATIONS_COLUMN))
+    {
+        rocksDBWrapper->createColumn(REMEDIATIONS_COLUMN);
+    }
 
     // Asserts there's no element with the key provided.
-    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper.get()));
     std::string key {entry->cveMetadata()->cveId()->str()};
-    std::string response;
-    EXPECT_EQ(false, rocksDBWrapper.get(key, response));
+    FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
+    EXPECT_EQ(false, rocksDBWrapper->get(key, dtoVulnRemediation.slice, REMEDIATIONS_COLUMN));
 }
 
 TEST_F(StoreRemediationsModelTest, x_remediationsNotPresent)
@@ -646,11 +657,16 @@ TEST_F(StoreRemediationsModelTest, x_remediationsNotPresent)
     auto entry = cve_v5::GetEntry(jbuf);
 
     // Create a mock RocksDBWrapper object
-    Utils::RocksDBWrapper rocksDBWrapper(REMEDIATIONS_DATABASE_PATH);
+    std::unique_ptr<Utils::IRocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+
+    if (!rocksDBWrapper->columnExists(REMEDIATIONS_COLUMN))
+    {
+        rocksDBWrapper->createColumn(REMEDIATIONS_COLUMN);
+    }
 
     // Asserts there's no element with the key provided.
-    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper));
+    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper.get()));
     std::string key {entry->cveMetadata()->cveId()->str()};
-    std::string response;
-    EXPECT_EQ(false, rocksDBWrapper.get(key, response));
+    FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
+    EXPECT_EQ(false, rocksDBWrapper->get(key, dtoVulnRemediation.slice, REMEDIATIONS_COLUMN));
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/updateCVECandidates_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/updateCVECandidates_test.cpp
@@ -17,13 +17,13 @@
 #include "updateCVECandidates.hpp"
 #include <unordered_map>
 
-const std::string cve5FlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
-const std::string vulnerabilityCandidateFlatbufferSchemaPath {FLATBUFFER_SCHEMAS_DIR "/vulnerabilityCandidate.fbs"};
+const std::string CVE5_FLATBUFFER_SCHEMA_PATH {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
+const std::string VULNERABILITY_CANDIDATE_FLATBUFFER_SCHEMA_PATH {FLATBUFFER_SCHEMAS_DIR "/vulnerabilityCandidate.fbs"};
 const char* INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
 
-const std::string cveId = "CVE-2010-0002";
+const std::string CVE_ID = "CVE-2010-0002";
 
-const std::string cveInput = R"(
+const std::string CVE_INPUT = R"(
     {
     "containers": {
         "adp": [
@@ -213,12 +213,12 @@ TEST_F(UpdateCVECandidatesTest, UpdateCVECandidateSuccess)
     std::string cve5FlatbufferSchemaStr;
 
     // Read schemas from filesystem.
-    bool valid = flatbuffers::LoadFile(cve5FlatbufferSchemaPath.c_str(), false, &cve5FlatbufferSchemaStr);
+    bool valid = flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr);
     ASSERT_EQ(valid, true);
 
     // Parse schemas and JSON example.
     flatbuffers::Parser parser;
-    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(cveInput.c_str()));
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(CVE_INPUT.c_str()));
     ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
@@ -231,11 +231,11 @@ TEST_F(UpdateCVECandidatesTest, UpdateCVECandidateSuccess)
     const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
     // Call function.
-    UpdateCVECandidates::storeVulnerabilityCandidate(cve5Flatbuffer, m_dbMap);
+    UpdateCVECandidates::storeVulnerabilityCandidate(cve5Flatbuffer, m_feedDatabase.get());
 
     // Verify Debian data
     rocksdb::PinnableSlice slice;
-    EXPECT_NO_THROW(m_dbMap.at("debian")->get("bash_CVE-2010-0002", slice));
+    EXPECT_NO_THROW(m_feedDatabase->get("bash_CVE-2010-0002", slice, "debian"));
 
     flatbuffers::Verifier verifierVulnCandidate(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
     EXPECT_EQ(NSVulnerabilityScanner::VerifyScanVulnerabilityCandidateArrayBuffer(verifierVulnCandidate), true);
@@ -245,7 +245,7 @@ TEST_F(UpdateCVECandidatesTest, UpdateCVECandidateSuccess)
     auto debianData = data->candidates()->Get(0);
 
     // Verify Debian values
-    EXPECT_EQ(debianData->cveId()->str(), cveId);
+    EXPECT_EQ(debianData->cveId()->str(), CVE_ID);
     EXPECT_EQ(debianData->defaultStatus(), NSVulnerabilityScanner::Status::Status_unaffected);
     EXPECT_EQ(debianData->platforms()->size(), 5);
     EXPECT_EQ(debianData->platforms()->Get(0)->str(), "bookworm");
@@ -256,7 +256,7 @@ TEST_F(UpdateCVECandidatesTest, UpdateCVECandidateSuccess)
     EXPECT_EQ(debianData->versions()->size(), 0);
 
     // Verify NVD data
-    EXPECT_NO_THROW(m_dbMap.at("nvd")->get("bash_CVE-2010-0002", slice));
+    EXPECT_NO_THROW(m_feedDatabase->get("bash_CVE-2010-0002", slice, "nvd"));
 
     flatbuffers::Verifier verifierVulnCandidate2(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
     EXPECT_EQ(NSVulnerabilityScanner::VerifyScanVulnerabilityCandidateArrayBuffer(verifierVulnCandidate2), true);
@@ -267,7 +267,7 @@ TEST_F(UpdateCVECandidatesTest, UpdateCVECandidateSuccess)
     auto nvdData = data->candidates()->Get(0);
 
     // Verify NVD values
-    EXPECT_EQ(nvdData->cveId()->str(), cveId);
+    EXPECT_EQ(nvdData->cveId()->str(), CVE_ID);
     EXPECT_EQ(nvdData->defaultStatus(), NSVulnerabilityScanner::Status::Status_unaffected);
     EXPECT_EQ(nvdData->platforms()->size(), 0);
     EXPECT_EQ(nvdData->versions()->size(), 4);
@@ -281,7 +281,7 @@ TEST_F(UpdateCVECandidatesTest, UpdateCVECandidateSuccess)
     EXPECT_EQ(nvdData->versions()->Get(3)->version()->str(), "3.2");
 
     // Verify Canonical data
-    EXPECT_NO_THROW(m_dbMap.at("canonical")->get("bash_CVE-2010-0002", slice));
+    EXPECT_NO_THROW(m_feedDatabase->get("bash_CVE-2010-0002", slice, "canonical"));
 
     flatbuffers::Verifier verifierVulnCandidate3(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
     EXPECT_EQ(NSVulnerabilityScanner::VerifyScanVulnerabilityCandidateArrayBuffer(verifierVulnCandidate3), true);
@@ -299,12 +299,12 @@ TEST_F(UpdateCVECandidatesTest, UpdateCVECandidateSuccess)
     EXPECT_EQ(canonicalData1->versions()->Get(0)->versionType()->str(), "custom");
     EXPECT_EQ(canonicalData1->versions()->Get(0)->lessThan()->str(), "98.0.4758.102");
     EXPECT_EQ(canonicalData1->versions()->Get(0)->lessThanOrEqual(), nullptr);
-    EXPECT_EQ(canonicalData1->cveId()->str(), cveId);
+    EXPECT_EQ(canonicalData1->cveId()->str(), CVE_ID);
     EXPECT_EQ(canonicalData1->defaultStatus(), NSVulnerabilityScanner::Status::Status_unknown);
     EXPECT_EQ(canonicalData1->platforms()->size(), 1);
     EXPECT_EQ(canonicalData1->platforms()->Get(0)->str(), "upstream");
 
-    EXPECT_EQ(canonicalData2->cveId()->str(), cveId);
+    EXPECT_EQ(canonicalData2->cveId()->str(), CVE_ID);
     EXPECT_EQ(canonicalData2->defaultStatus(), NSVulnerabilityScanner::Status::Status_unaffected);
     EXPECT_EQ(canonicalData2->platforms()->size(), 6);
     EXPECT_EQ(canonicalData2->platforms()->Get(0)->str(), "dapper");

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/updateCVECandidates_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/updateCVECandidates_test.hpp
@@ -30,7 +30,7 @@ protected:
      * @brief Map that contains the RocksDB instances.
      *
      */
-    std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>> m_dbMap;
+    std::unique_ptr<Utils::IRocksDBWrapper> m_feedDatabase;
 
     /**
      * @brief Construct a new UpdateCVECandidatesTest object
@@ -48,7 +48,10 @@ protected:
      * @brief SetUp.
      *
      */
-    void SetUp() {};
+    void SetUp()
+    {
+        m_feedDatabase = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+    };
 
     /**
      * @brief TearDown.
@@ -56,7 +59,9 @@ protected:
      */
     void TearDown()
     {
-        std::filesystem::remove_all(CANDIDATES_DATABASE_PATH);
+        m_feedDatabase->deleteAll();
+        m_feedDatabase.reset();
+        std::filesystem::remove_all(DATABASE_PATH);
     };
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
@@ -454,10 +454,8 @@ TEST_F(EventDecoderTest, TestCreatedResource)
 {
     std::vector<char> message {};
     auto jsonResource = nlohmann::json::parse(CREATED_RESOURCE);
-    auto eventContext = std::make_shared<EventContext>(EventContext {.message = message,
-                                                                     .resource = jsonResource,
-                                                                     .cvesDatabase = m_cvesDb,
-                                                                     .translationsDatabase = m_translationsDb});
+    auto eventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = jsonResource, .feedDatabase = m_feedDb.get()});
 
     std::shared_ptr<EventDecoder> eventDecoder;
 
@@ -469,7 +467,7 @@ TEST_F(EventDecoderTest, TestCreatedResource)
 
     // Verify flatbuffer.
     rocksdb::PinnableSlice slice;
-    EXPECT_TRUE(m_cvesDb->get(CVE_ID, slice));
+    EXPECT_TRUE(m_feedDb->get(CVE_ID, slice, COLUMNS.at(ResourceType::CVE)));
 
     flatbuffers::Verifier verifierCVE5(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
     EXPECT_TRUE(cve_v5::VerifyEntryBuffer(verifierCVE5));
@@ -494,10 +492,8 @@ TEST_F(EventDecoderTest, TestCreatedTranslationResource)
 {
     std::vector<char> message {};
     auto jsonResource = nlohmann::json::parse(CREATE_TRANSLATION);
-    auto eventContext = std::make_shared<EventContext>(EventContext {.message = message,
-                                                                     .resource = jsonResource,
-                                                                     .cvesDatabase = m_cvesDb,
-                                                                     .translationsDatabase = m_translationsDb});
+    auto eventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = jsonResource, .feedDatabase = m_feedDb.get()});
 
     std::shared_ptr<EventDecoder> eventDecoder;
 
@@ -509,7 +505,7 @@ TEST_F(EventDecoderTest, TestCreatedTranslationResource)
 
     // Verify flatbuffer.
     rocksdb::PinnableSlice slice;
-    EXPECT_TRUE(m_translationsDb->get(TRANSLATION_ID, slice));
+    EXPECT_TRUE(m_feedDb->get(TRANSLATION_ID, slice, COLUMNS.at(ResourceType::TRANSLATION)));
 
     flatbuffers::Verifier verifierTranslation(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
     EXPECT_TRUE(NSVulnerabilityScanner::VerifyTranslationEntryBuffer(verifierTranslation));
@@ -533,10 +529,8 @@ TEST_F(EventDecoderTest, TestUpdatedResource)
 {
     std::vector<char> message {};
     auto jsonResource = nlohmann::json::parse(CREATED_RESOURCE);
-    auto eventContext = std::make_shared<EventContext>(EventContext {.message = message,
-                                                                     .resource = jsonResource,
-                                                                     .cvesDatabase = m_cvesDb,
-                                                                     .translationsDatabase = m_translationsDb});
+    auto eventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = jsonResource, .feedDatabase = m_feedDb.get()});
 
     std::shared_ptr<EventDecoder> eventDecoder;
 
@@ -548,15 +542,13 @@ TEST_F(EventDecoderTest, TestUpdatedResource)
 
     // Apply update
     auto updatedJsonResource = nlohmann::json::parse(UPDATED_RESOURCE);
-    auto updatedEventContext = std::make_shared<EventContext>(EventContext {.message = message,
-                                                                            .resource = updatedJsonResource,
-                                                                            .cvesDatabase = m_cvesDb,
-                                                                            .translationsDatabase = m_translationsDb});
+    auto updatedEventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = updatedJsonResource, .feedDatabase = m_feedDb.get()});
     EXPECT_NO_THROW(eventDecoder->handleRequest(updatedEventContext));
 
     // Verify flatbuffer.
     rocksdb::PinnableSlice slice;
-    EXPECT_TRUE(m_cvesDb->get(CVE_ID, slice));
+    EXPECT_TRUE(m_feedDb->get(CVE_ID, slice, COLUMNS.at(ResourceType::CVE)));
 
     flatbuffers::Verifier verifierCVE5(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
     EXPECT_TRUE(cve_v5::VerifyEntryBuffer(verifierCVE5));
@@ -586,7 +578,7 @@ TEST_F(EventDecoderTest, TestUpdatedResourceCorrupted)
         uint8_t corruptedData[] = {
             0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
         rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
-        m_cvesDb->put("CVE-2010-0002", dbValue);
+        m_feedDb->put("CVE-2010-0002", dbValue, COLUMNS.at(ResourceType::CVE));
     }
 
     std::shared_ptr<EventDecoder> eventDecoder;
@@ -596,10 +588,8 @@ TEST_F(EventDecoderTest, TestUpdatedResourceCorrupted)
 
     // Apply update
     auto updatedJsonResource = nlohmann::json::parse(UPDATED_RESOURCE);
-    auto updatedEventContext = std::make_shared<EventContext>(EventContext {.message = message,
-                                                                            .resource = updatedJsonResource,
-                                                                            .cvesDatabase = m_cvesDb,
-                                                                            .translationsDatabase = m_translationsDb});
+    auto updatedEventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = updatedJsonResource, .feedDatabase = m_feedDb.get()});
 
     EXPECT_THROW(eventDecoder->handleRequest(updatedEventContext), std::runtime_error);
 }
@@ -611,10 +601,8 @@ TEST_F(EventDecoderTest, TestUpdatedTranslationResource)
 {
     std::vector<char> message {};
     auto jsonResource = nlohmann::json::parse(CREATE_TRANSLATION);
-    auto eventContext = std::make_shared<EventContext>(EventContext {.message = message,
-                                                                     .resource = jsonResource,
-                                                                     .cvesDatabase = m_cvesDb,
-                                                                     .translationsDatabase = m_translationsDb});
+    auto eventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = jsonResource, .feedDatabase = m_feedDb.get()});
 
     std::shared_ptr<EventDecoder> eventDecoder;
 
@@ -626,15 +614,13 @@ TEST_F(EventDecoderTest, TestUpdatedTranslationResource)
 
     // Apply update
     auto updatedJsonResource = nlohmann::json::parse(UPDATE_TRANSLATION);
-    auto updatedEventContext = std::make_shared<EventContext>(EventContext {.message = message,
-                                                                            .resource = updatedJsonResource,
-                                                                            .cvesDatabase = m_cvesDb,
-                                                                            .translationsDatabase = m_translationsDb});
+    auto updatedEventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = updatedJsonResource, .feedDatabase = m_feedDb.get()});
     EXPECT_NO_THROW(eventDecoder->handleRequest(updatedEventContext));
 
     // Verify flatbuffer.
     rocksdb::PinnableSlice slice;
-    EXPECT_TRUE(m_translationsDb->get(TRANSLATION_ID, slice));
+    EXPECT_TRUE(m_feedDb->get(TRANSLATION_ID, slice, COLUMNS.at(ResourceType::TRANSLATION)));
 
     flatbuffers::Verifier verifierTranslation(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
     EXPECT_TRUE(NSVulnerabilityScanner::VerifyTranslationEntryBuffer(verifierTranslation));
@@ -663,7 +649,7 @@ TEST_F(EventDecoderTest, TestUpdatedTranslationResourceCorrupted)
         uint8_t corruptedData[] = {
             0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
         rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
-        m_translationsDb->put("TID-0001", dbValue);
+        m_feedDb->put("TID-0001", dbValue, COLUMNS.at(ResourceType::TRANSLATION));
     }
 
     std::shared_ptr<EventDecoder> eventDecoder;
@@ -673,10 +659,8 @@ TEST_F(EventDecoderTest, TestUpdatedTranslationResourceCorrupted)
 
     // Apply update
     auto updatedJsonResource = nlohmann::json::parse(UPDATE_TRANSLATION);
-    auto updatedEventContext = std::make_shared<EventContext>(EventContext {.message = message,
-                                                                            .resource = updatedJsonResource,
-                                                                            .cvesDatabase = m_cvesDb,
-                                                                            .translationsDatabase = m_translationsDb});
+    auto updatedEventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = updatedJsonResource, .feedDatabase = m_feedDb.get()});
 
     EXPECT_THROW(eventDecoder->handleRequest(updatedEventContext), std::runtime_error);
 }
@@ -688,10 +672,8 @@ TEST_F(EventDecoderTest, TestDeletedTranslationResource)
 {
     std::vector<char> message {};
     auto jsonResource = nlohmann::json::parse(CREATE_TRANSLATION);
-    auto eventContext = std::make_shared<EventContext>(EventContext {.message = message,
-                                                                     .resource = jsonResource,
-                                                                     .cvesDatabase = m_cvesDb,
-                                                                     .translationsDatabase = m_translationsDb});
+    auto eventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = jsonResource, .feedDatabase = m_feedDb.get()});
 
     std::shared_ptr<EventDecoder> eventDecoder;
 
@@ -703,15 +685,13 @@ TEST_F(EventDecoderTest, TestDeletedTranslationResource)
 
     // Apply update
     auto deletedJsonResource = nlohmann::json::parse(DELETE_TRANSLATION);
-    auto deletedEventContext = std::make_shared<EventContext>(EventContext {.message = message,
-                                                                            .resource = deletedJsonResource,
-                                                                            .cvesDatabase = m_cvesDb,
-                                                                            .translationsDatabase = m_translationsDb});
+    auto deletedEventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = deletedJsonResource, .feedDatabase = m_feedDb.get()});
     EXPECT_NO_THROW(eventDecoder->handleRequest(deletedEventContext));
 
     // Verify flatbuffer.
     rocksdb::PinnableSlice slice;
-    EXPECT_FALSE(m_translationsDb->get(TRANSLATION_ID, slice));
+    EXPECT_FALSE(m_feedDb->get(TRANSLATION_ID, slice, COLUMNS.at(ResourceType::TRANSLATION)));
 }
 
 /*
@@ -721,10 +701,8 @@ TEST_F(EventDecoderTest, TestInvalidOperation)
 {
     std::vector<char> message {};
     auto jsonResource = nlohmann::json::parse(INVALID_TYPE);
-    auto eventContext = std::make_shared<EventContext>(EventContext {.message = message,
-                                                                     .resource = jsonResource,
-                                                                     .cvesDatabase = m_cvesDb,
-                                                                     .translationsDatabase = m_translationsDb});
+    auto eventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = jsonResource, .feedDatabase = m_feedDb.get()});
 
     std::shared_ptr<EventDecoder> eventDecoder;
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.hpp
@@ -15,8 +15,7 @@
 #include "rocksDBWrapper.hpp"
 #include "gtest/gtest.h"
 
-auto constexpr TEMP_CVES_DB {"cves_temp"};
-auto constexpr TEMP_TRANSLATIONS_DB {"translations_temp"};
+auto constexpr TEMP_FEED_DB {"feed_temp"};
 
 /**
  * @brief Runs unit tests for EventDecoder.
@@ -36,8 +35,7 @@ protected:
      */
     void SetUp() override
     {
-        m_cvesDb = std::make_unique<Utils::RocksDBWrapper>(TEMP_CVES_DB);
-        m_translationsDb = std::make_unique<Utils::RocksDBWrapper>(TEMP_TRANSLATIONS_DB);
+        m_feedDb = std::make_unique<Utils::RocksDBWrapper>(TEMP_FEED_DB);
     }
 
     /**
@@ -46,25 +44,14 @@ protected:
      */
     void TearDown() override
     {
-        m_cvesDb->deleteAll();
-        m_cvesDb.reset();
-        m_translationsDb->deleteAll();
-        m_translationsDb.reset();
-        std::remove(TEMP_CVES_DB);
-        std::remove(TEMP_TRANSLATIONS_DB);
+        std::remove(TEMP_FEED_DB);
     }
 
     /**
-     * @brief RocksDBWrapper instance for CVEs.
+     * @brief RocksDBWrapper instance for feeds.
      *
      */
-    std::unique_ptr<Utils::RocksDBWrapper> m_cvesDb;
-
-    /**
-     * @brief RocksDBWrapper instance for translations.
-     *
-     */
-    std::unique_ptr<Utils::RocksDBWrapper> m_translationsDb;
+    std::unique_ptr<Utils::IRocksDBWrapper> m_feedDb;
 };
 
 #endif // _EVENT_DECODER_TEST_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/feedIndexer_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/feedIndexer_test.cpp
@@ -36,10 +36,10 @@ TEST_F(FeedIndexerTest, TestHandleRequest)
     GTEST_SKIP();
     std::vector<char> message;
     nlohmann::json resource;
-    auto cvesDatabase = std::make_unique<Utils::RocksDBWrapper>("temp");
+    auto feedDatabase = std::make_unique<Utils::RocksDBWrapper>("temp");
     std::shared_ptr<IndexerConnector> indexerConnector;
-    auto eventContext = std::make_shared<EventContext>(EventContext {
-        .message = message, .resource = resource, .cvesDatabase = cvesDatabase, .translationsDatabase = nullptr});
+    auto eventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = resource, .feedDatabase = feedDatabase.get()});
 
     std::shared_ptr<FeedIndexer<IndexerConnector>> feedIndexer;
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanDispatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanDispatcher_test.cpp
@@ -33,8 +33,8 @@ TEST_F(ScanDispatcherTest, TestHandleRequest)
     std::vector<char> message;
     nlohmann::json resource;
     auto cvesDatabase = std::make_unique<Utils::RocksDBWrapper>("temp");
-    auto eventContext = std::make_shared<EventContext>(EventContext {
-        .message = message, .resource = resource, .cvesDatabase = cvesDatabase, .translationsDatabase = nullptr});
+    auto eventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = resource, .feedDatabase = cvesDatabase.get()});
 
     std::shared_ptr<ScanDispatcher> scanDispatcher;
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/storeModel_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/storeModel_test.cpp
@@ -109,16 +109,6 @@ const std::string CVE5_ENTRY {
             })"};
 
 /*
- * @brief Test instantiation of the StoreModel class.
- */
-TEST_F(StoreModelTest, TestInstantiationOfTheStoreModelClass)
-{
-    std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>> candidatesDatabase;
-    // Instantiation of the StoreModel class.
-    EXPECT_THROW(std::make_shared<StoreModel>(candidatesDatabase, nullptr, nullptr), std::runtime_error);
-}
-
-/*
  * @brief Test handleRequest of the StoreModel class.
  */
 TEST_F(StoreModelTest, TestHandleRequest)
@@ -131,23 +121,16 @@ TEST_F(StoreModelTest, TestHandleRequest)
 
     flatbuffers::FlatBufferBuilder& builder = parser.builder_;
 
-    auto cvesDatabase = std::make_unique<Utils::RocksDBWrapper>("temp");
-    std::shared_ptr<EventContext> eventContext = std::make_shared<EventContext>(EventContext {
-        .message = message, .resource = resource, .cvesDatabase = cvesDatabase, .translationsDatabase = nullptr});
+    auto feedDatabase = std::make_unique<Utils::RocksDBWrapper>("temp");
+    std::shared_ptr<EventContext> eventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = resource, .feedDatabase = feedDatabase.get()});
 
     eventContext->cve5Buffer = builder.Release();
 
     std::shared_ptr<StoreModel> storeModel;
-    std::map<std::string, std::unique_ptr<Utils::RocksDBWrapper>> candidatesDatabase;
-
-    std::unique_ptr<Utils::RocksDBWrapper> vulnerabilityDescription =
-        std::make_unique<Utils::RocksDBWrapper>("tempDesc");
-    std::unique_ptr<Utils::RocksDBWrapper> vulnerabilityRemediations =
-        std::make_unique<Utils::RocksDBWrapper>("tempRem");
 
     // Instantiation of the StoreModel class.
-    EXPECT_NO_THROW(storeModel = std::make_shared<StoreModel>(
-                        candidatesDatabase, vulnerabilityDescription.get(), vulnerabilityRemediations.get()));
+    EXPECT_NO_THROW(storeModel = std::make_shared<StoreModel>());
 
     // HandleRequest
     EXPECT_NO_THROW(storeModel->handleRequest(eventContext));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -445,12 +445,12 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
     const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
     // Call function.
-    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
+    std::unique_ptr<Utils::RocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper.get());
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(rocksDBWrapper.get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr));
+    ASSERT_TRUE(rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -499,12 +499,12 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_0)
     const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
     // Call function.
-    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
+    std::unique_ptr<Utils::RocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper.get());
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(rocksDBWrapper.get(CVE_JSON_STR_CVSS_V3_0, vulnerabilityDescriptionFBStr));
+    ASSERT_TRUE(rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_0, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -551,12 +551,12 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV2_0)
     const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
     // Call function.
-    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
+    std::unique_ptr<Utils::RocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper.get());
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(rocksDBWrapper.get(CVE_JSON_STR_CVSS_V2_0, vulnerabilityDescriptionFBStr));
+    ASSERT_TRUE(rocksDBWrapper->get(CVE_JSON_STR_CVSS_V2_0, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -609,12 +609,12 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
     const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
     // Call function.
-    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
+    std::unique_ptr<Utils::RocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper.get());
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(rocksDBWrapper.get(CVE_JSON_STR_MISSING_METRICS, vulnerabilityDescriptionFBStr));
+    ASSERT_TRUE(rocksDBWrapper->get(CVE_JSON_STR_MISSING_METRICS, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -658,10 +658,10 @@ TEST_F(UpdateCVEDescriptionTest, RejectedCVE5Entry)
     const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
     // Call function.
-    Utils::RocksDBWrapper rocksDBWrapper(DESCRIPTION_DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
+    std::unique_ptr<Utils::RocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper.get());
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_FALSE(rocksDBWrapper.get(CVE_JSON_STR_REJECTED_CVE, vulnerabilityDescriptionFBStr));
+    ASSERT_FALSE(rocksDBWrapper->get(CVE_JSON_STR_REJECTED_CVE, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
 }

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12.4)
 project(rocks_db_query_testtool)
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
+#set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
 
 file(GLOB ROCKS_DB_QUERY_TESTTOOL_SRC
     "*.cpp"

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12.4)
 project(rocks_db_query_testtool)
 
-#set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
 
 file(GLOB ROCKS_DB_QUERY_TESTTOOL_SRC
     "*.cpp"

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/argsParser.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/argsParser.hpp
@@ -33,6 +33,7 @@ public:
         : m_dbPath {paramValueOf(argc, argv, "-d")}
         , m_fbsPath {paramValueOf(argc, argv, "-f", std::make_pair(false, ""))}
         , m_key {paramValueOf(argc, argv, "-k", std::make_pair(false, ""))}
+        , m_columnFamily {paramValueOf(argc, argv, "-c", std::make_pair(false, ""))}
     {
     }
 
@@ -64,6 +65,16 @@ public:
     std::string getKey()
     {
         return m_key;
+    }
+
+    /**
+     * @brief Get the requested column family.
+     *
+     * @return std::string Column family.
+     */
+    std::string getColumnFamily()
+    {
+        return m_columnFamily;
     }
 
     /**
@@ -108,6 +119,7 @@ private:
     const std::string m_dbPath;
     const std::string m_fbsPath;
     const std::string m_key;
+    const std::string m_columnFamily;
 };
 
 #endif // _CMD_ARGS_PARSER_HPP_

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
@@ -66,7 +66,7 @@ int main(const int argc, const char** argv)
         else
         {
             rocksdb::PinnableSlice slice;
-            if (!rocksDB.get(requestedKey, slice))
+            if (!rocksDB.get(requestedKey, slice, cmdLineArgs.getColumnFamily()))
             {
                 throw std::runtime_error("Unable to find resource.");
             }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21010 |

## Description
This PR aims to add two things.

The first one is the management of column families, to avoid having multiple database instances in the code. The principal benefit of this is the maintenance and clean code.

The second one is the management of transactions to set the current offset only when the transactions are committed.
