### PR TITLE
Merge group files endpoints

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -1360,7 +1360,7 @@ async def get_group_files(request, group_id: str, pretty: bool = False, wait_for
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_group_file(request, group_id: str, file_name: str, return_format: str = 'json', pretty: bool = False,
+async def get_group_file(request, group_id: str, file_name: str, return_format: str = 'plain', pretty: bool = False,
                               wait_for_complete: bool = False) -> web.Response:
     """Get the files placed under the group directory in the specified format.
 
@@ -1398,7 +1398,7 @@ async def get_group_file(request, group_id: str, file_name: str, return_format: 
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    if return_format and return_format.lower() == 'plain':
+    if return_format == 'plain':
         return ConnexionResponse(body=data["data"], mimetype='text/plain')
 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -1363,7 +1363,7 @@ async def get_group_files(request, group_id: str, pretty: bool = False, wait_for
 
 async def get_group_file(request, group_id: str, file_name: str, raw: bool = None, pretty: bool = False,
                               wait_for_complete: bool = False) -> web.Response:
-    """Get the files placed under the group directory in the specified format.
+    """Get the files placed under the group directory.
 
     Parameters
     ----------

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -1362,7 +1362,7 @@ async def get_group_files(request, group_id: str, pretty: bool = False, wait_for
 
 
 async def get_group_file(request, group_id: str, file_name: str, raw: bool = False, pretty: bool = False,
-                              wait_for_complete: bool = False) -> web.Response:
+                              wait_for_complete: bool = False) -> web.Response | ConnexionResponse:
     """Get the files placed under the group directory.
 
     Parameters
@@ -1403,8 +1403,11 @@ async def get_group_file(request, group_id: str, file_name: str, raw: bool = Fal
         mimetype, _ = mimetypes.guess_type(file_name)
         if mimetype is None:
             mimetype = 'text/plain'
+        if file_name == 'agent.conf':
+            mimetype = 'application/xml'
 
-        return ConnexionResponse(body=data["data"], mimetype=mimetype)
+        return ConnexionResponse(body=data['data'], mimetype=mimetype)
+
 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -1361,7 +1361,7 @@ async def get_group_files(request, group_id: str, pretty: bool = False, wait_for
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_group_file(request, group_id: str, file_name: str, raw: bool = None, pretty: bool = False,
+async def get_group_file(request, group_id: str, file_name: str, raw: bool = False, pretty: bool = False,
                               wait_for_complete: bool = False) -> web.Response:
     """Get the files placed under the group directory.
 

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -23,10 +23,9 @@ with patch('wazuh.common.wazuh_uid'):
             get_agent_fields, get_agent_key, get_agent_no_group,
             get_agent_outdated, get_agent_summary_os, get_agent_summary_status,
             get_agent_upgrade, get_agents, get_agents_in_group, get_daemon_stats,
-            get_component_stats, get_group_config, get_group_file_json,
-            get_group_file_xml, get_group_files, get_list_group,
-            get_sync_agent, insert_agent, post_group, post_new_agent,
-            put_agent_single_group, put_group_config,
+            get_component_stats, get_group_config, get_group_file, get_group_files,
+            get_list_group, get_sync_agent, insert_agent, post_group,
+            post_new_agent, put_agent_single_group, put_group_config,
             put_multiple_agent_single_group, put_upgrade_agents,
             put_upgrade_custom_agents, reconnect_agents, restart_agent,
             restart_agents, restart_agents_by_group, restart_agents_by_node)
@@ -935,11 +934,12 @@ async def test_get_group_files(mock_exc, mock_dapi, mock_remove, mock_dfunc, moc
 @patch('api.controllers.agent_controller.remove_nones_to_dict')
 @patch('api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_get_group_file_json(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, mock_request=MagicMock()):
-    """Verify 'get_group_file_json' endpoint is working as expected."""
-    result = await get_group_file_json(request=mock_request,
+async def test_get_group_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, mock_request=MagicMock()):
+    """Verify 'get_group_file' endpoint is working as expected."""
+    result = await get_group_file(request=mock_request,
                                        group_id='001',
-                                       file_name='filename_value')
+                                       file_name='filename_value',
+                                       return_format='json')
     f_kwargs = {'group_list': ['001'],
                 'filename': 'filename_value',
                 'type_conf': mock_request.query.get('type', None),
@@ -956,35 +956,6 @@ async def test_get_group_file_json(mock_exc, mock_dapi, mock_remove, mock_dfunc,
     mock_exc.assert_called_once_with(mock_dfunc.return_value)
     mock_remove.assert_called_once_with(f_kwargs)
     assert isinstance(result, web_response.Response)
-
-
-@pytest.mark.asyncio
-@patch('api.configuration.api_conf')
-@patch('api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock())
-@patch('api.controllers.agent_controller.remove_nones_to_dict')
-@patch('api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
-@patch('api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_get_group_file_xml(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, mock_request=MagicMock()):
-    """Verify 'get_group_file_xml' endpoint is working as expected."""
-    result = await get_group_file_xml(request=mock_request,
-                                      group_id='001',
-                                      file_name='filename_value')
-    f_kwargs = {'group_list': ['001'],
-                'filename': 'filename_value',
-                'type_conf': mock_request.query.get('type', None),
-                'return_format': 'xml'
-                }
-    mock_dapi.assert_called_once_with(f=agent.get_file_conf,
-                                      f_kwargs=mock_remove.return_value,
-                                      request_type='local_master',
-                                      is_async=False,
-                                      wait_for_complete=False,
-                                      logger=ANY,
-                                      rbac_permissions=mock_request['token_info']['rbac_policies']
-                                      )
-    mock_exc.assert_called_once_with(mock_dfunc.return_value)
-    mock_remove.assert_called_once_with(f_kwargs)
-    assert isinstance(result, ConnexionResponse)
 
 
 @pytest.mark.asyncio

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -938,12 +938,11 @@ async def test_get_group_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
     """Verify 'get_group_file' endpoint is working as expected."""
     result = await get_group_file(request=mock_request,
                                        group_id='001',
-                                       file_name='filename_value',
-                                       return_format='json')
+                                       file_name='filename_value')
     f_kwargs = {'group_list': ['001'],
                 'filename': 'filename_value',
                 'type_conf': mock_request.query.get('type', None),
-                'return_format': 'json'
+                'raw': None
                 }
     mock_dapi.assert_called_once_with(f=agent.get_file_conf,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -942,7 +942,7 @@ async def test_get_group_file(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
     f_kwargs = {'group_list': ['001'],
                 'filename': 'filename_value',
                 'type_conf': mock_request.query.get('type', None),
-                'raw': None
+                'raw': False
                 }
     mock_dapi.assert_called_once_with(f=agent.get_file_conf,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6018,15 +6018,6 @@ components:
       schema:
         type: string
         format: alphanumeric
-    return_format:
-      in: query
-      name: return_format
-      description: "Response content format"
-      schema:
-        type: string
-        enum:
-          - json
-          - plain
     condition:
       in: query
       name: condition
@@ -8879,7 +8870,7 @@ paths:
         - $ref: '#/components/parameters/group_id'
         - $ref: '#/components/parameters/file_name'
         - $ref: '#/components/parameters/type_agents'
-        - $ref: '#/components/parameters/return_format'
+        - $ref: '#/components/parameters/raw'
       responses:
         '200':
           description: "Get group file in json format"

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6018,6 +6018,15 @@ components:
       schema:
         type: string
         format: alphanumeric
+    return_format:
+      in: query
+      name: return_format
+      description: "Response content format"
+      schema:
+        type: string
+        enum:
+          - json
+          - plain
     condition:
       in: query
       name: condition
@@ -8855,13 +8864,13 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
-  /groups/{group_id}/files/{file_name}/json:
+  /groups/{group_id}/files/{file_name}:
     get:
       tags:
         - Groups
       summary: "Get a file in group"
-      description: "Return the content of the specified group file parsed to JSON"
-      operationId: api.controllers.agent_controller.get_group_file_json
+      description: "Return the content of the specified group file"
+      operationId: api.controllers.agent_controller.get_group_file
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/group:read'
       parameters:
@@ -8870,6 +8879,7 @@ paths:
         - $ref: '#/components/parameters/group_id'
         - $ref: '#/components/parameters/file_name'
         - $ref: '#/components/parameters/type_agents'
+        - $ref: '#/components/parameters/return_format'
       responses:
         '200':
           description: "Get group file in json format"
@@ -8903,51 +8913,6 @@ paths:
                       checks:
                         - "f:/etc/fstab -> !r:/tmp;"
                 error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '403':
-          $ref: '#/components/responses/PermissionDeniedResponse'
-        '404':
-          $ref: '#/components/responses/ResourceNotFoundResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
-
-  /groups/{group_id}/files/{file_name}/xml:
-    get:
-      tags:
-        - Groups
-      summary: "Get a file in group"
-      description: "Return the contents of the specified group file parsed to XML"
-      operationId: api.controllers.agent_controller.get_group_file_xml
-      x-rbac-actions:
-        - $ref: '#/x-rbac-catalog/actions/group:read'
-      parameters:
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/group_id'
-        - $ref: '#/components/parameters/file_name'
-        - $ref: '#/components/parameters/type_agents'
-      responses:
-        '200':
-          description: "Get group file in xml format"
-          content:
-            application/xml:
-              schema:
-                type: string
-              example: |
-                <agent_config>
-                  <!-- Shared agent configuration here -->
-                  <agent_config os="Linux">
-                    <localfile>
-                      <location>/var/log/linux.log</location>
-                      <log_format>syslog</log_format>
-                    </localfile>
-                  </agent_config>
-                </agent_config>
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -3785,27 +3785,43 @@ stages:
           failed_items: []
 
 ---
-test_name: GET /groups/{group_id}/files/{filename}/json
+test_name: GET /groups/{group_id}/files/{filename}
 
 stages:
 
-  - name: Try get one file of a group
+  - name: Get one file of a group (JSON)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf/json"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        return_format: json
     response:
       status_code: 200
       json:
         error: 0
         data: !anything
 
+  - name: Get one file of a group (plain text)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        return_format: plain
+    response:
+      status_code: 200
+      headers:
+        content-type: text/plain; charset=utf-8
+
   - name: Try get one file of a group, bad group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/files/agent.conf/json"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/files/agent.conf"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3815,7 +3831,7 @@ stages:
   - name: Try get one file of a group, bad group (not aplhanumeric)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%_group/files/agent.conf/json"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%_group/files/agent.conf"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3824,41 +3840,27 @@ stages:
       json:
         <<: *error_spec
 
----
-test_name: GET /groups/{group_id}/files/{filename}/xml
-
-stages:
-
-  - name: Try get one file of a group
+  - name: Try get one file of a group, non existent file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf/xml"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.mg"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
-      status_code: 200
-      headers:
-        content-type: application/xml; charset=utf-8
+      status_code: 400
+      json:
+        error: 1006
 
-
-  - name: Try get one file of a group, bad group
+  - name: Try to get one file of a group, invalid format
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/files/agent.conf/xml"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
-    response:
-      <<: *resource_not_found_group
-
-  - name: Try get one file of a group, bad group (not aplhanumeric)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%_group/files/agent.conf/xml"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
+      params:
+        return_format: xml
     response:
       status_code: 400
       json:

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -3796,8 +3796,6 @@ stages:
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
-      params:
-        return_format: json
     response:
       status_code: 200
       json:
@@ -3812,7 +3810,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        return_format: plain
+        raw: true
     response:
       status_code: 200
       headers:
@@ -3851,20 +3849,6 @@ stages:
       status_code: 400
       json:
         error: 1006
-
-  - name: Try to get one file of a group, invalid format
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        return_format: xml
-    response:
-      status_code: 400
-      json:
-        <<: *error_spec
 
 ---
 test_name: GET /agents?name=agent_name

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -3802,10 +3802,24 @@ stages:
         error: 0
         data: !anything
 
-  - name: Get one file of a group (plain text)
+  - name: Get one file of a group (XML)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        raw: true
+    response:
+      status_code: 200
+      headers:
+        content-type: application/xml; charset=utf-8
+  
+  - name: Get one file of a group (plain text)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/merged.mg"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -457,14 +457,14 @@ stages:
          failed_items: []
 
 ---
-test_name: GET /groups/{group_id}/files/{filename}/json
+test_name: GET /groups/{group_id}/files/{filename}
 
 stages:
 
  - name: Try get one file of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf/json"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -474,39 +474,12 @@ stages:
  - name: Try get one file of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/files/agent.conf/json"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/files/agent.conf"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
    response:
      status_code: 200
-
----
-test_name: GET /groups/{group_id}/files/{filename}/xml
-
-stages:
-
- - name: Try get one file of a group (Denied)
-   request:
-     verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group1/files/agent.conf/xml"
-     method: GET
-     headers:
-       Authorization: "Bearer {test_login_token}"
-   response:
-      <<: *permission_denied
-
- - name: Try get one file of a group (Allowed)
-   request:
-     verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files/agent.conf/xml"
-     method: GET
-     headers:
-       Authorization: "Bearer {test_login_token}"
-   response:
-     status_code: 200
-     headers:
-       content-type: 'application/xml; charset=utf-8'
 
 ---
 test_name: GET /agents?name=agent_name

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -464,14 +464,14 @@ stages:
          failed_items: []
 
 ---
-test_name: GET /groups/{group_id}/files/{filename}/json
+test_name: GET /groups/{group_id}/files/{filename}
 
 stages:
 
  - name: Try get one file of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files/agent.conf/json"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files/agent.conf"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -481,39 +481,12 @@ stages:
  - name: Try get one file of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf/json"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
    response:
      status_code: 200
-
----
-test_name: GET /groups/{group_id}/files/{filename}/xml
-
-stages:
-
- - name: Try get one file of a group (Denied)
-   request:
-     verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files/agent.conf/xml"
-     method: GET
-     headers:
-       Authorization: "Bearer {test_login_token}"
-   response:
-      <<: *permission_denied
-
- - name: Try get one file of a group (Allowed)
-   request:
-     verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/files/agent.conf/xml"
-     method: GET
-     headers:
-       Authorization: "Bearer {test_login_token}"
-   response:
-     status_code: 200
-     headers:
-       content-type: "application/xml; charset=utf-8"
 
 ---
 test_name: GET /agents?name=agent_name

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -1486,27 +1486,13 @@ stages:
       <<: *permission_denied
 
 ---
-test_name: GET /groups/{group_id}/files/{filename}/json
+test_name: GET /groups/{group_id}/files/{filename}
 
 stages:
   - name: Try to get one file of a group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf/json"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      <<: *permission_denied
-
----
-test_name: GET /groups/{group_id}/files/{filename}/xml
-
-stages:
-  - name: Try to get one file of a group
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group2/files/agent.conf/xml"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1400,7 +1400,7 @@ def get_agents_sync_group(agent_list: list = None) -> AffectedItemsWazuhResult:
 
 
 @expose_resources(actions=["group:read"], resources=["group:id:{group_list}"], post_proc_func=None)
-def get_file_conf(group_list: list = None, type_conf: str = None, return_format: str = None,
+def get_file_conf(group_list: list = None, type_conf: str = None, raw: bool = None,
                   filename: str = None) -> WazuhResult:
     """Read configuration file for a specified group.
 
@@ -1410,8 +1410,8 @@ def get_file_conf(group_list: list = None, type_conf: str = None, return_format:
         List with the group ID.
     type_conf : str
         Type of file.
-    return_format : str
-        Response content format.
+    raw : bool
+        Respond in raw format.
     filename : str
         Filename to read config from.
 
@@ -1425,7 +1425,7 @@ def get_file_conf(group_list: list = None, type_conf: str = None, return_format:
     group_id = group_list[0]
 
     return WazuhResult({'data': configuration.get_file_conf(filename, group_id=group_id, type_conf=type_conf,
-                                                            return_format=return_format)})
+                                                            raw=raw)})
 
 
 @expose_resources(actions=["group:read"], resources=["group:id:{group_list}"], post_proc_func=None)

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1411,7 +1411,7 @@ def get_file_conf(group_list: list = None, type_conf: str = None, return_format:
     type_conf : str
         Type of file.
     return_format : str
-        Format of the answer (xml or json).
+        Response content format.
     filename : str
         Filename to read config from.
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1400,7 +1400,7 @@ def get_agents_sync_group(agent_list: list = None) -> AffectedItemsWazuhResult:
 
 
 @expose_resources(actions=["group:read"], resources=["group:id:{group_list}"], post_proc_func=None)
-def get_file_conf(group_list: list = None, type_conf: str = None, raw: bool = None,
+def get_file_conf(group_list: list = None, type_conf: str = None, raw: bool = False,
                   filename: str = None) -> WazuhResult:
     """Read configuration file for a specified group.
 

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -678,7 +678,7 @@ def get_agent_conf(group_id: str = None, offset: int = 0, limit: int = common.DA
     filename : str
         Name of the file to get. Default: 'agent.conf'
     return_format : str
-        Return format.
+        Response content format.
 
     Raises
     ------
@@ -703,9 +703,9 @@ def get_agent_conf(group_id: str = None, offset: int = 0, limit: int = common.DA
 
     try:
         # Read RAW file
-        if filename == 'agent.conf' and return_format and 'xml' == return_format.lower():
-            with open(agent_conf, 'r') as xml_data:
-                data = xml_data.read()
+        if filename == 'agent.conf' and return_format and return_format.lower() == 'plain':
+            with open(agent_conf, 'r') as raw_data:
+                data = raw_data.read()
                 return data
         # Parse XML to JSON
         else:
@@ -771,7 +771,7 @@ def get_agent_conf_multigroup(multigroup_id: str = None, offset: int = 0, limit:
 
 
 def get_file_conf(filename: str, group_id: str = None, type_conf: str = None, return_format: str = None) -> dict:
-    """Return the configuration file as dictionary.
+    """Return the configuration file content.
 
     Parameters
     ----------
@@ -779,10 +779,10 @@ def get_file_conf(filename: str, group_id: str = None, type_conf: str = None, re
         ID of the group with the file we want to get.
     filename : str
         Name of the file to get.
-    return_format : str
-        Return format.
     type_conf : str
         Type of the configuration we want to get.
+    return_format : str
+        Response content format.
 
     Raises
     ------
@@ -796,7 +796,7 @@ def get_file_conf(filename: str, group_id: str = None, type_conf: str = None, re
     Returns
     -------
     dict
-        Configuration file as dictionary.
+        File content as plain text or dictionary.
     """
     if not os_path.exists(os_path.join(common.SHARED_PATH, group_id)):
         raise WazuhResourceNotFound(1710, group_id)
@@ -805,6 +805,11 @@ def get_file_conf(filename: str, group_id: str = None, type_conf: str = None, re
 
     if not os_path.exists(file_path):
         raise WazuhError(1006, file_path)
+    
+    if return_format == 'plain':
+        with open(file_path, 'r') as raw_data:
+            data = raw_data.read()
+            return data
 
     types = {
         'conf': get_agent_conf,

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -604,20 +604,19 @@ def _merged_mg2json(file_path: str) -> List[dict]:
 
     # ![file_size] [file_name]
     regex_header = re.compile(r"^!(\d+)\s*(.*)")
-    regex_comment = re.compile(r"^\s*#")
 
     try:
         item = {}
         file_content = []
 
         with open(file_path) as f:
-            for line in f:
-                if re.search(regex_comment, line):
-                    continue
+            # Skip first line
+            next(f)
 
+            for line in f:
                 if match_header := re.search(regex_header, line):
-                    # Append previous item
                     if item:
+                        # Append previous item
                         item['file_content'] = ''.join(file_content)
                         data.append(item)
 
@@ -820,7 +819,7 @@ def get_agent_conf_multigroup(multigroup_id: str = None, offset: int = 0, limit:
     return {'totalItems': len(data), 'items': cut_array(data, offset=offset, limit=limit)}
 
 
-def get_file_conf(filename: str, group_id: str = None, type_conf: str = None, raw: bool = False) -> dict:
+def get_file_conf(filename: str, group_id: str = None, type_conf: str = None, raw: bool = False) -> dict | str:
     """Return the configuration file content.
 
     Parameters
@@ -845,7 +844,7 @@ def get_file_conf(filename: str, group_id: str = None, type_conf: str = None, ra
 
     Returns
     -------
-    dict
+    dict or str
         File content as plain text or dictionary.
     """
     if not os_path.exists(os_path.join(common.SHARED_PATH, group_id)):

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -714,7 +714,7 @@ def get_ossec_conf(section: str = None, field: str = None, conf_file: str = comm
 
 
 def get_agent_conf(group_id: str = None, offset: int = 0, limit: int = common.DATABASE_LIMIT,
-                   filename: str = 'agent.conf', raw: bool = None) -> Union[dict, str]:
+                   filename: str = 'agent.conf', raw: bool = False) -> Union[dict, str]:
     """Return agent.conf as dictionary.
 
     Parameters
@@ -820,7 +820,7 @@ def get_agent_conf_multigroup(multigroup_id: str = None, offset: int = 0, limit:
     return {'totalItems': len(data), 'items': cut_array(data, offset=offset, limit=limit)}
 
 
-def get_file_conf(filename: str, group_id: str = None, type_conf: str = None, raw: bool = None) -> dict:
+def get_file_conf(filename: str, group_id: str = None, type_conf: str = None, raw: bool = False) -> dict:
     """Return the configuration file content.
 
     Parameters

--- a/framework/wazuh/core/tests/data/configuration/default/merged.mg
+++ b/framework/wazuh/core/tests/data/configuration/default/merged.mg
@@ -1,0 +1,10 @@
+#default
+!77 ar.conf
+restart-ossec0 - restart-ossec.sh - 0
+restart-ossec0 - restart-ossec.cmd - 0
+!76 agent.conf
+<agent_config>
+
+  <!-- Shared agent configuration here -->
+
+</agent_config>

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -150,6 +150,7 @@ def test_rootkit_trojans2json():
 
 
 def test_merged_mg2json():
+    """Checks that _merged_mg2json parses the file content correctly."""
     with patch('builtins.open', return_value=Exception):
         with pytest.raises(WazuhError, match=".* 1101 .*"):
             configuration._merged_mg2json(file_path=os.path.join(

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -243,36 +243,36 @@ def test_get_file_conf():
     with patch('wazuh.core.common.SHARED_PATH', new=os.path.join(parent_directory, tmp_path, 'noexists')):
         with pytest.raises(WazuhError, match=".* 1710 .*"):
             configuration.get_file_conf(filename='ossec.conf', group_id='default', type_conf='conf',
-                                        return_format='xml')
+                                        return_format='plain')
 
     with patch('wazuh.core.common.SHARED_PATH', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         with pytest.raises(WazuhError, match=".* 1006 .*"):
             configuration.get_file_conf(filename='noexists.conf', group_id='default', type_conf='conf',
-                                        return_format='xml')
+                                        return_format='plain')
 
     with patch('wazuh.core.common.SHARED_PATH', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         assert isinstance(configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='conf',
-                                                      return_format='xml'), str)
+                                                      return_format='json'), dict)
         assert isinstance(configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='rcl',
-                                                      return_format='xml'), dict)
+                                                      return_format='json'), dict)
         assert isinstance(configuration.get_file_conf(filename='agent.conf', group_id='default',
-                                                      return_format='xml'), str)
+                                                      return_format='plain'), str)
         rootkit_files = [{'filename': 'NEW_ELEMENT', 'name': 'FOR', 'link': 'TESTING'}]
         assert configuration.get_file_conf(filename='rootkit_files.txt', group_id='default',
-                                           return_format='xml') == rootkit_files
+                                           return_format='json') == rootkit_files
         rootkit_trojans = [{'filename': 'NEW_ELEMENT', 'name': 'FOR', 'description': 'TESTING'}]
         assert configuration.get_file_conf(filename='rootkit_trojans.txt', group_id='default',
-                                           return_format='xml') == rootkit_trojans
+                                           return_format='json') == rootkit_trojans
         ar_list = ['restart-ossec0 - restart-ossec.sh - 0', 'restart-ossec0 - restart-ossec.cmd - 0',
                    'restart-wazuh0 - restart-ossec.sh - 0', 'restart-wazuh0 - restart-ossec.cmd - 0',
                    'restart-wazuh0 - restart-wazuh - 0', 'restart-wazuh0 - restart-wazuh.exe - 0']
-        assert configuration.get_file_conf(filename='ar.conf', group_id='default', return_format='xml') == ar_list
+        assert configuration.get_file_conf(filename='ar.conf', group_id='default', return_format='json') == ar_list
         rcl = {'vars': {}, 'controls': [{}, {'name': 'NEW_ELEMENT', 'cis': [], 'pci': [], 'condition': 'FOR',
                                              'reference': 'TESTING', 'checks': []}]}
-        assert configuration.get_file_conf(filename='rcl.conf', group_id='default', return_format='xml') == rcl
+        assert configuration.get_file_conf(filename='rcl.conf', group_id='default', return_format='json') == rcl
         with pytest.raises(WazuhError, match=".* 1104 .*"):
             configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='noconf',
-                                        return_format='xml')
+                                        return_format='json')
 
 
 def test_parse_internal_options():

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -149,6 +149,20 @@ def test_rootkit_trojans2json():
         parent_directory, tmp_path, 'configuration/trojan.txt'))[0]['filename'] == 'trojan'
 
 
+def test_merged_mg2json():
+    with patch('builtins.open', return_value=Exception):
+        with pytest.raises(WazuhError, match=".* 1101 .*"):
+            configuration._merged_mg2json(file_path=os.path.join(
+                parent_directory, tmp_path, 'configuration/default/merged.mg'))
+
+    item = configuration._merged_mg2json(file_path=os.path.join(
+        parent_directory, tmp_path, 'configuration/default/merged.mg'))[0]
+
+    assert item['file_name'] == 'ar.conf'
+    assert item['file_size'] == 77
+    assert item['file_content'] == 'restart-ossec0 - restart-ossec.sh - 0\nrestart-ossec0 - restart-ossec.cmd - 0\n'
+
+
 def test_get_ossec_conf():
     with patch('wazuh.core.configuration.load_wazuh_xml', return_value=Exception):
         with pytest.raises(WazuhError, match=".* 1101 .*"):
@@ -243,36 +257,33 @@ def test_get_file_conf():
     with patch('wazuh.core.common.SHARED_PATH', new=os.path.join(parent_directory, tmp_path, 'noexists')):
         with pytest.raises(WazuhError, match=".* 1710 .*"):
             configuration.get_file_conf(filename='ossec.conf', group_id='default', type_conf='conf',
-                                        return_format='plain')
+                                        raw=True)
 
     with patch('wazuh.core.common.SHARED_PATH', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         with pytest.raises(WazuhError, match=".* 1006 .*"):
             configuration.get_file_conf(filename='noexists.conf', group_id='default', type_conf='conf',
-                                        return_format='plain')
+                                        raw=True)
 
     with patch('wazuh.core.common.SHARED_PATH', new=os.path.join(parent_directory, tmp_path, 'configuration')):
-        assert isinstance(configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='conf',
-                                                      return_format='json'), dict)
-        assert isinstance(configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='rcl',
-                                                      return_format='json'), dict)
+        assert isinstance(configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='conf'),
+                          dict)
+        assert isinstance(configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='rcl'),
+                          dict)
         assert isinstance(configuration.get_file_conf(filename='agent.conf', group_id='default',
-                                                      return_format='plain'), str)
+                                                      raw=True), str)
         rootkit_files = [{'filename': 'NEW_ELEMENT', 'name': 'FOR', 'link': 'TESTING'}]
-        assert configuration.get_file_conf(filename='rootkit_files.txt', group_id='default',
-                                           return_format='json') == rootkit_files
+        assert configuration.get_file_conf(filename='rootkit_files.txt', group_id='default') == rootkit_files
         rootkit_trojans = [{'filename': 'NEW_ELEMENT', 'name': 'FOR', 'description': 'TESTING'}]
-        assert configuration.get_file_conf(filename='rootkit_trojans.txt', group_id='default',
-                                           return_format='json') == rootkit_trojans
+        assert configuration.get_file_conf(filename='rootkit_trojans.txt', group_id='default',) == rootkit_trojans
         ar_list = ['restart-ossec0 - restart-ossec.sh - 0', 'restart-ossec0 - restart-ossec.cmd - 0',
                    'restart-wazuh0 - restart-ossec.sh - 0', 'restart-wazuh0 - restart-ossec.cmd - 0',
                    'restart-wazuh0 - restart-wazuh - 0', 'restart-wazuh0 - restart-wazuh.exe - 0']
-        assert configuration.get_file_conf(filename='ar.conf', group_id='default', return_format='json') == ar_list
+        assert configuration.get_file_conf(filename='ar.conf', group_id='default') == ar_list
         rcl = {'vars': {}, 'controls': [{}, {'name': 'NEW_ELEMENT', 'cis': [], 'pci': [], 'condition': 'FOR',
                                              'reference': 'TESTING', 'checks': []}]}
-        assert configuration.get_file_conf(filename='rcl.conf', group_id='default', return_format='json') == rcl
+        assert configuration.get_file_conf(filename='rcl.conf', group_id='default') == rcl
         with pytest.raises(WazuhError, match=".* 1104 .*"):
-            configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='noconf',
-                                        return_format='json')
+            configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='noconf')
 
 
 def test_parse_internal_options():

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -227,8 +227,7 @@ get_rbac_actions:
           - GET /groups/{group_id}/agents
           - GET /groups/{group_id}/configuration
           - GET /groups/{group_id}/files
-          - GET /groups/{group_id}/files/{file_name}/json
-          - GET /groups/{group_id}/files/{file_name}/xml
+          - GET /groups/{group_id}/files/{file_name}
           - GET /overview/agents
       group:create:
         description: Create new agent groups


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/20851 |

## Description

Merges the `/groups/:group_id/files/:file_name/json` and `/groups/:group_id/files/:file_name/xml` endpoints into a single one that takes the `raw` parameter which defines whether the response content will be formatted in json or plain text. The response content-type is defined based on the file extension retrieved.

## Logs/Alerts example

<details><summary>Get merged.mg in plain text</summary>

`GET /groups/default/files/merged.mg?raw=true`

```
#default
!228 ar.conf
restart-ossec0 - restart-ossec.sh - 0
restart-ossec0 - restart-ossec.cmd - 0
restart-wazuh0 - restart-ossec.sh - 0
restart-wazuh0 - restart-ossec.cmd - 0
restart-wazuh0 - restart-wazuh - 0
restart-wazuh0 - restart-wazuh.exe - 0
!76 agent.conf
<agent_config>

  <!-- Shared agent configuration here -->

</agent_config>
!28411 cis_apache2224_rcl.txt
...
```

</details>

<details><summary>Get merged.mg in JSON</summary>

`GET /groups/default/files/merged.mg`

```json
{
    "data": [
        {
            "file_name": "ar.conf",
            "file_size": 228,
            "file_content": "restart-ossec0 - restart-ossec.sh - 0\nrestart-ossec0 - restart-ossec.cmd - 0\nrestart-wazuh0 - restart-ossec.sh - 0\nrestart-wazuh0 - restart-ossec.cmd - 0\nrestart-wazuh0 - restart-wazuh - 0\nrestart-wazuh0 - restart-wazuh.exe - 0\n"
        },
        {
            "file_name": "agent.conf",
            "file_size": 76,
            "file_content": "<agent_config>\n\n  <!-- Shared agent configuration here -->\n\n</agent_config>\n"
        },
        ...
 	]
}
```

</details>

<details><summary>Get file content using a configuration type</summary>

`GET /groups/default/files/agent.conf?type=conf`

```json
{
    "data": {
        "total_affected_items": 1,
        "affected_items": [
            {
                "filters": {},
                "config": {}
            }
        ]
    },
    "error": 0
}
```

</details>

> Failed checks are not related to the changes introduced.