### PR TITLE
Fix wpk upgrade fail in fedora 38

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -134,7 +134,7 @@ if [ -f /etc/systemd/system/${SERVICE}.service ] && [ ! -h /etc/systemd/system ]
 fi
 
 # Init backup
-# REHL <= 6 / Amazon linux
+# RHEL <= 6 / Amazon linux
 if [ -f "/etc/rc.d/init.d/${SERVICE}" ] && [ ! -h /etc/rc.d/init.d ]; then
     INIT_PATH="/etc/rc.d/init.d/${SERVICE}"
 fi
@@ -152,6 +152,7 @@ echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." >> ./logs/upgrade.log
 # Check tar dependency
 if ! which tar &> /dev/null; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - The tar package is required for this operation, exiting." >> ./logs/upgrade.log
+    echo -ne "1" > ./var/upgrade/upgrade_result
     exit 1
 fi
 

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -152,7 +152,7 @@ echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." >> ./logs/upgrade.log
 # Check tar dependency
 if ! which tar &> /dev/null; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - The tar package is required for this operation, exiting." >> ./logs/upgrade.log
-    echo -ne "1" > ./var/upgrade/upgrade_result
+    echo -ne "2" > ./var/upgrade/upgrade_result
     exit 1
 fi
 

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -149,6 +149,12 @@ mkdir -p ./backup
 
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." >> ./logs/upgrade.log
 
+# Check tar dependency
+if ! which tar &> /dev/null; then
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - The tar package is required for this operation, exiting." >> ./logs/upgrade.log
+    exit 1
+fi
+
 FOLDERS_TO_BACKUP=($WAZUH_HOME/{active-response,bin,etc,lib,queue,ruleset,wodles,agentless,logs/{ossec,wazuh},var/selinux} \
                    $OSSEC_INIT_FILE \
                    $SYSTEMD_SERVICE_UNIT_PATH \

--- a/src/init/pkg_installer_mac.sh
+++ b/src/init/pkg_installer_mac.sh
@@ -28,6 +28,12 @@ mkdir -p ./backup
 
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." >> ./logs/upgrade.log
 
+# Check tar dependency
+if ! which tar &> /dev/null; then
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - The tar package is required for this operation, exiting." >> ./logs/upgrade.log
+    exit 1
+fi
+
 FOLDERS_TO_BACKUP=($CURRENT_DIR/{active-response,bin,etc,lib,queue,ruleset,wodles,agentless,logs/{ossec,wazuh},var/selinux} \
                    /Library/LaunchDaemons/com.wazuh.agent.plist \
                    /Library/StartupItems/WAZUH)

--- a/src/init/pkg_installer_mac.sh
+++ b/src/init/pkg_installer_mac.sh
@@ -31,7 +31,7 @@ echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." >> ./logs/upgrade.log
 # Check tar dependency
 if ! which tar &> /dev/null; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - The tar package is required for this operation, exiting." >> ./logs/upgrade.log
-    echo -ne "1" > ./var/upgrade/upgrade_result
+    echo -ne "2" > ./var/upgrade/upgrade_result
     exit 1
 fi
 

--- a/src/init/pkg_installer_mac.sh
+++ b/src/init/pkg_installer_mac.sh
@@ -31,6 +31,7 @@ echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." >> ./logs/upgrade.log
 # Check tar dependency
 if ! which tar &> /dev/null; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - The tar package is required for this operation, exiting." >> ./logs/upgrade.log
+    echo -ne "1" > ./var/upgrade/upgrade_result
     exit 1
 fi
 

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
@@ -472,7 +472,7 @@ void test_wm_agent_upgrade_listen_messages_parse_error(void **state)
     cJSON_AddNumberToObject(response_json, "error", WM_UPGRADE_UNKNOWN_ERROR);
     cJSON_AddStringToObject(response_json, "message", upgrade_error_codes[WM_UPGRADE_UNKNOWN_ERROR]);
 
-    char *response = "{\"error\":25,\"message\":\"Upgrade procedure could not start\",\"data\":[{\"error\":25,\"message\":\"Upgrade procedure could not start\"}]}";
+    char *response = "{\"error\":26,\"message\":\"Upgrade procedure could not start\",\"data\":[{\"error\":26,\"message\":\"Upgrade procedure could not start\"}]}";
 
     expect_string(__wrap_OS_BindUnixDomainWithPerms, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomainWithPerms, type, SOCK_STREAM);
@@ -508,7 +508,7 @@ void test_wm_agent_upgrade_listen_messages_parse_error(void **state)
     will_return(__wrap_wm_agent_upgrade_parse_response, response_json);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
-    expect_string(__wrap__mtdebug1, formatted_msg, "(8156): Response message: '{\"error\":25,\"message\":\"Upgrade procedure could not start\",\"data\":[{\"error\":25,\"message\":\"Upgrade procedure could not start\"}]}'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8156): Response message: '{\"error\":26,\"message\":\"Upgrade procedure could not start\",\"data\":[{\"error\":26,\"message\":\"Upgrade procedure could not start\"}]}'");
 
     expect_value(__wrap_OS_SendSecureTCP, sock, peer);
     expect_value(__wrap_OS_SendSecureTCP, size, strlen(response));

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.c
@@ -28,16 +28,19 @@
 
 const char* upgrade_values[] = {
     [WM_UPGRADE_SUCCESSFUL] = "0",
+    [WM_UPGRADE_FAILED_DEPENDENCY] = "1",
     [WM_UPGRADE_FAILED] = "2"
 };
 
 const char* upgrade_messages[] = {
     [WM_UPGRADE_SUCCESSFUL] = "Upgrade was successful",
+    [WM_UPGRADE_FAILED_DEPENDENCY] = "Upgrade failed due missing dependency",
     [WM_UPGRADE_FAILED] = "Upgrade failed"
 };
 
 static const char *task_statuses_map[] = {
     [WM_UPGRADE_SUCCESSFUL] = WM_TASK_STATUS_DONE,
+    [WM_UPGRADE_FAILED_DEPENDENCY] = WM_TASK_STATUS_FAILED,
     [WM_UPGRADE_FAILED] = WM_TASK_STATUS_FAILED
 };
 
@@ -243,7 +246,7 @@ STATIC bool wm_upgrade_agent_search_upgrade_result(int *queue_fd) {
 
         wm_upgrade_agent_state state;
         for (state = 0; state < WM_UPGRADE_MAX_STATE; state++) {
-            // File can either be "0\n" or "2\n", so we are expecting a positive match
+            // File can either be "0\n", "1\n" or "2\n", so we are expecting a positive match
             if (strstr(buffer, upgrade_values[state]) != NULL) {
                 // Matched value, send message
                 wm_upgrade_agent_send_ack_message(queue_fd, state);

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.h
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.h
@@ -22,6 +22,7 @@
 
 typedef enum _wm_upgrade_agent_state {
     WM_UPGRADE_SUCCESSFUL = 0,
+    WM_UPGRADE_FAILED_DEPENDENCY,
     WM_UPGRADE_FAILED,
     WM_UPGRADE_MAX_STATE
 } wm_upgrade_agent_state;

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_commands.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_commands.c
@@ -190,7 +190,13 @@ char* wm_agent_upgrade_process_agent_result_command(const int* agent_ids, const 
     }
 
     if (task->error_code) {
-        json_task_module_request = wm_agent_upgrade_parse_task_module_request(WM_UPGRADE_AGENT_UPDATE_STATUS, agents_array, task->status, upgrade_error_codes[WM_UPGRADE_UPGRADE_ERROR]);
+        char *error = NULL;
+        if (task->error_code == 1) {
+            error = upgrade_error_codes[WM_UPGRADE_UPGRADE_ERROR_MISSING_PACKAGE];
+        } else {
+            error = upgrade_error_codes[WM_UPGRADE_UPGRADE_ERROR];
+        }
+        json_task_module_request = wm_agent_upgrade_parse_task_module_request(WM_UPGRADE_AGENT_UPDATE_STATUS, agents_array, task->status, error);
     } else {
         json_task_module_request = wm_agent_upgrade_parse_task_module_request(WM_UPGRADE_AGENT_UPDATE_STATUS, agents_array, task->status, NULL);
     }

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.c
@@ -48,6 +48,7 @@ const char* upgrade_error_codes[] = {
     [WM_UPGRADE_SEND_SHA1_ERROR] = "Send verify sha1 error",
     [WM_UPGRADE_SEND_UPGRADE_ERROR] = "Send upgrade command error",
     [WM_UPGRADE_UPGRADE_ERROR] = "Upgrade procedure exited with error code",
+    [WM_UPGRADE_UPGRADE_ERROR_MISSING_PACKAGE] = "Upgrade procedure exited with error code, missing package in agent",
     [WM_UPGRADE_UNKNOWN_ERROR] = "Upgrade procedure could not start"
 };
 

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.c
@@ -48,7 +48,7 @@ const char* upgrade_error_codes[] = {
     [WM_UPGRADE_SEND_SHA1_ERROR] = "Send verify sha1 error",
     [WM_UPGRADE_SEND_UPGRADE_ERROR] = "Send upgrade command error",
     [WM_UPGRADE_UPGRADE_ERROR] = "Upgrade procedure exited with error code",
-    [WM_UPGRADE_UPGRADE_ERROR_MISSING_PACKAGE] = "Upgrade procedure exited with error code, missing package in agent",
+    [WM_UPGRADE_UPGRADE_ERROR_MISSING_PACKAGE] = "Upgrade procedure exited with error code, missing dependency in agent",
     [WM_UPGRADE_UNKNOWN_ERROR] = "Upgrade procedure could not start"
 };
 

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.h
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.h
@@ -51,6 +51,7 @@ typedef enum _wm_upgrade_error_code {
     WM_UPGRADE_SEND_SHA1_ERROR,
     WM_UPGRADE_SEND_UPGRADE_ERROR,
     WM_UPGRADE_UPGRADE_ERROR,
+    WM_UPGRADE_UPGRADE_ERROR_MISSING_PACKAGE,
     WM_UPGRADE_UNKNOWN_ERROR
 } wm_upgrade_error_code;
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/20924|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team, it was found that some fedora images lack tar package. This causes a failure while creating a backup while upgrading an agent via WPK. To manage this situation, a check for this package has been introduced to abort the WPK upgrade in case tar dependency is not covered in this upgrading agent.

This problem was found in fedora 38 image, but this check has also been added for Mac OS agent to keep consistency between both OS comprobations.

### Note
This solution will work on agents from version `4.8.1` onwards since a new error code has been added and the version `4.8.1` is the first one which will handle this code. Even so, the error will always remain reflected in the `upgrade.log` file. 

To prevent this behavior, this commit https://github.com/wazuh/wazuh/pull/21729/commits/ad5d895df4bdd633a2abfe6dbf891c528053d2d3 has been introduced. This will avoid the timeout message but `Upgrade procedure exited with error code, missing dependency in agent` will not appear in the manager. We let the code prepared to just change the `upgrade_result` written value to `1` to get the specific message.

## Logs/Alerts example
With this update, the following logs will appear in the `upgrade.log` file if the tar package is not installed.
```
[root@fedora38 vagrant]# cat /var/ossec/logs/upgrade.log 
2024/02/05 11:14:58 - Generating Backup.
2024/02/05 11:14:58 - The tar package is required for this operation, exiting.
```
<!--
Paste here related logs and alerts
-->

## Tests
To test this fix, the branch `test-wpk-fedora` was created to create a WPK package to force the backup creation.
