### PR TITLE
Add UTs coverage for Publisher class on router module

### DIFF
--- a/src/shared_modules/router/src/publisher.hpp
+++ b/src/shared_modules/router/src/publisher.hpp
@@ -34,7 +34,6 @@ private:
     std::unique_ptr<MsgDispatcher> m_msgDispatcher {};
 
 public:
-    // LCOV_EXCL_START
     /**
      * @brief Class constructor. Initializes server socket and listen from it.
      *
@@ -79,7 +78,6 @@ public:
                 }
             });
     }
-    // LCOV_EXCL_STOP
 
     /**
      * @brief Pushes data into the message dispatcher.

--- a/src/shared_modules/router/tests/unit/publisher_test.cpp
+++ b/src/shared_modules/router/tests/unit/publisher_test.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "publisher_test.hpp"
+#include "socketClient.hpp"
 #include "src/publisher.hpp"
 #include <memory>
 #include <vector>
@@ -107,4 +108,127 @@ TEST_F(PublisherTest, TestPublishEmptyData)
 
     // Check that the Publisher class can publish empty data
     EXPECT_NO_THROW(publisher->push(emptyData));
+}
+
+/*
+ * @brief Tests send data to socket without header P
+ */
+TEST_F(PublisherTest, TestPublishSocketWithoutP)
+{
+    const std::string ENDPOINT_NAME = "test";
+    const std::string SOCKET_PATH = "test/";
+    std::condition_variable cv;
+    std::mutex cvMutex;
+
+    const auto publisher = std::make_shared<Publisher>(ENDPOINT_NAME, SOCKET_PATH);
+    auto socketClient = std::make_unique<SocketClient<Socket<OSPrimitives>, EpollWrapper>>(SOCKET_PATH + ENDPOINT_NAME);
+
+    nlohmann::json jsonMessage;
+    jsonMessage["type"] = "subscribe";
+    jsonMessage["subscriberId"] = "ID_0";
+    auto jsonMessageString = jsonMessage.dump();
+
+    int32_t onReadCallCount = 0;
+
+    socketClient->connect(
+        [&onReadCallCount, &cv](const char* body, uint32_t bodySize, const char*, uint32_t)
+        {
+            nlohmann::json result;
+            EXPECT_NO_THROW(result = nlohmann::json::parse(body, body + bodySize));
+            if (onReadCallCount == 0)
+            {
+                EXPECT_EQ(result.dump(), R"({"Result":"OK"})");
+            }
+            else
+            {
+                EXPECT_EQ(
+                    result.dump(),
+                    R"({"offset":57000,"paths":["GracefulShutdown.json"],"stageStatus":[{"stage":"download","status":"ok"}],"type":"offsets"})");
+            }
+            onReadCallCount++;
+            cv.notify_all();
+        },
+        [&jsonMessageString, &socketClient]()
+        { EXPECT_NO_THROW(socketClient->send(jsonMessageString.data(), jsonMessageString.size())); });
+
+    {
+        std::unique_lock<std::mutex> lk(cvMutex);
+        std::cv_status result = cv.wait_for(lk, std::chrono::seconds(5));
+        EXPECT_EQ(result, std::cv_status::no_timeout);
+    }
+
+    auto routerMessageJson = R"(
+    {
+        "type": "offsets",
+        "offset": 57000,
+        "paths":
+        [
+            "GracefulShutdown.json"
+        ],
+        "stageStatus":
+        [
+            {
+                "stage": "download",
+                "status": "ok"
+            }
+        ]
+    }
+    )"_json;
+    const auto routerMessagePayload = routerMessageJson.dump();
+    const auto routerMessage = std::vector<char>(routerMessagePayload.begin(), routerMessagePayload.end());
+    publisher->call(routerMessage);
+
+    {
+        std::unique_lock<std::mutex> lk(cvMutex);
+        std::cv_status result = cv.wait_for(lk, std::chrono::seconds(5));
+        EXPECT_EQ(result, std::cv_status::no_timeout);
+    }
+    EXPECT_EQ(onReadCallCount, 2);
+}
+
+/*
+ * @brief Tests send data to socket with header P
+ */
+TEST_F(PublisherTest, TestPublishSocketP)
+{
+    const std::string ENDPOINT_NAME = "test";
+    const std::string SOCKET_PATH = "test/";
+    std::condition_variable cv;
+    std::mutex cvMutex;
+
+    const auto publisher = std::make_shared<Publisher>(ENDPOINT_NAME, SOCKET_PATH);
+    auto socketClient = std::make_unique<SocketClient<Socket<OSPrimitives>, EpollWrapper>>(SOCKET_PATH + ENDPOINT_NAME);
+
+    auto routerMessageJson = R"(
+    {
+        "type": "offsets",
+        "offset": 57000,
+        "paths":
+        [
+            "GracefulShutdown.json"
+        ],
+        "stageStatus":
+        [
+            {
+                "stage": "download",
+                "status": "ok"
+            }
+        ]
+    }
+    )"_json;
+    const auto routerMessagePayload = routerMessageJson.dump();
+
+    socketClient->connect([](const char* body, uint32_t bodySize, const char*, uint32_t) {},
+                          [&cv, &routerMessagePayload, &socketClient]()
+                          {
+                              EXPECT_NO_THROW(
+                                  socketClient->send(routerMessagePayload.data(), routerMessagePayload.size(), "P", 1));
+                              cv.notify_all();
+                          });
+
+    {
+        std::unique_lock<std::mutex> lk(cvMutex);
+        std::cv_status result = cv.wait_for(lk, std::chrono::seconds(5));
+        EXPECT_EQ(result, std::cv_status::no_timeout);
+    }
 }


### PR DESCRIPTION
|Related issue|
|---|
|#21325|


## Description

The LCOV exclusion was removed, and the corresponding unit tests were added for the Publisher constructor.

## Tests

![image](https://github.com/wazuh/wazuh/assets/13617613/c1141db5-160b-4e14-8b85-1f6ed27365c7)

![image](https://github.com/wazuh/wazuh/assets/13617613/8fa5bd7d-17d6-49df-bc2c-5ffc45243ec7)

```
./router_unit_tests
[==========] Running 12 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 9 tests from PublisherTest
[ RUN      ] PublisherTest.TestPublisherInstantiation
Failed to set socket options
Failed to set socket options
[       OK ] PublisherTest.TestPublisherInstantiation (0 ms)
[ RUN      ] PublisherTest.TestPublisherWithInvalidSocketPath
Error removing FD from interface.
[       OK ] PublisherTest.TestPublisherWithInvalidSocketPath (0 ms)
[ RUN      ] PublisherTest.TestPublisherWithEmptyEndpointName
Error removing FD from interface.
[       OK ] PublisherTest.TestPublisherWithEmptyEndpointName (0 ms)
[ RUN      ] PublisherTest.TestPublisherWithEmptyEndpointNameAndSocketPath
Error removing FD from interface.
[       OK ] PublisherTest.TestPublisherWithEmptyEndpointNameAndSocketPath (0 ms)
[ RUN      ] PublisherTest.TestTwoPublishersWithTheSameEndpointNameAndSocketPath
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
[       OK ] PublisherTest.TestTwoPublishersWithTheSameEndpointNameAndSocketPath (0 ms)
[ RUN      ] PublisherTest.TestPublishValidData
Failed to set socket options
Failed to set socket options
[       OK ] PublisherTest.TestPublishValidData (0 ms)
[ RUN      ] PublisherTest.TestPublishEmptyData
Failed to set socket options
Failed to set socket options
[       OK ] PublisherTest.TestPublishEmptyData (0 ms)
[ RUN      ] PublisherTest.TestPublishSocketWithoutP
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
[       OK ] PublisherTest.TestPublishSocketWithoutP (10001 ms)
[ RUN      ] PublisherTest.TestPublishSocketP
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
[       OK ] PublisherTest.TestPublishSocketP (5000 ms)
[----------] 9 tests from PublisherTest (15004 ms total)

[----------] 3 tests from SubscriberTest
[ RUN      ] SubscriberTest.TestSubscriberInstantiation
[       OK ] SubscriberTest.TestSubscriberInstantiation (0 ms)
[ RUN      ] SubscriberTest.TestSubscriberWithEmptyObserverId
[       OK ] SubscriberTest.TestSubscriberWithEmptyObserverId (0 ms)
[ RUN      ] SubscriberTest.TestSubscriberUpdateMethod
[       OK ] SubscriberTest.TestSubscriberUpdateMethod (0 ms)
[----------] 3 tests from SubscriberTest (0 ms total)

[----------] Global test environment tear-down
[==========] 12 tests from 2 test suites ran. (15004 ms total)
[  PASSED  ] 12 tests.
```
