### PR TITLE
Disable VD in manager test cases

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -184,6 +184,12 @@ variables:
       <syscheck>
         <disabled>yes</disabled>
       </syscheck>
+    
+      <vulnerability-detection>
+        <enabled>no</enabled>
+        <index-status>yes</index-status>
+        <feed-update-interval>60m</feed-update-interval>
+      </vulnerability-detection>
     </ossec_config>
 
   valid_ossec_conf_with_update_check_disabled:
@@ -217,6 +223,12 @@ variables:
       <syscheck>
         <disabled>yes</disabled>
       </syscheck>
+    
+      <vulnerability-detection>
+        <enabled>no</enabled>
+        <index-status>yes</index-status>
+        <feed-update-interval>60m</feed-update-interval>
+      </vulnerability-detection>
     </ossec_config>
 
   invalid_ossec_conf:
@@ -232,6 +244,12 @@ variables:
         <log_alert_level>3</log_alert_level>
         <email_alert_level>12</email_alert_level>
       </alerts>
+    
+      <vulnerability-detection>
+        <enabled>no</enabled>
+        <index-status>yes</index-status>
+        <feed-update-interval>60m</feed-update-interval>
+      </vulnerability-detection>
 
       <remote>
     </ossec_config>
@@ -268,4 +286,10 @@ variables:
       <syscheck>
         <disabled>yes</disabled>
       </syscheck>
+    
+      <vulnerability-detection>
+        <enabled>no</enabled>
+        <index-status>yes</index-status>
+        <feed-update-interval>60m</feed-update-interval>
+      </vulnerability-detection>
     </ossec_config>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/21290|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Disable the Vulnerability Detector for test cases where the manager `ossec.conf` is configured.