### PR TITLE
Improve logging helper to avoid multiple vsnprintf calls

### DIFF
--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -124,7 +124,7 @@ int isChroot(void);
  * @param line Line number.
  * @param func Function name.
  * @param msg Message to send into the log.
- * @para args Variable arguments list.
+ * @param args Variable arguments list.
  */
 void mtLoggingFunctionsWrapper(int level, const char* tag, const char* file, int line, const char* func, const char* msg, va_list args);
 

--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -124,7 +124,8 @@ int isChroot(void);
  * @param line Line number.
  * @param func Function name.
  * @param msg Message to send into the log.
+ * @para args Variable arguments list.
  */
-void mtLoggingFunctionsWrapper(int level, const char* tag, const char* file, int line, const char* func, const char* msg);
+void mtLoggingFunctionsWrapper(int level, const char* tag, const char* file, int line, const char* func, const char* msg, va_list args);
 
 #endif /* DEBUG_H */

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -692,25 +692,32 @@ char * win_strerror(unsigned long error) {
 }
 #endif
 
-void mtLoggingFunctionsWrapper(int level, const char* tag, const char* file, int line, const char* func, const char* msg) {
+void mtLoggingFunctionsWrapper(int level, const char* tag, const char* file, int line, const char* func, const char* msg, va_list args) {
     switch(level) {
         case(LOGLEVEL_DEBUG):
-            _mtdebug1(tag, file, line, func, msg);
+            if (dbg_flag >= 1) {
+                _log(level, tag, file, line, func, msg, args);
+            }
             break;
         case(LOGLEVEL_DEBUG_VERBOSE):
-            _mtdebug2(tag, file, line, func, msg);
+            if (dbg_flag >= 2) {
+                _log(LOGLEVEL_DEBUG, tag, file, line, func, msg, args);
+            }
             break;
         case(LOGLEVEL_INFO):
-            _mtinfo(tag, file, line, func, msg);
-            break;
         case(LOGLEVEL_WARNING):
-            _mtwarn(tag, file, line, func, msg);
-            break;
         case(LOGLEVEL_ERROR):
-            _mterror(tag, file, line, func, msg);
+            _log(level, tag, file, line, func, msg, args);
             break;
         case(LOGLEVEL_CRITICAL):
-            _mterror_exit(tag, file, line, func, msg);
+            _log(level, tag, file, line, func, msg, args);
+#ifdef WIN32
+            /* If not MA */
+#ifndef MA
+            WinSetError();
+#endif
+#endif
+            exit(1);
             break;
         default:
             break;

--- a/src/shared_modules/common/commonDefs.h
+++ b/src/shared_modules/common/commonDefs.h
@@ -13,6 +13,7 @@
 #define _COMMON_DEFS_H_
 
 #include "cJSON.h"
+#include <stdarg.h>
 
 /**
  * @brief Represents the different host types to be used.
@@ -140,8 +141,9 @@ typedef void((*log_fnc_t)(const char* msg));
  * @param line     Line number where the log is generated.
  * @param func     Function name where the log is generated.
  * @param msg      Message to be logged.
+ * @param args     Variable list args.
  */
-typedef void ((*full_log_fnc_t)(int level, const char* tag, const char* file, int line, const char* func, const char* msg));
+typedef void ((*full_log_fnc_t)(int level, const char* tag, const char* file, int line, const char* func, const char* msg, va_list args));
 
 /**
 * @brief Definition to indicate the unlimited queue.

--- a/src/shared_modules/content_manager/include/contentManager.hpp
+++ b/src/shared_modules/content_manager/include/contentManager.hpp
@@ -41,10 +41,13 @@ public:
      * @param logFunction Log function.
      *
      */
-    void
-    start(const std::function<
-          void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>&
-              logFunction);
+    void start(const std::function<void(const int,
+                                        const std::string&,
+                                        const std::string&,
+                                        const int,
+                                        const std::string&,
+                                        const std::string&,
+                                        va_list)>& logFunction);
 
     /**
      * @brief Stop module facade.

--- a/src/shared_modules/content_manager/src/contentModule.cpp
+++ b/src/shared_modules/content_manager/src/contentModule.cpp
@@ -16,8 +16,8 @@
 #include <utility>
 
 void ContentModule::start(
-    const std::function<
-        void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>&
+    const std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
         logFunction)
 {
     ContentModuleFacade::instance().start(logFunction);
@@ -66,8 +66,9 @@ extern "C"
                           const std::string& file,
                           const int line,
                           const std::string& func,
-                          const std::string& logMessage)
-            { callbackLog(logLevel, tag.c_str(), file.c_str(), line, func.c_str(), logMessage.c_str()); });
+                          const std::string& logMessage,
+                          va_list args)
+            { callbackLog(logLevel, tag.c_str(), file.c_str(), line, func.c_str(), logMessage.c_str(), args); });
     }
 
     void content_manager_stop()

--- a/src/shared_modules/content_manager/src/contentModuleFacade.cpp
+++ b/src/shared_modules/content_manager/src/contentModuleFacade.cpp
@@ -13,13 +13,13 @@
 namespace Log
 {
     std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
         GLOBAL_LOG_FUNCTION;
 };
 
 void ContentModuleFacade::start(
-    const std::function<
-        void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>&
+    const std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
         logFunction)
 {
     Log::assignLogFunction(logFunction);

--- a/src/shared_modules/content_manager/src/contentModuleFacade.hpp
+++ b/src/shared_modules/content_manager/src/contentModuleFacade.hpp
@@ -33,10 +33,13 @@ public:
      *
      * @param logFunction Log function.
      */
-    void
-    start(const std::function<
-          void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>&
-              logFunction);
+    void start(const std::function<void(const int,
+                                        const std::string&,
+                                        const std::string&,
+                                        const int,
+                                        const std::string&,
+                                        const std::string&,
+                                        va_list)>& logFunction);
 
     /**
      * @brief Clear providers.

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -20,7 +20,7 @@
 namespace Log
 {
     std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
         GLOBAL_LOG_FUNCTION;
 };
 

--- a/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.cpp
@@ -20,7 +20,7 @@
 namespace Log
 {
     std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
         GLOBAL_LOG_FUNCTION;
 };
 

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -70,7 +70,8 @@ void logFunction(const int logLevel,
                  const std::string& file,
                  const int line,
                  const std::string& func,
-                 const std::string& message)
+                 const std::string& message,
+                 va_list args)
 {
     auto pos {file.find_last_of('/')};
     if (pos != std::string::npos)
@@ -88,23 +89,26 @@ void logFunction(const int logLevel,
                                                             {LOGLEVEL_CRITICAL, "CRITICAL"}};
     const auto levelTag {"[" + LOG_LEVEL_TAGS.at(logLevel) + "]"};
 
+    char formattedStr[OS_MAXSTR] = {0};
+    vsnprintf(formattedStr, OS_MAXSTR, message.c_str(), args);
+
     if (logLevel == LOGLEVEL_ERROR || logLevel == LOGLEVEL_CRITICAL)
     {
         // Error logs.
-        std::cerr << tag << ":" << levelTag << ": " << message.c_str() << std::endl;
+        std::cerr << tag << ":" << levelTag << ": " << formattedStr << std::endl;
     }
     else if (logLevel == LOGLEVEL_INFO || logLevel == LOGLEVEL_WARNING)
     {
         // Info and warning logs.
-        std::cout << tag << ":" << levelTag << ": " << message.c_str() << std::endl;
+        std::cout << tag << ":" << levelTag << ": " << formattedStr << std::endl;
     }
     else
     {
         // Debug logs.
         if (VERBOSE)
         {
-            std::cout << tag << ":" << levelTag << ":" << fileName << ":" << line << " " << func << ": "
-                      << message.c_str() << std::endl;
+            std::cout << tag << ":" << levelTag << ":" << fileName << ":" << line << " " << func << ": " << formattedStr
+                      << std::endl;
         }
     }
 }

--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -63,12 +63,15 @@ public:
      * @param templatePath Path to the template file.
      * @param logFunction Callback function to be called when trying to log a message.
      */
-    explicit IndexerConnector(
-        const nlohmann::json& config,
-        const std::string& templatePath,
-        const std::function<
-            void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>&
-            logFunction = {});
+    explicit IndexerConnector(const nlohmann::json& config,
+                              const std::string& templatePath,
+                              const std::function<void(const int,
+                                                       const std::string&,
+                                                       const std::string&,
+                                                       const int,
+                                                       const std::string&,
+                                                       const std::string&,
+                                                       va_list)>& logFunction = {});
 
     ~IndexerConnector();
 

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -19,7 +19,7 @@
 namespace Log
 {
     std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
         GLOBAL_LOG_FUNCTION;
 };
 constexpr auto IC_NAME {"indexer-connnector"};
@@ -36,8 +36,8 @@ constexpr auto DATABASE_BASE_PATH = "queue/indexer/";
 IndexerConnector::IndexerConnector(
     const nlohmann::json& config,
     const std::string& templatePath,
-    const std::function<
-        void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>&
+    const std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
         logFunction)
 {
     if (logFunction)

--- a/src/shared_modules/indexer_connector/testtool/main.cpp
+++ b/src/shared_modules/indexer_connector/testtool/main.cpp
@@ -4,6 +4,8 @@
 #include <iomanip>
 #include <iostream>
 
+auto constexpr MAXLEN {65536};
+
 std::string generateRandomString(size_t length)
 {
     const char alphanum[] = "0123456789"
@@ -100,7 +102,8 @@ int main(const int argc, const char* argv[])
                                              const std::string& file,
                                              const int line,
                                              const std::string& func,
-                                             const std::string& message)
+                                             const std::string& message,
+                                             va_list args)
                                           {
                                               auto pos = file.find_last_of('/');
                                               if (pos != std::string::npos)
@@ -108,16 +111,18 @@ int main(const int argc, const char* argv[])
                                                   pos++;
                                               }
                                               std::string fileName = file.substr(pos, file.size() - pos);
+                                              char formattedStr[MAXLEN] = {0};
+                                              vsnprintf(formattedStr, MAXLEN, message.c_str(), args);
 
                                               if (logLevel != LOG_ERROR)
                                               {
                                                   std::cout << tag << ":" << fileName << ":" << line << " " << func
-                                                            << " : " << message.c_str() << std::endl;
+                                                            << " : " << formattedStr << std::endl;
                                               }
                                               else
                                               {
                                                   std::cerr << tag << ":" << fileName << ":" << line << " " << func
-                                                            << " : " << message.c_str() << std::endl;
+                                                            << " : " << formattedStr << std::endl;
                                               }
                                           });
         // Read events file.

--- a/src/shared_modules/rsync/include/rsync.hpp
+++ b/src/shared_modules/rsync/include/rsync.hpp
@@ -50,7 +50,7 @@ class EXPORTED RemoteSync
          *
          * @param logFunction Log function.
          */
-        static void initializeFullLogFunction(const std::function<void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>& logFunction);
+        static void initializeFullLogFunction(const std::function<void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>& logFunction);
 
         /**
          * @brief Remote sync initializes the instance.

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -20,7 +20,7 @@
 namespace Log
 {
     std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
     GLOBAL_LOG_FUNCTION;
 };
 
@@ -57,9 +57,10 @@ EXPORTED void rsync_initialize_full_log_function(full_log_fnc_t logFunction)
                       const std::string & file,
                       const int line,
                       const std::string & func,
-                      const std::string & logMessage)
+                      const std::string & logMessage,
+                      va_list args)
     {
-        logFunction(logLevel, tag.c_str(), file.c_str(), line, func.c_str(), logMessage.c_str());
+        logFunction(logLevel, tag.c_str(), file.c_str(), line, func.c_str(), logMessage.c_str(), args);
     });
 }
 
@@ -243,7 +244,7 @@ void RemoteSync::initialize(std::function<void(const std::string&)> logFunction)
 
 void RemoteSync::initializeFullLogFunction(
     const std::function <
-    void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&) > &
+    void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list) > &
     logFunction)
 {
     Log::assignLogFunction(logFunction);

--- a/src/shared_modules/utils/loggerHelper.h
+++ b/src/shared_modules/utils/loggerHelper.h
@@ -54,17 +54,20 @@ namespace Log
 #pragma GCC visibility push(hidden)
 
     extern std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
         GLOBAL_LOG_FUNCTION;
 #pragma GCC visibility pop
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 
-    static void assignLogFunction(
-        const std::function<
-            void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>&
-            logFunction)
+    static void assignLogFunction(const std::function<void(const int,
+                                                           const std::string&,
+                                                           const std::string&,
+                                                           const int,
+                                                           const std::string&,
+                                                           const std::string&,
+                                                           va_list)>& logFunction)
     {
         if (!GLOBAL_LOG_FUNCTION)
         {
@@ -94,12 +97,10 @@ namespace Log
             {
                 std::va_list args;
                 va_start(args, msg);
-                char formattedStr[MAXLEN] = {0};
-                vsnprintf(formattedStr, MAXLEN, msg, args);
-                va_end(args);
 
-                GLOBAL_LOG_FUNCTION(
-                    LOGLEVEL_INFO, tag, sourceFile.file, sourceFile.line, sourceFile.func, formattedStr);
+                GLOBAL_LOG_FUNCTION(LOGLEVEL_INFO, tag, sourceFile.file, sourceFile.line, sourceFile.func, msg, args);
+
+                va_end(args);
             }
         }
 
@@ -116,12 +117,11 @@ namespace Log
             {
                 std::va_list args;
                 va_start(args, msg);
-                char formattedStr[MAXLEN] = {0};
-                vsnprintf(formattedStr, MAXLEN, msg, args);
-                va_end(args);
 
                 GLOBAL_LOG_FUNCTION(
-                    LOGLEVEL_WARNING, tag, sourceFile.file, sourceFile.line, sourceFile.func, formattedStr);
+                    LOGLEVEL_WARNING, tag, sourceFile.file, sourceFile.line, sourceFile.func, msg, args);
+
+                va_end(args);
             }
         }
 
@@ -138,12 +138,10 @@ namespace Log
             {
                 std::va_list args;
                 va_start(args, msg);
-                char formattedStr[MAXLEN] = {0};
-                vsnprintf(formattedStr, MAXLEN, msg, args);
-                va_end(args);
 
-                GLOBAL_LOG_FUNCTION(
-                    LOGLEVEL_DEBUG, tag, sourceFile.file, sourceFile.line, sourceFile.func, formattedStr);
+                GLOBAL_LOG_FUNCTION(LOGLEVEL_DEBUG, tag, sourceFile.file, sourceFile.line, sourceFile.func, msg, args);
+
+                va_end(args);
             }
         }
 
@@ -160,12 +158,11 @@ namespace Log
             {
                 std::va_list args;
                 va_start(args, msg);
-                char formattedStr[MAXLEN] = {0};
-                vsnprintf(formattedStr, MAXLEN, msg, args);
-                va_end(args);
 
                 GLOBAL_LOG_FUNCTION(
-                    LOGLEVEL_DEBUG_VERBOSE, tag, sourceFile.file, sourceFile.line, sourceFile.func, formattedStr);
+                    LOGLEVEL_DEBUG_VERBOSE, tag, sourceFile.file, sourceFile.line, sourceFile.func, msg, args);
+
+                va_end(args);
             }
         }
 
@@ -182,12 +179,10 @@ namespace Log
             {
                 std::va_list args;
                 va_start(args, msg);
-                char formattedStr[MAXLEN] = {0};
-                vsnprintf(formattedStr, MAXLEN, msg, args);
-                va_end(args);
 
-                GLOBAL_LOG_FUNCTION(
-                    LOGLEVEL_ERROR, tag, sourceFile.file, sourceFile.line, sourceFile.func, formattedStr);
+                GLOBAL_LOG_FUNCTION(LOGLEVEL_ERROR, tag, sourceFile.file, sourceFile.line, sourceFile.func, msg, args);
+
+                va_end(args);
             }
         }
     };

--- a/src/shared_modules/utils/tests/loggerHelper_test.cpp
+++ b/src/shared_modules/utils/tests/loggerHelper_test.cpp
@@ -17,7 +17,7 @@
 namespace Log
 {
     std::function<void(
-            const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
         GLOBAL_LOG_FUNCTION;
 };
 
@@ -35,45 +35,62 @@ constexpr auto WARNING_REGEX_THREAD = "warning Tag .+\\.cpp \\d+ operator\\(\\) 
 
 constexpr auto TAG = "Tag";
 
-void debugVerboseTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg)
+void debugVerboseTestFunction(
+    const char* tag, const char* file, int line, const char* func, const char* msg, va_list args)
 {
+    char buffer[MAXLEN];
+    vsnprintf(buffer, MAXLEN, msg, args);
+
     ssOutput << "debug_verbose"
-             << " " << tag << " " << file << " " << line << " " << func << " " << msg << std::endl;
+             << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
 }
 
-void debugTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg)
+void debugTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg, va_list args)
 {
+    char buffer[MAXLEN];
+    vsnprintf(buffer, MAXLEN, msg, args);
+
     ssOutput << "debug"
-             << " " << tag << " " << file << " " << line << " " << func << " " << msg << std::endl;
+             << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
 }
 
-void infoTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg)
+void infoTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg, va_list args)
 {
+    char buffer[MAXLEN];
+    vsnprintf(buffer, MAXLEN, msg, args);
+
     ssOutput << "info"
-             << " " << tag << " " << file << " " << line << " " << func << " " << msg << std::endl;
+             << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
 }
 
-void warningTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg)
+void warningTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg, va_list args)
 {
+    char buffer[MAXLEN];
+    vsnprintf(buffer, MAXLEN, msg, args);
+
     ssOutput << "warning"
-             << " " << tag << " " << file << " " << line << " " << func << " " << msg << std::endl;
+             << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
 }
 
-void errorTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg)
+void errorTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg, va_list args)
 {
+    char buffer[MAXLEN];
+    vsnprintf(buffer, MAXLEN, msg, args);
+
     ssOutput << "error"
-             << " " << tag << " " << file << " " << line << " " << func << " " << msg << std::endl;
+             << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
 }
 
-void logFunctionWrapper(int level, const char* tag, const char* file, int line, const char* func, const char* msg)
+void logFunctionWrapper(
+    int level, const char* tag, const char* file, int line, const char* func, const char* msg, va_list args)
 {
     switch (level)
     {
-        case (Log::LOGLEVEL_DEBUG): debugTestFunction(tag, file, line, func, msg); break;
-        case (Log::LOGLEVEL_DEBUG_VERBOSE): debugVerboseTestFunction(tag, file, line, func, msg); break;
-        case (Log::LOGLEVEL_INFO): infoTestFunction(tag, file, line, func, msg); break;
-        case (Log::LOGLEVEL_WARNING): warningTestFunction(tag, file, line, func, msg); break;
-        case (Log::LOGLEVEL_ERROR): errorTestFunction(tag, file, line, func, msg); break;
+        case (Log::LOGLEVEL_DEBUG): debugTestFunction(tag, file, line, func, msg, args); break;
+        case (Log::LOGLEVEL_DEBUG_VERBOSE): debugVerboseTestFunction(tag, file, line, func, msg, args); break;
+        case (Log::LOGLEVEL_INFO): infoTestFunction(tag, file, line, func, msg, args); break;
+        case (Log::LOGLEVEL_WARNING): warningTestFunction(tag, file, line, func, msg, args); break;
+        case (Log::LOGLEVEL_ERROR): errorTestFunction(tag, file, line, func, msg, args); break;
         default: break;
     }
 }

--- a/src/shared_modules/utils/tests/loggerHelper_test.h
+++ b/src/shared_modules/utils/tests/loggerHelper_test.h
@@ -21,7 +21,8 @@ void debugTestFunction(const char* tag, const char* file, int line, const char* 
 void infoTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg);
 void warningTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg);
 void errorTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg);
-void logFunctionWrapper(int level, const char* tag, const char* file, int line, const char* func, const char* msg);
+void logFunctionWrapper(
+    int level, const char* tag, const char* file, int line, const char* func, const char* msg, va_list args);
 std::stringstream ssOutput;
 
 class LoggerHelperTest : public ::testing::Test
@@ -38,8 +39,9 @@ protected:
                const std::string& file,
                const int line,
                const std::string& func,
-               const std::string& logMessage)
-            { logFunctionWrapper(logLevel, tag.c_str(), file.c_str(), line, func.c_str(), logMessage.c_str()); });
+               const std::string& logMessage,
+               va_list args)
+            { logFunctionWrapper(logLevel, tag.c_str(), file.c_str(), line, func.c_str(), logMessage.c_str(), args); });
     }
 
     virtual void SetUp()

--- a/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScanner.hpp
@@ -41,12 +41,15 @@ public:
      * @param configuration Scanner configuration.
      * @param noWaitToStop If true, the scanner will not wait to stop if any process is running.
      */
-    void
-    start(const std::function<void(
-              const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>&
-              logFunction,
-          const nlohmann::json& configuration,
-          bool noWaitToStop = true);
+    void start(const std::function<void(const int,
+                                        const std::string&,
+                                        const std::string&,
+                                        const int,
+                                        const std::string&,
+                                        const std::string&,
+                                        va_list)>& logFunction,
+               const nlohmann::json& configuration,
+               bool noWaitToStop = true);
     /**
      * @brief Stops vulnerability scanner.
      *

--- a/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScannerDefs.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScannerDefs.hpp
@@ -21,7 +21,7 @@
 namespace Log
 {
     inline std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
         GLOBAL_LOG_FUNCTION;
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
@@ -19,8 +19,8 @@
 // TODO: Remove LCOV flags once the implementation of the 'Indexer Connector' module is completed
 // LCOV_EXCL_START
 void VulnerabilityScanner::start(
-    const std::function<
-        void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>&
+    const std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
         logFunction,
     const nlohmann::json& configuration,
     const bool noWaitToStop)
@@ -52,8 +52,9 @@ extern "C"
                           const std::string& file,
                           const int line,
                           const std::string& func,
-                          const std::string& logMessage)
-            { callbackLog(logLevel, tag.c_str(), file.c_str(), line, func.c_str(), logMessage.c_str()); },
+                          const std::string& logMessage,
+                          va_list args)
+            { callbackLog(logLevel, tag.c_str(), file.c_str(), line, func.c_str(), logMessage.c_str(), args); },
             configurationNlohmann);
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -24,8 +24,8 @@ int MICROSEC_FACTOR = 1000000;
 // TODO: Remove LCOV flags once the implementation of the 'Indexer Connector' module is completed
 // LCOV_EXCL_START
 void VulnerabilityScannerFacade::start(
-    const std::function<
-        void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>&
+    const std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
         logFunction,
     const nlohmann::json& configuration,
     const bool noWaitToStop)

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -40,12 +40,15 @@ public:
      * @param configuration Facade configuration.
      * @param noWaitToStop If true, the facade will not wait to stop if any process is running.
      */
-    void
-    start(const std::function<void(
-              const int, const std::string&, const std::string&, const int, const std::string&, const std::string&)>&
-              logFunction,
-          const nlohmann::json& configuration,
-          bool noWaitToStop = true);
+    void start(const std::function<void(const int,
+                                        const std::string&,
+                                        const std::string&,
+                                        const int,
+                                        const std::string&,
+                                        const std::string&,
+                                        va_list)>& logFunction,
+               const nlohmann::json& configuration,
+               bool noWaitToStop = true);
 
     /**
      * @brief Stops facade.

--- a/src/wazuh_modules/vulnerability_scanner/tests/component/vulnerabilityScannerFacade_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/component/vulnerabilityScannerFacade_test.cpp
@@ -23,7 +23,8 @@ void logFunction(const int logLevel,
                  const std::string& file,
                  const int line,
                  const std::string& func,
-                 const std::string& logMessage)
+                 const std::string& logMessage,
+                 va_list args)
 {
     std::ignore = logLevel;
     std::ignore = logMessage;

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
@@ -116,13 +116,19 @@ int main(const int argc, const char* argv[])
     {
 
         // LOGLEVEL_INFO, tag, sourceFile.file, sourceFile.line, sourceFile.func, formattedStr
-        Log::assignLogFunction([](const int,
-                                  const std::string& tag,
-                                  const std::string& file,
-                                  const int line,
-                                  const std::string&,
-                                  const std::string& str)
-                               { std::cout << tag << "->" << file << ":" << line << " " << str << std::endl; });
+        Log::assignLogFunction(
+            [](const int,
+               const std::string& tag,
+               const std::string& file,
+               const int line,
+               const std::string&,
+               const std::string& str,
+               va_list args)
+            {
+                char formattedStr[MAXLEN] = {0};
+                vsnprintf(formattedStr, MAXLEN, str.c_str(), args);
+                std::cout << tag << "->" << file << ":" << line << " " << formattedStr << std::endl;
+            });
         // Reset required directories
         if (std::filesystem::exists("./queue/vd"))
         {

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
@@ -22,6 +22,8 @@
 #include <iostream>
 #include <thread>
 
+auto constexpr MAXLEN {65536};
+
 int main(const int argc, const char* argv[])
 {
     try
@@ -53,7 +55,8 @@ int main(const int argc, const char* argv[])
                const std::string& file,
                const int line,
                const std::string& func,
-               const std::string& message)
+               const std::string& message,
+               va_list args)
             {
                 auto pos = file.find_last_of('/');
                 if (pos != std::string::npos)
@@ -61,15 +64,17 @@ int main(const int argc, const char* argv[])
                     pos++;
                 }
                 std::string fileName = file.substr(pos, file.size() - pos);
+                char formattedStr[MAXLEN] = {0};
+                vsnprintf(formattedStr, MAXLEN, message.c_str(), args);
 
                 if (logLevel != LOG_ERROR)
                 {
-                    std::cout << tag << ":" << fileName << ":" << line << " " << func << " : " << message.c_str()
+                    std::cout << tag << ":" << fileName << ":" << line << " " << func << " : " << formattedStr
                               << std::endl;
                 }
                 else
                 {
-                    std::cerr << tag << ":" << fileName << ":" << line << " " << func << " : " << message.c_str()
+                    std::cerr << tag << ":" << fileName << ":" << line << " " << func << " : " << formattedStr
                               << std::endl;
                 }
             },

--- a/src/wazuh_modules/vulnerability_scanner/testtool/versionMatcher/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/versionMatcher/main.cpp
@@ -249,13 +249,19 @@ int main(const int argc, const char* argv[])
     {
 
         // LOGLEVEL_INFO, tag, sourceFile.file, sourceFile.line, sourceFile.func, formattedStr
-        Log::assignLogFunction([](const int,
-                                  const std::string& tag,
-                                  const std::string& file,
-                                  const int line,
-                                  const std::string&,
-                                  const std::string& str)
-                               { std::cout << tag << "->" << file << ":" << line << " " << str << std::endl; });
+        Log::assignLogFunction(
+            [](const int,
+               const std::string& tag,
+               const std::string& file,
+               const int line,
+               const std::string&,
+               const std::string& str,
+               va_list args)
+            {
+                char formattedStr[MAXLEN] = {0};
+                vsnprintf(formattedStr, MAXLEN, str.c_str(), args);
+                std::cout << tag << "->" << file << ":" << line << " " << formattedStr << std::endl;
+            });
         // Reset required directories
         if (std::filesystem::exists("./queue/vd"))
         {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21020 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR updates the `loggingHelper` to use a `va_list` as argument when calling the real log function to void an extra call to `vsnprintf`.



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

Manual tests were performed:
- The environment that crashed now prints the test string succesfully
- The local environment shows all the normal logs as expected
- The testtool of vulnerability detector keeps writing the output to the console as expected

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- [x] Review logs syntax and correct language
