### PR TITLE
Package format added as argument to the getCnaName method to temporary skip pypi format packages

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -545,13 +545,18 @@ public:
     }
 
     /**
-     * @brief Get CNA/ADP name based on the package vendor.
+     * @brief Get CNA/ADP name based on the package vendor and the package format.
      * @param vendor Package vendor.
      * @param format Package format.
      * @return CNA/ADP name.
      */
     std::string getCnaName(std::string_view vendor, std::string_view format)
     {
+        /**
+         * In the future, the pypi format will be processed with the OSV feed.
+         * But until this moment, this early return prevents false positives
+         * because of a wrong process using the nvd feed.
+         */
         if (!format.compare("pypi"))
         {
             return "";

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -547,10 +547,16 @@ public:
     /**
      * @brief Get CNA/ADP name based on the package vendor.
      * @param vendor Package vendor.
+     * @param format Package format.
      * @return CNA/ADP name.
      */
-    std::string getCnaName(std::string_view vendor)
+    std::string getCnaName(std::string_view vendor, std::string_view format)
     {
+        if (!format.compare("pypi"))
+        {
+            return "";
+        }
+
         const static std::map<std::string, std::string> vendorToCnaName = {{"canonical", "canonical"},
                                                                            {"ubuntu", "canonical"},
                                                                            {"debian", "debian"},

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -189,7 +189,24 @@ public:
             }
         };
 
-        const auto cnaName {m_databaseFeedManager->getCnaName(data->packageVendor())};
+        const auto cnaName {m_databaseFeedManager->getCnaName(data->packageVendor(), data->packageFormat())};
+
+        if (cnaName.empty())
+        {
+            logDebug1(WM_VULNSCAN_LOGTAG,
+                      "Vulnerability scan skipped because CNA can't be resolved for package '%s' on Agent '%s' (ID: "
+                      "'%s', Version: '%s'). "
+                      "Vendor: '%s'. Format: '%s'",
+                      packageName.c_str(),
+                      data->agentName().data(),
+                      data->agentId().data(),
+                      data->agentVersion().data(),
+                      data->packageVendor().data(),
+                      data->packageFormat().data());
+
+            return nullptr;
+        }
+
         logDebug1(WM_VULNSCAN_LOGTAG,
                   "Initiating a vulnerability scan for package '%s' with CVE Numbering Authorities (CNA) '%s' on Agent "
                   "'%s' (ID: '%s', Version: '%s').",

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockDatabaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockDatabaseFeedManager.hpp
@@ -98,7 +98,7 @@ public:
      *
      * @note This method is intended for testing purposes and does not perform any real action.
      */
-    MOCK_METHOD(std::string, getCnaName, (std::string_view vendor), ());
+    MOCK_METHOD(std::string, getCnaName, (std::string_view vendor, std::string_view format), ());
 };
 
 #endif // _MOCK_DATABASEFEEDMANAGER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -1094,24 +1094,32 @@ TEST_F(DatabaseFeedManagerTest, GetCNAName)
                                               TrampolineRouterSubscriber>>(spIndexerConnectorTramp, shouldStop, mutex)};
 
     // For canonical use mantainer name.
-    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Nikhil Kshirsagar <nikhil.kshirsagar@canonical.com>").c_str(),
-                 "canonical");
+    EXPECT_STREQ(
+        spDatabaseFeedManager->getCnaName("Nikhil Kshirsagar <nikhil.kshirsagar@canonical.com>", "deb").c_str(),
+        "canonical");
+
     // For ubuntu use mantainer name.
-    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>").c_str(),
-                 "canonical");
-    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Eric Desrochers <slashd@ubuntu.com>").c_str(), "canonical");
+    EXPECT_STREQ(
+        spDatabaseFeedManager->getCnaName("Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>", "deb").c_str(),
+        "canonical");
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Eric Desrochers <slashd@ubuntu.com>", "deb").c_str(), "canonical");
+
     // For debian use mantainer name.
-    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Debian GCC Maintainers <debian-gcc@lists.debian.org>").c_str(),
-                 "debian");
+    EXPECT_STREQ(
+        spDatabaseFeedManager->getCnaName("Debian GCC Maintainers <debian-gcc@lists.debian.org>", "deb").c_str(),
+        "debian");
 
     // For redhat use mantainer name.
-    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Red Hat, Inc. <loren@ipsum.com>").c_str(), "redhat");
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("Red Hat, Inc. <loren@ipsum.com>", "rpm").c_str(), "redhat");
 
     // For centos use mantainer name.
-    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("CentOS <lorem@ipsum.com>").c_str(), "redhat");
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("CentOS <lorem@ipsum.com>", "rpm").c_str(), "redhat");
 
     // By default use NVD
-    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("loremIpsum").c_str(), "nvd");
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName("loremIpsum", "").c_str(), "nvd");
+
+    // For Pypi packages.
+    EXPECT_STREQ(spDatabaseFeedManager->getCnaName(" ", "pypi").c_str(), "");
 }
 
 /* DatabaseFeedManagerMessageProcessor tests */

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
@@ -313,7 +313,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualTo)
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_)).WillOnce(testing::Return("cnaName"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_, _)).WillOnce(testing::Return("cnaName"));
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates(_, _, _))
         .WillOnce(testing::Invoke(mockGetVulnerabilitiesCandidates));
 
@@ -400,7 +400,7 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedEqualTo)
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_)).WillOnce(testing::Return("cnaName"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_, _)).WillOnce(testing::Return("cnaName"));
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates(_, _, _))
         .WillOnce(testing::Invoke(mockGetVulnerabilitiesCandidates));
 
@@ -478,7 +478,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThan)
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_)).WillOnce(testing::Return("cnaName"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_, _)).WillOnce(testing::Return("cnaName"));
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates(_, _, _))
         .WillOnce(testing::Invoke(mockGetVulnerabilitiesCandidates));
 
@@ -565,7 +565,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanOrEqual)
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_)).WillOnce(testing::Return("cnaName"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_, _)).WillOnce(testing::Return("cnaName"));
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates(_, _, _))
         .WillOnce(testing::Invoke(mockGetVulnerabilitiesCandidates));
 
@@ -652,7 +652,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanWithVersionNotZero)
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_)).WillOnce(testing::Return("cnaName"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_, _)).WillOnce(testing::Return("cnaName"));
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates(_, _, _))
         .WillOnce(testing::Invoke(mockGetVulnerabilitiesCandidates));
 
@@ -739,7 +739,7 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedLessThan)
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_)).WillOnce(testing::Return("cnaName"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_, _)).WillOnce(testing::Return("cnaName"));
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates(_, _, _))
         .WillOnce(testing::Invoke(mockGetVulnerabilitiesCandidates));
 
@@ -817,7 +817,7 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusAffected)
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_)).WillOnce(testing::Return("cnaName"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_, _)).WillOnce(testing::Return("cnaName"));
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates(_, _, _))
         .WillOnce(testing::Invoke(mockGetVulnerabilitiesCandidates));
 
@@ -904,7 +904,7 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusUnaffected)
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_)).WillOnce(testing::Return("cnaName"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_, _)).WillOnce(testing::Return("cnaName"));
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates(_, _, _))
         .WillOnce(testing::Invoke(mockGetVulnerabilitiesCandidates));
 
@@ -956,7 +956,7 @@ TEST_F(PackageScannerTest, TestPackageGetVulnerabilitiesCandidatesGeneratesExcep
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_)).WillOnce(testing::Return("cnaName"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaName(_, _)).WillOnce(testing::Return("cnaName"));
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates(_, _, _))
         .WillOnce(testing::Invoke(mockGetVulnerabilitiesCandidates));
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/policyManager_test.cpp
@@ -349,7 +349,7 @@ TEST_F(PolicyManagerTest, validConfigurationCheckFeedUpdateIntervalLessThan60m)
 
     EXPECT_STREQ(
         m_policyManager->getUpdaterConfiguration().dump().c_str(),
-        R"({"configData":{"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-offset","dataFormat":"json","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"queue/vd_updater/tmp","url":"https://cti-url.com","versionedContent":"false"},"interval":3600,"ondemand":true,"topicName":"vulnerability_feed_manager"})");
+        R"({"configData":{"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-offset","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"queue/vd_updater/tmp","url":"https://cti-url.com","versionedContent":"false"},"interval":3600,"ondemand":true,"topicName":"vulnerability_feed_manager"})");
 
     EXPECT_EQ(m_policyManager->getUpdaterConfiguration().at("interval"), 3600);
 }
@@ -373,7 +373,7 @@ TEST_F(PolicyManagerTest, validConfigurationCheckFeedUpdateIntervalGreaterThan60
 
     EXPECT_STREQ(
         m_policyManager->getUpdaterConfiguration().dump().c_str(),
-        R"({"configData":{"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-offset","dataFormat":"json","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"queue/vd_updater/tmp","url":"https://cti-url.com","versionedContent":"false"},"interval":3660,"ondemand":true,"topicName":"vulnerability_feed_manager"})");
+        R"({"configData":{"compressionType":"raw","contentFileName":"api_file.json","contentSource":"cti-offset","databasePath":"queue/vd_updater/rocksdb","deleteDownloadedContent":true,"offset":0,"outputFolder":"queue/vd_updater/tmp","url":"https://cti-url.com","versionedContent":"false"},"interval":3660,"ondemand":true,"topicName":"vulnerability_feed_manager"})");
 
     EXPECT_EQ(m_policyManager->getUpdaterConfiguration().at("interval"), 3660);
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21235  |

## Description

This PR modified the method TDatabaseFeedManager::getCnaName adding the packet format argument to allow the CNA decision algorithm to take it into account. For the particular case of PiPy format, temporary it return no CNA string. Also the PackageScanner logic was modified to allow skip scan of packages without CNA specified.
UTs were also added.

## Logs and Evidence
Previous to the changes the PyPi package "language-selector" was scanned against nvd feed and found as vulnerable.
Here are the previous logs:

```
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:53 at handleRequest(): DEBUG: Initiating a vulnerability scan for package 'language-selector' on Agent '78e8dc8901e2' (ID: '001', Version: 'v4.8.0').
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:191 at handleRequest(): DEBUG: Initiating a vulnerability scan for package 'language-selector' with CVE Numbering Authorities (CNA) 'nvd' on Agent '78e8dc8901e2' (ID: '001', Version: 'v4.8.0').
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:77 at operator()(): DEBUG: Scanning package - 'language-selector' (Installed Version: 0.1, Security Vulnerability: CVE-2011-0729). Identified vulnerability: Version: 0. Required Version Threshold: . Required Version Threshold (or Equal): 0.6.6.
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:129 at operator()(): INFO: Match found, the package 'language-selector', is vulnerable to 'CVE-2011-0729'. Current version: '0.1' (less than '' or equal to '0.6.6'). - Agent '78e8dc8901e2' (ID: '001', Version: 'v4.8.0').
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:77 at operator()(): DEBUG: Scanning package - 'language-selector' (Installed Version: 0.1, Security Vulnerability: CVE-2011-1842). Identified vulnerability: Version: 0. Required Version Threshold: . Required Version Threshold (or Equal): 0.6.6.
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:129 at operator()(): INFO: Match found, the package 'language-selector', is vulnerable to 'CVE-2011-1842'. Current version: '0.1' (less than '' or equal to '0.6.6'). - Agent '78e8dc8901e2' (ID: '001', Version: 'v4.8.0').
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:77 at operator()(): DEBUG: Scanning package - 'language-selector' (Installed Version: 0.1, Security Vulnerability: CVE-2013-1066). Identified vulnerability: Version: 0.110. Required Version Threshold: . Required Version Threshold (or Equal): .
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:77 at operator()(): DEBUG: Scanning package - 'language-selector' (Installed Version: 0.1, Security Vulnerability: CVE-2013-1066). Identified vulnerability: Version: 0.79. Required Version Threshold: . Required Version Threshold (or Equal): .
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:77 at operator()(): DEBUG: Scanning package - 'language-selector' (Installed Version: 0.1, Security Vulnerability: CVE-2013-1066). Identified vulnerability: Version: 0.79.1. Required Version Threshold: . Required Version Threshold (or Equal): .
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:77 at operator()(): DEBUG: Scanning package - 'language-selector' (Installed Version: 0.1, Security Vulnerability: CVE-2013-1066). Identified vulnerability: Version: 0.79.2. Required Version Threshold: . Required Version Threshold (or Equal): .
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:77 at operator()(): DEBUG: Scanning package - 'language-selector' (Installed Version: 0.1, Security Vulnerability: CVE-2013-1066). Identified vulnerability: Version: 0.79.3. Required Version Threshold: . Required Version Threshold (or Equal): .
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:77 at operator()(): DEBUG: Scanning package - 'language-selector' (Installed Version: 0.1, Security Vulnerability: CVE-2013-1066). Identified vulnerability: Version: 0.90. Required Version Threshold: . Required Version Threshold (or Equal): .
2024/01/16 13:15:56 wazuh-modulesd:vulnerability-scanner[41942] packageScanner.hpp:215 at handleRequest(): DEBUG: Vulnerability scan for package 'language-selector' on Agent '001' has completed.
```

After the modification, the same package is skip since its format is PyPi.
```
2024/01/16 16:58:38 wazuh-modulesd:vulnerability-scanner[85308] packageScanner.hpp:53 at handleRequest(): DEBUG: Initiating a vulnerability scan for package 'language-selector' on Agent '78e8dc8901e2' (ID: '001', Version: 'v4.8.0').
2024/01/16 16:58:38 wazuh-modulesd:vulnerability-scanner[85308] packageScanner.hpp:194 at handleRequest(): DEBUG: Vulnerability scan skipped because CNA can't be resolved for package 'language-selector' on Agent '78e8dc8901e2' (ID: '001', Version: 'v4.8.0'). Vendor: ' '. Format: 'pypi'
```

## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Run UTs successfully
- [ ] Run Manual tests