### PR TITLE
Add vulnerability detection related content

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -4075,6 +4075,8 @@ components:
     WazuhLogsSummary:
       type: object
       properties:
+          indexer-connector:
+            $ref: '#/components/schemas/LogSummary'
           wazuh-agentlessd:
             $ref: '#/components/schemas/LogSummary'
           wazuh-analysisd:
@@ -4099,7 +4101,7 @@ components:
             $ref: '#/components/schemas/LogSummary'
           wazuh-reportd:
             $ref: '#/components/schemas/LogSummary'
-          wazuh-rootcheck:
+          rootcheck:
             $ref: '#/components/schemas/LogSummary'
           wazuh-syscheckd:
             $ref: '#/components/schemas/LogSummary'
@@ -4121,6 +4123,8 @@ components:
             $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:command:
             $ref: '#/components/schemas/LogSummary'
+          wazuh-modulesd:content_manager:
+            $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:database:
             $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:docker-listener:
@@ -4132,6 +4136,8 @@ components:
           wazuh-modulesd:osquery:
             $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:syscollector:
+            $ref: '#/components/schemas/LogSummary'
+          wazuh-modulesd:vulnerability-scanner:
             $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:task-manager:
             $ref: '#/components/schemas/LogSummary'
@@ -6324,6 +6330,7 @@ components:
         - socket
         - syscheck
         - syslog_output
+        - vulnerability-detection
         - indexer
         # Wodle sections
         - aws-s3
@@ -10286,6 +10293,10 @@ paths:
                         scan_on_start: yes
                         interval: "12h"
                         skip_nfs: yes
+                      vulnerability-detection:
+                        enabled: yes
+                        index-status: yes
+                        feed-update-interval: "60m"
                       indexer:
                         enabled: yes
                         hosts:

--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -184,6 +184,12 @@ variables:
       <syscheck>
         <disabled>yes</disabled>
       </syscheck>
+    
+      <vulnerability-detection>
+        <enabled>no</enabled>
+        <index-status>yes</index-status>
+        <feed-update-interval>60m</feed-update-interval>
+      </vulnerability-detection>
     </ossec_config>
 
   valid_ossec_conf_with_update_check_disabled:
@@ -217,6 +223,12 @@ variables:
       <syscheck>
         <disabled>yes</disabled>
       </syscheck>
+    
+      <vulnerability-detection>
+        <enabled>no</enabled>
+        <index-status>yes</index-status>
+        <feed-update-interval>60m</feed-update-interval>
+      </vulnerability-detection>
     </ossec_config>
 
   invalid_ossec_conf:
@@ -232,6 +244,12 @@ variables:
         <log_alert_level>3</log_alert_level>
         <email_alert_level>12</email_alert_level>
       </alerts>
+    
+      <vulnerability-detection>
+        <enabled>no</enabled>
+        <index-status>yes</index-status>
+        <feed-update-interval>60m</feed-update-interval>
+      </vulnerability-detection>
 
       <remote>
     </ossec_config>
@@ -268,4 +286,10 @@ variables:
       <syscheck>
         <disabled>yes</disabled>
       </syscheck>
+    
+      <vulnerability-detection>
+        <enabled>no</enabled>
+        <index-status>yes</index-status>
+        <feed-update-interval>60m</feed-update-interval>
+      </vulnerability-detection>
     </ossec_config>

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -873,30 +873,7 @@ stages:
       json:
         error: 0
         data:
-          affected_items:
-            - sca: !anything
-            - wazuh-agentlessd: !anything
-            - wazuh-analysisd: !anything
-            - wazuh-authd: !anything
-            - wazuh-csyslogd: !anything
-            - wazuh-db: !anything
-            - wazuh-dbd: !anything
-            - wazuh-execd: !anything
-            - wazuh-integratord: !anything
-            - wazuh-logcollector: !anything
-            - wazuh-modulesd: !anything
-            - wazuh-modulesd:agent-upgrade: !anything
-            - wazuh-modulesd:ciscat: !anything
-            - wazuh-modulesd:control: !anything
-            - wazuh-modulesd:database: !anything
-            - wazuh-modulesd:download: !anything
-            - wazuh-modulesd:osquery: !anything
-            - wazuh-modulesd:syscollector: !anything
-            - wazuh-modulesd:task-manager: !anything
-            - wazuh-monitord: !anything
-            - wazuh-remoted: !anything
-            - wazuh-rootcheck: !anything
-            - wazuh-syscheckd: !anything
+          affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/21743 |

## Description

Adds the new vulnerability detection configuration to the AIT tests and restores the vulnerability detection fields that were deleted as part of https://github.com/wazuh/wazuh/pull/21542.

## Tests

https://github.com/wazuh/wazuh/issues/21743#issuecomment-1927770894

> The AIT tier 0/1 checks are failing because of https://github.com/wazuh/wazuh/issues/21803. I suspect it has to be with the workflow using cached steps.