### PR TITLE
Do not preserve ownership and permissions

### DIFF
--- a/.github/workflows/vulnerability-scanner-generate-database.yml
+++ b/.github/workflows/vulnerability-scanner-generate-database.yml
@@ -87,7 +87,7 @@ jobs:
           VD_FILENAME=vd_1.0.0_vd_${{ matrix.wazuh_version }}.tar.xz
 
           echo "Compressing file"
-          tar -cJf ${VD_FILENAME} queue
+          tar -cJf ${VD_FILENAME} --owner=0 --group=0 --no-same-owner --no-same-permissions queue
 
           if ! [ -f ${VD_FILENAME} ]; then
             echo "Error generating ${VD_FILENAME} file"


### PR DESCRIPTION
|Related issue|
|---|
|#21693|

## Description

Do not preserve ownership and permissions during vulnerability detector database compression. 

## Logs/Alerts example

- Original database compressed during GH workflow on Ubuntu Jammy
![2024-02-01_14-20](https://github.com/wazuh/wazuh/assets/13010397/5e8688eb-7cdb-4e21-9168-68bc2a100a7b)
![2024-02-01_14-44](https://github.com/wazuh/wazuh/assets/13010397/630773e3-2b35-4e62-ae31-dda4b1b09db3)
![2024-02-01_14-44_1](https://github.com/wazuh/wazuh/assets/13010397/30112b6b-5b81-41cc-9b32-067ebcc2a71d)
- Uncompressed tar.xz file on Centos7
![2024-02-01_14-51](https://github.com/wazuh/wazuh/assets/13010397/c66a96bb-e282-49c6-889d-ff7edf17d1cc)
![2024-02-01_14-55_1](https://github.com/wazuh/wazuh/assets/13010397/965f9ffd-24ee-4a75-b891-9fcac42305b5)
- Executed @LucioDonda script
![2024-02-01_14-57](https://github.com/wazuh/wazuh/assets/13010397/d5b2e73c-ac60-49bb-8056-99374d0c907a)

