### PR TITLE
Fix reading the update check configuration when no values are specified

### DIFF
--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -119,6 +119,8 @@ GETCONFIG_COMMAND = "getconfig"
 UPDATE_CHECK_OSSEC_FIELD = 'update_check'
 GLOBAL_KEY = 'global'
 YES_VALUE = 'yes'
+CTI_URL_FIELD = 'cti-url'
+DEFAULT_CTI_URL = 'https://cti.wazuh.com'
 
 
 def _insert(json_dst: dict, section_name: str, option: str, value: str):
@@ -1273,6 +1275,26 @@ def update_check_is_enabled() -> bool:
     bool
         True if UPDATE_CHECK_OSSEC_FIELD is 'yes' or isn't present, else False.
     """
-    global_configurations = get_ossec_conf(section=GLOBAL_KEY).get(GLOBAL_KEY, {})
+    try:
+        global_configurations = get_ossec_conf(section=GLOBAL_KEY).get(GLOBAL_KEY, {})
+        return global_configurations.get(UPDATE_CHECK_OSSEC_FIELD, YES_VALUE) == YES_VALUE
+    except WazuhError as e:
+        if e.code != 1106:
+            raise e
+        return True
 
-    return global_configurations.get(UPDATE_CHECK_OSSEC_FIELD, YES_VALUE) == YES_VALUE
+
+def get_cti_url() -> str:
+    """Get the CTI service URL from the configuration.
+    
+    Returns
+    -------
+    str
+        CTI service URL. The default value is returned if CTI_URL_FIELD isn't present.
+    """
+    try:
+        return get_ossec_conf(section=GLOBAL_KEY).get(GLOBAL_KEY, {}).get(CTI_URL_FIELD, DEFAULT_CTI_URL)
+    except WazuhError as e:
+        if e.code != 1106:
+            raise e
+        return DEFAULT_CTI_URL

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -21,7 +21,7 @@ from api import configuration
 from wazuh import WazuhError, WazuhException, WazuhInternalError
 from wazuh.core import common
 from wazuh.core.cluster.utils import get_manager_status
-from wazuh.core.configuration import GLOBAL_KEY, get_active_configuration, get_ossec_conf
+from wazuh.core.configuration import get_active_configuration, get_cti_url
 from wazuh.core.utils import get_utc_now, get_utc_strptime, tail
 from wazuh.core.wazuh_socket import WazuhSocket
 
@@ -29,7 +29,7 @@ from wazuh.core.wazuh_socket import WazuhSocket
 _re_logtest = re.compile(r"^.*(?:ERROR: |CRITICAL: )(?:\[.*\] )?(.*)$")
 
 OSSEC_LOG_FIELDS = ['timestamp', 'tag', 'level', 'description']
-CTI_URL = get_ossec_conf(section=GLOBAL_KEY).get(GLOBAL_KEY, {}).get('cti-url', 'https://cti.wazuh.com')
+CTI_URL = get_cti_url()
 RELEASE_UPDATES_URL = os.path.join(CTI_URL, 'api', 'v1', 'ping')
 ONE_DAY_SLEEP = 60 * 60 * 24
 WAZUH_UID_KEY = 'wazuh-uid'

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -502,7 +502,8 @@ def test_write_ossec_conf_exceptions():
         [{configuration.GLOBAL_KEY: {configuration.UPDATE_CHECK_OSSEC_FIELD: 'yes'}}, True],
         [{configuration.GLOBAL_KEY: {configuration.UPDATE_CHECK_OSSEC_FIELD: 'no'}}, False],
         [{configuration.GLOBAL_KEY: {}}, True],
-        [{}, True]
+        [{}, True],
+        [{'ossec_config': {}}, True]
     )
 )
 @patch('wazuh.core.configuration.get_ossec_conf')
@@ -514,3 +515,54 @@ def test_update_check_is_enabled(get_ossec_conf_mock, update_check_config, expec
     get_ossec_conf_mock.return_value = update_check_config
 
     assert configuration.update_check_is_enabled() == expected
+
+
+@pytest.mark.parametrize("error_id, value", [
+    (1101, None),
+    (1102, None),
+    (1103, None),
+    (1106, True)
+])
+def test_update_check_is_enabled_exceptions(error_id, value):
+    """Test update_check_is_enabled exception handling."""
+    with patch('wazuh.core.configuration.get_ossec_conf', side_effect=WazuhError(error_id), return_value=value):
+        if value is not None:
+            assert configuration.update_check_is_enabled() == value
+        else:
+            with pytest.raises(WazuhError, match=f'.* {error_id} .*'):
+                configuration.update_check_is_enabled()
+
+
+@pytest.mark.parametrize(
+    'config, expected',
+    (
+        [{configuration.GLOBAL_KEY: {configuration.CTI_URL_FIELD: configuration.DEFAULT_CTI_URL}},
+         configuration.DEFAULT_CTI_URL],
+        [{configuration.GLOBAL_KEY: {configuration.CTI_URL_FIELD: 'https://test-cti.com'}}, 'https://test-cti.com'],
+        [{configuration.GLOBAL_KEY: {}}, configuration.DEFAULT_CTI_URL],
+        [{}, configuration.DEFAULT_CTI_URL],
+        [{'ossec_config': {}}, configuration.DEFAULT_CTI_URL]
+    )
+)
+@patch('wazuh.core.configuration.get_ossec_conf')
+def test_get_cti_url(get_ossec_conf_mock, config, expected):
+    """Check that get_cti_url function returns the expected value, based on the CTI_URL_FIELD."""
+    get_ossec_conf_mock.return_value = config
+
+    assert configuration.get_cti_url() == expected
+
+
+@pytest.mark.parametrize("error_id, value", [
+    (1101, None),
+    (1102, None),
+    (1103, None),
+    (1106, configuration.DEFAULT_CTI_URL)
+])
+def test_get_cti_url_exceptions(error_id, value):
+    """Test get_cti_url exception handling."""
+    with patch('wazuh.core.configuration.get_ossec_conf', side_effect=WazuhError(error_id), return_value=value):
+        if value is not None:
+            assert configuration.get_cti_url() == value
+        else:
+            with pytest.raises(WazuhError, match=f'.* {error_id} .*'):
+                configuration.get_cti_url()


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/21402 |

## Description

Handles the exception thrown when the CTI configuration fields are not present and returns the default values instead.

## Configuration options

<details><summary>Configuration</summary>

```xml
<ossec_config>
  <remote>
    <connection>secure</connection>
    <port>1514</port>
  </remote>
</ossec_config>
```

</details>

<details><summary>Configuration 2</summary>

```xml
<ossec_config>
  <global>
    <update_check>yes</update_check>
    <cti-url>https://cti.wazuh.com</cti-url>
  </global>
  <remote>
    <connection>secure</connection>
    <port>1514</port>
  </remote>
</ossec_config>
```

</details>

<details><summary>Configuration 3</summary>

```xml
<ossec_config>
  <global>
  </global>
  <remote>
    <connection>secure</connection>
    <port>1514</port>
  </remote>
</ossec_config>
```

</details>

> The same results were obtained with all configurations.

## Logs/Alerts example

<details><summary>Starting the API</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-apid -f
Starting API in foreground
2024/01/15 15:54:48 INFO: Checking RBAC database integrity...
2024/01/15 15:54:48 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2024/01/15 15:54:48 INFO: RBAC database integrity check finished successfully
2024/01/15 15:54:50 INFO: Listening on 0.0.0.0:55000..
2024/01/15 15:54:50 INFO: Getting installation UID...
2024/01/15 15:54:50 INFO: Getting updates information...
======== Running on https://0.0.0.0:55000 ========
(Press CTRL+C to quit)
```

</details>


<details><summary>Starting all modules</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-control start
2024/01/15 16:06:55 wazuh-db[16582] debug_op.c:305 at os_logging_config(): DEBUG: (1228): Element 'log_format' without any option.
2024/01/15 16:06:55 wazuh-db[16582] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/01/15 16:06:55 wazuh-db[16582] main.c:125 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7616): List 'etc/lists/amazon/aws-eventnames' could not be loaded. Rule '80202' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7617): Signature ID '80202' was not found and will be ignored in the 'if_sid' option of rule '80203'.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '80203' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7617): Signature ID '80203' was not found and will be ignored in the 'if_sid' option of rule '80250'.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '80250' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7617): Signature ID '80202' was not found and will be ignored in the 'if_sid' option of rule '80251'.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '80251' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7620): Signature ID '80251' was not found. Invalid 'if_matched_sid'.Rule '80252' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7617): Signature ID '80202' was not found and will be ignored in the 'if_sid' option of rule '80253'.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '80253' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7617): Signature ID '80253' was not found and will be ignored in the 'if_sid' option of rule '80254'.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '80254' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7620): Signature ID '80254' was not found. Invalid 'if_matched_sid'.Rule '80255' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7616): List 'etc/lists/audit-keys' could not be loaded. Rule '80780' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7617): Signature ID '80780' was not found and will be ignored in the 'if_sid' option of rule '80781'.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '80781' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7617): Signature ID '80780' was not found and will be ignored in the 'if_sid' option of rule '80782'.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '80782' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7616): List 'etc/lists/audit-keys' could not be loaded. Rule '80783' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7617): Signature ID '80783' was not found and will be ignored in the 'if_sid' option of rule '80784'.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '80784' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7617): Signature ID '80783' was not found and will be ignored in the 'if_sid' option of rule '80785'.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '80785' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7616): List 'etc/lists/audit-keys' could not be loaded. Rule '80786' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7617): Signature ID '80786' was not found and will be ignored in the 'if_sid' option of rule '80787'.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '80787' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7617): Signature ID '80786' was not found and will be ignored in the 'if_sid' option of rule '80788'.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '80788' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7616): List 'etc/lists/audit-keys' could not be loaded. Rule '80789' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7610): Group 'audit_watch_write' was not found. Invalid 'if_group'. Rule '80790' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7610): Group 'audit_watch_write' was not found. Invalid 'if_group'. Rule '80791' will be ignored.
2024/01/15 16:06:55 wazuh-analysisd: WARNING: (7616): List 'etc/lists/audit-keys' could not be loaded. Rule '80792' will be ignored.
2024/01/15 16:06:55 wazuh-remoted[16587] debug_op.c:305 at os_logging_config(): DEBUG: (1228): Element 'log_format' without any option.
2024/01/15 16:06:55 wazuh-remoted[16587] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/01/15 16:06:55 wazuh-remoted[16587] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/01/15 16:06:55 wazuh-remoted[16587] main.c:148 at main(): DEBUG: This is not a worker
2024/01/15 16:06:55 wazuh-modulesd:router: INFO: Loaded router module.
2024/01/15 16:06:55 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Starting Wazuh v4.8.0...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2024/01/15 16:06:57 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
2024/01/15 16:06:57 wazuh-db[16699] debug_op.c:305 at os_logging_config(): DEBUG: (1228): Element 'log_format' without any option.
2024/01/15 16:06:57 wazuh-db[16699] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/01/15 16:06:57 wazuh-db[16699] main.c:125 at main(): DEBUG: Wazuh home directory: /var/ossec
Started wazuh-db...
Started wazuh-execd...
2024/01/15 16:06:58 wazuh-maild: INFO: E-Mail notification disabled. Clean Exit.
Started wazuh-maild...
Started wazuh-analysisd...
2024/01/15 16:06:59 wazuh-syscheckd: INFO: (6678): No directory provided for syscheck to monitor.
2024/01/15 16:06:59 wazuh-syscheckd: INFO: (6001): File integrity monitoring disabled.
2024/01/15 16:06:59 rootcheck: INFO: Rootcheck disabled.
Started wazuh-syscheckd...
2024/01/15 16:07:00 wazuh-remoted[16820] debug_op.c:305 at os_logging_config(): DEBUG: (1228): Element 'log_format' without any option.
2024/01/15 16:07:00 wazuh-remoted[16820] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/01/15 16:07:00 wazuh-remoted[16820] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/01/15 16:07:00 wazuh-remoted[16820] main.c:148 at main(): DEBUG: This is not a worker
Started wazuh-remoted...
2024/01/15 16:07:01 wazuh-logcollector: INFO: (1905): No file configured to monitor.
Started wazuh-logcollector...
Started wazuh-monitord...
2024/01/15 16:07:02 wazuh-modulesd:router: INFO: Loaded router module.
2024/01/15 16:07:02 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Started wazuh-modulesd...
Completed.
```

</details>


<details><summary>Modules status</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-control status
wazuh-clusterd not running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-maild not running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd not running...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
wazuh-apid is running...
```

</details>

## Tests


<details><summary>framework/wazuh/core/tests/test_configuration.py</summary>

```console
(venv10) gasti@pop-os:~/work/wazuh$ python3 -m pytest framework/wazuh/core/tests/test_configuration.py --disable-warnings
====================================================================== test session starts =======================================================================
platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-1.3.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 88 items                                                                                                                                               

framework/wazuh/core/tests/test_configuration.py ........................................................................................                  [100%]

======================================================================= 88 passed in 0.29s =======================================================================
```

</details>
