### PR TITLE
Fix invalid get when recover the cve list from the inventory list.

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
@@ -57,7 +57,7 @@ public:
             data->m_isInventoryEmpty = true;
             for (const auto& dbQuery : m_inventoryDatabase.seek(agentPackageKey))
             {
-                auto listCve = Utils::split(dbQuery.second.data(), ',');
+                auto listCve = Utils::split(dbQuery.second.ToString(), ',');
                 for (const auto& cve : listCve)
                 {
                     data->m_isInventoryEmpty = false;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/inventorySync_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/inventorySync_test.cpp
@@ -10,12 +10,32 @@
  */
 
 #include "inventorySync_test.hpp"
+#include "flatbuffers/include/syscollector_synchronization_schema.h"
+#include "scanOrchestrator.hpp"
 #include "scanOrchestrator/inventorySync.hpp"
 #include "scanOrchestrator/scanContext.hpp"
+#include "gmock/gmock-matchers.h"
 #include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
+
+const std::string INTEGRITY_CLEAR_MSG {
+    R"(
+            {
+                "agent_info": {
+                    "agent_id": "000",
+                    "agent_ip": "192.168.33.20",
+                    "agent_name": "focal",
+                    "node_name": "node01"
+                },
+                "data_type": "integrity_clear",
+                "data": {
+                    "attributes_type": "syscollector_packages",
+                    "id": 1700236640
+                }
+            }
+        )"};
 
 /*
  * @brief Test instantiation of the InventorySync class.
@@ -23,10 +43,55 @@
 TEST_F(InventorySyncTest, TestInstantiationOfTheInventorySyncClass)
 {
     // Instantiation of the InventorySync class.
-    // EXPECT_NO_THROW(std::make_shared<InventorySync>());
+    auto inventoryDatabase = std::make_unique<Utils::RocksDBWrapper>(INVENTORY_DB_PATH);
+    auto& inventorySyncRef = *inventoryDatabase;
+
+    EXPECT_NO_THROW(std::make_shared<InventorySync>(inventorySyncRef));
 }
 
 /*
  * @brief Test handleRequest of the InventorySync class.
  */
-TEST_F(InventorySyncTest, TestHandleRequest) {}
+TEST_F(InventorySyncTest, TestHandleRequestIntegrityClear)
+{
+    // Instantiation of the InventorySync class.
+    auto inventoryDatabase = std::make_unique<Utils::RocksDBWrapper>(INVENTORY_DB_PATH);
+
+    inventoryDatabase->put("node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5",
+                           "CVE-2021-33560,CVE-2019-13627,CVE-2021-40528");
+
+    auto& inventorySyncRef = *inventoryDatabase;
+
+    auto inventorySync = std::make_shared<InventorySync>(inventorySyncRef);
+
+    // Mock scanContext.
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
+    ASSERT_TRUE(parser.Parse(INTEGRITY_CLEAR_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorSync =
+        SyscollectorSynchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
+
+    // Create a ScanContext object.
+    auto scanContext = std::make_shared<ScanContext>(syscollectorSync);
+
+    // Call handleRequest method.
+    EXPECT_NO_THROW(inventorySync->handleRequest(scanContext));
+
+    for (const auto& [key, value] : scanContext->m_elements)
+    {
+        EXPECT_THAT(key,
+                    testing::AnyOf(testing::Eq("node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-40528"),
+                                   testing::Eq("node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2019-13627"),
+                                   testing::Eq("node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-33560")));
+        EXPECT_THAT(
+            value.dump(),
+            testing::AnyOf(
+                testing::Eq(
+                    R"({"id":"node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-40528","operation":"DELETED"})"),
+                testing::Eq(
+                    R"({"id":"node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2019-13627","operation":"DELETED"})"),
+                testing::Eq(
+                    R"({"id":"node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-33560","operation":"DELETED"})")));
+    }
+}


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21241 |

## Description
This PR aims to solve a problem during the integrity clear event the previous code uses the data() method, which retrieves the value from the slice, but the returned information from data() not are null-terminated, For this specific case the correct function to call is ToString.