### PR TITLE
Method TDatabaseFeedManager::getCnaName was modified to detect vendor…

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -566,9 +566,10 @@ public:
 
         const auto vendorLowerCase = Utils::toLowerCase(vendor.data());
         // LCOV_EXCL_START
-        const auto it = std::find_if(vendorToCnaName.begin(),
-                                     vendorToCnaName.end(),
-                                     [&](const auto& pair) { return Utils::startsWith(vendorLowerCase, pair.first); });
+        const auto it =
+            std::find_if(vendorToCnaName.begin(),
+                         vendorToCnaName.end(),
+                         [&](const auto& pair) { return vendorLowerCase.find(pair.first) != std::string::npos; });
         // LCOV_EXCL_STOP
 
         if (it == vendorToCnaName.end())

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -1093,9 +1093,13 @@ TEST_F(DatabaseFeedManagerTest, GetCNAName)
                                               TrampolineContentRegister,
                                               TrampolineRouterSubscriber>>(spIndexerConnectorTramp, shouldStop, mutex)};
 
+    // For canonical use mantainer name.
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Nikhil Kshirsagar <nikhil.kshirsagar@canonical.com>").c_str(),
+                 "canonical");
     // For ubuntu use mantainer name.
     EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>").c_str(),
                  "canonical");
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Eric Desrochers <slashd@ubuntu.com>").c_str(), "canonical");
     // For debian use mantainer name.
     EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Debian GCC Maintainers <debian-gcc@lists.debian.org>").c_str(),
                  "debian");


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21232  |

## Description

This PR modified the method TDatabaseFeedManager::getCnaName to allow the search of the vendor substring in the whole string of the package vendor.
UTs were also added.

## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Run UTs successfully
- [ ] Run Manual tests