### PR TITLE
Add PyJWT dependency for Wazuh API

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -5,6 +5,7 @@
 import asyncio
 import hashlib
 import json
+import jwt
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
@@ -12,7 +13,6 @@ from typing import Union
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
-from jose import JWTError, jwt
 from werkzeug.exceptions import Unauthorized
 
 import api.configuration as conf
@@ -295,5 +295,5 @@ def decode_token(token: str) -> dict:
             raise Unauthorized
 
         return payload
-    except JWTError as e:
+    except jwt.exceptions.PyJWTError as e:
         raise Unauthorized from e

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -7,7 +7,6 @@ import json
 import os
 import sys
 from copy import deepcopy
-from datetime import datetime
 from unittest.mock import patch, MagicMock, ANY, call
 
 from werkzeug.exceptions import Unauthorized

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -26,7 +26,6 @@ defusedxml==0.6.0
 docker==6.0.0
 docker-pycreds==0.4.0
 docutils==0.15.2
-ecdsa==0.16.1
 envparse==0.2.0
 Flask==2.2.5
 frozenlist==1.2.0
@@ -66,9 +65,9 @@ psutil==5.9.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.21
+PyJWT==2.8.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
-python-jose==3.1.0
 python-json-logger==2.0.2
 pytz==2020.1
 PyYAML==5.4.1


### PR DESCRIPTION
|Related issue|
|---|
| #21662 |


## Description

<!--
Add a clear description of how the problem has been solved.
-->

Adds the `PyJWT` dependency replacing `python-jose` and `ecdsa` since these are prone to security vulnerabilities and are not currently being maintained.

## Tests

The results of the API Integration tests can be found [here](https://github.com/wazuh/wazuh/issues/21662#issuecomment-1927282971).

> [!NOTE]
> The execution for the `Integration tests for API` in the chekcs to take into account is the one from Github Actions.

