### PR TITLE
InventorySync and OsDataCache tests coverage improved

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
@@ -39,6 +39,7 @@ public:
         : m_inventoryDatabase(inventoryDatabase)
     {
     }
+    // LCOV_EXCL_STOP
 
     /**
      * @brief Handles request and passes control to the next step of the chain.
@@ -152,7 +153,6 @@ public:
 
         return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
     }
-    // LCOV_EXCL_STOP
 };
 
 using InventorySync = TInventorySync<>;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
@@ -46,7 +46,6 @@ struct Os final
     std::string kernelRelease;  ///< Release of the kernel operating system.
 };
 
-// LCOV_EXCL_START
 /**
  * @brief OsDataCache class.
  */
@@ -144,5 +143,4 @@ public:
         m_osData.insertKey(agentId, osData);
     }
 };
-// LCOV_EXCL_STOP
 #endif // _OS_DATA_CACHE_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/inventorySync_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/inventorySync_test.cpp
@@ -10,36 +10,121 @@
  */
 
 #include "inventorySync_test.hpp"
+#include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_generated.h"
+#include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_schema.h"
+#include "../../../../shared_modules/utils/flatbuffers/include/syscollector_synchronization_generated.h"
+#include "../../../../shared_modules/utils/flatbuffers/include/syscollector_synchronization_schema.h"
+#include "../scanOrchestrator/inventorySync.hpp"
 #include "MockOsDataCache.hpp"
 #include "TrampolineOsDataCache.hpp"
-#include "flatbuffers/include/syscollector_synchronization_schema.h"
-#include "scanOrchestrator.hpp"
-#include "scanOrchestrator/inventorySync.hpp"
-#include "scanOrchestrator/scanContext.hpp"
-#include "gmock/gmock-matchers.h"
-#include <algorithm>
-#include <memory>
-#include <string>
-#include <vector>
+#include "flatbuffers/flatbuffer_builder.h"
+#include "flatbuffers/flatbuffers.h"
+#include "flatbuffers/idl.h"
+#include "json.hpp"
 
 using ::testing::_;
 
-const std::string INTEGRITY_CLEAR_MSG {
-    R"(
+namespace NSInventorySyncTest
+{
+    constexpr auto TEST_INVENTORY_DATABASE_PATH {"queue/vd/inventory"};
+
+    const std::string DELTA_PACKAGES_INSERTED_MSG =
+        R"(
             {
                 "agent_info": {
-                    "agent_id": "000",
+                    "agent_id": "001",
+                    "agent_ip": "192.168.33.20",
+                    "agent_name": "focal",
+                    "node_name": "node01"
+                },
+                "data_type": "dbsync_packages",
+                "data": {
+                    "architecture": "amd64",
+                    "checksum": "1e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
+                    "description": "library for GIF images library",
+                    "format": "deb",
+                    "groups": "libs",
+                    "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53",
+                    "multiarch": "same",
+                    "name": "libgif7",
+                    "priority": "optional",
+                    "scan_time": "2023/08/04 19:56:11",
+                    "size": 72,
+                    "source": "giflib",
+                    "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+                    "version": "5.1.9-1",
+                    "install_time": "1577890801"
+                },
+                "operation": "INSERTED"
+            }
+        )";
+
+    const std::string DELTA_PACKAGES_DELETED_MSG =
+        R"(
+            {
+                "agent_info": {
+                    "agent_id": "001",
+                    "agent_ip": "192.168.33.20",
+                    "agent_name": "focal",
+                    "node_name": "node01"
+                },
+                "data_type": "dbsync_packages",
+                "data": {
+                    "architecture": "amd64",
+                    "checksum": "1e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
+                    "description": "library for GIF images library",
+                    "format": "deb",
+                    "groups": "libs",
+                    "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53",
+                    "multiarch": "same",
+                    "name": "libgif7",
+                    "priority": "optional",
+                    "scan_time": "2023/08/04 19:56:11",
+                    "size": 72,
+                    "source": "giflib",
+                    "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+                    "version": "5.1.9-1",
+                    "install_time": "1577890801"
+                },
+                "operation": "DELETED"
+            }
+        )";
+
+    const std::string SYNCHRONIZATION_INTEGRITY_CLEAR_MSG =
+        R"(
+            {
+                "agent_info": {
+                    "agent_id": "001",
                     "agent_ip": "192.168.33.20",
                     "agent_name": "focal",
                     "node_name": "node01"
                 },
                 "data_type": "integrity_clear",
                 "data": {
-                    "attributes_type": "syscollector_packages",
-                    "id": 1700236640
+                    "id": 1700236640,
+                    "attributes_type": "syscollector_packages"
                 }
             }
-        )"};
+        )";
+
+    const std::string CVEID1 {"CVE-2024-5678"};
+    const std::string CVEID2 {"CVE-2023-5362"};
+} // namespace NSInventorySyncTest
+
+using namespace NSInventorySyncTest;
+
+void InventorySyncTest::SetUp()
+{
+    m_inventoryDatabase = std::make_unique<Utils::RocksDBWrapper>(TEST_INVENTORY_DATABASE_PATH);
+}
+
+void InventorySyncTest::TearDown()
+{
+    spOsDataCacheMock.reset();
+    m_inventoryDatabase->deleteAll();
+    m_inventoryDatabase.reset();
+    std::filesystem::remove_all(TEST_INVENTORY_DATABASE_PATH);
+}
 
 void InventorySyncTest::SetUp() {}
 
@@ -54,26 +139,19 @@ void InventorySyncTest::TearDown()
 TEST_F(InventorySyncTest, TestInstantiationOfTheInventorySyncClass)
 {
     // Instantiation of the InventorySync class.
-    auto inventoryDatabase = std::make_unique<Utils::RocksDBWrapper>(INVENTORY_DB_PATH);
-    auto& inventorySyncRef = *inventoryDatabase;
-
-    EXPECT_NO_THROW(std::make_shared<TInventorySync<TScanContext<TrampolineOsDataCache>>>(inventorySyncRef));
+    EXPECT_NO_THROW(std::make_shared<TInventorySync<TScanContext<TrampolineOsDataCache>>>(*m_inventoryDatabase));
 }
 
 /*
- * @brief Test handleRequest of the InventorySync class.
+ * @brief Test handleRequest of the InventorySync class (Integrity Clear).
  */
 TEST_F(InventorySyncTest, TestHandleRequestIntegrityClear)
 {
     // Instantiation of the InventorySync class.
-    auto inventoryDatabase = std::make_unique<Utils::RocksDBWrapper>(INVENTORY_DB_PATH);
+    m_inventoryDatabase->put("node01_001_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5",
+                             "CVE-2021-33560,CVE-2019-13627,CVE-2021-40528");
 
-    inventoryDatabase->put("node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5",
-                           "CVE-2021-33560,CVE-2019-13627,CVE-2021-40528");
-
-    auto& inventorySyncRef = *inventoryDatabase;
-
-    auto inventorySync = std::make_shared<TInventorySync<TScanContext<TrampolineOsDataCache>>>(inventorySyncRef);
+    auto inventorySync = std::make_shared<TInventorySync<TScanContext<TrampolineOsDataCache>>>(*m_inventoryDatabase);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -97,31 +175,199 @@ TEST_F(InventorySyncTest, TestHandleRequestIntegrityClear)
     // Mock scanContext.
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
-    ASSERT_TRUE(parser.Parse(INTEGRITY_CLEAR_MSG.c_str()));
+    ASSERT_TRUE(parser.Parse(SYNCHRONIZATION_INTEGRITY_CLEAR_MSG.c_str()));
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorSync =
         SyscollectorSynchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
 
     // Create a ScanContext object.
-    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorSync);
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorSync);
 
     // Call handleRequest method.
-    EXPECT_NO_THROW(inventorySync->handleRequest(scanContext));
+    std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
+    EXPECT_NO_THROW(scanContextResult = inventorySync->handleRequest(scanContextOriginal));
 
-    for (const auto& [key, value] : scanContext->m_elements)
+    EXPECT_EQ(scanContextResult->m_elements.size(), 3);
+    for (const auto& [key, value] : scanContextResult->m_elements)
     {
         EXPECT_THAT(key,
-                    testing::AnyOf(testing::Eq("node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-40528"),
-                                   testing::Eq("node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2019-13627"),
-                                   testing::Eq("node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-33560")));
+                    testing::AnyOf(testing::Eq("node01_001_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-40528"),
+                                   testing::Eq("node01_001_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2019-13627"),
+                                   testing::Eq("node01_001_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-33560")));
         EXPECT_THAT(
             value.dump(),
             testing::AnyOf(
                 testing::Eq(
-                    R"({"id":"node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-40528","operation":"DELETED"})"),
+                    R"({"id":"node01_001_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-40528","operation":"DELETED"})"),
                 testing::Eq(
-                    R"({"id":"node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2019-13627","operation":"DELETED"})"),
+                    R"({"id":"node01_001_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2019-13627","operation":"DELETED"})"),
                 testing::Eq(
-                    R"({"id":"node01_000_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-33560","operation":"DELETED"})")));
+                    R"({"id":"node01_001_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5_CVE-2021-33560","operation":"DELETED"})")));
     }
+
+    std::string inventoryEntry;
+    EXPECT_FALSE(m_inventoryDatabase->get("node01_001_fdbd3c83c04c74d0cc7ad2f0e04ed88adfd74ad5", inventoryEntry));
+}
+
+/*
+ * @brief Test handleRequest of the InventorySync class (Package Insert Non Existing).
+ */
+TEST_F(InventorySyncTest, TestHandleRequestPackageInsertNonExisting)
+{
+    // Instantiation of the InventorySync class.
+    auto inventorySync = std::make_shared<TInventorySync<TScanContext<TrampolineOsDataCache>>>(*m_inventoryDatabase);
+
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "osdata_codeName",
+               .majorVersion = "osdata_majorVersion",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "osdata_platform",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    // Mock scanContext.
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorDelta =
+        SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+
+    // Create a ScanContext object.
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+    scanContextOriginal->m_elements[CVEID1] = nlohmann::json::object(); // Mock one vulnerability
+
+    // Call handleRequest method.
+    std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
+    EXPECT_NO_THROW(scanContextResult = inventorySync->handleRequest(scanContextOriginal));
+
+    std::string inventoryEntry;
+    EXPECT_TRUE(m_inventoryDatabase->get("node01_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53", inventoryEntry));
+
+    EXPECT_STREQ(inventoryEntry.c_str(), CVEID1.c_str());
+}
+
+/*
+ * @brief Test handleRequest of the InventorySync class (Package Insert Already Existing).
+ */
+TEST_F(InventorySyncTest, TestHandleRequestPackageInsertAlreadyExisting)
+{
+    // Instantiation of the InventorySync class.
+    m_inventoryDatabase->put("node01_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53", CVEID2);
+
+    auto inventorySync = std::make_shared<TInventorySync<TScanContext<TrampolineOsDataCache>>>(*m_inventoryDatabase);
+
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "osdata_codeName",
+               .majorVersion = "osdata_majorVersion",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "osdata_platform",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    // Mock scanContext.
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorDelta =
+        SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+
+    // Create a ScanContext object.
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+    scanContextOriginal->m_elements[CVEID1] = nlohmann::json::object(); // Mock one vulnerability
+
+    // Call handleRequest method.
+    std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
+    EXPECT_NO_THROW(scanContextResult = inventorySync->handleRequest(scanContextOriginal));
+
+    std::string inventoryEntry;
+    EXPECT_TRUE(m_inventoryDatabase->get("node01_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53", inventoryEntry));
+
+    auto listCve = Utils::split(inventoryEntry, ',');
+    EXPECT_EQ(listCve.size(), 2);
+    for (const auto& key : listCve)
+    {
+        EXPECT_THAT(key, testing::AnyOf(testing::Eq(CVEID1.c_str()), testing::Eq(CVEID2.c_str())));
+    }
+}
+
+/*
+ * @brief Test handleRequest of the InventorySync class (Package Delete).
+ */
+TEST_F(InventorySyncTest, TestHandleRequestPackageDelete)
+{
+    // Instantiation of the InventorySync class.
+    m_inventoryDatabase->put("node01_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53", CVEID1);
+
+    auto inventorySync = std::make_shared<TInventorySync<TScanContext<TrampolineOsDataCache>>>(*m_inventoryDatabase);
+
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "osdata_codeName",
+               .majorVersion = "osdata_majorVersion",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "osdata_platform",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    // Mock scanContext.
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_DELETED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorDelta =
+        SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+
+    // Create a ScanContext object.
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+
+    // Call handleRequest method.
+    std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
+    EXPECT_NO_THROW(scanContextResult = inventorySync->handleRequest(scanContextOriginal));
+
+    EXPECT_EQ(scanContextResult->m_elements.size(), 1);
+
+    std::string expectedKey = "node01_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_" + CVEID1;
+    std::unordered_map<std::string, nlohmann::json>::const_iterator itElement;
+    EXPECT_NE(itElement = scanContextResult->m_elements.find(expectedKey), scanContextResult->m_elements.end());
+
+    std::string expectedValue =
+        R"({"id":"node01_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_)" + CVEID1 + R"(","operation":"DELETED"})";
+    EXPECT_STREQ(itElement->second.dump().c_str(), expectedValue.c_str());
+
+    std::string inventoryEntry;
+    EXPECT_FALSE(m_inventoryDatabase->get("node01_001_ec465b7eb5fa011a336e95614072e4c7f1a65a53", inventoryEntry));
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/inventorySync_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/inventorySync_test.cpp
@@ -126,13 +126,6 @@ void InventorySyncTest::TearDown()
     std::filesystem::remove_all(TEST_INVENTORY_DATABASE_PATH);
 }
 
-void InventorySyncTest::SetUp() {}
-
-void InventorySyncTest::TearDown()
-{
-    spOsDataCacheMock.reset();
-}
-
 /*
  * @brief Test instantiation of the InventorySync class.
  */

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/inventorySync_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/inventorySync_test.hpp
@@ -12,6 +12,7 @@
 #ifndef _INVENTORY_SYNC_TEST_HPP
 #define _INVENTORY_SYNC_TEST_HPP
 
+#include "rocksDBWrapper.hpp"
 #include "gtest/gtest.h"
 
 /**
@@ -21,17 +22,23 @@ class InventorySyncTest : public ::testing::Test
 {
 protected:
     // LCOV_EXCL_START
+    /**
+     * @brief RocksDB inventory database instance.
+     *
+     */
+    std::unique_ptr<Utils::RocksDBWrapper> m_inventoryDatabase;
+
     InventorySyncTest() = default;
     ~InventorySyncTest() override = default;
 
     /**
-     * @brief Set the environment for testing.
+     * @brief Set up for every test.
      *
      */
     void SetUp() override;
 
     /**
-     * @brief Clean the environment after testing.
+     * @brief Tear down for every test.
      *
      */
     void TearDown() override;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21222 |

## Description

This PR adds tests to InventorySync and OsDataCache classes.
The code coverage of these 2 classes is improved.
![image](https://github.com/wazuh/wazuh/assets/101227434/e6c0d949-a8fb-43cf-b858-c30c3aa276e3)

## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Run UTs successfully
- [ ] Run Manual tests