### PR TITLE
UTs added to ResultIndexer class

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/resultIndexer.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/resultIndexer.hpp
@@ -12,7 +12,6 @@
 #ifndef _RESULT_INDEXER_HPP
 #define _RESULT_INDEXER_HPP
 
-#include "../policyManager/policyManager.hpp"
 #include "chainOfResponsability.hpp"
 #include "indexerConnector.hpp"
 #include "scanContext.hpp"
@@ -20,11 +19,14 @@
 /**
  * @brief ResultIndexer class.
  *
+ * @tparam TIndexerConnector indexer connector type.
+ * @tparam TScanContext scan context type.
  */
-class ResultIndexer final : public AbstractHandler<std::shared_ptr<ScanContext>>
+template<typename TIndexerConnector = IndexerConnector, typename TScanContext = ScanContext>
+class TResultIndexer final : public AbstractHandler<std::shared_ptr<TScanContext>>
 {
 private:
-    std::shared_ptr<IndexerConnector> m_indexerConnector;
+    std::shared_ptr<TIndexerConnector> m_indexerConnector;
 
 public:
     // LCOV_EXCL_START
@@ -33,18 +35,19 @@ public:
      *
      * @param indexerConnector Indexer connector.
      */
-    explicit ResultIndexer(std::shared_ptr<IndexerConnector> indexerConnector)
-        : m_indexerConnector(std::move(indexerConnector))
+    explicit TResultIndexer(std::shared_ptr<TIndexerConnector>& indexerConnector)
+        : m_indexerConnector(indexerConnector)
     {
     }
+    // LCOV_EXCL_STOP
 
     /**
      * @brief Handles request and passes control to the next step of the chain.
      *
      * @param data Scan context.
-     * @return std::shared_ptr<ScanContext> Abstract handler.
+     * @return std::shared_ptr<TScanContext> Abstract handler.
      */
-    std::shared_ptr<ScanContext> handleRequest(std::shared_ptr<ScanContext> data) override
+    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
     {
         if (m_indexerConnector != nullptr)
         {
@@ -54,9 +57,10 @@ public:
                 m_indexerConnector->publish(value.dump());
             }
         }
-        return AbstractHandler<std::shared_ptr<ScanContext>>::handleRequest(std::move(data));
+        return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
     }
-    // LCOV_EXCL_STOP
 };
+
+using ResultIndexer = TResultIndexer<>;
 
 #endif // _RESULT_INDEXER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/resultIndexer.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/resultIndexer.hpp
@@ -35,8 +35,8 @@ public:
      *
      * @param indexerConnector Indexer connector.
      */
-    explicit TResultIndexer(std::shared_ptr<TIndexerConnector>& indexerConnector)
-        : m_indexerConnector(indexerConnector)
+    explicit TResultIndexer(std::shared_ptr<TIndexerConnector> indexerConnector)
+        : m_indexerConnector(std::move(indexerConnector))
     {
     }
     // LCOV_EXCL_STOP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/resultIndexer_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/resultIndexer_test.cpp
@@ -10,23 +10,111 @@
  */
 
 #include "resultIndexer_test.hpp"
-#include "scanOrchestrator/resultIndexer.hpp"
-#include "scanOrchestrator/scanContext.hpp"
-#include <algorithm>
-#include <memory>
-#include <string>
-#include <vector>
+#include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_generated.h"
+#include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_schema.h"
+#include "MockIndexerConnector.hpp"
+#include "MockOsDataCache.hpp"
+#include "TrampolineOsDataCache.hpp"
+#include "TrampolineIndexerConnector.hpp"
+#include "flatbuffers/flatbuffer_builder.h"
+#include "flatbuffers/flatbuffers.h"
+#include "flatbuffers/idl.h"
+#include "json.hpp"
+#include "../scanOrchestrator/resultIndexer.hpp"
+#include "../scanOrchestrator/scanContext.hpp"
 
-/*
- * @brief Test instantiation of the ResultIndexer class.
- */
-TEST_F(ResultIndexerTest, TestInstantiationOfTheResultIndexerClass)
+using ::testing::_;
+
+namespace NSResultIndexerTest
 {
-    // Instantiation of the ResultIndexer class.
-    // EXPECT_NO_THROW(std::make_shared<ResultIndexer>());
+    const std::string DELTA_PACKAGES_INSERTED_MSG =
+        R"(
+            {
+                "agent_info": {
+                    "agent_id": "001",
+                    "agent_ip": "192.168.33.20",
+                    "agent_name": "focal",
+                    "node_name": "node01"
+                },
+                "data_type": "dbsync_packages",
+                "data": {
+                    "architecture": "amd64",
+                    "checksum": "1e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
+                    "description": "library for GIF images library",
+                    "format": "deb",
+                    "groups": "libs",
+                    "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53",
+                    "multiarch": "same",
+                    "name": "libgif7",
+                    "priority": "optional",
+                    "scan_time": "2023/08/04 19:56:11",
+                    "size": 72,
+                    "source": "giflib",
+                    "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+                    "version": "5.1.9-1",
+                    "install_time": "1577890801"
+                },
+                "operation": "INSERTED"
+            }
+        )";
+
+    const std::string CVEID {"CVE-2024-1234"};
+} // namespace NSResultIndexerTest
+
+using namespace NSResultIndexerTest;
+
+// External shared pointers definitions
+extern std::shared_ptr<MockIndexerConnector> spIndexerConnectorMock;
+
+void ResultIndexerTest::SetUp() {}
+
+void ResultIndexerTest::TearDown()
+{
+    spIndexerConnectorMock.reset();
+    spOsDataCacheMock.reset();
 }
 
 /*
  * @brief Test handleRequest of the ResultIndexer class.
  */
-TEST_F(ResultIndexerTest, TestHandleRequest) {}
+TEST_F(ResultIndexerTest, TestHandleRequest)
+{
+    auto elementValue = nlohmann::json::parse(R"({"key_test": "value_test"})");
+
+    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+    EXPECT_CALL(*spIndexerConnectorMock, publish(elementValue.dump())).Times(1);
+
+    auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
+
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "osdata_codeName",
+               .majorVersion = "osdata_majorVersion",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "osdata_platform",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorDelta =
+        SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+    scanContextOriginal->m_elements[CVEID] = elementValue; // Mock one vulnerability
+
+    auto spResultIndexer = std::make_shared<TResultIndexer<TrampolineIndexerConnector, TScanContext<TrampolineOsDataCache>>>(pIndexerConnectorTrap);
+
+    EXPECT_NO_THROW(spResultIndexer->handleRequest(scanContextOriginal));
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/resultIndexer_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/resultIndexer_test.cpp
@@ -12,16 +12,16 @@
 #include "resultIndexer_test.hpp"
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_generated.h"
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_schema.h"
+#include "../scanOrchestrator/resultIndexer.hpp"
+#include "../scanOrchestrator/scanContext.hpp"
 #include "MockIndexerConnector.hpp"
 #include "MockOsDataCache.hpp"
-#include "TrampolineOsDataCache.hpp"
 #include "TrampolineIndexerConnector.hpp"
+#include "TrampolineOsDataCache.hpp"
 #include "flatbuffers/flatbuffer_builder.h"
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "json.hpp"
-#include "../scanOrchestrator/resultIndexer.hpp"
-#include "../scanOrchestrator/scanContext.hpp"
 
 using ::testing::_;
 
@@ -62,9 +62,6 @@ namespace NSResultIndexerTest
 } // namespace NSResultIndexerTest
 
 using namespace NSResultIndexerTest;
-
-// External shared pointers definitions
-extern std::shared_ptr<MockIndexerConnector> spIndexerConnectorMock;
 
 void ResultIndexerTest::SetUp() {}
 
@@ -114,7 +111,9 @@ TEST_F(ResultIndexerTest, TestHandleRequest)
     auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
     scanContextOriginal->m_elements[CVEID] = elementValue; // Mock one vulnerability
 
-    auto spResultIndexer = std::make_shared<TResultIndexer<TrampolineIndexerConnector, TScanContext<TrampolineOsDataCache>>>(pIndexerConnectorTrap);
+    auto spResultIndexer =
+        std::make_shared<TResultIndexer<TrampolineIndexerConnector, TScanContext<TrampolineOsDataCache>>>(
+            pIndexerConnectorTrap);
 
     EXPECT_NO_THROW(spResultIndexer->handleRequest(scanContextOriginal));
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/resultIndexer_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/resultIndexer_test.hpp
@@ -23,6 +23,18 @@ protected:
     // LCOV_EXCL_START
     ResultIndexerTest() = default;
     ~ResultIndexerTest() override = default;
+
+    /**
+     * @brief Set the environment for testing.
+     *
+     */
+    void SetUp() override;
+
+    /**
+     * @brief Clean the environment after testing.
+     *
+     */
+    void TearDown() override;
     // LCOV_EXCL_STOP
 };
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21225 |

## Description

This PR adds tests to ResultIndexer class.
The code coverage of this class is improved.
![image](https://github.com/wazuh/wazuh/assets/101227434/e07f6fa6-16cf-4709-bc43-753ebb9a0643)

## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Run UTs successfully
- [ ] Run Manual tests