### PR TITLE
Enhancement/21194 network small data type

### DIFF
--- a/src/shared_modules/utils/flatbuffers/schemas/syscollectorDeltas/syscollector_deltas.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/syscollectorDeltas/syscollector_deltas.fbs
@@ -39,8 +39,8 @@ table dbsync_network_iface {
     mac:string;
     tx_packets:uint;
     rx_packets:uint;
-    tx_bytes:uint;
-    rx_bytes:uint;
+    tx_bytes:long;
+    rx_bytes:long;
     tx_errors:uint;
     rx_errors:uint;
     tx_dropped:uint;

--- a/src/shared_modules/utils/flatbuffers/schemas/syscollectorDeltas/syscollector_deltas.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/syscollectorDeltas/syscollector_deltas.fbs
@@ -37,14 +37,14 @@ table dbsync_network_iface {
     state:string;
     mtu:uint32;
     mac:string;
-    tx_packets:uint;
-    rx_packets:uint;
+    tx_packets:long;
+    rx_packets:long;
     tx_bytes:long;
     rx_bytes:long;
-    tx_errors:uint;
-    rx_errors:uint;
-    tx_dropped:uint;
-    rx_dropped:uint;
+    tx_errors:long;
+    rx_errors:long;
+    tx_dropped:long;
+    rx_dropped:long;
     checksum:string;
     item_id:string;
 }

--- a/src/shared_modules/utils/flatbuffers/schemas/syscollectorRsync/syscollector_synchronization.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/syscollectorRsync/syscollector_synchronization.fbs
@@ -45,15 +45,15 @@ table syscollector_network_iface {
     mtu:uint32;
     name:string;
     rx_bytes:long;
-    rx_dropped:uint;
-    rx_errors:uint;
-    rx_packets:uint;
+    rx_dropped:long;
+    rx_errors:long;
+    rx_packets:long;
     scan_time:string;
     state:string;
     tx_bytes:long;
-    tx_dropped:uint;
-    tx_errors:uint;
-    tx_packets:uint;
+    tx_dropped:long;
+    tx_errors:long;
+    tx_packets:long;
     type:string;
 }
 

--- a/src/shared_modules/utils/flatbuffers/schemas/syscollectorRsync/syscollector_synchronization.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/syscollectorRsync/syscollector_synchronization.fbs
@@ -44,13 +44,13 @@ table syscollector_network_iface {
     mac:string;
     mtu:uint32;
     name:string;
-    rx_bytes:uint;
+    rx_bytes:long;
     rx_dropped:uint;
     rx_errors:uint;
     rx_packets:uint;
     scan_time:string;
     state:string;
-    tx_bytes:uint;
+    tx_bytes:long;
     tx_dropped:uint;
     tx_errors:uint;
     tx_packets:uint;

--- a/src/wazuh_modules/syscollector/tests/sysCollectorFlatbuffers/syscollectorFb_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorFlatbuffers/syscollectorFb_test.cpp
@@ -310,6 +310,33 @@ TEST(SyscollectorFbTest, JSONParseNetItf)
 
 }
 
+TEST(SyscollectorFbTest, JSONParseNetItfNegativeValue)
+{
+    // Syscollector network iface can send negative values for some fields. This test is to avoid reverting the changes in the flatbuffer schema.
+    const std::string alert_json =
+        "{\n  agent_info: {\n    agent_id: \"001\",\n    node_name: \"node01\"\n  },\n  data_type: \"state\",\n  data: {\n    attributes_type: \"syscollector_network_iface\",\n    attributes: {\n      checksum: \"92a69b6285431e7d67da91e5006d23246628f13c\",\n      item_id: \"7a60750dd3c25c53f21ff7f44b4743664ddbb66a\",\n      mac: \"XX:XX:XX:XX:XX:XX\",\n      mtu: 1500,\n      name: \"enp0s3\",\n      rx_bytes: -255555,\n      rx_dropped: 255555,\n      rx_errors: 255555,\n      rx_packets: 255555,\n      scan_time: \"0000/00/00 00:00:00\",\n      state: \"up\",\n      tx_bytes: 255555,\n      tx_dropped: 255555,\n      tx_errors: 255555,\n      tx_packets: 255555,\n      type: \"quantic_fiber\"\n    },\n    index: \"7a60750dd3c25c53f21ff7f44b4743664ddbb66a\",\n    timestamp: \"\"\n  }\n}\n";
+
+    flatbuffers::Parser parser;
+    std::string schemaFile;
+
+    bool loadSuccess = flatbuffers::LoadFile(syscollector_message.c_str(), false, &schemaFile);
+
+    EXPECT_TRUE(loadSuccess);
+
+    bool parseSuccess = parser.Parse(schemaFile.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(alert_json.c_str());
+
+    EXPECT_TRUE(parseSuccess);
+
+    std::string json_gen;
+
+    bool genSuccess = GenText(parser, parser.builder_.GetBufferPointer(), &json_gen);
+
+    EXPECT_FALSE(genSuccess);
+
+    EXPECT_STREQ(alert_json.c_str(), json_gen.c_str());
+
+}
+
 TEST(SyscollectorFbTest, JSONIntegrityGlobal)
 {
 

--- a/src/wazuh_modules/syscollector/tests/sysCollectorFlatbuffers/syscollectorFb_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorFlatbuffers/syscollectorFb_test.cpp
@@ -310,11 +310,11 @@ TEST(SyscollectorFbTest, JSONParseNetItf)
 
 }
 
-TEST(SyscollectorFbTest, JSONParseNetItfNegativeValue)
+TEST(SyscollectorFbTest, JSONParseNetItfNegativeValues)
 {
     // Syscollector network iface can send negative values for some fields. This test is to avoid reverting the changes in the flatbuffer schema.
     const std::string alert_json =
-        "{\n  agent_info: {\n    agent_id: \"001\",\n    node_name: \"node01\"\n  },\n  data_type: \"state\",\n  data: {\n    attributes_type: \"syscollector_network_iface\",\n    attributes: {\n      checksum: \"92a69b6285431e7d67da91e5006d23246628f13c\",\n      item_id: \"7a60750dd3c25c53f21ff7f44b4743664ddbb66a\",\n      mac: \"XX:XX:XX:XX:XX:XX\",\n      mtu: 1500,\n      name: \"enp0s3\",\n      rx_bytes: -255555,\n      rx_dropped: 255555,\n      rx_errors: 255555,\n      rx_packets: 255555,\n      scan_time: \"0000/00/00 00:00:00\",\n      state: \"up\",\n      tx_bytes: 255555,\n      tx_dropped: 255555,\n      tx_errors: 255555,\n      tx_packets: 255555,\n      type: \"quantic_fiber\"\n    },\n    index: \"7a60750dd3c25c53f21ff7f44b4743664ddbb66a\",\n    timestamp: \"\"\n  }\n}\n";
+        "{\n  agent_info: {\n    agent_id: \"001\",\n    node_name: \"node01\"\n  },\n  data_type: \"state\",\n  data: {\n    attributes_type: \"syscollector_network_iface\",\n    attributes: {\n      checksum: \"92a69b6285431e7d67da91e5006d23246628f13c\",\n      item_id: \"7a60750dd3c25c53f21ff7f44b4743664ddbb66a\",\n      mac: \"XX:XX:XX:XX:XX:XX\",\n      mtu: 1500,\n      name: \"enp0s3\",\n      rx_bytes: -255555,\n      rx_dropped: -255555,\n      rx_errors: -255555,\n      rx_packets: -255555,\n      scan_time: \"0000/00/00 00:00:00\",\n      state: \"up\",\n      tx_bytes: -255555,\n      tx_dropped: -255555,\n      tx_errors: -255555,\n      tx_packets: -255555,\n      type: \"quantic_fiber\"\n    },\n    index: \"7a60750dd3c25c53f21ff7f44b4743664ddbb66a\",\n    timestamp: \"\"\n  }\n}\n";
 
     flatbuffers::Parser parser;
     std::string schemaFile;


### PR DESCRIPTION
|Related issue|
|---|
|#21194|

## Description

This simple PR is intended to avoid flatbuffer conversion errors by not making the flatbuffer schema too strict. 
The information came as a char*, it would add overhead to sanitize that string, without mentioning that converting to JSON to later come back to char * is not practical.

## DoD

![2024-01-08_17-07](https://github.com/wazuh/wazuh/assets/13010397/c39f3554-649e-4915-88cc-1986c78fcf45)
![2024-01-09_04-42](https://github.com/wazuh/wazuh/assets/13010397/7089f1e8-758c-4ba8-a958-51239c956713)

## Logs/Alerts example

Please check the analysis here https://github.com/wazuh/wazuh/issues/21194#issuecomment-1881407603

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Added unit tests (for new features)