### PR TITLE
Introducing std::unordered_map for Matching Package Formats to Corresponding `VersionObjectType`

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -68,9 +68,10 @@ public:
                 std::string versionStringLessThanOrEqual {version->lessThanOrEqual() ? version->lessThanOrEqual()->str()
                                                                                      : ""};
                 VersionObjectType objectType = VersionObjectType::Unspecified;
-                if (m_mapVendors.find(data->packageFormat()) != m_mapVendors.end())
+                const auto it = m_mapVendors.find(data->packageFormat());
+                if (it != m_mapVendors.end())
                 {
-                    objectType = m_mapVendors.at(data->packageFormat());
+                    objectType = it->second;
                 }
 
                 logDebug2(WM_VULNSCAN_LOGTAG,

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -26,6 +26,8 @@ class PackageScanner final : public AbstractHandler<std::shared_ptr<ScanContext>
 {
 private:
     std::shared_ptr<DatabaseFeedManager> m_databaseFeedManager;
+    std::unordered_map<std::string_view, VersionObjectType> m_mapVendors {{"deb", VersionObjectType::DPKG},
+                                                                          {"rpm", VersionObjectType::RPM}};
 
 public:
     // LCOV_EXCL_START
@@ -65,6 +67,11 @@ public:
                 std::string versionStringLessThan {version->lessThan() ? version->lessThan()->str() : ""};
                 std::string versionStringLessThanOrEqual {version->lessThanOrEqual() ? version->lessThanOrEqual()->str()
                                                                                      : ""};
+                VersionObjectType objectType = VersionObjectType::Unspecified;
+                if (m_mapVendors.find(data->packageFormat()) != m_mapVendors.end())
+                {
+                    objectType = m_mapVendors.at(data->packageFormat());
+                }
 
                 logDebug2(WM_VULNSCAN_LOGTAG,
                           "Scanning package - '%s' (Installed Version: %s, Security Vulnerability: %s). Identified "
@@ -79,7 +86,7 @@ public:
 
                 if (versionStringLessThan.empty() && versionStringLessThanOrEqual.empty())
                 {
-                    if (VersionMatcher::compare(packageVersion, versionString) == 0)
+                    if (VersionMatcher::compare(packageVersion, versionString, objectType) == 0)
                     {
                         if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                         {
@@ -109,12 +116,12 @@ public:
                 else
                 {
                     if ((versionString.compare("0") == 0 ||
-                         VersionMatcher::compare(packageVersion, versionString) >= 0))
+                         VersionMatcher::compare(packageVersion, versionString, objectType) >= 0))
                     {
                         if (((!versionStringLessThan.empty() && versionStringLessThan.compare("*") != 0 &&
-                              VersionMatcher::compare(packageVersion, versionStringLessThan) < 0) ||
+                              VersionMatcher::compare(packageVersion, versionStringLessThan, objectType) < 0) ||
                              (!versionStringLessThanOrEqual.empty() &&
-                              VersionMatcher::compare(packageVersion, versionStringLessThanOrEqual) <= 0)))
+                              VersionMatcher::compare(packageVersion, versionStringLessThanOrEqual, objectType) <= 0)))
                         {
                             if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                             {


### PR DESCRIPTION
|Related issue|
|---|
|#21234|
|#21239|

## Objective
This pull request addresses a critical development task focused on optimizing and enhancing the efficiency of the system's package handling. The primary objective is to introduce a `std::unordered_map` data structure designed to efficiently map package formats to their respective `VersionObjectType`. This improvement streamlines the lookup process and facilitates faster and more efficient mapping, contributing to overall performance enhancements within the system.


## Description
-  The primary purpose of introducing the `std::unordered_map` is to replace existing, potentially less efficient methods of package format mapping. The map enables quick and direct lookup, eliminating unnecessary overhead and improving the overall performance of package handling.
- Enhances code readability by centralizing and formalizing the mapping of package formats to `VersionObjectType`.
- Provides a scalable and maintainable solution for incorporating additional package formats in the future.

## Quality Assurance
No new tests have been added to validate the quality of this implementation


<details><summary>ScanBuild report</summary>

Command:

```bash
scan-build-15 -enable-checker alpha.core.CastSize -enable-checker alpha.core.CastToStruct -enable-checker alpha.core.Conversion -enable-checker alpha.core.IdenticalExpr -enable-checker alpha.core.SizeofPtr -enable-checker alpha.core.TestAfterDivZero --exclude external make TARGET=server DEBUG=1 -j$(nproc)
```

```bash

Done building server

scan-build: No bugs found.

```

</details>

<details><summary>Clang-Format</summary>

```bash
---------------------------------
PASSED: Clang-format check passed
---------------------------------
```
</details>


## Exploratory tests

### Setup
- Clone this branch 
- Compile with `TARGET=server`
- Install manager
- Set `wazuh_modules.debug=2` and restart manager
- Optional: Install indexer and dashboard
- Connect an agent to the manager
- Wait until the scan ends

<details><summary>Show log</summary>

```text
2024/01/10 21:05:55 wazuh-modulesd:vulnerability-scanner[73821] packageScanner.hpp:128 at operator()(): INFO: Match found, the package 'procps', is vulnerable to 'CVE-2023-4016'. Current version: '2:3.3.17-6ubuntu2.1' (less than '2:4.0.3-1ubuntu1.23.04.1' or equal to ''). - Agent 'agent_ubuntu_22' (ID: '002', Version: '').
2024/01/10 21:05:57 wazuh-modulesd:vulnerability-scanner[73821] packageScanner.hpp:128 at operator()(): INFO: Match found, the package 'tar', is vulnerable to 'CVE-2022-48303'. Current version: '1.34+dfsg-1ubuntu0.1.22.04.2' (less than '1.34+dfsg-1ubuntu0.1.22.10.1' or equal to ''). - Agent 'agent_ubuntu_22' (ID: '002', Version: '').
2024/01/10 21:05:57 wazuh-modulesd:vulnerability-scanner[73821] packageScanner.hpp:128 at operator()(): INFO: Match found, the package 'util-linux', is vulnerable to 'CVE-2021-3995'. Current version: '2.37.2-4ubuntu3' (less than '2.37.3-1' or equal to ''). - Agent 'agent_ubuntu_22' (ID: '002', Version: '').
2024/01/10 21:05:57 wazuh-modulesd:vulnerability-scanner[73821] packageScanner.hpp:128 at operator()(): INFO: Match found, the package 'util-linux', is vulnerable to 'CVE-2021-3996'. Current version: '2.37.2-4ubuntu3' (less than '2.37.3-1' or equal to ''). - Agent 'agent_ubuntu_22' (ID: '002', Version: '').
2024/01/10 21:05:57 wazuh-modulesd:vulnerability-scanner[73821] packageScanner.hpp:128 at operator()(): INFO: Match found, the package 'libcap2', is vulnerable to 'CVE-2023-2602'. Current version: '1:2.44-1ubuntu0.22.04.1' (less than '1:2.44-1ubuntu0.22.10.1' or equal to ''). - Agent 'agent_ubuntu_22' (ID: '002', Version: '').
2024/01/10 21:05:57 wazuh-modulesd:vulnerability-scanner[73821] packageScanner.hpp:128 at operator()(): INFO: Match found, the package 'libcap2', is vulnerable to 'CVE-2023-2603'. Current version: '1:2.44-1ubuntu0.22.04.1' (less than '1:2.44-1ubuntu0.22.10.1' or equal to ''). - Agent 'agent_ubuntu_22' (ID: '002', Version: '').
2024/01/10 21:06:00 wazuh-modulesd:vulnerability-scanner[73821] packageScanner.hpp:128 at operator()(): INFO: Match found, the package 'bash', is vulnerable to 'CVE-2022-3715'. Current version: '5.1-6ubuntu1' (less than '5.2' or equal to ''). - Agent 'agent_ubuntu_22' (ID: '002', Version: '').
2024/01/10 21:06:02 wazuh-modulesd:vulnerability-scanner[73821] packageScanner.hpp:128 at operator()(): INFO: Match found, the package 'dpkg', is vulnerable to 'CVE-2022-1664'. Current version: '1.21.1ubuntu2.2' (less than '1.21.9ubuntu1' or equal to ''). - Agent 'agent_ubuntu_22' (ID: '002', Version: '').
2024/01/10 21:06:06 wazuh-modulesd:vulnerability-scanner[73821] packageScanner.hpp:128 at operator()(): INFO: Match found, the package 'python3.10', is vulnerable to 'CVE-2023-40217'. Current version: '3.10.12-1~22.04.3' (less than '3.10.13-1' or equal to ''). - Agent 'agent_ubuntu_22' (ID: '002', Version: '').
2024/01/10 21:06:06 wazuh-modulesd:vulnerability-scanner[73821] packageScanner.hpp:128 at operator()(): INFO: Match found, the package 'libtasn1-6', is vulnerable to 'CVE-2021-46848'. Current version: '4.18.0-4build1' (less than '4.19.0-2' or equal to ''). - Agent 'agent_ubuntu_22' (ID: '002', Version: '').
```

</details>

<details><summary>Show dashboard for agent Ubuntu22</summary>

![image](https://github.com/wazuh/wazuh/assets/27935340/2f4f409b-28a2-4c4a-8833-0131170b9354)

</details>

<details><summary>Show testtool output</summary>

```bash
 ./src/build/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_scanner_testtool -c src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.json -t src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json -i src/wazuh_modules/vulnerability_scanner/testtool/scanner/file1.json 
```

```text
indexer-connnector:indexerConnector.cpp:191 operator() : Error initializing IndexerConnector: Couldn't connect to server, we will try again after 4 seconds.
wazuh-modulesd:vulnerability-scanner:osDataCache.hpp:129 getOsData : Error quering Wazuh-DB: Timeout waiting for DB response
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:53 handleRequest : Initiating a vulnerability scan for package 'wazuh' on Agent '' (ID: '001', Version: '').
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:191 handleRequest : Initiating a vulnerability scan for package 'wazuh' with CVE Numbering Authorities (CNA) 'nvd' on Agent '' (ID: '001', Version: '').
=== TMP DEBUG === Match deb/rpm in m_mapVendors
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:77 operator() : Scanning package - 'wazuh' (Installed Version: 4.2.0, Security Vulnerability: CVE-2018-19666). Identified vulnerability: Version: 1.0.0. Required Version Threshold: . Required Version Threshold (or Equal): 2.1.1.
=== TMP DEBUG === Match deb/rpm in m_mapVendors
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:77 operator() : Scanning package - 'wazuh' (Installed Version: 4.2.0, Security Vulnerability: CVE-2021-26814). Identified vulnerability: Version: 4.0.0. Required Version Threshold: . Required Version Threshold (or Equal): 4.0.3.
=== TMP DEBUG === Match deb/rpm in m_mapVendors
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:77 operator() : Scanning package - 'wazuh' (Installed Version: 4.2.0, Security Vulnerability: CVE-2021-41821). Identified vulnerability: Version: 0. Required Version Threshold: . Required Version Threshold (or Equal): 4.1.5.
=== TMP DEBUG === Match deb/rpm in m_mapVendors
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:77 operator() : Scanning package - 'wazuh' (Installed Version: 4.2.0, Security Vulnerability: CVE-2021-44079). Identified vulnerability: Version: 4.2.0. Required Version Threshold: 4.2.5. Required Version Threshold (or Equal): .
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:129 operator() : Match found, the package 'wazuh', is vulnerable to 'CVE-2021-44079'. Current version: '4.2.0' (less than '4.2.5' or equal to ''). - Agent '' (ID: '001', Version: '').
=== TMP DEBUG === Match deb/rpm in m_mapVendors
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:77 operator() : Scanning package - 'wazuh' (Installed Version: 4.2.0, Security Vulnerability: CVE-2022-40497). Identified vulnerability: Version: 3.6.1. Required Version Threshold: . Required Version Threshold (or Equal): 3.13.5.
=== TMP DEBUG === Match deb/rpm in m_mapVendors
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:77 operator() : Scanning package - 'wazuh' (Installed Version: 4.2.0, Security Vulnerability: CVE-2022-40497). Identified vulnerability: Version: 4.0.0. Required Version Threshold: . Required Version Threshold (or Equal): 4.2.7.
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:129 operator() : Match found, the package 'wazuh', is vulnerable to 'CVE-2022-40497'. Current version: '4.2.0' (less than '' or equal to '4.2.7'). - Agent '' (ID: '001', Version: '').
wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:215 handleRequest : Vulnerability scan for package 'wazuh' on Agent '001' has completed.
wazuh-modulesd:vulnerability-scanner:sendReport.hpp:66 handleRequest : Vulnerability detected report for agent ID 001, package: wazuh, cve: CVE-2022-40497
Failed to send message: Error sending data to socket: 107 Transport endpoint is not connected
Error modifying FD from interface.
```

</details>




### Check summary
- [x] Style and quality of SCA.
- [x] Documentation clear.
- [x] Functionality optimizated.
