### PR TITLE
Fix utils unit test

### DIFF
--- a/src/shared_modules/utils/socketClient.hpp
+++ b/src/shared_modules/utils/socketClient.hpp
@@ -54,7 +54,7 @@ private:
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to send pending messages: " << e.what() << std::endl;
+            // Error sending pending messages
         }
     }
 
@@ -207,7 +207,7 @@ public:
             }
             catch (const std::exception& e)
             {
-                std::cerr << "Failed to connect to socket: " << e.what() << std::endl;
+                // Failure to connect to socket
                 delay = std::min(delay * 2, MAX_DELAY);
             }
         } while (!m_cv.wait_for(lock, std::chrono::seconds(delay), [&]() { return m_shouldStop.load(); }));
@@ -222,7 +222,7 @@ public:
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to send message: " << e.what() << std::endl;
+            // Error sending message
             m_epoll->modifyDescriptor(m_socket->fileDescriptor(), EPOLLIN | EPOLLOUT);
         }
     }

--- a/src/shared_modules/utils/socketServer.hpp
+++ b/src/shared_modules/utils/socketServer.hpp
@@ -67,7 +67,7 @@ private:
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to send pending messages: " << e.what() << std::endl;
+            // Error sending pending messages
         }
     }
 

--- a/src/shared_modules/utils/tests/timeHelper_test.cpp
+++ b/src/shared_modules/utils/tests/timeHelper_test.cpp
@@ -69,8 +69,14 @@ TEST_F(TimeUtilsTest, CheckCompactTimestampInvalidFormat)
 
 TEST_F(TimeUtilsTest, TimestampToISO8601)
 {
-    EXPECT_EQ("2020-12-28T18:00:00.000Z", Utils::timestampToISO8601("2020/12/28 15:00:00"));
-    EXPECT_EQ("2020-12-29T00:00:00.000Z", Utils::timestampToISO8601("2020/12/28 21:00:00"));
+    // Get timestamp in local time
+    const auto timestamp {Utils::getTimestamp(std::time(nullptr), false)};
+    // Get current ISO8601 timestamp in UTC
+    const auto currentISO8601 {Utils::getCurrentISO8601()};
+    // replace milliseconds to 000Z to align with timestamp format
+    const auto currentISO8601ZeroMs {currentISO8601.substr(0, currentISO8601.size() - 4) + "000Z"};
+
+    EXPECT_EQ(currentISO8601ZeroMs, Utils::timestampToISO8601(timestamp));
     EXPECT_EQ("", Utils::timestampToISO8601("21:00:00"));
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#21559|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR is intended to solve the problems encountered in utils unit test. Change list:

 - [Logic is added to obtain the time and harcoding is eliminated](https://github.com/wazuh/wazuh/commit/8443c58f36787a4ddec928ec5f416a4b0912e75b)
 - [Delete unnecessary messages](https://github.com/wazuh/wazuh/commit/21ad93464a9093edccf79c69ae4b12b1a9973568)

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

```
vagrant@jammy:~/shared$ cat wazuh-dev-21559-fix_utils_unit_test/src/result-ctest.txt 
Internal ctest changing into directory: /home/vagrant/shared/wazuh-dev-21559-fix_utils_unit_test/src/build
Test project /home/vagrant/shared/wazuh-dev-21559-fix_utils_unit_test/src/build
      Start  1: utils_unit_test
 1/10 Test  #1: utils_unit_test .........................   Passed   53.19 sec
      Start  2: utils_benchmark_test
 2/10 Test  #2: utils_benchmark_test ....................   Passed    7.07 sec
      Start  3: router_component_tests
 3/10 Test  #3: router_component_tests ..................   Passed    0.12 sec
      Start  4: router_unit_tests
 4/10 Test  #4: router_unit_tests .......................   Passed    0.05 sec
      Start  5: content_manager_component_tests
 5/10 Test  #5: content_manager_component_tests .........   Passed   34.48 sec
      Start  6: content_manager_unit_tests
 6/10 Test  #6: content_manager_unit_tests ..............   Passed   17.23 sec
      Start  7: indexer_connector_unit_tests
 7/10 Test  #7: indexer_connector_unit_tests ............   Passed   50.98 sec
      Start  8: vulnerability_scanner_unit_tests
 8/10 Test  #8: vulnerability_scanner_unit_tests ........   Passed   12.09 sec
      Start  9: vulnerability_scanner_component_tests
 9/10 Test  #9: vulnerability_scanner_component_tests ...   Passed    0.49 sec
      Start 10: vulnerability_scanner_benchmark_tests
10/10 Test #10: vulnerability_scanner_benchmark_tests ...   Passed    3.03 sec

100% tests passed, 0 tests failed out of 10

Total Test time (real) = 178.80 sec

```