### PR TITLE
Fixed permissions inheritance on Windows install script

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -345,7 +345,7 @@ public function config()
         ' Remove last backslash from home_dir
         install_dir = Left(home_dir, Len(home_dir) - 1)
 
-        setPermsInherit = "icacls """ & install_dir & """ /inheritancelevel:d /q"
+        setPermsInherit = "icacls """ & install_dir & """ /inheritancelevel:e /q"
         WshShell.run setPermsInherit, 0, True
 
         remUserPerm = "icacls """ & install_dir & """ /remove *S-1-5-32-545 /q"


### PR DESCRIPTION
|Related issue|
|---|
|#20727|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

A problem with permissions inheritance on Windows installer was detected which prevented access to Wazuh's folder when a upgrade was made, although the error was in the installer (the installer left a state that was functional but would be troublesome when an update was executed).

Permissions inheritance was enabled for the Wazuh's 'folder in order to mitigate this.
