### PR TITLE
Indexer Connector - Add component tests

### DIFF
--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -74,7 +74,7 @@ public:
                                                        const std::string&,
                                                        const std::string&,
                                                        va_list)>& logFunction = {},
-                              const uint32_t timeout = INTERVAL);
+                              const uint32_t& timeout = INTERVAL);
 
     ~IndexerConnector();
 

--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -21,6 +21,7 @@
 class ServerSelector;
 class SecureCommunication;
 
+#include "../src/monitoring.hpp"
 #include "threadEventDispatcher.hpp"
 #include <json.hpp>
 #include <string>
@@ -62,6 +63,7 @@ public:
      * @param config Indexer configuration, including database_path and servers.
      * @param templatePath Path to the template file.
      * @param logFunction Callback function to be called when trying to log a message.
+     * @param timeout Server selector time interval.
      */
     explicit IndexerConnector(const nlohmann::json& config,
                               const std::string& templatePath,
@@ -71,7 +73,8 @@ public:
                                                        const int,
                                                        const std::string&,
                                                        const std::string&,
-                                                       va_list)>& logFunction = {});
+                                                       va_list)>& logFunction = {},
+                              const uint32_t timeout = INTERVAL);
 
     ~IndexerConnector();
 

--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -18,10 +18,11 @@
 #define EXPORTED
 #endif
 
+static constexpr auto DEFAULT_INTERVAL = 60u;
+
 class ServerSelector;
 class SecureCommunication;
 
-#include "../src/monitoring.hpp"
 #include "threadEventDispatcher.hpp"
 #include <json.hpp>
 #include <string>
@@ -74,7 +75,7 @@ public:
                                                        const std::string&,
                                                        const std::string&,
                                                        va_list)>& logFunction = {},
-                              const uint32_t& timeout = INTERVAL);
+                              const uint32_t& timeout = DEFAULT_INTERVAL);
 
     ~IndexerConnector();
 

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -39,7 +39,7 @@ IndexerConnector::IndexerConnector(
     const std::function<void(
         const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
         logFunction,
-    const uint32_t timeout)
+    const uint32_t& timeout)
 {
     if (logFunction)
     {

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -27,8 +27,6 @@ namespace Log
 constexpr auto IC_NAME {"indexer-connector"};
 constexpr auto MAX_WAIT_TIME {60};
 
-// TODO: remove the LCOV flags when the implementation of this class is completed
-// LCOV_EXCL_START
 std::unordered_map<IndexerConnector*, std::unique_ptr<ThreadDispatchQueue>> QUEUE_MAP;
 
 // Single thread because the events needs to be processed in order.
@@ -40,7 +38,8 @@ IndexerConnector::IndexerConnector(
     const std::string& templatePath,
     const std::function<void(
         const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
-        logFunction)
+        logFunction,
+    const uint32_t timeout)
 {
     if (logFunction)
     {
@@ -97,7 +96,7 @@ IndexerConnector::IndexerConnector(
     nlohmann::json templateData = nlohmann::json::parse(templateFile);
 
     // Initialize publisher.
-    auto selector {std::make_shared<ServerSelector>(config.at("hosts"), INTERVAL, secureCommunication)};
+    auto selector {std::make_shared<ServerSelector>(config.at("hosts"), timeout, secureCommunication)};
 
     QUEUE_MAP[this] = std::make_unique<ThreadDispatchQueue>(
         [=](std::queue<std::string>& dataQueue)
@@ -257,4 +256,3 @@ void IndexerConnector::initialize(const nlohmann::json& templateData,
     m_initialized = true;
     logInfo(IC_NAME, "IndexerConnector initialized.");
 }
-// LCOV_EXCL_STOP

--- a/src/shared_modules/indexer_connector/tests/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/tests/CMakeLists.txt
@@ -8,3 +8,4 @@ include_directories(${SRC_FOLDER}/shared_modules/indexer_connector/src/)
 link_directories(${SRC_FOLDER}/external/googletest/lib/)
 
 add_subdirectory(unit)
+add_subdirectory(component)

--- a/src/shared_modules/indexer_connector/tests/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.12.4)
 
+set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage -fsanitize=address,leak,undefined")
+
 include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
 include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
 include_directories(${SRC_FOLDER}/shared_modules/indexer_connector/include/)

--- a/src/shared_modules/indexer_connector/tests/component/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/tests/component/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.12.4)
+
+project(indexer_connector_component_tests)
+
+set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage -fsanitize=address,leak,undefined")
+
+file(GLOB SOURCES
+        *.cpp
+)
+
+add_executable(${PROJECT_NAME} ${SOURCES})
+
+target_link_libraries(${PROJECT_NAME}
+        urlrequest
+        debug gtestd
+        debug gtest_maind
+        optimized gtest
+        optimized gtest_main
+        indexer_connector
+        pthread
+)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/src/shared_modules/indexer_connector/tests/component/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/tests/component/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.12.4)
 
 project(indexer_connector_component_tests)
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage -fsanitize=address,leak,undefined")
-
 file(GLOB SOURCES
         *.cpp
 )

--- a/src/shared_modules/indexer_connector/tests/component/fakeIndexer.hpp
+++ b/src/shared_modules/indexer_connector/tests/component/fakeIndexer.hpp
@@ -1,0 +1,209 @@
+/*
+ * Wazuh Indexer Connector - Component tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * January 09, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _FAKE_OPEN_SEARCH_SERVER_HPP
+#define _FAKE_OPEN_SEARCH_SERVER_HPP
+
+#include <external/cpp-httplib/httplib.h>
+#include <external/nlohmann/json.hpp>
+#include <functional>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+
+/**
+ * @brief This class is a simple HTTP server that provides a fake OpenSearch server.
+ */
+class FakeIndexer
+{
+private:
+    httplib::Server m_server;
+    std::thread m_thread;
+    int m_port;
+    std::string m_host, m_health, m_indexName;
+    bool m_indexerInitialized;
+    std::function<void(const std::string&)> m_initTemplateCallback, m_initIndexCallback, m_publishCallback;
+
+public:
+    /**
+     * @brief Class constructor.
+     *
+     * @param host Host of the server.
+     * @param port Port of the server.
+     * @param health Health status of the server.
+     * @param indexName Name of the index.
+     */
+    FakeIndexer(std::string host, int port, std::string health, std::string indexName)
+        : m_thread(&FakeIndexer::run, this)
+        , m_host(std::move(host))
+        , m_health(std::move(health))
+        , m_port(port)
+        , m_indexName(std::move(indexName))
+        , m_indexerInitialized(false)
+        , m_publishCallback({})
+        , m_initIndexCallback({})
+        , m_initTemplateCallback({})
+    {
+        // Wait until server is ready.
+        while (!m_server.is_running())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+
+    ~FakeIndexer()
+    {
+        m_server.stop();
+        if (m_thread.joinable())
+        {
+            m_thread.join();
+        }
+    }
+
+    /**
+     * @brief Sets the health of the server.
+     *
+     * @param health New health value.
+     */
+    void setHealth(std::string health)
+    {
+        m_health = health;
+    }
+
+    /**
+     * @brief Sets the publish callback.
+     *
+     * @param callback New callback.
+     */
+    void setPublishCallback(std::function<void(const std::string&)> callback)
+    {
+        m_publishCallback = callback;
+    }
+
+    /**
+     * @brief Sets the init index callback.
+     *
+     * @param callback New callback.
+     */
+    void setInitIndexCallback(std::function<void(const std::string&)> callback)
+    {
+        m_initIndexCallback = callback;
+    }
+
+    /**
+     * @brief Sets the init template callback.
+     *
+     * @param callback New callback.
+     */
+    void setInitTemplateCallback(std::function<void(const std::string&)> callback)
+    {
+        m_initTemplateCallback = callback;
+    }
+
+    /**
+     * @brief Returns a the initialized variable.
+     *
+     * @return True if initialized, false otherwise.
+     */
+    bool initialized() const
+    {
+        return m_indexerInitialized;
+    }
+
+    /**
+     * @brief Starts the server and listens for new connections.
+     *
+     * Setups a fake OpenSearch endpoint, configures the server and starts listening
+     * for new connections.
+     *
+     */
+    void run()
+    {
+        // Endpoint where the health status is returned.
+        m_server.Get(
+            "/_cat/health",
+            [this](const httplib::Request& req, httplib::Response& res)
+            {
+                std::stringstream ss;
+                ss << "epoch      timestamp cluster            status node.total node.data discovered_cluster_manager "
+                      "shards pri relo init unassign pending_tasks max_task_wait_time active_shards_percent\n";
+                ss << "1694645550 22:52:30 opensearch-cluster " << m_health << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
+                res.set_content(ss.str(), "text/plain");
+            });
+
+        // Endpoint where the index is initialized.
+        m_server.Put("/" + m_indexName,
+                     [this](const httplib::Request& req, httplib::Response& res)
+                     {
+                         try
+                         {
+                             if (m_initIndexCallback)
+                             {
+                                 m_initIndexCallback(req.body);
+                             }
+                             m_indexerInitialized = true;
+                             res.status = 200;
+                             res.set_content("Index initialized", "text/plain");
+                         }
+                         catch (const std::exception& e)
+                         {
+                             res.status = 500;
+                             res.set_content(e.what(), "text/plain");
+                         }
+                     });
+
+        // Endpoint where the template is initialized.
+        m_server.Put("/_index_template/" + m_indexName + "_template",
+                     [this](const httplib::Request& req, httplib::Response& res)
+                     {
+                         try
+                         {
+                             if (m_initTemplateCallback)
+                             {
+                                 m_initTemplateCallback(req.body);
+                             }
+                             res.status = 200;
+                             res.set_content("Template initialized", "text/plain");
+                         }
+                         catch (const std::exception& e)
+                         {
+                             res.status = 500;
+                             res.set_content(e.what(), "text/plain");
+                         }
+                     });
+
+        // Endpoint where the publications are made into.
+        m_server.Post("/_bulk",
+                      [this](const httplib::Request& req, httplib::Response& res)
+                      {
+                          try
+                          {
+                              if (m_publishCallback)
+                              {
+                                  m_publishCallback(req.body);
+                              }
+                              res.status = 200;
+                              res.set_content("Content published", "text/plain");
+                          }
+                          catch (const std::exception& e)
+                          {
+                              res.status = 500;
+                              res.set_content(e.what(), "text/plain");
+                          }
+                      });
+
+        m_server.set_keep_alive_max_count(1);
+        m_server.listen(m_host.c_str(), m_port);
+    }
+};
+
+#endif // _FAKE_OPEN_SEARCH_SERVER_HPP

--- a/src/shared_modules/indexer_connector/tests/component/fakeIndexer.hpp
+++ b/src/shared_modules/indexer_connector/tests/component/fakeIndexer.hpp
@@ -9,8 +9,8 @@
  * Foundation.
  */
 
-#ifndef _FAKE_OPEN_SEARCH_SERVER_HPP
-#define _FAKE_OPEN_SEARCH_SERVER_HPP
+#ifndef _FAKE_INDEXER_HPP
+#define _FAKE_INDEXER_HPP
 
 #include <external/cpp-httplib/httplib.h>
 #include <external/nlohmann/json.hpp>
@@ -31,7 +31,9 @@ private:
     int m_port;
     std::string m_host, m_health, m_indexName;
     bool m_indexerInitialized;
-    std::function<void(const std::string&)> m_initTemplateCallback, m_initIndexCallback, m_publishCallback;
+    std::function<void(const std::string&)> m_initTemplateCallback = {};
+    std::function<void(const std::string&)> m_initIndexCallback = {};
+    std::function<void(const std::string&)> m_publishCallback = {};
 
 public:
     /**
@@ -206,4 +208,4 @@ public:
     }
 };
 
-#endif // _FAKE_OPEN_SEARCH_SERVER_HPP
+#endif // _FAKE_INDEXER_HPP

--- a/src/shared_modules/indexer_connector/tests/component/fakeIndexer.hpp
+++ b/src/shared_modules/indexer_connector/tests/component/fakeIndexer.hpp
@@ -30,7 +30,7 @@ private:
     std::thread m_thread;
     int m_port;
     std::string m_host, m_health, m_indexName;
-    bool m_indexerInitialized;
+    bool m_indexerInitialized = false;
     std::function<void(const std::string&)> m_initTemplateCallback = {};
     std::function<void(const std::string&)> m_initIndexCallback = {};
     std::function<void(const std::string&)> m_publishCallback = {};
@@ -50,10 +50,6 @@ public:
         , m_health(std::move(health))
         , m_port(port)
         , m_indexName(std::move(indexName))
-        , m_indexerInitialized(false)
-        , m_publishCallback({})
-        , m_initIndexCallback({})
-        , m_initTemplateCallback({})
     {
         // Wait until server is ready.
         while (!m_server.is_running())
@@ -112,7 +108,7 @@ public:
     }
 
     /**
-     * @brief Returns a the initialized variable.
+     * @brief Returns the indexer initialized flag.
      *
      * @return True if initialized, false otherwise.
      */

--- a/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
@@ -1,0 +1,541 @@
+/*
+ * Wazuh Indexer Connector - Component tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * January 09, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "indexerConnector_test.hpp"
+#include "fakeIndexer.hpp"
+#include "indexerConnector.hpp"
+#include "json.hpp"
+#include "stringHelper.h"
+#include "gtest/gtest.h"
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+
+// Template.
+static const auto TEMPLATE_FILE_PATH {std::filesystem::temp_directory_path() / "template.json"};
+static const auto TEMPLATE_DATA = R"({"template":"templateData"})"_json;
+
+// Indexers.
+static const auto INDEXER_TIMEOUT {0u};
+static const std::string INDEXER_HOSTNAME {"localhost"};
+static const auto INDEXER_NAME {"IndexerConnectorTest"};
+static const auto MAX_INDEXER_INIT_TIME_MS {2000};
+static const auto MAX_INDEXER_PUBLISH_TIME_MS {5500};
+static const auto INDEX_ID_A {"A"};
+static const auto INDEX_ID_B {"B"};
+
+// Indexer A.
+static const auto A_IDX {0};
+static const auto A_PORT {9999};
+static const auto A_ADDRESS {INDEXER_HOSTNAME + ":" + std::to_string(A_PORT)};
+
+// Indexer B.
+static const auto B_IDX {1};
+static const auto B_PORT {8888};
+static const auto B_ADDRESS {INDEXER_HOSTNAME + ":" + std::to_string(B_PORT)};
+
+// Indexer C.
+static const auto C_IDX {2};
+static const auto C_PORT {7777};
+static const auto C_ADDRESS {INDEXER_HOSTNAME + ":" + std::to_string(C_PORT)};
+
+// Dummy log function used on tests.
+static void logFunction(const int logLevel,
+                        const std::string& tag,
+                        const std::string& file,
+                        const int line,
+                        const std::string& func,
+                        const std::string& logMessage,
+                        va_list args)
+{
+    std::ignore = logLevel;
+    std::ignore = logMessage;
+}
+
+void IndexerConnectorTest::SetUp()
+{
+    // Create dummy template file.
+    std::ofstream outputFile(TEMPLATE_FILE_PATH);
+    outputFile << TEMPLATE_DATA.dump();
+    outputFile.close();
+
+    // Initialize fake indexers.
+    m_indexerServers.push_back(std::make_unique<FakeIndexer>(INDEXER_HOSTNAME, A_PORT, "green", INDEXER_NAME));
+    m_indexerServers.push_back(std::make_unique<FakeIndexer>(INDEXER_HOSTNAME, B_PORT, "red", INDEXER_NAME));
+    m_indexerServers.push_back(std::make_unique<FakeIndexer>(INDEXER_HOSTNAME, C_PORT, "red", INDEXER_NAME));
+}
+
+void IndexerConnectorTest::TearDown()
+{
+    const auto QUEUE_FOLDER {std::filesystem::current_path() / "queue"};
+
+    // Remove generated data.
+    std::filesystem::remove(TEMPLATE_FILE_PATH);
+    std::filesystem::remove_all(QUEUE_FOLDER);
+
+    // Delete fake indexers.
+    for (auto& server : m_indexerServers)
+    {
+        server.reset();
+    }
+    m_indexerServers.clear();
+}
+
+void IndexerConnectorTest::waitUntil(const std::function<bool()>& stopCondition,
+                                     const unsigned int& maxSleepTimeMs) const
+{
+    const unsigned int sleepTimeMilli {100};
+    unsigned int totalSleepTime {0};
+
+    do
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(sleepTimeMilli));
+        totalSleepTime += sleepTimeMilli;
+
+        if (totalSleepTime > maxSleepTimeMs)
+        {
+            throw std::runtime_error {"Waiting took too long"};
+        }
+
+    } while (!stopCondition());
+}
+
+/**
+ * @brief Test the connection to an available server. The initialization is checked by reading the index and template
+ * data.
+ *
+ */
+TEST_F(IndexerConnectorTest, Connection)
+{
+    // Callback used to check if the indexer connector is correctly initialized.
+    // This callback should be called twice: The first time to initialize the template and the second one to initialize
+    // the index.
+    nlohmann::json indexData, templateData;
+    unsigned int callbackCalled {0};
+    const auto checkInitDataCallback {[&callbackCalled, &indexData, &templateData](const std::string& data)
+                                      {
+                                          auto responseData = nlohmann::json::parse(data);
+                                          ++callbackCalled;
+
+                                          if (1 == callbackCalled)
+                                          {
+                                              templateData = std::move(responseData);
+                                              return;
+                                          }
+
+                                          indexData = std::move(responseData);
+                                      }};
+    m_indexerServers[A_IDX]->setInitTemplateCallback(checkInitDataCallback);
+    m_indexerServers[A_IDX]->setInitIndexCallback(checkInitDataCallback);
+
+    // Create connector and wait until the connection is established.
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    ASSERT_NO_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS));
+
+    // Check init data.
+    constexpr auto EXPECTED_CALLBACK_CALLED_TIMES {2};
+    ASSERT_EQ(callbackCalled, EXPECTED_CALLBACK_CALLED_TIMES);
+    ASSERT_EQ(templateData, TEMPLATE_DATA);
+    ASSERT_EQ(indexData, TEMPLATE_DATA.at("template"));
+}
+
+/**
+ * @brief Test the connection to an available server with user and password data.
+ *
+ * @note The credentials are dummy ones and there are no functionality checks here. The target of this test is to
+ * increase the test coverage.
+ *
+ */
+TEST_F(IndexerConnectorTest, ConnectionWithUserAndPassword)
+{
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
+    indexerConfig["username"] = "user";
+    indexerConfig["password"] = "password";
+
+    // Create connector and wait until the connection is established.
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    EXPECT_NO_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS));
+}
+
+/**
+ * @brief Test the connection to an available server with SSL credentials.
+ *
+ * @note The SSL data is a dummy one and there are no functionality checks here. The target of this test is to increase
+ * the test coverage.
+ *
+ */
+TEST_F(IndexerConnectorTest, ConnectionWithSslCredentials)
+{
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
+    indexerConfig["ssl"]["certificate_authorities"] = nlohmann::json::array({"/etc/filebeat/certs/root-ca.pem"});
+    indexerConfig["ssl"]["certificate"] = "/etc/filebeat/certs/filebeat.pem";
+    indexerConfig["ssl"]["key"] = "/etc/filebeat/certs/filebeat-key.pem";
+
+    // Create connector and wait until the connection is established.
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    EXPECT_NO_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS));
+}
+
+/**
+ * @brief Test the connection to an unavailable server.
+ *
+ */
+TEST_F(IndexerConnectorTest, ConnectionUnavailableServer)
+{
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({B_ADDRESS});
+
+    // Create connector and wait until the max time is reached.
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    EXPECT_THROW(waitUntil([this]() { return m_indexerServers[B_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS),
+                 std::runtime_error);
+}
+
+/**
+ * @brief Test the connection to a list of servers. The connection is expected to be made to the only available server.
+ *
+ */
+TEST_F(IndexerConnectorTest, ConnectionMultipleServers)
+{
+    // Set the servers health.
+    m_indexerServers[A_IDX]->setHealth("red");
+    m_indexerServers[B_IDX]->setHealth("red");
+    m_indexerServers[C_IDX]->setHealth("green");
+
+    // Create connector and wait until the connection is made with the available server.
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS, B_ADDRESS, C_ADDRESS});
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    ASSERT_NO_THROW(waitUntil([this]() { return m_indexerServers[C_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS));
+}
+
+/**
+ * @brief Test the connection to an inexistant server.
+ *
+ */
+TEST_F(IndexerConnectorTest, ConnectionInvalidServer)
+{
+    // Trigger connection and expect that it is not made.
+    constexpr auto INEXISTANT_SERVER {"localhost:6789"};
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({INEXISTANT_SERVER});
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    ASSERT_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS),
+                 std::runtime_error);
+}
+
+/**
+ * @brief Test the connection to a server that responds the template initialization with an error.
+ *
+ */
+TEST_F(IndexerConnectorTest, ConnectionInitTemplateErrorFromServer)
+{
+    // Callback function that checks if the callback was executed or not.
+    auto callbackCalled {false};
+    const auto forceErrorCallback {[&callbackCalled](const std::string& data)
+                                   {
+                                       callbackCalled = true;
+                                       throw std::runtime_error {"Forced server error"};
+                                   }};
+    m_indexerServers[A_IDX]->setInitTemplateCallback(forceErrorCallback);
+
+    // Create connector and wait until the connection is established.
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    ASSERT_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS),
+                 std::runtime_error);
+}
+
+/**
+ * @brief Test the connection to a server that responds the index initialization with an error.
+ *
+ */
+TEST_F(IndexerConnectorTest, ConnectionInitIndexErrorFromServer)
+{
+    // Callback function that checks if the callback was executed or not.
+    auto callbackCalled {false};
+    const auto forceErrorCallback {[&callbackCalled](const std::string& data)
+                                   {
+                                       callbackCalled = true;
+                                       throw std::runtime_error {"Forced server error"};
+                                   }};
+    m_indexerServers[A_IDX]->setInitIndexCallback(forceErrorCallback);
+
+    // Create connector and wait until the connection is established.
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    ASSERT_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS),
+                 std::runtime_error);
+}
+
+/**
+ * @brief Test the connection and posterior data publication into a server. The published data is checked against the
+ * expected one.
+ *
+ */
+TEST_F(IndexerConnectorTest, Publish)
+{
+    nlohmann::json expectedMetadata;
+    expectedMetadata["index"]["_index"] = INDEXER_NAME;
+    expectedMetadata["index"]["_id"] = INDEX_ID_A;
+
+    // Callback that checks the expected data to be published.
+    // The format of the data published is divided in two lines:
+    // First line: JSON data with the metadata (indexer name, index ID)
+    // Second line: Index data.
+    constexpr auto INDEX_DATA {"content"};
+    auto callbackCalled {false};
+    const auto checkPublishedData {[&expectedMetadata, &callbackCalled, &INDEX_DATA](const std::string& data)
+                                   {
+                                       const auto splitData {Utils::split(data, '\n')};
+                                       ASSERT_EQ(nlohmann::json::parse(splitData.front()), expectedMetadata);
+                                       ASSERT_EQ(nlohmann::json::parse(splitData.back()), INDEX_DATA);
+                                       callbackCalled = true;
+                                   }};
+    m_indexerServers[A_IDX]->setPublishCallback(checkPublishedData);
+
+    // Create connector and wait until the connection is established.
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    ASSERT_NO_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS));
+
+    // Publish content and wait until the publication finishes.
+    nlohmann::json publishData;
+    publishData["id"] = INDEX_ID_A;
+    publishData["operation"] = "INSERT";
+    publishData["data"] = INDEX_DATA;
+    ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
+    ASSERT_NO_THROW(waitUntil([&callbackCalled]() { return callbackCalled; }, MAX_INDEXER_PUBLISH_TIME_MS));
+}
+
+/**
+ * @brief Test the connection and posterior data publication into a server. The published data is checked against the
+ * expected one. The publication contains a DELETED operation.
+ *
+ */
+TEST_F(IndexerConnectorTest, PublishDeleted)
+{
+    nlohmann::json expectedMetadata;
+    expectedMetadata["delete"]["_index"] = INDEXER_NAME;
+    expectedMetadata["delete"]["_id"] = INDEX_ID_A;
+
+    // Callback that checks the expected data to be published.
+    // The format of the data published is divided in two lines:
+    // First line: JSON data with the metadata (indexer name, index ID)
+    // Second line: Index data. When the operation is DELETED, no data is present.
+    auto callbackCalled {false};
+    const auto checkPublishedData {[&expectedMetadata, &callbackCalled](const std::string& data)
+                                   {
+                                       const auto splitData {Utils::split(data, '\n')};
+                                       ASSERT_EQ(nlohmann::json::parse(splitData.front()), expectedMetadata);
+                                       callbackCalled = true;
+                                   }};
+    m_indexerServers[A_IDX]->setPublishCallback(checkPublishedData);
+
+    // Create connector and wait until the connection is established.
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    ASSERT_NO_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS));
+
+    // Publish content and wait until the publication finishes.
+    nlohmann::json publishData;
+    publishData["id"] = INDEX_ID_A;
+    publishData["operation"] = "DELETED";
+    ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
+    ASSERT_NO_THROW(waitUntil([&callbackCalled]() { return callbackCalled; }, MAX_INDEXER_PUBLISH_TIME_MS));
+}
+
+/**
+ * @brief Test the publication to an unavailable server.
+ *
+ */
+TEST_F(IndexerConnectorTest, PublishUnavailableServer)
+{
+    // Callback function that checks if the callback was executed or not.
+    auto callbackCalled {false};
+    const auto checkPublishedData {[&callbackCalled](const std::string& data)
+                                   {
+                                       callbackCalled = true;
+                                   }};
+    m_indexerServers[B_IDX]->setPublishCallback(checkPublishedData);
+
+    // Initialize connector.
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({B_ADDRESS});
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+
+    // Trigger publication and expect that it is not made.
+    const auto publishData = R"({"dummy":true})"_json;
+    ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
+    ASSERT_THROW(waitUntil([&callbackCalled]() { return callbackCalled; }, MAX_INDEXER_PUBLISH_TIME_MS),
+                 std::runtime_error);
+}
+
+/**
+ * @brief Test the connection and posterior publication of invalid data to an available server.
+ *
+ */
+TEST_F(IndexerConnectorTest, PublishInvalidData)
+{
+    // Callback function that checks if the callback was executed or not.
+    auto callbackCalled {false};
+    const auto checkCallbackCalled {[&callbackCalled](const std::string& data)
+                                    {
+                                        callbackCalled = true;
+                                    }};
+    m_indexerServers[A_IDX]->setPublishCallback(checkCallbackCalled);
+
+    // Create connector and wait until the connection is established.
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    ASSERT_NO_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS));
+
+    // Trigger publication and expect that it is not made.
+    nlohmann::json publishData;
+    publishData["operation"] = "DELETED";
+    ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
+    ASSERT_THROW(waitUntil([&callbackCalled]() { return callbackCalled; }, MAX_INDEXER_PUBLISH_TIME_MS),
+                 std::runtime_error);
+}
+
+/**
+ * @brief Test the connection and posterior double data publication into a server. The published data is checked against
+ * the expected one.
+ *
+ */
+TEST_F(IndexerConnectorTest, PublishTwoIndexes)
+{
+    auto publishedData = nlohmann::json::array();
+
+    // Callback that stores the published data into a JSON array. It also counts the times the callback was called.
+    // The format of the data published is divided in two lines:
+    // First line: JSON data with the metadata (indexer name, index ID).
+    // Second line: Index data.
+    auto callbackCalled {false};
+    const auto checkPublishedData {[&callbackCalled, &publishedData](const std::string& data)
+                                   {
+                                       const auto splitData {Utils::split(data, '\n')};
+                                       nlohmann::json entry;
+                                       entry["metadata"] = nlohmann::json::parse(splitData.front());
+                                       entry["data"] = nlohmann::json::parse(splitData.back());
+                                       publishedData.push_back(std::move(entry));
+                                       callbackCalled = true;
+                                   }};
+    m_indexerServers[A_IDX]->setPublishCallback(checkPublishedData);
+
+    // Create connector and wait until the connection is established.
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    ASSERT_NO_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS));
+
+    // Publish content to INDEX_ID_A and wait until is finished.
+    constexpr auto INDEX_DATA_A {"contentA"};
+    nlohmann::json publishData;
+    publishData["id"] = INDEX_ID_A;
+    publishData["operation"] = "INSERT";
+    publishData["data"] = INDEX_DATA_A;
+    ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
+    ASSERT_NO_THROW(waitUntil([&callbackCalled]() { return callbackCalled; }, MAX_INDEXER_PUBLISH_TIME_MS));
+
+    // Publish content to INDEX_ID_B and wait until is finished..
+    const auto INDEX_DATA_B = R"({"contentB":true})"_json;
+    publishData["id"] = INDEX_ID_B;
+    publishData["data"] = INDEX_DATA_B;
+    ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
+    callbackCalled = false;
+    ASSERT_NO_THROW(waitUntil([&callbackCalled]() { return callbackCalled; }, MAX_INDEXER_PUBLISH_TIME_MS));
+
+    // Check expected data.
+    nlohmann::json expectedDataA;
+    expectedDataA["metadata"]["index"]["_index"] = INDEXER_NAME;
+    expectedDataA["metadata"]["index"]["_id"] = INDEX_ID_A;
+    expectedDataA["data"] = INDEX_DATA_A;
+    nlohmann::json expectedDataB;
+    expectedDataB["metadata"]["index"]["_index"] = INDEXER_NAME;
+    expectedDataB["metadata"]["index"]["_id"] = INDEX_ID_B;
+    expectedDataB["data"] = INDEX_DATA_B;
+    const auto expectedData = nlohmann::json::array({expectedDataA, expectedDataB});
+    ASSERT_EQ(expectedData, publishedData);
+}
+
+/**
+ * @brief Test the connection and posterior publication to a server that responds the publication with an error.
+ *
+ */
+TEST_F(IndexerConnectorTest, PublishErrorFromServer)
+{
+    // Callback function that checks if the callback was executed or not.
+    auto callbackCalled {false};
+    const auto forceErrorCallback {[&callbackCalled](const std::string& data)
+                                   {
+                                       callbackCalled = true;
+                                       throw std::runtime_error {"Forced server error"};
+                                   }};
+    m_indexerServers[A_IDX]->setPublishCallback(forceErrorCallback);
+
+    // Create connector and wait until the connection is established.
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
+    auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT)};
+    ASSERT_NO_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS));
+
+    // Trigger publication and expect that it is not made.
+    nlohmann::json publishData;
+    publishData["id"] = INDEX_ID_A;
+    publishData["operation"] = "DELETED";
+    ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
+    ASSERT_NO_THROW(waitUntil([&callbackCalled]() { return callbackCalled; }, MAX_INDEXER_PUBLISH_TIME_MS));
+}
+
+/**
+ * @brief Test the connection to a server with an invalid template file path.
+ *
+ */
+TEST_F(IndexerConnectorTest, TemplateFileNotFoundThrows)
+{
+    nlohmann::json indexerConfig;
+    indexerConfig["name"] = INDEXER_NAME;
+    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
+
+    constexpr auto INVALID_TEMPLATE_FILE_PATH {"inexistant.json"};
+    EXPECT_THROW(IndexerConnector(indexerConfig, INVALID_TEMPLATE_FILE_PATH, logFunction, INDEXER_TIMEOUT),
+                 std::runtime_error);
+}

--- a/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
@@ -58,7 +58,7 @@ static const auto TEMPLATE_DATA = R"(
 // Indexers.
 static const auto INDEXER_TIMEOUT {0u};
 static const std::string INDEXER_HOSTNAME {"localhost"};
-static const auto INDEXER_NAME {"indexer_connector_test"}; // Should be in lowcase for a real indexer.
+static const auto INDEXER_NAME {"indexer_connector_test"}; // Should be in lowercase for a real indexer.
 static const auto MAX_INDEXER_INIT_TIME_MS {2000};
 static const auto MAX_INDEXER_PUBLISH_TIME_MS {5500};
 static const auto INDEX_ID_A {"A"};

--- a/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
@@ -27,12 +27,38 @@
 
 // Template.
 static const auto TEMPLATE_FILE_PATH {std::filesystem::temp_directory_path() / "template.json"};
-static const auto TEMPLATE_DATA = R"({"template":"templateData"})"_json;
+static const auto TEMPLATE_DATA = R"(
+    {
+        "index_patterns": [
+            "logs-2020-01-*"
+        ],
+        "template": {
+            "aliases": {
+                "my_logs": {}
+            },
+            "settings": {
+                "number_of_shards": 2,
+                "number_of_replicas": 1
+            },
+            "mappings": {
+                "properties": {
+                    "timestamp": {
+                        "type": "date",
+                        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+                    },
+                    "value": {
+                        "type": "double"
+                    }
+                }
+            }
+        }
+    }
+)"_json; // Real template example.
 
 // Indexers.
 static const auto INDEXER_TIMEOUT {0u};
 static const std::string INDEXER_HOSTNAME {"localhost"};
-static const auto INDEXER_NAME {"IndexerConnectorTest"};
+static const auto INDEXER_NAME {"indexer_connector_test"}; // Should be in lowcase for a real indexer.
 static const auto MAX_INDEXER_INIT_TIME_MS {2000};
 static const auto MAX_INDEXER_PUBLISH_TIME_MS {5500};
 static const auto INDEX_ID_A {"A"};

--- a/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
@@ -89,7 +89,12 @@ static void logFunction(const int logLevel,
                         va_list args)
 {
     std::ignore = logLevel;
+    std::ignore = tag;
+    std::ignore = file;
+    std::ignore = line;
+    std::ignore = func;
     std::ignore = logMessage;
+    std::ignore = args;
 }
 
 void IndexerConnectorTest::SetUp()
@@ -150,7 +155,8 @@ TEST_F(IndexerConnectorTest, Connection)
     // Callback used to check if the indexer connector is correctly initialized.
     // This callback should be called twice: The first time to initialize the template and the second one to initialize
     // the index.
-    nlohmann::json indexData, templateData;
+    nlohmann::json indexData;
+    nlohmann::json templateData;
     unsigned int callbackCalled {0};
     const auto checkInitDataCallback {[&callbackCalled, &indexData, &templateData](const std::string& data)
                                       {
@@ -284,6 +290,7 @@ TEST_F(IndexerConnectorTest, ConnectionInitTemplateErrorFromServer)
     auto callbackCalled {false};
     const auto forceErrorCallback {[&callbackCalled](const std::string& data)
                                    {
+                                       std::ignore = data;
                                        callbackCalled = true;
                                        throw std::runtime_error {"Forced server error"};
                                    }};
@@ -308,6 +315,7 @@ TEST_F(IndexerConnectorTest, ConnectionInitIndexErrorFromServer)
     auto callbackCalled {false};
     const auto forceErrorCallback {[&callbackCalled](const std::string& data)
                                    {
+                                       std::ignore = data;
                                        callbackCalled = true;
                                        throw std::runtime_error {"Forced server error"};
                                    }};
@@ -413,6 +421,7 @@ TEST_F(IndexerConnectorTest, PublishUnavailableServer)
     auto callbackCalled {false};
     const auto checkPublishedData {[&callbackCalled](const std::string& data)
                                    {
+                                       std::ignore = data;
                                        callbackCalled = true;
                                    }};
     m_indexerServers[B_IDX]->setPublishCallback(checkPublishedData);
@@ -440,6 +449,7 @@ TEST_F(IndexerConnectorTest, PublishInvalidData)
     auto callbackCalled {false};
     const auto checkCallbackCalled {[&callbackCalled](const std::string& data)
                                     {
+                                        std::ignore = data;
                                         callbackCalled = true;
                                     }};
     m_indexerServers[A_IDX]->setPublishCallback(checkCallbackCalled);
@@ -500,7 +510,7 @@ TEST_F(IndexerConnectorTest, PublishTwoIndexes)
     ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
     ASSERT_NO_THROW(waitUntil([&callbackCalled]() { return callbackCalled; }, MAX_INDEXER_PUBLISH_TIME_MS));
 
-    // Publish content to INDEX_ID_B and wait until is finished..
+    // Publish content to INDEX_ID_B and wait until is finished.
     const auto INDEX_DATA_B = R"({"contentB":true})"_json;
     publishData["id"] = INDEX_ID_B;
     publishData["data"] = INDEX_DATA_B;
@@ -531,6 +541,7 @@ TEST_F(IndexerConnectorTest, PublishErrorFromServer)
     auto callbackCalled {false};
     const auto forceErrorCallback {[&callbackCalled](const std::string& data)
                                    {
+                                       std::ignore = data;
                                        callbackCalled = true;
                                        throw std::runtime_error {"Forced server error"};
                                    }};

--- a/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.hpp
@@ -1,0 +1,55 @@
+/*
+ * Wazuh Indexer Connector - Component tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * January 09, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _INDEXER_CONNECTOR_TEST_HPP
+#define _INDEXER_CONNECTOR_TEST_HPP
+
+#include "fakeIndexer.hpp"
+#include "gtest/gtest.h"
+#include <functional>
+#include <memory>
+#include <vector>
+
+/**
+ * @brief Runs unit tests for IndexerConnector class.
+ *
+ */
+class IndexerConnectorTest : public ::testing::Test
+{
+protected:
+    IndexerConnectorTest() = default;
+    ~IndexerConnectorTest() = default;
+
+    std::vector<std::unique_ptr<FakeIndexer>> m_indexerServers; ///< List of indexer servers.
+
+    /**
+     * @brief Setup routine for each test fixture.
+     *
+     */
+    void SetUp() override;
+
+    /**
+     * @brief Teardown routine for each test fixture.
+     *
+     */
+    void TearDown() override;
+
+    /**
+     * @brief Waits until the stop condition is true or the max sleep time is reached. In the later, an exception is
+     * thrown.
+     *
+     * @param stopCondition Wait stop condition function.
+     * @param maxSleepTimeMs Max time to wait.
+     */
+    void waitUntil(const std::function<bool()>& stopCondition, const unsigned int& maxSleepTimeMs) const;
+};
+
+#endif // _INDEXER_CONNECTOR_TEST_HPP

--- a/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.hpp
@@ -43,7 +43,7 @@ protected:
     void TearDown() override;
 
     /**
-     * @brief Waits until the stop condition is true or the max sleep time is reached. In the later, an exception is
+     * @brief Waits until the stop condition is true or the max sleep time is reached. In the latter, an exception is
      * thrown.
      *
      * @param stopCondition Wait stop condition function.

--- a/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.hpp
@@ -26,7 +26,7 @@ class IndexerConnectorTest : public ::testing::Test
 {
 protected:
     IndexerConnectorTest() = default;
-    ~IndexerConnectorTest() = default;
+    ~IndexerConnectorTest() override = default;
 
     std::vector<std::unique_ptr<FakeIndexer>> m_indexerServers; ///< List of indexer servers.
 

--- a/src/shared_modules/indexer_connector/tests/component/main.cpp
+++ b/src/shared_modules/indexer_connector/tests/component/main.cpp
@@ -1,0 +1,18 @@
+/*
+ * Wazuh Indexer Connector - Component tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * January 09, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/shared_modules/indexer_connector/tests/unit/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/tests/unit/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.12.4)
 
 project(indexer_connector_unit_tests)
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage -fsanitize=address,leak,undefined")
-
 file(GLOB SOURCES
         *.cpp
 )


### PR DESCRIPTION
|Related issue|
|---|
|#21288 |

## Description

This PR adds new tests to the Indexer Connector shared module.

Change log:
- New component tests added.
- Removed exclusion of coverage analysis.
- Added timeout parameter to the indexer connector class. This was useful/necessary to make testing possible.

## Results

The coverage report was generated locally, given that a known issue (https://github.com/wazuh/wazuh/issues/21405) prevents `lcov` from including all the .gcda files.
- [coverage.tar.gz](https://github.com/wazuh/wazuh/files/13907543/coverage.tar.gz)

Coverage at **98.3%**:
![image](https://github.com/wazuh/wazuh/assets/42682247/888e6ef5-286e-48c6-92cb-e37751a81fb9)
![image](https://github.com/wazuh/wazuh/assets/42682247/fb4835a5-828d-4f72-8338-491100f4d5de)
