### PR TITLE
Let Wazuh try to start Whodata with increasing timeout

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -561,6 +561,9 @@
 #define FIM_ERROR_TRANSACTION                       "(6719): Could not start DBSync transaction (%s)"
 #define FIM_ERROR_PATH_TOO_LONG                     "(6720): The path '%s%s' is too long. The maximum length is %d characters."
 
+#define FIM_AUDITPOL_ATTEMPT_FAIL                   "(6955): Auditpol command failed, attempt number: %d"
+#define FIM_AUDITPOL_FINAL_FAIL                     "(6956): After %d attempts the Auditpol command could not be executed successfully."
+
 /* Wazuh Logtest error messsages */
 #define LOGTEST_ERROR_BIND_SOCK                     "(7300): Unable to bind to socket '%s'. Errno: (%d) %s"
 #define LOGTEST_ERROR_ACCEPT_CONN                   "(7301): Failure to accept connection. Errno: %s"

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -71,8 +71,6 @@
 #define FIM_WHODATA_POLICY_CHANGE_CHECKER       "(6952): Audit policy change detected. Switching directories to realtime."
 #define FIM_WHODATA_POLICY_CHANGE_CHANNEL       "(6953): Event 4719 received due to changes in audit policy. Switching directories to realtime."
 #define FIM_EMPTY_CHANGED_ATTRIBUTES            "(6954): Entry '%s' does not have any modified fields. No event will be generated."
-#define FIM_AUDITPOL_ATTEMPT_FAIL               "(6955): Auditpol command failed, attempt number: %d"
-#define FIM_AUDITPOL_FINAL_FAIL                 "(6956): After %d attempts the Auditpol command could not be executed successfully."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -71,6 +71,8 @@
 #define FIM_WHODATA_POLICY_CHANGE_CHECKER       "(6952): Audit policy change detected. Switching directories to realtime."
 #define FIM_WHODATA_POLICY_CHANGE_CHANNEL       "(6953): Event 4719 received due to changes in audit policy. Switching directories to realtime."
 #define FIM_EMPTY_CHANGED_ATTRIBUTES            "(6954): Entry '%s' does not have any modified fields. No event will be generated."
+#define FIM_AUDITPOL_ATTEMPT_FAIL               "(6955): Auditpol command failed, attempt number: %d"
+#define FIM_AUDITPOL_FINAL_FAIL                 "(6956): After %d attempts the Auditpol command could not be executed successfully."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/syscheckd/src/whodata/win_whodata.c
+++ b/src/syscheckd/src/whodata/win_whodata.c
@@ -555,9 +555,18 @@ int restore_audit_policies() {
         merror(FIM_ERROR_WHODATA_RESTORE_POLICIES);
         return 1;
     }
+
     // Get the current policies
     char *cmd_output = NULL;
-    const int wm_exec_ret_code = wm_exec(command, &cmd_output, &result_code, 5, NULL);
+    int wm_exec_ret_code;
+    int i, retries = 5;
+
+    for (i = 0; i <= retries; i++) {
+        wm_exec_ret_code = wm_exec(command, &cmd_output, &result_code, 5+i, NULL);
+        if (wm_exec_ret_code > 1) {
+            break;
+        }
+    }
 
     if (wm_exec_ret_code < 0) {
         merror(FIM_ERROR_WHODATA_AUDITPOL, "failed to execute command");
@@ -1262,7 +1271,17 @@ int set_policies() {
     snprintf(command, OS_SIZE_1024, WPOL_BACKUP_COMMAND, WPOL_BACKUP_FILE);
 
     // Get the current policies
-    int wm_exec_ret_code = wm_exec(command, NULL, &result_code, 5, NULL);
+
+    int wm_exec_ret_code;
+    int i, retries = 5;
+
+    for (i = 0; i <= retries; i++) {
+        wm_exec_ret_code = wm_exec(command, NULL, &result_code, 5+i, NULL);
+        if (!(wm_exec_ret_code || result_code)) {
+            break;
+        }
+    }
+
     if (wm_exec_ret_code || result_code) {
         retval = 2;
         merror(FIM_WARN_WHODATA_AUTOCONF);
@@ -1292,7 +1311,13 @@ int set_policies() {
     snprintf(command, OS_SIZE_1024, WPOL_RESTORE_COMMAND, WPOL_NEW_FILE);
 
     // Set the new policies
-    wm_exec_ret_code = wm_exec(command, NULL, &result_code, 5, NULL);
+    for (i = 0; i <= retries; i++) {
+        wm_exec_ret_code = wm_exec(command, NULL, &result_code, 5+i, NULL);
+        if (!(wm_exec_ret_code || result_code)) {
+            break;
+        }
+    }
+
     if (wm_exec_ret_code || result_code) {
         retval = 2;
         merror(FIM_WARN_WHODATA_AUTOCONF);

--- a/src/syscheckd/src/whodata/win_whodata.c
+++ b/src/syscheckd/src/whodata/win_whodata.c
@@ -561,8 +561,9 @@ int restore_audit_policies() {
     int wm_exec_ret_code, i;
     int retries = 5;
     int timeout = 5;
-    BOOL cmd_failed = 0;
+    BOOL cmd_failed;
     for (i = 0; i <= retries; i++) {
+        cmd_failed = 0;
         wm_exec_ret_code = wm_exec(command, &cmd_output, &result_code, timeout+i, NULL);
         if (wm_exec_ret_code < 0) {
             merror(FIM_ERROR_WHODATA_AUDITPOL, "failed to execute command");
@@ -589,7 +590,7 @@ int restore_audit_policies() {
        merror(FIM_AUDITPOL_FINAL_FAIL, i);
     } 
 
-    return 0;
+    return cmd_failed;
 }
 
 PEVT_VARIANT whodata_event_render(EVT_HANDLE event) {
@@ -1283,7 +1284,7 @@ int set_policies() {
             merror(FIM_AUDITPOL_ATTEMPT_FAIL, i+1);
         }
         else {
-            retval = 0;
+            retval = 1;
             break;
         }
     }
@@ -1323,7 +1324,7 @@ int set_policies() {
             merror(FIM_AUDITPOL_ATTEMPT_FAIL, i+1);
         }
         else {
-            retval = 0;
+            retval = 1;
             break;
         }
     }

--- a/src/syscheckd/src/whodata/win_whodata.c
+++ b/src/syscheckd/src/whodata/win_whodata.c
@@ -558,11 +558,11 @@ int restore_audit_policies() {
 
     // Get the current policies
     char *cmd_output = NULL;
-    int wm_exec_ret_code, i;
+    int wm_exec_ret_code, i = 0;
     int retries = 5;
     int timeout = 5;
     BOOL cmd_failed;
-    for (i = 0; i <= retries; i++) {
+    do {
         cmd_failed = 0;
         wm_exec_ret_code = wm_exec(command, &cmd_output, &result_code, timeout+i, NULL);
         if (wm_exec_ret_code < 0) {
@@ -579,12 +579,11 @@ int restore_audit_policies() {
             os_free(cmd_output);
             cmd_failed = 1;
         }
-        if (!cmd_failed) {
-            break;
-        } else {
+        if (cmd_failed) {
             merror(FIM_AUDITPOL_ATTEMPT_FAIL, i+1);
         }
-    }
+        i++;
+    } while (i <= retries && cmd_failed);
     
     if (i == retries + 1) {
        merror(FIM_AUDITPOL_FINAL_FAIL, i);
@@ -1274,20 +1273,19 @@ int set_policies() {
     snprintf(command, OS_SIZE_1024, WPOL_BACKUP_COMMAND, WPOL_BACKUP_FILE);
 
     // Get the current policies
-    int wm_exec_ret_code, i;
+    int wm_exec_ret_code, i = 0;
     int retries = 5;
     int timeout = 5;
-    for (i = 0; i <= retries; i++) {
+    do {
         wm_exec_ret_code = wm_exec(command, NULL, &result_code, timeout+i, NULL);
         if (wm_exec_ret_code || result_code) {
             retval = 2;
             merror(FIM_AUDITPOL_ATTEMPT_FAIL, i+1);
-        }
-        else {
+        } else {
             retval = 1;
-            break;
         }
-    }
+        i++;
+    } while (i <= retries && (wm_exec_ret_code || result_code));
 
     if (retval == 2) {
         merror(FIM_WARN_WHODATA_AUTOCONF);
@@ -1316,18 +1314,18 @@ int set_policies() {
 
     snprintf(command, OS_SIZE_1024, WPOL_RESTORE_COMMAND, WPOL_NEW_FILE);
 
-    // Set the new policies 
-    for (i = 0; i <= retries; i++) {
+    // Set the new policies
+    i = 0;
+    do { 
         wm_exec_ret_code = wm_exec(command, NULL, &result_code, timeout+i, NULL);
         if (wm_exec_ret_code || result_code) {
             retval = 2;
             merror(FIM_AUDITPOL_ATTEMPT_FAIL, i+1);
-        }
-        else {
+        } else {
             retval = 1;
-            break;
         }
-    }
+        i++;
+    } while (i <= retries && (wm_exec_ret_code || result_code));
 
     if (retval == 2) {
         merror(FIM_WARN_WHODATA_AUTOCONF);

--- a/src/syscheckd/src/whodata/win_whodata.c
+++ b/src/syscheckd/src/whodata/win_whodata.c
@@ -581,12 +581,12 @@ int restore_audit_policies() {
         if (!cmd_failed) {
             break;
         } else {
-            merror("Auditpol command failed, attempt number %d", i+1);
+            merror(FIM_AUDITPOL_ATTEMPT_FAIL, i+1);
         }
     }
     
     if (i == retries + 1) {
-       merror("After %d attempts the Auditpol command could not be executed successfully.", i);
+       merror(FIM_AUDITPOL_FINAL_FAIL, i);
     } 
 
     return 0;
@@ -1280,7 +1280,7 @@ int set_policies() {
         wm_exec_ret_code = wm_exec(command, NULL, &result_code, timeout+i, NULL);
         if (wm_exec_ret_code || result_code) {
             retval = 2;
-            merror("Auditpol command failed, attempt number %d", i+1);
+            merror(FIM_AUDITPOL_ATTEMPT_FAIL, i+1);
         }
         else {
             retval = 0;
@@ -1320,7 +1320,7 @@ int set_policies() {
         wm_exec_ret_code = wm_exec(command, NULL, &result_code, timeout+i, NULL);
         if (wm_exec_ret_code || result_code) {
             retval = 2;
-            merror("Auditpol command failed, attempt number %d", i+1);
+            merror(FIM_AUDITPOL_ATTEMPT_FAIL, i+1);
         }
         else {
             retval = 0;

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -3904,15 +3904,18 @@ void test_restore_audit_policies_command_failed(void **state) {
     expect_string(__wrap_IsFile, file, "tmp\\backup-policies");
     will_return(__wrap_IsFile, 0);
 
-    expect_string(__wrap_wm_exec, command, "auditpol /restore /file:\"tmp\\backup-policies\"");
-    expect_value(__wrap_wm_exec, secs, 5);
-    expect_value(__wrap_wm_exec, add_path, NULL);
-    will_return(__wrap_wm_exec, "OUTPUT COMMAND");
-    will_return(__wrap_wm_exec, -1);
-    will_return(__wrap_wm_exec, -1);
+    int i;
+    int retries = 5;
+    char error_msgs[retries + 1][OS_SIZE_1024];
 
-    expect_string(__wrap__merror, formatted_msg, "(6635): Auditpol backup error: 'failed to execute command'.");
+    for (i = 0;  i <= retries; i++) {
+	    expect_wm_exec("auditpol /restore /file:\"tmp\\backup-policies\"", retries+i, NULL, "OUTPUT COMMAND", -1, -1);
+        expect_string(__wrap__merror, formatted_msg, "(6635): Auditpol backup error: 'failed to execute command'.");
+        snprintf(error_msgs[i], sizeof(error_msgs[i]), "(6955): Auditpol command failed, attempt number: %d", i + 1);
+        expect_string(__wrap__merror, formatted_msg, error_msgs[i]);
+    }
 
+    expect_string(__wrap__merror, formatted_msg, "(6956): After 6 attempts the Auditpol command could not be executed successfully.");
     int ret = restore_audit_policies();
     assert_int_equal(ret, 1);
 }
@@ -3921,15 +3924,19 @@ void test_restore_audit_policies_command2_failed(void **state) {
     expect_string(__wrap_IsFile, file, "tmp\\backup-policies");
     will_return(__wrap_IsFile, 0);
 
-    expect_string(__wrap_wm_exec, command, "auditpol /restore /file:\"tmp\\backup-policies\"");
-    expect_value(__wrap_wm_exec, secs, 5);
-    expect_value(__wrap_wm_exec, add_path, NULL);
-    will_return(__wrap_wm_exec, "OUTPUT COMMAND");
-    will_return(__wrap_wm_exec, -1);
-    will_return(__wrap_wm_exec, 1);
+    int i;
+    int retries = 5;
+    char error_msgs[retries + 1][OS_SIZE_1024];
 
-    expect_string(__wrap__merror, formatted_msg, "(6635): Auditpol backup error: 'time overtaken while running the command'.");
 
+    for (i = 0;  i <= retries; i++) {
+        expect_wm_exec("auditpol /restore /file:\"tmp\\backup-policies\"", retries+i, NULL, "OUTPUT COMMAND", -1, 1);
+        expect_string(__wrap__merror, formatted_msg, "(6635): Auditpol backup error: 'time overtaken while running the command'.");
+        snprintf(error_msgs[i], sizeof(error_msgs[i]), "(6955): Auditpol command failed, attempt number: %d", i + 1);
+        expect_string(__wrap__merror, formatted_msg, error_msgs[i]);
+    }
+
+    expect_string(__wrap__merror, formatted_msg, "(6956): After 6 attempts the Auditpol command could not be executed successfully.");
     int ret = restore_audit_policies();
     assert_int_equal(ret, 1);
 }
@@ -3938,15 +3945,18 @@ void test_restore_audit_policies_command3_failed(void **state) {
     expect_string(__wrap_IsFile, file, "tmp\\backup-policies");
     will_return(__wrap_IsFile, 0);
 
-    expect_string(__wrap_wm_exec, command, "auditpol /restore /file:\"tmp\\backup-policies\"");
-    expect_value(__wrap_wm_exec, secs, 5);
-    expect_value(__wrap_wm_exec, add_path, NULL);
-    will_return(__wrap_wm_exec, "OUTPUT COMMAND");
-    will_return(__wrap_wm_exec, -1);
-    will_return(__wrap_wm_exec, 0);
+    int i;
+    int retries = 5;
+    char error_msgs[retries + 1][OS_SIZE_1024];
 
-    expect_string(__wrap__merror, formatted_msg, "(6635): Auditpol backup error: 'command returned failure'. Output: 'OUTPUT COMMAND'.");
+    for (i = 0;  i <= retries; i++) {
+        expect_wm_exec("auditpol /restore /file:\"tmp\\backup-policies\"", retries+i, NULL, "OUTPUT COMMAND", -1, 0);
+        expect_string(__wrap__merror, formatted_msg, "(6635): Auditpol backup error: 'command returned failure'. Output: 'OUTPUT COMMAND'.");
+        snprintf(error_msgs[i], sizeof(error_msgs[i]), "(6955): Auditpol command failed, attempt number: %d", i + 1);
+        expect_string(__wrap__merror, formatted_msg, error_msgs[i]);
+    }
 
+    expect_string(__wrap__merror, formatted_msg, "(6956): After 6 attempts the Auditpol command could not be executed successfully.");
     int ret = restore_audit_policies();
     assert_int_equal(ret, 1);
 }
@@ -6342,11 +6352,47 @@ void test_run_whodata_scan_no_auto_audit_policies(void **state) {
     expect_value(__wrap_wm_exec, add_path, NULL);
     will_return(__wrap_wm_exec, 1);
     will_return(__wrap_wm_exec, 0);
+    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 1");
+
+    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
+    expect_value(__wrap_wm_exec, secs, 6);
+    expect_value(__wrap_wm_exec, add_path, NULL);
+    will_return(__wrap_wm_exec, 1);
+    will_return(__wrap_wm_exec, 0);
+    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 2");
+
+    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
+    expect_value(__wrap_wm_exec, secs, 7);
+    expect_value(__wrap_wm_exec, add_path, NULL);
+    will_return(__wrap_wm_exec, 1);
+    will_return(__wrap_wm_exec, 0);
+    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 3");
+
+    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
+    expect_value(__wrap_wm_exec, secs, 8);
+    expect_value(__wrap_wm_exec, add_path, NULL);
+    will_return(__wrap_wm_exec, 1);
+    will_return(__wrap_wm_exec, 0);
+    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 4");
+
+    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
+    expect_value(__wrap_wm_exec, secs, 9);
+    expect_value(__wrap_wm_exec, add_path, NULL);
+    will_return(__wrap_wm_exec, 1);
+    will_return(__wrap_wm_exec, 0);
+    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 5");
+
+    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
+    expect_value(__wrap_wm_exec, secs, 10);
+    expect_value(__wrap_wm_exec, add_path, NULL);
+    will_return(__wrap_wm_exec, 1);
+    will_return(__wrap_wm_exec, 0);
+    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 6");
 
     expect_string(__wrap__merror, formatted_msg,
         "(6915): Audit policies could not be auto-configured due to the Windows version. Check if they are correct for whodata mode.");
-}
 
+}
     expect_string(__wrap__merror, formatted_msg, "(6916): Local audit policies could not be configured.");
 
     ret = run_whodata_scan();
@@ -6600,11 +6646,15 @@ void test_set_policies_fail_getting_policies(void **state) {
     expect_string(__wrap_IsFile, file, "tmp\\backup-policies");
     will_return(__wrap_IsFile, 1);
 
-    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
-    expect_value(__wrap_wm_exec, secs, 5);
-    expect_value(__wrap_wm_exec, add_path, NULL);
-    will_return(__wrap_wm_exec, 1);
-    will_return(__wrap_wm_exec, 0);
+    int i;
+    int retries = 5;
+    char error_msgs[retries+1][OS_SIZE_1024];
+
+    for (i = 0;  i <= retries; i++) {
+        expect_wm_exec("auditpol /backup /file:\"tmp\\backup-policies\"", retries+i, NULL, NULL, 1, 0);
+        snprintf(error_msgs[i], sizeof(error_msgs[i]), "(6955): Auditpol command failed, attempt number: %d", i + 1);
+        expect_string(__wrap__merror, formatted_msg, error_msgs[i]);
+    }
 
     expect_string(__wrap__merror, formatted_msg,
     "(6915): Audit policies could not be auto-configured due to the Windows version. Check if they are correct for whodata mode.");
@@ -6712,11 +6762,16 @@ void test_set_policies_unable_to_restore_policies(void **state) {
     expect_value(__wrap_fclose, _File, (FILE*)2345);
     will_return(__wrap_fclose, 0);
 
-    expect_string(__wrap_wm_exec, command, "auditpol /restore /file:\"tmp\\new-policies\"");
-    expect_value(__wrap_wm_exec, secs, 5);
-    expect_value(__wrap_wm_exec, add_path, NULL);
-    will_return(__wrap_wm_exec, 1);
-    will_return(__wrap_wm_exec, 0);
+    int i;
+    int retries = 5;
+    char error_msgs[retries+1][OS_SIZE_1024];
+
+    for (i = 0;  i <= retries; i++) {
+        expect_wm_exec("auditpol /restore /file:\"tmp\\new-policies\"", retries+i, NULL, NULL, 1, 0);
+        snprintf(error_msgs[i], sizeof(error_msgs[i]), "(6955): Auditpol command failed, attempt number: %d", i + 1);
+        expect_string(__wrap__merror, formatted_msg, error_msgs[i]);
+    }
+
     expect_string(__wrap__merror, formatted_msg,
         "(6915): Audit policies could not be auto-configured due to the Windows version. Check if they are correct for whodata mode.");
 
@@ -6727,6 +6782,7 @@ void test_set_policies_unable_to_restore_policies(void **state) {
 
     assert_int_equal(ret, 2);
 }
+
 void test_set_policies_success(void **state) {
     int ret;
 

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -6347,47 +6347,15 @@ void test_run_whodata_scan_no_auto_audit_policies(void **state) {
     expect_string(__wrap_remove, filename, "tmp\\backup-policies");
     will_return(__wrap_remove, 0);
 
-    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
-    expect_value(__wrap_wm_exec, secs, 5);
-    expect_value(__wrap_wm_exec, add_path, NULL);
-    will_return(__wrap_wm_exec, 1);
-    will_return(__wrap_wm_exec, 0);
-    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 1");
+    int i;
+    int retries = 5;
+    char error_msgs[retries + 1][OS_SIZE_1024];
 
-    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
-    expect_value(__wrap_wm_exec, secs, 6);
-    expect_value(__wrap_wm_exec, add_path, NULL);
-    will_return(__wrap_wm_exec, 1);
-    will_return(__wrap_wm_exec, 0);
-    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 2");
-
-    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
-    expect_value(__wrap_wm_exec, secs, 7);
-    expect_value(__wrap_wm_exec, add_path, NULL);
-    will_return(__wrap_wm_exec, 1);
-    will_return(__wrap_wm_exec, 0);
-    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 3");
-
-    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
-    expect_value(__wrap_wm_exec, secs, 8);
-    expect_value(__wrap_wm_exec, add_path, NULL);
-    will_return(__wrap_wm_exec, 1);
-    will_return(__wrap_wm_exec, 0);
-    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 4");
-
-    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
-    expect_value(__wrap_wm_exec, secs, 9);
-    expect_value(__wrap_wm_exec, add_path, NULL);
-    will_return(__wrap_wm_exec, 1);
-    will_return(__wrap_wm_exec, 0);
-    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 5");
-
-    expect_string(__wrap_wm_exec, command, "auditpol /backup /file:\"tmp\\backup-policies\"");
-    expect_value(__wrap_wm_exec, secs, 10);
-    expect_value(__wrap_wm_exec, add_path, NULL);
-    will_return(__wrap_wm_exec, 1);
-    will_return(__wrap_wm_exec, 0);
-    expect_string(__wrap__merror, formatted_msg, "(6955): Auditpol command failed, attempt number: 6");
+    for (i = 0;  i <= retries; i++) {
+        expect_wm_exec("auditpol /backup /file:\"tmp\\backup-policies\"", retries+i, NULL, NULL, 1, 0);
+        snprintf(error_msgs[i], sizeof(error_msgs[i]), "(6955): Auditpol command failed, attempt number: %d", i + 1);
+        expect_string(__wrap__merror, formatted_msg, error_msgs[i]);
+    }
 
     expect_string(__wrap__merror, formatted_msg,
         "(6915): Audit policies could not be auto-configured due to the Windows version. Check if they are correct for whodata mode.");

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_exec_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_exec_wrappers.c
@@ -30,3 +30,15 @@ int __wrap_wm_exec(char *command, char **output, int *exitcode, int secs, const 
 
     return mock();
 }
+
+void expect_wm_exec(char *command, int sec, const char * add_path, char *output_command, int exitcode, int return_code) {
+    expect_string(__wrap_wm_exec, command, command);
+    expect_value(__wrap_wm_exec, secs, sec);
+    expect_value(__wrap_wm_exec, add_path, add_path);
+    if (output_command != NULL) {
+	    will_return(__wrap_wm_exec, output_command);
+    }
+    will_return(__wrap_wm_exec, exitcode);
+    will_return(__wrap_wm_exec, return_code);
+}
+

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_exec_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_exec_wrappers.h
@@ -12,5 +12,6 @@
 #define WM_EXEC_WRAPPERS_H
 
 int __wrap_wm_exec(char *command, char **output, int *exitcode, int secs, const char * add_path);
+void expect_wm_exec(char *command, int sec, const char * add_path, char *output_command, int exitcode, int return_code);
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/21420|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
As reported in https://github.com/wazuh/wazuh/issues/21420, problems while starting Whodata in Windows were found. The reason was that the timeout, while getting the current Whodata policies or setting the new ones, was running out, resulting in Wazuh not being capable of loading Whodata and just running in real time mode.

The proposed solutions establish a loop where this operation is tried to be performed with increasing timeout while the returned value is not expected.


<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
To test it Whodata must be enabled in at least one folder to be monitored, in order to make Wazuh load Whodata.

<!--
When proceed, this section should include new configuration parameters.
-->

## Tests
To test it I have built a `.msi` file via this Jenkins job: https://ci.wazuh.info/job/Packages_builder_win/16679/

After rebooting the agent up to 150 times and making wazuh load Whodata in each time, the logs showing problems while starting it have not been recorded.

Attached the resulting `ossec.log` file with the tests done: [fixed_ossec.log](https://github.com/wazuh/wazuh/files/13952564/fixed_ossec.log)