### PR TITLE
Remove user and password tags from indexer configuration

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10389,8 +10389,6 @@ paths:
                         enabled: yes
                         hosts:
                           host: http://127.0.0.1:9200
-                        username: admin
-                        password: admin
                       syscheck:
                         disabled: no
                         frequency: 43200

--- a/etc/templates/config/generic/wodle-indexer.manager.template
+++ b/etc/templates/config/generic/wodle-indexer.manager.template
@@ -3,8 +3,6 @@
     <hosts>
       <host>https://0.0.0.0:9200</host>
     </hosts>
-    <username>admin</username>
-    <password>admin</password>
     <ssl>
       <certificate_authorities>
         <ca>/etc/filebeat/certs/root-ca.pem</ca>

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -53,8 +53,6 @@ IndexerConnector::IndexerConnector(
     std::string caRootCertificate;
     std::string sslCertificate;
     std::string sslKey;
-    std::string username;
-    std::string password;
 
     auto secureCommunication = SecureCommunication::builder();
 
@@ -77,14 +75,7 @@ IndexerConnector::IndexerConnector(
         }
     }
 
-    if (config.contains("username") && config.contains("password"))
-    {
-        username = config.at("username").get_ref<const std::string&>();
-        password = config.at("password").get_ref<const std::string&>();
-    }
-
-    secureCommunication.basicAuth(username + ":" + password)
-        .sslCertificate(sslCertificate)
+    secureCommunication.sslCertificate(sslCertificate)
         .sslKey(sslKey)
         .caRootCertificate(caRootCertificate);
 

--- a/src/shared_modules/indexer_connector/testtool/input/config.json
+++ b/src/shared_modules/indexer_connector/testtool/input/config.json
@@ -2,8 +2,6 @@
   "name": "wazuh-states-vulnerabilities",
   "enabled": "yes",
   "hosts": ["https://0.0.0.0:9200"],
-  "username": "admin",
-  "password": "admin",
   "ssl": {
     "certificate_authorities": ["~/root-ca.pem"],
     "certificate": "~/indexer.pem",

--- a/src/unit_tests/config/test_indexer.c
+++ b/src/unit_tests/config/test_indexer.c
@@ -56,8 +56,6 @@ void test_read_full_configuration(void **state) {
             "<host>http://10.2.20.2:9200</host>"
             "<host>https://10.2.20.42:9200</host>"
         "</hosts>"
-        "<username>user</username>"
-        "<password>pwd</password>"
         "<ssl>"
         "<certificate_authorities>"
             "<ca>/var/ossec/</ca>"
@@ -71,7 +69,7 @@ void test_read_full_configuration(void **state) {
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
     cJSON_free(json_result);
 }
 
@@ -82,8 +80,6 @@ void test_read_duplicate_configuration(void **state) {
         "<host>http://10.2.20.2:9200</host>"
         "<host>https://10.2.20.42:9200</host>"
         "</hosts>"
-        "<username>user</username>"
-        "<password>pwd</password>"
         "<ssl>"
         "<certificate_authorities>"
         "<ca>/var/ossec/</ca>"
@@ -97,8 +93,6 @@ void test_read_duplicate_configuration(void **state) {
         "<host>http://10.2.20.2:9200</host>"
         "<host>https://10.2.20.42:9200</host>"
         "</hosts>"
-        "<username>user</username>"
-        "<password>pwd</password>"
         "<ssl>"
         "<certificate_authorities>"
         "<ca>/var/ossec/</ca>"
@@ -112,7 +106,7 @@ void test_read_duplicate_configuration(void **state) {
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
     cJSON_free(json_result);
 }
 
@@ -123,8 +117,6 @@ void test_read_multiple_configuration(void **state) {
         "<host>http://10.1.10.1:9200</host>"
         "<host>https://10.1.10.41:9200</host>"
         "</hosts>"
-        "<username>user</username>"
-        "<password>pwd</password>"
         "<ssl>"
         "<certificate_authorities>"
         "<ca>/var/ossec/</ca>"
@@ -138,8 +130,6 @@ void test_read_multiple_configuration(void **state) {
         "<host>http://10.2.20.2:9200</host>"
         "<host>https://10.2.20.42:9200</host>"
         "</hosts>"
-        "<username>user_2</username>"
-        "<password>pwd_2</password>"
         "<ssl>"
         "<certificate_authorities>"
         "<ca>/var/ossec2/</ca>"
@@ -153,7 +143,7 @@ void test_read_multiple_configuration(void **state) {
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user_2\",\"password\":\"pwd_2\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec2/\",\"/var/ossec_cert2/\"],\"certificate\":\"cert_2\",\"key\":\"key_example_2\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"ssl\":{\"certificate_authorities\":[\"/var/ossec2/\",\"/var/ossec_cert2/\"],\"certificate\":\"cert_2\",\"key\":\"key_example_2\"}}");
     cJSON_free(json_result);
 }
 
@@ -174,8 +164,6 @@ void test_read_empty_field_configuration(void **state) {
             "<host>http://10.2.20.2:9200</host>"
             "<host>https://10.2.20.42:9200</host>"
         "</hosts>"
-        "<username>user</username>"
-        "<password>pwd</password>"
         "<ssl>"
         "<certificate_authorities>"
             "<ca>/var/ossec/</ca>"
@@ -189,7 +177,7 @@ void test_read_empty_field_configuration(void **state) {
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"\"}}");
     cJSON_free(json_result);
 }
 
@@ -198,8 +186,6 @@ void test_read_field_host_0_entries_configuration(void **state) {
         "<enabled>yes</enabled>"
         "<hosts>"
         "</hosts>"
-        "<username>user</username>"
-        "<password>pwd</password>"
         "<ssl>"
         "<certificate_authorities>"
             "<ca>/var/ossec/</ca>"
@@ -213,7 +199,7 @@ void test_read_field_host_0_entries_configuration(void **state) {
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[],\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
     cJSON_free(json_result);
 }
 
@@ -223,8 +209,6 @@ void test_read_field_host_1_entries_configuration(void **state) {
         "<hosts>"
             "<host>http://10.2.20.2:9200</host>"
         "</hosts>"
-        "<username>user</username>"
-        "<password>pwd</password>"
         "<ssl>"
         "<certificate_authorities>"
             "<ca>/var/ossec/</ca>"
@@ -238,7 +222,7 @@ void test_read_field_host_1_entries_configuration(void **state) {
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\"],\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
     cJSON_free(json_result);
 }
 
@@ -249,8 +233,6 @@ void test_read_field_certificate_authorities_0_entries_configuration(void **stat
             "<host>http://10.2.20.2:9200</host>"
             "<host>https://10.2.20.42:9200</host>"
         "</hosts>"
-        "<username>user</username>"
-        "<password>pwd</password>"
         "<ssl>"
         "<certificate_authorities>"
         "</certificate_authorities>"
@@ -262,7 +244,7 @@ void test_read_field_certificate_authorities_0_entries_configuration(void **stat
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"ssl\":{\"certificate_authorities\":[],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
     cJSON_free(json_result);
 }
 
@@ -273,8 +255,6 @@ void test_read_field_certificate_authorities_1_entries_configuration(void **stat
             "<host>http://10.2.20.2:9200</host>"
             "<host>https://10.2.20.42:9200</host>"
         "</hosts>"
-        "<username>user</username>"
-        "<password>pwd</password>"
         "<ssl>"
         "<certificate_authorities>"
             "<ca>/var/ossec/</ca>"
@@ -287,7 +267,7 @@ void test_read_field_certificate_authorities_1_entries_configuration(void **stat
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"username\":\"user\",\"password\":\"pwd\",\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
     cJSON_free(json_result);
 }
 

--- a/src/unit_tests/config_files/test_vulnerability_detection.conf
+++ b/src/unit_tests/config_files/test_vulnerability_detection.conf
@@ -4,8 +4,6 @@
         <hosts>
             <host>https://INDEXER-IP:9200</host>
         </hosts>
-        <username>USER</username>
-        <password>PASS</password>
         <ssl>
             <certificate_authorities>
                 <ca>CA</ca>

--- a/src/unit_tests/config_files/test_vulnerability_detection_duplicate_configuration.conf
+++ b/src/unit_tests/config_files/test_vulnerability_detection_duplicate_configuration.conf
@@ -4,8 +4,6 @@
         <hosts>
             <host>https://INDEXER-IP:9200</host>
         </hosts>
-        <username>USER</username>
-        <password>PASS</password>
         <ssl>
             <certificate_authorities>
                 <ca>CA</ca>
@@ -26,8 +24,6 @@
         <hosts>
             <host>https://INDEXER-IP:9200</host>
         </hosts>
-        <username>USER</username>
-        <password>PASS</password>
         <ssl>
             <certificate_authorities>
                 <ca>CA</ca>

--- a/src/unit_tests/config_files/test_vulnerability_detection_multiple_configuration.conf
+++ b/src/unit_tests/config_files/test_vulnerability_detection_multiple_configuration.conf
@@ -4,8 +4,6 @@
         <hosts>
             <host>https://INDEXER-IP:9200</host>
         </hosts>
-        <username>USER</username>
-        <password>PASS</password>
         <ssl>
             <certificate_authorities>
                 <ca>CA</ca>
@@ -26,8 +24,6 @@
         <hosts>
             <host>https://INDEXER-IP-2:9200</host>
         </hosts>
-        <username>USER_2</username>
-        <password>PASS_2</password>
         <ssl>
             <certificate_authorities>
                 <ca>CA_2</ca>

--- a/src/unit_tests/wazuh_modules/vulnerability_detection/test_wm_vulnerability_detection.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detection/test_wm_vulnerability_detection.c
@@ -141,7 +141,6 @@ void test_read_configuration(void** state) {
     assert_string_equal(json_indexer_result,
                         "{\"enabled\":\"yes\","
                         "\"hosts\":[\"https://INDEXER-IP:9200\"],"
-                        "\"username\":\"USER\",\"password\":\"PASS\","
                         "\"ssl\":{\"certificate_authorities\":[\"CA\"],"
                         "\"certificate\":\"CERT\",\"key\":\"KEY\"}}");
 
@@ -176,7 +175,6 @@ void test_read_duplicate_configuration(void **state) {
     assert_string_equal(json_indexer_result,
                         "{\"enabled\":\"yes\","
                         "\"hosts\":[\"https://INDEXER-IP:9200\"],"
-                        "\"username\":\"USER\",\"password\":\"PASS\","
                         "\"ssl\":{\"certificate_authorities\":[\"CA\"],"
                         "\"certificate\":\"CERT\",\"key\":\"KEY\"}}");
 
@@ -211,7 +209,6 @@ void test_read_multiple_configuration(void **state) {
     assert_string_equal(json_indexer_result,
                         "{\"enabled\":\"yes\","
                         "\"hosts\":[\"https://INDEXER-IP-2:9200\"],"
-                        "\"username\":\"USER_2\",\"password\":\"PASS_2\","
                         "\"ssl\":{\"certificate_authorities\":[\"CA_2\"],"
                         "\"certificate\":\"CERT_2\",\"key\":\"KEY_2\"}}");
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/21574 |

## Description

As explained in the related issue, this PR removes the parsing processes currently used to load the user and password configuration of the 'indexer' tag from the `ossec.conf` file.

For this it was necessary to identify and remove the parsing code responsible for extracting the user and password from the 'indexer' tag configuration, look for templates that used these tags and remove them from there and modify the unit tests

## Tests
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] All UTs passed
- [x] Coverage unchanged