### PR TITLE
Improved Logging for Vulnerability Detector

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeRemediationsModel.hpp
@@ -68,7 +68,7 @@ public:
 
         if (!remediations)
         {
-            logError(WM_VULNSCAN_LOGTAG, "Empty remediations");
+            logError(WM_VULNSCAN_LOGTAG, "Remediations database is empty");
             return;
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -309,7 +309,7 @@ public:
                 }
                 catch (const std::exception& ex)
                 {
-                    logError(WM_VULNSCAN_LOGTAG, ex.what());
+                    logError(WM_VULNSCAN_LOGTAG, "Error initialization manager configuration: %s.", ex.what());
                 }
             });
     }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
@@ -68,7 +68,7 @@ public:
                     json["id"] = elementKey;
                     data->m_elements[elementKey] = json;
                 }
-                logDebug2(WM_VULNSCAN_LOGTAG, "Deleting all agent packages for key: %s", dbQuery.first.c_str());
+                logDebug2(WM_VULNSCAN_LOGTAG, "Deleting all agent packages key: %s", dbQuery.first.c_str());
                 m_inventoryDatabase.delete_(dbQuery.first);
             }
         }
@@ -118,7 +118,7 @@ public:
                 {
                     insertListString.append(value);
                     logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Updating agent package kv: %s - %s",
+                              "Updating agent package kv: %s -> %s",
                               agentPackageKey.c_str(),
                               insertListString.c_str());
                     m_inventoryDatabase.put(agentPackageKey, insertListString);
@@ -137,7 +137,7 @@ public:
                 {
                     insertListString.pop_back();
                     logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Inserting agent package kv: %s - %s",
+                              "Inserting agent package key: %s -> %s",
                               agentPackageKey.c_str(),
                               insertListString.c_str());
                     m_inventoryDatabase.put(agentPackageKey, insertListString);

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
@@ -118,7 +118,7 @@ public:
                 {
                     insertListString.append(value);
                     logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Updating agent package kv: %s -> %s",
+                              "Updating agent package key: %s -> %s",
                               agentPackageKey.c_str(),
                               insertListString.c_str());
                     m_inventoryDatabase.put(agentPackageKey, insertListString);

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -48,6 +48,13 @@ public:
     {
         const std::string packageName {Utils::toLowerCase(std::string(data->packageName()))};
 
+        logDebug1(WM_VULNSCAN_LOGTAG,
+                  "Start vulnerability scan for package '%s' in agent ID: '%s' -- Name: '%s'. Version: '%s'",
+                  packageName.c_str(),
+                  data->agentId().data(),
+                  data->agentName().data(),
+                  data->agentVersion().data());
+
         auto vulnerabilityScan =
             [&](const std::string& cnaName, const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
@@ -60,7 +67,8 @@ public:
                                                                                      : ""};
 
                 logDebug2(WM_VULNSCAN_LOGTAG,
-                          "SCAN -> Package: %s, Version: %s, CVE: %s, Ver: %s, RLT: %s, RLTE: %s",
+                          "Scanning package - '%s' (Installed Version: %s, Security Vulnerability: %s). Vulnerable to "
+                          "Version: %s. Required Version Threshold: %s. Required Version Threshold (or Equal): %s.",
                           packageName.c_str(),
                           packageVersion.c_str(),
                           callbackData.cveId()->str().c_str(),
@@ -70,18 +78,18 @@ public:
 
                 if (versionStringLessThan.empty() && versionStringLessThanOrEqual.empty())
                 {
-                    if (VersionMatcher::compare(packageVersion, versionString) == 0)
+                    if (VersionMatcher::compare(packageVersion, versionString) == 0) // Version exacta
                     {
                         if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                         {
-                            logDebug1(WM_VULNSCAN_LOGTAG,
-                                      "MATCH Package: %s, Version: %s, CVE: %s, Ver: %s, RLT: %s, RLTE: %s",
-                                      packageName.c_str(),
-                                      packageVersion.c_str(),
-                                      callbackData.cveId()->str().c_str(),
-                                      versionString.c_str(),
-                                      versionStringLessThan.c_str(),
-                                      versionStringLessThanOrEqual.c_str());
+                            logDebug1(
+                                WM_VULNSCAN_LOGTAG,
+                                "Match found, the package '%s', is vulnerable to '%s'. The current version: '%s' is "
+                                "equal to '%s'.",
+                                packageName.c_str(),
+                                callbackData.cveId()->str().c_str(),
+                                packageVersion.c_str(),
+                                versionString.c_str());
 
                             data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
                             return true;
@@ -102,14 +110,16 @@ public:
                              (!versionStringLessThanOrEqual.empty() &&
                               VersionMatcher::compare(packageVersion, versionStringLessThanOrEqual) <= 0)))
                         {
-                            if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
+                            if (version->status() ==
+                                NSVulnerabilityScanner::Status::Status_affected) // Version menor que o igual que
                             {
                                 logDebug1(WM_VULNSCAN_LOGTAG,
-                                          "MATCH Package: %s, Version: %s, CVE: %s, Ver: %s, RLT: %s, RLTE: %s",
+                                          "Match found, the package '%s', is vulnerable to '%s'. The current version: "
+                                          "'%s' is "
+                                          "less than '%s' or equal to '%s'.",
                                           packageName.c_str(),
-                                          packageVersion.c_str(),
                                           callbackData.cveId()->str().c_str(),
-                                          versionString.c_str(),
+                                          packageVersion.c_str(),
                                           versionStringLessThan.c_str(),
                                           versionStringLessThanOrEqual.c_str());
 
@@ -119,14 +129,17 @@ public:
                             else
                             {
                                 logDebug2(WM_VULNSCAN_LOGTAG,
-                                          "NO MATCH because the default status, Package: %s, Version: %s, CVE: %s, "
-                                          "Ver: %s, RLT: %s, RLTE: %s",
+                                          "No match due to default status for Package: %s, Version: %s while scanning "
+                                          "for Vulnerability: %s, "
+                                          "Installed Version: %s, Required Version Threshold: %s, Required Version "
+                                          "Threshold (or Equal): %s",
                                           packageName.c_str(),
                                           packageVersion.c_str(),
                                           callbackData.cveId()->str().c_str(),
                                           versionString.c_str(),
                                           versionStringLessThan.c_str(),
                                           versionStringLessThanOrEqual.c_str());
+
                                 return false;
                             }
                         }
@@ -137,7 +150,7 @@ public:
             if (defaultStatus == NSVulnerabilityScanner::Status::Status_affected)
             {
                 logDebug1(WM_VULNSCAN_LOGTAG,
-                          "MATCH Package: %s, CVE: %s by default status.",
+                          "Match found for Package: %s for vulnerability: %s due to default status.",
                           packageName.c_str(),
                           callbackData.cveId()->str().c_str());
 
@@ -152,7 +165,8 @@ public:
 
         const auto cnaName {m_databaseFeedManager->getCnaName(data->packageVendor())};
         logDebug1(WM_VULNSCAN_LOGTAG,
-                  "Scanning package: '%s', CNA: '%s'. From agent ID: '%s', name: '%s', version: '%s'",
+                  "Scanning package: '%s', CVE Numbering Authorities (CNA): '%s'. From agent ID: '%s', name: '%s', "
+                  "version: '%s'. No vulnerabilities was found",
                   packageName.c_str(),
                   cnaName.c_str(),
                   data->agentId().data(),
@@ -166,11 +180,18 @@ public:
         catch (const std::exception& e)
         {
             logWarn(WM_VULNSCAN_LOGTAG,
-                    "Failed to scan package: '%s', CNA: '%s', Error: '%s'",
+                    "Failed to scan package: '%s', CVE Numbering Authorities (CNA): '%s', Error: '%s'",
                     packageName.c_str(),
                     cnaName.c_str(),
                     e.what());
         }
+
+        // Vulnerability scan ended for agent and package...
+
+        logDebug1(WM_VULNSCAN_LOGTAG,
+                  "Vulnerability scan ended for package '%s' in agent ID: '%s'.",
+                  packageName.c_str(),
+                  data->agentId().data());
 
         if (data->m_elements.empty())
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -61,10 +61,10 @@ public:
             for (const auto& version : *callbackData.versions())
             {
                 const std::string packageVersion {data->packageVersion()};
-                std::string versionString {version->version() ? version->version()->str() : "N/A"};
-                std::string versionStringLessThan {version->lessThan() ? version->lessThan()->str() : "N/A"};
+                std::string versionString {version->version() ? version->version()->str() : ""};
+                std::string versionStringLessThan {version->lessThan() ? version->lessThan()->str() : ""};
                 std::string versionStringLessThanOrEqual {version->lessThanOrEqual() ? version->lessThanOrEqual()->str()
-                                                                                     : "N/A"};
+                                                                                     : ""};
 
                 logDebug2(WM_VULNSCAN_LOGTAG,
                           "Scanning package - '%s' (Installed Version: %s, Security Vulnerability: %s). Identified "

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -49,10 +49,10 @@ public:
         const std::string packageName {Utils::toLowerCase(std::string(data->packageName()))};
 
         logDebug1(WM_VULNSCAN_LOGTAG,
-                  "Start vulnerability scan for package '%s' in agent ID: '%s' -- Name: '%s'. Version: '%s'",
+                  "Initiating a vulnerability scan for package '%s' on Agent '%s' (ID: '%s', Version: '%s').",
                   packageName.c_str(),
-                  data->agentId().data(),
                   data->agentName().data(),
+                  data->agentId().data(),
                   data->agentVersion().data());
 
         auto vulnerabilityScan =
@@ -61,13 +61,14 @@ public:
             for (const auto& version : *callbackData.versions())
             {
                 const std::string packageVersion {data->packageVersion()};
-                std::string versionString {version->version() ? version->version()->str() : ""};
-                std::string versionStringLessThan {version->lessThan() ? version->lessThan()->str() : ""};
+                std::string versionString {version->version() ? version->version()->str() : "N/A"};
+                std::string versionStringLessThan {version->lessThan() ? version->lessThan()->str() : "N/A"};
                 std::string versionStringLessThanOrEqual {version->lessThanOrEqual() ? version->lessThanOrEqual()->str()
-                                                                                     : ""};
+                                                                                     : "N/A"};
 
                 logDebug2(WM_VULNSCAN_LOGTAG,
-                          "Scanning package - '%s' (Installed Version: %s, Security Vulnerability: %s). Vulnerable to "
+                          "Scanning package - '%s' (Installed Version: %s, Security Vulnerability: %s). Identified "
+                          "vulnerability: "
                           "Version: %s. Required Version Threshold: %s. Required Version Threshold (or Equal): %s.",
                           packageName.c_str(),
                           packageVersion.c_str(),
@@ -78,18 +79,17 @@ public:
 
                 if (versionStringLessThan.empty() && versionStringLessThanOrEqual.empty())
                 {
-                    if (VersionMatcher::compare(packageVersion, versionString) == 0) // Version exacta
+                    if (VersionMatcher::compare(packageVersion, versionString) == 0)
                     {
                         if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                         {
-                            logDebug1(
-                                WM_VULNSCAN_LOGTAG,
-                                "Match found, the package '%s', is vulnerable to '%s'. The current version: '%s' is "
-                                "equal to '%s'.",
-                                packageName.c_str(),
-                                callbackData.cveId()->str().c_str(),
-                                packageVersion.c_str(),
-                                versionString.c_str());
+                            logDebug1(WM_VULNSCAN_LOGTAG,
+                                      "Match found, the package '%s', is vulnerable to '%s'. Current version: '%s' is "
+                                      "equal to '%s'.",
+                                      packageName.c_str(),
+                                      callbackData.cveId()->str().c_str(),
+                                      packageVersion.c_str(),
+                                      versionString.c_str());
 
                             data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
                             return true;
@@ -110,13 +110,12 @@ public:
                              (!versionStringLessThanOrEqual.empty() &&
                               VersionMatcher::compare(packageVersion, versionStringLessThanOrEqual) <= 0)))
                         {
-                            if (version->status() ==
-                                NSVulnerabilityScanner::Status::Status_affected) // Version menor que o igual que
+                            if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                             {
                                 logDebug1(WM_VULNSCAN_LOGTAG,
-                                          "Match found, the package '%s', is vulnerable to '%s'. The current version: "
-                                          "'%s' is "
-                                          "less than '%s' or equal to '%s'.",
+                                          "Match found, the package '%s', is vulnerable to '%s'. Current version: "
+                                          "'%s' ("
+                                          "less than '%s' or equal to '%s').",
                                           packageName.c_str(),
                                           callbackData.cveId()->str().c_str(),
                                           packageVersion.c_str(),
@@ -165,12 +164,12 @@ public:
 
         const auto cnaName {m_databaseFeedManager->getCnaName(data->packageVendor())};
         logDebug1(WM_VULNSCAN_LOGTAG,
-                  "Scanning package: '%s', CVE Numbering Authorities (CNA): '%s'. From agent ID: '%s', name: '%s', "
-                  "version: '%s'. No vulnerabilities was found",
+                  "Initiating a vulnerability scan for package '%s' with CVE Numbering Authorities (CNA) '%s' on Agent "
+                  "'%s' (ID: '%s', Version: '%s').",
                   packageName.c_str(),
                   cnaName.c_str(),
-                  data->agentId().data(),
                   data->agentName().data(),
+                  data->agentId().data(),
                   data->agentVersion().data());
 
         try
@@ -189,7 +188,7 @@ public:
         // Vulnerability scan ended for agent and package...
 
         logDebug1(WM_VULNSCAN_LOGTAG,
-                  "Vulnerability scan ended for package '%s' in agent ID: '%s'.",
+                  "Vulnerability scan for package '%s' on Agent '%s' has completed.",
                   packageName.c_str(),
                   data->agentId().data());
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -83,13 +83,16 @@ public:
                     {
                         if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                         {
-                            logDebug1(WM_VULNSCAN_LOGTAG,
-                                      "Match found, the package '%s', is vulnerable to '%s'. Current version: '%s' is "
-                                      "equal to '%s'.",
-                                      packageName.c_str(),
-                                      callbackData.cveId()->str().c_str(),
-                                      packageVersion.c_str(),
-                                      versionString.c_str());
+                            logInfo(WM_VULNSCAN_LOGTAG,
+                                    "Match found, the package '%s', is vulnerable to '%s'. Current version: '%s' is "
+                                    "equal to '%s'. - Agent '%s' (ID: '%s', Version: '%s').",
+                                    packageName.c_str(),
+                                    callbackData.cveId()->str().c_str(),
+                                    packageVersion.c_str(),
+                                    versionString.c_str(),
+                                    data->agentName().data(),
+                                    data->agentId().data(),
+                                    data->agentVersion().data());
 
                             data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
                             return true;
@@ -112,15 +115,18 @@ public:
                         {
                             if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                             {
-                                logDebug1(WM_VULNSCAN_LOGTAG,
-                                          "Match found, the package '%s', is vulnerable to '%s'. Current version: "
-                                          "'%s' ("
-                                          "less than '%s' or equal to '%s').",
-                                          packageName.c_str(),
-                                          callbackData.cveId()->str().c_str(),
-                                          packageVersion.c_str(),
-                                          versionStringLessThan.c_str(),
-                                          versionStringLessThanOrEqual.c_str());
+                                logInfo(WM_VULNSCAN_LOGTAG,
+                                        "Match found, the package '%s', is vulnerable to '%s'. Current version: "
+                                        "'%s' ("
+                                        "less than '%s' or equal to '%s'). - Agent '%s' (ID: '%s', Version: '%s').",
+                                        packageName.c_str(),
+                                        callbackData.cveId()->str().c_str(),
+                                        packageVersion.c_str(),
+                                        versionStringLessThan.c_str(),
+                                        versionStringLessThanOrEqual.c_str(),
+                                        data->agentName().data(),
+                                        data->agentId().data(),
+                                        data->agentVersion().data());
 
                                 data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
                                 return true;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/resultIndexer.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/resultIndexer.hpp
@@ -50,7 +50,7 @@ public:
         {
             for (const auto& [key, value] : data->m_elements)
             {
-                logDebug2(WM_VULNSCAN_LOGTAG, "Processing key: %s", key.c_str());
+                logDebug2(WM_VULNSCAN_LOGTAG, "Processing and publish key: %s", key.c_str());
                 m_indexerConnector->publish(value.dump());
             }
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
@@ -54,7 +54,7 @@ private:
         Amzn amznVer {};
         switch (type)
         {
-            default: logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject. Invalid type"); return nullptr;
+            default: logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject: Invalid type."); return nullptr;
             case VersionObjectType::Unspecified:
                 if (VersionObjectCalVer::match(version, calVer))
                 {
@@ -87,9 +87,9 @@ private:
                 else
                 {
                     logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (Unspecified). Unrecognized type. "
-                              "Version string: %s",
+                              "Error creating VersionObject (Unspecified). Unrecognized type. Version string: %s",
                               version.c_str());
+
                     return nullptr;
                 }
                 break;
@@ -102,9 +102,10 @@ private:
                 else
                 {
                     logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (CalVer). Version string dont match the "
-                              "type specified. Version string: %s",
+                              "Error creating VersionObject (CalVer). Version string doesn't match the specified type. "
+                              "Version string: %s",
                               version.c_str());
+
                     return nullptr;
                 }
                 break;
@@ -117,8 +118,8 @@ private:
                 else
                 {
                     logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (PEP440). Version string dont match the "
-                              "type specified. Version string: %s",
+                              "Error creating VersionObject (PEP440). Version string doesn't match the specified type. "
+                              "Version string: %s",
                               version.c_str());
                     return nullptr;
                 }
@@ -130,10 +131,11 @@ private:
                 }
                 else
                 {
-                    logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (MajorMinor). Version string dont match "
-                              "the type specified. Version string: %s",
-                              version.c_str());
+                    logDebug2(
+                        WM_VULNSCAN_LOGTAG,
+                        "Error creating VersionObject (MajorMinor). Version string doesn't match the specified type. "
+                        "Version string: %s",
+                        version.c_str());
                     return nullptr;
                 }
                 break;
@@ -146,8 +148,8 @@ private:
                 else
                 {
                     logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (SemVer). Version string dont match the "
-                              "type specified. Version string: %s",
+                              "Error creating VersionObject (SemVer). Version string doesn't match the specified type. "
+                              "Version string: %s",
                               version.c_str());
                     return nullptr;
                 }
@@ -160,8 +162,8 @@ private:
                 else
                 {
                     logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (dpkg). Version string dont match the "
-                              "type specified. Version string: %s",
+                              "Error creating VersionObject (DPKG). Version string doesn't match the specified type. "
+                              "Version string: %s",
                               version.c_str());
                     return nullptr;
                 }
@@ -174,8 +176,8 @@ private:
                 else
                 {
                     logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (RPMver). The version string doesn't match the "
-                              "specified type. Version string: %s",
+                              "Error creating VersionObject (RPM). Version string doesn't match the specified type. "
+                              "Version string: %s",
                               version.c_str());
                     return nullptr;
                 }
@@ -188,8 +190,8 @@ private:
                 else
                 {
                     logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (AMZNVer). The version string doesn't match the "
-                              "specified type. Version string: %s",
+                              "Error creating VersionObject (AMZN). Version string doesn't match the specified type. "
+                              "Version string: %s",
                               version.c_str());
                     return nullptr;
                 }

--- a/src/wazuh_modules/vulnerability_scanner/testtool/versionMatcher/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/versionMatcher/main.cpp
@@ -127,9 +127,11 @@ std::shared_ptr<IVersionObject> createVersionObject(const std::string& version, 
     MajorMinor majorMinor {};
     SemVer semVer {};
     Dpkg dpkgVer {};
+    Rpm rpmVer {};
+    Amzn amznVer {};
     switch (type)
     {
-        default: logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject. Invalid type"); return nullptr;
+        default: logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject: Invalid type."); return nullptr;
         case VersionObjectType::Unspecified:
             if (VersionObjectCalVer::match(version, calVer))
             {
@@ -143,6 +145,10 @@ std::shared_ptr<IVersionObject> createVersionObject(const std::string& version, 
             {
                 return std::make_shared<VersionObjectMajorMinor>(majorMinor);
             }
+            else if (VersionObjectRpm::match(version, rpmVer))
+            {
+                return std::make_shared<VersionObjectRpm>(rpmVer);
+            }
             else if (VersionObjectDpkg::match(version, dpkgVer))
             {
                 return std::make_shared<VersionObjectDpkg>(dpkgVer);
@@ -151,12 +157,16 @@ std::shared_ptr<IVersionObject> createVersionObject(const std::string& version, 
             {
                 return std::make_shared<VersionObjectSemVer>(semVer);
             }
+            else if (VersionObjectAmzn::match(version, amznVer))
+            {
+                return std::make_shared<VersionObjectAmzn>(amznVer);
+            }
             else
             {
                 logDebug2(WM_VULNSCAN_LOGTAG,
-                          "Error creating VersionObject (Unspecified). Unrecognized type. "
-                          "Version string: %s",
+                          "Error creating VersionObject (Unspecified). Unrecognized type. Version string: %s",
                           version.c_str());
+
                 return nullptr;
             }
             break;
@@ -169,9 +179,10 @@ std::shared_ptr<IVersionObject> createVersionObject(const std::string& version, 
             else
             {
                 logDebug2(WM_VULNSCAN_LOGTAG,
-                          "Error creating VersionObject (CalVer). Version string dont match the "
-                          "type specified. Version string: %s",
+                          "Error creating VersionObject (CalVer). Version string doesn't match the specified type. "
+                          "Version string: %s",
                           version.c_str());
+
                 return nullptr;
             }
             break;
@@ -184,8 +195,8 @@ std::shared_ptr<IVersionObject> createVersionObject(const std::string& version, 
             else
             {
                 logDebug2(WM_VULNSCAN_LOGTAG,
-                          "Error creating VersionObject (PEP440). Version string dont match the "
-                          "type specified. Version string: %s",
+                          "Error creating VersionObject (PEP440). Version string doesn't match the specified type. "
+                          "Version string: %s",
                           version.c_str());
                 return nullptr;
             }
@@ -198,8 +209,8 @@ std::shared_ptr<IVersionObject> createVersionObject(const std::string& version, 
             else
             {
                 logDebug2(WM_VULNSCAN_LOGTAG,
-                          "Error creating VersionObject (MajorMinor). Version string dont match "
-                          "the type specified. Version string: %s",
+                          "Error creating VersionObject (MajorMinor). Version string doesn't match the specified type. "
+                          "Version string: %s",
                           version.c_str());
                 return nullptr;
             }
@@ -213,8 +224,8 @@ std::shared_ptr<IVersionObject> createVersionObject(const std::string& version, 
             else
             {
                 logDebug2(WM_VULNSCAN_LOGTAG,
-                          "Error creating VersionObject (SemVer). Version string dont match the "
-                          "type specified. Version string: %s",
+                          "Error creating VersionObject (SemVer). Version string doesn't match the specified type. "
+                          "Version string: %s",
                           version.c_str());
                 return nullptr;
             }
@@ -227,8 +238,36 @@ std::shared_ptr<IVersionObject> createVersionObject(const std::string& version, 
             else
             {
                 logDebug2(WM_VULNSCAN_LOGTAG,
-                          "Error creating VersionObject (dpkg). Version string dont match the "
-                          "type specified. Version string: %s",
+                          "Error creating VersionObject (DPKG). Version string doesn't match the specified type. "
+                          "Version string: %s",
+                          version.c_str());
+                return nullptr;
+            }
+            break;
+        case VersionObjectType::RPM:
+            if (VersionObjectRpm::match(version, rpmVer))
+            {
+                return std::make_shared<VersionObjectRpm>(rpmVer);
+            }
+            else
+            {
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Error creating VersionObject (RPM). Version string doesn't match the specified type. "
+                          "Version string: %s",
+                          version.c_str());
+                return nullptr;
+            }
+            break;
+        case VersionObjectType::AMZN:
+            if (VersionObjectAmzn::match(version, amznVer))
+            {
+                return std::make_shared<VersionObjectAmzn>(amznVer);
+            }
+            else
+            {
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Error creating VersionObject (AMZN). Version string doesn't match the specified type. "
+                          "Version string: %s",
                           version.c_str());
                 return nullptr;
             }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20928 |

## Objective
This pull request addresses an essential development task aimed at enhancing the logging functionality of the vulnerability detector in the system. The primary focus is on improving the clarity and informativeness of log messages generated during vulnerability detection processes. Specifically, this fix introduces enhancements to log messages to provide additional context and visibility into the detection process. Notably, the addition of the `info` log level is implemented to signify when a match is found in a package, providing valuable insights for monitoring and troubleshooting.

## Description
- The proposed fix introduces enhancements to log messages generated by the vulnerability detector. The improvements aim to provide more context, detail, and clarity in log entries related to the detection of vulnerabilities.

## Quality Assurance
No tests have been added to validate the quality of this implementation

<details><summary>ScanBuild report</summary>

Command:

```bash
scan-build-15 -enable-checker alpha.core.CastSize -enable-checker alpha.core.CastToStruct -enable-checker alpha.core.Conversion -enable-checker alpha.core.IdenticalExpr -enable-checker alpha.core.SizeofPtr -enable-checker alpha.core.TestAfterDivZero --exclude external make TARGET=server DEBUG=1 -j$(nproc)
```

```bash

Done building server

scan-build: No bugs found.

```

</details>

<details><summary>Clang-Format</summary>

```bash
---------------------------------
PASSED: Clang-format check passed
---------------------------------
```
</details>


## Exploratory tests

### Setup
- Clone this branch 
- Compile with `TARGET=server`
- Install manager
- Set `wazuh_modules.debug=2` and restart manager
- Optional: Install indexer
- Connect an agent to the manager
- Wait until the scan ends

<details><summary>Show log</summary>

```text
2023/12/08 09:42:38 wazuh-modulesd:vulnerability-scanner[40979] packageScanner.hpp:62 at operator()(): DEBUG: SCAN -> Package: tar, Version: 1.34+dfsg-1ubuntu0.1.22.04.1, CVE: CVE-2022-48303, Ver: 0, RLT: 1.34+dfsg-1ubuntu0.1.22.10.1, RLTE: 
2023/12/08 09:42:38 wazuh-modulesd:vulnerability-scanner[40979] packageScanner.hpp:107 at operator()(): DEBUG: MATCH Package: tar, Version: 1.34+dfsg-1ubuntu0.1.22.04.1, CVE: CVE-2022-48303, Ver: 0, RLT: 1.34+dfsg-1ubuntu0.1.22.10.1, RLTE:
[...]
2023/12/08 09:43:34 wazuh-modulesd:vulnerability-scanner[40979] packageScanner.hpp:62 at operator()(): DEBUG: SCAN -> Package: dpkg, Version: 1.21.1ubuntu2.2, CVE: CVE-2022-1664, Ver: 0, RLT: 1.21.9ubuntu1, RLTE: 
2023/12/08 09:43:34 wazuh-modulesd:vulnerability-scanner[40979] packageScanner.hpp:107 at operator()(): DEBUG: MATCH Package: dpkg, Version: 1.21.1ubuntu2.2, CVE: CVE-2022-1664, Ver: 0, RLT: 1.21.9ubuntu1, RLTE

//New format
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] resultIndexer.hpp:53 at handleRequest(): DEBUG: Processing and publish key: CVE-2021-3520
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:51 at handleRequest(): DEBUG: Initiating a vulnerability scan for package 'libidn2' on Agent '0635b7aa6181' (ID: '007', Version: 'v4.7.0').
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:166 at handleRequest(): DEBUG: Initiating a vulnerability scan for package 'libidn2' with CVE Numbering Authorities (CNA) 'redhat' on Agent '0635b7aa6181' (ID: '007', Version: 'v4.7.0').
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:69 at operator()(): DEBUG: Scanning package - 'libidn2' (Installed Version: 2.2.0-1.el8, Security Vulnerability: CVE-2019-18224). Identified vulnerability: Version: 0. Required Version Threshold: 2.2.0-1.el8.aarch64. Required Version Threshold (or Equal): N/A.
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:115 at operator()(): DEBUG: Match found, the package 'libidn2', is vulnerable to 'CVE-2019-18224'. Current version: '2.2.0-1.el8' (less than '2.2.0-1.el8.aarch64' or equal to 'N/A').
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:190 at handleRequest(): DEBUG: Vulnerability scan for package 'libidn2' on Agent '007' has completed.
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] inventorySync.hpp:139 at handleRequest(): DEBUG: Inserting agent package key: node01_007_fd44bffdb31aef1b8244a6737bb518485a3ed4a3 -> CVE-2019-18224
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] sendReport.hpp:66 at handleRequest(): DEBUG: REPORT: 1:[007] (0635b7aa6181) any->vulnerability-scanner:{"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2019-18224","description":"idn2_to_ascii_4i in lib/lookup.c in GNU libidn2 before 2.1.1 has a heap-based buffer overflow via a long domain string.","enumeration":"CVE","package":{"architecture":"x86_64","build_version":"","checksum":"","description":"Library to support IDNA2008 internationalized domain names","install_scope":"","installed":"2021-09-15T14:17:30.000Z","license":"","name":"libidn2","path":" ","reference":"","size":287762,"type":"rpm","version":"2.2.0-1.el8"},"reference":"https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12420, https://github.com/libidn/libidn2/commit/e4d1558aa2c1c04a05066ee8600f37603890ba8c, https://github.com/libidn/libidn2/compare/libidn2-2.1.0...libidn2-2.1.1, http://lists.opensuse.org/opensuse-security-announce/2019-12/msg00008.html, http://lists.opensuse.org/opensuse-security-announce/2019-12/msg00009.html, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/JDQVQ2XPV5BTZUFINT7AFJSKNNBVURNJ/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/MINU5RKDFE6TKAFY5DRFN3WSFDS4DYVS/, https://seclists.org/bugtraq/2020/Feb/4, https://security.gentoo.org/glsa/202003-63, https://usn.ubuntu.com/4168-1/, https://www.debian.org/security/2020/dsa-4613","report_id":"","scanner":{"vendor":"Wazuh"},"score":{"base":7.5,"environmental":0.0,"temporal":0.0,"version":"2.0"},"severity":"High","status":"Active"}}
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] resultIndexer.hpp:53 at handleRequest(): DEBUG: Processing and publish key: CVE-2019-18224
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:51 at handleRequest(): DEBUG: Initiating a vulnerability scan for package 'libkcapi' on Agent '0635b7aa6181' (ID: '007', Version: 'v4.7.0').
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:166 at handleRequest(): DEBUG: Initiating a vulnerability scan for package 'libkcapi' with CVE Numbering Authorities (CNA) 'redhat' on Agent '0635b7aa6181' (ID: '007', Version: 'v4.7.0').
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:190 at handleRequest(): DEBUG: Vulnerability scan for package 'libkcapi' on Agent '007' has completed.
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:51 at handleRequest(): DEBUG: Initiating a vulnerability scan for package 'libpwquality' on Agent '0635b7aa6181' (ID: '007', Version: 'v4.7.0').
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:166 at handleRequest(): DEBUG: Initiating a vulnerability scan for package 'libpwquality' with CVE Numbering Authorities (CNA) 'redhat' on Agent '0635b7aa6181' (ID: '007', Version: 'v4.7.0').
2024/01/03 10:03:48 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:190 at handleRequest(): DEBUG: Vulnerability scan for package 'libpwquality' on Agent '007' has completed.
2024/01/03 10:03:49 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:51 at handleRequest(): DEBUG: Initiating a vulnerability scan for package 'elfutils-libelf' on Agent '0635b7aa6181' (ID: '007', Version: 'v4.7.0').
2024/01/03 10:03:49 wazuh-modulesd:vulnerability-scanner[9058] packageScanner.hpp:166 at handleRequest(): DEBUG: Initiating a vulnerability scan for package 'elfutils-libelf' with CVE Numbering Authorities (CNA) 'redhat' on Agent '0635b7aa6181' (ID: '007', Version: 'v4.7.0').
```

</details>


### Check summary
- [x] Style and quality of SCA.
- [x] Documentation clear.
- [x] Functionality optimizated.
