### PR TITLE
Vulnerability Scanner - Fix bad version match logic for Amazon

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.cpp
@@ -11,4 +11,4 @@
 
 #include "versionObjectAmzn.hpp"
 
-std::regex VersionObjectAmzn::m_parserRegex(R"((\d+:)?(\d+)\.?(\d+)?\.?(\d+)?-(\d+)?)");
+std::regex VersionObjectAmzn::m_parserRegex(R"((\d+:)?(\d+)\.?(\d+)?\.?(\d+)?-?(\d+)?)");

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectAmzn.hpp
@@ -56,19 +56,19 @@ public:
     static bool match(const std::string& version, Amzn& output)
     {
         std::smatch parserMatches;
-        if ((std::regex_search(version, parserMatches, m_parserRegex) == false) || (parserMatches.size() != 5))
+        if (false == std::regex_search(version, parserMatches, m_parserRegex))
         {
-
-            output.epoch = parserMatches.str(1).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(1)));
-            output.major = parserMatches.str(2).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(2)));
-            output.minor = parserMatches.str(3).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(3)));
-            output.patch = parserMatches.str(4).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(4)));
-            output.release = parserMatches.str(5).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(5)));
-            return true;
+            return false;
         }
 
-        return false;
+        output.epoch = parserMatches.str(1).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(1)));
+        output.major = parserMatches.str(2).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(2)));
+        output.minor = parserMatches.str(3).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(3)));
+        output.patch = parserMatches.str(4).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(4)));
+        output.release = parserMatches.str(5).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(5)));
+        return true;
     }
+
     /**
      * @brief Constructor.
      *

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
@@ -541,3 +541,11 @@ TEST_F(VersionMatcherTest, compareAmznLinux_casesRealScan)
                   "5.4.4-3.amzn2023.0.2", "lua-libs-5.4.4-3.amzn2022.x86_64.rpm", VersionObjectType::AMZN),
               0);
 }
+
+TEST_F(VersionMatcherTest, compareAmznLinux_invalidVersions)
+{
+    EXPECT_EQ(VersionMatcher::compare("", "1.15.1-6.amzn2023.0.3", VersionObjectType::AMZN),
+              INVALID_VERSION_OBJECT_TYPE);
+    EXPECT_EQ(VersionMatcher::compare("1.15.1-6.amzn2023.0.3", "A-B-C", VersionObjectType::AMZN),
+              INVALID_VERSION_OBJECT_TYPE);
+}


### PR DESCRIPTION
|Related issue|
|---|
| #21686 |

## Description

This issue fixes a bad logic in the match method for the Amazon versions. In addition, the regex is also improved.

## Results

The previous UT keep passing OK, and new tests for invalid versions were added.

I've also checked that all the normalized versions of the ALAS feeds pass this validation.