### PR TITLE
Fix error on osquery configuration parsing due to signed integer over…

### DIFF
--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -587,7 +587,7 @@ char * abspath(const char * path, char * buffer, size_t size);
  * @return The content of the file
  * @retval NULL The file doesn't exist or its size exceeds the maximum allowed
  */
-char * w_get_file_content(const char * path, long max_size);
+char * w_get_file_content(const char * path, unsigned long max_size);
 
 
 /**

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -3293,7 +3293,7 @@ char * abspath(const char * path, char * buffer, size_t size) {
 }
 
 /* Return the content of a file from a given path */
-char * w_get_file_content(const char * path, long max_size) {
+char * w_get_file_content(const char * path, unsigned long max_size) {
     FILE * fp = NULL;
     char * buffer = NULL;
     long size;
@@ -3318,7 +3318,7 @@ char * w_get_file_content(const char * path, long max_size) {
     }
 
     // Check file size limit
-    if (size > max_size) {
+    if ((unsigned long)size > max_size) {
         mdebug1("Cannot load file '%s': it exceeds %ld MiB", path, (max_size / (1024 * 1024)));
         goto end;
     }


### PR DESCRIPTION
…flow

|Related issue|
|---|
|Closes #21671|

This PR aims to fix a signed integer check while reading JSON files.

The limit is set to `(long) 2147483648`, but the Windows agent (32-bit) interprets that as -2 GiB, producing an error like this:

```
2024/02/05 11:55:15 wazuh-agent[17724] file_op.c:3328 at w_get_file_content(): INFO: size = 1065, max_size = -2147483648
2024/02/05 11:59:42 wazuh-agent[18504] file_op.c:3322 at w_get_file_content(): DEBUG: Cannot load file 'C:\osquery.conf': it exceeds -2048 MiB
2024/02/05 11:59:42 wazuh-agent[18504] json_op.c:20 at json_fread(): DEBUG: Cannot get the content of the file: C:\osquery.conf
2024/02/05 11:59:42 wazuh-modulesd:osquery[18504] wm_osquery_monitor.c:562 at wm_osquery_packs(): ERROR: Couldn't load configuration file 'C:\osquery.conf'. Maybe format is invalid.
```

## Tests

- [x] The agent no longer prints that error.