### PR TITLE
Fix Segmentation fault in wazuh-analysisd when socket is configured

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -433,7 +433,7 @@ int main_analysisd(int argc, char **argv)
     }
 
 /* Check sockets */
-    if (Config.socket_list) {
+    if (Config.socket_list && Config.forwarders_list) {
         forwarder_socket_list = Config.socket_list;
 
         for(int num_sk = 0; forwarder_socket_list && forwarder_socket_list[num_sk].name; num_sk++) {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -442,7 +442,7 @@ int main_analysisd(int argc, char **argv)
 
         for (int target_num = 0; Config.forwarders_list[target_num]; target_num++) {
             int found = -1;
-            for (int num_sk = 0; forwarder_socket_list && forwarder_socket_list->name; num_sk++) {
+            for (int num_sk = 0; forwarder_socket_list && forwarder_socket_list[num_sk].name; num_sk++) {
                 found = strcmp(forwarder_socket_list[num_sk].name, Config.forwarders_list[target_num]);
                 if (found == 0) {
                     break;


### PR DESCRIPTION
|Related issue|
|---|
|#21437|

## Description

According to the latest [documentation updates](https://github.com/wazuh/wazuh-documentation/blob/e3dd3ef1cdae2bbdd4ed3107c37783767110d103/source/user-manual/manager/fluent-forwarder.rst#L160), `fluentd` support has been added to `analysisd` and for this it is necessary to add an extra configuration to `global` called `forward_to`. If this is done correctly the error does not occur.

This segmentation fault is happening because of the following code:

```c++
if (Config.socket_list) {
        forwarder_socket_list = Config.socket_list;

        for(int num_sk = 0; forwarder_socket_list && forwarder_socket_list[num_sk].name; num_sk++) {
            mdebug1("Socket '%s' (%s) added. Location: %s", forwarder_socket_list[num_sk].name, forwarder_socket_list[num_sk].mode == IPPROTO_UDP ? "udp" : "tcp", forwarder_socket_list[num_sk].location);
        }

        for (int target_num = 0; Config.forwarders_list[target_num]; target_num++) {
...
```

If we add a `socket` to the configuration, `Config.socket_list` will be valid, but if we do not add `forward_to`, `Config.forwarders_list` will be empty and access will be attempted throwing a segmentation fault.

Adding an extra `Config.forwarders_list` check will be enough to avoid this bug.

```c++
if (Config.socket_list && Config.forwarders_list) {
```

## Configuration options

For `logcollector` (original issue error)
```xml
  <fluent-forward>
    <enabled>yes</enabled>
    <tag>debug.test</tag>
    <socket_path>/var/run/fluent.sock</socket_path>
    <address>localhost</address>
    <port>24224</port>
    <shared_key>demo</shared_key>
    <ca_file>/tmp/tlsTest/rootCA.pem</ca_file>
  </fluent-forward>

  <socket>
    <name>fluent_socket</name>
    <location>/var/run/fluent.sock</location>
    <mode>udp</mode>
  </socket>

  <localfile>
    <log_format>syslog</log_format>
    <location>/tmp/fluentd.log</location>
    <target>fluent_socket</target>
  </localfile>
```

For `analysisd`
```xml
<fluent-forward>
  <enabled>yes</enabled>
  <tag>debug.test</tag>
  <socket_path>/var/ossec/var/run/fluent.sock</socket_path>
  <address>localhost</address>
  <port>24224</port>
</fluent-forward>

<socket>
  <name>fluent_socket</name>
  <location>/var/ossec/var/run/fluent.sock</location>
  <mode>udp</mode>
</socket>

<global>
  <forward_to>fluent_socket</forward_to>
</global>
```

## Logs/Alerts example

Before (`logcollector`):
```console
2024/01/17 17:42:04 wazuh-analysisd[137818] analysisd.c:410 at main(): DEBUG: Read configuration ...
2024/01/17 17:42:04 wazuh-analysisd[137818] analysisd.c:440 at main(): DEBUG: Socket 'fluent_socket' (udp) added. Location: /var/run/fluent.sock
Segmentation fault (core dumped)
wazuh-analysisd: Configuration error. Exiting
```

After (`logcollector`):
```console
2024/01/17 17:54:49 wazuh-analysisd[141797] analysisd.c:410 at main(): DEBUG: Read configuration ...
2024/01/17 17:54:49 wazuh-analysisd[141797] analysisd.c:533 at main(): DEBUG: Chrooted to directory: /var/ossec, using user: wazuh
2024/01/17 17:54:49 wazuh-analysisd[141797] analysisd.c:590 at main(): DEBUG: Reading decoder file ruleset/decoders/0005-wazuh_decoders.xml.
```

Before (`analysisd`):
```console
2024/01/17 18:01:57 wazuh-analysisd[148384] analysisd.c:410 at main(): DEBUG: Read configuration ...
2024/01/17 18:01:57 wazuh-analysisd[148384] analysisd.c:440 at main(): DEBUG: Socket 'fluent_socket' (udp) added. Location: /var/ossec/var/run/fluent.sock
2024/01/17 18:01:57 wazuh-analysisd[148384] analysisd.c:533 at main(): DEBUG: Chrooted to directory: /var/ossec, using user: wazuh
2024/01/17 18:01:57 wazuh-analysisd[154267] analysisd.c:590 at main(): DEBUG: Reading decoder file ruleset/decoders/0005-wazuh_decoders.xml.
```

After (`analysisd`):
```console
2024/01/17 18:04:38 wazuh-analysisd[154267] analysisd.c:410 at main(): DEBUG: Read configuration ...
2024/01/17 18:04:38 wazuh-analysisd[154267] analysisd.c:440 at main(): DEBUG: Socket 'fluent_socket' (udp) added. Location: /var/ossec/var/run/fluent.sock
2024/01/17 18:04:38 wazuh-analysisd[154267] analysisd.c:533 at main(): DEBUG: Chrooted to directory: /var/ossec, using user: wazuh
2024/01/17 18:04:38 wazuh-analysisd[154267] analysisd.c:590 at main(): DEBUG: Reading decoder file ruleset/decoders/0005-wazuh_decoders.xml.
```
