### PR TITLE
Fix coverity warnings for vulnerability detector

### DIFF
--- a/src/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelper.h
@@ -214,7 +214,7 @@ namespace PackageLinuxHelper
             }
             else if (data.is_string())
             {
-                auto stringData = data.get_ref<const std::string&>();
+                const auto& stringData = data.get_ref<const std::string&>();
 
                 if (stringData.length())
                 {

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -182,7 +182,7 @@ private:
         }
 
         // Store last file hash.
-        const auto lastDownloadedFileHash {spUpdaterContext->spUpdaterBaseContext->downloadedFileHash};
+        const std::string lastDownloadedFileHash {spUpdaterContext->spUpdaterBaseContext->downloadedFileHash};
 
         // Run the updater chain
         m_spUpdaterOrchestration->handleRequest(spUpdaterContext);

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -51,7 +51,7 @@ IndexerConnector::IndexerConnector(
     }
 
     // Get index name.
-    auto indexName {config.at("name").get_ref<const std::string&>()};
+    const auto& indexName {config.at("name").get_ref<const std::string&>()};
 
     std::string caRootCertificate;
     std::string sslCertificate;
@@ -199,7 +199,10 @@ IndexerConnector::IndexerConnector(
                         sleepTime = std::chrono::seconds(MAX_WAIT_TIME);
                     }
 
-                    initialize(templateData, indexName, selector, secureCommunication);
+                    initialize(std::move(templateData),
+                               std::move(indexName),
+                               std::move(selector),
+                               std::move(secureCommunication));
                 }
                 catch (const std::exception& e)
                 {

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -185,6 +185,7 @@ IndexerConnector::IndexerConnector(
         DATABASE_WORKERS);
 
     m_initializeThread = std::thread(
+        // coverity[copy_constructor_call]
         [=]()
         {
             auto sleepTime = std::chrono::seconds(1);

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -199,10 +199,7 @@ IndexerConnector::IndexerConnector(
                         sleepTime = std::chrono::seconds(MAX_WAIT_TIME);
                     }
 
-                    initialize(std::move(templateData),
-                               std::move(indexName),
-                               std::move(selector),
-                               std::move(secureCommunication));
+                    initialize(templateData, indexName, selector, secureCommunication);
                 }
                 catch (const std::exception& e)
                 {

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
@@ -39,10 +39,10 @@ public:
                 throw std::runtime_error("CVE5 buffer is empty");
             }
             auto cve5Entry = cve_v5::GetEntry(data->cve5Buffer.data());
-            auto type = data->resource.contains("type") ? data->resource.at("type").get<std::string>() : "";
-            auto state = cve5Entry->cveMetadata()
-                             ? cve5Entry->cveMetadata()->state() ? cve5Entry->cveMetadata()->state()->str() : ""
-                             : "";
+            const auto& type = data->resource.contains("type") ? data->resource.at("type").get<std::string>() : "";
+            const auto& state = cve5Entry->cveMetadata()
+                                    ? cve5Entry->cveMetadata()->state() ? cve5Entry->cveMetadata()->state()->str() : ""
+                                    : "";
 
             if ("update" == type)
             {

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -81,14 +81,14 @@ void VulnerabilityScannerFacade::start(
             {
                 while (!dataQueue.empty())
                 {
-                    auto data = dataQueue.front();
-                    dataQueue.pop();
+                    auto& data = dataQueue.front();
                     m_reportSocketClient->send(data.c_str(), data.size());
                     // We wait to keep the maximum number of events per second
                     if (m_reportsWait > 0)
                     {
                         std::this_thread::sleep_for(std::chrono::microseconds(m_reportsWait));
                     }
+                    dataQueue.pop();
                 }
             },
             REPORTS_QUEUE_PATH,
@@ -99,31 +99,31 @@ void VulnerabilityScannerFacade::start(
         policyManager.addSubscriber(m_databaseFeedManager);
 
         // Init Orchestrator
-        auto scanOrchestrator = std::make_shared<ScanOrchestrator>(
+        m_scanOrchestrator = std::make_shared<ScanOrchestrator>(
             m_indexerConnector, m_databaseFeedManager, m_reportDispatcher, m_internalMutex);
 
         // Subscription to syscollector delta events.
         m_syscollectorDeltasSubscription =
             std::make_unique<RouterSubscriber>("deltas-syscollector", "vulnerability_scanner_deltas");
         m_syscollectorDeltasSubscription->subscribe(
-            [scanOrchestrator](const std::vector<char>& message)
+            [&](const std::vector<char>& message)
             {
                 std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> data =
                     SyscollectorDeltas::GetDelta(message.data());
 
-                scanOrchestrator->run(data);
+                m_scanOrchestrator->run(data);
             });
 
         // Subscription to syscollector rsync events.
         m_syscollectorRsyncSubscription =
             std::make_unique<RouterSubscriber>("rsync-syscollector", "vulnerability_scanner_rsync");
         m_syscollectorRsyncSubscription->subscribe(
-            [scanOrchestrator](const std::vector<char>& message)
+            [&](const std::vector<char>& message)
             {
                 std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> data =
                     SyscollectorSynchronization::GetSyncMsg(message.data());
 
-                scanOrchestrator->run(data);
+                m_scanOrchestrator->run(data);
             });
 
         logInfo(WM_VULNSCAN_LOGTAG, "Vulnerability scanner module started");

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -99,31 +99,31 @@ void VulnerabilityScannerFacade::start(
         policyManager.addSubscriber(m_databaseFeedManager);
 
         // Init Orchestrator
-        m_scanOrchestrator = std::make_shared<ScanOrchestrator>(
+        auto scanOrchestrator = std::make_shared<ScanOrchestrator>(
             m_indexerConnector, m_databaseFeedManager, m_reportDispatcher, m_internalMutex);
 
         // Subscription to syscollector delta events.
         m_syscollectorDeltasSubscription =
             std::make_unique<RouterSubscriber>("deltas-syscollector", "vulnerability_scanner_deltas");
         m_syscollectorDeltasSubscription->subscribe(
-            [&](const std::vector<char>& message)
+            [scanOrchestrator](const std::vector<char>& message)
             {
                 std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> data =
                     SyscollectorDeltas::GetDelta(message.data());
 
-                m_scanOrchestrator->run(data);
+                scanOrchestrator->run(data);
             });
 
         // Subscription to syscollector rsync events.
         m_syscollectorRsyncSubscription =
             std::make_unique<RouterSubscriber>("rsync-syscollector", "vulnerability_scanner_rsync");
         m_syscollectorRsyncSubscription->subscribe(
-            [&](const std::vector<char>& message)
+            [scanOrchestrator](const std::vector<char>& message)
             {
                 std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> data =
                     SyscollectorSynchronization::GetSyncMsg(message.data());
 
-                m_scanOrchestrator->run(data);
+                scanOrchestrator->run(data);
             });
 
         logInfo(WM_VULNSCAN_LOGTAG, "Vulnerability scanner module started");

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -106,6 +106,7 @@ void VulnerabilityScannerFacade::start(
         m_syscollectorDeltasSubscription =
             std::make_unique<RouterSubscriber>("deltas-syscollector", "vulnerability_scanner_deltas");
         m_syscollectorDeltasSubscription->subscribe(
+            // coverity[copy_constructor_call]
             [scanOrchestrator](const std::vector<char>& message)
             {
                 std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> data =
@@ -118,6 +119,7 @@ void VulnerabilityScannerFacade::start(
         m_syscollectorRsyncSubscription =
             std::make_unique<RouterSubscriber>("rsync-syscollector", "vulnerability_scanner_rsync");
         m_syscollectorRsyncSubscription->subscribe(
+            // coverity[copy_constructor_call]
             [scanOrchestrator](const std::vector<char>& message)
             {
                 std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*> data =

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -59,7 +59,6 @@ public:
     void stop();
 
 private:
-    std::shared_ptr<ScanOrchestrator> m_scanOrchestrator;
     std::unique_ptr<RouterSubscriber> m_syscollectorDeltasSubscription;
     std::unique_ptr<RouterSubscriber> m_syscollectorRsyncSubscription;
     std::unique_ptr<PolicyManager> m_policyManager;

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -59,6 +59,7 @@ public:
     void stop();
 
 private:
+    std::shared_ptr<ScanOrchestrator> m_scanOrchestrator;
     std::unique_ptr<RouterSubscriber> m_syscollectorDeltasSubscription;
     std::unique_ptr<RouterSubscriber> m_syscollectorRsyncSubscription;
     std::unique_ptr<PolicyManager> m_policyManager;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21640 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->


This PR fixes some coverity warnings:
- At `src/data_provider/src/packages/packageLinuxParserHelper.h` the **auto** variable was set as an automatic const reference
- At `src/shared_modules/content_manager/src/actionOrchestrator.hpp` we force the copy with `std::string` because we need to keep the value
- At `src/shared_modules/indexer_connector/src/indexerConnector.cpp`  an **auto** variable was set to reference, and the some parameters were moved to avoid copies. This is considered correct because those variables aren't used in other place.
- At `src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp`, the copy was avoided by creating a member variable and capturing by reference in the lambdas
- At `src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp` the **auto** variable was set as an automatic const reference

## Tests

  - [ ] Coverity
 