### PR TITLE
Updated warning message for invalid registry type

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -279,6 +279,7 @@
 #define FIM_WILDCARDS_REGISTERS_START       "(6372): Starting configuration for Windows registry wildcards."
 #define FIM_WILDCARDS_ADD_REGISTER          "(6373): Expanding entry '%s' to '%s' to monitor FIM events."
 #define FIM_WILDCARDS_REGISTERS_FINALIZE    "(6374): Wildcard configuration successfully completed."
+#define FIM_REG_VAL_INVALID_TYPE            "(6375): Invalid registry value type for report_changes. Registry key: '%s'. Registry value: '%s'."
 
 /* Modules messages */
 #define WM_UPGRADE_RESULT_AGENT_INFO         "(8151): Agent Information obtained: '%s'"

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -52,7 +52,7 @@
 #define FIM_WHODATA_RENDER_EVENT                "(6933): Error rendering the event. Error %lu."
 #define FIM_WHODATA_RENDER_PARAM                "(6934): Invalid number of rendered parameters."
 #define FIM_DB_TEMPORARY_FILE_POSITION          "(6935): Unable to reposition temporary file to beginning. Error[%d]: '%s'"
-#define FIM_REG_VAL_WRONG_TYPE                  "(6936): Wrong registry value type processed for report_changes."
+#define FIM_REG_VAL_WRONG_TYPE                  "(6936): Wrong registry value type processed for report_changes. Check registry path: '%s'"
 #define FIM_INVALID_REG_OPTION_SKIP             "(6937): Invalid option '%s' for attribute '%s'. The registry '%s' not be monitored."
 #define FIM_REGISTRY_EVENT_NULL_ENTRY           "(6938): Invalid null registry event."
 #define FIM_REGISTRY_EVENT_NULL_ENTRY_KEY       "(6939): Invalid registry event with a null key was detected."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -52,7 +52,7 @@
 #define FIM_WHODATA_RENDER_EVENT                "(6933): Error rendering the event. Error %lu."
 #define FIM_WHODATA_RENDER_PARAM                "(6934): Invalid number of rendered parameters."
 #define FIM_DB_TEMPORARY_FILE_POSITION          "(6935): Unable to reposition temporary file to beginning. Error[%d]: '%s'"
-#define FIM_REG_VAL_WRONG_TYPE                  "(6936): Wrong registry value type processed for report_changes. Check registry path: '%s'"
+#define FIM_REG_VAL_WRONG_TYPE                  "(6936): Wrong registry value type processed for report_changes."
 #define FIM_INVALID_REG_OPTION_SKIP             "(6937): Invalid option '%s' for attribute '%s'. The registry '%s' not be monitored."
 #define FIM_REGISTRY_EVENT_NULL_ENTRY           "(6938): Invalid null registry event."
 #define FIM_REGISTRY_EVENT_NULL_ENTRY_KEY       "(6939): Invalid registry event with a null key was detected."

--- a/src/syscheckd/src/fim_diff_changes.c
+++ b/src/syscheckd/src/fim_diff_changes.c
@@ -374,7 +374,7 @@ int fim_diff_registry_tmp(const char *value_data,
 
             default:
                 // Wrong type
-                mwarn(FIM_REG_VAL_WRONG_TYPE);
+                mwarn(FIM_REG_VAL_WRONG_TYPE, diff->file_origin);
                 ret = -1;
                 break;
         }

--- a/src/syscheckd/src/fim_diff_changes.c
+++ b/src/syscheckd/src/fim_diff_changes.c
@@ -210,6 +210,7 @@ char *fim_registry_value_diff(const char *key_name,
     if (data_type == REG_NONE || data_type == REG_BINARY || data_type == REG_LINK ||
         data_type == REG_RESOURCE_LIST || data_type == REG_FULL_RESOURCE_DESCRIPTOR ||
         data_type == REG_RESOURCE_REQUIREMENTS_LIST) {
+            mdebug2(FIM_REG_VAL_INVALID_TYPE, key_name, value_name);
             return NULL;
     }
 

--- a/src/syscheckd/src/fim_diff_changes.c
+++ b/src/syscheckd/src/fim_diff_changes.c
@@ -207,9 +207,12 @@ char *fim_registry_value_diff(const char *key_name,
     int limits_reached;
 
     // Invalid types for report_changes
-    if (data_type == REG_NONE || data_type == REG_BINARY || data_type == REG_LINK ||
-        data_type == REG_RESOURCE_LIST || data_type == REG_FULL_RESOURCE_DESCRIPTOR ||
-        data_type == REG_RESOURCE_REQUIREMENTS_LIST) {
+    if (!(data_type == REG_SZ ||
+          data_type == REG_EXPAND_SZ ||
+          data_type == REG_MULTI_SZ ||
+          data_type == REG_DWORD ||
+          data_type == REG_DWORD_BIG_ENDIAN ||
+          data_type == REG_QWORD)) {
             mdebug2(FIM_REG_VAL_INVALID_TYPE, key_name, value_name);
             return NULL;
     }
@@ -375,7 +378,7 @@ int fim_diff_registry_tmp(const char *value_data,
 
             default:
                 // Wrong type
-                mwarn(FIM_REG_VAL_WRONG_TYPE, diff->file_origin);
+                mwarn(FIM_REG_VAL_WRONG_TYPE);
                 ret = -1;
                 break;
         }

--- a/src/unit_tests/syscheckd/test_fim_diff_changes.c
+++ b/src/unit_tests/syscheckd/test_fim_diff_changes.c
@@ -1232,6 +1232,10 @@ void test_fim_registry_value_diff_wrong_data_type(void **state) {
     DWORD data_type = REG_NONE;
     registry_t *configuration = &syscheck.registry[0];
 
+    char debug2_message[OS_SIZE_1024];
+    snprintf(debug2_message, OS_SIZE_1024, FIM_REG_VAL_INVALID_TYPE, key_name, value_name);
+    expect_string(__wrap__mdebug2, formatted_msg, debug2_message);
+
     char *diff_str = fim_registry_value_diff(key_name, value_name, value_data, data_type, configuration);
 
     assert_ptr_equal(diff_str, NULL);

--- a/src/unit_tests/syscheckd/test_fim_diff_changes.c
+++ b/src/unit_tests/syscheckd/test_fim_diff_changes.c
@@ -1215,7 +1215,9 @@ void test_fim_diff_registry_tmp_default_type(void **state) {
 
     expect_fopen(diff->file_origin, "w", fp);
 
-    expect_string(__wrap__mwarn, formatted_msg, FIM_REG_VAL_WRONG_TYPE);
+    char warn_message[OS_SIZE_1024];
+    snprintf(warn_message, OS_SIZE_1024, FIM_REG_VAL_WRONG_TYPE, diff->file_origin);
+    expect_string(__wrap__mwarn, formatted_msg, warn_message);
 
     expect_fclose(fp, 0);
 

--- a/src/unit_tests/syscheckd/test_fim_diff_changes.c
+++ b/src/unit_tests/syscheckd/test_fim_diff_changes.c
@@ -1215,9 +1215,7 @@ void test_fim_diff_registry_tmp_default_type(void **state) {
 
     expect_fopen(diff->file_origin, "w", fp);
 
-    char warn_message[OS_SIZE_1024];
-    snprintf(warn_message, OS_SIZE_1024, FIM_REG_VAL_WRONG_TYPE, diff->file_origin);
-    expect_string(__wrap__mwarn, formatted_msg, warn_message);
+    expect_string(__wrap__mwarn, formatted_msg, FIM_REG_VAL_WRONG_TYPE);
 
     expect_fclose(fp, 0);
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/20422 |

Closes #20422

## Description

Added the registry path to the warning message to help troubleshooting.

When a key as multiple subkeys with multiple values, the expected behavior is to monitor the ones that can be monitored (REG_SZ, REG_MULTI_SZ, REG_DWORD, REG_DWORD_BIG_ENDIAN, and REG_QWORD) and ignore the ones which cannot be monitored.

At this point, adding the path of the values which cannot be monitored with `report_changes` attribute to the log message would provide valuable information to the user. Currently it creates only FUD on the user.

**N.B:** I believe I needed to update [this test](https://github.com/wazuh/wazuh/blob/a8f413c81c0e3f7b1a79b1bf08ffbcd5bbcbaa01/src/unit_tests/syscheckd/test_fim_diff_changes.c#L1218) yet I was not sure how to properly do that.

## Configuration options
## Checking debug message:


```
    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>10</frequency>

    <!-- Default files to be monitored. -->
    <windows_registry report_changes="yes" arch="both">HKEY_LOCAL_MACHINE\Software\test</windows_registry>
```

## Logs/Alerts example

```
2024/02/05 04:32:58 wazuh-agent[3108] registry.c:1087 at fim_registry_scan(): DEBUG: (6031): Registry integrity monitoring scan started
2024/02/05 04:32:58 wazuh-agent[3108] registry.c:1096 at fim_registry_scan(): DEBUG: (6207): Attempt to read: '[x64] HKEY_LOCAL_MACHINE\Software\test'
2024/02/05 04:32:58 wazuh-agent[3108] syscheck_op.c:857 at process_ace_info(): DEBUG: No information could be extracted from the account linked to the SID. Error: 1332.
2024/02/05 04:32:58 wazuh-agent[3108] run_check.c:124 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_LOCAL_MACHINE\\Software\\test","index":"67c9694465c169e9773c5a71601a7589105bb69e","version":3,"mode":"scheduled","type":"modified","arch":"[x64]","timestamp":1707136378,"attributes":{"type":"registry_key","perm":{"S-1-5-32-545":{"name":"Users","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-5-32-544":{"name":"Administrators","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-5-18":{"name":"SYSTEM","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-3-0":{"name":"CREATOR OWNER","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-15-2-1":{"name":"ALL APPLICATION PACKAGES","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681":{"allowed":["read_control","read_data","read_ea","write_ea"]}},"uid":"S-1-5-32-544","user_name":"Administrators","gid":"S-1-5-21-3998916298-3045149832-3922110584-513","group_name":"","mtime":1707136376,"checksum":"4462dd388ac58a79845651023281fddfad4fe5f1"},"old_attributes":{"type":"registry_key","perm":{"S-1-5-32-545":{"name":"Users","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-5-32-544":{"name":"Administrators","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-5-18":{"name":"SYSTEM","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-3-0":{"name":"CREATOR OWNER","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-15-2-1":{"name":"ALL APPLICATION PACKAGES","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681":{"allowed":["read_control","read_data","read_ea","write_ea"]}},"uid":"S-1-5-32-544","user_name":"Administrators","gid":"S-1-5-32-544","group_name":"","mtime":1707136247,"checksum":"4462dd388ac58a79845651023281fddfad4fe5f1"},"changed_attributes":["mtime"]}}
2024/02/05 04:32:58 wazuh-agent[3108] run_check.c:124 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_LOCAL_MACHINE\\Software\\test","index":"5302a798bb586e1396d2962c42ef602d3098e67a","version":3,"mode":"scheduled","type":"modified","arch":"[x64]","value_name":"string_test","timestamp":1707136378,"attributes":{"type":"registry_value","value_type":"REG_SZ","size":5,"hash_md5":"912ec803b2ce49e4a541068d495ab570","hash_sha1":"3da541559918a808c2402bba5012f6c60b27661c","hash_sha256":"f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b","checksum":"0e36d07c0a82fd995f2342376c8027b51d8316d5"},"old_attributes":{"type":"registry_value","size":1,"value_type":"REG_SZ","hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},"changed_attributes":["size","md5","sha1","sha256"],"content_changes":"---\n> asdf\n"}}
2024/02/05 04:32:58 wazuh-agent[3108] fim_diff_changes.c:216 at fim_registry_value_diff(): DEBUG: (6375): Invalid registry value type for report_changes. Registry key: 'HKEY_LOCAL_MACHINE\Software\test'. Registry value: 'binary_test'.
2024/02/05 04:32:58 wazuh-agent[3108] run_check.c:124 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_LOCAL_MACHINE\\Software\\test","index":"a19c02f15930760f8801f21c080302107002f0ca","version":3,"mode":"scheduled","type":"modified","arch":"[x64]","value_name":"binary_test","timestamp":1707136378,"attributes":{"type":"registry_value","value_type":"REG_BINARY","size":2,"hash_md5":"0d6ef5a3e285efb96346a53133ce291a","hash_sha1":"9ce5cd266fc46ecb9b5d1497d12d27de9dc7aefd","hash_sha256":"338f680f1c1607d5cd4de1a3118eeb0b62ecf32421a5d9e3224dfc70958bfb64","checksum":"2939ee45ecbf43dbc32892f814fa2cee900dd100"},"old_attributes":{"type":"registry_value","size":0,"value_type":"REG_BINARY","hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},"changed_attributes":["size","md5","sha1","sha256"]}}
2024/02/05 04:32:58 wazuh-agent[3108] registry.c:1096 at fim_registry_scan(): DEBUG: (6207): Attempt to read: '[x32] HKEY_LOCAL_MACHINE\Software\test'
2024/02/05 04:32:58 wazuh-agent[3108] registry.c:995 at fim_open_key(): DEBUG: (6920): Unable to open registry key: 'Software\test' arch: '[x32]'.
2024/02/05 04:32:58 wazuh-agent[3108] registry.c:1115 at fim_registry_scan(): DEBUG: (6032): Registry integrity monitoring scan ended
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language