### PR TITLE
Avoid skipping vulnerabilities scan due to empty platforms array.

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
@@ -119,7 +119,11 @@ public:
                 }
 
                 auto candidate = NSVulnerabilityScanner::CreateScanVulnerabilityCandidateDirect(
-                    candidateBuilderRef, cveId->c_str(), defaultStatus, &platformsVec, &versionFBArray);
+                    candidateBuilderRef,
+                    cveId->c_str(),
+                    defaultStatus,
+                    affected->platforms() && affected->platforms()->size() ? &platformsVec : nullptr,
+                    &versionFBArray);
 
                 candidatesArraysMap.at(productName).first.push_back(candidate);
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -63,8 +63,8 @@ public:
         auto vulnerabilityScan =
             [&](const std::string& cnaName, const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
-            // if the platforms are not empty, we need to check if the platform is in the list.
-            if (callbackData.platforms())
+            // If the platform array is not empty, we need to check if the platform is in the list.
+            if (callbackData.platforms() && callbackData.platforms()->size())
             {
                 bool matchPlatform {false};
                 for (const auto& platform : *callbackData.platforms())

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -63,8 +63,8 @@ public:
         auto vulnerabilityScan =
             [&](const std::string& cnaName, const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
-            // If the platform array is not empty, we need to check if the platform is in the list.
-            if (callbackData.platforms() && callbackData.platforms()->size())
+            // if the platforms are not empty, we need to check if the platform is in the list.
+            if (callbackData.platforms())
             {
                 bool matchPlatform {false};
                 for (const auto& platform : *callbackData.platforms())

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVECandidates_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVECandidates_test.cpp
@@ -276,7 +276,7 @@ TEST_F(UpdateCVECandidatesTest, UpdateCVECandidateSuccess)
     // Verify NVD values
     EXPECT_EQ(nvdData->cveId()->str(), CVE_ID);
     EXPECT_EQ(nvdData->defaultStatus(), NSVulnerabilityScanner::Status::Status_unaffected);
-    EXPECT_EQ(nvdData->platforms()->size(), 0);
+    EXPECT_EQ(nvdData->platforms(), nullptr);
     EXPECT_EQ(nvdData->versions()->size(), 4);
     EXPECT_EQ(nvdData->versions()->Get(0)->status(), NSVulnerabilityScanner::Status::Status_affected);
     EXPECT_EQ(nvdData->versions()->Get(0)->version()->str(), "3.2.48");


### PR DESCRIPTION
|Related issue|
|---|
|#21597|

## Description

This change avoids skipping the vulnerabilities scan when the platform array has no elements.

## Logs/Alerts example

![image](https://github.com/wazuh/wazuh/assets/13010397/36c7bee0-86c3-495d-84ec-eaffb4a5fbb0)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation