### PR TITLE
Change CloudTrail event input format

### DIFF
--- a/wodles/aws/aws_tools.py
+++ b/wodles/aws/aws_tools.py
@@ -254,7 +254,7 @@ def args_valid_iam_role_arn(iam_role_arn):
     """
     pattern = r'^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$'
 
-    if not re.match(pattern, iam_role_arn):
+    if not re.match(pattern, iam_role_arn, re.IGNORECASE):
         raise argparse.ArgumentTypeError("Invalid ARN Role specified. Value must be a valid ARN Role.")
 
     return iam_role_arn


### PR DESCRIPTION
|Related issue|
|---|
| #21648  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

- The function responsible for verifying the expected `ARN` format was modified.

- It was changed to accept both '**arn**' and '**aRN**' formats as valid inputs.

- The corresponding unit tests were successfully executed.

## Tests

<details>

<summary>Unit-Tests Test_tools</summary>

```console
(unittest-env) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest wodles/aws/tests/test_tools.py -v
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.4.0, pluggy-0.13.1 -- /home/wazuh/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-37-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.4.0', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '0.3.0', 'metadata': '3.0.0', 'html': '2.1.1', 'trio': '0.7.0', 'asyncio': '0.15.1'}}
rootdir: /home/wazuh/Git/wazuh/wodles/aws/tests
configfile: pytest.ini
plugins: aiohttp-0.3.0, metadata-3.0.0, html-2.1.1, trio-0.7.0, asyncio-0.15.1
collected 31 items                                                                                                                                                                                         

wodles/aws/tests/test_tools.py::test_debug[0] PASSED                                                                                                                                                 [  3%]
wodles/aws/tests/test_tools.py::test_debug[1] PASSED                                                                                                                                                 [  6%]
wodles/aws/tests/test_tools.py::test_debug[2] PASSED                                                                                                                                                 [  9%]
wodles/aws/tests/test_tools.py::test_arg_valid_date PASSED                                                                                                                                           [ 12%]
wodles/aws/tests/test_tools.py::test_arg_valid_date_raises_exception_when_invalid_format_provided PASSED                                                                                             [ 16%]
wodles/aws/tests/test_tools.py::test_arg_valid_key[prefix] PASSED                                                                                                                                    [ 19%]
wodles/aws/tests/test_tools.py::test_arg_valid_key[prefix/] PASSED                                                                                                                                   [ 22%]
wodles/aws/tests/test_tools.py::test_arg_valid_key[] PASSED                                                                                                                                          [ 25%]
wodles/aws/tests/test_tools.py::test_arg_valid_key_raises_exception_when_invalid_format_provided PASSED                                                                                              [ 29%]
wodles/aws/tests/test_tools.py::test_arg_valid_accountid[123456789123] PASSED                                                                                                                        [ 32%]
wodles/aws/tests/test_tools.py::test_arg_valid_accountid[123456789123,123456789123] PASSED                                                                                                           [ 35%]
wodles/aws/tests/test_tools.py::test_arg_valid_accountid[123456789123,123456789123,123456789123] PASSED                                                                                              [ 38%]
wodles/aws/tests/test_tools.py::test_arg_valid_accountid[None] PASSED                                                                                                                                [ 41%]
wodles/aws/tests/test_tools.py::test_arg_valid_accountid_raises_exception_when_invalid_account_provided[12345678912] PASSED                                                                          [ 45%]
wodles/aws/tests/test_tools.py::test_arg_valid_accountid_raises_exception_when_invalid_account_provided[123456789123,12345678912] PASSED                                                             [ 48%]
wodles/aws/tests/test_tools.py::test_arg_valid_accountid_raises_exception_when_invalid_account_provided[123456789123,123456789123,123456789abc] PASSED                                               [ 51%]
wodles/aws/tests/test_tools.py::test_arg_valid_regions[us-east-1] PASSED                                                                                                                             [ 54%]
wodles/aws/tests/test_tools.py::test_arg_valid_regions[us-east-1,us-east-1] PASSED                                                                                                                   [ 58%]
wodles/aws/tests/test_tools.py::test_arg_valid_regions[us-east-1,us-east-1,us-east-1] PASSED                                                                                                         [ 61%]
wodles/aws/tests/test_tools.py::test_arg_valid_regions[None] PASSED                                                                                                                                  [ 64%]
wodles/aws/tests/test_tools.py::test_arg_valid_regions_raises_exception_when_invalid_region_provided PASSED                                                                                          [ 67%]
wodles/aws/tests/test_tools.py::test_arg_valid_iam_role_duration[900] PASSED                                                                                                                         [ 70%]
wodles/aws/tests/test_tools.py::test_arg_valid_iam_role_duration[3600] PASSED                                                                                                                        [ 74%]
wodles/aws/tests/test_tools.py::test_arg_valid_bucket_name_raises_exception_when_invalid_bucket_name_provided PASSED                                                                                 [ 77%]
wodles/aws/tests/test_tools.py::test_arg_valid_iam_role_duration_raises_exception_when_invalid_duration_provided[899] PASSED                                                                         [ 80%]
wodles/aws/tests/test_tools.py::test_arg_valid_iam_role_duration_raises_exception_when_invalid_duration_provided[3601] PASSED                                                                        [ 83%]
wodles/aws/tests/test_tools.py::test_get_aws_config_params PASSED                                                                                                                                    [ 87%]
wodles/aws/tests/test_tools.py::test_get_script_arguments[--bucket] PASSED                                                                                                                           [ 90%]
wodles/aws/tests/test_tools.py::test_get_script_arguments[--service] PASSED                                                                                                                          [ 93%]
wodles/aws/tests/test_tools.py::test_get_script_arguments_required[args0] PASSED                                                                                                                     [ 96%]
wodles/aws/tests/test_tools.py::test_get_script_arguments_iam_role_duration_but_no_iam_role_arn_raises_exception PASSED                                                                              [100%]

============================================================================================= warnings summary =============================================================================================
../../venv/unittest-env/lib/python3.9/site-packages/_pytest/config/__init__.py:1373
  /home/wazuh/venv/unittest-env/lib/python3.9/site-packages/_pytest/config/__init__.py:1373: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================================== 31 passed, 1 warning in 0.19s =======================================================================================
```

</details>