### PR TITLE
Use lowercase package name key for vulnerability candidates

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
@@ -15,6 +15,7 @@
 #include "cve5_generated.h"
 #include "flatbuffers/flatbuffers.h"
 #include "rocksDBWrapper.hpp"
+#include "stringHelper.h"
 #include "vulnerabilityCandidate_generated.h"
 
 const std::unordered_map<std::string, NSVulnerabilityScanner::Status> VERSION_STATUS_MAP {
@@ -62,15 +63,16 @@ public:
                     continue;
                 }
 
-                if (candidatesArraysMap.find(affected->product()->str()) == candidatesArraysMap.end())
+                const auto productName = Utils::toLowerCase(affected->product()->str());
+                if (candidatesArraysMap.find(productName) == candidatesArraysMap.end())
                 {
                     candidatesArraysMap.emplace(
-                        affected->product()->str(),
+                        productName,
                         std::pair<std::vector<flatbuffers::Offset<NSVulnerabilityScanner::ScanVulnerabilityCandidate>>,
                                   flatbuffers::FlatBufferBuilder>());
                 }
 
-                auto& candidateBuilderRef = candidatesArraysMap.at(affected->product()->str()).second;
+                auto& candidateBuilderRef = candidatesArraysMap.at(productName).second;
 
                 // Versions array
                 std::vector<flatbuffers::Offset<NSVulnerabilityScanner::Version>> versionFBArray;
@@ -119,7 +121,7 @@ public:
                 auto candidate = NSVulnerabilityScanner::CreateScanVulnerabilityCandidateDirect(
                     candidateBuilderRef, cveId->c_str(), defaultStatus, &platformsVec, &versionFBArray);
 
-                candidatesArraysMap.at(affected->product()->str()).first.push_back(candidate);
+                candidatesArraysMap.at(productName).first.push_back(candidate);
             }
 
             for (auto& [key, value] : candidatesArraysMap)

--- a/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/updateCVECandidates_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/databaseFeedManager/updateCVECandidates_test.cpp
@@ -23,6 +23,7 @@ const char* INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
 
 const std::string CVE_ID = "CVE-2010-0002";
 
+// Product name with capital letters will be normalized to lowercase
 const std::string CVE_INPUT = R"(
     {
     "containers": {
@@ -31,7 +32,7 @@ const std::string CVE_INPUT = R"(
                 "affected": [
                     {
                         "defaultStatus": "unknown",
-                        "product": "bash",
+                        "product": "Bash",
                         "vendor" : "canonical",
                         "platforms": [
                             "upstream"
@@ -47,7 +48,7 @@ const std::string CVE_INPUT = R"(
                     },
                     {
                         "defaultStatus": "unaffected",
-                        "product": "bash",
+                        "product": "baSH",
                         "vendor" : "canonical",
                         "platforms": [
                             "dapper",
@@ -121,7 +122,7 @@ const std::string CVE_INPUT = R"(
                         "cpe:2.3:a:gnu:bash:3.2:*:*:*:*:*:*:*"
                     ],
                     "defaultStatus": "unaffected",
-                    "product": "bash",
+                    "product": "BASH",
                     "vendor": "gnu",
                     "versions": [
                         {


### PR DESCRIPTION
|Related issue|
|---|
|#21285|

## Description

Use package names in lowercase as part of the vulnerability candidates database key

## Logs/Alerts example

These are all the cases with uppercase letters in the package name. 

[alma_keys_san_upper.txt](https://github.com/wazuh/wazuh/files/13889481/alma_keys_san_upper.txt)
[redhat_keys_san_upper.txt](https://github.com/wazuh/wazuh/files/13889482/redhat_keys_san_upper.txt)
[suse_keys_san_upper.txt](https://github.com/wazuh/wazuh/files/13889483/suse_keys_san_upper.txt)

## Tests

<details><summary>Packages installed</summary>

![2024-01-10_12-27](https://github.com/wazuh/wazuh/assets/13010397/8b0db951-2759-48c6-b3e6-00d9123442d6)
![2024-01-10_13-08](https://github.com/wazuh/wazuh/assets/13010397/cc09a0bb-35f1-4582-bd55-546df6904c97)
![2024-01-10_13-08_1](https://github.com/wazuh/wazuh/assets/13010397/31f2918f-0ea1-4cd0-be9b-3d992337f739)

</details>

Example logs 

![image](https://github.com/wazuh/wazuh/assets/13010397/aff335bf-7760-41fa-9788-1b7e58a2950f)
![image](https://github.com/wazuh/wazuh/assets/13010397/54dc30db-d39f-4bb3-9953-4ca3c92aba56)
![image](https://github.com/wazuh/wazuh/assets/13010397/fb05f8ac-a838-4c50-a5ef-35a02e2e0a21)

Example alerts  

```json
{
  "assigner": "redhat",
  "cve": "CVE-2023-3428",
  "cvss": {
    "cvss3": {
      "base_score": "5.500000",
      "vector": {
        "availability": "HIGH",
        "confidentiality_impact": "NONE",
        "integrity_impact": "NONE",
        "privileges_required": "NONE",
        "scope": "UNCHANGED",
        "user_interaction": "REQUIRED"
      }
    }
  },
  "cwe_reference": "CWE-787",
  "enumeration": "CVE",
  "package": {
    "architecture": "x86_64",
    "condition": "Package less than 7.1.1-19",
    "name": "ImageMagick",
    "version": "6.9.12.93-2.el9.next"
  },
  "published": "2023-10-04T19:15:10Z",
  "rationale": "A heap-based buffer overflow vulnerability was found  in coders/tiff.c in ImageMagick. This issue may allow a local attacker to trick the user into opening a specially crafted file, resulting in an application crash and denial of service.",
  "reference": "https://bugzilla.redhat.com/show_bug.cgi?id=2218369, https://access.redhat.com/security/cve/CVE-2023-3428",
  "severity": "Medium",
  "status": "Active",
  "title": "CVE-2023-3428 affects ImageMagick",
  "type": "Packages",
  "updated": "2023-10-10T13:10:46Z"
}
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation