### PR TITLE
Auto-adjustment for Time Values Below 60 Minutes

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -115,6 +115,15 @@ private:
             newPolicy["vulnerability-detection"]["feed-update-interval"] = "60m";
         }
 
+        if (Utils::parseStrToTime(newPolicy.at("vulnerability-detection").at("feed-update-interval")) <
+            Utils::parseStrToTime("60m"))
+        {
+            logWarn(WM_VULNSCAN_LOGTAG,
+                    "The 'feed-update-interval' option at module 'vulnerability-detection' must be at least 1 "
+                    "hour. Automatically set to 60 minutes.");
+            newPolicy["vulnerability-detection"]["feed-update-interval"] = "60m";
+        }
+
         if (!newPolicy.contains("updater"))
         {
             newPolicy["updater"] = nlohmann::json::object();

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/policyManager_test.cpp
@@ -329,3 +329,51 @@ TEST_F(PolicyManagerTest, validConfigurationVulnerabilityScannerIgnoreIndexStatu
     EXPECT_FALSE(m_policyManager->isVulnerabilityDetectionEnabled());
     EXPECT_FALSE(m_policyManager->isIndexerEnabled());
 }
+
+TEST_F(PolicyManagerTest, validConfigurationCheckFeedUpdateIntervalLessThan60m)
+{
+    // If the feed-update-interval is less than 60m, it should be set to 60m.
+    const auto& configJson {nlohmann::json::parse(R"({
+      "vulnerability-detection": {
+        "enabled": "yes",
+        "index-status": "yes",
+        "feed-update-interval": "10m",
+        "cti-url": "https://cti-url.com"
+      }
+    })")};
+    EXPECT_NO_THROW(m_policyManager->initialize(configJson));
+
+    EXPECT_TRUE(m_policyManager->isVulnerabilityDetectionEnabled());
+
+    EXPECT_EQ(m_policyManager->getFeedUpdateTime(), 3600);
+
+    EXPECT_STREQ(
+        m_policyManager->getUpdaterConfiguration().dump().c_str(),
+        R"({"configData":{"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-offset","dataFormat":"json","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"queue/vd_updater/tmp","url":"https://cti-url.com","versionedContent":"false"},"interval":3600,"ondemand":true,"topicName":"vulnerability_feed_manager"})");
+
+    EXPECT_EQ(m_policyManager->getUpdaterConfiguration().at("interval"), 3600);
+}
+
+TEST_F(PolicyManagerTest, validConfigurationCheckFeedUpdateIntervalGreaterThan60m)
+{
+    // If the feed-update-interval is greater than 60m, it should be set to the specified value.
+    const auto& configJson {nlohmann::json::parse(R"({
+      "vulnerability-detection": {
+        "enabled": "yes",
+        "index-status": "yes",
+        "feed-update-interval": "61m",
+        "cti-url": "https://cti-url.com"
+      }
+    })")};
+    EXPECT_NO_THROW(m_policyManager->initialize(configJson));
+
+    EXPECT_TRUE(m_policyManager->isVulnerabilityDetectionEnabled());
+
+    EXPECT_EQ(m_policyManager->getFeedUpdateTime(), 3660);
+
+    EXPECT_STREQ(
+        m_policyManager->getUpdaterConfiguration().dump().c_str(),
+        R"({"configData":{"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-offset","dataFormat":"json","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"queue/vd_updater/tmp","url":"https://cti-url.com","versionedContent":"false"},"interval":3660,"ondemand":true,"topicName":"vulnerability_feed_manager"})");
+
+    EXPECT_EQ(m_policyManager->getUpdaterConfiguration().at("interval"), 3660);
+}


### PR DESCRIPTION
|Related issue|
|---|
|#21304|

## Description
When a user sets a time value below 60 minutes:

A warning message should be displayed.
The time value should automatically be adjusted to 60 minutes.

## Tests
```
[----------] 14 tests from PolicyManagerTest
[ RUN      ] PolicyManagerTest.invalidConfigurationIDWithVD
[       OK ] PolicyManagerTest.invalidConfigurationIDWithVD (0 ms)
[ RUN      ] PolicyManagerTest.invalidConfigurationURLFeed
[       OK ] PolicyManagerTest.invalidConfigurationURLFeed (0 ms)
[ RUN      ] PolicyManagerTest.invalidConfigurationNegativeTime
[       OK ] PolicyManagerTest.invalidConfigurationNegativeTime (0 ms)
[ RUN      ] PolicyManagerTest.invalidConfigurationIDWithTypo
[       OK ] PolicyManagerTest.invalidConfigurationIDWithTypo (0 ms)
[ RUN      ] PolicyManagerTest.invalidConfigurationVDWithTypo
[       OK ] PolicyManagerTest.invalidConfigurationVDWithTypo (0 ms)
[ RUN      ] PolicyManagerTest.invalidConfigurationVDWithoutIDStatus
[       OK ] PolicyManagerTest.invalidConfigurationVDWithoutIDStatus (0 ms)
[ RUN      ] PolicyManagerTest.validConfigurationCheckParameters
[       OK ] PolicyManagerTest.validConfigurationCheckParameters (0 ms)
[ RUN      ] PolicyManagerTest.validConfigurationCheckParametersOffline
[       OK ] PolicyManagerTest.validConfigurationCheckParametersOffline (0 ms)
[ RUN      ] PolicyManagerTest.validConfigurationDefaultValues
[       OK ] PolicyManagerTest.validConfigurationDefaultValues (0 ms)
[ RUN      ] PolicyManagerTest.invalidConfigurationNoCTIUrl
[       OK ] PolicyManagerTest.invalidConfigurationNoCTIUrl (0 ms)
[ RUN      ] PolicyManagerTest.validConfigurationDefaultValuesNoIndexer
[       OK ] PolicyManagerTest.validConfigurationDefaultValuesNoIndexer (0 ms)
[ RUN      ] PolicyManagerTest.validConfigurationVulnerabilityScannerIgnoreIndexStatus
[       OK ] PolicyManagerTest.validConfigurationVulnerabilityScannerIgnoreIndexStatus (0 ms)
[ RUN      ] PolicyManagerTest.validConfigurationCheckFeedUpdateIntervalLessThan60m
[       OK ] PolicyManagerTest.validConfigurationCheckFeedUpdateIntervalLessThan60m (0 ms)
[ RUN      ] PolicyManagerTest.validConfigurationCheckFeedUpdateIntervalGreaterThan60m
[       OK ] PolicyManagerTest.validConfigurationCheckFeedUpdateIntervalGreaterThan60m (0 ms)
[----------] 14 tests from PolicyManagerTest (6 ms total)

```

![image](https://github.com/wazuh/wazuh/assets/13617613/ba55f1d8-8151-4989-a16f-e6612b00d1b9)


- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Added unit testing