### PR TITLE
Vulnerability Scanner - Add a version match method

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
@@ -22,9 +22,8 @@
 #include "versionObjectRpm.hpp"
 #include "versionObjectSemVer.hpp"
 #include "vulnerabilityScannerDefs.hpp"
-#include <iostream>
 #include <memory>
-#include <regex>
+#include <stdexcept>
 #include <string>
 
 constexpr auto INVALID_VERSION_OBJECT_TYPE = 0x7FFFFFFF;
@@ -232,6 +231,26 @@ public:
             }
         }
         return INVALID_VERSION_OBJECT_TYPE;
+    }
+
+    /**
+     * @brief Checks whether a version string matches the given version type.
+     *
+     * @details An unspecified version type is not allowed.
+     *
+     * @param version Version to validate.
+     * @param type Version type.
+     * @return true If the version is valid.
+     * @return false If the version is not valid.
+     */
+    static bool match(const std::string& version, const VersionObjectType& type)
+    {
+        if (VersionObjectType::Unspecified == type)
+        {
+            throw std::runtime_error {"Unspecified version type is not allowed"};
+        }
+
+        return (nullptr != createVersionObject(version, type));
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
@@ -243,7 +243,7 @@ public:
      * @return true If the version is valid.
      * @return false If the version is not valid.
      */
-    static bool match(const std::string& version, const VersionObjectType& type)
+    static bool match(const std::string& version, VersionObjectType type)
     {
         if (VersionObjectType::Unspecified == type)
         {

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
@@ -549,3 +549,93 @@ TEST_F(VersionMatcherTest, compareAmznLinux_invalidVersions)
     EXPECT_EQ(VersionMatcher::compare("1.15.1-6.amzn2023.0.3", "A-B-C", VersionObjectType::AMZN),
               INVALID_VERSION_OBJECT_TYPE);
 }
+
+TEST_F(VersionMatcherTest, matchCalVer)
+{
+    EXPECT_TRUE(VersionMatcher::match("2023.11.02.1", VersionObjectType::CalVer));
+    EXPECT_TRUE(VersionMatcher::match("2021.01", VersionObjectType::CalVer));
+    EXPECT_TRUE(VersionMatcher::match("2023.2.5", VersionObjectType::CalVer));
+    EXPECT_TRUE(VersionMatcher::match("2021.12.17", VersionObjectType::CalVer));
+
+    EXPECT_FALSE(VersionMatcher::match("21.0.0", VersionObjectType::CalVer));
+    EXPECT_FALSE(VersionMatcher::match("202.11.02.1", VersionObjectType::CalVer));
+}
+
+TEST_F(VersionMatcherTest, matchPEP440)
+{
+    EXPECT_TRUE(VersionMatcher::match("1!2.0b2.post345.dev456", VersionObjectType::PEP440));
+    EXPECT_TRUE(VersionMatcher::match("1.0b2.post345.dev456", VersionObjectType::PEP440));
+
+    EXPECT_FALSE(VersionMatcher::match("1!2.0b2.345.dev456", VersionObjectType::PEP440));
+}
+
+TEST_F(VersionMatcherTest, matchMajorMinor)
+{
+    EXPECT_TRUE(VersionMatcher::match("3.0", VersionObjectType::MajorMinor));
+    EXPECT_TRUE(VersionMatcher::match("1-6", VersionObjectType::MajorMinor));
+
+    EXPECT_FALSE(VersionMatcher::match("3.A", VersionObjectType::MajorMinor));
+    EXPECT_FALSE(VersionMatcher::match("3.0.1", VersionObjectType::MajorMinor));
+    EXPECT_FALSE(VersionMatcher::match("B.3", VersionObjectType::MajorMinor));
+    EXPECT_FALSE(VersionMatcher::match("C-6", VersionObjectType::MajorMinor));
+    EXPECT_FALSE(VersionMatcher::match("7", VersionObjectType::MajorMinor));
+    EXPECT_FALSE(VersionMatcher::match("7.", VersionObjectType::MajorMinor));
+    EXPECT_FALSE(VersionMatcher::match("7-", VersionObjectType::MajorMinor));
+}
+
+TEST_F(VersionMatcherTest, matchSemVer)
+{
+    EXPECT_TRUE(VersionMatcher::match("1.2.2-beta+001", VersionObjectType::SemVer));
+    EXPECT_TRUE(VersionMatcher::match("1.0.1-alpha", VersionObjectType::SemVer));
+    EXPECT_TRUE(VersionMatcher::match("2.1.0-dev", VersionObjectType::SemVer));
+    EXPECT_TRUE(VersionMatcher::match("2.1.0-RC1", VersionObjectType::SemVer));
+    EXPECT_TRUE(VersionMatcher::match("1.2.3", VersionObjectType::SemVer));
+
+    EXPECT_FALSE(VersionMatcher::match("1.2.B", VersionObjectType::SemVer));
+    EXPECT_FALSE(VersionMatcher::match("1:5.15.8-2ubuntu2.0", VersionObjectType::SemVer));
+}
+
+TEST_F(VersionMatcherTest, matchDPKG)
+{
+    EXPECT_TRUE(VersionMatcher::match("1:5.15.8-2ubuntu2.0", VersionObjectType::DPKG));
+    EXPECT_TRUE(VersionMatcher::match("20230206.0~ds2-1.1", VersionObjectType::DPKG));
+    EXPECT_TRUE(VersionMatcher::match("5.15.0-1052.57~20.04.1", VersionObjectType::DPKG));
+
+    EXPECT_FALSE(VersionMatcher::match("21.1-19-gbad84ad4-0ubuntu1~16.04.1", VersionObjectType::DPKG));
+    EXPECT_FALSE(VersionMatcher::match("19.4-56-g06e324ff-0ubuntu1", VersionObjectType::DPKG));
+    EXPECT_FALSE(VersionMatcher::match("1.39+1.40-WIP-2006.11.14+dfsg-2ubuntu1.1", VersionObjectType::DPKG));
+}
+
+TEST_F(VersionMatcherTest, matchRPM)
+{
+    EXPECT_TRUE(VersionMatcher::match("1:4.8.0-2.amzn2023.0.2", VersionObjectType::RPM));
+    EXPECT_TRUE(VersionMatcher::match("2020.3-8.el92", VersionObjectType::RPM));
+    EXPECT_TRUE(VersionMatcher::match("3.1.2-1.el9", VersionObjectType::RPM));
+    EXPECT_TRUE(VersionMatcher::match("20180407-10.el9", VersionObjectType::RPM));
+
+    EXPECT_FALSE(VersionMatcher::match("5.5.6.0_2003-04-09", VersionObjectType::RPM));
+    EXPECT_FALSE(VersionMatcher::match("6.9-11-0", VersionObjectType::RPM));
+}
+
+TEST_F(VersionMatcherTest, matchAMZN)
+{
+    EXPECT_TRUE(VersionMatcher::match("1:4.8.0-2.amzn2023.0.2", VersionObjectType::AMZN));
+    EXPECT_TRUE(VersionMatcher::match("2020.3-8.el92", VersionObjectType::AMZN));
+    EXPECT_TRUE(VersionMatcher::match("3.1.2-1.el9", VersionObjectType::AMZN));
+    EXPECT_TRUE(VersionMatcher::match("20180407-10.el9", VersionObjectType::AMZN));
+    EXPECT_TRUE(VersionMatcher::match("5.5.6.0_2003-04-09", VersionObjectType::AMZN));
+    EXPECT_TRUE(VersionMatcher::match("6.9-11-0", VersionObjectType::AMZN));
+    EXPECT_TRUE(VersionMatcher::match("1!2.0b2.post345.dev45", VersionObjectType::AMZN));
+    EXPECT_TRUE(VersionMatcher::match("16.04.1", VersionObjectType::AMZN));
+
+    EXPECT_TRUE(VersionMatcher::match("3.0.1", VersionObjectType::AMZN));
+    EXPECT_TRUE(VersionMatcher::match("2020.05.12", VersionObjectType::AMZN));
+    EXPECT_TRUE(VersionMatcher::match("", VersionObjectType::AMZN));
+}
+
+TEST_F(VersionMatcherTest, matchUnspecified)
+{
+    EXPECT_THROW(VersionMatcher::match("2023.11.02.1", VersionObjectType::Unspecified), std::runtime_error);
+    EXPECT_THROW(VersionMatcher::match("", VersionObjectType::Unspecified), std::runtime_error);
+    EXPECT_THROW(VersionMatcher::match("1:5.15.8-2ubuntu2.0", VersionObjectType::Unspecified), std::runtime_error);
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
@@ -628,9 +628,9 @@ TEST_F(VersionMatcherTest, matchAMZN)
     EXPECT_TRUE(VersionMatcher::match("1!2.0b2.post345.dev45", VersionObjectType::AMZN));
     EXPECT_TRUE(VersionMatcher::match("16.04.1", VersionObjectType::AMZN));
 
-    EXPECT_TRUE(VersionMatcher::match("3.0.1", VersionObjectType::AMZN));
-    EXPECT_TRUE(VersionMatcher::match("2020.05.12", VersionObjectType::AMZN));
-    EXPECT_TRUE(VersionMatcher::match("", VersionObjectType::AMZN));
+    EXPECT_FALSE(VersionMatcher::match("-..-", VersionObjectType::AMZN));
+    EXPECT_FALSE(VersionMatcher::match("A.B.C", VersionObjectType::AMZN));
+    EXPECT_FALSE(VersionMatcher::match("", VersionObjectType::AMZN));
 }
 
 TEST_F(VersionMatcherTest, matchUnspecified)


### PR DESCRIPTION
|Related issue|
|---|
| Closes #21675 |

## Description

This PR makes a little addition to the `VersionMatcher` class: A new method that checks whether a version is compatible against an specific version type.

## Results

UTs showing that the new feature works:
```bash
# ./vulnerability_scanner_unit_tests --gtest_filter=VersionMatcherTest.match*
Note: Google Test filter = VersionMatcherTest.match*
[==========] Running 8 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 8 tests from VersionMatcherTest
[ RUN      ] VersionMatcherTest.matchCalVer
[       OK ] VersionMatcherTest.matchCalVer (0 ms)
[ RUN      ] VersionMatcherTest.matchPEP440
[       OK ] VersionMatcherTest.matchPEP440 (0 ms)
[ RUN      ] VersionMatcherTest.matchMajorMinor
[       OK ] VersionMatcherTest.matchMajorMinor (0 ms)
[ RUN      ] VersionMatcherTest.matchSemVer
[       OK ] VersionMatcherTest.matchSemVer (0 ms)
[ RUN      ] VersionMatcherTest.matchDPKG
[       OK ] VersionMatcherTest.matchDPKG (0 ms)
[ RUN      ] VersionMatcherTest.matchRPM
[       OK ] VersionMatcherTest.matchRPM (0 ms)
[ RUN      ] VersionMatcherTest.matchAMZN
[       OK ] VersionMatcherTest.matchAMZN (0 ms)
[ RUN      ] VersionMatcherTest.matchUnspecified
[       OK ] VersionMatcherTest.matchUnspecified (0 ms)
[----------] 8 tests from VersionMatcherTest (2 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 8 tests.
```