### PR TITLE
Avoid forwarding syscollector messages to vulnerability detector for not supported agents

### DIFF
--- a/src/shared/agent_messages_adapter.c
+++ b/src/shared/agent_messages_adapter.c
@@ -26,8 +26,14 @@ char* adapt_delta_message(const char* data, const char* name, const char* id, co
     char* msg_to_send = NULL;
 
     j_msg = cJSON_Parse(data);
-    if(!j_msg) {
+    if (!j_msg) {
         return NULL;
+    } else {
+        // Legacy agents prior to 4.2 used a different message format that isn't supported
+        if (cJSON_GetObjectItem(j_msg, "ID") && cJSON_GetObjectItem(j_msg, "timestamp")) {
+            cJSON_Delete(j_msg);
+            return NULL;
+        }
     }
 
     j_msg_to_send = cJSON_CreateObject();
@@ -75,8 +81,14 @@ char* adapt_sync_message(const char* data, const char* name, const char* id, con
     char* msg_to_send = NULL;
 
     j_msg = cJSON_Parse(data);
-    if(!j_msg) {
+    if (!j_msg) {
         return NULL;
+    } else {
+        // Legacy agents prior to 4.2 used a different message format that isn't supported
+        if (cJSON_GetObjectItem(j_msg, "ID") && cJSON_GetObjectItem(j_msg, "timestamp")) {
+            cJSON_Delete(j_msg);
+            return NULL;
+        }
     }
 
     j_msg_to_send = cJSON_CreateObject();

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -2405,6 +2405,28 @@ void test_router_message_forward_valid_delta_hotfixes_json_message(void **state)
     router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
 }
 
+void test_router_message_forward_legacy_agent_message(void **state) {
+    test_agent_info* data = (test_agent_info*)(*state);
+    char* message = "d:syscollector:{\"type\":\"program\",\"ID\":710378877,\"timestamp\":\"2024/01/12 22:47:29\",\"program\":{\"format\":\"deb\","
+                    "\"name\":\"isc-dhcp-common\",\"priority\":\"important\",\"group\":\"net\",\"size\":163,\"vendor\":\"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>\""
+                    ",\"architecture\":\"amd64\",\"source\":\"isc-dhcp\",\"version\":\"4.4.1-2.1ubuntu9\",\"description\":\"common manpages relevant to all of the isc-dhcp packages\"}}";
+
+    router_syscollector_handle = (ROUTER_PROVIDER_HANDLE)(1);
+
+    // This type of message must be discarded
+    router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
+}
+
+void test_router_message_forward_legacy_agent_end_message(void **state) {
+    test_agent_info* data = (test_agent_info*)(*state);
+    char* message = "d:syscollector:{\"type\":\"process_end\",\"ID\":1998297930,\"timestamp\":\"2024/01/13 00:08:55\"}";
+
+    router_syscollector_handle = (ROUTER_PROVIDER_HANDLE)(1);
+
+    // This type of message must be discarded
+    router_message_forward(message, data->agent_id, data->agent_ip, data->agent_name);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -2474,6 +2496,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_ports_json_message, setup_remoted_configuration, teardown_remoted_configuration),
         cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_processes_json_message, setup_remoted_configuration, teardown_remoted_configuration),
         cmocka_unit_test_setup_teardown(test_router_message_forward_valid_delta_hotfixes_json_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_legacy_agent_message, setup_remoted_configuration, teardown_remoted_configuration),
+        cmocka_unit_test_setup_teardown(test_router_message_forward_legacy_agent_end_message, setup_remoted_configuration, teardown_remoted_configuration),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes  #21349|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR verifies the format of the syscollector messages and drops them before sending them to vulnerability detector in case they correspond to the old (prior to 4.2) synchronization mechanism.
UT were added.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

It was confirmed that after connecting agents v4.1.5 and v3.13.6, the error messages no longer appear.
But the failure of the daemon couldn't be reproduced.

Here are some examples of legacy messages 

```
d:syscollector:{"type":"process","ID":1729679817,"timestamp":"2024/01/12 22:47:41","process":{"pid":1752,"name":"systemd-network","state":"S","ppid":1,"utime":7,"stime":4,"cmd":"/lib/systemd/systemd-networkd","euser":"systemd-network","ruser":"systemd-network","suser":"systemd-network","egroup":"systemd-network","rgroup":"systemd-network","sgroup":"systemd-network","fgroup":"systemd-network","priority":20,"nice":0,"size":7036,"vm_size":28144,"resident":2087,"share":1821,"start_time":11587,"pgrp":1752,"session":1752,"nlwp":1,"tgid":1752,"tty":0,"processor":0}}

d:syscollector:{"type":"process_end","ID":1608435955,"timestamp":"2024/01/13 02:19:28"}

d:syscollector:{"type":"port","ID":620714146,"timestamp":"2024/01/12 22:47:41","port":{"protocol":"tcp","local_ip":"127.0.0.53","local_port":53,"remote_ip":"0.0.0.0","remote_port":0,"tx_queue":0,"rx_queue":0,"inode":23330,"state":"listening"}}

d:syscollector:{"type":"port_end","ID":620714146,"timestamp":"2024/01/12 22:47:41"}

d:syscollector:{"type":"program","ID":710378877,"timestamp":"2024/01/12 22:47:29","program":{"format":"deb","name":"python3-httplib2","priority":"optional","group":"python","size":132,"vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","architecture":"all","source":"python-httplib2","version":"0.18.1-1","description":"comprehensive HTTP client library written for Python3"}}

d:syscollector:{"type":"program_end","ID":710378877,"timestamp":"2024/01/12 22:47:29"}
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- [x] Added unit tests (for new features)
