### PR TITLE
Fix pool mutex locking/unlocking in wdb_parser after merging 4.7.1 to 4.8.

### DIFF
--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -761,9 +761,9 @@ int wdb_parse(char * input, char * output, int peer) {
             snprintf(path, sizeof(path), "%s/%s.db", WDB2_DIR, wdb->id);
             if (!w_is_file(path)) {
                 mwarn("DB(%s) not found. This behavior is unexpected, the database will be recreated.", path);
-                w_mutex_lock(&pool_mutex);
+                rwlock_lock_write(&pool_mutex);
                 wdb_close(wdb, FALSE);
-                w_mutex_unlock(&pool_mutex);
+                rwlock_unlock(&pool_mutex);
             }
         }
         return result;
@@ -1404,9 +1404,9 @@ int wdb_parse(char * input, char * output, int peer) {
             snprintf(path, sizeof(path), "%s/%s.db", WDB2_DIR, WDB_GLOB_NAME);
             if (!w_is_file(path)) {
                 mwarn("DB(%s) not found. This behavior is unexpected, the database will be recreated.", path);
-                w_mutex_lock(&pool_mutex);
+                rwlock_lock_write(&pool_mutex);
                 wdb_close(wdb, FALSE);
-                w_mutex_unlock(&pool_mutex);
+                rwlock_unlock(&pool_mutex);
             }
         }
         return result;


### PR DESCRIPTION
|Related issue|
|---|
|#21589|

## Description

This PR fixes the inconsistency in the use of `pool_mutex `that remained after the merge from `4.7.1` to `4.8.` The usage of `w_mutex_lock/unlock` has been changed to `rwlock_lock/unlock`.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation


<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [x] AddressSanitizer
