### PR TITLE
Fix compilation in debug mode, avoid the address sanitizer enforcement

### DIFF
--- a/src/shared_modules/content_manager/testtool/CMakeLists.txt
+++ b/src/shared_modules/content_manager/testtool/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12.4)
 
+if (FSANITIZE)
 set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
+endif()
 
 project(content_manager_test_tool)
 

--- a/src/shared_modules/indexer_connector/testtool/CMakeLists.txt
+++ b/src/shared_modules/indexer_connector/testtool/CMakeLists.txt
@@ -10,7 +10,9 @@ file(GLOB INDEXER_CONNECTOR_TOOL_SRC
     )
 
 # Add address sanitizer
+if(FSANITIZE)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer")
+endif()
 
 add_executable(indexer_connector_tool
     ${INDEXER_CONNECTOR_TOOL_SRC}

--- a/src/shared_modules/router/testtool/CMakeLists.txt
+++ b/src/shared_modules/router/testtool/CMakeLists.txt
@@ -3,7 +3,9 @@ cmake_minimum_required(VERSION 3.12.4)
 project(router_test_tool)
 
 # Use fsanitize for debug build
+if (FSANITIZE)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address,undefined -fno-omit-frame-pointer")
+endif()
 
 enable_testing()
 

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.12.4)
 project(database_feed_manager_testtool)
 
+if(FSANITIZE)
 set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
+endif()
 
 link_directories(${SRC_FOLDER}/external/curl/lib/.libs/)
 

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.12.4)
 project(rocks_db_query_testtool)
 
+if(FSANITIZE)
 set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
+endif()
 
 file(GLOB ROCKS_DB_QUERY_TESTTOOL_SRC
     "*.cpp"

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12.4)
 
+if(FSANITIZE)
 set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
+endif()
 
 file(GLOB VD_SCANNER_TESTTOOL_SRC
     "*.cpp"

--- a/src/wazuh_modules/vulnerability_scanner/testtool/versionMatcher/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/versionMatcher/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.12.4)
 project(version_matcher_testtool)
 
+if(FSANITIZE)
 set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
+endif()
 
 link_directories(${SRC_FOLDER}/external/curl/lib/.libs/)
 

--- a/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/wazuhDBQuery/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.12.4)
 project(wazuh_db_query_testtool)
 
+if(FSANITIZE)
 set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
+endif()
 
 file(GLOB WAZUH_DB_QUERY_TESTTOOL_SRC
     "*.cpp"


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21332|

## Description

This PR aims to fix some problems encountered during the package creation with the debug flag enabled.