### PR TITLE
Create a Github Actions matrix to allow content versioning

### DIFF
--- a/.github/actions/compile_and_test/action.yml
+++ b/.github/actions/compile_and_test/action.yml
@@ -1,5 +1,5 @@
 name: "Compile and test"
-description: "Executes a compilation and test routine based on a path. It also validates the right execution with ASAN or Valgrind"
+description: "Executes a compilation and test (optional) routine based on a path. It also validates the right execution with ASAN or Valgrind"
 
 inputs:
   path:
@@ -10,6 +10,10 @@ inputs:
     required: false
     description: "Enable address sanitizer"
     default: "false"
+  test:
+    required: false
+    description: "Run tests"
+    default: "true"
 
 runs:
   using: "composite"
@@ -40,33 +44,44 @@ runs:
           echo $REVISION
 
           cd ${{ inputs.path }}
-
-          if [[ "${{ inputs.asan }}" != "false" ]]; then
-            # Compile for ASAN
-            echo "Compiling for ASAN"
-            export COMPILATION_FLAGS="-g -fsanitize=address -fsanitize=undefined -fsanitize=leak"
-          else
-            # Compile for valgrind and coverage
-            echo "Compiling for valgrind and coverage"
-            export COMPILATION_FLAGS="-fprofile-arcs -ftest-coverage -lgcov --coverage"
-          fi
-          # Read version and revision file.
           mkdir -p build && cd build
-          cmake -DSRC_FOLDER=${SRC_FOLDER} -DCMAKE_CXX_FLAGS="$COMPILATION_FLAGS" -DUNIT_TEST=ON -DVERSION="$VERSION" -DREVISION="$REVISION" .. && make -j2
+
+          if [[ ${{ inputs.test }} == "false" ]]; then
+            echo "Compiling without tests"
+            cmake -DSRC_FOLDER=${SRC_FOLDER} -DVERSION="$VERSION" -DREVISION="$REVISION" .. && make -j2
+          else
+            if [[ "${{ inputs.asan }}" != "false" ]]; then
+              # Compile for ASAN
+              echo "Compiling for ASAN"
+              export COMPILATION_FLAGS="-g -fsanitize=address -fsanitize=undefined -fsanitize=leak"
+            else
+              # Compile for valgrind and coverage
+              echo "Compiling for valgrind and coverage"
+              export COMPILATION_FLAGS="-fprofile-arcs -ftest-coverage -lgcov --coverage"
+            fi
+            # Read version and revision file.
+            cmake -DSRC_FOLDER=${SRC_FOLDER} -DCMAKE_CXX_FLAGS="$COMPILATION_FLAGS" -DUNIT_TEST=ON -DVERSION="$VERSION" -DREVISION="$REVISION" .. && make -j2
+          fi
+
         shell: bash
 
       - name: Test
         run: |
 
-          cd ${{ inputs.path }}/build
-
-          if [[ "${{ inputs.asan }}" != "false" ]]; then
-            # Run for ASAN
-            echo "Running tests for ASAN"
-            ctest --output-on-failure
+          if [[ ${{ inputs.test }} == "false" ]]; then
+            echo "Skipping tests"
           else
-            # Run for valgrind and coverage
-            echo "Running tests for valgrind and coverage"
-            valgrind ctest --output-on-failure
+            cd ${{ inputs.path }}/build
+
+            if [[ "${{ inputs.asan }}" != "false" ]]; then
+              # Run for ASAN
+              echo "Running tests for ASAN"
+              ctest --output-on-failure
+            else
+              # Run for valgrind and coverage
+              echo "Running tests for valgrind and coverage"
+              valgrind ctest --output-on-failure
+            fi
           fi
+
         shell: bash

--- a/.github/actions/vulnerability_scanner_deps/action.yml
+++ b/.github/actions/vulnerability_scanner_deps/action.yml
@@ -26,7 +26,8 @@ runs:
           make build_gtest TARGET=server -j2
           make build_benchmark TARGET=server -j2
           make libwazuhext.so TARGET=server -j2
-          make build_syscollector TARGET=server -j2
+          # Only the schemas are required from syscollector
+          mkdir -p wazuh_modules/syscollector/build && cmake -DTARGET=server -B wazuh_modules/syscollector/build -S wazuh_modules/syscollector && make -C wazuh_modules/syscollector/build compile_schemas compile_schemas_deltas -j2
         shell: bash
 
       - name: Build http-request

--- a/.github/workflows/vulnerability-scanner-generate-database.yml
+++ b/.github/workflows/vulnerability-scanner-generate-database.yml
@@ -4,9 +4,18 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
+  pull_request:
+    paths:
+      - ".github/workflows/vulnerability-scanner-generate-database.yml"
+      - ".github/actions/compile_and_test/action.yml"
+      - ".github/actions/vulnerability_scanner_deps/action.yml"
 
 jobs:
   vulnerability-scanner-upload-database:
+    strategy:
+          fail-fast: false
+          matrix:
+              wazuh_version: ["4.8.0"]
     runs-on: ubuntu-latest
 
     steps:
@@ -14,6 +23,19 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
+
+      - name: Checkout correct branch
+        run: |
+          git checkout tags/v${{ matrix.wazuh_version }} || echo "Failed to find tag v${{ matrix.wazuh_version }}"
+          git checkout ${{ matrix.wazuh_version }} || echo "Failed to find branch ${{ matrix.wazuh_version }}"
+          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+          if [[ $BRANCH == "master" ]]; then
+            echo failed to find branch/tag ${{ matrix.wazuh_version }}
+            exit 1
+          fi
+        shell: bash
 
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
@@ -23,28 +45,32 @@ jobs:
       ########################
 
       # Router
-      - name: Router - Compilation and test
+      - name: Router - Compilation
         uses: ./.github/actions/compile_and_test
         with:
           path: src/shared_modules/router
+          test: false
 
       # Indexer connector
-      - name: Indexer connector - Compilation and test
+      - name: Indexer connector - Compilation
         uses: ./.github/actions/compile_and_test
         with:
           path: src/shared_modules/indexer_connector
+          test: false
 
       # Content manager
-      - name: Content manager - Compilation and test
+      - name: Content manager - Compilation
         uses: ./.github/actions/compile_and_test
         with:
           path: src/shared_modules/content_manager
+          test: false
 
       # Vulnerability scanner
-      - name: Vulnerability scanner - Compilation and test
+      - name: Vulnerability scanner - Compilation
         uses: ./.github/actions/compile_and_test
         with:
           path: src/wazuh_modules/vulnerability_scanner
+          test: false
 
       - name: Vulnerability scanner - Run vd_scanner_testtool
         run: |
@@ -57,12 +83,12 @@ jobs:
           rm -rf queue/sockets
           rm -rf queue/router
           rm -rf queue/vd_updater/tmp
-          
-          VD_FILENAME=vd_1.0.0_vd_4.8.0.tar.xz
-          
+
+          VD_FILENAME=vd_1.0.0_vd_${{ matrix.wazuh_version }}.tar.xz
+
           echo "Compressing file"
           tar -cJf ${VD_FILENAME} queue
-          
+
           if ! [ -f ${VD_FILENAME} ]; then
             echo "Error generating ${VD_FILENAME} file"
           else
@@ -73,11 +99,16 @@ jobs:
 
       - name: Vulnerability scanner - Uploading file to S3
         run: |
-          root_folder=$(pwd)
-          bucket="${{ secrets.FEED_AWS_BUCKET }}"
-          file="vd_1.0.0_vd_4.8.0.tar.xz"
-          dest_dir="deps/vulnerability_model_database"
-          aws s3 cp ${file} s3://${bucket}/${dest_dir}/${file} --acl public-read
+          echo "Event that triggered the workflow: ${{ github.event_name }}"
+          if [[ ${{ github.event_name == 'pull_request' }} ]]; then
+            echo "Skipping upload to S3 for pull requests"
+          else
+            root_folder=$(pwd)
+            bucket="${{ secrets.FEED_AWS_BUCKET }}"
+            file="vd_1.0.0_vd_${{ matrix.wazuh_version }}.tar.xz"
+            dest_dir="deps/vulnerability_model_database"
+            aws s3 cp ${file} s3://${bucket}/${dest_dir}/${file} --acl public-read
+          fi
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.FEED_AWS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.FEED_AWS_SECRET_ACCESS_KEY}}

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -8,6 +8,8 @@ on:
   # Path filtering
     paths:
       - ".github/workflows/vulnerability-scanner-tests.yml"
+      - ".github/actions/compile_and_test/action.yml"
+      - ".github/actions/vulnerability_scanner_deps/action.yml"
       - "src/shared_modules/router/**"
       - "src/shared_modules/content_manager/**"
       - "src/shared_modules/indexer_connector/**"


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21540|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR creates a matrix to allow generating the vulnerability detector DBs with different version.
It also speeds up the workflow:
- Only the **syscollector** schemas are compiled
- The tests are skipped when not required

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

It was confirmed that now the vulnerability detector workflow takes less time after removing the unnecessary compilation steps 

![2024-01-23_10-37](https://github.com/wazuh/wazuh/assets/65046601/c3127771-67f2-43f8-854a-afe599401ea7)

The vulnerability detector DB generation now has a matrix and the value is the expected

![2024-01-23_10-40](https://github.com/wazuh/wazuh/assets/65046601/13747e28-18f5-49e2-a52b-d0bf4cda0e91)

Also, it takes less time now that it doesn't run the UT

![2024-01-23_10-43](https://github.com/wazuh/wazuh/assets/65046601/54dca5d1-5016-46ef-b952-c2bc9ba6c188)

- [x] CI Pass