### PR TITLE
Update legacy-template.json

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
@@ -33,17 +33,7 @@
     },
     "mappings": {
       "date_detection": false,
-      "dynamic_templates": [
-        {
-          "strings_as_keyword": {
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "match_mapping_type": "string"
-          }
-        }
-      ],
+      "dynamic": "strict",
       "properties": {
         "@timestamp": {
           "type": "date"
@@ -269,6 +259,10 @@
             "cluster": {
               "properties": {
                 "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "node": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
@@ -124,9 +124,6 @@
             }
           }
         },
-        "labels": {
-          "type": "object"
-        },
         "message": {
           "type": "text"
         },


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-indexer/issues/140 |


## Description

Adds a new custom field `wazuh.cluster.node`.

It also adds **strict** dynamic mapping mode, which rejects documents with unmapped fields.

Upload as usual with:
```
curl -u admin:admin -k -X PUT "https://localhost:9200/_index_template/wazuh-vulnerability-detector" -H "Content-Type: application/json" -d @legacy-template.json
```

![image](https://github.com/wazuh/wazuh/assets/15186973/dc2141d8-69c5-4f6e-8bdd-cdf3405de81e)
