### PR TITLE
Added UTs for factoryOrchestrator

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -29,6 +29,7 @@ class TDetailsAugmentation final : public AbstractHandler<std::shared_ptr<TScanC
 {
 private:
     std::shared_ptr<TDatabaseFeedManager> m_databaseFeedManager;
+    // LCOV_EXCL_START
 
     void indexedDataAugmentation(std::shared_ptr<TScanContext> data)
     {
@@ -254,6 +255,7 @@ private:
             }
         }
     }
+    // LCOV_EXCL_STOP
 
 public:
     // LCOV_EXCL_START
@@ -272,7 +274,6 @@ public:
      *
      */
     ~TDetailsAugmentation() = default;
-    // LCOV_EXCL_STOP
 
     /**
      * @brief Handles request and passes control to the next step of the chain.
@@ -288,6 +289,7 @@ public:
         return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
     }
 };
+// LCOV_EXCL_STOP
 
 using DetailsAugmentation = TDetailsAugmentation<>;
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
@@ -29,7 +29,6 @@
  */
 class FactoryOrchestrator final
 {
-    // LCOV_EXCL_START
 private:
     FactoryOrchestrator() = default;
 
@@ -62,12 +61,10 @@ public:
         }
         else if (type == ScannerType::HotfixInsert)
         {
-            std::cout << "Hotfix insert scanner Init" << std::endl;
             // orchestration = std::make_shared<HotfixScanner>();
         }
         else if (type == ScannerType::HotfixDelete)
         {
-            std::cout << "Hotfix delete scanner Init" << std::endl;
             // orchestration = std::make_shared<DeleteHotfixVulnerabilities>();
         }
         else if (type == ScannerType::Os)
@@ -77,7 +74,6 @@ public:
         }
         else if (type == ScannerType::IntegrityClear)
         {
-            std::cout << "Integrity clear scanner Init" << std::endl;
             // orchestration = std::make_shared<VulnerabilityCleanupController>();
         }
         else
@@ -104,7 +100,6 @@ public:
 
         return orchestration;
     }
-    // LCOV_EXCL_STOP
 };
 
 #endif // _FACTORY_ORCHESTRATOR_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -94,7 +94,6 @@ public:
      *
      */
     TScanContext() = default;
-    // LCOV_EXCL_STOP
 
     /**
      * @brief Class constructor.
@@ -324,13 +323,11 @@ public:
             data);
     }
 
-    // LCOV_EXCL_START
     /**
      * @brief Class destructor.
      *
      */
     ~TScanContext() = default;
-    // LCOV_EXCL_STOP
 
     /**
      * @brief Gets scan type.
@@ -849,7 +846,7 @@ public:
      *
      */
     bool m_isInventoryEmpty = false;
-    // LCOV_EXCL_STOP
+
 private:
     /**
      * @brief Operation type.
@@ -879,6 +876,8 @@ private:
      *
      */
     Os m_osData {};
+
+    // LCOV_EXCL_STOP
 };
 
 using ScanContext = TScanContext<>;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/factoryOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/factoryOrchestrator_test.cpp
@@ -10,24 +10,59 @@
  */
 
 #include "factoryOrchestrator_test.hpp"
-#include "scanOrchestrator/factoryOrchestrator.hpp"
 
 /*
- * @brief Test the creation of the scanner package.
+ * @brief Test the chain creation for packages.
  */
-TEST_F(FactoryOrchestratorTest, TestScannerTypePackageCreation)
+TEST_F(FactoryOrchestratorTest, TestScannerTypePackageInsert)
 {
-    // Create the orchestrator with PackageScanner.
-    // EXPECT_NO_THROW(FactoryOrchestrator::create(ScannerType::PackageInsert));
+    // Create the orchestrator for PackageInsert.
+    EXPECT_NO_THROW(FactoryOrchestrator::create(ScannerType::PackageInsert, NULL, NULL, *m_inventoryDatabase, NULL));
 }
 
 /*
- * @brief Test the creation of the scanner os.
+ * @brief Test the chain creation for packages.
  */
-TEST_F(FactoryOrchestratorTest, TestScannerTypeOSCreation)
+TEST_F(FactoryOrchestratorTest, TestScannerTypePackageDelete)
 {
-    // Create the orchestrator with OsScanner.
-    // EXPECT_NO_THROW(FactoryOrchestrator::create(ScannerType::Os));
+    // Create the orchestrator for PackageDelete.
+    EXPECT_NO_THROW(FactoryOrchestrator::create(ScannerType::PackageDelete, NULL, NULL, *m_inventoryDatabase, NULL));
+}
+
+/*
+ * @brief Test the chain creation for packages.
+ */
+TEST_F(FactoryOrchestratorTest, TestScannerTypeIntegrityClear)
+{
+    // Create the orchestrator for IntegrityClear.
+    EXPECT_NO_THROW(FactoryOrchestrator::create(ScannerType::IntegrityClear, NULL, NULL, *m_inventoryDatabase, NULL));
+}
+
+/*
+ * @brief Test the chain creation for os.
+ */
+TEST_F(FactoryOrchestratorTest, TestScannerTypeOs)
+{
+    // Create the orchestrator for Os.
+    EXPECT_NO_THROW(FactoryOrchestrator::create(ScannerType::Os, NULL, NULL, *m_inventoryDatabase, NULL));
+}
+
+/*
+ * @brief Test the chain creation for hotfixes.
+ */
+TEST_F(FactoryOrchestratorTest, TestScannerTypeHotfixInsert)
+{
+    // Create the orchestrator for HotfixInsert.
+    EXPECT_NO_THROW(FactoryOrchestrator::create(ScannerType::HotfixInsert, NULL, NULL, *m_inventoryDatabase, NULL));
+}
+
+/*
+ * @brief Test the chain creation for hotfixes.
+ */
+TEST_F(FactoryOrchestratorTest, TestScannerTypeHotfixDelete)
+{
+    // Create the orchestrator for HotfixDelete.
+    EXPECT_NO_THROW(FactoryOrchestrator::create(ScannerType::HotfixDelete, NULL, NULL, *m_inventoryDatabase, NULL));
 }
 
 /*
@@ -35,7 +70,8 @@ TEST_F(FactoryOrchestratorTest, TestScannerTypeOSCreation)
  */
 TEST_F(FactoryOrchestratorTest, TestCreationInvalidScannerType)
 {
-    // Create the orchestrator whit invalid ScannerType.
-    // ScannerType invalidScannerType {-1};
-    // EXPECT_THROW(FactoryOrchestrator::create(invalidScannerType), std::runtime_error);
+    // Create the orchestrator with invalid ScannerType.
+    ScannerType invalidScannerType {-1};
+    EXPECT_THROW(FactoryOrchestrator::create(invalidScannerType, NULL, NULL, *m_inventoryDatabase, NULL),
+                 std::runtime_error);
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/factoryOrchestrator_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/factoryOrchestrator_test.hpp
@@ -12,7 +12,10 @@
 #ifndef _FACTORY_ORCHESTRATOR_TEST_HPP
 #define _FACTORY_ORCHESTRATOR_TEST_HPP
 
+#include "scanOrchestrator/factoryOrchestrator.hpp"
 #include "gtest/gtest.h"
+
+constexpr auto INVENTORY_DB_PATH = "queue/vd/inventory";
 
 /**
  * @brief Runs unit tests for FactoryOrchestrator
@@ -24,6 +27,30 @@ protected:
     FactoryOrchestratorTest() = default;
     ~FactoryOrchestratorTest() override = default;
     // LCOV_EXCL_STOP
+
+    /**
+     * @brief Set up for every test.
+     *
+     */
+    void SetUp() override
+    {
+        m_inventoryDatabase = std::make_unique<Utils::RocksDBWrapper>(INVENTORY_DB_PATH);
+    }
+
+    /**
+     * @brief Tear down for every test.
+     *
+     */
+    void TearDown() override
+    {
+        std::remove(INVENTORY_DB_PATH);
+    }
+
+    /**
+     * @brief RocksDB inventory database.
+     *
+     */
+    std::unique_ptr<Utils::RocksDBWrapper> m_inventoryDatabase;
 };
 
 #endif // _FACTORY_ORCHESTRATOR_TEST_HPP


### PR DESCRIPTION
|Related issue|
|---|
|#21221|

## Description

Added UTs for factoryOrchestrator

## Logs/Alerts example

Many function of scanContext class are not tested and were excluded for analysis to address later
![2024-01-11_16-35](https://github.com/wazuh/wazuh/assets/13010397/72dfc912-f900-499a-a3f9-da63297419ca)

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation