### PR TITLE
Reject AWS inspector service unsupported regions

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -112,14 +112,22 @@ def main(argv):
                 if aws_config.has_option(profile, "region"):
                     options.regions.append(aws_config.get(profile, "region"))
                 else:
-                    aws_tools.debug("+++ Warning: No regions were specified, trying to get events from all regions", 1)
-                    options.regions = aws_tools.ALL_REGIONS
+                    if service_type == services.inspector.AWSInspector:
+                        aws_tools.debug(
+                            "+++ Warning: No regions were specified, trying to get events from supported regions", 1
+                        )
+                        options.regions = services.inspector.SUPPORTED_REGIONS
+                    else:
+                        aws_tools.debug(
+                            "+++ Warning: No regions were specified, trying to get events from all regions", 1
+                        )
+                        options.regions = aws_tools.ALL_REGIONS
 
             for region in options.regions:
                 try:
                     service_type.check_region(region)
-                except ValueError:
-                    aws_tools.debug(f"+++ ERROR: The region '{region}' is not a valid one.", 1)
+                except ValueError as exc:
+                    aws_tools.debug(f"+++ ERROR: {exc}", 1)
                     exit(22)
 
                 aws_tools.debug('+++ Getting alerts from "{}" region.'.format(region), 1)

--- a/wodles/aws/services/aws_service.py
+++ b/wodles/aws/services/aws_service.py
@@ -135,6 +135,14 @@ class AWSService(wazuh_integration.WazuhAWSDatabase):
 
     @staticmethod
     def check_region(region: str) -> None:
+        """
+        Check if the region is valid.
+        
+        Parameters
+        ----------
+        region : str
+            AWS region.
+        """
         if region not in aws_tools.ALL_REGIONS:
             raise ValueError(f"Invalid region '{region}'")
 

--- a/wodles/aws/services/inspector.py
+++ b/wodles/aws/services/inspector.py
@@ -13,6 +13,12 @@ sys.path.insert(0, path.dirname(path.dirname(path.abspath(__file__))))
 import aws_tools
 
 
+SUPPORTED_REGIONS = (
+    'ap-northeast-1', 'ap-northeast-2', 'ap-south-1', 'ap-southeast-2', 'eu-central-1', 'eu-north-1', 'eu-west-1',
+    'eu-west-2', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'
+)
+
+
 class AWSInspector(aws_service.AWSService):
     """
     Class for getting AWS Inspector logs
@@ -137,3 +143,16 @@ class AWSInspector(aws_service.AWSService):
             'retain_db_records': self.retain_db_records})
         # close connection with DB
         self.close_db()
+
+    @staticmethod
+    def check_region(region: str) -> None:
+        """
+        Check if the region is supported.
+        
+        Parameters
+        ----------
+        region : str
+            AWS region.
+        """
+        if region not in SUPPORTED_REGIONS:
+            raise ValueError(f"Unsupported region '{region}'")

--- a/wodles/aws/tests/test_aws_s3.py
+++ b/wodles/aws/tests/test_aws_s3.py
@@ -2,17 +2,16 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import argparse
 import os
 import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
-import configparser
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
 import aws_s3
 import aws_tools
+import services
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '.'))
 import aws_utils as utils
@@ -58,45 +57,36 @@ def test_main(mock_arguments, args: list[str], class_):
         instance.check_bucket.assert_called_once()
         instance.iter_bucket.assert_called_once()
     elif 'service' in args[1]:
-        assert mocked_class.call_count == len(aws_tools.ALL_REGIONS)
-        assert instance.get_alerts.call_count == len(aws_tools.ALL_REGIONS)
+        if args[2] == 'inspector':
+            assert mocked_class.call_count == len(services.inspector.SUPPORTED_REGIONS)
+            assert instance.get_alerts.call_count == len(services.inspector.SUPPORTED_REGIONS)
+        else:
+            assert mocked_class.call_count == len(aws_tools.ALL_REGIONS)
+            assert instance.get_alerts.call_count == len(aws_tools.ALL_REGIONS)
     elif 'subscriber' in args[1]:
         mocked_class.assert_called_once()
         instance.sync_events.assert_called_once()
 
 
-@pytest.mark.parametrize('args', [
-    ['main', '--bucket', 'bucket-name', '--type', 'invalid'],
-    ['main', '--service', 'invalid'],
-    ['main', '--subscriber', 'invalid']
+@pytest.mark.parametrize('args, error_code', [
+    (['main', '--bucket', 'bucket-name', '--type', 'invalid'], utils.INVALID_TYPE_ERROR_CODE),
+    (['main', '--service', 'invalid'], utils.INVALID_TYPE_ERROR_CODE),
+    (['main', '--subscriber', 'invalid'], utils.INVALID_TYPE_ERROR_CODE),
+    (['main', '--service', 'cloudwatchlogs', '--regions', 'in-valid-1'], utils.INVALID_REGION_ERROR_CODE),
+    (['main', '--service', 'inspector', '--regions', 'in-valid-1'], utils.INVALID_REGION_ERROR_CODE),
+    (['main', '--service', 'inspector', '--regions', 'af-south-1'], utils.INVALID_REGION_ERROR_CODE)
 ])
-@patch('aws_tools.get_script_arguments', side_effect=aws_tools.get_script_arguments)
-def test_main_type_ko(mock_arguments, args: list[str]):
+def test_main_type_ko(args: list[str], error_code: int):
     """Test 'main' function handles exceptions when receiving invalid buckets or services.
 
     Parameters
     ----------
     args : list[str]
         List of arguments that make the `main` function exit.
+    error_code : int
+        Expected error code.
     """
     with patch("sys.argv", args), \
             pytest.raises(SystemExit) as e:
         aws_s3.main(args)
-    assert e.value.code == utils.INVALID_TYPE_ERROR_CODE
-
-
-@patch('aws_tools.get_script_arguments', side_effect=aws_tools.get_script_arguments)
-def test_main_invalid_region_ko(mock_arguments):
-    """Test 'main' function handles exceptions when receiving invalid region.
-
-    Parameters
-    ----------
-    args : list[str]
-        List of arguments that make the `main` function exit.
-    """
-    args = ['main', '--service', 'inspector', '--regions', 'in-valid-1']
-
-    with patch("sys.argv", args), \
-            pytest.raises(SystemExit) as e:
-        aws_s3.main(args)
-    assert e.value.code == utils.INVALID_REGION_ERROR_CODE
+    assert e.value.code == error_code


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/21419|

## Description

Checks if the regions used are supported by the inspector service when using it.

## Logs/Alerts example

### Inspector service execution using different regions

#### Supported

<details><summary>us-east-1</summary>

```console
root@wazuh-master:/# /var/ossec/wodles/aws/aws-s3 -sr inspector -d 2 -s 2022-JAN-26 -r us-east-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Table does not exist; create
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ 117 events collected and processed in us-east-1
```

</details>

<details><summary>ap-northeast-1</summary>

```console
root@wazuh-master:/# /var/ossec/wodles/aws/aws-s3 -sr inspector -d 2 -s 2022-JAN-26 -r ap-northeast-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Getting alerts from "ap-northeast-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ There are no new events in the "ap-northeast-1" region
```

</details>

#### Not supported

<details><summary>af-south-1</summary>

```console
root@wazuh-master:/# /var/ossec/wodles/aws/aws-s3 -sr inspector -d 2 -s 2022-JAN-26 -r af-south-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ ERROR: Unsupported region 'af-south-1'
```

</details>

<details><summary>eu-south-1</summary>

```console
root@wazuh-master:/# /var/ossec/wodles/aws/aws-s3 -sr inspector -d 2 -s 2022-JAN-26 -r eu-south-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ ERROR: Unsupported region 'eu-south-1'
```

</details>

#### All regions

<details><summary>No region specified</summary>

```console
root@wazuh-master:/# /var/ossec/wodles/aws/aws-s3 -sr inspector -d 2 -s 2022-JAN-26
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Warning: No regions were specified, trying to get events from supported regions
DEBUG: +++ Getting alerts from "ap-northeast-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2024-01-18 14:21:24.124795
DEBUG: +++ There are no new events in the "ap-northeast-1" region
DEBUG: +++ Getting alerts from "ap-northeast-2" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ There are no new events in the "ap-northeast-2" region
DEBUG: +++ Getting alerts from "ap-south-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ There are no new events in the "ap-south-1" region
DEBUG: +++ Getting alerts from "ap-southeast-2" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ There are no new events in the "ap-southeast-2" region
DEBUG: +++ Getting alerts from "eu-central-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ There are no new events in the "eu-central-1" region
DEBUG: +++ Getting alerts from "eu-north-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ There are no new events in the "eu-north-1" region
DEBUG: +++ Getting alerts from "eu-west-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ There are no new events in the "eu-west-1" region
DEBUG: +++ Getting alerts from "eu-west-2" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ There are no new events in the "eu-west-2" region
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2024-01-18 14:14:35.529822
DEBUG: +++ There are no new events in the "us-east-1" region
DEBUG: +++ Getting alerts from "us-east-2" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ There are no new events in the "us-east-2" region
DEBUG: +++ Getting alerts from "us-west-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ There are no new events in the "us-west-1" region
DEBUG: +++ Getting alerts from "us-west-2" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Listing findings starting from 2022-01-26 00:00:00
DEBUG: +++ There are no new events in the "us-west-2" region
```

</details>

### Cloudwatchlogs execution using an invalid region

<details><summary>in-region-1</summary>

```console
root@wazuh-master:/# /var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -d 2 -s 2022-JAN-26 -r in-region-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ ERROR: Invalid region 'in-region-1'
```

</details>

### Tests

<details><summary>wodles/aws/tests/test_aws_s3.py</summary>

```console
(venv10) gasti@pop-os:~/work/wazuh$ python3 -m pytest wodles/aws/tests/test_aws_s3.py --disable-warnings
================================================================================= test session starts =================================================================================
platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-1.3.0
rootdir: /home/gasti/work/wazuh/wodles/aws/tests
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.7.0, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 20 items                                                                                                                                                                    

wodles/aws/tests/test_aws_s3.py ....................                                                                                                                            [100%]

================================================================================= 20 passed in 0.20s ==================================================================================
```

</details>