### PR TITLE
Avoid empty `data.aws` fields in non-AWS alerts

### DIFF
--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -7,7 +7,8 @@
         "field": "data.aws.region",
         "value": "{{data.aws.awsRegion}}",
         "override": false,
-        "ignore_failure": true
+        "ignore_failure": true,
+        "ignore_empty_value" : true
       }
     },
     {
@@ -15,7 +16,8 @@
         "field": "data.aws.accountId",
         "value": "{{data.aws.aws_account_id}}",
         "override": false,
-        "ignore_failure": true
+        "ignore_failure": true,
+        "ignore_empty_value" : true
       }
     },
     {

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -7,7 +7,8 @@
         "field": "data.aws.region",
         "value": "{{data.aws.awsRegion}}",
         "override": false,
-        "ignore_failure": true
+        "ignore_failure": true,
+        "ignore_empty_value" : true
       }
     },
     {
@@ -15,7 +16,8 @@
         "field": "data.aws.accountId",
         "value": "{{data.aws.aws_account_id}}",
         "override": false,
-        "ignore_failure": true
+        "ignore_failure": true,
+        "ignore_empty_value" : true
       }
     },
     {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/21339|

## Description

This pull request updates the Filebeat module's `pipeline.json` files to avoid empty fields in `data.aws.region` and `data.aws.accountId`

## Tests

- See https://github.com/wazuh/wazuh/issues/21339#issuecomment-1898683131