### PR TITLE
Windows Server 2022 Vulnerability Detector fix

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -9110,14 +9110,27 @@ int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_entries *msu) {
 void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
     const char *win10_pattern = "Windows 10";
     const char *win11_pattern = "Windows 11";
+    const char *ws22_pattern = "Windows Server 2022";
     const char *version_pattern = " Version ";
     const char *version_pattern_lower = " version ";
+    const char *v23h2_pattern = ", 23H2";
 
     size_t w10_patter_len = strlen(win10_pattern);
     size_t w11_patter_len = strlen(win11_pattern);
+    size_t ws22_patter_len = strlen(ws22_pattern);
     size_t ver_patter_len = strlen(version_pattern);
+    size_t v23h2_patter_check_len = strlen(v23h2_pattern);
+    size_t v23h2_patter_len = 2;
 
-    if (strncmp(msu->product, win10_pattern, w10_patter_len) && strncmp(msu->product, win11_pattern, w11_patter_len)) {
+    bool isWin10 = false;
+    bool isWin11 = false;
+    bool isWS22 = false;
+
+    isWin10 = !strncmp(msu->product, win10_pattern, w10_patter_len);
+    isWin11 = !strncmp(msu->product, win11_pattern, w11_patter_len);
+    isWS22  = !strncmp(msu->product, ws22_pattern, ws22_patter_len);
+
+    if (!isWin10 && !isWin11 && !isWS22) {
         w_strdup("1", msu->check_type);
         return;
     }
@@ -9134,6 +9147,11 @@ void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
         return;
     }
 
+    if (!strncmp(msu->product + ws22_patter_len, v23h2_pattern, v23h2_patter_check_len)) {
+        msu->check_type = w_tolower_str(strtok(msu->product + ws22_patter_len + v23h2_patter_len, " "));
+        return;
+    }
+
     for (; patchs; patchs = patchs->next) {
         cJSON *product_json = cJSON_GetObjectItem(patchs, "product");
         char *product_name;
@@ -9142,13 +9160,9 @@ void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
             continue;
         }
 
-        if (strncmp(product_name, win10_pattern, w10_patter_len) ||
-            strncmp(product_name + w10_patter_len, version_pattern, ver_patter_len)) {
-            continue;
-        }
-
-        if (strncmp(product_name, win11_pattern, w11_patter_len) ||
-            strncmp(product_name + w11_patter_len, version_pattern, ver_patter_len)) {
+        if ( (!isWin10 || strncmp(product_name, win10_pattern, w10_patter_len) || strncmp(product_name + w10_patter_len, version_pattern, ver_patter_len))
+          && (!isWin11 || strncmp(product_name, win11_pattern, w11_patter_len) || strncmp(product_name + w11_patter_len, version_pattern, ver_patter_len))
+          && (!isWS22 || strncmp(product_name, ws22_pattern, ws22_patter_len) || strncmp(product_name + ws22_patter_len, v23h2_pattern, v23h2_patter_check_len)) ) {
             continue;
         }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -4289,10 +4289,12 @@ char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver, char *win_ver
     char extra_check[OS_SIZE_256] = { '\0' };
     const char *sp_check_template = " AND (M1.PRODUCT NOT LIKE '%%Service Pack%%' OR "\
                                     "M1.PRODUCT LIKE '%%Service Pack %c%%')";
-    const char *w10_check_template = " AND M1.CHECK_TYPE IS NOT 0 AND "\
+    const char *w10_w11_ws23h2_check_template = " AND M1.CHECK_TYPE IS NOT 0 AND "\
                                      " M1.CVEID IN (SELECT CVEID FROM MSU WHERE CVEID = M1.CVEID AND CHECK_TYPE IS '%s') AND "\
                                      " M1.CHECK_TYPE = '%s'";
-
+    const char *ws22_check_template = " AND M1.CHECK_TYPE IS NOT 0 AND "\
+                                     " M1.CVEID IN (SELECT CVEID FROM MSU WHERE CVEID = M1.CVEID AND CHECK_TYPE IS '%s') AND "\
+                                     " (M1.CHECK_TYPE IN('%s','1') OR M1.CHECK_TYPE IS NULL)";
     os_calloc(OS_SIZE_512, sizeof(char), request);
 
     if (*s_cpe->part != 'o') {
@@ -4300,12 +4302,18 @@ char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver, char *win_ver
         return request;
     }
 
-    if (s_cpe->update && !wm_vuldet_is_cpe_wc(s_cpe->update)) {
-        if (!strncmp(s_cpe->update, "sp", 2)) {
+    if (s_cpe->update && !wm_vuldet_is_cpe_wc(s_cpe->update) && !strncmp(s_cpe->update, "sp", 2)) {
             snprintf(extra_check, OS_SIZE_256, sp_check_template, s_cpe->update[2]);
+    } else if (s_cpe->version && !wm_vuldet_is_cpe_wc(s_cpe->version)) {
+        if (dist_ver == FEED_W10 || dist_ver == FEED_W11) {
+            snprintf(extra_check, OS_SIZE_256, w10_w11_ws23h2_check_template, win_version, win_version);
+        } else if (dist_ver == FEED_WS2022) {
+            if (!strncmp(win_version, "23h2", 4)) {
+                snprintf(extra_check, OS_SIZE_256, w10_w11_ws23h2_check_template, win_version, win_version);
+            } else {
+                snprintf(extra_check, OS_SIZE_256, ws22_check_template, win_version, win_version);
+            }
         }
-    } else if (s_cpe->version && (dist_ver == FEED_W10 || dist_ver == FEED_W11) && !wm_vuldet_is_cpe_wc(s_cpe->version)) {
-        snprintf(extra_check, OS_SIZE_256, w10_check_template, win_version, win_version);
     }
 
     snprintf(request, OS_SIZE_512,


### PR DESCRIPTION
|Related issue|
|---|
|#21127|

## Description

As it was explained in the issue, MSU provided information about patches for `Windows Server 2022` without specific versioning. Now, it also provides for `Windows Server 2022 23H2`, which does not include the patches for  `Windows Server 2022` without this version.

Because of this, `Windows Server 2022` was included for products who need to do the extra checking (`check_type`).

## Logs/Alerts example

For a `Windows Server 2022 23H2` agent:

```console
2024/01/05 15:23:37 wazuh-modulesd:vulnerability-detector[161537] wm_vuln_detector_nvd.c:2414 at wm_vuldet_process_agent_nvd_vulnerabilities(): DEBUG: (5467): Agent '001' is vulnerable to 'CVE-2023-36046'. Condition: 'KB5032202 patch is not installed'
```

For a `Windows Server 2022 21H2` agent:

```console
2024/01/05 16:23:39 wazuh-modulesd:vulnerability-detector[161537] wm_vuln_detector_nvd.c:3792 at wm_vuldet_check_hotfix(): DEBUG: (5454): We have not found a hotfix that solves 'CVE-2023-36046' for agent '002' in the Microsoft feed, so it is not possible to know it is vulnerable.
```




## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
