### PR TITLE
Use memmove instead of memcpy in the nb_recv() function to avoid unwanted behavior.

### DIFF
--- a/src/remoted/netbuffer.c
+++ b/src/remoted/netbuffer.c
@@ -110,7 +110,7 @@ int nb_recv(netbuffer_t * buffer, int sock) {
 
     if (i > 0) {
         if (i < sockbuf->data_len) {
-            memcpy(sockbuf->data, sockbuf->data + i, sockbuf->data_len - i);
+            memmove(sockbuf->data, sockbuf->data + i, sockbuf->data_len - i);
         }
 
         sockbuf->data_len -= i;

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -79,7 +79,7 @@ list(APPEND remoted_names "test_netbuffer")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,wnet_order -Wl,--wrap,wnotify_modify \
                             -Wl,--wrap,bqueue_push -Wl,--wrap,bqueue_peek -Wl,--wrap,bqueue_drop -Wl,--wrap,bqueue_clear -Wl,--wrap,sleep \
                             -Wl,--wrap,send -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,fcntl -Wl,--wrap,getpid \
-                            -Wl,--wrap,bqueue_used -Wl,--wrap,rem_inc_send_discarded")
+                            -Wl,--wrap,bqueue_used -Wl,--wrap,rem_inc_send_discarded -Wl,--wrap,recv -Wl,--wrap,rem_msgpush")
 
 list(APPEND remoted_names "test_sendmsg")
 list(APPEND remoted_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,OS_IsAllowedID -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \


### PR DESCRIPTION
|Related issue|
|---|
|#21014|


## Description

In the research of #21014 it was noticed that [memcpy ](https://pubs.opengroup.org/onlinepubs/7908799/xsh/memcpy.html)has undefined behavior when the src object and the dst object overlap (as in the nb_recv function). Therefore, this PR changes the use of memcpy to [memmove()](https://cplusplus.com/reference/cstring/memmove) which does not have this problem. After the change it was not possible to replicate the warning `"Unexpected message (hex): '....'"` again.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Added unit tests (for new features) 

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  

 



