### PR TITLE
Replace new log checksum chain message from wazuh-monitord

### DIFF
--- a/src/monitord/sign_log.c
+++ b/src/monitord/sign_log.c
@@ -46,6 +46,8 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
     unsigned char md[SHA_DIGEST_LENGTH];
     unsigned char md256[SHA256_DIGEST_LENGTH];
 
+    bool sum_file_ok = true;
+
     /* Clear the memory */
     memset(logfilesum, '\0', OS_FLSIZE + 1);
     memset(logfilesum_old, '\0', OS_FLSIZE + 1);
@@ -64,23 +66,25 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
 
     /* Generate MD5 of the old file */
     if (OS_MD5_File(logfilesum_old, mf_sum_old, OS_TEXT) < 0) {
-        minfo("No previous md5 checksum found: '%s'. "
-               "Starting over.", logfilesum_old);
+        sum_file_ok = false;
         strncpy(mf_sum_old, "none", 6);
     }
 
     /* Generate SHA-1 of the old file  */
     if (OS_SHA1_File(logfilesum_old, sf_sum_old, OS_TEXT) < 0) {
-        minfo("No previous sha1 checksum found: '%s'. "
-               "Starting over.", logfilesum_old);
+        sum_file_ok = false;
         strncpy(sf_sum_old, "none", 6);
     }
 
     /* Generate SHA-256 of the old file  */
     if (OS_SHA256_File(logfilesum_old, sf256_sum_old, OS_TEXT) < 0) {
-        minfo("No previous sha256 checksum found: '%s'. "
-               "Starting over.", logfilesum_old);
+        sum_file_ok = false;
         strncpy(sf256_sum_old, "none", 6);
+    }
+
+    if (!sum_file_ok) {
+        mdebug1("Checksum for previous log file is missing: '%s'. "
+                "Starting new sequence.", logfilesum_old);
     }
 
     /* Generate MD5, SHA-1, and SHA-256 of the current file */


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21601|

This PR aims to replace the new log checksum chain message:

1. Let it be easier to understand.
2. Change the log type to debug.
3. Join all hashing logs (MD5 / SHA1 / SHA256) into one.

## Sample

<details><summary><b>🔴 Old logs</b></summary>

> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous md5 checksum found: 'logs/archives/2024/Jan/ossec-archive-18.log.sum'. Starting over.
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous sha1 checksum found: 'logs/archives/2024/Jan/ossec-archive-18.log.sum'. Starting over.
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous sha256 checksum found: 'logs/archives/2024/Jan/ossec-archive-18.log.sum'. Starting over.
>
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous md5 checksum found: 'logs/archives/2024/Jan/ossec-archive-18.json.sum'. Starting over.
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous sha1 checksum found: 'logs/archives/2024/Jan/ossec-archive-18.json.sum'. Starting over.
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous sha256 checksum found: 'logs/archives/2024/Jan/ossec-archive-18.json.sum'. Starting over.
>
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous md5 checksum found: 'logs/alerts/2024/Jan/ossec-alerts-18.log.sum'. Starting over.
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous sha1 checksum found: 'logs/alerts/2024/Jan/ossec-alerts-18.log.sum'. Starting over.
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous sha256 checksum found: 'logs/alerts/2024/Jan/ossec-alerts-18.log.sum'. Starting over.
>
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous md5 checksum found: 'logs/alerts/2024/Jan/ossec-alerts-18.json.sum'. Starting over.
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous sha1 checksum found: 'logs/alerts/2024/Jan/ossec-alerts-18.json.sum'. Starting over.
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous sha256 checksum found: 'logs/alerts/2024/Jan/ossec-alerts-18.json.sum'. Starting over.
>
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous md5 checksum found: 'logs/firewall/2024/Jan/ossec-firewall-18.log.sum'. Starting over.
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous sha1 checksum found: 'logs/firewall/2024/Jan/ossec-firewall-18.log.sum'. Starting over.
> 2024/01/20 00:08:28 wazuh-monitord: INFO: No previous sha256 checksum found: 'logs/firewall/2024/Jan/ossec-firewall-18.log.sum'. Starting over.

</details>

<details><summary><b>🟢 New logs</b></summary>

> 2024/01/24 16:23:30 wazuh-monitord[37756] sign_log.c:86 at OS_SignLog(): DEBUG: Checksum for previous log file is missing: 'logs/archives/2024/Jan/ossec-archive-23.log.sum'. Starting new sequence.
>
> 2024/01/24 16:23:30 wazuh-monitord[37756] sign_log.c:86 at OS_SignLog(): DEBUG: Checksum for previous log file is missing: 'logs/archives/2024/Jan/ossec-archive-23.json.sum'. Starting new sequence.
>
> 2024/01/24 16:23:30 wazuh-monitord[37756] sign_log.c:86 at OS_SignLog(): DEBUG: Checksum for previous log file is missing: 'logs/alerts/2024/Jan/ossec-alerts-23.log.sum'. Starting new sequence.
>
> 2024/01/24 16:23:30 wazuh-monitord[37756] sign_log.c:86 at OS_SignLog(): DEBUG: Checksum for previous log file is missing: 'logs/alerts/2024/Jan/ossec-alerts-23.json.sum'. Starting new sequence.
>
> 2024/01/24 16:23:30 wazuh-monitord[37756] sign_log.c:86 at OS_SignLog(): DEBUG: Checksum for previous log file is missing: 'logs/firewall/2024/Jan/ossec-firewall-23.log.sum'. Starting new sequence.

</details>

## Tests

- [x] Build from sources.
- [x] wazuh-monitord shows the new log in debug mode (as shown above).
