### PR TITLE
Creating a persistent queue for the vulnerability detector reports

### DIFF
--- a/.github/workflows/vulnerability-scanner-generate-database.yml
+++ b/.github/workflows/vulnerability-scanner-generate-database.yml
@@ -87,6 +87,7 @@ jobs:
           rm -rf queue/sockets
           rm -rf queue/router
           rm -rf queue/vd_updater/tmp
+          rm -rf queue/vd/reports
 
           VD_FILENAME=vd_1.0.0_vd_${{ matrix.wazuh_version }}.tar.xz
 

--- a/src/shared_modules/utils/threadEventDispatcher.hpp
+++ b/src/shared_modules/utils/threadEventDispatcher.hpp
@@ -93,7 +93,7 @@ private:
         {
             while (m_running)
             {
-                std::queue<Type> data = m_queue->popBulk(ELEMENTS_PER_BULK);
+                std::queue<Type> data = m_queue->popBulk(m_bulkSize);
                 if (!data.empty())
                 {
                     m_functor(data);

--- a/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScannerDefs.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScannerDefs.hpp
@@ -15,8 +15,11 @@
 #define VS_WM_NAME         "vulnerability-scanner"
 #define WM_VULNSCAN_LOGTAG "wazuh-modulesd:" VS_WM_NAME
 
+#include "threadEventDispatcher.hpp"
 #include <functional>
 #include <string>
+
+using ReportDispatcher = ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>;
 
 namespace Log
 {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
@@ -57,8 +57,7 @@ public:
            std::shared_ptr<TDatabaseFeedManager> databaseFeedManager,
            std::shared_ptr<TIndexerConnector> indexerConnector,
            Utils::RocksDBWrapper& inventoryDatabase,
-           std::shared_ptr<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>
-               reportDispatcher)
+           std::shared_ptr<ReportDispatcher> reportDispatcher)
     {
         std::shared_ptr<AbstractHandler<std::shared_ptr<TScanContext>>> orchestration;
         if (type == ScannerType::PackageInsert)

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
@@ -49,7 +49,7 @@ public:
      * @param databaseFeedManager DatabaseFeedManager object.
      * @param indexerConnector Indexer connector object.
      * @param inventoryDatabase Inventory database.
-     * @param reportSocketClient Socket client to send vulnerability reports.
+     * @param reportDispatcher Report dispatcher queue to send vulnerability reports.
      * @return std::shared_ptr<ScanContext> Abstract handler.
      */
     static std::shared_ptr<AbstractHandler<std::shared_ptr<TScanContext>>>
@@ -57,7 +57,8 @@ public:
            std::shared_ptr<TDatabaseFeedManager> databaseFeedManager,
            std::shared_ptr<TIndexerConnector> indexerConnector,
            Utils::RocksDBWrapper& inventoryDatabase,
-           std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> reportSocketClient)
+           std::shared_ptr<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>
+               reportDispatcher)
     {
         std::shared_ptr<AbstractHandler<std::shared_ptr<TScanContext>>> orchestration;
         if (type == ScannerType::PackageInsert)
@@ -104,7 +105,7 @@ public:
             orchestration->setLast(std::make_shared<TDetailsAugmentation>(databaseFeedManager));
         }
 
-        orchestration->setLast(std::make_shared<TSendReport>(reportSocketClient));
+        orchestration->setLast(std::make_shared<TSendReport>(reportDispatcher));
         orchestration->setLast(std::make_shared<TResultIndexer>(indexerConnector));
 
         return orchestration;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -43,14 +43,15 @@ public:
      *
      * @param indexerConnector Indexer connector.
      * @param databaseFeedManager Database feed manager.
-     * @param reportSocketClient Socket client to send vulnerability reports.
+     * @param reportDispatcher Report dispatcher queue to send vulnerability reports.
      * @param mutex Mutex to protect the access to the internal databases.
      */
     // LCOV_EXCL_START
     explicit TScanOrchestrator(
         std::shared_ptr<TIndexerConnector> indexerConnector,
         std::shared_ptr<TDatabaseFeedManager> databaseFeedManager,
-        std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> reportSocketClient,
+        std::shared_ptr<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>
+            reportDispatcher,
         std::shared_mutex& mutex)
         : m_mutex {mutex}
     {
@@ -58,16 +59,16 @@ public:
         auto& inventoryDatabase = *m_inventoryDatabase;
 
         m_osOrchestration = TFactoryOrchestrator::create(
-            ScannerType::Os, databaseFeedManager, indexerConnector, inventoryDatabase, reportSocketClient);
+            ScannerType::Os, databaseFeedManager, indexerConnector, inventoryDatabase, reportDispatcher);
         m_packageInsertOrchestration = TFactoryOrchestrator::create(
-            ScannerType::PackageInsert, databaseFeedManager, indexerConnector, inventoryDatabase, reportSocketClient);
+            ScannerType::PackageInsert, databaseFeedManager, indexerConnector, inventoryDatabase, reportDispatcher);
         m_packageDeleteOrchestration = TFactoryOrchestrator::create(
-            ScannerType::PackageDelete, databaseFeedManager, indexerConnector, inventoryDatabase, reportSocketClient);
+            ScannerType::PackageDelete, databaseFeedManager, indexerConnector, inventoryDatabase, reportDispatcher);
         m_integrityClearOrchestration = TFactoryOrchestrator::create(ScannerType::IntegrityClear,
                                                                      std::move(databaseFeedManager),
                                                                      std::move(indexerConnector),
                                                                      inventoryDatabase,
-                                                                     std::move(reportSocketClient));
+                                                                     std::move(reportDispatcher));
         //  m_hotfixInsertOrchestration = TFactoryOrchestrator::create(ScannerType::HotfixInsert);
         //  m_hotfixDeleteOrchestration = TFactoryOrchestrator::create(ScannerType::HotfixDelete);
     }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -47,12 +47,10 @@ public:
      * @param mutex Mutex to protect the access to the internal databases.
      */
     // LCOV_EXCL_START
-    explicit TScanOrchestrator(
-        std::shared_ptr<TIndexerConnector> indexerConnector,
-        std::shared_ptr<TDatabaseFeedManager> databaseFeedManager,
-        std::shared_ptr<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>
-            reportDispatcher,
-        std::shared_mutex& mutex)
+    explicit TScanOrchestrator(std::shared_ptr<TIndexerConnector> indexerConnector,
+                               std::shared_ptr<TDatabaseFeedManager> databaseFeedManager,
+                               std::shared_ptr<ReportDispatcher> reportDispatcher,
+                               std::shared_mutex& mutex)
         : m_mutex {mutex}
     {
         m_inventoryDatabase = std::make_unique<Utils::RocksDBWrapper>(INVENTORY_DB_PATH);

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/sendReport.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/sendReport.hpp
@@ -19,18 +19,20 @@ template<typename TScanContext = ScanContext>
 class TSendReport final : public AbstractHandler<std::shared_ptr<TScanContext>>
 {
 private:
-    std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> m_reportSocketClient;
+    std::shared_ptr<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>
+        m_reportDispatcher;
 
 public:
     // LCOV_EXCL_START
     /**
      * @brief Construct a new Send Report object
      *
-     * @param reportSocketClient Socket client instance.
+     * @param reportDispatcher Report queue instance.
      */
     explicit TSendReport(
-        std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> reportSocketClient)
-        : m_reportSocketClient(std::move(reportSocketClient))
+        std::shared_ptr<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>
+            reportDispatcher)
+        : m_reportDispatcher(std::move(reportDispatcher))
     {
     }
     // LCOV_EXCL_STOP
@@ -75,10 +77,8 @@ public:
                           data->getType() != ScannerType::IntegrityClear ? packageName.c_str() : "all",
                           data->getType() != ScannerType::IntegrityClear ? key.c_str() : "all");
 
-                m_reportSocketClient->send(message.c_str(), message.size());
-
-                // TODO: This should be in a separate thread to avoid delaying the process chain.
-                std::this_thread::sleep_for(std::chrono::microseconds(SOCKET_WAIT));
+                // The report is sent in another thread.
+                m_reportDispatcher->push(message);
             }
             catch (...)
             {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/sendReport.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/sendReport.hpp
@@ -19,8 +19,7 @@ template<typename TScanContext = ScanContext>
 class TSendReport final : public AbstractHandler<std::shared_ptr<TScanContext>>
 {
 private:
-    std::shared_ptr<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>
-        m_reportDispatcher;
+    std::shared_ptr<ReportDispatcher> m_reportDispatcher;
 
 public:
     // LCOV_EXCL_START
@@ -29,9 +28,7 @@ public:
      *
      * @param reportDispatcher Report queue instance.
      */
-    explicit TSendReport(
-        std::shared_ptr<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>
-            reportDispatcher)
+    explicit TSendReport(std::shared_ptr<ReportDispatcher> reportDispatcher)
         : m_reportDispatcher(std::move(reportDispatcher))
     {
     }

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -150,5 +150,5 @@ void VulnerabilityScannerFacade::stop()
     m_syscollectorRsyncSubscription.reset();
     m_syscollectorDeltasSubscription.reset();
     PolicyManager::instance().teardown();
-    m_reportDispatcher->cancel();
+    m_reportDispatcher.reset();
 }

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -76,25 +76,24 @@ void VulnerabilityScannerFacade::start(
             std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(DEFAULT_QUEUE_PATH);
         m_reportSocketClient->connect(
             [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader) {}, []() {}, SOCK_DGRAM);
-        m_reportDispatcher =
-            std::make_shared<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>(
-                [this](std::queue<std::string>& dataQueue)
+        m_reportDispatcher = std::make_shared<ReportDispatcher>(
+            [this](std::queue<std::string>& dataQueue)
+            {
+                while (!dataQueue.empty())
                 {
-                    while (!dataQueue.empty())
+                    auto data = dataQueue.front();
+                    dataQueue.pop();
+                    m_reportSocketClient->send(data.c_str(), data.size());
+                    // We wait to keep the maximum number of events per second
+                    if (m_reportsWait > 0)
                     {
-                        auto data = dataQueue.front();
-                        dataQueue.pop();
-                        m_reportSocketClient->send(data.c_str(), data.size());
-                        // We wait to keep the maximum number of events per second
-                        if (m_reportsWait > 0)
-                        {
-                            std::this_thread::sleep_for(std::chrono::microseconds(m_reportsWait));
-                        }
+                        std::this_thread::sleep_for(std::chrono::microseconds(m_reportsWait));
                     }
-                },
-                REPORTS_QUEUE_PATH,
-                REPORTS_BULK_SIZE,
-                REPORTS_THREADS_NUMBER);
+                }
+            },
+            REPORTS_QUEUE_PATH,
+            REPORTS_BULK_SIZE,
+            REPORTS_THREADS_NUMBER);
 
         // Add subscribers for policy updates.
         policyManager.addSubscriber(m_databaseFeedManager);

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -18,8 +18,10 @@
 
 constexpr auto VULNERABILITY_SCANNER_TEMPLATE = "queue/indexer/vd_states_template.json";
 constexpr auto DEFAULT_QUEUE_PATH = "queue/sockets/queue";
-int SOCKET_WAIT = 0;
-int MICROSEC_FACTOR = 1000000;
+constexpr auto REPORTS_QUEUE_PATH = "queue/vd/reports";
+constexpr auto REPORTS_BULK_SIZE {1};
+constexpr auto REPORTS_THREADS_NUMBER {1};
+constexpr auto MICROSEC_FACTOR {1000000};
 
 // TODO: Remove LCOV flags once the implementation of the 'Indexer Connector' module is completed
 // LCOV_EXCL_START
@@ -68,19 +70,38 @@ void VulnerabilityScannerFacade::start(
         // Socket client initialization to send vulnerability reports.
         if (configuration.contains("wmMaxEps") && configuration.at("wmMaxEps").is_number())
         {
-            SOCKET_WAIT = MICROSEC_FACTOR / configuration.at("wmMaxEps").get<int>();
+            m_reportsWait = MICROSEC_FACTOR / configuration.at("wmMaxEps").get<int>();
         }
         m_reportSocketClient =
             std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(DEFAULT_QUEUE_PATH);
         m_reportSocketClient->connect(
             [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader) {}, []() {}, SOCK_DGRAM);
+        m_reportDispatcher =
+            std::make_shared<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>(
+                [this](std::queue<std::string>& dataQueue)
+                {
+                    while (!dataQueue.empty())
+                    {
+                        auto data = dataQueue.front();
+                        dataQueue.pop();
+                        m_reportSocketClient->send(data.c_str(), data.size());
+                        // We wait to keep the maximum number of events per second
+                        if (m_reportsWait > 0)
+                        {
+                            std::this_thread::sleep_for(std::chrono::microseconds(m_reportsWait));
+                        }
+                    }
+                },
+                REPORTS_QUEUE_PATH,
+                REPORTS_BULK_SIZE,
+                REPORTS_THREADS_NUMBER);
 
         // Add subscribers for policy updates.
         policyManager.addSubscriber(m_databaseFeedManager);
 
         // Init Orchestrator
         auto scanOrchestrator = std::make_shared<ScanOrchestrator>(
-            m_indexerConnector, m_databaseFeedManager, m_reportSocketClient, m_internalMutex);
+            m_indexerConnector, m_databaseFeedManager, m_reportDispatcher, m_internalMutex);
 
         // Subscription to syscollector delta events.
         m_syscollectorDeltasSubscription =
@@ -130,4 +151,5 @@ void VulnerabilityScannerFacade::stop()
     m_syscollectorRsyncSubscription.reset();
     m_syscollectorDeltasSubscription.reset();
     PolicyManager::instance().teardown();
+    m_reportDispatcher->cancel();
 }

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -65,6 +65,9 @@ private:
     std::shared_ptr<DatabaseFeedManager> m_databaseFeedManager;
     std::shared_ptr<IndexerConnector> m_indexerConnector;
     std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> m_reportSocketClient;
+    int m_reportsWait {0};
+    std::shared_ptr<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>
+        m_reportDispatcher;
     std::atomic<bool> m_shouldStop {false};
     bool m_noWaitToStop {true};
     std::shared_mutex m_internalMutex;

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -66,8 +66,7 @@ private:
     std::shared_ptr<IndexerConnector> m_indexerConnector;
     std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> m_reportSocketClient;
     int m_reportsWait {0};
-    std::shared_ptr<ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>>>
-        m_reportDispatcher;
+    std::shared_ptr<ReportDispatcher> m_reportDispatcher;
     std::atomic<bool> m_shouldStop {false};
     bool m_noWaitToStop {true};
     std::shared_mutex m_internalMutex;

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockSendReport.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockSendReport.hpp
@@ -31,10 +31,9 @@ public:
     /**
      * @brief Construct a new Mock Send Report object
      *
-     * @param reportSocketClient SocketClient instance to send reports.
+     * @param reportDispatcher Report dispatcher instance.
      */
-    MockSendReport(
-        std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> reportSocketClient) {};
+    MockSendReport(std::shared_ptr<ReportDispatcher> reportDispatcher) {};
     virtual ~MockSendReport() = default;
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineFactoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineFactoryOrchestrator.hpp
@@ -42,7 +42,7 @@ public:
      * @param databaseFeedManager DatabaseFeedManager object.
      * @param indexerConnector Indexer connector object.
      * @param inventoryDatabase Inventory database.
-     * @param reportSocketClient Socket client to send vulnerability reports.
+     * @param reportDispatcher Report queue instance.
      * @return std::shared_ptr<ScanContext> Abstract handler.
      */
     static std::shared_ptr<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>
@@ -50,7 +50,7 @@ public:
            std::shared_ptr<MockDatabaseFeedManager> databaseFeedManager,
            std::shared_ptr<MockIndexerConnector> indexerConnector,
            Utils::RocksDBWrapper& inventoryDatabase,
-           std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> reportSocketClient)
+           std::shared_ptr<ReportDispatcher> reportDispatcher)
     {
         return spFactoryOrchestratorMock->create();
     }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
@@ -24,6 +24,10 @@
 #include "flatbuffers/idl.h"
 #include "json.hpp"
 
+auto constexpr TEST_REPORTS_QUEUE_PATH {"queue/vd/reports"};
+auto constexpr TEST_REPORTS_BULK_SIZE {1};
+auto constexpr TEST_REPORTS_THREADS_NUMBER {1};
+
 using ::testing::_;
 
 namespace NSScanOrchestratorTest
@@ -247,8 +251,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsert)
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorDelta =
         SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
 
-    std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> socketClient =
-        std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(TEST_PATH);
+    auto spReportDispatcher = std::make_shared<ReportDispatcher>([](std::queue<std::string>& dataQueue) {},
+                                                                 TEST_REPORTS_QUEUE_PATH,
+                                                                 TEST_REPORTS_BULK_SIZE,
+                                                                 TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
     TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
@@ -256,7 +262,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsert)
                       MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
                       MockIndexerConnector,
                       MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, socketClient, mutexScanOrchestrator);
+        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorDelta));
 }
@@ -316,8 +322,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageDelete)
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorDelta =
         SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
 
-    std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> socketClient =
-        std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(TEST_PATH);
+    auto spReportDispatcher = std::make_shared<ReportDispatcher>([](std::queue<std::string>& dataQueue) {},
+                                                                 TEST_REPORTS_QUEUE_PATH,
+                                                                 TEST_REPORTS_BULK_SIZE,
+                                                                 TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
     TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
@@ -325,7 +333,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageDelete)
                       MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
                       MockIndexerConnector,
                       MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, socketClient, mutexScanOrchestrator);
+        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorDelta));
 }
@@ -385,8 +393,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixInsert)
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorDelta =
         SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
 
-    std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> socketClient =
-        std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(TEST_PATH);
+    auto spReportDispatcher = std::make_shared<ReportDispatcher>([](std::queue<std::string>& dataQueue) {},
+                                                                 TEST_REPORTS_QUEUE_PATH,
+                                                                 TEST_REPORTS_BULK_SIZE,
+                                                                 TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
     TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
@@ -394,7 +404,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixInsert)
                       MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
                       MockIndexerConnector,
                       MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, socketClient, mutexScanOrchestrator);
+        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorDelta));
 }
@@ -454,8 +464,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixDelete)
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorDelta =
         SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
 
-    std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> socketClient =
-        std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(TEST_PATH);
+    auto spReportDispatcher = std::make_shared<ReportDispatcher>([](std::queue<std::string>& dataQueue) {},
+                                                                 TEST_REPORTS_QUEUE_PATH,
+                                                                 TEST_REPORTS_BULK_SIZE,
+                                                                 TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
     TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
@@ -463,7 +475,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixDelete)
                       MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
                       MockIndexerConnector,
                       MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, socketClient, mutexScanOrchestrator);
+        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorDelta));
 }
@@ -507,8 +519,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeOs)
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorDelta =
         SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
 
-    std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> socketClient =
-        std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(TEST_PATH);
+    auto spReportDispatcher = std::make_shared<ReportDispatcher>([](std::queue<std::string>& dataQueue) {},
+                                                                 TEST_REPORTS_QUEUE_PATH,
+                                                                 TEST_REPORTS_BULK_SIZE,
+                                                                 TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
     TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
@@ -516,7 +530,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeOs)
                       MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
                       MockIndexerConnector,
                       MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, socketClient, mutexScanOrchestrator);
+        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorDelta));
 }
@@ -576,8 +590,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeIntegrityClear)
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*>
         syscollectorSynchronization = SyscollectorSynchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
 
-    std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> socketClient =
-        std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(TEST_PATH);
+    auto spReportDispatcher = std::make_shared<ReportDispatcher>([](std::queue<std::string>& dataQueue) {},
+                                                                 TEST_REPORTS_QUEUE_PATH,
+                                                                 TEST_REPORTS_BULK_SIZE,
+                                                                 TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
     TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
@@ -585,7 +601,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeIntegrityClear)
                       MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
                       MockIndexerConnector,
                       MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, socketClient, mutexScanOrchestrator);
+        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorSynchronization));
 }
@@ -652,8 +668,10 @@ TEST_F(ScanOrchestratorTest, TestRunOrchestrationThatGeneratesException)
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> syscollectorDelta =
         SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
 
-    std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> socketClient =
-        std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(TEST_PATH);
+    auto spReportDispatcher = std::make_shared<ReportDispatcher>([](std::queue<std::string>& dataQueue) {},
+                                                                 TEST_REPORTS_QUEUE_PATH,
+                                                                 TEST_REPORTS_BULK_SIZE,
+                                                                 TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
     TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
@@ -661,7 +679,7 @@ TEST_F(ScanOrchestratorTest, TestRunOrchestrationThatGeneratesException)
                       MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
                       MockIndexerConnector,
                       MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, socketClient, mutexScanOrchestrator);
+        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     Log::assignLogFunction(
         [](const int,

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
@@ -27,6 +27,9 @@ using ::testing::_;
 
 const std::string TEST_PATH {"/tmp/socket"};
 const size_t MAX_RETRIES {10};
+auto constexpr TEST_REPORTS_QUEUE_PATH {"queue/vd/reports"};
+auto constexpr TEST_REPORTS_BULK_SIZE {1};
+auto constexpr TEST_REPORTS_THREADS_NUMBER {1};
 
 const std::string SYNC_STATE_MSG {
     R"(
@@ -243,9 +246,22 @@ TEST_F(SendReportTest, SendFormattedMsg)
     // Connect to server.
     socketClient->connect(
         [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader) {}, []() {}, SOCK_DGRAM);
+    auto reportDispatcher = std::make_shared<ReportDispatcher>(
+        [&](std::queue<std::string>& dataQueue)
+        {
+            while (!dataQueue.empty())
+            {
+                auto data = dataQueue.front();
+                dataQueue.pop();
+                socketClient->send(data.c_str(), data.size());
+            }
+        },
+        TEST_REPORTS_QUEUE_PATH,
+        TEST_REPORTS_BULK_SIZE,
+        TEST_REPORTS_THREADS_NUMBER);
 
     // Send report instance.
-    TSendReport<TScanContext<TrampolineOsDataCache>> sendReport(socketClient);
+    TSendReport<TScanContext<TrampolineOsDataCache>> sendReport(reportDispatcher);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -347,9 +363,22 @@ TEST_F(SendReportTest, InvalidEncodingValue)
     // Connect to server.
     socketClient->connect(
         [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader) {}, []() {}, SOCK_DGRAM);
+    auto reportDispatcher = std::make_shared<ReportDispatcher>(
+        [&](std::queue<std::string>& dataQueue)
+        {
+            while (!dataQueue.empty())
+            {
+                auto data = dataQueue.front();
+                dataQueue.pop();
+                socketClient->send(data.c_str(), data.size());
+            }
+        },
+        TEST_REPORTS_QUEUE_PATH,
+        TEST_REPORTS_BULK_SIZE,
+        TEST_REPORTS_THREADS_NUMBER);
 
     // Send report instance.
-    TSendReport<TScanContext<TrampolineOsDataCache>> sendReport(socketClient);
+    TSendReport<TScanContext<TrampolineOsDataCache>> sendReport(reportDispatcher);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -451,9 +480,22 @@ TEST_F(SendReportTest, SendFormattedClearMsg)
     // Connect to server.
     socketClient->connect(
         [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader) {}, []() {}, SOCK_DGRAM);
+    auto reportDispatcher = std::make_shared<ReportDispatcher>(
+        [&](std::queue<std::string>& dataQueue)
+        {
+            while (!dataQueue.empty())
+            {
+                auto data = dataQueue.front();
+                dataQueue.pop();
+                socketClient->send(data.c_str(), data.size());
+            }
+        },
+        TEST_REPORTS_QUEUE_PATH,
+        TEST_REPORTS_BULK_SIZE,
+        TEST_REPORTS_THREADS_NUMBER);
 
     // Send report instance.
-    TSendReport<TScanContext<TrampolineOsDataCache>> sendReport(socketClient);
+    TSendReport<TScanContext<TrampolineOsDataCache>> sendReport(reportDispatcher);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -552,9 +594,22 @@ TEST_F(SendReportTest, SendFormattedDeltaMsg)
     // Connect to server.
     socketClient->connect(
         [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader) {}, []() {}, SOCK_DGRAM);
+    auto reportDispatcher = std::make_shared<ReportDispatcher>(
+        [&](std::queue<std::string>& dataQueue)
+        {
+            while (!dataQueue.empty())
+            {
+                auto data = dataQueue.front();
+                dataQueue.pop();
+                socketClient->send(data.c_str(), data.size());
+            }
+        },
+        TEST_REPORTS_QUEUE_PATH,
+        TEST_REPORTS_BULK_SIZE,
+        TEST_REPORTS_THREADS_NUMBER);
 
     // Send report instance.
-    TSendReport<TScanContext<TrampolineOsDataCache>> sendReport(socketClient);
+    TSendReport<TScanContext<TrampolineOsDataCache>> sendReport(reportDispatcher);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
@@ -29,6 +29,7 @@
 auto constexpr MAXLEN {65536};
 auto constexpr DEFAULT_QUEUE_PATH {"queue/sockets/queue"};
 auto constexpr DEFAULT_WDB_SOCKET {"queue/db/wdb"};
+auto constexpr DEFAULT_SOCKETS_PATH {"queue/sockets"};
 std::mutex G_MUTEX;
 
 /**
@@ -230,6 +231,10 @@ int main(const int argc, const char* argv[])
         FakeReportServer fakeReportServer(DEFAULT_QUEUE_PATH);
         if (cmdLineArgs.getFakeReportServer())
         {
+            if (!std::filesystem::exists(DEFAULT_SOCKETS_PATH))
+            {
+                std::filesystem::create_directories(DEFAULT_SOCKETS_PATH);
+            }
             fakeReportServer.start();
         }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21600 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR creates a dispatching queue in charge of sending the reports to **analysisd** to avoid the sleep method and the blocking call in the main thread.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

The alerts are generated as expected

![2024-02-01_00-05](https://github.com/wazuh/wazuh/assets/65046601/586832a9-9e07-4ae3-af44-ef6474e527ed)

The test tool also confirms that the reports are sent

![2024-02-01_00-18](https://github.com/wazuh/wazuh/assets/65046601/ea8a6ec7-9e56-47d5-b7dc-36d152c9b241)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- [x] Added unit tests (for new features)