### PR TITLE
Replace metadata file

### DIFF
--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -17,10 +17,9 @@ from api.models.security_model import (CreateUserModel, PolicyModel, RoleModel,
 from api.models.security_token_response_model import TokenResponseModel
 from api.util import (deprecate_endpoint, parse_api_param, raise_if_exc,
                       remove_nones_to_dict)
-from wazuh import security
+from wazuh import security, __version__
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
-from wazuh.core.common import WAZUH_VERSION
 from wazuh.core.exception import WazuhException, WazuhPermissionError
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.core.security import revoke_tokens
@@ -30,7 +29,7 @@ logger = logging.getLogger('wazuh-api')
 auth_re = re.compile(r'basic (.*)', re.IGNORECASE)
 
 
-@deprecate_endpoint(link=f'https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/reference.html#'
+@deprecate_endpoint(link=f'https://documentation.wazuh.com/{__version__}/user-manual/api/reference.html#'
                          f'operation/api.controllers.security_controller.login_user')
 async def deprecated_login_user(user: str, raw: bool = False) -> web.Response:
     """User/password authentication to get an access token.

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3666,9 +3666,6 @@ components:
         version:
           type: string
           description: "Wazuh version"
-        compilation_date:
-          type: string
-          format: date-time
         type:
           type: string
           description: "Wazuh installation type"
@@ -10255,7 +10252,6 @@ paths:
                   affected_items:
                     - path: /var/ossec
                       version: v4.3.0
-                      compilation_date: "2021-05-27T09:06:48Z"
                       type: server
                       max_agents: unlimited
                       openssl_support: yes
@@ -11932,7 +11928,6 @@ paths:
                   affected_items:
                     - path: /var/ossec
                       version: v4.3.0
-                      compilation_date: "2021-05-27T09:06:48Z"
                       type: server
                       max_agents: unlimited
                       openssl_support: yes

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1568,7 +1568,6 @@ stages:
           affected_items:
             - path: !anystr
               version: !anystr
-              compilation_date: !anystr
               type: !anystr
               max_agents: !anystr
               openssl_support: !anystr

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -57,8 +57,7 @@ stages:
         error: 0
         data:
           affected_items:
-            - compilation_date: !anystr
-              max_agents: !anystr
+            - max_agents: !anystr
               openssl_support: !anystr
               path: !anystr
               type: !anystr

--- a/framework/setup.py
+++ b/framework/setup.py
@@ -4,35 +4,12 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import json
-# Install the package locally: python setup.py install
-# Install the package dev: python setup.py develop
-import os
-from datetime import datetime, timezone
+from wazuh import __version__
 
 from setuptools import setup, find_namespace_packages
-from setuptools.command.install import install
-
-WAZUH_VERSION='4.8.0'
-
-
-class InstallCommand(install):
-    """Inherited class. Overrides the run method to generate the wazuh.json file."""
-
-    def run(self):
-        here = os.path.abspath(os.path.dirname(__file__))
-        with open(os.path.join(here, 'wazuh', 'core', 'wazuh.json'),
-                  encoding='utf-8', mode='w') as file:
-            json.dump({'install_type': 'server',
-                       'wazuh_version': f'v{WAZUH_VERSION}',
-                       'installation_date': datetime.utcnow().replace(tzinfo=timezone.utc).strftime(
-                           '%a %b %d %H:%M:%S UTC %Y')
-                       }, file)
-        install.run(self)
-
 
 setup(name='wazuh',
-      version=WAZUH_VERSION,
+      version=__version__,
       description='Wazuh control with Python',
       url='https://github.com/wazuh',
       author='Wazuh',
@@ -44,7 +21,4 @@ setup(name='wazuh',
       include_package_data=True,
       install_requires=[],
       zip_safe=False,
-      cmdclass={
-          'install': InstallCommand
-      }
       )

--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -4,7 +4,6 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from datetime import datetime, timezone
 from time import strftime
 
 from wazuh.core import common
@@ -45,9 +44,8 @@ class Wazuh:
         :return:
         """
 
-        self.version = common.WAZUH_VERSION
-        self.installation_date = common.WAZUH_INSTALLATION_DATE
-        self.type = common.WAZUH_INSTALL_TYPE
+        self.version = f'v{__version__}'
+        self.type = 'server'
         self.path = common.WAZUH_PATH
         self.max_agents = 'unlimited'
         self.openssl_support = 'N/A'
@@ -65,14 +63,8 @@ class Wazuh:
         return False
 
     def to_dict(self):
-        date_format = '%a %b %d %H:%M:%S %Z %Y'
-        try:
-            compilation_date = datetime.strptime(self.installation_date, date_format).replace(tzinfo=timezone.utc)
-        except ValueError:
-            compilation_date = datetime.utcnow().replace(tzinfo=timezone.utc)
         return {'path': self.path,
                 'version': self.version,
-                'compilation_date': compilation_date,
                 'type': self.type,
                 'max_agents': self.max_agents,
                 'openssl_support': self.openssl_support,

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -102,9 +102,7 @@ class DistributedAPI:
         self.origin_module = 'API'
         self.nodes = nodes if nodes is not None else list()
         if not basic_services:
-            self.basic_services = ('wazuh-modulesd', 'wazuh-analysisd', 'wazuh-execd', 'wazuh-db')
-            if common.WAZUH_INSTALL_TYPE != "local":
-                self.basic_services += ('wazuh-remoted',)
+            self.basic_services = ('wazuh-modulesd', 'wazuh-analysisd', 'wazuh-execd', 'wazuh-db', 'wazuh-remoted')
         else:
             self.basic_services = basic_services
 

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -100,8 +100,7 @@ class TestingLogger:
     {'api_timeout': 15},
     {'api_timeout': 5}
 ])
-@patch('wazuh.core.cluster.dapi.dapi.common.WAZUH_INSTALL_TYPE', return_value='local')
-def test_DistributedAPI(install_type_mock, kwargs):
+def test_DistributedAPI(kwargs):
     """Test constructor from DistributedAPI class.
 
     Parameters

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -172,22 +172,6 @@ LISTS_EXTENSION = ''
 COMPILED_LISTS_EXTENSION = '.cdb'
 
 
-# ============================================ Wazuh constants - Metadata  =============================================
-try:
-    here = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(here, 'wazuh.json'), 'r') as f:
-        metadata = json.load(f)
-except (FileNotFoundError, PermissionError):
-    metadata = {
-        'install_type': 'server',
-        'installation_date': '',
-        'wazuh_version': ''
-    }
-WAZUH_INSTALL_TYPE = metadata['install_type']
-WAZUH_VERSION = metadata['wazuh_version']
-WAZUH_INSTALLATION_DATE = metadata['installation_date']
-
-
 # ========================================= Wazuh constants - Size and limits ==========================================
 MAX_SOCKET_BUFFER_SIZE = 64 * 1024  # 64KB.
 MAX_QUERY_FILTERS_RESERVED_SIZE = MAX_SOCKET_BUFFER_SIZE - 4 * 1024  # MAX_BUFFER_SIZE - 4KB.

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -6,10 +6,11 @@
 from copy import deepcopy
 from typing import Union
 
-from wazuh.core.common import MAX_SOCKET_BUFFER_SIZE, WAZUH_VERSION, AGENT_NAME_LEN_LIMIT, MAX_GROUPS_PER_MULTIGROUP
+from wazuh.core.cluster import __version__
+from wazuh.core.common import MAX_SOCKET_BUFFER_SIZE, AGENT_NAME_LEN_LIMIT, MAX_GROUPS_PER_MULTIGROUP
 
 GENERIC_ERROR_MSG = "Wazuh Internal Error. See log for more detail"
-DOCU_VERSION = 'current' if WAZUH_VERSION == '' else '.'.join(WAZUH_VERSION.split('.')[:2]).lstrip('v')
+DOCU_VERSION = 'current' if __version__ == '' else '.'.join(__version__.split('.')[:2]).lstrip('v')
 
 class WazuhException(Exception):
     """

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -64,7 +64,6 @@ WAZUH_AGENT="../src/init/wazuh-client.sh"
 WAZUH_LOCAL="../src/init/wazuh-local.sh"
 NSIS_FILE="../src/win32/wazuh-installer.nsi"
 MSI_FILE="../src/win32/wazuh-installer.wxs"
-FW_SETUP="../framework/setup.py"
 FW_INIT="../framework/wazuh/__init__.py"
 CLUSTER_INIT="../framework/wazuh/core/cluster/__init__.py"
 API_SETUP="../api/setup.py"
@@ -123,7 +122,6 @@ then
 
     # Framework
 
-    sed -E -i'' -e "s/WAZUH_VERSION='.+'/WAZUH_VERSION='${version:1}'/g" $FW_SETUP
     sed -E -i'' -e "s/__version__ = '.+'/__version__ = '${version:1}'/g" $FW_INIT
 
     # Cluster


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/21568 |


## Description

Removes the `wazuh.json` metadata file created during the framework installation and obtains the values from constants and the creation time of the embedded interpreter.


## Logs/Alerts example

<details><summary>Installation from sources</summary>

```console
root@bed2453ca7dc:/wazuh# ./install.sh
...
Done building server

Wait for success...
success
Removing old SCA policies...
Installing SCA policies...
Installing additional SCA policies...
Makefile:2588: warning: overriding recipe for target 'win32/ui_resource.o'
Makefile:2528: warning: ignoring old recipe for target 'win32/ui_resource.o'
Makefile:2591: warning: overriding recipe for target 'win32/auth_resource.o'
Makefile:2531: warning: ignoring old recipe for target 'win32/auth_resource.o'
mkdir -p /var/ossec/framework/python
cp external/cpython.tar.gz /var/ossec/framework/python/cpython.tar.gz && tar -xf /var/ossec/framework/python/cpython.tar.gz -C /var/ossec/framework/python && rm -rf /var/ossec/framework/python/cpython.tar.gz
find /var/ossec/framework/python -name "*libpython3.10.so.1.0" -exec ln -f {} /var/ossec/lib/libpython3.10.so.1.0 \;
cd ../framework && /var/ossec/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/ossec/framework/python && rm -rf build/
Processing /wazuh/framework
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: wazuh
  Building wheel for wazuh (pyproject.toml) ... done
  Created wheel for wazuh: filename=wazuh-4.8.0-py3-none-any.whl size=295372 sha256=9a3b9da220ba7892777f2c9148b9fa55f6823f9c703a9751c9912545c08d072b
  Stored in directory: /tmp/pip-ephem-wheel-cache-jqpkix8n/wheels/fe/47/7c/2c289aea2e8a5cc5ac8936e5cecbbfc0bdd996d57bb70da19a
Successfully built wazuh
Installing collected packages: wazuh
Successfully installed wazuh-4.8.0
chown -R root:wazuh /var/ossec/framework/python
chmod -R o=- /var/ossec/framework/python
cd ../api && /var/ossec/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/ossec/framework/python && rm -rf build/
Processing /wazuh/api
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: api
  Building wheel for api (pyproject.toml) ... done
  Created wheel for api: filename=api-4.8.0-py3-none-any.whl size=160761 sha256=80c3c87b052ae82c7952d865b84c170b176a97d58fe3e3ab84bb2678f3377dd8
  Stored in directory: /tmp/pip-ephem-wheel-cache-biwu5xfa/wheels/2c/ed/d5/5358cdcfa6f68fc41b8ca02118521c75da82e9ec6d16f50822
Successfully built api
Installing collected packages: api
Successfully installed api-4.8.0
cd ../tools/mitre && /var/ossec/framework/python/bin/python3 mitredb.py -d /var/ossec/var/db/mitre.db
Generating self-signed certificate for wazuh-authd...


 - System is Debian (Ubuntu or derivative).
 - Init script modified to start Wazuh during boot.
Starting Wazuh...
server
2024/01/22 19:06:59 wazuh-modulesd:router: INFO: Loaded router module.
2024/01/22 19:06:59 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Starting Wazuh v4.8.0...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2024/01/22 19:07:00 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
2024/01/22 19:07:05 wazuh-modulesd:router: INFO: Loaded router module.
2024/01/22 19:07:05 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Started wazuh-modulesd...
Completed.
```

</details>

<details><summary>wazuh-control info</summary>

```console
root@bed2453ca7dc:/wazuh# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.8.0"
WAZUH_REVISION="40802"
WAZUH_TYPE="server"
```

</details>

<details><summary>wazuh-control status</summary>

```console
root@bed2453ca7dc:/wazuh# /var/ossec/bin/wazuh-control status
wazuh-clusterd not running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-maild not running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
wazuh-apid is running...
```

</details>

<details><summary><code>GET /manager/info</code></summary>

```console
root@bed2453ca7dc:/wazuh# curl -H "Authorization: Bearer $TOKEN" -X GET -k https://0.0.0.0:55000/manager/info
{
    "data": {
        "affected_items": [
            {
                "path": "/var/ossec",
                "version": "v4.8.0",
                "type": "server",
                "max_agents": "unlimited",
                "openssl_support": "yes",
                "tz_offset": "+0000",
                "tz_name": "UTC"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "Basic information was successfully read",
    "error": 0
}
```

</details>

<details><summary><code>GET /cluster/wazuh-worker1/info</code></summary>

```console
root@bed2453ca7dc:/wazuh# curl -H "Authorization: Bearer $TOKEN" -X GET -k https://0.0.0.0:55000/manager/info
{
    "data": {
        "affected_items": [
            {
                "path": "/var/ossec",
                "version": "v4.8.0",
                "type": "server",
                "max_agents": "unlimited",
                "openssl_support": "yes",
                "tz_offset": "+0000",
                "tz_name": "UTC"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "Basic information was successfully read in specified node",
    "error": 0
}
```

</details>

> Failed checks are not related to the changes introduced