### PR TITLE
Remove test xfail mark

### DIFF
--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1565,9 +1565,6 @@ stages:
 ---
 test_name: GET /manager/version/check
 
-marks:
-  - xfail
-
 stages:
   - name: Get wazuh version
     request:


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/21417 |

## Description

Removes the `xfail` mark from the `GET /manager/version/check` test case in `test_manager_endpoints.tavern.yaml`.

## Tests

<details><summary>test_manager_endpoints.tavern.yaml</summary>

```console

```

</details>