### PR TITLE
Add support for Amazon Linux 1, and Amazon Linux 2023 in dist-detect.sh

### DIFF
--- a/src/init/dist-detect.sh
+++ b/src/init/dist-detect.sh
@@ -21,9 +21,6 @@ if [ -r "/etc/os-release" ]; then
     if [ "X$DIST_VER" = "X" ]; then
         DIST_VER="0"
     fi
-    if [ "$DIST_NAME" = "amzn" ] && [ "$DIST_VER" != "2" ]; then
-        DIST_VER="1"
-    fi
     DIST_SUBVER=$(echo $VERSION_ID | sed -rn 's/[^0-9]*[0-9]+\.([0-9]+).*/\1/p')
     if [ "X$DIST_SUBVER" = "X" ]; then
         DIST_SUBVER="0"

--- a/src/init/dist-detect.sh
+++ b/src/init/dist-detect.sh
@@ -21,7 +21,7 @@ if [ -r "/etc/os-release" ]; then
     if [ "X$DIST_VER" = "X" ]; then
         DIST_VER="0"
     fi
-    if [ "$DIST_NAME" = "amzn" ] && [ "$DIST_VER" = "2018.03" ]; then
+    if [ "$DIST_NAME" = "amzn" ] && [ "$DIST_VER" = "2018" ]; then
         DIST_VER="1"
     fi
     DIST_SUBVER=$(echo $VERSION_ID | sed -rn 's/[^0-9]*[0-9]+\.([0-9]+).*/\1/p')

--- a/src/init/dist-detect.sh
+++ b/src/init/dist-detect.sh
@@ -21,6 +21,9 @@ if [ -r "/etc/os-release" ]; then
     if [ "X$DIST_VER" = "X" ]; then
         DIST_VER="0"
     fi
+    if [ "$DIST_NAME" = "amzn" ] && [ "$DIST_VER" = "2018.03" ]; then
+        DIST_VER="1"
+    fi
     DIST_SUBVER=$(echo $VERSION_ID | sed -rn 's/[^0-9]*[0-9]+\.([0-9]+).*/\1/p')
     if [ "X$DIST_SUBVER" = "X" ]; then
         DIST_SUBVER="0"


### PR DESCRIPTION
|Related issue|
|---|
|#18905|

### Objective
Add Amazon Linux 1 and Amazon Linux 2023 support in the distribution check script.

This is implemented by two scripts in different repositories.
a. wazuh/wazuh
b. wazuh/wazuh-packages

Therefore merge must be done "atomically". 

### Checks
- [X] Local tests OK :green_circle: 
- [ ] Verify Merge in wazuh/wazuh
- [ ] Verify Merge in wazuh/wazuh-packages [commit](https://github.com/wazuh/wazuh-packages/commit/58942992cde566f550fe56be3bd4c5d2d2b9a587)
