### PR TITLE
Implement Helper Functions for MaxMind GeoIP and ASN Data Retrieval

### DIFF
--- a/src/engine/source/base/utils/ipUtils.cpp
+++ b/src/engine/source/base/utils/ipUtils.cpp
@@ -15,13 +15,11 @@ uint32_t IPv4ToUInt(const std::string& ipStr)
 
     if (sscanf(ipStr.c_str(), "%d.%d.%d.%d%c", &a, &b, &c, &d, &z) != 4)
     {
-        throw std::invalid_argument(fmt::format(
-            "Engine ip utils: Invalid IPv4 address format (\"\").", ipStr.c_str()));
+        throw std::invalid_argument("Invalid IPv4 address format");
     }
     else if (a < 0 || a > 255 || b < 0 || b > 255 || c < 0 || c > 255 || d < 0 || d > 255)
     {
-        throw std::invalid_argument(fmt::format(
-            "Engine ip utils: Invalid IPv4 address format (\"\").", ipStr.c_str()));
+        throw std::invalid_argument("Invalid IPv4 address format");
     }
 
     ipUInt = a << 24;
@@ -50,18 +48,15 @@ uint32_t IPv4MaskUInt(const std::string& maskStr)
         auto intMask = std::stoi(maskStr, &afterMask);
         if (intMask < 0 || intMask > 32)
         {
-            throw std::invalid_argument(
-                fmt::format("Engine ip utils: Invalid IPv4 mask \"{}\".", maskStr));
+            throw std::invalid_argument("Invalid IPv4 mask format");
         }
-        else if (afterMask != maskStr.size())
+
+        if (afterMask != maskStr.size())
         {
-            throw std::invalid_argument(
-                fmt::format("Engine ip utils: Invalid IPv4 mask \"{}\".", maskStr));
+            throw std::invalid_argument("Invalid IPv4 mask format");
         }
-        else
-        {
-            maskUInt = 0xFFFFFFFF << (32 - intMask);
-        }
+
+        maskUInt = intMask == 0 ? 0 : 0xFFFFFFFF << (32 - intMask);
     }
 
     return maskUInt;
@@ -69,25 +64,44 @@ uint32_t IPv4MaskUInt(const std::string& maskStr)
 
 bool checkStrIsIPv4(const std::string& ip)
 {
-
-    char buf[sizeof(struct in_addr)];
-    if (inet_pton(AF_INET, ip.c_str(), buf))
-    {
-        return true;
-    }
-    return false;
+    struct in_addr buf;
+    return inet_pton(AF_INET, ip.c_str(), &buf) == 1;
 }
 
 bool checkStrIsIPv6(const std::string& ip)
 {
+    struct in6_addr buf;
+    return inet_pton(AF_INET6, ip.c_str(), &buf) == 1;
+}
 
-    // Support RFC 2373
-    char buf[sizeof(struct in6_addr)];
-    if (inet_pton(AF_INET6, ip.c_str(), buf))
+bool isSpecialIPv4Address(const std::string& ip)
+{
+    uint32_t ipUInt = IPv4ToUInt(ip);
+
+    if ((ipUInt >= 0x0A000000 && ipUInt <= 0x0AFFFFFF)     // 10.x.x.x range
+        || (ipUInt >= 0xAC100000 && ipUInt <= 0xAC1FFFFF)  // 172.16.x.x to 172.31.x.x
+        || (ipUInt >= 0xC0A80000 && ipUInt <= 0xC0A8FFFF) // 192.168.x.x range
+        || (ipUInt >= 0x7F000000 && ipUInt <= 0x7FFFFFFF)) // 127.x.x.x loopback range
+
     {
         return true;
     }
     return false;
 }
+
+
+bool isSpecialIPv6Address(const std::string& ip)
+{
+    struct in6_addr addr;
+    if (inet_pton(AF_INET6, ip.c_str(), &addr) != 1)
+    {
+        throw std::invalid_argument("Invalid IPv6 address");
+    }
+
+    return IN6_IS_ADDR_LOOPBACK(&addr)                              // Loopback
+           || IN6_IS_ADDR_LINKLOCAL(&addr)                          // Link-local fe80::/10
+           || (addr.s6_addr[0] == 0xFC || addr.s6_addr[0] == 0xFD); // ULA fc00::/7
+}
+
 
 } // namespace utils::ip

--- a/src/engine/source/base/utils/ipUtils.hpp
+++ b/src/engine/source/base/utils/ipUtils.hpp
@@ -50,6 +50,30 @@ bool checkStrIsIPv4(const std::string& ip);
  */
 bool checkStrIsIPv6(const std::string& ip);
 
+/**
+ * @brief Check if a IPv4 is a special address
+ *
+ * A special IPv4 address can be a loopback address or a private address
+ * @param ip
+ * @return true if the ip is a special address
+ * @throw std::invalid_argument if the ip is not valid
+ */
+bool isSpecialIPv4Address(const std::string& ip);
+
+/**
+ * @brief Checks if the given IPv6 address is a special address.
+ *
+ * A special IPv6 address can be:
+ * - loopback address (::1/128)
+ * - link-local address (fe80::/10),
+ * - Unique Local Address (ULA) (fc00::/7).
+ *
+ * @param ip The IPv6 address to check.
+ * @return True if the address is a special IPv6 address, false otherwise.
+ * @throws std::invalid_argument If the given IP address is not a valid IPv6 address.
+ */
+bool isSpecialIPv6Address(const std::string& ip);
+
 } // namespace utils::ip
 
 #endif // _IP_UTILS_H

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -147,6 +147,7 @@ add_executable(builder_utest
     ${UNIT_SRC_DIR}/builders/opmap/time_test.cpp
     ${UNIT_SRC_DIR}/builders/opmap/hash_test.cpp
     ${UNIT_SRC_DIR}/builders/opmap/kvdb_test.cpp
+    ${UNIT_SRC_DIR}/builders/opmap/mmdb_test.cpp
     ${UNIT_SRC_DIR}/builders/opmap/activeResponse_test.cpp
     ${UNIT_SRC_DIR}/builders/opmap/upgradeConfirmation_test.cpp
 
@@ -167,6 +168,7 @@ target_link_libraries(builder_utest
     store::mocks
     defs::mocks
     schemval::mocks
+    mmdb::mocks
 )
 gtest_discover_tests(builder_utest)
 

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(builder STATIC
     # TODO: Move to separate files
     ${SRC_DIR}/builders/opmap/opBuilderHelperMap.cpp
     ${SRC_DIR}/builders/opmap/kvdb.cpp
+    ${SRC_DIR}/builders/opmap/mmdb.cpp
     ${SRC_DIR}/builders/opmap/activeResponse.cpp
     ${SRC_DIR}/builders/opmap/upgradeConfirmation.cpp
     ${SRC_DIR}/builders/opmap/wdb.cpp
@@ -68,7 +69,6 @@ add_library(builder STATIC
     # Transform
     ${SRC_DIR}/builders/optransform/array.cpp
     ${SRC_DIR}/builders/optransform/hlp.cpp
-    ${SRC_DIR}/builders/optransform/mmdb.cpp
     ${SRC_DIR}/builders/optransform/netinfoAddress.cpp
     ${SRC_DIR}/builders/optransform/sca.cpp
     ${SRC_DIR}/builders/optransform/windows.cpp

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(builder STATIC
     # Transform
     ${SRC_DIR}/builders/optransform/array.cpp
     ${SRC_DIR}/builders/optransform/hlp.cpp
+    ${SRC_DIR}/builders/optransform/mmdb.cpp
     ${SRC_DIR}/builders/optransform/netinfoAddress.cpp
     ${SRC_DIR}/builders/optransform/sca.cpp
     ${SRC_DIR}/builders/optransform/windows.cpp
@@ -86,12 +87,12 @@ target_link_libraries(builder
     logpar
     date::date
     kvdb::mocks
+    mmdb::immdb
     sockiface::mocks
     wdb::mocks
     schemf::mocks
 
     PRIVATE
-
     schemf::ischema
 
 )

--- a/src/engine/source/builder/include/builder/builder.hpp
+++ b/src/engine/source/builder/include/builder/builder.hpp
@@ -11,6 +11,7 @@
 #include <sockiface/isockFactory.hpp>
 #include <store/istore.hpp>
 #include <wdb/iwdbManager.hpp>
+#include <mmdb/imanager.hpp>
 
 #include <builder/ibuilder.hpp>
 #include <builder/ivalidator.hpp>
@@ -27,6 +28,8 @@ struct BuilderDeps
     std::shared_ptr<kvdbManager::IKVDBManager> kvdbManager;
     std::shared_ptr<sockiface::ISockFactory> sockFactory;
     std::shared_ptr<wazuhdb::IWDBManager> wdbManager;
+    std::shared_ptr<mmdb::IManager> mmdbManager;
+
     // std::shared_ptr<Registry<HelperBuilder>> helperRegistry;
     // std::shared_ptr<schemf::ISchema> schema;
     // bool forceFieldNaming = false;

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
@@ -314,11 +314,27 @@ FilterOp opBuilderHelperRegexNotMatch(const Reference& targetField,
  * @param rawParameters vector of parameters as present in the raw definition
  * @param definitions handler with definitions
  * @return Expression The lifter with the `ip_cidr_match` filter.
- * @throw  std::runtime_error if the parameter is not a cidr.
  */
 FilterOp opBuilderHelperIPCIDR(const Reference& targetField,
                                const std::vector<OpArg>& opArgs,
                                const std::shared_ptr<const IBuildCtx>& buildCtx);
+
+/**
+ * @brief Create `is_public_ip` helper function that filters events if the field
+ * is a public IP address.
+ *
+ * This helper filters events if the field is a public IP address IPv4 or if the field is a
+ * IPv6 address then a filter is created to check if the field is not a special IPv6 address (like loopback, link-local,
+ * etc.).
+ * @param targetField target field of the helper
+ * @param rawName name of the helper as present in the raw definition
+ * @param rawParameters vector of parameters as present in the raw definition
+ * @param definitions handler with definitions
+ * @return FilterOp The lifter with the `is_public_ip` filter.
+ */
+FilterOp opBuilderHelperPublicIP(const Reference& targetField,
+                                 const std::vector<OpArg>& opArgs,
+                                 const std::shared_ptr<const IBuildCtx>& buildCtx);
 
 /**
  * @brief Create `array_contains` helper function that filters events if the field

--- a/src/engine/source/builder/src/builders/opmap/mmdb.cpp
+++ b/src/engine/source/builder/src/builders/opmap/mmdb.cpp
@@ -15,7 +15,7 @@ MapOp dumpFailTransform(const std::string& trace, const std::shared_ptr<const Ru
 }
 
 // Only for the MMDB City / Country db
-json::Json getGeoCityECS(const std::shared_ptr<::mmdb::IResult>& result)
+json::Json mapGeoToECS(const std::shared_ptr<::mmdb::IResult>& result)
 {
     json::Json cityData;
     cityData.setObject();
@@ -78,7 +78,7 @@ json::Json getGeoCityECS(const std::shared_ptr<::mmdb::IResult>& result)
     return cityData;
 }
 
-json::Json getASECS(const std::shared_ptr<::mmdb::IResult>& result)
+json::Json mapAStoECS(const std::shared_ptr<::mmdb::IResult>& result)
 {
     json::Json asData;
     asData.setObject();
@@ -113,12 +113,12 @@ MapBuilder getMMDBGeoBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManage
         const auto& ipRef = *std::static_pointer_cast<Reference>(opArgs[0]);
         const auto& schema = buildCtx->schema();
 
-        const std::string successTrace {fmt::format("[{}] -> Success", name)};
+        const std::string successTrace {fmt::format("{} -> Success", name)};
         const std::string notFoundTrace {
-            fmt::format("[{}] -> Failure: Reference to ip [{}] not found or not an string", name, ipRef.dotPath())};
-        const std::string notValidIPTrace {fmt::format("[{}] -> Failure: IP string is not a valid IP.", name)};
-        const std::string notFoundDBTrace {fmt::format("[{}] -> Failure: IP Not found in DB", name)};
-        const std::string emptyDataTrace {fmt::format("[{}] -> Failure: Empty wcs data", name)};
+            fmt::format("{} -> Failure: Reference to ip {} not found or not an string", name, ipRef.dotPath())};
+        const std::string notValidIPTrace {fmt::format("{} -> Failure: IP string is not a valid IP.", name)};
+        const std::string notFoundDBTrace {fmt::format("{} -> Failure: IP Not found in DB", name)};
+        const std::string emptyDataTrace {fmt::format("{} -> Failure: Empty wcs data", name)};
 
         // Geo only accepts IP
         if (schema.hasField(ipRef.dotPath()) && schema.getType(ipRef.dotPath()) != schemf::Type::IP)
@@ -131,7 +131,7 @@ MapBuilder getMMDBGeoBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManage
         auto runstate = buildCtx->runState();
         if (base::isError(resDB))
         {
-            const auto trace =  fmt::format("[{}] -> Failure: handler error: {}", name, base::getError(resDB).message);
+            const auto trace =  fmt::format("{} -> Failure: handler error: {}", name, base::getError(resDB).message);
             return dumpFailTransform(trace, runstate);
         }
 
@@ -162,7 +162,7 @@ MapBuilder getMMDBGeoBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManage
                 RETURN_FAILURE(runstate, json::Json {}, notFoundDBTrace);
             }
 
-            auto geo = getGeoCityECS(result);
+            auto geo = mapGeoToECS(result);
 
             if (geo.size() == 0)
             {
@@ -187,12 +187,12 @@ MapBuilder getMMDBASNBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManage
         const auto& ipRef = *std::static_pointer_cast<Reference>(opArgs[0]);
         const auto& schema = buildCtx->schema();
 
-        const std::string successTrace {fmt::format("[{}] -> Success", name)};
+        const std::string successTrace {fmt::format("{} -> Success", name)};
         const std::string notFoundTrace {
-            fmt::format("[{}] -> Failure: Reference to ip [{}] not found or not an string", name, ipRef.dotPath())};
-        const std::string notValidIPTrace {fmt::format("[{}] -> Failure: IP string is not a valid IP.", name)};
-        const std::string notFoundDBTrace {fmt::format("[{}] -> Failure: IP Not found in DB", name)};
-        const std::string emptyDataTrace {fmt::format("[{}] -> Failure: Empty wcs data", name)};
+            fmt::format("{} -> Failure: Reference to ip {} not found or not an string", name, ipRef.dotPath())};
+        const std::string notValidIPTrace {fmt::format("{} -> Failure: IP string is not a valid IP.", name)};
+        const std::string notFoundDBTrace {fmt::format("{} -> Failure: IP Not found in DB", name)};
+        const std::string emptyDataTrace {fmt::format("{} -> Failure: Empty wcs data", name)};
 
         // Geo only accepts IP
         if (schema.hasField(ipRef.dotPath()) && schema.getType(ipRef.dotPath()) != schemf::Type::IP)
@@ -235,7 +235,7 @@ MapBuilder getMMDBASNBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManage
                 RETURN_FAILURE(runstate, json::Json {}, notFoundDBTrace);
             }
 
-            auto as = getASECS(result);
+            auto as = mapAStoECS(result);
 
             if (as.size() == 0)
             {

--- a/src/engine/source/builder/src/builders/opmap/mmdb.cpp
+++ b/src/engine/source/builder/src/builders/opmap/mmdb.cpp
@@ -75,6 +75,18 @@ json::Json mapGeoToECS(const std::shared_ptr<::mmdb::IResult>& result)
         cityData.setString(getResponse(timeZone), "/timezone");
     }
 
+    auto regionIsoCode = result->getString("subdivisions.0.iso_code");
+    if (!base::isError(regionIsoCode))
+    {
+        cityData.setString(getResponse(regionIsoCode), "/region_iso_code");
+    }
+
+    auto regionName = result->getString("subdivisions.0.names.en");
+    if (!base::isError(regionName))
+    {
+        cityData.setString(getResponse(regionName), "/region_name");
+    }
+
     return cityData;
 }
 

--- a/src/engine/source/builder/src/builders/opmap/mmdb.hpp
+++ b/src/engine/source/builder/src/builders/opmap/mmdb.hpp
@@ -8,18 +8,31 @@
 namespace builder::builders::mmdb
 {
 /**
- * @brief Get the Windows Helper Builder object
+ * @brief Get the builder for the MMDB Geo operation.
  *
- * Obtains the helper that maps A SidList to a SidListDesc, where Sid identifiers for common Windows SIDs are replaced
- * by their names.
- * This helpers needs a kvdb where the mappings between the different parts of the SID and the SID names are stored.
+ * This builder is used to create a Geo operation that uses the MaxMind DB file format, offered by MaxMind Inc.
+ * http://www.maxmind.com for looking up IP addresses in MMDB databases. The extract the fields from the MMDB database
+ * according to the Wazuh schema.
  *
- * @param kvdb kvdb manager to obtain the kvdb handler
- * @param kvdbScopeName kvdb scope name
- * @param schema schema
- * @return HelperBuilder
+ * @param mmdbManager The MMDB manager.
+ * @return The builder for the MMDB Geo operation.
+ * @see mmdb::IManager
  */
 MapBuilder getMMDBGeoBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManager);
+
+/**
+ * @brief Get the builder for the MMDB ASN operation.
+ *
+ * This builder is used to create an ASN operation that uses the MaxMind DB file format, offered by MaxMind Inc.
+ * http://www.maxmind.com for looking up IP addresses in MMDB databases. The extract the fields from the MMDB database
+ * according to the Wazuh schema:
+ * - as.organization.name: The name of the organization that owns the ASN.
+ * - as.number: The ASN number.
+ *
+ * @param mmdbManager The MMDB manager.
+ * @return The builder for the MMDB ASN operation.
+ * @see mmdb::IManager
+ */
 MapBuilder getMMDBASNBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManager);
 
 } // namespace builder::builders

--- a/src/engine/source/builder/src/builders/opmap/mmdb.hpp
+++ b/src/engine/source/builder/src/builders/opmap/mmdb.hpp
@@ -19,8 +19,8 @@ namespace builder::builders::mmdb
  * @param schema schema
  * @return HelperBuilder
  */
-TransformBuilder getMMDBGeoBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManager);
-TransformBuilder getMMDBASNBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManager);
+MapBuilder getMMDBGeoBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManager);
+MapBuilder getMMDBASNBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManager);
 
 } // namespace builder::builders
 

--- a/src/engine/source/builder/src/builders/optransform/mmdb.cpp
+++ b/src/engine/source/builder/src/builders/optransform/mmdb.cpp
@@ -1,0 +1,264 @@
+#include "mmdb.hpp"
+
+namespace builder::builders::mmdb
+{
+
+namespace
+{
+TransformOp dumpFailTransform(const std::string& trace, const std::shared_ptr<const RunState>& runstate)
+{
+
+    return [trace, runstate](base::Event event) -> TransformResult
+    {
+        RETURN_FAILURE(runstate, event, trace);
+    };
+}
+
+// Only for the MMDB City / Country db
+json::Json getGeoCityECS(const std::shared_ptr<::mmdb::IResult>& result)
+{
+    json::Json cityData;
+    cityData.setObject();
+
+    // Geo data
+    auto city = result->getString("city.names.en");
+    if (!base::isError(city))
+    {
+        cityData.setString(getResponse(city), "/geo/city_name");
+    }
+
+    auto continentCode = result->getString("continent.code");
+    if (!base::isError(continentCode))
+    {
+        cityData.setString(getResponse(continentCode), "/geo/continent_code");
+    }
+
+    auto continentName = result->getString("continent.names.en");
+    if (!base::isError(continentName))
+    {
+        cityData.setString(getResponse(continentName), "/geo/continent_name");
+    }
+
+    auto countryIsoCode = result->getString("country.iso_code");
+    if (!base::isError(countryIsoCode))
+    {
+        cityData.setString(getResponse(countryIsoCode), "/geo/country_iso_code");
+    }
+
+    auto countryName = result->getString("country.names.en");
+    if (!base::isError(countryName))
+    {
+        cityData.setString(getResponse(countryName), "/geo/country_name");
+    }
+
+    auto lat = result->getDouble("location.latitude");
+    if (!base::isError(lat))
+    {
+        cityData.setDouble(getResponse(lat), "/geo/location/lat");
+    }
+
+    auto lon = result->getDouble("location.longitude");
+    if (!base::isError(lon))
+    {
+        cityData.setDouble(getResponse(lon), "/geo/location/lon");
+    }
+
+    auto postalCode = result->getString("postal.code");
+    if (!base::isError(postalCode))
+    {
+        cityData.setString(getResponse(postalCode), "/geo/postal_code");
+    }
+
+    auto timeZone = result->getString("location.time_zone");
+    if (!base::isError(timeZone))
+    {
+        cityData.setString(getResponse(timeZone), "/geo/timezone");
+    }
+
+    return cityData;
+}
+
+json::Json getASECS(const std::shared_ptr<::mmdb::IResult>& result)
+{
+    json::Json asData;
+    asData.setObject();
+
+    auto asn = result->getUint32("autonomous_system_number");
+    if (!base::isError(asn))
+    {
+        asData.setInt64(getResponse(asn), "/as/number");
+    }
+
+    auto asnOrg = result->getString("autonomous_system_organization");
+    if (!base::isError(asnOrg))
+    {
+        asData.setString(getResponse(asnOrg), "/as/organization/name");
+    }
+
+    return asData;
+}
+
+} // namespace
+
+TransformBuilder getMMDBGeoBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManager)
+{
+    return [mmdbManager](const Reference& targetField,
+                         const std::vector<OpArg>& opArgs,
+                         const std::shared_ptr<const IBuildCtx>& buildCtx) -> TransformOp
+    {
+        const auto name = buildCtx->context().opName;
+
+        utils::assertSize(opArgs, 1, utils::MAX_OP_ARGS);
+        utils::assertRef(opArgs, 0);
+
+        const auto& ipRef = *std::static_pointer_cast<Reference>(opArgs[0]);
+        const auto& schema = buildCtx->schema();
+
+        const std::string successTrace {fmt::format("[{}] -> Success", name)};
+        const std::string notFoundTrace {
+            fmt::format("[{}] -> Failure: Reference to ip [{}] not found or not an string", name, ipRef.dotPath())};
+        const std::string notValidIPTrace {fmt::format("[{}] -> Failure: IP string is not a valid IP.", name)};
+        const std::string notFoundDBTrace {fmt::format("[{}] -> Failure: IP Not found in DB", name)};
+
+        // Geo only accepts IP
+        if (schema.hasField(ipRef.dotPath()) && schema.getType(ipRef.dotPath()) != schemf::Type::IP)
+        {
+            throw std::runtime_error(fmt::format("The reference '{}' is not an IP.", ipRef.dotPath()));
+        }
+
+        auto resDB = mmdbManager->getHandler("mm-geolite2-city");
+        // TODO Temporary error handling, this should be mandatory
+        if (base::isError(resDB))
+        {
+            const auto& runState = buildCtx->runState();
+            return dumpFailTransform(
+                fmt::format("[{}] -> Failure: handler error: {}", name, base::getError(resDB).message), runState);
+        }
+
+        // auto dbHandler = base::getResponse<std::shared_ptr<::mmdb::IHandler>>(resDB);
+        return [=,
+                targetField = targetField.jsonPath(),
+                dbHandler = base::getResponse(resDB),
+                srcRef = ipRef.jsonPath(),
+                runState = buildCtx->runState()](base::Event event) -> TransformResult
+        {
+            // Get the ip
+            auto ipStr = event->getString(srcRef);
+            if (!ipStr)
+            {
+                RETURN_FAILURE(runState, event, notFoundTrace);
+            }
+
+            // Check if the ip is valid
+            std::shared_ptr<::mmdb::IResult> result;
+            try
+            {
+                result = dbHandler->lookup(ipStr.value());
+            }
+            catch (std::runtime_error& e)
+            {
+                RETURN_FAILURE(runState, event, notValidIPTrace + " " + e.what());
+            }
+
+            if (!result->hasData())
+            {
+                RETURN_FAILURE(runState, event, notFoundDBTrace);
+            }
+
+            auto geo = getGeoCityECS(result);
+
+            if (event->exists(targetField))
+            {
+                event->merge(false, geo, targetField);
+            }
+            else
+            {
+                event->set(targetField, geo);
+            }
+
+            RETURN_SUCCESS(runState, event, successTrace);
+        };
+    };
+};
+
+TransformBuilder getMMDBASNBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManager)
+{
+    return [mmdbManager](const Reference& targetField,
+                         const std::vector<OpArg>& opArgs,
+                         const std::shared_ptr<const IBuildCtx>& buildCtx) -> TransformOp
+    {
+        const auto name = buildCtx->context().opName;
+
+        utils::assertSize(opArgs, 1, utils::MAX_OP_ARGS);
+        utils::assertRef(opArgs, 0);
+
+        const auto& ipRef = *std::static_pointer_cast<Reference>(opArgs[0]);
+        const auto& schema = buildCtx->schema();
+
+        const std::string successTrace {fmt::format("[{}] -> Success", name)};
+        const std::string notFoundTrace {
+            fmt::format("[{}] -> Failure: Reference to ip [{}] not found or not an string", name, ipRef.dotPath())};
+        const std::string notValidIPTrace {fmt::format("[{}] -> Failure: IP string is not a valid IP.", name)};
+        const std::string notFoundDBTrace {fmt::format("[{}] -> Failure: IP Not found in DB", name)};
+
+        // Geo only accepts IP
+        if (schema.hasField(ipRef.dotPath()) && schema.getType(ipRef.dotPath()) != schemf::Type::IP)
+        {
+            throw std::runtime_error(fmt::format("The reference '{}' is not an IP.", ipRef.dotPath()));
+        }
+
+        auto resDB = mmdbManager->getHandler("mm-geolite2-asn");
+        // TODO Temporary error handling, this should be mandatory
+        if (base::isError(resDB))
+        {
+            const auto& runState = buildCtx->runState();
+            return dumpFailTransform("Error getting mmdb handler: " + base::getError(resDB).message, runState);
+        }
+
+        // auto dbHandler = base::getResponse<std::shared_ptr<::mmdb::IHandler>>(resDB);
+        return [=,
+                targetField = targetField.jsonPath(),
+                dbHandler = base::getResponse(resDB),
+                srcRef = ipRef.jsonPath(),
+                runState = buildCtx->runState()](base::Event event) -> TransformResult
+        {
+            // Get the ip
+            auto ipStr = event->getString(srcRef);
+            if (!ipStr)
+            {
+                RETURN_FAILURE(runState, event, notFoundTrace);
+            }
+
+            // Check if the ip is valid
+            std::shared_ptr<::mmdb::IResult> result;
+            try
+            {
+                result = dbHandler->lookup(ipStr.value());
+            }
+            catch (std::runtime_error& e)
+            {
+                RETURN_FAILURE(runState, event, notValidIPTrace + " " + e.what());
+            }
+
+            if (!result->hasData())
+            {
+                RETURN_FAILURE(runState, event, notFoundDBTrace);
+            }
+
+            auto as = getASECS(result);
+
+            if(event->exists(targetField))
+            {
+                event->merge(false, as, targetField);
+            }
+            else
+            {
+                event->set(targetField, as);
+            }
+
+            RETURN_SUCCESS(runState, event, successTrace);
+        };
+    };
+};
+
+} // namespace builder::builders::mmdb

--- a/src/engine/source/builder/src/builders/optransform/mmdb.hpp
+++ b/src/engine/source/builder/src/builders/optransform/mmdb.hpp
@@ -1,0 +1,27 @@
+#ifndef _BUILDER_BUILDERS_OPTRANSFORM_MMDB_HPP
+#define _BUILDER_BUILDERS_OPTRANSFORM_MMDB_HPP
+
+#include <mmdb/imanager.hpp>
+
+#include "builders/types.hpp"
+
+namespace builder::builders::mmdb
+{
+/**
+ * @brief Get the Windows Helper Builder object
+ *
+ * Obtains the helper that maps A SidList to a SidListDesc, where Sid identifiers for common Windows SIDs are replaced
+ * by their names.
+ * This helpers needs a kvdb where the mappings between the different parts of the SID and the SID names are stored.
+ *
+ * @param kvdb kvdb manager to obtain the kvdb handler
+ * @param kvdbScopeName kvdb scope name
+ * @param schema schema
+ * @return HelperBuilder
+ */
+TransformBuilder getMMDBGeoBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManager);
+TransformBuilder getMMDBASNBuilder(const std::shared_ptr<::mmdb::IManager>& mmdbManager);
+
+} // namespace builder::builders
+
+#endif // _BUILDER_BUILDERS_OPTRANSFORM_MMDB_HPP

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -81,6 +81,8 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
     registry->template add<builders::OpBuilderEntry>(
         "ip_cidr_match", {schemval::ValidationToken {schemf::Type::IP}, builders::opfilter::opBuilderHelperIPCIDR});
     registry->template add<builders::OpBuilderEntry>(
+        "is_public_ip", {schemval::ValidationToken {schemf::Type::IP}, builders::opfilter::opBuilderHelperPublicIP});
+    registry->template add<builders::OpBuilderEntry>(
         "is_array", {schemval::ValidationToken {}, builders::opfilter::opBuilderHelperIsArray});
     registry->template add<builders::OpBuilderEntry>(
         "is_boolean", {schemval::ValidationToken {}, builders::opfilter::opBuilderHelperIsBool});

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -23,6 +23,7 @@
 #include "builders/opmap/kvdb.hpp"
 #include "builders/optransform/array.hpp"
 #include "builders/optransform/hlp.hpp"
+#include "builders/optransform/mmdb.hpp"
 #include "builders/optransform/netinfoAddress.hpp"
 #include "builders/optransform/sca.hpp"
 #include "builders/optransform/windows.hpp"
@@ -208,6 +209,11 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
         "get_value", {schemval::ValidationToken {}, builders::opBuilderHelperGetValue}); // TODO: add validation
     registry->template add<builders::OpBuilderEntry>(
         "merge_value", {schemval::ValidationToken {schemf::Type::OBJECT}, builders::opBuilderHelperMergeValue});
+    // Transform helpers: MMDB functions
+    registry->template add<builders::OpBuilderEntry>(
+        "geoip", {schemval::ValidationToken {schemf::Type::OBJECT}, builders::mmdb::getMMDBGeoBuilder(deps.mmdbManager)});
+    registry->template add<builders::OpBuilderEntry>(
+        "as", {schemval::ValidationToken {schemf::Type::OBJECT}, builders::mmdb::getMMDBASNBuilder(deps.mmdbManager)});
     // Global event helpers
     registry->template add<builders::OpBuilderEntry>(
         "erase_custom_fields", {schemval::ValidationToken {}, builders::opBuilderHelperEraseCustomFields});

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -16,6 +16,7 @@
 #include "builders/opmap/activeResponse.hpp"
 #include "builders/opmap/map.hpp"
 #include "builders/opmap/opBuilderHelperMap.hpp"
+#include "builders/opmap/mmdb.hpp"
 #include "builders/opmap/upgradeConfirmation.hpp"
 #include "builders/opmap/wdb.hpp"
 
@@ -23,7 +24,6 @@
 #include "builders/opmap/kvdb.hpp"
 #include "builders/optransform/array.hpp"
 #include "builders/optransform/hlp.hpp"
-#include "builders/optransform/mmdb.hpp"
 #include "builders/optransform/netinfoAddress.hpp"
 #include "builders/optransform/sca.hpp"
 #include "builders/optransform/windows.hpp"

--- a/src/engine/source/builder/test/src/unit/builders/opfilter/ip_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opfilter/ip_test.cpp
@@ -5,7 +5,7 @@
 namespace filterbuildtest
 {
 INSTANTIATE_TEST_SUITE_P(
-    Builders,
+    BuilderIPCIDR,
     FilterBuilderTest,
     testing::Values(
         FilterT({}, opfilter::opBuilderHelperIPCIDR, FAILURE()),
@@ -19,11 +19,19 @@ INSTANTIATE_TEST_SUITE_P(
                 opfilter::opBuilderHelperIPCIDR,
                 SUCCESS())),
     testNameFormatter<FilterBuilderTest>("IPCIDR"));
+
+INSTANTIATE_TEST_SUITE_P(
+    BuilderPublicIP,
+    FilterBuilderTest,
+    testing::Values(FilterT({}, opfilter::opBuilderHelperPublicIP, SUCCESS()),
+                    FilterT({makeValue(R"("192.168.255.255")")}, opfilter::opBuilderHelperPublicIP, FAILURE()),
+                    FilterT({makeRef("ref")}, opfilter::opBuilderHelperPublicIP, FAILURE())),
+    testNameFormatter<FilterBuilderTest>("PublicIP"));
 } // namespace filterbuildtest
 
 namespace filteroperatestest
 {
-INSTANTIATE_TEST_SUITE_P(Builders,
+INSTANTIATE_TEST_SUITE_P(BuilderIPCIDR,
                          FilterOperationTest,
                          testing::Values(FilterT(R"({"target": "192.168.255.255/24"})",
                                                  opfilter::opBuilderHelperIPCIDR,
@@ -46,4 +54,27 @@ INSTANTIATE_TEST_SUITE_P(Builders,
                                                  {makeValue(R"("192.168.255.0")"), makeValue(R"("255.255.255.0")")},
                                                  FAILURE())),
                          testNameFormatter<FilterOperationTest>("IPCIDR"));
+
+INSTANTIATE_TEST_SUITE_P(
+    BuilderPublicIP,
+    FilterOperationTest,
+    testing::Values(
+        // Invalid input
+        FilterT(R"({"notTarget": "8.8.8.8"})", opfilter::opBuilderHelperPublicIP, "target", {}, FAILURE()),
+        FilterT(R"({"target": null})", opfilter::opBuilderHelperPublicIP, "target", {}, FAILURE()),
+        FilterT(R"({"target": 123})", opfilter::opBuilderHelperPublicIP, "target", {}, FAILURE()),
+        FilterT(R"({"target": 123.45})", opfilter::opBuilderHelperPublicIP, "target", {}, FAILURE()),
+        FilterT(R"({"target": {"target": "::1"}})", opfilter::opBuilderHelperPublicIP, "target", {}, FAILURE()),
+        // Special IPs
+        FilterT(R"({"target": "::1"})", opfilter::opBuilderHelperPublicIP, "target", {}, FAILURE()),
+        FilterT(R"({"target": "127.0.0.1"})", opfilter::opBuilderHelperPublicIP, "target", {}, FAILURE()),
+        FilterT(R"({"target": "127.1.1.1"})", opfilter::opBuilderHelperPublicIP, "target", {}, FAILURE()),
+        FilterT(R"({"target": "192.168.1.1"})", opfilter::opBuilderHelperPublicIP, "target", {}, FAILURE()),
+        FilterT(R"({"target": "10.0.0.1"})", opfilter::opBuilderHelperPublicIP, "target", {}, FAILURE()),
+        // Public IP
+        FilterT(R"({"target": "8.8.8.8"})", opfilter::opBuilderHelperPublicIP, "target", {}, SUCCESS()),
+        FilterT(R"({"target": "2001:4860:4860::8888"})", opfilter::opBuilderHelperPublicIP, "target", {}, SUCCESS())
+        // End of test cases
+        ),
+    testNameFormatter<FilterOperationTest>("PUBLICIP"));
 } // namespace filteroperatestest

--- a/src/engine/source/builder/test/src/unit/builders/opmap/mmdb_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opmap/mmdb_test.cpp
@@ -1,0 +1,219 @@
+#include "builders/baseBuilders_test.hpp"
+
+#include "builders/opmap/mmdb.hpp"
+
+#include <mmdb/mockHandler.hpp>
+#include <mmdb/mockManager.hpp>
+#include <mmdb/mockResult.hpp>
+
+namespace
+{
+using namespace builder::builders::mmdb;
+
+// Common expectations for builders and operations
+auto expectContext()
+{
+    return [](const BuildersMocks& mocks)
+    {
+        EXPECT_CALL(*mocks.ctx, context());
+        return None {};
+    };
+}
+
+auto customRefExpected()
+{
+    return [](const BuildersMocks& mocks)
+    {
+        EXPECT_CALL(*mocks.ctx, schema());
+        EXPECT_CALL(*mocks.schema, hasField(DotPath("ref"))).WillOnce(testing::Return(false));
+        return None {};
+    };
+}
+
+auto expectTypeRef(schemf::Type type, bool success = false)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        if (!success)
+        {
+            EXPECT_CALL(*mocks.ctx, context());
+        }
+        EXPECT_CALL(*mocks.ctx, schema()).Times(testing::AtLeast(1));
+        EXPECT_CALL(*mocks.schema, hasField(DotPath("ref"))).WillOnce(testing::Return(true));
+        EXPECT_CALL(*mocks.schema, getType(DotPath("ref"))).WillRepeatedly(testing::Return(type));
+        return None {};
+    };
+}
+
+auto customRefExpected(const json::Json& value)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        EXPECT_CALL(*mocks.ctx, schema());
+        EXPECT_CALL(*mocks.schema, hasField(DotPath("ref"))).WillOnce(testing::Return(false));
+
+        return value;
+    };
+}
+
+// AS: Builder getters for building test
+namespace as
+{
+mapbuildtest::BuilderGetter getBuilderNoHandler()
+{
+    return []()
+    {
+        auto mmdbManager = std::make_shared<::mmdb::MockManager>();
+        return getMMDBASNBuilder(mmdbManager);
+    };
+}
+
+mapbuildtest::BuilderGetter getBuilderWHandler(bool failHandler = false)
+{
+    return [=]()
+    {
+        auto mmdbManager = std::make_shared<::mmdb::MockManager>();
+        auto mmdbHandler = std::make_shared<::mmdb::MockHandler>();
+        if (failHandler)
+        {
+            EXPECT_CALL(*mmdbManager, getHandler("mm-geolite2-asn")).WillOnce(testing::Return(base::Error {"error"}));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbManager, getHandler("mm-geolite2-asn")).WillOnce(testing::Return(mmdbHandler));
+        }
+        return getMMDBASNBuilder(mmdbManager);
+    };
+}
+
+// AS operation
+mapbuildtest::BuilderGetter getBuilderHandlerNoResult(bool validIP = true)
+{
+    return [=]()
+    {
+        auto mmdbManager = std::make_shared<::mmdb::MockManager>();
+        auto mmdbHandler = std::make_shared<::mmdb::MockHandler>();
+        if (!validIP)
+        {
+            EXPECT_CALL(*mmdbHandler, lookup(testing::_)).WillOnce(testing::Throw(std::runtime_error {"Invalid IP"}));
+        }
+        else
+        {
+            auto mmdbResult = std::make_shared<::mmdb::MockResult>();
+            EXPECT_CALL(*mmdbResult, hasData()).WillOnce(testing::Return(false));
+            EXPECT_CALL(*mmdbHandler, lookup(testing::_)).WillOnce(testing::Return(mmdbResult));
+        }
+        EXPECT_CALL(*mmdbManager, getHandler("mm-geolite2-asn")).WillOnce(testing::Return(mmdbHandler));
+        return getMMDBASNBuilder(mmdbManager);
+    };
+}
+
+mapbuildtest::BuilderGetter getBuilderHandlerResult(bool hasASN, bool hasASOrg)
+{
+    // Path from the root MaxMind object
+    const DotPath asnPath {"autonomous_system_number"};
+    const DotPath asOrgPath {"autonomous_system_organization"};
+
+    return [=]()
+    {
+        auto mmdbManager = std::make_shared<::mmdb::MockManager>();
+        auto mmdbHandler = std::make_shared<::mmdb::MockHandler>();
+        auto mmdbResult = std::make_shared<::mmdb::MockResult>();
+        if (hasASN)
+        {
+            EXPECT_CALL(*mmdbResult, getUint32(asnPath)).WillOnce(testing::Return(123u));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getUint32(asnPath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        if (hasASOrg)
+        {
+            EXPECT_CALL(*mmdbResult, getString(asOrgPath)).WillOnce(testing::Return("AS Org"));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getString(asOrgPath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        EXPECT_CALL(*mmdbResult, hasData()).WillOnce(testing::Return(true));
+        EXPECT_CALL(*mmdbHandler, lookup(testing::_)).WillOnce(testing::Return(mmdbResult));
+        EXPECT_CALL(*mmdbManager, getHandler("mm-geolite2-asn")).WillOnce(testing::Return(mmdbHandler));
+        return getMMDBASNBuilder(mmdbManager);
+    };
+}
+
+} // namespace as
+
+// Geo builder
+
+} // namespace
+
+namespace mapbuildtest
+{
+INSTANTIATE_TEST_SUITE_P(
+    Builders,
+    MapBuilderWithDepsTest,
+    testing::Values(
+        /*** ASN ***/
+        // Only accept a ref with a ip to map an object
+        MapDepsT({}, as::getBuilderNoHandler(), FAILURE(expectContext())),
+        MapDepsT({makeValue(R"("value")")}, as::getBuilderNoHandler(), FAILURE(expectContext())),
+        MapDepsT({makeRef("ref")}, as::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::TEXT))),
+        MapDepsT({makeRef("ref")}, as::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::KEYWORD))),
+        MapDepsT({makeRef("ref")}, as::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::INTEGER))),
+        MapDepsT({makeRef("ref")}, as::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::OBJECT))),
+        MapDepsT({makeRef("ref")}, as::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::NESTED))),
+        MapDepsT({makeRef("ref")}, as::getBuilderWHandler(), SUCCESS(customRefExpected())),
+        // TODO: Fail Handler, Temporary error handling, this should be mandatory
+        MapDepsT({makeRef("ref")}, as::getBuilderWHandler(), SUCCESS(expectTypeRef(schemf::Type::IP, true))),
+        MapDepsT({makeRef("ref")}, as::getBuilderWHandler(true), SUCCESS(expectTypeRef(schemf::Type::IP, true)))
+        // End of test values
+        ),
+    testNameFormatter<MapBuilderWithDepsTest>("mmdb_asn"));
+} // namespace mapbuildtest
+
+namespace mapoperatestest
+{
+INSTANTIATE_TEST_SUITE_P(
+    Builders,
+    MapOperationWithDepsTest,
+    testing::Values(
+        /*** ASN ***/
+        // Bad ref
+        MapDepsT(
+            R"({"ref": {"some":"data"}})", as::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": {}})", as::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": false})", as::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": ["::1"]})", as::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": 123})", as::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": 123.34})", as::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(
+            R"({"ref": "1.2.3.4"})", as::getBuilderHandlerNoResult(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        // No result
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 as::getBuilderHandlerNoResult(false),
+                 {makeRef("ref")},
+                 FAILURE(customRefExpected())),
+        // Partial result
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 as::getBuilderHandlerResult(false, false),
+                 {makeRef("ref")},
+                 FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 as::getBuilderHandlerResult(true, false),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"number": 123})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 as::getBuilderHandlerResult(false, true),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"organization": {"name": "AS Org"}})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 as::getBuilderHandlerResult(true, true),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"number": 123, "organization": {"name": "AS Org"}})"})))
+        // End of test values
+        ),
+    testNameFormatter<MapOperationWithDepsTest>("mmdb_asn"));
+} // namespace mapoperatestest

--- a/src/engine/source/builder/test/src/unit/builders/opmap/mmdb_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opmap/mmdb_test.cpp
@@ -147,16 +147,184 @@ mapbuildtest::BuilderGetter getBuilderHandlerResult(bool hasASN, bool hasASOrg)
 } // namespace as
 
 // Geo builder
+namespace geo
+{
+mapbuildtest::BuilderGetter getBuilderNoHandler()
+{
+    return []()
+    {
+        auto mmdbManager = std::make_shared<::mmdb::MockManager>();
+        return getMMDBGeoBuilder(mmdbManager);
+    };
+}
+
+mapbuildtest::BuilderGetter getBuilderWHandler(bool failHandler = false)
+{
+    return [=]()
+    {
+        auto mmdbManager = std::make_shared<::mmdb::MockManager>();
+        auto mmdbHandler = std::make_shared<::mmdb::MockHandler>();
+        if (failHandler)
+        {
+            EXPECT_CALL(*mmdbManager, getHandler("mm-geolite2-city")).WillOnce(testing::Return(base::Error {"error"}));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbManager, getHandler("mm-geolite2-city")).WillOnce(testing::Return(mmdbHandler));
+        }
+        return getMMDBGeoBuilder(mmdbManager);
+    };
+}
+
+// AS operation
+mapbuildtest::BuilderGetter getBuilderHandlerNoResult(bool validIP = true)
+{
+    return [=]()
+    {
+        auto mmdbManager = std::make_shared<::mmdb::MockManager>();
+        auto mmdbHandler = std::make_shared<::mmdb::MockHandler>();
+        if (!validIP)
+        {
+            EXPECT_CALL(*mmdbHandler, lookup(testing::_)).WillOnce(testing::Throw(std::runtime_error {"Invalid IP"}));
+        }
+        else
+        {
+            auto mmdbResult = std::make_shared<::mmdb::MockResult>();
+            EXPECT_CALL(*mmdbResult, hasData()).WillOnce(testing::Return(false));
+            EXPECT_CALL(*mmdbHandler, lookup(testing::_)).WillOnce(testing::Return(mmdbResult));
+        }
+        EXPECT_CALL(*mmdbManager, getHandler("mm-geolite2-city")).WillOnce(testing::Return(mmdbHandler));
+        return getMMDBGeoBuilder(mmdbManager);
+    };
+}
+
+mapbuildtest::BuilderGetter getBuilderHandlerResult(bool hasCity,
+                                                    bool hasContinentCode,
+                                                    bool hasContinentName,
+                                                    bool hasCountryIsoCode,
+                                                    bool hasCountryName,
+                                                    bool hasLatitude,
+                                                    bool hasLongitude,
+                                                    bool hasPostalCode,
+                                                    bool hasTimeZone)
+{
+    // Path from the root MaxMind object
+    const DotPath cityPath {"city.names.en"};
+    const DotPath continentCodePath {"continent.code"};
+    const DotPath continentNamePath {"continent.names.en"};
+    const DotPath countryIsoCodePath {"country.iso_code"};
+    const DotPath countryNamePath {"country.names.en"};
+    const DotPath latitudePath {"location.latitude"};
+    const DotPath longitudePath {"location.longitude"};
+    const DotPath postalCodePath {"postal.code"};
+    const DotPath timeZonePath {"location.time_zone"};
+
+    return [=]()
+    {
+        auto mmdbManager = std::make_shared<::mmdb::MockManager>();
+        auto mmdbHandler = std::make_shared<::mmdb::MockHandler>();
+        auto mmdbResult = std::make_shared<::mmdb::MockResult>();
+
+        if (hasCity)
+        {
+            EXPECT_CALL(*mmdbResult, getString(cityPath)).WillOnce(testing::Return("City"));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getString(cityPath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        if (hasContinentCode)
+        {
+            EXPECT_CALL(*mmdbResult, getString(continentCodePath)).WillOnce(testing::Return("CC"));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getString(continentCodePath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        if (hasContinentName)
+        {
+            EXPECT_CALL(*mmdbResult, getString(continentNamePath)).WillOnce(testing::Return("Continent"));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getString(continentNamePath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        if (hasCountryIsoCode)
+        {
+            EXPECT_CALL(*mmdbResult, getString(countryIsoCodePath)).WillOnce(testing::Return("CI"));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getString(countryIsoCodePath))
+                .WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        if (hasCountryName)
+        {
+            EXPECT_CALL(*mmdbResult, getString(countryNamePath)).WillOnce(testing::Return("Country"));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getString(countryNamePath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        if (hasLatitude)
+        {
+            EXPECT_CALL(*mmdbResult, getDouble(latitudePath)).WillOnce(testing::Return(1.23));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getDouble(latitudePath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        if (hasLongitude)
+        {
+            EXPECT_CALL(*mmdbResult, getDouble(longitudePath)).WillOnce(testing::Return(4.56));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getDouble(longitudePath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        if (hasPostalCode)
+        {
+            EXPECT_CALL(*mmdbResult, getString(postalCodePath)).WillOnce(testing::Return("12345"));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getString(postalCodePath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        if (hasTimeZone)
+        {
+            EXPECT_CALL(*mmdbResult, getString(timeZonePath)).WillOnce(testing::Return("TZ"));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getString(timeZonePath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        EXPECT_CALL(*mmdbResult, hasData()).WillOnce(testing::Return(true));
+        EXPECT_CALL(*mmdbHandler, lookup(testing::_)).WillOnce(testing::Return(mmdbResult));
+        EXPECT_CALL(*mmdbManager, getHandler("mm-geolite2-city")).WillOnce(testing::Return(mmdbHandler));
+        return getMMDBGeoBuilder(mmdbManager);
+    };
+}
+
+} // namespace geo
 
 } // namespace
 
 namespace mapbuildtest
 {
+/*** ASN ***/
 INSTANTIATE_TEST_SUITE_P(
-    Builders,
+    BuilderAS,
     MapBuilderWithDepsTest,
     testing::Values(
-        /*** ASN ***/
         // Only accept a ref with a ip to map an object
         MapDepsT({}, as::getBuilderNoHandler(), FAILURE(expectContext())),
         MapDepsT({makeValue(R"("value")")}, as::getBuilderNoHandler(), FAILURE(expectContext())),
@@ -166,21 +334,43 @@ INSTANTIATE_TEST_SUITE_P(
         MapDepsT({makeRef("ref")}, as::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::OBJECT))),
         MapDepsT({makeRef("ref")}, as::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::NESTED))),
         MapDepsT({makeRef("ref")}, as::getBuilderWHandler(), SUCCESS(customRefExpected())),
-        // TODO: Fail Handler, Temporary error handling, this should be mandatory
+        // #TODO: Fail Handler, Temporary error handling, this should be mandatory
         MapDepsT({makeRef("ref")}, as::getBuilderWHandler(), SUCCESS(expectTypeRef(schemf::Type::IP, true))),
         MapDepsT({makeRef("ref")}, as::getBuilderWHandler(true), SUCCESS(expectTypeRef(schemf::Type::IP, true)))
         // End of test values
         ),
     testNameFormatter<MapBuilderWithDepsTest>("mmdb_asn"));
+
+/*** Geo ***/
+INSTANTIATE_TEST_SUITE_P(
+    BuilderGeo,
+    MapBuilderWithDepsTest,
+    testing::Values(
+        // Only accept a ref with a ip to map an object
+        MapDepsT({}, geo::getBuilderNoHandler(), FAILURE(expectContext())),
+        MapDepsT({makeValue(R"("value")")}, geo::getBuilderNoHandler(), FAILURE(expectContext())),
+        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::TEXT))),
+        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::KEYWORD))),
+        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::INTEGER))),
+        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::OBJECT))),
+        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::NESTED))),
+        MapDepsT({makeRef("ref")}, geo::getBuilderWHandler(), SUCCESS(customRefExpected())),
+        // #TODO: Fail Handler, Temporary error handling, this should be mandatory
+        MapDepsT({makeRef("ref")}, geo::getBuilderWHandler(), SUCCESS(expectTypeRef(schemf::Type::IP, true))),
+        MapDepsT({makeRef("ref")}, geo::getBuilderWHandler(true), SUCCESS(expectTypeRef(schemf::Type::IP, true)))
+        // End of test values
+        ),
+    testNameFormatter<MapBuilderWithDepsTest>("mmdb_geo"));
+
 } // namespace mapbuildtest
 
 namespace mapoperatestest
 {
+/*** ASN ***/
 INSTANTIATE_TEST_SUITE_P(
-    Builders,
+    BuilderOpAs,
     MapOperationWithDepsTest,
     testing::Values(
-        /*** ASN ***/
         // Bad ref
         MapDepsT(
             R"({"ref": {"some":"data"}})", as::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
@@ -213,6 +403,89 @@ INSTANTIATE_TEST_SUITE_P(
                  as::getBuilderHandlerResult(true, true),
                  {makeRef("ref")},
                  SUCCESS(customRefExpected(json::Json {R"({"number": 123, "organization": {"name": "AS Org"}})"})))
+        // End of test values
+        ),
+    testNameFormatter<MapOperationWithDepsTest>("mmdb_asn"));
+
+/*** ASN ***/
+INSTANTIATE_TEST_SUITE_P(
+    BuilderOpGeo,
+    MapOperationWithDepsTest,
+    testing::Values(
+        // Bad ref
+        MapDepsT(
+            R"({"ref": {"some":"data"}})", geo::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": {}})", geo::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": false})", geo::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": ["::1"]})", geo::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": 123})", geo::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": 123.34})", geo::getBuilderWHandler(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapDepsT(
+            R"({"ref": "1.2.3.4"})", geo::getBuilderHandlerNoResult(), {makeRef("ref")}, FAILURE(customRefExpected())),
+        // No result
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerNoResult(false),
+                 {makeRef("ref")},
+                 FAILURE(customRefExpected())),
+        // Partial result
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(false, false, false, false, false, false, false, false, false),
+                 {makeRef("ref")},
+                 FAILURE(customRefExpected())),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(true, false, false, false, false, false, false, false, false),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"city_name": "City"})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(false, true, false, false, false, false, false, false, false),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"continent_code": "CC"})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(false, false, true, false, false, false, false, false, false),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"continent_name": "Continent"})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(false, false, false, true, false, false, false, false, false),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"country_iso_code": "CI"})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(false, false, false, false, true, false, false, false, false),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"country_name": "Country"})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(false, false, false, false, false, true, false, false, false),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"location": {"lat": 1.23}})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(false, false, false, false, false, false, true, false, false),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"location": {"lon": 4.56}})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(false, false, false, false, false, false, false, true, false),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"postal_code": "12345"})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(false, false, false, false, false, false, false, false, true),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"({"timezone": "TZ"})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(true, true, true, true, true, true, true, true, true),
+                 {makeRef("ref")},
+                 SUCCESS(customRefExpected(json::Json {R"(
+                    {
+                        "city_name": "City",
+                        "continent_code": "CC",
+                        "continent_name": "Continent",
+                        "country_iso_code": "CI",
+                        "country_name": "Country",
+                        "location": {
+                            "lat": 1.23,
+                            "lon": 4.56
+                        },
+                        "postal_code": "12345",
+                        "timezone": "TZ"
+                    }
+                )"})))
         // End of test values
         ),
     testNameFormatter<MapOperationWithDepsTest>("mmdb_asn"));

--- a/src/engine/source/builder/test/src/unit/builders/opmap/mmdb_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opmap/mmdb_test.cpp
@@ -206,7 +206,10 @@ mapbuildtest::BuilderGetter getBuilderHandlerResult(bool hasCity,
                                                     bool hasLatitude,
                                                     bool hasLongitude,
                                                     bool hasPostalCode,
-                                                    bool hasTimeZone)
+                                                    bool hasTimeZone,
+                                                    bool hasRegionCode,
+                                                    bool hasRegionName
+                                                    )
 {
     // Path from the root MaxMind object
     const DotPath cityPath {"city.names.en"};
@@ -218,6 +221,8 @@ mapbuildtest::BuilderGetter getBuilderHandlerResult(bool hasCity,
     const DotPath longitudePath {"location.longitude"};
     const DotPath postalCodePath {"postal.code"};
     const DotPath timeZonePath {"location.time_zone"};
+    const DotPath regionCodePath {"subdivisions.0.iso_code"};
+    const DotPath regionNamePath {"subdivisions.0.names.en"};
 
     return [=]()
     {
@@ -305,6 +310,24 @@ mapbuildtest::BuilderGetter getBuilderHandlerResult(bool hasCity,
         else
         {
             EXPECT_CALL(*mmdbResult, getString(timeZonePath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        if (hasRegionCode)
+        {
+            EXPECT_CALL(*mmdbResult, getString(regionCodePath)).WillOnce(testing::Return("RC"));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getString(regionCodePath)).WillOnce(testing::Return(base::Error {"Not found"}));
+        }
+
+        if (hasRegionName)
+        {
+            EXPECT_CALL(*mmdbResult, getString(regionNamePath)).WillOnce(testing::Return("Region"));
+        }
+        else
+        {
+            EXPECT_CALL(*mmdbResult, getString(regionNamePath)).WillOnce(testing::Return(base::Error {"Not found"}));
         }
 
         EXPECT_CALL(*mmdbResult, hasData()).WillOnce(testing::Return(true));
@@ -429,47 +452,55 @@ INSTANTIATE_TEST_SUITE_P(
                  FAILURE(customRefExpected())),
         // Partial result
         MapDepsT(R"({"ref": "1.2.3.4"})",
-                 geo::getBuilderHandlerResult(false, false, false, false, false, false, false, false, false),
+                 geo::getBuilderHandlerResult(false, false, false, false, false, false, false, false, false, false, false),
                  {makeRef("ref")},
                  FAILURE(customRefExpected())),
         MapDepsT(R"({"ref": "1.2.3.4"})",
-                 geo::getBuilderHandlerResult(true, false, false, false, false, false, false, false, false),
+                 geo::getBuilderHandlerResult(true, false, false, false, false, false, false, false, false, false, false),
                  {makeRef("ref")},
                  SUCCESS(customRefExpected(json::Json {R"({"city_name": "City"})"}))),
         MapDepsT(R"({"ref": "1.2.3.4"})",
-                 geo::getBuilderHandlerResult(false, true, false, false, false, false, false, false, false),
+                 geo::getBuilderHandlerResult(false, true, false, false, false, false, false, false, false, false, false),
                  {makeRef("ref")},
                  SUCCESS(customRefExpected(json::Json {R"({"continent_code": "CC"})"}))),
         MapDepsT(R"({"ref": "1.2.3.4"})",
-                 geo::getBuilderHandlerResult(false, false, true, false, false, false, false, false, false),
+                 geo::getBuilderHandlerResult(false, false, true, false, false, false, false, false, false, false, false),
                  {makeRef("ref")},
                  SUCCESS(customRefExpected(json::Json {R"({"continent_name": "Continent"})"}))),
         MapDepsT(R"({"ref": "1.2.3.4"})",
-                 geo::getBuilderHandlerResult(false, false, false, true, false, false, false, false, false),
+                 geo::getBuilderHandlerResult(false, false, false, true, false, false, false, false, false, false, false),
                  {makeRef("ref")},
                  SUCCESS(customRefExpected(json::Json {R"({"country_iso_code": "CI"})"}))),
         MapDepsT(R"({"ref": "1.2.3.4"})",
-                 geo::getBuilderHandlerResult(false, false, false, false, true, false, false, false, false),
+                 geo::getBuilderHandlerResult(false, false, false, false, true, false, false, false, false, false, false),
                  {makeRef("ref")},
                  SUCCESS(customRefExpected(json::Json {R"({"country_name": "Country"})"}))),
         MapDepsT(R"({"ref": "1.2.3.4"})",
-                 geo::getBuilderHandlerResult(false, false, false, false, false, true, false, false, false),
+                 geo::getBuilderHandlerResult(false, false, false, false, false, true, false, false, false, false, false),
                  {makeRef("ref")},
                  SUCCESS(customRefExpected(json::Json {R"({"location": {"lat": 1.23}})"}))),
         MapDepsT(R"({"ref": "1.2.3.4"})",
-                 geo::getBuilderHandlerResult(false, false, false, false, false, false, true, false, false),
+                 geo::getBuilderHandlerResult(false, false, false, false, false, false, true, false, false, false, false),
                  {makeRef("ref")},
                  SUCCESS(customRefExpected(json::Json {R"({"location": {"lon": 4.56}})"}))),
         MapDepsT(R"({"ref": "1.2.3.4"})",
-                 geo::getBuilderHandlerResult(false, false, false, false, false, false, false, true, false),
+                 geo::getBuilderHandlerResult(false, false, false, false, false, false, false, true, false, false, false),
                  {makeRef("ref")},
                  SUCCESS(customRefExpected(json::Json {R"({"postal_code": "12345"})"}))),
         MapDepsT(R"({"ref": "1.2.3.4"})",
-                 geo::getBuilderHandlerResult(false, false, false, false, false, false, false, false, true),
+                 geo::getBuilderHandlerResult(false, false, false, false, false, false, false, false, true, false, false),
                  {makeRef("ref")},
                  SUCCESS(customRefExpected(json::Json {R"({"timezone": "TZ"})"}))),
         MapDepsT(R"({"ref": "1.2.3.4"})",
-                 geo::getBuilderHandlerResult(true, true, true, true, true, true, true, true, true),
+                 geo::getBuilderHandlerResult(false, false, false, false, false, false, false, false, false, true, false),
+                {makeRef("ref")},
+                SUCCESS(customRefExpected(json::Json {R"({"region_iso_code": "RC"})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                geo::getBuilderHandlerResult(false, false, false, false, false, false, false, false, false, false, true),
+                {makeRef("ref")},
+                SUCCESS(customRefExpected(json::Json {R"({"region_name": "Region"})"}))),
+        MapDepsT(R"({"ref": "1.2.3.4"})",
+                 geo::getBuilderHandlerResult(true, true, true, true, true, true, true, true, true, true, true),
                  {makeRef("ref")},
                  SUCCESS(customRefExpected(json::Json {R"(
                     {
@@ -483,7 +514,9 @@ INSTANTIATE_TEST_SUITE_P(
                             "lon": 4.56
                         },
                         "postal_code": "12345",
-                        "timezone": "TZ"
+                        "timezone": "TZ",
+                        "region_iso_code": "RC",
+                        "region_name": "Region"
                     }
                 )"})))
         // End of test values

--- a/src/engine/source/builder/test/src/unit/builders/opmap/mmdb_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opmap/mmdb_test.cpp
@@ -30,11 +30,11 @@ auto customRefExpected()
     };
 }
 
-auto expectTypeRef(schemf::Type type, bool success = false)
+auto expectTypeRef(schemf::Type type, bool expContxt = false)
 {
     return [=](const BuildersMocks& mocks)
     {
-        if (!success)
+        if (!expContxt)
         {
             EXPECT_CALL(*mocks.ctx, context());
         }
@@ -347,13 +347,13 @@ INSTANTIATE_TEST_SUITE_P(
     MapBuilderWithDepsTest,
     testing::Values(
         // Only accept a ref with a ip to map an object
-        MapDepsT({}, geo::getBuilderNoHandler(), FAILURE(expectContext())),
-        MapDepsT({makeValue(R"("value")")}, geo::getBuilderNoHandler(), FAILURE(expectContext())),
-        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::TEXT))),
-        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::KEYWORD))),
-        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::INTEGER))),
-        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::OBJECT))),
-        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::NESTED))),
+        MapDepsT({}, geo::getBuilderNoHandler(), FAILURE()),
+        MapDepsT({makeValue(R"("value")")}, geo::getBuilderNoHandler(), FAILURE()),
+        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::TEXT, true))),
+        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::KEYWORD, true))),
+        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::INTEGER, true))),
+        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::OBJECT, true))),
+        MapDepsT({makeRef("ref")}, geo::getBuilderNoHandler(), FAILURE(expectTypeRef(schemf::Type::NESTED, true))),
         MapDepsT({makeRef("ref")}, geo::getBuilderWHandler(), SUCCESS(customRefExpected())),
         // #TODO: Fail Handler, Temporary error handling, this should be mandatory
         MapDepsT({makeRef("ref")}, geo::getBuilderWHandler(), SUCCESS(expectTypeRef(schemf::Type::IP, true))),

--- a/src/engine/source/cmds/CMakeLists.txt
+++ b/src/engine/source/cmds/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(cmds
     conf::iconf
     eMessages
     metrics
+    mmdb::mmdb
     schemf
     schemval
     wdb

--- a/src/engine/source/cmds/src/defaultSettings.hpp
+++ b/src/engine/source/cmds/src/defaultSettings.hpp
@@ -48,6 +48,13 @@ constexpr auto ENGINE_KVDB_CLI_RECORDS = 50;
 constexpr auto ENGINE_ROUTER_THREADS = 1;
 constexpr auto ENGINE_ROUTER_THREADS_ENV = "WZE_ROUTER_THREADS";
 
+// Maxmind module
+constexpr auto ENGINE_MMDB_ASN_PATH = "";
+constexpr auto ENGINE_MMDB_ASN_PATH_ENV = "WZE_MMDB_ASN_PATH";
+
+constexpr auto ENGINE_MMDB_CITY_PATH = "";
+constexpr auto ENGINE_MMDB_CITY_PATH_ENV = "WZE_MMDB_CITY_PATH";
+
 // Queue Module
 constexpr auto ENGINE_QUEUE_SIZE = 1000000;
 constexpr auto ENGINE_QUEUE_SIZE_ENV = "WZE_QUEUE_SIZE";

--- a/src/engine/source/cmds/src/start.cpp
+++ b/src/engine/source/cmds/src/start.cpp
@@ -33,7 +33,7 @@
 #include <queue/concurrentQueue.hpp>
 #include <rbac/rbac.hpp>
 #include <router/orchestrator.hpp>
-
+#include <mmdb/manager.hpp>
 #include <schemf/schema.hpp>
 #include <schemval/validator.hpp>
 #include <server/endpoints/unixDatagram.hpp> // Event
@@ -74,6 +74,10 @@ struct Options
     std::string fileStorage;
     // KVDB
     std::string kvdbPath;
+    // Maxmind db paths
+    std::string mmdbASNPath;
+    std::string mmdbCityPath;
+    // Orchestration
     int routerThreads;
     // Queue
     int queueSize;
@@ -141,6 +145,10 @@ void runStart(ConfHandler confManager)
     // KVDB config
     const auto kvdbPath = confManager->get<std::string>("server.kvdb_path");
 
+    // Maxmind db paths
+    const auto mmdbASNPath = confManager->get<std::string>("server.mmdb_asn_path");
+    const auto mmdbCityPath = confManager->get<std::string>("server.mmdb_city_path");
+
     // Router Config
     const auto routerThreads = confManager->get<int>("server.router_threads");
 
@@ -180,6 +188,7 @@ void runStart(ConfHandler confManager)
     std::shared_ptr<hlp::logpar::Logpar> logpar;
     std::shared_ptr<kvdbManager::KVDBManager> kvdbManager;
     std::shared_ptr<metricsManager::MetricsManager> metrics;
+    std::shared_ptr<mmdb::Manager> mmdbManager;
     std::shared_ptr<schemf::Schema> schema;
     std::shared_ptr<sockiface::UnixSocketFactory> sockFactory;
     std::shared_ptr<wazuhdb::WDBManager> wdbManager;
@@ -215,6 +224,39 @@ void runStart(ConfHandler confManager)
                     kvdbManager->finalize();
                     LOG_INFO("KVDB terminated.");
                 });
+        }
+
+        // MMDB
+        {
+            // TODO: This is a optional right now, but it be mandatory in the future
+            mmdbManager = std::make_shared<mmdb::Manager>();
+            if (!mmdbASNPath.empty())
+            {
+                LOG_INFO("Loading ASN MMDB database from: {}", mmdbASNPath);
+                mmdbManager->addHandler("mm-geolite2-asn", mmdbASNPath);
+            }
+            else
+            {
+                LOG_WARNING("ASN MMDB database path is empty, MMDB will not be available.");
+            }
+
+            if (!mmdbCityPath.empty())
+            {
+                LOG_INFO("Loading City MMDB database from: {}", mmdbCityPath);
+                mmdbManager->addHandler("mm-geolite2-city", mmdbCityPath);
+            }
+            else
+            {
+                LOG_WARNING("City MMDB database path is empty, MMDB will not be available.");
+            }
+            if (!mmdbASNPath.empty() || !mmdbCityPath.empty())
+            {
+                LOG_INFO("MMDB initialized.");
+            }
+            else
+            {
+                LOG_WARNING("MMDB not initialized.");
+            }
         }
 
         // Schema
@@ -263,6 +305,7 @@ void runStart(ConfHandler confManager)
             builderDeps.sockFactory = std::make_shared<sockiface::UnixSocketFactory>();
             builderDeps.wdbManager =
                 std::make_shared<wazuhdb::WDBManager>(std::string(wazuhdb::WDB_SOCK_PATH), builderDeps.sockFactory);
+            builderDeps.mmdbManager = mmdbManager;
             auto defs = std::make_shared<defs::DefinitionsBuilder>();
             auto schemaValidator = std::make_shared<schemval::Validator>(schema);
             builder = std::make_shared<builder::Builder>(store, schema, defs, schemaValidator, builderDeps);
@@ -486,6 +529,21 @@ void configure(CLI::App_p app)
         ->default_val(ENGINE_KVDB_PATH)
         ->check(CLI::ExistingDirectory)
         ->envname(ENGINE_KVDB_PATH_ENV);
+
+    // Maxmind db paths
+    serverApp
+        ->add_option(
+            "--mmdb_asn_path", options->mmdbASNPath, "Sets the path to the Maxmind ASN database in mmdb format.")
+        ->default_val(ENGINE_MMDB_ASN_PATH)
+        ->check(CLI::ExistingFile)
+        ->envname(ENGINE_MMDB_ASN_PATH_ENV);
+
+    serverApp
+        ->add_option(
+            "--mmdb_city_path", options->mmdbCityPath, "Sets the path to the Maxmind City database in mmdb format.")
+        ->default_val(ENGINE_MMDB_CITY_PATH)
+        ->check(CLI::ExistingFile)
+        ->envname(ENGINE_MMDB_CITY_PATH_ENV);
 
     // Router module
     serverApp

--- a/src/engine/source/mmdb/CMakeLists.txt
+++ b/src/engine/source/mmdb/CMakeLists.txt
@@ -55,16 +55,16 @@ if(ENGINE_BUILD_TEST)
     set(MMDB_PATH_TEST "${TEST_SRC_DIR}/testdb.mmdb")
 
     # Mocks
-    # add_library(mmdb_mocks INTERFACE)
-    # target_include_directories(mmdb_mocks INTERFACE ${TEST_MOCK_DIR})
-    # target_link_libraries(mmdb_mocks INTERFACE gmock mmdb::immdb)
-    # add_library(mmdb::mocks ALIAS mmdb_mocks)
+    add_library(mmdb_mocks INTERFACE)
+    target_include_directories(mmdb_mocks INTERFACE ${TEST_MOCK_DIR})
+    target_link_libraries(mmdb_mocks INTERFACE gmock mmdb::immdb)
+    add_library(mmdb::mocks ALIAS mmdb_mocks)
 
     # mmdb component test
     add_executable(mmdb_ctest
         ${COMPONENT_SRC_DIR}/manager_test.cpp
         ${COMPONENT_SRC_DIR}/handler_test.cpp
-        #${COMPONENT_SRC_DIR}/result_test.cpp
+        ${COMPONENT_SRC_DIR}/result_test.cpp
     )
     target_include_directories(mmdb_ctest PRIVATE ${SRC_DIR})
     target_link_libraries(mmdb_ctest

--- a/src/engine/source/mmdb/CMakeLists.txt
+++ b/src/engine/source/mmdb/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(mmdb::immdb ALIAS mmdb_immdb)
 add_library(mmdb_mmdb STATIC
     ${SRC_DIR}/result.cpp
     ${SRC_DIR}/handler.cpp
+    ${SRC_DIR}/manager.cpp
 )
 
 

--- a/src/engine/source/mmdb/CMakeLists.txt
+++ b/src/engine/source/mmdb/CMakeLists.txt
@@ -61,15 +61,23 @@ if(ENGINE_BUILD_TEST)
     # add_library(mmdb::mocks ALIAS mmdb_mocks)
 
     # mmdb component test
-    # add_executable(mmdb_ctest
-    #     ${COMPONENT_SRC_DIR}/mmdb_test.cpp
-    # )
-    # target_include_directories(mmdb_ctest PRIVATE ${SRC_DIR})
-    # target_link_libraries(mmdb_ctest
-    #     gtest_main
-    #     base
-    #     mmdb::mmdb
-    # )
+    add_executable(mmdb_ctest
+        ${COMPONENT_SRC_DIR}/manager_test.cpp
+        ${COMPONENT_SRC_DIR}/handler_test.cpp
+        #${COMPONENT_SRC_DIR}/result_test.cpp
+    )
+    target_include_directories(mmdb_ctest PRIVATE ${SRC_DIR})
+    target_link_libraries(mmdb_ctest
+        PUBLIC
+        gtest_main
+        base
+        mmdb::mmdb
+
+        PRIVATE
+        maxminddb::maxminddb
+    )
+    target_compile_definitions(mmdb_ctest PRIVATE MMDB_PATH_TEST="${MMDB_PATH_TEST}")
+
 
     # mmdb unit test
     add_executable(mmdb_utest
@@ -78,8 +86,11 @@ if(ENGINE_BUILD_TEST)
     )
     target_include_directories(mmdb_utest PRIVATE ${SRC_DIR})
     target_link_libraries(mmdb_utest
+        PUBLIC
         gtest_main
         mmdb::mmdb
+
+        PRIVATE
         maxminddb::maxminddb
     )
     target_compile_definitions(mmdb_utest PRIVATE MMDB_PATH_TEST="${MMDB_PATH_TEST}")

--- a/src/engine/source/mmdb/include/mmdb/manager.hpp
+++ b/src/engine/source/mmdb/include/mmdb/manager.hpp
@@ -7,7 +7,9 @@
 
 namespace mmdb
 {
-
+/**
+ * @copydoc IManager
+ */
 class Manager : public IManager
 {
 

--- a/src/engine/source/mmdb/include/mmdb/manager.hpp
+++ b/src/engine/source/mmdb/include/mmdb/manager.hpp
@@ -1,0 +1,38 @@
+#ifndef _MMDB_MANAGER_HPP
+#define _MMDB_MANAGER_HPP
+
+#include <map>
+
+#include <mmdb/imanager.hpp>
+
+namespace mmdb
+{
+
+class Manager : public IManager
+{
+
+private:
+    std::map<std::string, std::shared_ptr<IHandler>> m_handlers; ///< The handlers managed by the manager.
+
+public:
+    Manager() = default;
+    ~Manager() = default;
+
+    /**
+     * @copydoc IManager::addHandler
+     */
+    void addHandler(const std::string& name, const std::string& mmdbPath) override;
+
+    /**
+     * @copydoc IManager::removeHandler
+     */
+    void removeHandler(const std::string& name) override;
+
+    /**
+     * @copydoc IManager::getHandler
+     */
+    base::RespOrError<std::shared_ptr<IHandler>> getHandler(const std::string& name) const override;
+};
+} // namespace mmdb
+
+#endif // _MMDB_MANAGER_HPP

--- a/src/engine/source/mmdb/interface/mmdb/ihandler.hpp
+++ b/src/engine/source/mmdb/interface/mmdb/ihandler.hpp
@@ -23,7 +23,7 @@ class IHandler
          * @brief Search a IP address in the MMDB database.
          *
          * @param ip The IP address to search.
-         * @return A MMDBResult object containing the result of the search.
+         * @return A Result object containing the result of the search.
          */
         virtual std::shared_ptr<IResult> lookup(const std::string& ip) const = 0;
 };

--- a/src/engine/source/mmdb/interface/mmdb/imanager.hpp
+++ b/src/engine/source/mmdb/interface/mmdb/imanager.hpp
@@ -1,0 +1,47 @@
+#ifndef _MMDB_IMANAGER_HPP
+#define _MMDB_IMANAGER_HPP
+#include <memory>
+#include <string>
+
+#include <error.hpp>
+
+#include <mmdb/ihandler.hpp>
+
+namespace mmdb
+{
+/**
+ * @brief A manager for MMDB handlers, which are used to look up IP addresses in MMDB databases.
+ * The manager is responsible for creating and managing the handlers.
+ * @see IHandler
+ * @note thread-safe if is compiled with free and malloc thread-safe
+ */
+class IManager
+{
+
+public:
+    virtual ~IManager() = default;
+
+    /**
+     * @brief Add a new handler to the manager.
+     * @param name The name of the handler.
+     * @param mmdbPath The path to the MMDB database.
+     * @throw if the handler already exists or cannot be created.
+     */
+    virtual void addHandler(const std::string& name, const std::string& mmdbPath) = 0;
+
+    /**
+     * @brief Remove a handler from the manager if it exists.
+     * @param name The name of the handler to remove.
+     */
+    virtual void removeHandler(const std::string& name) = 0;
+
+    /**
+     * @brief Get a handler from the manager.
+     * @param name The name of the handler to get.
+     * @return The handler if it exists or an error if it does not.
+     */
+    virtual base::RespOrError<std::shared_ptr<IHandler>> getHandler(const std::string& name) const = 0;
+};
+} // namespace mmdb
+
+#endif // _MMDB_IMANAGER_HPP

--- a/src/engine/source/mmdb/interface/mmdb/imanager.hpp
+++ b/src/engine/source/mmdb/interface/mmdb/imanager.hpp
@@ -12,6 +12,11 @@ namespace mmdb
 /**
  * @brief A manager for MMDB handlers, which are used to look up IP addresses in MMDB databases.
  * The manager is responsible for creating and managing the handlers.
+ *
+ * mmdb is the module that provides the interface to the MaxMind DB file format, offered by MaxMind Inc.
+ * https://www.maxmind.com
+ * This module also uses the MaxMind DB C library, which is a C library for reading MaxMind DB files.
+ * https://maxmind.github.io/libmaxminddb/
  * @see IHandler
  * @note thread-safe if is compiled with free and malloc thread-safe
  */

--- a/src/engine/source/mmdb/src/handler.cpp
+++ b/src/engine/source/mmdb/src/handler.cpp
@@ -1,3 +1,5 @@
+#include <logging/logging.hpp>
+
 #include "handler.hpp"
 
 namespace mmdb
@@ -24,6 +26,7 @@ void Handler::close()
 {
     if (isOpen)
     {
+        LOG_DEBUG("Closing {} database", dbPath);
         MMDB_close(mmdb.get());
         isOpen = false;
     }
@@ -41,21 +44,21 @@ std::shared_ptr<IResult> Handler::lookup(const std::string& ipStr) const
 
     if (0 != gai_error) // translation error
     {
-        std::string msg {"Error from getaddrinfo for "};
+        std::string msg {"Error translating IP address "};
         msg += ipStr;
         msg += ": ";
         msg += gai_strerror(gai_error);
         throw std::runtime_error(msg);
     }
 
-    if (MMDB_SUCCESS != mmdb_error) // libmaxminddb error
+    if (MMDB_SUCCESS != mmdb_error) // libmaxminddb error, should not happen
     {
-        std::string msg {"Got an error from libmaxminddb: "};
+        std::string msg {"Error from libmaxminddb: "};
         msg += MMDB_strerror(mmdb_error);
         throw std::runtime_error(msg);
     }
 
-    return std::make_shared<MMDBResult>(result);
+    return std::make_shared<Result>(result);
 }
 
 } // namespace mmdb

--- a/src/engine/source/mmdb/src/manager.cpp
+++ b/src/engine/source/mmdb/src/manager.cpp
@@ -1,0 +1,43 @@
+#include <mmdb/manager.hpp>
+
+#include "handler.hpp"
+
+namespace mmdb
+{
+
+void Manager::addHandler(const std::string& name, const std::string& mmdbPath) 
+{
+    if (m_handlers.find(name) != m_handlers.end())
+    {
+        throw std::runtime_error {"Handler already exists"};
+    }
+    if (mmdbPath.empty())
+    {
+        throw std::runtime_error {"MMDB path is empty"};
+    }
+
+    auto handler = std::make_shared<Handler>(mmdbPath);
+    auto error = handler->open();
+    if (error)
+    {
+        throw std::runtime_error {error->message};
+    }
+    m_handlers[name] = handler;
+}
+
+void Manager::removeHandler(const std::string& name) 
+{
+    m_handlers.erase(name);
+}
+
+base::RespOrError<std::shared_ptr<IHandler>> Manager::getHandler(const std::string& name) const 
+{
+    auto it = m_handlers.find(name);
+    if (it == m_handlers.end())
+    {
+        return base::Error {"Handler does not exist"};
+    }
+    return it->second;
+}
+
+} // namespace mmdb

--- a/src/engine/source/mmdb/src/result.cpp
+++ b/src/engine/source/mmdb/src/result.cpp
@@ -240,7 +240,7 @@ MMDB_entry_data_list_s* dumpEntryDataList(MMDB_entry_data_list_s* eDataList, jso
 
 } // namespace
 
-base::RespOrError<MMDB_entry_data_s> MMDBResult::getEData(const DotPath& path) const
+base::RespOrError<MMDB_entry_data_s> Result::getEData(const DotPath& path) const
 {
     if (!m_result.found_entry)
     {
@@ -262,7 +262,7 @@ base::RespOrError<MMDB_entry_data_s> MMDBResult::getEData(const DotPath& path) c
 /*******************************************************************************
  *                             DUMP METHODS
  ******************************************************************************/
-json::Json MMDBResult::mmDump() const
+json::Json Result::mmDump() const
 {
     if (!m_result.found_entry)
     {
@@ -284,7 +284,7 @@ json::Json MMDBResult::mmDump() const
 /*******************************************************************************
  *                              GET VALUE METHODS
  ******************************************************************************/
-base::RespOrError<std::string> MMDBResult::getString(const DotPath& path) const
+base::RespOrError<std::string> Result::getString(const DotPath& path) const
 {
     auto eDataRes = getEData(path);
     if (base::isError(eDataRes))
@@ -301,7 +301,7 @@ base::RespOrError<std::string> MMDBResult::getString(const DotPath& path) const
     return std::string {eData.utf8_string, eData.data_size};
 }
 
-base::RespOrError<uint32_t> MMDBResult::getUint32(const DotPath& path) const
+base::RespOrError<uint32_t> Result::getUint32(const DotPath& path) const
 {
     auto eDataRes = getEData(path);
     if (base::isError(eDataRes))
@@ -318,7 +318,7 @@ base::RespOrError<uint32_t> MMDBResult::getUint32(const DotPath& path) const
     return eData.uint32;
 }
 
-base::RespOrError<double> MMDBResult::getDouble(const DotPath& path) const
+base::RespOrError<double> Result::getDouble(const DotPath& path) const
 {
     auto eDataRes = getEData(path);
     if (base::isError(eDataRes))
@@ -335,7 +335,7 @@ base::RespOrError<double> MMDBResult::getDouble(const DotPath& path) const
     return eData.double_value;
 }
 
-base::RespOrError<json::Json> MMDBResult::getAsJson(const DotPath& path) const
+base::RespOrError<json::Json> Result::getAsJson(const DotPath& path) const
 {
     auto eDataRes = getEData(path);
     if (base::isError(eDataRes))

--- a/src/engine/source/mmdb/src/result.cpp
+++ b/src/engine/source/mmdb/src/result.cpp
@@ -278,6 +278,7 @@ json::Json Result::mmDump() const
 
     json::Json jDump {};
     dumpEntryDataList(eDataList, jDump, "");
+    MMDB_free_entry_data_list(eDataList);
     return jDump;
 }
 

--- a/src/engine/source/mmdb/src/result.hpp
+++ b/src/engine/source/mmdb/src/result.hpp
@@ -11,7 +11,7 @@
 namespace mmdb
 {
 
-class MMDBResult : public IResult
+class Result : public IResult
 {
 private:
     MMDB_lookup_result_s m_result; ///< The MMDB lookup result.
@@ -24,12 +24,12 @@ private:
     base::RespOrError<MMDB_entry_data_s> getEData(const DotPath& path) const;
 
 public:
-    MMDBResult(MMDB_lookup_result_s result)
+    Result(MMDB_lookup_result_s result)
         : m_result(result)
     {
     }
 
-    ~MMDBResult()
+    ~Result()
     {
         // MMDB_free_entry_data_list(result.entry_data_list);
     }

--- a/src/engine/source/mmdb/src/result.hpp
+++ b/src/engine/source/mmdb/src/result.hpp
@@ -29,10 +29,7 @@ public:
     {
     }
 
-    ~Result()
-    {
-        // MMDB_free_entry_data_list(result.entry_data_list);
-    }
+    ~Result() = default;
 
     /**
      * @copydoc IResult::hasData()

--- a/src/engine/source/mmdb/test/mocks/mmdb/mockHandler.hpp
+++ b/src/engine/source/mmdb/test/mocks/mmdb/mockHandler.hpp
@@ -1,0 +1,18 @@
+#ifndef _MMDB_MOCK_HANDLER_HPP
+#define _MMDB_MOCK_HANDLER_HPP
+
+#include <gmock/gmock.h>
+
+#include <mmdb/ihandler.hpp>
+
+namespace mmdb
+{
+class MockHandler : public IHandler
+{
+public:
+    MOCK_METHOD(bool, isAvailable, (), (const, override));
+    MOCK_METHOD(std::shared_ptr<IResult>, lookup, (const std::string& ip), (const, override));
+};
+} // namespace mmdb
+
+#endif // _MMDB_MOCK_HANDLER_HPP

--- a/src/engine/source/mmdb/test/mocks/mmdb/mockManager.hpp
+++ b/src/engine/source/mmdb/test/mocks/mmdb/mockManager.hpp
@@ -1,0 +1,19 @@
+#ifndef _MMDB_MOCK_MANAGER_HPP
+#define _MMDB_MOCK_MANAGER_HPP
+
+#include <gmock/gmock.h>
+
+#include <mmdb/mockManager.hpp>
+
+namespace mmdb
+{
+class MockManager : public IManager
+{
+public:
+    MOCK_METHOD(void, addHandler, (const std::string& name, const std::string& mmdbPath), (override));
+    MOCK_METHOD(void, removeHandler, (const std::string& name), (override));
+    MOCK_METHOD(base::RespOrError<std::shared_ptr<IHandler>>, getHandler, (const std::string& name), (const, override));
+};
+} // namespace mmdb
+
+#endif // _MMDB_MOCK_MANAGER_HPP

--- a/src/engine/source/mmdb/test/mocks/mmdb/mockResult.hpp
+++ b/src/engine/source/mmdb/test/mocks/mmdb/mockResult.hpp
@@ -1,0 +1,21 @@
+#ifndef _MMDB_MOCK_RESULT_HPP
+#define _MMDB_MOCK_RESULT_HPP
+
+#include <gmock/gmock.h>
+
+#include <mmdb/iresult.hpp>
+
+namespace mmdb
+{
+class MockResult : public IResult
+{
+public:
+    MOCK_METHOD(bool, hasData, (), (const, override));
+    MOCK_METHOD(base::RespOrError<std::string>, getString, (const DotPath& path), (const, override));
+    MOCK_METHOD(base::RespOrError<uint32_t>, getUint32, (const DotPath& path), (const, override));
+    MOCK_METHOD(base::RespOrError<double>, getDouble, (const DotPath& path), (const, override));
+    MOCK_METHOD(base::RespOrError<json::Json>, getAsJson, (const DotPath& path), (const, override));
+};
+} // namespace mmdb
+
+#endif // _MMDB_MOCK_RESULT_HPP

--- a/src/engine/source/mmdb/test/mocks/mmdb/mockResult.hpp
+++ b/src/engine/source/mmdb/test/mocks/mmdb/mockResult.hpp
@@ -15,6 +15,7 @@ public:
     MOCK_METHOD(base::RespOrError<uint32_t>, getUint32, (const DotPath& path), (const, override));
     MOCK_METHOD(base::RespOrError<double>, getDouble, (const DotPath& path), (const, override));
     MOCK_METHOD(base::RespOrError<json::Json>, getAsJson, (const DotPath& path), (const, override));
+    MOCK_METHOD(json::Json, mmDump, (), (const, override));
 };
 } // namespace mmdb
 

--- a/src/engine/source/mmdb/test/src/component/handler_test.cpp
+++ b/src/engine/source/mmdb/test/src/component/handler_test.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+
+#include <logging/logging.hpp>
+
+#include <mmdb/manager.hpp>
+
+class HandlerTest : public ::testing::Test
+{
+protected:
+    std::shared_ptr<mmdb::IHandler> m_handler;
+    const std::string ipFullData {"1.2.3.4"};
+    const std::string ipMinimalData {"1.2.3.5"};
+    const std::string ipNotFound {"1.2.3.6"};
+
+    void SetUp() override
+    {
+        logging::testInit();
+        mmdb::Manager manager;
+        ASSERT_NO_THROW(manager.addHandler("test", MMDB_PATH_TEST));
+        m_handler = base::getResponse(manager.getHandler("test"));
+    }
+};
+
+TEST_F(HandlerTest, isAvailable)
+{
+    ASSERT_TRUE(m_handler->isAvailable());
+}
+
+TEST_F(HandlerTest, lookupOk)
+{
+    ASSERT_TRUE(m_handler->lookup(ipFullData)->hasData());
+    ASSERT_TRUE(m_handler->lookup(ipMinimalData)->hasData());
+    ASSERT_FALSE(m_handler->lookup(ipNotFound)->hasData());
+    ASSERT_THROW(m_handler->lookup("invalid_ip"), std::runtime_error);
+}

--- a/src/engine/source/mmdb/test/src/component/manager_test.cpp
+++ b/src/engine/source/mmdb/test/src/component/manager_test.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include <logging/logging.hpp>
+
+#include <mmdb/manager.hpp>
+
+namespace
+{
+const std::string g_maxmindDbPath {MMDB_PATH_TEST};
+} // namespace
+
+class ManagerTest : public ::testing::Test
+{
+protected:
+    void SetUp() override { logging::testInit(); }
+};
+
+TEST_F(ManagerTest, create)
+{
+    ASSERT_NO_THROW(mmdb::Manager manager);
+}
+
+TEST_F(ManagerTest, addHandler)
+{
+    mmdb::Manager manager;
+    ASSERT_NO_THROW(manager.addHandler("test", g_maxmindDbPath));                  // OK
+    ASSERT_THROW(manager.addHandler("test", g_maxmindDbPath), std::runtime_error); // Handler already exists
+}
+
+TEST_F(ManagerTest, removeHandler)
+{
+    mmdb::Manager manager;
+    manager.addHandler("test", g_maxmindDbPath);
+    ASSERT_NO_THROW(manager.removeHandler("test")); // OK
+    ASSERT_NO_THROW(manager.removeHandler("test")); // OK, handler does not exist but it is not an error
+}
+
+TEST_F(ManagerTest, getHandler)
+{
+    mmdb::Manager manager;
+    manager.addHandler("test", g_maxmindDbPath);
+    auto handler = manager.getHandler("test");
+    ASSERT_FALSE(base::isError(handler));
+    ASSERT_TRUE(base::getResponse(handler) != nullptr);
+    handler = manager.getHandler("test2");
+
+    ASSERT_TRUE(base::isError(handler));
+    ASSERT_EQ(base::getError(handler).message, "Handler does not exist");
+}

--- a/src/engine/source/mmdb/test/src/component/result_test.cpp
+++ b/src/engine/source/mmdb/test/src/component/result_test.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 
-#include <handler.hpp>
+#include <logging/logging.hpp>
+
+#include <mmdb/manager.hpp>
+
 
 namespace
 {
@@ -54,6 +57,7 @@ protected:
         m_handler = base::getResponse(manager.getHandler("test"));
 
         m_jDumpFull = json::Json {JSON_IP_FULLDATA};
+        m_jDumpFull.setFloat(122.0838, "/test_float");
         m_jDumpMinimal = json::Json  {JSON_IP_MINDATA};
     }
 };

--- a/src/engine/source/mmdb/test/src/component/result_test.cpp
+++ b/src/engine/source/mmdb/test/src/component/result_test.cpp
@@ -1,0 +1,151 @@
+#include <gtest/gtest.h>
+
+#include <handler.hpp>
+
+namespace
+{
+
+constexpr auto JSON_IP_FULLDATA {R"(
+{
+  "test_array": [
+    "a",
+    "b",
+    "c"
+  ],
+  "test_boolean": true,
+  "test_bytes": "abcd",
+  "test_double": 37.386,
+  "test_map": {
+    "test_str1": "Wazuh",
+    "test_str2": "Wazuh2"
+  },
+  "test_uint128": "0x0000000000000000ab54a98ceb1f0ad2",
+  "test_uint16": 123,
+  "test_uint32": 94043,
+  "test_uint64": "1234567890"
+}
+)"};
+
+constexpr auto JSON_IP_MINDATA  {R"(
+{
+  "test_map": {
+    "test_str1": "Missing values"
+  }
+}
+)"};
+
+class ResultTest : public ::testing::Test
+{
+protected:
+    std::shared_ptr<mmdb::IHandler> m_handler;
+
+    const std::string m_ipFullData {"1.2.3.4"};
+    const std::string m_ipMinimalData {"1.2.3.5"};
+    const std::string m_ipNotFound {"1.2.3.6"};
+
+    json::Json m_jDumpFull {};
+    json::Json m_jDumpMinimal {};
+
+    void SetUp() override
+    {
+        logging::testInit();
+        mmdb::Manager manager;
+        ASSERT_NO_THROW(manager.addHandler("test", MMDB_PATH_TEST));
+        m_handler = base::getResponse(manager.getHandler("test"));
+
+        m_jDumpFull = json::Json {JSON_IP_FULLDATA};
+        m_jDumpMinimal = json::Json  {JSON_IP_MINDATA};
+    }
+};
+
+} // namespace
+TEST_F(ResultTest, hasData)
+{
+    ASSERT_TRUE(m_handler->lookup(m_ipFullData)->hasData());
+    ASSERT_TRUE(m_handler->lookup(m_ipMinimalData)->hasData());
+    ASSERT_FALSE(m_handler->lookup(m_ipNotFound)->hasData());
+}
+
+TEST_F(ResultTest, mmdump)
+{
+    ASSERT_EQ(m_handler->lookup(m_ipFullData)->mmDump(), m_jDumpFull);
+    ASSERT_EQ(m_handler->lookup(m_ipMinimalData)->mmDump(), m_jDumpMinimal);
+    ASSERT_EQ(m_handler->lookup(m_ipNotFound)->mmDump(), json::Json {});
+}
+
+TEST_F(ResultTest, getString)
+{
+
+    auto res = m_handler->lookup(m_ipFullData)->getString("test_map.test_str2");
+    ASSERT_FALSE(base::isError(res));
+    ASSERT_EQ(base::getResponse(res), "Wazuh2");
+    res = m_handler->lookup(m_ipMinimalData)->getString("test_map.test_str2");
+    ASSERT_TRUE(base::isError(res));
+}
+
+TEST_F(ResultTest, getUint32)
+{
+    auto res = m_handler->lookup(m_ipFullData)->getUint32("test_uint32");
+    ASSERT_FALSE(base::isError(res));
+    ASSERT_EQ(base::getResponse(res), 94043);
+    res = m_handler->lookup(m_ipMinimalData)->getUint32("test_uint32");
+    ASSERT_TRUE(base::isError(res));
+}
+
+TEST_F(ResultTest, getDouble)
+{
+    auto res = m_handler->lookup(m_ipFullData)->getDouble("test_double");
+    ASSERT_FALSE(base::isError(res));
+    ASSERT_EQ(base::getResponse(res), 37.386);
+    res = m_handler->lookup(m_ipMinimalData)->getDouble("test_double");
+    ASSERT_TRUE(base::isError(res));
+}
+
+TEST_F(ResultTest, getAsJson)
+{
+    auto res = m_handler->lookup(m_ipFullData);
+    ASSERT_TRUE(res->hasData());
+
+    // No support for arrays and maps
+    auto j = res->getAsJson("test_array");
+    ASSERT_TRUE(base::isError(j));
+
+    j = res->getAsJson("test_map");
+    ASSERT_TRUE(base::isError(j));
+
+    // Supported types
+    // Boolean
+    j = res->getAsJson("test_boolean");
+    ASSERT_FALSE(base::isError(j));
+    ASSERT_EQ(base::getResponse(j), json::Json {"true"});
+
+    // Bytes
+    j = res->getAsJson("test_bytes");
+    ASSERT_FALSE(base::isError(j));
+    ASSERT_EQ(base::getResponse(j), json::Json {R"("abcd")"});
+
+    // Double
+    j = res->getAsJson("test_double");
+    ASSERT_FALSE(base::isError(j));
+    ASSERT_EQ(base::getResponse(j), json::Json {"37.386"});
+
+    // Uint128
+    j = res->getAsJson("test_uint128");
+    ASSERT_FALSE(base::isError(j));
+    ASSERT_EQ(base::getResponse(j), json::Json {R"("0x0000000000000000ab54a98ceb1f0ad2")"});
+
+    // Uint16
+    j = res->getAsJson("test_uint16");
+    ASSERT_FALSE(base::isError(j));
+    ASSERT_EQ(base::getResponse(j), json::Json {"123"});
+
+    // Uint32
+    j = res->getAsJson("test_uint32");
+    ASSERT_FALSE(base::isError(j));
+    ASSERT_EQ(base::getResponse(j), json::Json {"94043"});
+
+    // Uint64
+    j = res->getAsJson("test_uint64");
+    ASSERT_FALSE(base::isError(j));
+    ASSERT_EQ(base::getResponse(j), json::Json {R"("1234567890")"});
+}

--- a/src/engine/source/mmdb/test/src/unit/handler_test.cpp
+++ b/src/engine/source/mmdb/test/src/unit/handler_test.cpp
@@ -8,9 +8,18 @@ const std::string g_maxmindDbPath {MMDB_PATH_TEST};
 const std::string g_ipFullData {"1.2.3.4"};
 const std::string g_ipMinimalData {"1.2.3.5"};
 const std::string g_ipNotFound {"1.2.3.6"};
-}
+} // namespace
 
-TEST(HandlerTest, openOk)
+class HandlerTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        logging::testInit();
+    }
+};
+
+TEST_F(HandlerTest, openOk)
 {
     mmdb::Handler handler(g_maxmindDbPath);
     ASSERT_FALSE(handler.isAvailable());
@@ -19,7 +28,7 @@ TEST(HandlerTest, openOk)
     ASSERT_TRUE(handler.isAvailable());
 }
 
-TEST(HandlerTest, openFail)
+TEST_F(HandlerTest, openFail)
 {
     mmdb::Handler handler("invalid_path");
     ASSERT_FALSE(handler.isAvailable());
@@ -28,7 +37,7 @@ TEST(HandlerTest, openFail)
     ASSERT_FALSE(handler.isAvailable());
 }
 
-TEST(HandlerTest, close)
+TEST_F(HandlerTest, close)
 {
     mmdb::Handler handler(g_maxmindDbPath);
     ASSERT_FALSE(handler.isAvailable());
@@ -39,7 +48,7 @@ TEST(HandlerTest, close)
     ASSERT_FALSE(handler.isAvailable());
 }
 
-TEST(HandlerTest, lookupOk)
+TEST_F(HandlerTest, lookupOk)
 {
     mmdb::Handler handler(g_maxmindDbPath);
     auto error = handler.open();

--- a/src/engine/source/mmdb/test/src/unit/result_test.cpp
+++ b/src/engine/source/mmdb/test/src/unit/result_test.cpp
@@ -150,3 +150,10 @@ TEST_F(ResultTest, getAsJson)
     ASSERT_FALSE(base::isError(j));
     ASSERT_EQ(base::getResponse(j), json::Json {R"("1234567890")"});
 }
+
+TEST_F(ResultTest, getArrayStr)
+{
+    auto res = m_handler->lookup(g_ipFullData)->getString("test_array.0");
+    ASSERT_FALSE(base::isError(res));
+    ASSERT_EQ(base::getResponse(res), "a");
+}

--- a/src/engine/source/mmdb/test/src/unit/result_test.cpp
+++ b/src/engine/source/mmdb/test/src/unit/result_test.cpp
@@ -45,6 +45,7 @@ protected:
 
     void SetUp() override
     {
+        logging::testInit();
         auto handler = std::make_shared<mmdb::Handler>(g_maxmindDbPath);
         auto error = handler->open();
         if (error)

--- a/src/engine/test/source/base/ipUtils_test.cpp
+++ b/src/engine/test/source/base/ipUtils_test.cpp
@@ -30,9 +30,43 @@ TEST(IPv4ToUInt, Valid_range)
 {
     EXPECT_EQ(utils::ip::IPv4ToUInt("0.0.0.0"), 0x0);
     EXPECT_EQ(utils::ip::IPv4ToUInt("127.0.0.1"), 0x7F'00'00'01);
-    EXPECT_EQ(utils::ip::IPv4ToUInt("192.168.0.1"),
-              0b11000000'10101000'00000000'00000001);
+    EXPECT_EQ(utils::ip::IPv4ToUInt("192.168.0.1"), 0b11000000'10101000'00000000'00000001);
     EXPECT_EQ(utils::ip::IPv4ToUInt("255.255.255.255"), 0xFFFFFFFF);
+}
+
+TEST(IPv4MaskUInt, Invalid_format)
+{
+    EXPECT_THROW(utils::ip::IPv4MaskUInt(""), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("1.2"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("1.2.3"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("1.2.3.4."), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("1.2.3.255."), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("1.2.3.4.5"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt(" 1.1.1.1 "), std::invalid_argument);
+}
+
+TEST(IPv4MaskUInt, Invalid_range)
+{
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("-1.1.1.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("1.-1.1.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("1.1.-1.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("1.1.1.-1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("256.1.1.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("1.256.1.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("1.1.256.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::IPv4MaskUInt("1.1.1.256"), std::invalid_argument);
+}
+
+TEST(IPv4MaskUInt, Valid_range)
+{
+    EXPECT_EQ(utils::ip::IPv4MaskUInt("255.255.255.0"), 0xFFFFFF00);
+    EXPECT_EQ(utils::ip::IPv4MaskUInt("255.255.0.0"), 0xFFFF0000);
+    EXPECT_EQ(utils::ip::IPv4MaskUInt("255.0.0.0"), 0xFF000000);
+    EXPECT_EQ(utils::ip::IPv4MaskUInt("8"), 0xFF000000);
+    EXPECT_EQ(utils::ip::IPv4MaskUInt("16"), 0xFFFF0000);
+    EXPECT_EQ(utils::ip::IPv4MaskUInt("24"), 0xFFFFFF00);
+    EXPECT_EQ(utils::ip::IPv4MaskUInt("32"), 0xFFFFFFFF);
+    EXPECT_EQ(utils::ip::IPv4MaskUInt("0"), 0x0);
 }
 
 TEST(checkStrIsIPv4, Invalid_format)
@@ -69,8 +103,6 @@ TEST(checkStrIsIPv4, Valid_range)
     EXPECT_TRUE(utils::ip::checkStrIsIPv4("255.255.255.255"));
 }
 
-
-
 TEST(checkStrIsIPv6, Invalid_format)
 {
     EXPECT_FALSE(utils::ip::checkStrIsIPv6(""));
@@ -91,7 +123,6 @@ TEST(checkStrIsIPv6, Invalid_range)
     EXPECT_FALSE(utils::ip::checkStrIsIPv6("1:1:1:1:1:1:1:G"));
     EXPECT_FALSE(utils::ip::checkStrIsIPv6("::G"));
     EXPECT_FALSE(utils::ip::checkStrIsIPv6("56FE::2159:5BBC::6594"));
-
 
     EXPECT_FALSE(utils::ip::checkStrIsIPv6("x:x:x:x:x:x:x:x"));
     EXPECT_FALSE(utils::ip::checkStrIsIPv6("x:x:x:x:x:x:x:x"));
@@ -114,4 +145,96 @@ TEST(checkStrIsIPv6, Valid_range)
     EXPECT_TRUE(utils::ip::checkStrIsIPv6("21E5:69AA:FFFF:1:E100:B691:1285:F56E"));
     EXPECT_TRUE(utils::ip::checkStrIsIPv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
     EXPECT_TRUE(utils::ip::checkStrIsIPv6("2001:db8:85a3:0:0:8a2e:370:7334"));
+}
+
+TEST(isSpecialIPv4Address, Invalid_format)
+{
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address(""), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("1.2"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("1.2.3"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("1.2.3.4.5"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address(".1.2.3.4"), std::invalid_argument);
+}
+
+TEST(isSpecialIPv4Address, Invalid_range)
+{
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("-1.1.1.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("1.-1.1.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("1.1.-1.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("1.1.1.-1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("256.1.1.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("1.256.1.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("1.1.256.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv4Address("1.1.1.256"), std::invalid_argument);
+}
+
+TEST(isSpecialIPv4Address, Valid_range)
+{
+    EXPECT_FALSE(utils::ip::isSpecialIPv4Address("1.1.1.1"));
+    EXPECT_FALSE(utils::ip::isSpecialIPv4Address("8.8.8.8"));
+
+    EXPECT_FALSE(utils::ip::isSpecialIPv4Address("192.167.255.255"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("192.168.0.0"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("192.168.0.1"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("192.168.255.254"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("192.168.255.255"));
+    EXPECT_FALSE(utils::ip::isSpecialIPv4Address("192.169.0.0"));
+
+    EXPECT_FALSE(utils::ip::isSpecialIPv4Address("9.255.255.255"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("10.0.0.0"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("10.0.0.1"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("10.255.255.254"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("10.255.255.255"));
+    EXPECT_FALSE(utils::ip::isSpecialIPv4Address("11.0.0.0"));
+
+    EXPECT_FALSE(utils::ip::isSpecialIPv4Address("172.15.255.255"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("172.16.0.0"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("172.16.0.1"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("172.31.255.254"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv4Address("172.31.255.255"));
+    EXPECT_FALSE(utils::ip::isSpecialIPv4Address("172.32.0.0"));
+}
+
+TEST(isSpecialIPv6Address, Invalid_format)
+{
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address(""), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address("1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address("1.2"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address("1.2.3"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address(" 1.2.3.4 "), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address(".1.2.3.4."), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address("1.2.3.4."), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address(""), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address("only text"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address("1233.1.1.1"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address("x:x:x:x:x:x:x:x"), std::invalid_argument);
+}
+
+TEST(isSpecialIPv6Address, Invalid_range)
+{
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address("1:1:1:1:1:1:1:G"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address("::G"), std::invalid_argument);
+    EXPECT_THROW(utils::ip::isSpecialIPv6Address("56FE::2159:5BBC::6594"), std::invalid_argument);
+}
+
+TEST(isSpecialIPv6Address, Valid_range)
+{
+    // Loopback
+    EXPECT_TRUE(utils::ip::isSpecialIPv6Address("::1"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv6Address("fe80::"));
+    // Link-local
+    EXPECT_TRUE(utils::ip::isSpecialIPv6Address("fe80::1"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv6Address("fe80::1:1"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv6Address("fc00::"));
+    // ULA
+    EXPECT_TRUE(utils::ip::isSpecialIPv6Address("fc00::1"));
+    EXPECT_TRUE(utils::ip::isSpecialIPv6Address("fc00::1:1"));
+
+    EXPECT_FALSE(utils::ip::isSpecialIPv6Address("2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
+    EXPECT_FALSE(utils::ip::isSpecialIPv6Address("1:1:1:1:1:1:1:1"));
+    EXPECT_FALSE(utils::ip::isSpecialIPv6Address("2001:0db8:1234:0000:0000:0000:0000:0001"));
+    EXPECT_FALSE(utils::ip::isSpecialIPv6Address("2001:db8:1234::1"));
+    EXPECT_FALSE(utils::ip::isSpecialIPv6Address("2001:db8:1234:0:0:0:0:1"));
+    EXPECT_FALSE(utils::ip::isSpecialIPv6Address("2001:0db8:1234:ffff:ffff:ffff:ffff:ffff"));
 }

--- a/src/engine/tools/engine-suite/src/engine_test/integration.py
+++ b/src/engine/tools/engine-suite/src/engine_test/integration.py
@@ -151,7 +151,7 @@ class Integration(CrudIntegration):
         return response
 
     def response_to_yml(self, response):
-        response = yaml.dump(response, sort_keys=True, Dumper=EngineDumper)
+        response = yaml.dump(response, sort_keys=True, Dumper=EngineDumper, allow_unicode=True)
         return response
 
     def write_output_file(self, events_parsed):


### PR DESCRIPTION
|Related issue|
|---|
|#21703|


### Overview

This Pull Request introduces two essential helper functions, `geoip` and `as`, designed to facilitate the retrieval of geographical and autonomous system number (ASN) information from MaxMind's databases. These functions are integral to enriching events within the Wazuh-Engine, providing valuable context and enhancing analysis capabilities. Additionally, this PR integrates the MaxMind module as a dependency in the Wazuh-Engine's build process.

### Changes Introduced

- **GeoIP Helper Function (`geoip`)**: A new function that queries the MaxMind GeoIP database, returning geographical information based on IP addresses.
- **ASN Helper Function (`asn`)**: Implements functionality to fetch ASN details from the MaxMind ASN database using IP addresses.
- **Build Process Integration**: The MaxMind module is now included as a dependency in the Wazuh-Engine's build process, ensuring seamless data retrieval and module functionality.

### Implementation Details

- The `geoip` and `asn` functions are designed with performance and error handling in mind, ensuring efficient and reliable data retrieval.
- Integration of the MaxMind module into the build process follows best practices to maintain the Wazuh-Engine's performance and stability.
- Unit tests have been added to validate the functionality of the helper functions and their integration with the MaxMind databases.

### Testing and Validation

- Conducted comprehensive unit testing to ensure the accuracy and reliability of the `geoip` and `asn` functions.
- Verified the seamless integration of the MaxMind module as a dependency, ensuring no disruptions to the Wazuh-Engine's build process.

### Output

Decoder:
```yml
parents:
  - decoder/core-localfile/0

parse|event.original:
  - <message>
 
normalize:
    - map:
      - ip: $message
      - source.geo: geoip($ip)
      - source.as: as($ip)

```

output:
```yml
╰─# engine-test run -p policy/test/0 syslog -dd                  

Enter any events [ENTER to send event, CTRL+C to finish]:

1.1.1.1


---
traces:
[🟢] decoder/zz_test/0 -> success
  ↳ [/event/original: <message>] -> Success
  ↳ ip: map($message) -> Success
  ↳ [source.geo: geoip($ip)] -> Failure: Empty wcs data
  ↳ [source.as: as($ip)] -> Success

output:
  agent:
    id: '001'
    name: wazuh-agent-1
    type: wazuh-agent
  event:
    original: 1.1.1.1
  host:
    id: '001'
  ip: 1.1.1.1
  message: 1.1.1.1
  source:
    as:
      number: 13335.0
      organization:
        name: CLOUDFLARENET
  wazuh:
    isInternal: true
    location: '[001] (wazuh-agent-1) any->/tmp/syslog.log'
    origin: /tmp/syslog.log
    queue: 49.0
    registered_ip: any
    source: logcollector



Enter any events [ENTER to send event, CTRL+C to finish]:

1.1.2.2


---
traces:
[🟢] decoder/zz_test/0 -> success
  ↳ [/event/original: <message>] -> Success
  ↳ ip: map($message) -> Success
  ↳ [source.geo: geoip($ip)] -> Success
  ↳ [source.as: as($ip)] -> Failure: IP Not found in DB

output:
  agent:
    id: '001'
    name: wazuh-agent-1
    type: wazuh-agent
  event:
    original: 1.1.2.2
  host:
    id: '001'
  ip: 1.1.2.2
  message: 1.1.2.2
  source:
    geo:
      continent_code: AS
      continent_name: Asia
      country_iso_code: CN
      country_name: China
      location:
        lat: 34.7732
        lon: 113.722
      timezone: Asia/Shanghai
  wazuh:
    isInternal: true
    location: '[001] (wazuh-agent-1) any->/tmp/syslog.log'
    origin: /tmp/syslog.log
    queue: 49.0
    registered_ip: any
    source: logcollector



Enter any events [ENTER to send event, CTRL+C to finish]:

8.8.8.8


---
traces:
[🟢] decoder/zz_test/0 -> success
  ↳ [/event/original: <message>] -> Success
  ↳ ip: map($message) -> Success
  ↳ [source.geo: geoip($ip)] -> Success
  ↳ [source.as: as($ip)] -> Success

output:
  agent:
    id: '001'
    name: wazuh-agent-1
    type: wazuh-agent
  event:
    original: 8.8.8.8
  host:
    id: '001'
  ip: 8.8.8.8
  message: 8.8.8.8
  source:
    as:
      number: 15169.0
      organization:
        name: GOOGLE
    geo:
      continent_code: NA
      continent_name: North America
      country_iso_code: US
      country_name: United States
      location:
        lat: 37.751
        lon: -97.822
      timezone: America/Chicago
  wazuh:
    isInternal: true
    location: '[001] (wazuh-agent-1) any->/tmp/syslog.log'
    origin: /tmp/syslog.log
    queue: 49.0
    registered_ip: any
    source: logcollector



Enter any events [ENTER to send event, CTRL+C to finish]:

invalid_ip


---
traces:
[🟢] decoder/zz_test/0 -> success
  ↳ [/event/original: <message>] -> Success
  ↳ ip: map($message) -> Success
  ↳ [source.geo: geoip($ip)] -> Failure: IP string is not a valid IP. Error translating IP address invalid_ip: Name or service not known
  ↳ [source.as: as($ip)] -> Failure: IP string is not a valid IP. Error translating IP address invalid_ip: Name or service not known

output:
  agent:
    id: '001'
    name: wazuh-agent-1
    type: wazuh-agent
  event:
    original: invalid_ip
  host:
    id: '001'
  ip: invalid_ip
  message: invalid_ip
  wazuh:
    isInternal: true
    location: '[001] (wazuh-agent-1) any->/tmp/syslog.log'
    origin: /tmp/syslog.log
    queue: 49.0
    registered_ip: any
    source: logcollector


```

### Documentation

- Updated the developer documentation to include details on the implementation and usage of the `geoip` and `asn` helper functions.
- Provided examples and guidance on leveraging these functions for event enrichment within the Wazuh-Engine.

### Impact

- Enhances the Wazuh-Engine's event analysis capabilities by providing detailed GeoIP and ASN information.
- Streamlines the process of integrating MaxMind's databases into the Wazuh ecosystem, setting a foundation for further data enrichment features.
