### PR TITLE
Rework SCA for Debian Linux 12

### DIFF
--- a/ruleset/sca/debian/cis_debian12.yml
+++ b/ruleset/sca/debian/cis_debian12.yml
@@ -557,7 +557,7 @@ checks:
     condition: any
     rules:
       - 'f:/etc/sudoers -> r:Defaults\s*\t*use_pty'
-      - 'd:/etc/sudoers -> r: \.* -> r:Defaults\s*\t*use_pty'
+      - 'd:/etc/sudoers.d/ -> r: \.* -> r:Defaults\s*\t*use_pty'
 
   # 1.3.3 Ensure sudo log file exists (Automated)
   - id: 33027
@@ -575,7 +575,7 @@ checks:
     condition: any
     rules:
       - 'f:/etc/sudoers -> r:Defaults\s*\t*logfile=\S+'
-      - 'd:/etc/sudoers -> r: \.* -> r:Defaults\s*\t*logfile=\S+'
+      - 'd:/etc/sudoers.d/ -> r: \.* -> r:Defaults\s*\t*logfile=\S+'
 
   ###############################################
   # 1.4 Filesystem Integrity Checking


### PR DESCRIPTION
|Wazuh version| Component | 
|---| --- |
| 4.4.x | SCA | 

Solve Wrong sudoers check in Debian 12 SCA

- [X] Solve typos.
- [ ] Increase check coverage. 
- [ ] Improve rules implementation.
- [X] Improve texts.
- [X] Solve reported issues.

- https://github.com/wazuh/wazuh/issues/21421