### PR TITLE
Adding fake Wazuh-DB and Analysisd servers to vulnerability detector test tool

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/argsParser.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/argsParser.hpp
@@ -126,6 +126,8 @@ public:
                   << "\t-t TEMPLATE_FILE\tSpecifies the template file.\n"
                   << "\t-s WAIT_TIME\t\tSpecifies the wait before exit.\n"
                   << "\t-d \t\t\tOnly download content.\n"
+                  << "\t-r \t\t\tFake report server that will receive the alerts messages.\n"
+                  << "\t-b FAKE_DB_FILE\t\tFake DB JSON file with the mocked agent OS data.\n"
                   << "\nExample:"
                   << "\n\t./vd_scanner_testtool -c config.json\n"
                   << "\n\t./vd_scanner_testtool -c config.json -t template.json\n"

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/argsParser.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/argsParser.hpp
@@ -35,6 +35,8 @@ public:
         , m_waitTime {paramValueOf(argc, argv, "-s", std::make_pair(false, "0"))}
         , m_inputFiles {splitActions(paramValueOf(argc, argv, "-i", std::make_pair(false, "")))}
         , m_onlyDownloadContent {paramExists(argc, argv, "-d", std::make_pair(false, false))}
+        , m_fakeReportServer {paramExists(argc, argv, "-r", std::make_pair(false, false))}
+        , m_fakeDBServer {paramValueOf(argc, argv, "-b", std::make_pair(false, ""))}
     {
         // If only download content is enabled, check for other flags
         if (m_onlyDownloadContent)
@@ -93,6 +95,26 @@ public:
     }
 
     /**
+     * @brief Gets whether the report server should be faked.
+     *
+     * @return true or false according to the value of the variable.
+     */
+    bool getFakeReportServer() const
+    {
+        return m_fakeReportServer;
+    }
+
+    /**
+     * @brief Gets the fake agent data file path.
+     *
+     * @return Path to the json file with fake agent data.
+     */
+    const std::string& getFakeDBServer() const
+    {
+        return m_fakeDBServer;
+    }
+
+    /**
      * @brief Shows the help to the user.
      */
     static void showHelp()
@@ -109,6 +131,7 @@ public:
                   << "\n\t./vd_scanner_testtool -c config.json -t template.json\n"
                   << "\n\t./vd_scanner_testtool -c config.json -t template.json -d\n"
                   << "\n\t./vd_scanner_testtool -c config.json -t template.json -s 10\n"
+                  << "\n\t./vd_scanner_testtool -c config.json -t template.json -s 10 -r -b fakeAgentData.json\n"
                   << "\n\t./vd_scanner_testtool -c config.json -t template.json -s 5 -i a.json,b.json,c.json\n"
                   << std::endl;
     }
@@ -186,6 +209,8 @@ private:
     const std::string m_waitTime;
     const std::vector<std::string> m_inputFiles;
     const bool m_onlyDownloadContent;
+    const bool m_fakeReportServer;
+    const std::string m_fakeDBServer;
 };
 
 #endif // _CMD_ARGS_PARSER_HPP_

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/fakeAgentData/agentData.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/fakeAgentData/agentData.json
@@ -1,0 +1,37 @@
+{
+    "000": {
+        "architecture": "x86_64",
+        "checksum": "1704514361693635656",
+        "hostname": "ubuntu-jammy",
+        "os_codename": "jammy",
+        "os_major": "22",
+        "os_minor": "04",
+        "os_name": "Ubuntu",
+        "os_patch": "3",
+        "os_platform": "ubuntu",
+        "os_version": "22.04.3 LTS (Jammy Jellyfish)",
+        "reference": "f22553c945b045bfc0d162cb890344d2f4fa8609",
+        "release": "5.15.0-91-generic",
+        "scan_id": 0,
+        "scan_time": "2024/01/06 04:12:44",
+        "sysname": "Linux",
+        "triaged": 0,
+        "version": "#101-Ubuntu SMP Tue Nov 14 13:30:08 UTC 2023"
+    },
+    "001": {
+        "architecture": "x86_64",
+        "checksum": "1704514864922425008",
+        "hostname": "vagrant",
+        "os_major": "2",
+        "os_name": "Amazon Linux",
+        "os_platform": "amzn",
+        "os_version": "2",
+        "reference": "e778c1fe83f2b15cdb013471a2c8223132c9e1ca",
+        "release": "4.14.311-233.529.amzn2.x86_64",
+        "scan_id": 0,
+        "scan_time": "2024/01/06 04:21:05",
+        "sysname": "Linux",
+        "triaged": 0,
+        "version": "#1 SMP Thu Mar 23 09:54:12 UTC 2023"
+    }
+}

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
@@ -43,6 +43,14 @@ private:
     char m_buffer[MAXLEN] {0};
     size_t m_bytesReceived {0};
     std::string m_path;
+    struct sockaddr_un m_clientAddr
+    {
+    };
+    struct sockaddr_un m_serverAddr
+    {
+        .sun_family = AF_UNIX
+    };
+    socklen_t m_clientSize;
 
 public:
     /**
@@ -54,6 +62,7 @@ public:
     {
         m_socketServer = socket(AF_UNIX, SOCK_DGRAM, 0);
         m_path = path;
+        m_clientSize = sizeof(m_clientAddr);
     }
 
     /**
@@ -62,15 +71,6 @@ public:
      */
     void start()
     {
-        struct sockaddr_un clientAddr
-        {
-        };
-        struct sockaddr_un serverAddr
-        {
-            .sun_family = AF_UNIX
-        };
-        socklen_t clientSize = sizeof(clientAddr);
-
         if (m_socketServer < 0)
         {
             throw std::runtime_error("Failed to create socket. Reason: " + std::string(strerror(errno)));
@@ -84,17 +84,17 @@ public:
         m_fakeServerThread = std::thread(
             [&]()
             {
-                std::strcpy(serverAddr.sun_path, m_path.c_str());
+                std::strcpy(m_serverAddr.sun_path, m_path.c_str());
 
-                if (bind(m_socketServer, (struct sockaddr*)&serverAddr, sizeof(serverAddr)) < 0)
+                if (bind(m_socketServer, (struct sockaddr*)&m_serverAddr, sizeof(m_serverAddr)) < 0)
                 {
                     throw std::runtime_error("Failed to bind socket: " + std::string(strerror(errno)));
                 }
 
                 do
                 {
-                    m_bytesReceived =
-                        recvfrom(m_socketServer, m_buffer, MAXLEN - 1, 0, (struct sockaddr*)&clientAddr, &clientSize);
+                    m_bytesReceived = recvfrom(
+                        m_socketServer, m_buffer, MAXLEN - 1, 0, (struct sockaddr*)&m_clientAddr, &m_clientSize);
 
                     std::lock_guard<std::mutex> lock(g_mutex);
                     if (m_bytesReceived > 0)

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
@@ -18,11 +18,127 @@
 #include "flatbuffers/include/syscollector_synchronization_schema.h"
 #include "routerModule.hpp"
 #include "routerProvider.hpp"
+#include "socketClient.hpp"
+#include "socketServer.hpp"
+#include "stringHelper.h"
 #include "vulnerabilityScanner.hpp"
 #include <iostream>
 #include <thread>
 
 auto constexpr MAXLEN {65536};
+auto constexpr DEFAULT_QUEUE_PATH {"queue/sockets/queue"};
+auto constexpr DEFAULT_WDB_SOCKET {"queue/db/wdb"};
+std::mutex g_mutex;
+
+/**
+ * @brief Class used to create a server for the alerts messages.
+ *
+ */
+class FakeReportServer
+{
+private:
+    int m_socketServer;
+    std::thread m_fakeServerThread;
+    std::atomic<bool> m_shouldStop {false};
+    char m_buffer[MAXLEN] {0};
+    size_t m_bytesReceived {0};
+    std::string m_path;
+
+public:
+    /**
+     * @brief Construct a new Fake Report Server object
+     *
+     * @param path Location of the server to create.
+     */
+    FakeReportServer(std::string path)
+    {
+        m_socketServer = socket(AF_UNIX, SOCK_DGRAM, 0);
+        m_path = path;
+    }
+
+    /**
+     * @brief Initiates the main thread.
+     *
+     */
+    void start()
+    {
+        struct sockaddr_un clientAddr
+        {
+        };
+        struct sockaddr_un serverAddr
+        {
+            .sun_family = AF_UNIX
+        };
+        socklen_t clientSize = sizeof(clientAddr);
+
+        if (m_socketServer < 0)
+        {
+            throw std::runtime_error("Failed to create socket. Reason: " + std::string(strerror(errno)));
+        }
+
+        if (std::filesystem::exists(m_path))
+        {
+            std::filesystem::remove(m_path);
+        }
+
+        m_fakeServerThread = std::thread(
+            [&]()
+            {
+                std::strcpy(serverAddr.sun_path, m_path.c_str());
+
+                if (bind(m_socketServer, (struct sockaddr*)&serverAddr, sizeof(serverAddr)) < 0)
+                {
+                    throw std::runtime_error("Failed to bind socket: " + std::string(strerror(errno)));
+                }
+
+                do
+                {
+                    m_bytesReceived =
+                        recvfrom(m_socketServer, m_buffer, MAXLEN - 1, 0, (struct sockaddr*)&clientAddr, &clientSize);
+
+                    std::lock_guard<std::mutex> lock(g_mutex);
+                    if (m_bytesReceived > 0)
+                    {
+                        if (m_bytesReceived > (MAXLEN - 1))
+                        {
+                            m_bytesReceived = MAXLEN - 1;
+                        }
+                        m_buffer[m_bytesReceived] = '\0';
+                        std::cout << "Fake report server message: " << std::string(m_buffer, m_bytesReceived)
+                                  << std::endl;
+                    }
+                    else
+                    {
+                        std::cout << "Fake report server err message: " << strerror(errno) << std::endl;
+                    }
+
+                } while (!m_shouldStop.load());
+            });
+    }
+
+    /**
+     * @brief Sends the stop signal to the main thread.
+     *
+     */
+    void stop()
+    {
+        m_shouldStop.store(true);
+    }
+
+    /**
+     * @brief Waits for the thread to join and cleans.
+     *
+     */
+    void waitForStop()
+    {
+        if (m_fakeServerThread.joinable())
+        {
+            m_fakeServerThread.join();
+        }
+        close(m_socketServer);
+        std::filesystem::remove(m_path);
+    }
+};
 
 int main(const int argc, const char* argv[])
 {
@@ -49,6 +165,54 @@ int main(const int argc, const char* argv[])
         routerProviderDbSync.start();
         routerProviderRSync.start();
 
+        // Fake Wazuh-DB server
+        auto fakeDBServer =
+            std::make_shared<SocketServer<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>>(DEFAULT_WDB_SOCKET);
+        nlohmann::json fakeAgentData;
+        if (!cmdLineArgs.getFakeDBServer().empty())
+        {
+            fakeAgentData = nlohmann::json::parse(std::ifstream(cmdLineArgs.getFakeDBServer()));
+
+            fakeDBServer->listen(
+                [&](const int fd, const char* data, uint32_t dataSize, const char*, uint32_t)
+                {
+                    auto messageReceived = std::string(data, dataSize);
+
+                    auto tokens = Utils::split(messageReceived, ' ');
+                    std::string errMessage = "err Query not supported";
+                    if (tokens.size() >= 2)
+                    {
+                        if (tokens[0] == "agent" && Utils::isNumber(tokens[1]))
+                        {
+                            if (fakeAgentData.contains(tokens[1]))
+                            {
+                                std::string successMessage = "ok " + fakeAgentData[tokens[1]].dump();
+                                fakeDBServer->send(fd, successMessage.c_str(), successMessage.size());
+                            }
+                            else
+                            {
+                                fakeDBServer->send(fd, "ok []", 5);
+                            }
+                        }
+                        else
+                        {
+                            fakeDBServer->send(fd, errMessage.c_str(), errMessage.size());
+                        }
+                    }
+                    else
+                    {
+                        fakeDBServer->send(fd, errMessage.c_str(), errMessage.size());
+                    }
+                });
+        }
+
+        // Fake alerts server
+        FakeReportServer fakeReportServer(DEFAULT_QUEUE_PATH);
+        if (cmdLineArgs.getFakeReportServer())
+        {
+            fakeReportServer.start();
+        }
+
         vulnerabilityScanner.start(
             [](const int logLevel,
                const std::string& tag,
@@ -67,6 +231,7 @@ int main(const int argc, const char* argv[])
                 char formattedStr[MAXLEN] = {0};
                 vsnprintf(formattedStr, MAXLEN, message.c_str(), args);
 
+                std::lock_guard<std::mutex> lock(g_mutex);
                 if (logLevel != LOG_ERROR)
                 {
                     std::cout << tag << ":" << fileName << ":" << line << " " << func << " : " << formattedStr
@@ -148,6 +313,26 @@ int main(const int argc, const char* argv[])
         vulnerabilityScanner.stop();
         routerModule.stop();
         ContentModule::instance().stop();
+        if (cmdLineArgs.getFakeReportServer())
+        {
+            fakeReportServer.stop();
+            // The server has a blocking recv(), sending any message to the socket will unblock it.
+            auto tempSocketClient =
+                std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(
+                    DEFAULT_QUEUE_PATH);
+            tempSocketClient->connect(
+                [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader) {},
+                []() {},
+                SOCK_DGRAM);
+            tempSocketClient->send("stop", 4);
+
+            fakeReportServer.waitForStop();
+            tempSocketClient->stop();
+        }
+        if (!cmdLineArgs.getFakeDBServer().empty())
+        {
+            fakeDBServer->stop();
+        }
     }
     catch (const std::exception& e)
     {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #20762|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR adds new flags to the vulnerability detector test tool to allow the testing without deploying a full Wazuh server
- The fake alerts server will print the messages received
- The fake Wazuh-DB server is able to read a JSON file with fake data and return it to the client

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

The fake report server prints the alerts

![2024-01-09_19-48](https://github.com/wazuh/wazuh/assets/65046601/9d72ad51-4e1a-4f0e-a920-b2ff45f043a0)

The fake Wazuh-DB server receives the queries and the fake OS data is present in the indexed data

![2024-01-09_19-49](https://github.com/wazuh/wazuh/assets/65046601/10cf44bc-0ca8-45d0-977d-481b97a7874b)

![2024-01-09_19-50](https://github.com/wazuh/wazuh/assets/65046601/8a1a6550-f1b6-4fb1-b474-a80870ac67ed)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
