### PR TITLE
Remove unwanted elements

### DIFF
--- a/src/wazuh_modules/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/wm_vulnerability_scanner.c
@@ -132,5 +132,9 @@ cJSON* wm_vulnerability_scanner_dump(wm_vulnerability_scanner_t * data)
 {
     cJSON *root = cJSON_CreateObject();
     cJSON_AddItemToObject(root, "vulnerability-detection", cJSON_Duplicate(data->vulnerability_detection, TRUE));
+    cJSON_DeleteItemFromObject(cJSON_GetObjectItem(root, "vulnerability-detection"), "index-status");
+    cJSON_DeleteItemFromObject(cJSON_GetObjectItem(root, "vulnerability-detection"), "cti-url");
+    cJSON_DeleteItemFromObject(cJSON_GetObjectItem(root, "vulnerability-detection"), "clusterName");
+
     return root;
 }

--- a/src/wazuh_modules/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/wm_vulnerability_scanner.c
@@ -132,7 +132,7 @@ cJSON* wm_vulnerability_scanner_dump(wm_vulnerability_scanner_t * data)
 {
     cJSON *root = cJSON_CreateObject();
     cJSON_AddItemToObject(root, "vulnerability-detection", cJSON_Duplicate(data->vulnerability_detection, TRUE));
-    cJSON_DeleteItemFromObject(cJSON_GetObjectItem(root, "vulnerability-detection"), "index-status");
+    cJSON_DeleteItemFromObject(cJSON_GetObjectItem(root, "vulnerability-detection"), "indexer-status");
     cJSON_DeleteItemFromObject(cJSON_GetObjectItem(root, "vulnerability-detection"), "cti-url");
     cJSON_DeleteItemFromObject(cJSON_GetObjectItem(root, "vulnerability-detection"), "clusterName");
 


### PR DESCRIPTION
|Related issue|
|---|
|#21656|

## Description

The following elements are removed from the configuration dump for the vulnerability detector module
- cti-url
- indexer-status
- clusterName

## Logs/Alerts example

- Before 
![2024-01-30_11-32](https://github.com/wazuh/wazuh/assets/13010397/3412031e-4c7d-4c2f-a858-7df45c59be9b)
- After 
![2024-01-30_18-50](https://github.com/wazuh/wazuh/assets/13010397/91c63a73-1f87-424d-90fc-478af3cca74b)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation