### PR TITLE
 Prevent macOS agent installation to start automatically

### DIFF
--- a/src/init/darwin-init.sh
+++ b/src/init/darwin-init.sh
@@ -37,7 +37,6 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 
 chown root:wheel $SERVICE
 chmod u=rw-,go=r-- $SERVICE
-launchctl load $SERVICE
 
 echo '
 #!/bin/sh


### PR DESCRIPTION
|Related issue|
|---|
|#21636|

## Description

The `launchctl load` command was removed from an installation script as it produces the start of Wazuh after its installation. 

## Checks
- [x] Package installation
- [x] Retrocompatibility with older Wazuh versions
