### PR TITLE
Add backup configuration fixture

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -134,6 +134,18 @@ def load_wazuh_basic_configuration():
 
 
 @pytest.fixture()
+def backup_wazuh_configuration() -> None:
+    """Backup wazuh configuration. Saves the initial configuration and restores it after the test."""
+    # Save configuration
+    backup_config = configuration.get_wazuh_conf()
+
+    yield
+
+    # Restore configuration
+    configuration.write_wazuh_conf(backup_config)
+
+
+@pytest.fixture()
 def set_wazuh_configuration(test_configuration: dict) -> None:
     """Set wazuh configuration
 

--- a/tests/integration/test_api/test_config/test_upload_configuration/test_upload_configuration.py
+++ b/tests/integration/test_api/test_config/test_upload_configuration/test_upload_configuration.py
@@ -76,8 +76,8 @@ daemons_handler_configuration = {'daemons': API_DAEMONS_REQUIREMENTS}
 # Tests
 @pytest.mark.tier(level=0)
 @pytest.mark.parametrize('test_configuration,test_metadata', zip(test_configuration, test_metadata), ids=test_cases_ids)
-def test_upload_configuration(test_configuration, test_metadata, add_configuration, truncate_monitored_files,
-                              daemons_handler, wait_for_api_start):
+def test_upload_configuration(test_configuration, test_metadata, backup_wazuh_configuration, add_configuration,
+                              truncate_monitored_files, daemons_handler, wait_for_api_start):
     """
     description: Check if the API works when uploading configurations.
 
@@ -107,6 +107,9 @@ def test_upload_configuration(test_configuration, test_metadata, add_configurati
         - test_metadata:
             type: dict
             brief: Metadata from the test case.
+        - backup_wazuh_configuration:
+            type: fixture
+            brief: Save the initial wazuh configuration and restore it after the test.
         - add_configuration:
             type: fixture
             brief: Add configuration to the Wazuh API configuration files.


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/21401 |

## Description

Adds a fixture to backup the Wazuh configuration. Useful for tests that make changes to it via the API (`set_wazuh_configuration` writes to it using a dictionary).

> [!Note]
> The issue this PR fixes has a `patch` release target but the test is only in the `master` branch.
>
> The failed check is not related to the changes.