### PR TITLE
Update manager and cluster AITs

### DIFF
--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -847,6 +847,8 @@ stages:
         content-type: application/octet-stream
     response:
       status_code: 200
+      json:
+        error: 0
     delay_after: !float "{cluster_sync_delay}"
 
   - name: Request validation

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -835,8 +835,7 @@ stages:
           total_affected_items: 3
           total_failed_items: 0
 
-  #### Upload corrupted rules file
-  - name: Upload corrupted configuration
+  - name: Upload corrupted rules file
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/rules/files/new-rules_corrupted.xml"

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1009,7 +1009,7 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/rules/files/new-rules_corrupted.xml"
       method: PUT
-      data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n  <rule id=\"111111\" level=\"XXX\">\n      <if_sid>5716</if_sid>\n      <srcip>1.1.1.1</srcip>\n      <description>sshd: authentication failed from IP 1.1.1.1.</description>\n      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n    </rule>\n  </group>\n"
+      data: "{corrupted_rules_file}"
       headers:
         Authorization: "Bearer {test_login_token}"
         content-type: application/octet-stream

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1002,9 +1002,7 @@ test_name: GET /manager/validation (KO)
 
 stages:
 
-  #### Upload corrupted rules file
-  # PUT /rules/files
-  - name: Upload corrupted
+  - name: Upload corrupted rules file
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/rules/files/new-rules_corrupted.xml"


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/21484 |

## Description

Makes the `Upload corrupted rules file` step equal in the tests `test_manager_endpoints.tavern.yaml` and `test_cluster_endpoints.tavern.yaml` .

> Integration tests for API - Tier 0 and 1 are failing because the [fix](https://github.com/wazuh/wazuh/issues/21402) was introduced in 4.8.0 and hasn't been merged to master yet. The Install manager on CentOS 7 check failure is also not related to the changes introduced.