### PR TITLE
Changes to install files, adding new wazuh-keystore tool

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -908,7 +908,7 @@ InstallCommon()
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/fim/db
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/syscollector
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/syscollector/db
-
+  ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/keystore 
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/logcollector
 
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/ruleset
@@ -1288,6 +1288,8 @@ InstallServer()
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../framework/wrappers/generic_wrapper.sh ${INSTALLDIR}/integrations/shuffle
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../framework/wrappers/generic_wrapper.sh ${INSTALLDIR}/integrations/maltiverse
 
+    # Keystore
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} wazuh-keystore ${INSTALLDIR}/bin/
 }
 
 InstallAgent()


### PR DESCRIPTION
|Related issue|
|---|
|closes #21668|

## Description
The objective is to include the installation of the `wazuh-keystore` tool, which will be located in the bin directory. This tool is essential for managing the keystore within the Wazuh environment.

This PR is related to [#2804](https://github.com/wazuh/wazuh-packages/pull/2804) which complies with the necessary changes in [wazuh-packages](https://github.com/wazuh/wazuh-packages)

## Tests

Centos test
```shell
[root@44fc8ae8f64c /]# cat /etc/os-release 
NAME="CentOS Linux"
VERSION="8"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="CentOS Linux 8"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:8"
HOME_URL="https://centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"
CENTOS_MANTISBT_PROJECT="CentOS-8"
CENTOS_MANTISBT_PROJECT_VERSION="8"
[root@44fc8ae8f64c /]# cd /var/ossec/bin/
[root@44fc8ae8f64c bin]# ./wazuh-keystore -h

Usage: wazuh-keystore <option(s)>
Options:
        -h                      Show this help message
        -f COLUMN_FAMILY        Specifies the target column family for the insertion.
        -k KEY                  Specifies the key for the key-value pair.
        -v VALUE                Specifies the value associated with the key.

Example:
        ./wazuh-keystore -f indexer -k username -v admin

[root@44fc8ae8f64c bin]# ./wazuh-keystore -f indexer -k username -v admin
[root@44fc8ae8f64c bin]# ls -l ../queue/keystore/
total 80
-rw-r--r-- 1 root root     0 Jan 31 14:10 000004.log
-rw-r--r-- 1 root root  1307 Jan 31 14:10 000012.sst
-rw-r--r-- 1 root root    16 Jan 31 14:10 CURRENT
-rw-r--r-- 1 root root    36 Jan 31 14:10 IDENTITY
-rw-r--r-- 1 root root     0 Jan 31 14:10 LOCK
-rw-r--r-- 1 root root 44845 Jan 31 14:10 LOG
-rw-r--r-- 1 root root   258 Jan 31 14:10 MANIFEST-000005
-rw-r--r-- 1 root root  7080 Jan 31 14:10 OPTIONS-000009
-rw-r--r-- 1 root root 11466 Jan 31 14:10 OPTIONS-000011

``` 
Ubuntu Test
```shell
✔ 14:12 $ ./docker\ exec\ -it\ determined_borg\ bash 
root@72a10253b9d0:/# cat /etc/os-release 
PRETTY_NAME="Ubuntu 22.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.3 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
root@72a10253b9d0:/# cd /var/ossec/bin/
root@72a10253b9d0:/var/ossec/bin# ./wazuh-keystore -h

Usage: wazuh-keystore <option(s)>
Options:
        -h                      Show this help message
        -f COLUMN_FAMILY        Specifies the target column family for the insertion.
        -k KEY                  Specifies the key for the key-value pair.
        -v VALUE                Specifies the value associated with the key.

Example:
        ./wazuh-keystore -f indexer -k username -v admin

root@72a10253b9d0:/var/ossec/bin# ./wazuh-keystore -f indexer -k username -v admin
root@72a10253b9d0:/var/ossec/bin# ll ../queue/keystore/
total 88
drwxr-x---  2 wazuh wazuh  4096 Jan 31 14:14 ./
drwxr-x--- 19 root  wazuh  4096 Jan 30 00:38 ../
-rw-r--r--  1 root  root      0 Jan 31 14:14 000004.log
-rw-r--r--  1 root  root   1307 Jan 31 14:14 000012.sst
-rw-r--r--  1 root  root     16 Jan 31 14:14 CURRENT
-rw-r--r--  1 root  root     36 Jan 31 14:14 IDENTITY
-rw-r--r--  1 root  root      0 Jan 31 14:14 LOCK
-rw-r--r--  1 root  root  44850 Jan 31 14:14 LOG
-rw-r--r--  1 root  root    258 Jan 31 14:14 MANIFEST-000005
-rw-r--r--  1 root  root   7080 Jan 31 14:14 OPTIONS-000009
-rw-r--r--  1 root  root  11466 Jan 31 14:14 OPTIONS-000011

``` 


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [X] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors