### PR TITLE
Fix GitHub actions Valgrind cache error

### DIFF
--- a/.github/actions/compile_and_test/action.yml
+++ b/.github/actions/compile_and_test/action.yml
@@ -19,7 +19,7 @@ runs:
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: valgrind libc6-dbg
+          packages: valgrind
           version: 1.0
 
       # Dependencies for coverage:


### PR DESCRIPTION
|Related issue|
|---|
| #21546 |

## Description
This PR fixes a recurrent issue with the cache for Valgrind on GA

Changelog:
- Removed libc6-dbg from GA cache

## Tests
- [Execution 1](https://github.com/wazuh/wazuh/actions/runs/7574243904/attempts/1)
- [Execution 2](https://github.com/wazuh/wazuh/actions/runs/7574243904/job/20630402153)
- [Execution 3](https://github.com/wazuh/wazuh/actions/runs/7575006230)