### PR TITLE
Avoid slash followed by invalid characters in wfopen for Windows

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2592,10 +2592,10 @@ win32/manage_agents.exe: win32/manage_agents_resource.o win32/version-app.o win3
 win32/setup-windows.exe: win32/win_service_rk.o win32/setup-win.o win32/setup-shared.o
 	${OSSEC_CCBIN} -DARGV0=\"setup-windows\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/setup-syscheck.exe: win32/setup-syscheck.o win32/setup-shared.o
+win32/setup-syscheck.exe: win32/win_service_rk.o win32/setup-syscheck.o win32/setup-shared.o
 	${OSSEC_CCBIN} -DARGV0=\"setup-syscheck\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/setup-iis.exe: win32/setup-iis.o
+win32/setup-iis.exe: win32/win_service_rk.o win32/setup-iis.o
 	${OSSEC_CCBIN} -DARGV0=\"setup-iis\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 win32/ui_resource.o: win32/ui/win32ui.rc

--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -28,7 +28,7 @@ static cJSON* get_srcip_from_win_eventdata(const cJSON *data);
 void write_debug_file(const char *ar_name, const char *msg) {
     char *timestamp = w_get_timestamp(time(NULL));
 
-    FILE *ar_log_file = fopen(LOG_FILE, "a");
+    FILE *ar_log_file = wfopen(LOG_FILE, "a");
 
     if (ar_log_file) {
         fprintf(ar_log_file, "%s %s: %s\n", timestamp, ar_name, msg);
@@ -500,7 +500,7 @@ int lock(const char *lock_path, const char *lock_pid_path, const char *log_path,
         if (mkdir(lock_path, S_IRWXG) == 0) {
             // Lock acquired (setting the pid)
             pid_t pid = getpid();
-            if (pid_file = fopen(lock_pid_path, "w"), !pid_file) {
+            if (pid_file = wfopen(lock_pid_path, "w"), !pid_file) {
                 write_debug_file(log_path, "Cannot write pid file");
                 return OS_INVALID;
             } else {
@@ -511,7 +511,7 @@ int lock(const char *lock_path, const char *lock_pid_path, const char *log_path,
         }
 
         // Getting currently/saved PID locking the file
-        if (pid_file = fopen(lock_pid_path, "r"), !pid_file) {
+        if (pid_file = wfopen(lock_pid_path, "r"), !pid_file) {
             write_debug_file(log_path, "Cannot read pid file");
         } else {
             read = fscanf(pid_file, "%d", &current_pid);
@@ -603,7 +603,7 @@ int lock(const char *lock_path, const char *lock_pid_path, const char *log_path,
                 if (mkdir(lock_path, S_IRWXG) == 0) {
                     // Lock acquired (setting the pid)
                     pid_t pid = getpid();
-                    pid_file = fopen(lock_pid_path, "w");
+                    pid_file = wfopen(lock_pid_path, "w");
                     fprintf(pid_file, "%d", (int)pid);
                     fclose(pid_file);
 

--- a/src/active-response/firewalls/pf.c
+++ b/src/active-response/firewalls/pf.c
@@ -270,7 +270,7 @@ static int checking_if_its_configured(const char *log_prog_name, const char *pat
 static int write_cmd_to_file(const char *path, const char *cmd) {
     int retVal = 0;
     if (path != NULL && cmd != NULL) {
-        FILE *fp = fopen(path, "a+");
+        FILE *fp = wfopen(path, "a+");
         if (fp != NULL) {
             fprintf(fp, "%s\n", cmd);
             retVal = 1;

--- a/src/active-response/host-deny.c
+++ b/src/active-response/host-deny.c
@@ -104,7 +104,7 @@ int main (int argc, char **argv) {
             return OS_INVALID;
         }
 
-        host_deny_fp = fopen(hosts_deny_path, "r");
+        host_deny_fp = wfopen(hosts_deny_path, "r");
         if (!host_deny_fp) {
             memset(log_msg, '\0', OS_MAXSTR);
             snprintf(log_msg, OS_MAXSTR -1, "Could not open file '%s'", hosts_deny_path);
@@ -130,7 +130,7 @@ int main (int argc, char **argv) {
         fclose(host_deny_fp);
 
         // Open again to append rule
-        host_deny_fp = fopen(hosts_deny_path, "a");
+        host_deny_fp = wfopen(hosts_deny_path, "a");
         if (!host_deny_fp) {
             memset(log_msg, '\0', OS_MAXSTR);
             snprintf(log_msg, OS_MAXSTR -1, "Could not open file '%s'", hosts_deny_path);
@@ -167,7 +167,7 @@ int main (int argc, char **argv) {
 
         bool write_fail = false;
 
-        host_deny_fp = fopen(hosts_deny_path, "r");
+        host_deny_fp = wfopen(hosts_deny_path, "r");
         if (!host_deny_fp) {
             memset(log_msg, '\0', OS_MAXSTR);
             snprintf(log_msg, OS_MAXSTR -1, "Could not open file '%s'", hosts_deny_path);
@@ -178,7 +178,7 @@ int main (int argc, char **argv) {
         }
 
         // Create the temporary file
-        temp_host_deny_fp = fopen(temp_hosts_deny_path, "w");
+        temp_host_deny_fp = wfopen(temp_hosts_deny_path, "w");
         if (!temp_host_deny_fp) {
             memset(log_msg, '\0', OS_MAXSTR);
             snprintf(log_msg, OS_MAXSTR -1, "Could not open file '%s'", temp_hosts_deny_path);

--- a/src/active-response/ip-customblock.c
+++ b/src/active-response/ip-customblock.c
@@ -69,7 +69,7 @@ int main (int argc, char **argv) {
             return OS_INVALID;
         }
 
-        FILE *fp = fopen(srcip_path, "a");
+        FILE *fp = wfopen(srcip_path, "a");
         if(fp == NULL) {
             memset(log_msg, '\0', OS_MAXSTR);
             snprintf(log_msg, OS_MAXSTR - 1, "Error creating %s file", srcip_path);

--- a/src/active-response/route-null.c
+++ b/src/active-response/route-null.c
@@ -140,7 +140,7 @@ int main (int argc, char **argv) {
         snprintf(cmd, OS_MAXSTR, "%%WINDIR%%\\system32\\ipconfig.exe | %%WINDIR%%\\system32\\findstr.exe /R /C:\"%s\" > %s", regex, tmp_file);
         system(cmd);
 
-        FILE *fp = fopen(tmp_file, "r");
+        FILE *fp = wfopen(tmp_file, "r");
         if(fp != NULL) {
             char output_buf[OS_MAXSTR];
             while (fgets(output_buf, OS_MAXSTR, fp)) {

--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
     w_ch_exec_dir();
 
     /* Check permissions */
-    fp = fopen(OSSECCONF, "r");
+    fp = wfopen(OSSECCONF, "r");
     if (fp) {
         fclose(fp);
     } else {

--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -128,7 +128,7 @@ int add_agent(int json_output)
     if (sock = auth_connect(), sock < 0) {
         authd_running = 0;
         /* Check if we can open the auth_file */
-        fp = fopen(KEYS_FILE, "a");
+        fp = wfopen(KEYS_FILE, "a");
         if (!fp) {
             if (json_output) {
                 char buffer[1024];

--- a/src/addagent/manage_keys.c
+++ b/src/addagent/manage_keys.c
@@ -143,7 +143,7 @@ int k_import(const char *cmdimport)
                     }
 #endif
 
-                    fp = fopen(tmp_path, "w");
+                    fp = wfopen(tmp_path, "w");
                     if (!fp) {
                         if (unlink(tmp_path)) {
                             minfo(DELETE_ERROR, tmp_path, errno, strerror(errno));
@@ -243,7 +243,7 @@ int k_extract(const char *cmdextract, int json_output)
     }
 
     /* Try to open the auth file */
-    fp = fopen(KEYS_FILE, "r");
+    fp = wfopen(KEYS_FILE, "r");
     if (!fp) {
         if (json_output) {
             char buffer[1024];
@@ -337,14 +337,14 @@ int k_bulkload(const char *cmdbulk)
 
     /* Check if we can open the input file */
     printf("Opening: [%s]\n", cmdbulk);
-    infp = fopen(cmdbulk, "r");
+    infp = wfopen(cmdbulk, "r");
     if (!infp) {
         perror("Failed.");
         merror_exit(FOPEN_ERROR, cmdbulk, errno, strerror(errno));
     }
 
     /* Check if we can open the auth_file */
-    fp = fopen(KEYS_FILE, "a");
+    fp = wfopen(KEYS_FILE, "a");
     if (!fp) {
         merror_exit(FOPEN_ERROR, KEYS_FILE, errno, strerror(errno));
     }
@@ -446,7 +446,7 @@ int k_bulkload(const char *cmdbulk)
             time3 = time(0);
             rand2 = os_random();
 
-            fp = fopen(KEYS_FILE, "a");
+            fp = wfopen(KEYS_FILE, "a");
             if (!fp) {
                 merror_exit(FOPEN_ERROR, KEYS_FILE, errno, strerror(errno));
             }

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -89,7 +89,7 @@ int OS_RemoveAgent(const char *u_id) {
     if (!id_exist)
         return 0;
 
-    fp = fopen(KEYS_FILE, "r");
+    fp = wfopen(KEYS_FILE, "r");
 
     if (!fp)
         return 0;
@@ -236,7 +236,7 @@ char *getNameById(const char *id)
         return (NULL);
     }
 
-    fp = fopen(KEYS_FILE, "r");
+    fp = wfopen(KEYS_FILE, "r");
     if (!fp) {
         return (NULL);
     }
@@ -296,7 +296,7 @@ int IDExist(const char *id, int discard_removed)
         return (0);
     }
 
-    fp = fopen(KEYS_FILE, "r");
+    fp = wfopen(KEYS_FILE, "r");
 
     if (!fp) {
         return (0);
@@ -380,7 +380,7 @@ int NameExist(const char *u_name)
         return (0);
     }
 
-    fp = fopen(KEYS_FILE, "r");
+    fp = wfopen(KEYS_FILE, "r");
 
     if (!fp) {
         return (0);
@@ -432,7 +432,7 @@ char *IPExist(const char *u_ip)
     if (!(u_ip && strncmp(u_ip, "any", 3)) || strchr(u_ip, '/'))
         return NULL;
 
-    fp = fopen(KEYS_FILE, "r");
+    fp = wfopen(KEYS_FILE, "r");
 
     if (!fp)
         return NULL;
@@ -484,7 +484,7 @@ int print_agents(int print_status, int active_only, int inactive_only, int csv_o
     char line_read[FILE_SIZE + 1];
     line_read[FILE_SIZE] = '\0';
 
-    fp = fopen(KEYS_FILE, "r");
+    fp = wfopen(KEYS_FILE, "r");
     if (!fp) {
         return (0);
     }
@@ -634,7 +634,7 @@ void OS_RemoveAgentTimestamp(const char *id)
     char line[OS_BUFFER_SIZE];
     char * sep;
 
-    fp = fopen(TIMESTAMP_FILE, "r");
+    fp = wfopen(TIMESTAMP_FILE, "r");
 
     if (!fp) {
         return;

--- a/src/agentlessd/agentlessd.c
+++ b/src/agentlessd/agentlessd.c
@@ -38,7 +38,7 @@ static int save_agentless_entry(const char *host, const char *script, const char
     snprintf(sys_location, 1024, "%s/(%s) %s",
              AGENTLESS_ENTRYDIR, script, host);
 
-    fp = fopen(sys_location, "w");
+    fp = wfopen(sys_location, "w");
     if (fp) {
         fprintf(fp, "type: %s\n", agttype);
         fclose(fp);
@@ -105,7 +105,7 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
     snprintf(buf, 2048, "%s/%s->%s/diff.%d",
              DIFF_DIR, host, script, (int)alert_diff_time);
 
-    fp = fopen(buf, "r");
+    fp = wfopen(buf, "r");
     if (!fp) {
         merror("Unable to generate diff alert.");
         return (0);
@@ -221,7 +221,7 @@ static int check_diff_file(const char *host, const char *script)
 
     snprintf(diff_location, sizeof(diff_location), DIFF_DIR "/%s->%s/diff.%d", host, script, (int)date_of_change);
 
-    if (fp = fopen(diff_location, "wb"), !fp) {
+    if (fp = wfopen(diff_location, "wb"), !fp) {
         merror("Unable to open diff file '%s': %s (%d)", diff_location, strerror(errno), errno);
         wpclose(wfd);
         return 0;
@@ -258,7 +258,7 @@ static FILE *open_diff_file(const char *host, const char *script)
     snprintf(sys_location, 1024, "%s/%s->%s/%s", DIFF_DIR, host, script,
              DIFF_NEW_FILE);
 
-    fp = fopen(sys_location, "w");
+    fp = wfopen(sys_location, "w");
 
     /* If we can't open, try creating the directory */
     if (!fp) {
@@ -272,7 +272,7 @@ static FILE *open_diff_file(const char *host, const char *script)
 
         snprintf(sys_location, 1024, "%s/%s->%s/%s", DIFF_DIR, host,
                  script, DIFF_NEW_FILE);
-        fp = fopen(sys_location, "w");
+        fp = wfopen(sys_location, "w");
         if (!fp) {
             merror(FOPEN_ERROR, sys_location, errno, strerror(errno));
             return (NULL);

--- a/src/analysisd/active-response.c
+++ b/src/analysisd/active-response.c
@@ -43,7 +43,7 @@ int AR_ReadConfig(const char *cfgfile)
     modules |= CAR;
 
     /* Clean ar file */
-    fp = fopen(DEFAULTAR, "w");
+    fp = wfopen(DEFAULTAR, "w");
     if (!fp) {
         merror(FOPEN_ERROR, DEFAULTAR, errno, strerror(errno));
         return (OS_INVALID);

--- a/src/analysisd/alerts/getloglocation.c
+++ b/src/analysisd/alerts/getloglocation.c
@@ -136,7 +136,7 @@ FILE * openlog(FILE * fp, char * path, const char * logdir, int year, const char
         }
     }
 
-    if (fp = fopen(path, "a"), !fp) {
+    if (fp = wfopen(path, "a"), !fp) {
         merror_exit("Error opening logfile: '%s': (%d) %s", path, errno, strerror(errno));
     }
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1136,7 +1136,7 @@ static void DumpLogstats()
              "totals",
              today);
 
-    flog = fopen(logfile, "a");
+    flog = wfopen(logfile, "a");
     if (!flog) {
         merror(FOPEN_ERROR, logfile, errno, strerror(errno));
         return;

--- a/src/analysisd/decoders/hostinfo.c
+++ b/src/analysisd/decoders/hostinfo.c
@@ -83,13 +83,13 @@ void HostinfoInit()
     snprintf(_hi_buf, OS_SIZE_1024, "%s", HOSTINFO_FILE);
 
     /* r+ to read and write. Do not truncate */
-    _hi_fp = fopen(_hi_buf, "r+");
+    _hi_fp = wfopen(_hi_buf, "r+");
     if (!_hi_fp) {
         /* Try opening with a w flag, file probably does not exist */
-        _hi_fp = fopen(_hi_buf, "w");
+        _hi_fp = wfopen(_hi_buf, "w");
         if (_hi_fp) {
             fclose(_hi_fp);
-            _hi_fp = fopen(_hi_buf, "r+");
+            _hi_fp = wfopen(_hi_buf, "r+");
         }
     }
     if (!_hi_fp) {

--- a/src/analysisd/dodiff.c
+++ b/src/analysisd/dodiff.c
@@ -16,7 +16,7 @@ static int _add2last(const char *str, size_t strsize, const char *file)
 {
     FILE *fp;
 
-    fp = fopen(file, "w");
+    fp = wfopen(file, "w");
     if (!fp) {
         /* Try to create the directories */
         char *dirrule = NULL;
@@ -53,7 +53,7 @@ static int _add2last(const char *str, size_t strsize, const char *file)
         }
         *dirrule = '/';
 
-        fp = fopen(file, "w");
+        fp = wfopen(file, "w");
         if (!fp) {
             merror(FOPEN_ERROR, file, errno, strerror(errno));
             return (0);
@@ -117,7 +117,7 @@ int doDiff(RuleInfo *rule, struct _Eventinfo *lf)
     } else {
         FILE *fp;
         size_t n;
-        fp = fopen(flastfile, "r");
+        fp = wfopen(flastfile, "r");
         if (!fp) {
             merror(FOPEN_ERROR, flastfile, errno, strerror(errno));
             return (0);

--- a/src/analysisd/fts.c
+++ b/src/analysisd/fts.c
@@ -78,10 +78,10 @@ int FTS_Init(int threads, OSList **fts_list, OSHash **fts_store)
     }
 
     /* Create fts list */
-    fp_list = fopen(FTS_QUEUE, "r+");
+    fp_list = wfopen(FTS_QUEUE, "r+");
     if (!fp_list) {
         /* Create the file if we cant open it */
-        fp_list = fopen(FTS_QUEUE, "w+");
+        fp_list = wfopen(FTS_QUEUE, "w+");
         if (fp_list) {
             fclose(fp_list);
         }
@@ -100,7 +100,7 @@ int FTS_Init(int threads, OSList **fts_list, OSHash **fts_store)
             }
         }
 
-        fp_list = fopen(FTS_QUEUE, "r+");
+        fp_list = wfopen(FTS_QUEUE, "r+");
         if (!fp_list) {
             merror(FOPEN_ERROR, FTS_QUEUE, errno, strerror(errno));
             return (0);
@@ -130,10 +130,10 @@ int FTS_Init(int threads, OSList **fts_list, OSHash **fts_store)
     }
 
     /* Create ignore list */
-    *fp_ignore = fopen(IG_QUEUE, "r+");
+    *fp_ignore = wfopen(IG_QUEUE, "r+");
     if (!*fp_ignore) {
         /* Create the file if we cannot open it */
-        *fp_ignore = fopen(IG_QUEUE, "w+");
+        *fp_ignore = wfopen(IG_QUEUE, "w+");
         if (*fp_ignore) {
             fclose(*fp_ignore);
         }
@@ -152,7 +152,7 @@ int FTS_Init(int threads, OSList **fts_list, OSHash **fts_store)
             }
         }
 
-        *fp_ignore = fopen(IG_QUEUE, "r+");
+        *fp_ignore = wfopen(IG_QUEUE, "r+");
         if (!*fp_ignore) {
             merror(FOPEN_ERROR, IG_QUEUE, errno, strerror(errno));
             return (0);
@@ -160,7 +160,7 @@ int FTS_Init(int threads, OSList **fts_list, OSHash **fts_store)
     }
 
     for (i = 1; i < threads; i++) {
-        fp_ignore[i] = fopen(IG_QUEUE, "r+");
+        fp_ignore[i] = wfopen(IG_QUEUE, "r+");
     }
 
     return (1);

--- a/src/analysisd/lists.c
+++ b/src/analysisd/lists.c
@@ -48,7 +48,7 @@ int Lists_OP_LoadList(char *listfile, ListNode **cdblists, OSList* log_msg)
     snprintf(b_filename, OS_MAXSTR, "%.65531s.cdb", a_filename);
 
     /* Check if the CDB list file is actually available */
-    FILE *txt_fd = fopen(a_filename, "r");
+    FILE *txt_fd = wfopen(a_filename, "r");
     if (!txt_fd)
     {
         smwarn(log_msg, FOPEN_ERROR, a_filename, errno, strerror(errno));

--- a/src/analysisd/lists_make.c
+++ b/src/analysisd/lists_make.c
@@ -49,12 +49,12 @@ void Lists_OP_MakeCDB(const char *txt_filename, const char *cdb_filename, const 
     	if (show_message){
             printf(" * CDB list %s has been updated successfully\n", cdb_filename);
         }
-        if (tmp_fd = fopen(tmp_filename, "w+"), !tmp_fd) {
+        if (tmp_fd = wfopen(tmp_filename, "w+"), !tmp_fd) {
             merror(FOPEN_ERROR, tmp_filename, errno, strerror(errno));
             return;
         }
         cdb_make_start(&cdbm, tmp_fd);
-        if (!(txt_fd = fopen(txt_filename, "r"))) {
+        if (!(txt_fd = wfopen(txt_filename, "r"))) {
             merror(FOPEN_ERROR, txt_filename, errno, strerror(errno));
             return;
         }

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -285,7 +285,7 @@ int w_analysisd_write_state() {
     snprintf(path, sizeof(path), OS_PIDFILE "/%s.state", __local_name);
     snprintf(path_temp, sizeof(path_temp), "%s.temp", path);
 
-    if (fp = fopen(path_temp, "w"), !fp) {
+    if (fp = wfopen(path_temp, "w"), !fp) {
         merror(FOPEN_ERROR, path_temp, errno, strerror(errno));
         return -1;
     }

--- a/src/analysisd/stats.c
+++ b/src/analysisd/stats.c
@@ -83,7 +83,7 @@ static void print_totals(void)
              "totals",
              today);
 
-    flog = fopen(logfile, "a");
+    flog = wfopen(logfile, "a");
     if (!flog) {
         merror(FOPEN_ERROR, logfile, errno, strerror(errno));
         return;
@@ -165,7 +165,7 @@ void Update_Hour()
         }
 
         snprintf(_hourly, 128, "%s/%d", STATQUEUE, i);
-        fp = fopen(_hourly, "w");
+        fp = wfopen(_hourly, "w");
         if (fp) {
             fprintf(fp, "%d", _RHour[i]);
             fclose(fp);
@@ -209,7 +209,7 @@ void Update_Hour()
             }
 
             snprintf(_weekly, 128, "%s/%d/%d", STATWQUEUE, i, j);
-            fp = fopen(_weekly, "w");
+            fp = wfopen(_weekly, "w");
             if (fp) {
                 fprintf(fp, "%d", _RWHour[i][j]);
                 fclose(fp);
@@ -331,7 +331,7 @@ int Init_Stats_Directories(){
 
         else {
             FILE *fp;
-            fp = fopen(_hourly, "r");
+            fp = wfopen(_hourly, "r");
             if (!fp) {
                 _RHour[i] = 0;
             } else {
@@ -364,7 +364,7 @@ int Init_Stats_Directories(){
                 _RWHour[i][j] = 0;
             } else {
                 FILE *fp;
-                fp = fopen(_weekly, "r");
+                fp = wfopen(_weekly, "r");
                 if (!fp) {
                     _RWHour[i][j] = 0;
                 } else {

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -243,7 +243,7 @@ int receive_msg()
                          SHAREDCFG_DIR,
                          tmp_msg);
 
-                fp = fopen(file, "w");
+                fp = wfopen(file, "w");
                 if (!fp) {
                     merror(FOPEN_ERROR, file, errno, strerror(errno));
                 }

--- a/src/client-agent/state.c
+++ b/src/client-agent/state.c
@@ -83,7 +83,7 @@ int write_state() {
 #ifdef WIN32
     snprintf(path, sizeof(path), "%s.state", __local_name);
 
-    if (fp = fopen(path, "w"), !fp) {
+    if (fp = wfopen(path, "w"), !fp) {
         merror(FOPEN_ERROR, path, errno, strerror(errno));
         w_mutex_unlock(&state_mutex);
         return -1;
@@ -93,7 +93,7 @@ int write_state() {
     snprintf(path, sizeof(path), OS_PIDFILE "/%s.state", __local_name);
     snprintf(path_temp, sizeof(path_temp), "%s.temp", path);
 
-    if (fp = fopen(path_temp, "w"), !fp) {
+    if (fp = wfopen(path_temp, "w"), !fp) {
         merror(FOPEN_ERROR, path_temp, errno, strerror(errno));
         w_mutex_unlock(&state_mutex);
         return -1;

--- a/src/config/active-response.c
+++ b/src/config/active-response.c
@@ -50,7 +50,7 @@ int ReadActiveResponses(XML_NODE node, void *d1, void *d2)
     char *tmp_location = NULL;
 
     /* Open shared ar file */
-    fp = fopen(DEFAULTAR, "a");
+    fp = wfopen(DEFAULTAR, "a");
     if (!fp) {
         merror(FOPEN_ERROR, DEFAULTAR, errno, strerror(errno));
         return (-1);

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -89,6 +89,18 @@ ino_t File_Inode(const char *file) __attribute__((nonnull));
 wino_t get_fp_inode(FILE * fp);
 
 
+#ifdef WIN32
+/**
+ * @brief Get the file information of the specified file pointer.
+ *
+ * @param fp File pointer.
+ * @param fileInfo File information.
+ * @return 0 in case of error, not 0 in success.
+ */
+int get_fp_file_information(FILE * fp, BY_HANDLE_FILE_INFORMATION fileInfo);
+#endif
+
+
 /**
  * @brief Get the size of the specified file.
  *

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -94,10 +94,10 @@ wino_t get_fp_inode(FILE * fp);
  * @brief Get the file information of the specified file pointer.
  *
  * @param fp File pointer.
- * @param fileInfo File information.
+ * @param fileInfo Pointer to file information.
  * @return 0 in case of error, not 0 in success.
  */
-int get_fp_file_information(FILE * fp, BY_HANDLE_FILE_INFORMATION fileInfo);
+int get_fp_file_information(FILE * fp, LPBY_HANDLE_FILE_INFORMATION fileInfo);
 #endif
 
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -620,7 +620,7 @@ void LogCollectorStart()
                      * ensure it's fresh when hardlinks are used (like alerts.log).
                      */
                     FILE *tf;
-                    tf = fopen(current->file, "r");
+                    tf = wfopen(current->file, "r");
                     if(tf == NULL) {
                         if (errno == ENOENT) {
                             if(current->exists==1){
@@ -997,7 +997,7 @@ int handle_file(int i, int j, __attribute__((unused)) int do_fseek, int do_log)
 #ifndef WIN32
     struct stat stat_fd = { .st_mode = 0 };
 
-    lf->fp = fopen(lf->file, "r");
+    lf->fp = wfopen(lf->file, "r");
     if (!lf->fp) {
         if (do_log == 1 && lf->exists == 1) {
             merror(FOPEN_ERROR, lf->file, errno, strerror(errno));
@@ -1107,7 +1107,7 @@ error:
 /* Reload file: open after close, and restore position */
 int reload_file(logreader * lf) {
 #ifndef WIN32
-    lf->fp = fopen(lf->file, "r");
+    lf->fp = wfopen(lf->file, "r");
 
     if (!lf->fp) {
         return -1;
@@ -2612,7 +2612,7 @@ STATIC void w_initialize_file_status() {
     /* Read json file to load last read positions */
     FILE * fd = NULL;
 
-    if (fd = fopen(LOCALFILE_STATUS, "r"), fd != NULL) {
+    if (fd = wfopen(LOCALFILE_STATUS, "r"), fd != NULL) {
         char str[OS_MAXSTR] = {0};
 
         if (fread(str, 1, OS_MAXSTR - 1, fd) < 1) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1027,7 +1027,7 @@ int handle_file(int i, int j, __attribute__((unused)) int do_fseek, int do_log)
     /* On windows, we also need the real inode, which is the combination
      * of the index low + index high numbers.
      */
-    if (!get_fp_file_information(lf->fp, lpFileInformation)) {
+    if (!get_fp_file_information(lf->fp, &lpFileInformation)) {
         merror("Unable to get file information by handle.");
         fclose(lf->fp);
         lf->fp = NULL;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -982,7 +982,6 @@ int update_fname(int i, int j)
 /* Open, get the fileno, seek to the end and update mtime */
 int handle_file(int i, int j, __attribute__((unused)) int do_fseek, int do_log)
 {
-    int fd;
     logreader *lf;
 
     if (j < 0) {
@@ -994,9 +993,7 @@ int handle_file(int i, int j, __attribute__((unused)) int do_fseek, int do_log)
     /* We must be able to open the file, fseek and get the
      * time of change from it.
      */
-#ifndef WIN32
-    struct stat stat_fd = { .st_mode = 0 };
-
+    
     lf->fp = wfopen(lf->file, "r");
     if (!lf->fp) {
         if (do_log == 1 && lf->exists == 1) {
@@ -1005,6 +1002,11 @@ int handle_file(int i, int j, __attribute__((unused)) int do_fseek, int do_log)
         }
         goto error;
     }
+
+#ifndef WIN32
+    struct stat stat_fd = { .st_mode = 0 };
+    int fd;
+
     /* Get inode number for fp */
     fd = fileno(lf->fp);
     if (fstat(fd, &stat_fd) == -1) {
@@ -1022,37 +1024,10 @@ int handle_file(int i, int j, __attribute__((unused)) int do_fseek, int do_log)
     BY_HANDLE_FILE_INFORMATION lpFileInformation;
     memset(&lpFileInformation, 0, sizeof(BY_HANDLE_FILE_INFORMATION));
 
-    lf->fp = NULL;
-    lf->h = CreateFile(lf->file, GENERIC_READ,
-                            FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-                            NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-    if (lf->h == INVALID_HANDLE_VALUE) {
-        if (do_log == 1) {
-            DWORD error = GetLastError();
-            merror(FOPEN_ERROR, lf->file, (int)error, win_strerror(error));
-        }
-        goto error;
-    }
-
-    fd = _open_osfhandle((intptr_t)lf->h, 0);
-
-    if (fd == -1) {
-        merror(FOPEN_ERROR, lf->file, errno, strerror(errno));
-        CloseHandle(lf->h);
-        goto error;
-    }
-    lf->fp = _fdopen(fd, "r");
-    if (!lf->fp) {
-        merror(FOPEN_ERROR, lf->file, errno, strerror(errno));
-        _close(fd);
-        goto error;
-    }
-
-
     /* On windows, we also need the real inode, which is the combination
      * of the index low + index high numbers.
      */
-    if (GetFileInformationByHandle(lf->h, &lpFileInformation) == 0) {
+    if (!get_fp_file_information(lf->fp, lpFileInformation)) {
         merror("Unable to get file information by handle.");
         fclose(lf->fp);
         lf->fp = NULL;
@@ -1106,37 +1081,11 @@ error:
 
 /* Reload file: open after close, and restore position */
 int reload_file(logreader * lf) {
-#ifndef WIN32
     lf->fp = wfopen(lf->file, "r");
 
     if (!lf->fp) {
         return -1;
     }
-#else
-    int fd;
-
-    lf->h = CreateFile(lf->file, GENERIC_READ,
-                            FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-                            NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-
-    if (lf->h == INVALID_HANDLE_VALUE) {
-        return (-1);
-    }
-
-    fd = _open_osfhandle((intptr_t)lf->h, 0);
-
-    if (fd == -1) {
-        CloseHandle(lf->h);
-        return (-1);
-    }
-
-    lf->fp = _fdopen(fd, "r");
-
-    if (!lf->fp) {
-        _close(fd);
-        return (-1);
-    }
-#endif
 
     fsetpos(lf->fp, &lf->position);
     return 0;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -994,7 +994,8 @@ int handle_file(int i, int j, __attribute__((unused)) int do_fseek, int do_log)
      * time of change from it.
      */
     
-    lf->fp = wfopen(lf->file, "r");
+    /* TODO: Support text mode on Windows */
+    lf->fp = wfopen(lf->file, "rb");
     if (!lf->fp) {
         if (do_log == 1 && lf->exists == 1) {
             merror(FOPEN_ERROR, lf->file, errno, strerror(errno));
@@ -1081,7 +1082,9 @@ error:
 
 /* Reload file: open after close, and restore position */
 int reload_file(logreader * lf) {
-    lf->fp = wfopen(lf->file, "r");
+    
+    /* TODO: Support text mode on Windows */
+    lf->fp = wfopen(lf->file, "rb");
 
     if (!lf->fp) {
         return -1;

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -558,7 +558,7 @@ void win_read_vista_sec()
     FILE *fp;
 
     /* Vista security */
-    fp = fopen("vista_sec.txt", "r");
+    fp = wfopen("vista_sec.txt", "r");
     if (!fp) merror_exit("Unable to read vista security descriptions.");
 
     /* Creating the hash */

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -231,13 +231,13 @@ EVT_HANDLE read_bookmark(os_channel *channel)
     wchar_t bookmark_xml[OS_MAXSTR];
 
     /* If we have a stored bookmark, start from it */
-    if ((fp = fopen(channel->bookmark_filename, "r")) == NULL) {
+    if ((fp = wfopen(channel->bookmark_filename, "r")) == NULL) {
         /* Check if the error was not because the
          * file did not exist which should be logged
          */
         if (errno != ENOENT) {
             merror(
-                "Could not fopen() existing bookmark (%s) for (%s) which returned [(%d)-(%s)]",
+                "Could not wfopen() existing bookmark (%s) for (%s) which returned [(%d)-(%s)]",
                 channel->bookmark_filename,
                 channel->evt_log,
                 errno,
@@ -351,9 +351,9 @@ int update_bookmark(EVT_HANDLE evt, os_channel *channel)
         goto cleanup;
     }
 
-    if ((fp = fopen(channel->bookmark_filename, "w")) == NULL) {
+    if ((fp = wfopen(channel->bookmark_filename, "w")) == NULL) {
         mwarn(
-            "Could not fopen() bookmark (%s) for (%s) which returned [(%d)-(%s)]",
+            "Could not wfopen() bookmark (%s) for (%s) which returned [(%d)-(%s)]",
             channel->bookmark_filename,
             channel->evt_log,
             errno,

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -116,7 +116,7 @@ STATIC void w_logcollector_state_dump() {
 
     FILE * lc_state_file = NULL;
 
-    if (lc_state_file = fopen(LOGCOLLECTOR_STATE, "w"), lc_state_file != NULL) {
+    if (lc_state_file = wfopen(LOGCOLLECTOR_STATE, "w"), lc_state_file != NULL) {
         if (fwrite(lc_state_str, sizeof(char), len + 1, lc_state_file) < 1) {
             merror(FWRITE_ERROR, LOGCOLLECTOR_STATE, errno, strerror(errno));
         }

--- a/src/monitord/compress_log.c
+++ b/src/monitord/compress_log.c
@@ -35,7 +35,7 @@ void OS_CompressLog(const char *logfile)
     snprintf(logfileGZ, OS_FLSIZE, "%s.gz", logfile);
 
     /* Read log file */
-    log = fopen(logfile, "r");
+    log = wfopen(logfile, "r");
     if (!log) {
         /* Do not warn in here, since the alert file may not exist */
         return;

--- a/src/monitord/generate_reports.c
+++ b/src/monitord/generate_reports.c
@@ -53,7 +53,7 @@ void generate_reports(int cday, int cmon, int cyear, const struct tm *p)
                 snprintf(fname, 255, "/logs/.report-%d.log", (int)getpid());
 
                 minfo("Starting daily reporting for '%s'", mond.reports[s]->title);
-                mond.reports[s]->r_filter.fp = fopen(fname, "w+");
+                mond.reports[s]->r_filter.fp = wfopen(fname, "w+");
                 if (!mond.reports[s]->r_filter.fp) {
                     merror("Unable to open temporary reports file.");
                     s++;

--- a/src/monitord/sign_log.c
+++ b/src/monitord/sign_log.c
@@ -89,7 +89,7 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
 
     /* Generate MD5, SHA-1, and SHA-256 of the current file */
 
-    if (fp = fopen(logfile_r, "r"), fp) {
+    if (fp = wfopen(logfile_r, "r"), fp) {
         while (n = fread(buffer, 1, 2048, fp), n > 0) {
             EVP_DigestUpdate(sha1_ctx, buffer, n);
             EVP_DigestUpdate(md5_ctx, buffer, n);
@@ -101,7 +101,7 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
         // Include rotated files
 
         for (i = 1; snprintf(logfile_r, OS_FLSIZE + 1, "%s-%.3d.%s", logfile, i, ext), !IsFile(logfile_r) && FileSize(logfile_r) > 0; i++) {
-            if (fp = fopen(logfile_r, "r"), fp) {
+            if (fp = wfopen(logfile_r, "r"), fp) {
                 while (n = fread(buffer, 1, 2048, fp), n > 0) {
                     EVP_DigestUpdate(sha1_ctx, buffer, n);
                     EVP_DigestUpdate(md5_ctx, buffer, n);
@@ -146,7 +146,7 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
     EVP_MD_CTX_free(sha1_ctx);
     EVP_MD_CTX_free(sha256_ctx);
 
-    fp = fopen(logfilesum, "w");
+    fp = wfopen(logfilesum, "w");
     if (!fp) {
         merror(FOPEN_ERROR, logfilesum, errno, strerror(errno));
         return;

--- a/src/os_auth/generate_cert.c
+++ b/src/os_auth/generate_cert.c
@@ -155,7 +155,7 @@ void add_x509_ext(X509* cert, X509V3_CTX *ctx, int ext_nid, const char *value) {
 }
 
 int dump_key_cert(EVP_PKEY* key, X509* x509, const char* key_name, const char* cert_name) {
-    FILE* key_file = fopen(key_name, "wb");
+    FILE* key_file = wfopen(key_name, "wb");
 
     if(!key_file)
     {
@@ -172,7 +172,7 @@ int dump_key_cert(EVP_PKEY* key, X509* x509, const char* key_name, const char* c
 
     fclose(key_file);
 
-    FILE* x509_file = fopen(cert_name, "wb");
+    FILE* x509_file = wfopen(cert_name, "wb");
     if(!x509_file)
     {
         merror("Cannot open %s.", cert_name);

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -237,7 +237,7 @@ int main(int argc, char **argv)
                     }
                     else {
                         if (w_str_is_number(optarg)) {
-                            merror_exit("-%c needs a valid list of SSL ciphers", c); 
+                            merror_exit("-%c needs a valid list of SSL ciphers", c);
                         }
                         ciphers = optarg;
                     }
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
                         }
                     }
                     else {
-                        merror_exit("-%c needs a numeric argument", c);   
+                        merror_exit("-%c needs a numeric argument", c);
                     }
                     break;
 
@@ -304,7 +304,7 @@ int main(int argc, char **argv)
                     if (!optarg) {
                         merror_exit("-%c needs an argument", c);
                     }
-                    
+
                     if (w_str_is_number(optarg)) {
                         generate_certificate = true;
                         if (snprintf(cert_key_bits, OS_SIZE_32 + 1, "%s", optarg) > OS_SIZE_32) {
@@ -514,7 +514,7 @@ int main(int argc, char **argv)
     minfo(STARTUP_MSG, (int)getpid());
 
     /* Checking client keys file */
-    fp = fopen(KEYS_FILE, "a");
+    fp = wfopen(KEYS_FILE, "a");
     if (!fp) {
         merror("Unable to open %s (key file)", KEYS_FILE);
         exit(1);
@@ -536,7 +536,7 @@ int main(int argc, char **argv)
 
         /* Check if password is enabled */
         if (config.flags.use_password) {
-            fp = fopen(AUTHD_PASS, "r");
+            fp = wfopen(AUTHD_PASS, "r");
             buf[0] = '\0';
 
             /* Checking if there is a custom password file */

--- a/src/os_crypto/hmac/hmac.c
+++ b/src/os_crypto/hmac/hmac.c
@@ -11,13 +11,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <openssl/sha.h>
-#include <openssl/evp.h>
-#include <openssl/core_names.h>
+
 
 #include "file_op.h"
 #include "headers/defs.h"
 #include "../sha1/sha1_op.h"
+#include <openssl/sha.h>
+#include <openssl/evp.h>
+#include <openssl/core_names.h>
 #include "hmac.h"
 
 int OS_HMAC_SHA1_Str(const char *key, const char *text, os_sha1 output)

--- a/src/os_crypto/hmac/hmac.c
+++ b/src/os_crypto/hmac/hmac.c
@@ -11,13 +11,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-
-
-#include "headers/defs.h"
-#include "../sha1/sha1_op.h"
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <openssl/core_names.h>
+
+#include "file_op.h"
+#include "headers/defs.h"
+#include "../sha1/sha1_op.h"
 #include "hmac.h"
 
 int OS_HMAC_SHA1_Str(const char *key, const char *text, os_sha1 output)

--- a/src/os_crypto/hmac/hmac.c
+++ b/src/os_crypto/hmac/hmac.c
@@ -99,7 +99,7 @@ int OS_HMAC_SHA1_File(const char *key, const char *file_path, os_sha1 output, in
     EVP_MAC_CTX *ctx = NULL;
     OSSL_PARAM params[3];
 
-    fp = fopen(file_path, mode == OS_BINARY ? "rb" : "r");
+    fp = wfopen(file_path, mode == OS_BINARY ? "rb" : "r");
     if (!fp) {
         return -1;
     }

--- a/src/os_crypto/md5_sha1/md5_sha1_op.c
+++ b/src/os_crypto/md5_sha1/md5_sha1_op.c
@@ -10,11 +10,11 @@
 
 #include <stdio.h>
 #include <string.h>
+
+#include "file_op.h"
+#include "md5_sha1_op.h"
 #include <openssl/evp.h>
 #include <openssl/sha.h>
-
-#include "md5_sha1_op.h"
-#include "file_op.h"
 #include "headers/defs.h"
 
 int OS_MD5_SHA1_File(const char *fname, const char *prefilter_cmd, os_md5 md5output, os_sha1 sha1output, int mode)

--- a/src/os_crypto/md5_sha1/md5_sha1_op.c
+++ b/src/os_crypto/md5_sha1/md5_sha1_op.c
@@ -31,7 +31,7 @@ int OS_MD5_SHA1_File(const char *fname, const char *prefilter_cmd, os_md5 md5out
 
     /* Use prefilter_cmd if set */
     if (prefilter_cmd == NULL) {
-        fp = fopen(fname, mode == OS_BINARY ? "rb" : "r");
+        fp = wfopen(fname, mode == OS_BINARY ? "rb" : "r");
         if (!fp) {
             return (-1);
         }

--- a/src/os_crypto/md5_sha1/md5_sha1_op.c
+++ b/src/os_crypto/md5_sha1/md5_sha1_op.c
@@ -10,10 +10,11 @@
 
 #include <stdio.h>
 #include <string.h>
-
-#include "md5_sha1_op.h"
 #include <openssl/evp.h>
 #include <openssl/sha.h>
+
+#include "md5_sha1_op.h"
+#include "file_op.h"
 #include "headers/defs.h"
 
 int OS_MD5_SHA1_File(const char *fname, const char *prefilter_cmd, os_md5 md5output, os_sha1 sha1output, int mode)

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -35,7 +35,7 @@ int OS_SHA1_File(const char *fname, os_sha1 output, int mode) {
     memset(output, 0, sizeof(os_sha1));
     buf[2049] = '\0';
 
-    fp = fopen(fname, mode == OS_BINARY ? "rb" : "r");
+    fp = wfopen(fname, mode == OS_BINARY ? "rb" : "r");
     if (!fp) {
         return (-1);
     }
@@ -155,7 +155,7 @@ int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 o
         open_fd = lpFileInformation.nFileIndexLow + lpFileInformation.nFileIndexHigh;
     }
 #else
-    if (fp = fopen(fname, mode == OS_BINARY ? "rb" : "r"), fp == NULL) {
+    if (fp = wfopen(fname, mode == OS_BINARY ? "rb" : "r"), fp == NULL) {
         return -1;
     }
 #endif

--- a/src/os_crypto/sha256/sha256_op.c
+++ b/src/os_crypto/sha256/sha256_op.c
@@ -27,7 +27,7 @@ int OS_SHA256_File(const char *fname, os_sha256 output, int mode)
     memset(output, 0, sizeof(os_sha256));
     buf[2049] = '\0';
 
-    fp = fopen(fname, mode == OS_BINARY ? "rb" : "r");
+    fp = wfopen(fname, mode == OS_BINARY ? "rb" : "r");
     if (!fp) {
         return (-1);
     }

--- a/src/os_crypto/sha256/sha256_op.c
+++ b/src/os_crypto/sha256/sha256_op.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "file_op.h"
 #include "sha256_op.h"
 #include "headers/defs.h"
 

--- a/src/os_crypto/sha512/sha512_op.c
+++ b/src/os_crypto/sha512/sha512_op.c
@@ -24,7 +24,7 @@ int OS_SHA512_File(const char *fname, os_sha512 output, int mode)
 
     buf[2049] = '\0';
 
-    fp = fopen(fname, mode == OS_BINARY ? "rb" : "r");
+    fp = wfopen(fname, mode == OS_BINARY ? "rb" : "r");
     if (!fp) {
         return (-1);
     }

--- a/src/os_crypto/sha512/sha512_op.c
+++ b/src/os_crypto/sha512/sha512_op.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <openssl/evp.h>
 
+#include "file_op.h"
 #include "sha512_op.h"
 #include "headers/defs.h"
 

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -155,7 +155,7 @@ int OS_CheckKeys()
         return (0);
     }
 
-    fp = fopen(KEYS_FILE, "r");
+    fp = wfopen(KEYS_FILE, "r");
     if (!fp) {
         /* We can leave from here */
         merror(FOPEN_ERROR, KEYS_FILE, errno, strerror(errno));
@@ -195,7 +195,7 @@ void OS_ReadKeys(keystore *keys, key_mode_t key_mode, int save_removed)
     }
 
     keys->inode = File_Inode(keys_file);
-    fp = fopen(keys_file, "r");
+    fp = wfopen(keys_file, "r");
     if (!fp) {
         if (!pass_empty_keyfile) {
             /* We can leave from here */
@@ -750,7 +750,7 @@ int w_get_agent_net_protocol_from_keystore(keystore * keys, const char * agent_i
 int OS_ReadTimestamps(keystore * keys) {
     char line[OS_BUFFER_SIZE];
 
-    FILE * fp = fopen(TIMESTAMP_FILE, "r");
+    FILE * fp = wfopen(TIMESTAMP_FILE, "r");
 
     if (fp == NULL) {
         return errno == ENOENT ? 0 : -1;

--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -91,11 +91,11 @@ void OS_StartCounter(keystore *keys)
             snprintf(rids_file, OS_FLSIZE, "%s/%s", RIDS_DIR, keys->keyentries[i]->id);
         }
 
-        keys->keyentries[i]->fp = fopen(rids_file, "r+");
+        keys->keyentries[i]->fp = wfopen(rids_file, "r+");
 
         /* If nothing is there, try to open as write only */
         if (!keys->keyentries[i]->fp) {
-            keys->keyentries[i]->fp = fopen(rids_file, "w");
+            keys->keyentries[i]->fp = wfopen(rids_file, "w");
             if (!keys->keyentries[i]->fp) {
                 int my_error = errno;
 
@@ -181,9 +181,9 @@ static void StoreCounter(const keystore *keys, int id, unsigned int global, unsi
     if (!keys->keyentries[id]->fp) {
         char rids_file[OS_FLSIZE + 1];
         snprintf(rids_file, OS_FLSIZE, "%s/%s", RIDS_DIR, keys->keyentries[id]->id);
-        keys->keyentries[id]->fp = fopen(rids_file, "r+");
+        keys->keyentries[id]->fp = wfopen(rids_file, "r+");
         if (!keys->keyentries[id]->fp) {
-            keys->keyentries[id]->fp = fopen(rids_file, "w");
+            keys->keyentries[id]->fp = wfopen(rids_file, "w");
             if (!keys->keyentries[id]->fp) {
                 int my_error = errno;
 
@@ -219,10 +219,10 @@ static void ReloadCounter(const keystore *keys, unsigned int id, const char * ci
     new_inode = File_Inode(rids_file);
 
     if (keys->keyentries[id]->inode != new_inode) {
-        keys->keyentries[id]->fp = fopen(rids_file, "r+");
+        keys->keyentries[id]->fp = wfopen(rids_file, "r+");
 
         if (!keys->keyentries[id]->fp) {
-            keys->keyentries[id]->fp = fopen(rids_file, "w");
+            keys->keyentries[id]->fp = wfopen(rids_file, "w");
             if (!keys->keyentries[id]->fp) {
                 goto fail_open;
             }

--- a/src/os_crypto/signature/signature.c
+++ b/src/os_crypto/signature/signature.c
@@ -37,7 +37,7 @@ int w_wpk_unsign(const char * source, const char * target, const char ** ca_stor
 
     // Read signed file
 
-    if (filein = fopen(source, "rb"), !filein) {
+    if (filein = wfopen(source, "rb"), !filein) {
         merror("opening input file: %s", strerror(errno));
         goto cleanup;
     }
@@ -147,7 +147,7 @@ int w_wpk_unsign(const char * source, const char * target, const char ** ca_stor
 
     // Extract file
 
-    if (fileout = fopen(target, "wb"), !fileout) {
+    if (fileout = wfopen(target, "wb"), !fileout) {
         merror("Opening output file: %s", strerror(errno));
         goto cleanup;
     }

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -39,7 +39,7 @@ int ReadExecConfig()
     exec_size = 0;
 
     /* Open file */
-    fp = fopen(DEFAULTAR, "r");
+    fp = wfopen(DEFAULTAR, "r");
     if (!fp) {
         merror(FOPEN_ERROR, DEFAULTAR, errno, strerror(errno));
         return (0);
@@ -99,7 +99,7 @@ int ReadExecConfig()
                      "%s/%s",
                      AR_BINDIR,
                      str_pt);
-            process_file = fopen(exec_cmd[exec_size], "r");
+            process_file = wfopen(exec_cmd[exec_size], "r");
             if (!process_file) {
                 if (f_time_reading) {
                     minfo("Active response command not present: '%s'. "

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -155,7 +155,7 @@ size_t wcom_uncompress(const char * source, const char * target, char ** output)
         return strlen(*output);
     }
 
-    if (ftarget = fopen(final_target, "wb"), !ftarget) {
+    if (ftarget = wfopen(final_target, "wb"), !ftarget) {
         gzclose(fsource);
         merror("At WCOM uncompress: Unable to open '%s'", final_target);
         os_strdup("err Unable to open target", *output);

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -278,7 +278,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
             snprintf(exec_tmp_file, 2048, "/tmp/%s-%d-%ld.alert",
                         integrator_config[s]->name, (int)time(0), (long int)os_random());
 
-            fp = fopen(exec_tmp_file, "w");
+            fp = wfopen(exec_tmp_file, "w");
             if(!fp)
             {
                 mdebug2("File %s couldn't be created.", exec_tmp_file);
@@ -415,7 +415,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                 snprintf(opt_tmp_file, 2048, "/tmp/%s-%d-%ld.options",
                             integrator_config[s]->name, (int)time(0), (long int) os_random());
 
-                fp = fopen(opt_tmp_file, "w");
+                fp = wfopen(opt_tmp_file, "w");
                 if (!fp) {
                     mdebug2("File %s couldn't be created.", opt_tmp_file);
                     opt_tmp_file[0] = '\0';

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -206,7 +206,7 @@ int OS_ReadXML_Ex(const char *file, OS_XML *_lxml, bool flag_truncate) {
     /* Initialize xml structure */
     memset(_lxml, 0, sizeof(OS_XML));
 
-    fp = fopen(file, "r");
+    fp = wfopen(file, "r");
     if (!fp) {
         xml_error(_lxml, "XMLERR: File '%s' not found.", file);
         return (-2);

--- a/src/os_xml/os_xml_writer.c
+++ b/src/os_xml/os_xml_writer.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "file_op.h"
 #include "os_xml.h"
 #include "os_xml_internal.h"
 

--- a/src/os_xml/os_xml_writer.c
+++ b/src/os_xml/os_xml_writer.c
@@ -44,7 +44,7 @@ int OS_WriteXML(const char *infile, const char *outfile, const char **nodes,
     FILE *fp_out;
 
     /* Open infile */
-    fp_in = fopen(infile, "r");
+    fp_in = wfopen(infile, "r");
     if (!fp_in) {
         return (XMLW_NOIN);
     }
@@ -52,7 +52,7 @@ int OS_WriteXML(const char *infile, const char *outfile, const char **nodes,
     setvbuf(fp_in, NULL,_IOFBF , XML_MAXSIZE + 1);
 
     /* Open outfile */
-    fp_out = fopen(outfile, "w");
+    fp_out = wfopen(outfile, "w");
     if (!fp_out) {
         fclose(fp_in);
         return (XMLW_NOOUT);
@@ -314,4 +314,3 @@ static int _WReadElem(FILE *fp_in, FILE *fp_out, unsigned int position,
 
     return (-1);
 }
-

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -691,7 +691,7 @@ STATIC void c_group(const char *group, OSHash **_f_time, os_md5 *_merged_sum, ch
     if ((!r_group || !r_group->merged_is_downloaded) && (!is_multigroup || create_merged)) {
         if (create_merged) {
             if (disk_storage) {
-                if (finalfp = fopen(merged_tmp, "w"), finalfp == NULL) {
+                if (finalfp = wfopen(merged_tmp, "w"), finalfp == NULL) {
                     merror("Unable to create merged file: '%s' due to [(%d)-(%s)].", merged_tmp, errno, strerror(errno));
                     return;
                 }
@@ -749,7 +749,7 @@ STATIC void c_group(const char *group, OSHash **_f_time, os_md5 *_merged_sum, ch
                 if (disk_storage) {
                     OS_MoveFile(merged_tmp, merged);
                 } else {
-                    if (finalfp = fopen(merged, "w"), finalfp == NULL) {
+                    if (finalfp = wfopen(merged, "w"), finalfp == NULL) {
                         merror("Unable to open file: '%s' due to [(%d)-(%s)].", merged, errno, strerror(errno));
                         os_free(finalbuf);
                         return;
@@ -1593,7 +1593,7 @@ static int send_file_toagent(const char *agent_id, const char *group, const char
         snprintf(file, OS_SIZE_1024, "%s/%s/%s", sharedcfg_dir, group, name);
     }
 
-    fp = fopen(file, "r");
+    fp = wfopen(file, "r");
     if (!fp) {
         mdebug1(FOPEN_ERROR, file, errno, strerror(errno));
         return OS_INVALID;

--- a/src/remoted/shared_download.c
+++ b/src/remoted/shared_download.c
@@ -265,7 +265,7 @@ error:
 }
 
 int w_do_parsing(const char * yaml_file, remote_files_group ** agent_remote_group) {
-    FILE *fh = fopen(yaml_file, "r");
+    FILE *fh = wfopen(yaml_file, "r");
     yaml_parser_t parser;
     yaml_event_t  event;
     int retval = W_PARSER_ERROR;

--- a/src/remoted/state.c
+++ b/src/remoted/state.c
@@ -163,7 +163,7 @@ int rem_write_state() {
     snprintf(path, sizeof(path), OS_PIDFILE "/%s.state", __local_name);
     snprintf(path_temp, sizeof(path_temp), "%s.temp", path);
 
-    if (fp = fopen(path_temp, "w"), !fp) {
+    if (fp = wfopen(path_temp, "w"), !fp) {
         merror(FOPEN_ERROR, path_temp, errno, strerror(errno));
         return -1;
     }

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -404,9 +404,9 @@ void check_rc_sys(const char *basedir)
 
     /* Open output files */
     if (rootcheck.notify != QUEUE) {
-        _wx = fopen("rootcheck-rw-rw-rw-.txt", "w");
-        _ww = fopen("rootcheck-rwxrwxrwx.txt", "w");
-        _suid = fopen("rootcheck-suid-files.txt", "w");
+        _wx = wfopen("rootcheck-rw-rw-rw-.txt", "w");
+        _ww = wfopen("rootcheck-rwxrwxrwx.txt", "w");
+        _suid = wfopen("rootcheck-suid-files.txt", "w");
     } else {
         _wx = NULL;
         _ww = NULL;

--- a/src/rootcheck/common.c
+++ b/src/rootcheck/common.c
@@ -134,7 +134,7 @@ int rk_check_file(char *file, char *pattern)
             full_negate = pt_check_negate(pattern);
             /* Check for content in the file */
             mtdebug2(ARGV0, "Checking file: %s", file);
-            fp = fopen(file, "r");
+            fp = wfopen(file, "r");
             if (fp) {
 
                 mtdebug2(ARGV0, "Starting new file: %s", file);
@@ -470,7 +470,7 @@ int is_file(char *file_name)
 #ifndef WIN32
             (access(file_name, F_OK) < 0) &&
 #endif
-            ((fp = fopen(file_name, "r")) == NULL)) {
+            ((fp = wfopen(file_name, "r")) == NULL)) {
         return ret;
     }
 

--- a/src/rootcheck/os_string.c
+++ b/src/rootcheck/os_string.c
@@ -168,7 +168,7 @@ int os_string(char *file, char *regex)
     }
 
     /* Open the file */
-    oss.fp = fopen(file, "r");
+    oss.fp = wfopen(file, "r");
     if (!oss.fp) {
         free(bfr);
         return (0);

--- a/src/rootcheck/os_string.c
+++ b/src/rootcheck/os_string.c
@@ -37,6 +37,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include "file_op.h"
 #include <stdlib.h>
 #include <string.h>
 #include <locale.h>

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -101,12 +101,12 @@ char *os_read_agent_name()
 
     mdebug2("Calling os_read_agent_name().");
 
-    fp = fopen(AGENT_INFO_FILE, "r");
+    fp = wfopen(AGENT_INFO_FILE, "r");
 
     /* We give 1 second for the file to be created */
     if (!fp) {
         sleep(1);
-        fp = fopen(AGENT_INFO_FILE, "r");
+        fp = wfopen(AGENT_INFO_FILE, "r");
     }
 
     if (!fp) {
@@ -148,7 +148,7 @@ char *os_read_agent_ip()
 
     mdebug2("Calling os_read_agent_ip().");
 
-    fp = fopen(AGENT_INFO_FILE, "r");
+    fp = wfopen(AGENT_INFO_FILE, "r");
     if (!fp) {
         merror(FOPEN_ERROR, AGENT_INFO_FILE, errno, strerror(errno));
         return (NULL);
@@ -179,7 +179,7 @@ char *os_read_agent_id()
 
     mdebug2("Calling os_read_agent_id().");
 
-    fp = fopen(AGENT_INFO_FILE, "r");
+    fp = wfopen(AGENT_INFO_FILE, "r");
     if (!fp) {
         merror(FOPEN_ERROR, AGENT_INFO_FILE, errno, strerror(errno));
         return (NULL);
@@ -216,7 +216,7 @@ char *os_read_agent_profile()
     FILE *fp;
 
     mdebug2("Calling os_read_agent_profile().");
-    fp = fopen(AGENT_INFO_FILE, "r");
+    fp = wfopen(AGENT_INFO_FILE, "r");
 
     if (!fp) {
         merror(FOPEN_ERROR, AGENT_INFO_FILE, errno, strerror(errno));
@@ -253,7 +253,7 @@ int os_write_agent_info(const char *agent_name, __attribute__((unused)) const ch
 {
     FILE *fp;
 
-    fp = fopen(AGENT_INFO_FILE, "w");
+    fp = wfopen(AGENT_INFO_FILE, "w");
     if (!fp) {
         merror(FOPEN_ERROR, AGENT_INFO_FILE, errno, strerror(errno));
         return (0);
@@ -786,7 +786,7 @@ char * get_agent_id_from_name(const char *agent_name) {
 
     snprintf(path,PATH_MAX,"%s", KEYS_FILE);
 
-    fp = fopen(path, "r");
+    fp = wfopen(path, "r");
 
     if (!fp) {
         mdebug1("Couldnt open file '%s'", KEYS_FILE);

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -21,13 +21,13 @@ int bzip2_compress(const char *file, const char *filebz2) {
         return -1;
     }
 
-    input = fopen(file, "rb");
+    input = wfopen(file, "rb");
     if (!input) {
         mdebug2(FOPEN_ERROR, file, errno, strerror(errno));
         return -1;
     }
 
-    output = fopen(filebz2, "wb");
+    output = wfopen(filebz2, "wb");
     if (!output) {
         mdebug2(FOPEN_ERROR, filebz2, errno, strerror(errno));
         fclose(input);
@@ -80,13 +80,13 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
         return -1;
     }
 
-    input = fopen(filebz2, "rb");
+    input = wfopen(filebz2, "rb");
     if (!input) {
         mdebug2(FOPEN_ERROR, filebz2, errno, strerror(errno));
         return -1;
     }
 
-     output = fopen(file, "wb");
+     output = wfopen(file, "wb");
     if (!output) {
         mdebug2(FOPEN_ERROR, file, errno, strerror(errno));
         fclose(input);

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -132,10 +132,10 @@ static void _log_function(int level, const char *tag, const char * file, int lin
         logfile[sizeof(logfile) - 1] = '\0';
 
         if (!IsFile(logfile)) {
-            fp = fopen(logfile, "a");
+            fp = wfopen(logfile, "a");
         } else {
             oldmask = umask(0006);
-            fp = fopen(logfile, "w");
+            fp = wfopen(logfile, "w");
             umask(oldmask);
 
             // Make sure that the group is ossec
@@ -153,7 +153,7 @@ static void _log_function(int level, const char *tag, const char * file, int lin
 #else
         strncpy(logfile, LOGJSONFILE, sizeof(logfile) - 1);
         logfile[sizeof(logfile) - 1] = '\0';
-        fp = fopen(logfile, "a");
+        fp = wfopen(logfile, "a");
 #endif
 
         if (fp) {
@@ -198,10 +198,10 @@ static void _log_function(int level, const char *tag, const char * file, int lin
         logfile[sizeof(logfile) - 1] = '\0';
 
         if (!IsFile(logfile)) {
-            fp = fopen(logfile, "a");
+            fp = wfopen(logfile, "a");
         } else {
             oldmask = umask(0006);
-            fp = fopen(logfile, "w");
+            fp = wfopen(logfile, "w");
             umask(oldmask);
 
             // Make sure that the group is ossec
@@ -219,7 +219,7 @@ static void _log_function(int level, const char *tag, const char * file, int lin
 #else
         strncpy(logfile, LOGFILE, sizeof(logfile) - 1);
         logfile[sizeof(logfile) - 1] = '\0';
-        fp = fopen(logfile, "a");
+        fp = wfopen(logfile, "a");
 #endif
 
         /* Maybe log to syslog if the log file is not available */

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -399,7 +399,7 @@ static int w_enrollment_store_key_entry(const char* keys) {
 
 #ifdef WIN32
     FILE *fp;
-    fp = fopen(KEYS_FILE, "w");
+    fp = wfopen(KEYS_FILE, "w");
 
     if (!fp) {
         merror(FOPEN_ERROR, KEYS_FILE, errno, strerror(errno));
@@ -607,7 +607,7 @@ static void w_enrollment_load_pass(w_enrollment_cert *cert_cfg) {
     /* Checking if there is a custom password file */
     if (cert_cfg->authpass == NULL) {
         FILE *fp;
-        fp = fopen(cert_cfg->authpass_file, "r");
+        fp = wfopen(cert_cfg->authpass_file, "r");
 
         if (fp) {
             char buf[4096];

--- a/src/shared/file-queue.c
+++ b/src/shared/file-queue.c
@@ -60,7 +60,7 @@ static int Handle_Queue(file_queue *fileq, int flags)
         /* We must be able to open the file, fseek and get the
          * time of change from it.
          */
-        fileq->fp = fopen(fileq->file_name, "r");
+        fileq->fp = wfopen(fileq->file_name, "r");
         if (!fileq->fp) {
             /* Queue not available */
             return (0);

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2710,7 +2710,7 @@ FILE * wfopen(const char * pathname, const char * mode) {
     FILE * fp;
     int i;
 
-    if (pathname[0] == '\\' || pathname[0] == '/') {
+    if (pathname != NULL && (pathname[0] == '\\' || pathname[0] == '/')) {
         char nextChar = pathname[1];
         if (nextChar != '\0' && strchr("\\/?\"<>|", nextChar)) {
             errno = EINVAL;

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2710,6 +2710,14 @@ FILE * wfopen(const char * pathname, const char * mode) {
     FILE * fp;
     int i;
 
+    if (pathname[0] == '\\' || pathname[0] == '/') {
+        char nextChar = pathname[1];
+        if (nextChar != '\0' && strchr("\\/?\"<>|", nextChar)) {
+            errno = EINVAL;
+            return NULL;
+        }
+    }
+
     for (i = 0; mode[i]; ++i) {
         switch (mode[i]) {
         case '+':

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2769,15 +2769,18 @@ FILE * wfopen(const char * pathname, const char * mode) {
     hFile = CreateFile(pathname, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
 
     if (hFile == INVALID_HANDLE_VALUE) {
+        errno = GetLastError();
         return NULL;
     }
 
     if (fd = _open_osfhandle((intptr_t)hFile, flags), fd < 0) {
+        errno = GetLastError();
         CloseHandle(hFile);
         return NULL;
     }
 
     if (fp = _fdopen(fd, mode), fp == NULL) {
+        errno = GetLastError();
         CloseHandle(hFile);
         return NULL;
     }

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -543,7 +543,7 @@ int CreatePID(const char *name, int pid)
 
     snprintf(file, 255, "%s/%s-%d.pid", OS_PIDFILE, name, pid);
 
-    fp = fopen(file, "a");
+    fp = wfopen(file, "a");
     if (!fp) {
         return (-1);
     }
@@ -571,7 +571,7 @@ char *GetRandomNoise()
     size_t n;
 
     /* Reading urandom */
-    fp = fopen("/dev/urandom", "r");
+    fp = wfopen("/dev/urandom", "r");
     if(!fp)
     {
         return(NULL);
@@ -637,7 +637,7 @@ int UnmergeFiles(const char *finalpath, const char *optdir, int mode, const char
     FILE *fp;
     FILE *finalfp;
 
-    finalfp = fopen(finalpath, mode == OS_BINARY ? "rb" : "r");
+    finalfp = wfopen(finalpath, mode == OS_BINARY ? "rb" : "r");
     if (!finalfp) {
         merror("Unable to read merged file: '%s' due to [(%d)-(%s)].", finalpath, errno, strerror(errno));
         return (0);
@@ -712,7 +712,7 @@ int UnmergeFiles(const char *finalpath, const char *optdir, int mode, const char
         /* Open filename */
 
         if (state_ok) {
-            if (fp = fopen(tmp_file, mode == OS_BINARY ? "wb" : "w"), !fp) {
+            if (fp = wfopen(tmp_file, mode == OS_BINARY ? "wb" : "w"), !fp) {
                 ret = 0;
                 merror("Unable to unmerge file '%s' due to [(%d)-(%s)].", tmp_file, errno, strerror(errno));
             }
@@ -794,7 +794,7 @@ int TestUnmergeFiles(const char *finalpath, int mode)
     char buf[2048 + 1];
     FILE *finalfp;
 
-    finalfp = fopen(finalpath, mode == OS_BINARY ? "rb" : "r");
+    finalfp = wfopen(finalpath, mode == OS_BINARY ? "rb" : "r");
     if (!finalfp) {
         merror("Unable to read merged file: '%s'.", finalpath);
         return (0);
@@ -902,7 +902,7 @@ int MergeAppendFile(FILE *finalfp, const char *files, int path_offset)
         }
     }
 
-    if (fp = fopen(files, "r"), fp == NULL) {
+    if (fp = wfopen(files, "r"), fp == NULL) {
         merror("Unable to open file: '%s' due to [(%d)-(%s)].", files, errno, strerror(errno));
         return (0);
     }
@@ -953,7 +953,7 @@ int checkBinaryFile(const char *f_name) {
 
     str[OS_MAXSTR] = '\0';
 
-    fp = fopen(f_name, "r");
+    fp = wfopen(f_name, "r");
 
      if (!fp) {
         merror("Unable to open file '%s' due to [(%d)-(%s)].", f_name, errno, strerror(errno));
@@ -2237,7 +2237,7 @@ int TempFile(File *file, const char *source, int copy) {
         return -1;
     }
 
-    fp_src = fopen(source,"r");
+    fp_src = wfopen(source,"r");
 
 #ifndef WIN32
     struct stat buf;
@@ -2317,14 +2317,14 @@ int OS_MoveFile(const char *src, const char *dst) {
 
     mdebug1("Couldn't rename %s: %s", dst, strerror(errno));
 
-    fp_src = fopen(src, "r");
+    fp_src = wfopen(src, "r");
 
     if (!fp_src) {
         merror("Couldn't open file '%s'", src);
         return -1;
     }
 
-    fp_dst = fopen(dst, "w");
+    fp_dst = wfopen(dst, "w");
 
     if (!fp_dst) {
         merror("Couldn't open file '%s'", dst);
@@ -2365,7 +2365,7 @@ int w_copy_file(const char *src, const char *dst, char mode, char * message, int
     char buffer[4096];
     int status = 0;
 
-    fp_src = fopen(src, "r");
+    fp_src = wfopen(src, "r");
 
     if (!fp_src) {
         if(!silent) {
@@ -2376,10 +2376,10 @@ int w_copy_file(const char *src, const char *dst, char mode, char * message, int
 
     /* Append to file */
     if (mode == 'a') {
-        fp_dst = fopen(dst, "a");
+        fp_dst = wfopen(dst, "a");
     }
     else {
-        fp_dst = fopen(dst, "w");
+        fp_dst = wfopen(dst, "w");
     }
 
 
@@ -2851,7 +2851,7 @@ int w_uncompress_gzfile(const char *gzfilesrc, const char *gzfiledst) {
     umask(0027);
 
     /* Read file */
-    fd = fopen(gzfiledst, "wb");
+    fd = wfopen(gzfiledst, "wb");
     if (!fd) {
         merror("in w_uncompress_gzfile(): fopen error %s (%d):'%s'",
                 gzfiledst,
@@ -2909,7 +2909,7 @@ int is_ascii_utf8(const char * file, unsigned int max_lines_ascii, unsigned int 
     fpos_t begin;
     FILE *fp;
 
-    fp = fopen(file, "r");
+    fp = wfopen(file, "r");
 
     if (!fp) {
         mdebug1(OPEN_UNABLE, file);
@@ -3078,7 +3078,7 @@ int is_usc2(const char * file) {
     int retval = 0;
     FILE *fp;
 
-    fp = fopen(file, "r");
+    fp = wfopen(file, "r");
 
     if (!fp) {
         mdebug1(OPEN_UNABLE, file);
@@ -3314,7 +3314,7 @@ char * w_get_file_content(const char * path, long max_size) {
     }
 
     // Load file
-    if (fp = fopen(path, "r"), !fp) {
+    if (fp = wfopen(path, "r"), !fp) {
         mdebug1(FOPEN_ERROR, path, errno, strerror(errno));
         goto end;
     }
@@ -3362,7 +3362,7 @@ FILE * w_get_file_pointer(const char * path) {
     }
 
     // Load file
-    if (fp = fopen(path, "r"), !fp) {
+    if (fp = wfopen(path, "r"), !fp) {
         mdebug1(FOPEN_ERROR, path, errno, strerror(errno));
         return NULL;
     }
@@ -3376,7 +3376,7 @@ int w_is_compressed_gz_file(const char * path) {
     int retval = 0;
     FILE *fp;
 
-    fp = fopen(path, "rb");
+    fp = wfopen(path, "rb");
 
     /* Magic number: 1f 8b */
     if (fp && fread(buf, 1, 2, fp) == 2) {
@@ -3398,7 +3398,7 @@ int w_is_compressed_bz2_file(const char * path) {
     int retval = 0;
     FILE *fp;
 
-    fp = fopen(path, "rb");
+    fp = wfopen(path, "rb");
 
     /* Magic number: 42 5a 68 */
     if (fp && fread(buf, 1, 3, fp) == 3) {

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2710,12 +2710,9 @@ FILE * wfopen(const char * pathname, const char * mode) {
     FILE * fp;
     int i;
 
-    if (pathname != NULL && (pathname[0] == '\\' || pathname[0] == '/')) {
-        char nextChar = pathname[1];
-        if (nextChar != '\0' && strchr("\\/?\"<>|", nextChar)) {
-            errno = EINVAL;
-            return NULL;
-        }
+    if (pathname && strchr("\\/", pathname[0]) && strchr("\\/?\"<>|", pathname[1])) {
+        errno = EINVAL;
+        return NULL;
     }
 
     for (i = 0; mode[i]; ++i) {

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2631,7 +2631,7 @@ wino_t get_fp_inode(FILE * fp) {
 
 
 #ifdef WIN32
-int get_fp_file_information(FILE * fp, BY_HANDLE_FILE_INFORMATION fileInfo) {
+int get_fp_file_information(FILE * fp, LPBY_HANDLE_FILE_INFORMATION fileInfo) {
     int fd;
     HANDLE h;
 
@@ -2643,7 +2643,7 @@ int get_fp_file_information(FILE * fp, BY_HANDLE_FILE_INFORMATION fileInfo) {
         return 0;
     }
 
-    return GetFileInformationByHandle(h, &fileInfo);
+    return GetFileInformationByHandle(h, fileInfo);
 }
 #endif
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2630,6 +2630,24 @@ wino_t get_fp_inode(FILE * fp) {
 }
 
 
+#ifdef WIN32
+int get_fp_file_information(FILE * fp, BY_HANDLE_FILE_INFORMATION fileInfo) {
+    int fd;
+    HANDLE h;
+
+    if (fd = _fileno(fp), fd < 0) {
+        return 0;
+    }
+
+    if (h = (HANDLE)_get_osfhandle(fd), h == INVALID_HANDLE_VALUE) {
+        return 0;
+    }
+
+    return GetFileInformationByHandle(h, &fileInfo);
+}
+#endif
+
+
 long get_fp_size(FILE * fp) {
     long offset;
     long size;

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2724,7 +2724,7 @@ FILE * wfopen(const char * pathname, const char * mode) {
         case 'a':
             dwDesiredAccess = GENERIC_WRITE;
             dwCreationDisposition = OPEN_ALWAYS;
-            flags = _O_CREAT;
+            flags = _O_APPEND;
             break;
         case 'b':
             flags &= ~_O_TEXT;

--- a/src/shared/json-queue.c
+++ b/src/shared/json-queue.c
@@ -26,7 +26,7 @@ int jqueue_open(file_queue * queue, int tail) {
         fclose(queue->fp);
     }
 
-    if (queue->fp = fopen(queue->file_name, "r"), !queue->fp) {
+    if (queue->fp = wfopen(queue->file_name, "r"), !queue->fp) {
         merror(FOPEN_ERROR, queue->file_name, errno, strerror(errno));
         return -1;
     }

--- a/src/shared/json_op.c
+++ b/src/shared/json_op.c
@@ -49,7 +49,7 @@ int json_fwrite(const char * path, const cJSON * item) {
 
     size = strlen(buffer);
 
-    if (fp = fopen(path, "w"), !fp) {
+    if (fp = wfopen(path, "w"), !fp) {
         mdebug1(FOPEN_ERROR, path, errno, strerror(errno));
         goto end;
     }

--- a/src/shared/os_utils.c
+++ b/src/shared/os_utils.c
@@ -120,7 +120,7 @@ OSList *w_os_get_process_list()
 #endif
 /* Check if a file exists */
 int w_is_file(const char * const file) {
-    FILE *fp = fopen(file, "r");
+    FILE *fp = wfopen(file, "r");
     int is_exist = 0;
     if (fp != NULL) {
         is_exist = 1;
@@ -325,7 +325,7 @@ OSList *w_os_get_process_list()
 }
 
 typedef BOOL (WINAPI *LPFN_WOW64DISABLEWOW64FSREDIRECTION)(PVOID *OldValue);
- 
+
 void SafeWow64DisableWow64FsRedirection(PVOID *oldValue) {
     LPFN_WOW64DISABLEWOW64FSREDIRECTION Wow64DisableWow64FsRedirection = NULL;
     HMODULE kernel32 = GetModuleHandle(TEXT("kernel32.dll"));

--- a/src/shared/report_op.c
+++ b/src/shared/report_op.c
@@ -403,7 +403,7 @@ void os_ReportdStart(report_filter *r_filter)
     os_calloc(1, sizeof(file_queue), fileq);
 
     if (r_filter->report_type == REPORT_TYPE_DAILY && r_filter->filename) {
-        fileq->fp = fopen(r_filter->filename, "r");
+        fileq->fp = wfopen(r_filter->filename, "r");
         if (!fileq->fp) {
             merror("Unable to open alerts file to generate report.");
             goto cleanup;

--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -94,7 +94,7 @@ int wurl_get(const char * url, const char * dest, const char * header, const cha
         char const *cert = find_cert_list();
 
         old_mask = umask(0006);
-        fp = fopen(dest, "wb");
+        fp = wfopen(dest, "wb");
         umask(old_mask);
         if (!fp) {
             mdebug1(FOPEN_ERROR, dest, errno, strerror(errno));

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -96,7 +96,7 @@ static char *_read_file(const char *high_name, const char *low_name, const char 
     char *ret;
     int i;
 
-    fp = fopen(defines_file, "r");
+    fp = wfopen(defines_file, "r");
     if (!fp) {
         if (strcmp(defines_file, OSSEC_LDEFINES) != 0) {
             merror(FOPEN_ERROR, defines_file, errno, strerror(errno));

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -408,9 +408,9 @@ os_info *get_unix_version()
     os_calloc(1,sizeof(os_info),info);
 
     // Try to open /etc/os-release
-    os_release = fopen("/etc/os-release", "r");
+    os_release = wfopen("/etc/os-release", "r");
     // Try to open /usr/lib/os-release
-    if (!os_release) os_release = fopen("/usr/lib/os-release", "r");
+    if (!os_release) os_release = wfopen("/usr/lib/os-release", "r");
 
     if (os_release) {
         while (fgets(buff, sizeof(buff)- 1, os_release)) {
@@ -463,7 +463,7 @@ os_info *get_unix_version()
                 regex_t regexCompiled;
                 regmatch_t match[2];
                 int match_size;
-                if (version_release = fopen("/etc/centos-release","r"), version_release){
+                if (version_release = wfopen("/etc/centos-release","r"), version_release){
                     os_free(info->os_version);
                     static const char *pattern = "([0-9][0-9]*\\.?[0-9]*)\\.*";
                     if (regcomp(&regexCompiled, pattern, REG_EXTENDED)) {
@@ -498,7 +498,7 @@ os_info *get_unix_version()
         int match_size;
 
         // CentOS
-        if (version_release = fopen("/etc/centos-release","r"), version_release){
+        if (version_release = wfopen("/etc/centos-release","r"), version_release){
             info->os_name = strdup("CentOS Linux");
             info->os_platform = strdup("centos");
             static const char *pattern = "([0-9][0-9]*\\.?[0-9]*)\\.*";
@@ -516,7 +516,7 @@ os_info *get_unix_version()
             regfree(&regexCompiled);
             fclose(version_release);
         // Fedora
-        } else if (version_release = fopen("/etc/fedora-release","r"), version_release){
+        } else if (version_release = wfopen("/etc/fedora-release","r"), version_release){
             info->os_name = strdup("Fedora");
             info->os_platform = strdup("fedora");
             static const char *pattern = " ([0-9][0-9]*) ";
@@ -534,7 +534,7 @@ os_info *get_unix_version()
             regfree(&regexCompiled);
             fclose(version_release);
         // RedHat
-        } else if (version_release = fopen("/etc/redhat-release","r"), version_release){
+        } else if (version_release = wfopen("/etc/redhat-release","r"), version_release){
             static const char *pattern = "([0-9][0-9]*\\.?[0-9]*)\\.*";
             if (regcomp(&regexCompiled, pattern, REG_EXTENDED)) {
                 merror_exit("Can not compile regular expression.");
@@ -565,7 +565,7 @@ os_info *get_unix_version()
             regfree(&regexCompiled);
             fclose(version_release);
         // Arch
-        } else if (version_release = fopen("/etc/arch-release","r"), version_release){
+        } else if (version_release = wfopen("/etc/arch-release","r"), version_release){
             info->os_name = strdup("Arch Linux");
             info->os_platform = strdup("arch");
             static const char *pattern = "([0-9][0-9]*\\.?[0-9]*)\\.*";
@@ -587,7 +587,7 @@ os_info *get_unix_version()
             regfree(&regexCompiled);
             fclose(version_release);
         // Ubuntu
-        } else if (version_release = fopen("/etc/lsb-release","r"), version_release){
+        } else if (version_release = wfopen("/etc/lsb-release","r"), version_release){
             info->os_name = strdup("Ubuntu");
             info->os_platform = strdup("ubuntu");
             while (fgets(buff, sizeof(buff) - 1, version_release)) {
@@ -600,7 +600,7 @@ os_info *get_unix_version()
 
             fclose(version_release);
         // Gentoo
-        } else if (version_release = fopen("/etc/gentoo-release","r"), version_release){
+        } else if (version_release = wfopen("/etc/gentoo-release","r"), version_release){
             info->os_name = strdup("Gentoo");
             info->os_platform = strdup("gentoo");
             static const char *pattern = " ([0-9][0-9]*\\.?[0-9]*)\\.*";
@@ -618,7 +618,7 @@ os_info *get_unix_version()
             regfree(&regexCompiled);
             fclose(version_release);
         // SuSE
-        } else if (version_release = fopen("/etc/SuSE-release","r"), version_release){
+        } else if (version_release = wfopen("/etc/SuSE-release","r"), version_release){
             info->os_name = strdup("SuSE Linux");
             info->os_platform = strdup("suse");
             static const char *pattern = ".*VERSION = ([0-9][0-9]*)";
@@ -636,7 +636,7 @@ os_info *get_unix_version()
             regfree(&regexCompiled);
             fclose(version_release);
         // Debian
-        } else if (version_release = fopen("/etc/debian_version","r"), version_release){
+        } else if (version_release = wfopen("/etc/debian_version","r"), version_release){
             info->os_name = strdup("Debian GNU/Linux");
             info->os_platform = strdup("debian");
             static const char *pattern = "([0-9][0-9]*\\.?[0-9]*)\\.*";
@@ -654,7 +654,7 @@ os_info *get_unix_version()
             regfree(&regexCompiled);
             fclose(version_release);
         // Slackware
-        } else if (version_release = fopen("/etc/slackware-version","r"), version_release){
+        } else if (version_release = wfopen("/etc/slackware-version","r"), version_release){
             info->os_name = strdup("Slackware");
             info->os_platform = strdup("slackware");
             static const char *pattern = " ([0-9][0-9]*\\.?[0-9]*)\\.*";
@@ -672,7 +672,7 @@ os_info *get_unix_version()
             regfree(&regexCompiled);
             fclose(version_release);
         // Alpine
-        } else if (version_release = fopen("/etc/alpine-release","r"), version_release){
+        } else if (version_release = wfopen("/etc/alpine-release","r"), version_release){
             info->os_name = strdup("Alpine Linux");
             info->os_platform = strdup("alpine");
             static const char *pattern = "([0-9]+\\.)?([0-9]+\\.)?([0-9]+)";
@@ -783,7 +783,7 @@ os_info *get_unix_version()
                     info->os_name = strdup("SunOS");
                     info->os_platform = strdup("sunos");
 
-                    if (os_release = fopen("/etc/release", "r"), os_release) {
+                    if (os_release = wfopen("/etc/release", "r"), os_release) {
                         if (fgets(buff, sizeof(buff) - 1, os_release) == NULL) {
                             merror("Cannot read from /etc/release.");
                             fclose(os_release);
@@ -1000,7 +1000,7 @@ int get_nproc() {
     char string[OS_MAXSTR];
     int cpu_cores = 0;
 
-    if (!(fp = fopen("/proc/cpuinfo", "r"))) {
+    if (!(fp = wfopen("/proc/cpuinfo", "r"))) {
         mwarn("Unable to read cpuinfo file");
     } else {
         while (fgets(string, OS_MAXSTR, fp) != NULL){

--- a/src/shared/wait_op.c
+++ b/src/shared/wait_op.c
@@ -22,7 +22,7 @@ void os_setwait()
 
     /* For same threads */
     __wait_lock = 1;
-    fp = fopen(WAIT_FILE, "w");
+    fp = wfopen(WAIT_FILE, "w");
 
     if (fp) {
         fprintf(fp, "l");

--- a/src/shared/yaml2json.c
+++ b/src/shared/yaml2json.c
@@ -39,7 +39,7 @@ int yaml_parse_file(const char * path, yaml_document_t * document) {
     FILE * finput;
     int error = -1;
 
-    if (finput = fopen(path, "rb"), finput) {
+    if (finput = wfopen(path, "rb"), finput) {
         yaml_parser_initialize(&parser);
         yaml_parser_set_input_file(&parser, finput);
 

--- a/src/syscheckd/src/fim_diff_changes.c
+++ b/src/syscheckd/src/fim_diff_changes.c
@@ -338,7 +338,7 @@ int fim_diff_registry_tmp(const char *value_data,
     int ret = 0;
 
     mkdir_ex(diff->tmp_folder);
-    FILE *fp = fopen(diff->file_origin, "w");
+    FILE *fp = wfopen(diff->file_origin, "w");
     if (NULL != fp) {
         switch (data_type) {
             case REG_SZ:

--- a/src/syscheckd/src/whodata/audit_healthcheck.c
+++ b/src/syscheckd/src/whodata/audit_healthcheck.c
@@ -54,7 +54,7 @@ int audit_health_check(int audit_socket) {
 
     // Generate open events until they get picked up
     do {
-        fp = fopen(abs_path_healthcheck_file, "w");
+        fp = wfopen(abs_path_healthcheck_file, "w");
 
         if (!fp) {
             mdebug1(FIM_AUDIT_HEALTHCHECK_FILE);

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -87,7 +87,7 @@ int configure_audisp(const char *audisp_path, const char *audisp_config) {
 
     abspath(AUDIT_CONF_FILE, buffer, PATH_MAX);
 
-    fp = fopen(AUDIT_CONF_FILE, "w");
+    fp = wfopen(AUDIT_CONF_FILE, "w");
     if (!fp) {
         merror(FOPEN_ERROR, AUDIT_CONF_FILE, errno, strerror(errno));
         return -1;
@@ -210,7 +210,7 @@ void audit_create_rules_file() {
     OSListNode *node_it;
     FILE *fp;
 
-    fp = fopen(AUDIT_RULES_FILE, "w");
+    fp = wfopen(AUDIT_RULES_FILE, "w");
     if (!fp) {
         merror(FOPEN_ERROR, AUDIT_RULES_FILE, errno, strerror(errno));
         return;

--- a/src/syscheckd/src/whodata/win_whodata.c
+++ b/src/syscheckd/src/whodata/win_whodata.c
@@ -1269,11 +1269,11 @@ int set_policies() {
         goto end;
     }
 
-    if (f_backup = fopen (WPOL_BACKUP_FILE, "r"), !f_backup) {
+    if (f_backup = wfopen(WPOL_BACKUP_FILE, "r"), !f_backup) {
         merror(FIM_ERROR_WPOL_BACKUP_FILE_OPEN, WPOL_BACKUP_FILE, strerror(errno), errno);
         goto end;
     }
-    if (f_new = fopen (WPOL_NEW_FILE, "w"), !f_new) {
+    if (f_new = wfopen(WPOL_NEW_FILE, "w"), !f_new) {
         merror(FIM_ERROR_WPOL_BACKUP_FILE_OPEN, WPOL_NEW_FILE, strerror(errno), errno);
         goto end;
     }

--- a/src/unit_tests/addagent/CMakeLists.txt
+++ b/src/unit_tests/addagent/CMakeLists.txt
@@ -27,7 +27,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 list(APPEND addagent_names "test_manage_keys")
 list(APPEND addagent_flags "${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS} \
                             -Wl,--wrap,mkstemp_ex \
-                            -Wl,--wrap,stat -Wl,--wrap,chmod -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fprintf -Wl,--wrap,fgets -Wl,--wrap,rename_ex\
+                            -Wl,--wrap,stat -Wl,--wrap,chmod -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fprintf -Wl,--wrap,fgets -Wl,--wrap,rename_ex\
                             -Wl,--wrap,encode_base64 -Wl,--wrap,decode_base64")
 
 list(LENGTH addagent_names count)

--- a/src/unit_tests/addagent/CMakeLists.txt
+++ b/src/unit_tests/addagent/CMakeLists.txt
@@ -27,8 +27,8 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 list(APPEND addagent_names "test_manage_keys")
 list(APPEND addagent_flags "${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS} \
                             -Wl,--wrap,mkstemp_ex \
-                            -Wl,--wrap,stat -Wl,--wrap,chmod -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fprintf -Wl,--wrap,fgets -Wl,--wrap,rename_ex\
-                            -Wl,--wrap,encode_base64 -Wl,--wrap,decode_base64")
+                            -Wl,--wrap,stat -Wl,--wrap,chmod -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fprintf -Wl,--wrap,fgets -Wl,--wrap,rename_ex\
+                            -Wl,--wrap,encode_base64 -Wl,--wrap,decode_base64 -Wl,--wrap,wfopen")
 
 list(LENGTH addagent_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/addagent/test_manage_keys.c
+++ b/src/unit_tests/addagent/test_manage_keys.c
@@ -52,9 +52,9 @@ void test_k_import_successful(void **state) {
     expect_string(__wrap_chmod, path, CLIENT_KEYS_FILENAME);
     will_return(__wrap_chmod, 0);
 
-    expect_string(__wrap_fopen, path, CLIENT_KEYS_FILENAME);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, "test");
+    expect_string(__wrap_wfopen, path, CLIENT_KEYS_FILENAME);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, "test");
 
     expect_value(__wrap_fprintf, __stream, "test");
     expect_string(__wrap_fprintf, formatted_msg, KEY_DECODED_SUCCESSFUL "\n");

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -56,7 +56,7 @@ list(APPEND analysisd_flags "-Wl,--wrap,OS_SendUnix -Wl,--wrap,wdb_get_agent_inf
                              ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND analysisd_names "test_log")
-list(APPEND analysisd_flags "-Wl,--wrap,fprintf,-wrap,fflush,--wrap,fclose,--wrap,fgets,--wrap,fgetpos,--wrap,fopen \
+list(APPEND analysisd_flags "-Wl,--wrap,fprintf,-wrap,fflush,--wrap,fclose,--wrap,fgets,--wrap,fgetpos,--wrap,wfopen \
                              -Wl,--wrap,fread,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,fputc \
                              -Wl,--wrap,ctime_r")
 

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -56,9 +56,9 @@ list(APPEND analysisd_flags "-Wl,--wrap,OS_SendUnix -Wl,--wrap,wdb_get_agent_inf
                              ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND analysisd_names "test_log")
-list(APPEND analysisd_flags "-Wl,--wrap,fprintf,-wrap,fflush,--wrap,fclose,--wrap,fgets,--wrap,fgetpos,--wrap,wfopen \
+list(APPEND analysisd_flags "-Wl,--wrap,fprintf,-wrap,fflush,--wrap,fclose,--wrap,fgets,--wrap,fgetpos,--wrap,fopen \
                              -Wl,--wrap,fread,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,fputc \
-                             -Wl,--wrap,ctime_r")
+                             -Wl,--wrap,ctime_r -Wl,--wrap,wfopen")
 
 list(APPEND analysisd_names "test_labels")
 list(APPEND analysisd_flags "-Wl,--wrap,wdb_get_agent_labels")

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -35,10 +35,10 @@ else()
                                     -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetpos \
                                     -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_AddArrayToObject -Wl,--wrap,cJSON_AddStringToObject \
                                     -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,pthread_rwlock_wrlock \
-                                    -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_Delete -Wl,--wrap,wfopen -Wl,--wrap,clearerr \
+                                    -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_Delete -Wl,--wrap,fopen -Wl,--wrap,clearerr \
                                     -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_GetArraySize -Wl,--wrap,cJSON_GetArrayItem \
                                     -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,OS_SHA1_File_Nbytes -Wl,--wrap,fileno -Wl,--wrap,fstat \
-                                    -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
+                                    -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,wfopen \
                                     -Wl,--wrap,stat -Wl,--wrap=fgetc -Wl,--wrap=w_fseek -Wl,--wrap,w_ftell \
                                     -Wl,--wrap,OS_SHA1_File_Nbytes_with_fp_check -Wl,--wrap,cJSON_CreateString \
                                     -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,wpclose -Wl,--wrap,kill \
@@ -46,22 +46,22 @@ else()
                                     ${HASH_OP_WRAPPERS}")
 
     list(APPEND logcollector_names "test_read_multiline_regex")
-    list(APPEND logcollector_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+    list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                     -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc\
                                     -Wl,--wrap,time -Wl,--wrap,can_read -Wl,--wrap,w_ftell -Wl,--wrap,w_expression_match \
                                     -Wl,--wrap,w_msg_hash_queues_push -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status \
                                     -Wl,--wrap=w_get_hash_context -Wl,--wrap=_fseeki64 -Wl,--wrap=OS_SHA1_Stream \
-                                    -Wl,--wrap=w_fseek -Wl,--wrap,_mdebug2")
+                                    -Wl,--wrap=w_fseek -Wl,--wrap,_mdebug2 -Wl,--wrap,wfopen")
 
     list(APPEND logcollector_names "test_localfile-config")
-    list(APPEND logcollector_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+    list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,wfopen \
                                     -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc\
                                     -Wl,--wrap,w_get_attr_val_by_name -Wl,--wrap,fgetpos ${DEBUG_OP_WRAPPERS}")
 
     list(APPEND logcollector_names "test_state")
-    list(APPEND logcollector_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+    list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                     -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc \
-                                    -Wl,--wrap,fgetpos -Wl,--wrap,time \
+                                    -Wl,--wrap,fgetpos -Wl,--wrap,time -Wl,--wrap,wfopen \
                                     -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray \
                                     -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddNumberToObject \
                                     -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddItemToObject \
@@ -80,32 +80,32 @@ else()
     list(APPEND logcollector_names "test_macos_log")
     list(APPEND logcollector_flags "-Wl,--wrap,wpopenv -Wl,--wrap,fileno -Wl,--wrap,fcntl -Wl,--wrap,_merror \
                                     -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
-                                    -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
+                                    -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
                                     -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,wpclose -Wl,--wrap,access \
                                     -Wl,--wrap,getpid -Wl,--wrap,_minfo -Wl,--wrap,pthread_rwlock_wrlock \
                                     -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_rdlock \
-                                    -Wl,--wrap,so_get_function_sym -Wl,--wrap,so_get_module_handle \
+                                    -Wl,--wrap,so_get_function_sym -Wl,--wrap,so_get_module_handle -Wl,--wrap,wfopen \
                                     -Wl,--wrap,_mdebug1 -Wl,--wrap,w_get_os_codename -Wl,--wrap,w_get_process_childs")
 
     list(APPEND logcollector_names "test_read_macos")
     list(APPEND logcollector_flags "-Wl,--wrap,w_expression_match -Wl,--wrap,can_read -Wl,--wrap,fgets \
                                     -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,_mdebug2\
-                                    -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
+                                    -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
                                     -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,_merror -Wl,--wrap,waitpid \
                                     -Wl,--wrap,w_msg_hash_queues_push -Wl,--wrap,_mdebug1 -Wl,--wrap,_minfo \
                                     -Wl,--wrap,kill -Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,strerror \
                                     -Wl,--wrap,time -Wl,--wrap,so_get_function_sym -Wl,--wrap,so_get_module_handle \
                                     -Wl,--wrap,isDebug -Wl,--wrap,w_get_first_child -Wl,--wrap,w_is_macos_sierra \
                                     -Wl,--wrap,w_macos_set_log_settings -Wl,--wrap,w_macos_set_last_log_timestamp \
-                                    -Wl,--wrap,w_macos_set_is_valid_data")
+                                    -Wl,--wrap,w_macos_set_is_valid_data -Wl,--wrap,wfopen")
 
     list(APPEND logcollector_names "test_read_multiline")
-    list(APPEND logcollector_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+    list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                     -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc\
                                     -Wl,--wrap,time -Wl,--wrap,can_read -Wl,--wrap,w_ftell -Wl,--wrap,w_expression_match \
                                     -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status -Wl,--wrap,_merror \
                                     -Wl,--wrap=w_get_hash_context -Wl,--wrap=_fseeki64 -Wl,--wrap=OS_SHA1_Stream \
-                                    -Wl,--wrap=w_fseek")
+                                    -Wl,--wrap=w_fseek -Wl,--wrap,wfopen")
 endif()
 
 list(LENGTH logcollector_names count)

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -31,7 +31,7 @@ if(${TARGET} STREQUAL "winagent")
 else()
     list(APPEND logcollector_names "test_logcollector")
     list(APPEND logcollector_flags "-Wl,--wrap,OS_SHA1_Stream -Wl,--wrap,merror_exit \
-                                    -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
+                                    -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
                                     -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetpos \
                                     -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_AddArrayToObject -Wl,--wrap,cJSON_AddStringToObject \
                                     -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,pthread_rwlock_wrlock \
@@ -46,7 +46,7 @@ else()
                                     ${HASH_OP_WRAPPERS}")
 
     list(APPEND logcollector_names "test_read_multiline_regex")
-    list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+    list(APPEND logcollector_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                     -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc\
                                     -Wl,--wrap,time -Wl,--wrap,can_read -Wl,--wrap,w_ftell -Wl,--wrap,w_expression_match \
                                     -Wl,--wrap,w_msg_hash_queues_push -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status \
@@ -54,12 +54,12 @@ else()
                                     -Wl,--wrap=w_fseek -Wl,--wrap,_mdebug2")
 
     list(APPEND logcollector_names "test_localfile-config")
-    list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+    list(APPEND logcollector_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                     -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc\
                                     -Wl,--wrap,w_get_attr_val_by_name -Wl,--wrap,fgetpos ${DEBUG_OP_WRAPPERS}")
 
     list(APPEND logcollector_names "test_state")
-    list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+    list(APPEND logcollector_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                     -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc \
                                     -Wl,--wrap,fgetpos -Wl,--wrap,time \
                                     -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray \
@@ -80,7 +80,7 @@ else()
     list(APPEND logcollector_names "test_macos_log")
     list(APPEND logcollector_flags "-Wl,--wrap,wpopenv -Wl,--wrap,fileno -Wl,--wrap,fcntl -Wl,--wrap,_merror \
                                     -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
-                                    -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
+                                    -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
                                     -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,wpclose -Wl,--wrap,access \
                                     -Wl,--wrap,getpid -Wl,--wrap,_minfo -Wl,--wrap,pthread_rwlock_wrlock \
                                     -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_rdlock \
@@ -90,7 +90,7 @@ else()
     list(APPEND logcollector_names "test_read_macos")
     list(APPEND logcollector_flags "-Wl,--wrap,w_expression_match -Wl,--wrap,can_read -Wl,--wrap,fgets \
                                     -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,_mdebug2\
-                                    -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
+                                    -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
                                     -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,_merror -Wl,--wrap,waitpid \
                                     -Wl,--wrap,w_msg_hash_queues_push -Wl,--wrap,_mdebug1 -Wl,--wrap,_minfo \
                                     -Wl,--wrap,kill -Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,strerror \
@@ -100,7 +100,7 @@ else()
                                     -Wl,--wrap,w_macos_set_is_valid_data")
 
     list(APPEND logcollector_names "test_read_multiline")
-    list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+    list(APPEND logcollector_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                     -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc\
                                     -Wl,--wrap,time -Wl,--wrap,can_read -Wl,--wrap,w_ftell -Wl,--wrap,w_expression_match \
                                     -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status -Wl,--wrap,_merror \

--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -1619,9 +1619,9 @@ void test_w_initialize_file_status_fopen_fail(void ** state) {
     expect_function_call(__wrap_OSHash_SetFreeDataPointer);
     will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
-    expect_string(__wrap_fopen, path, LOCALFILE_STATUS);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, LOCALFILE_STATUS);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
 
     expect_string(__wrap__merror, formatted_msg, "(1103): Could not open file 'queue/logcollector/file_status.json' due to [(0)-(Success)].");
 
@@ -1637,9 +1637,9 @@ void test_w_initialize_file_status_fread_fail(void ** state) {
     expect_function_call(__wrap_OSHash_SetFreeDataPointer);
     will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
-    expect_string(__wrap_fopen, path, LOCALFILE_STATUS);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, "test");
+    expect_string(__wrap_wfopen, path, LOCALFILE_STATUS);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, "test");
 
     will_return(__wrap_fread, "test");
     will_return(__wrap_fread, 0);
@@ -1672,9 +1672,9 @@ void test_w_initialize_file_status_OK(void ** state) {
     expect_function_call(__wrap_OSHash_SetFreeDataPointer);
     will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
-    expect_string(__wrap_fopen, path, LOCALFILE_STATUS);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, "test");
+    expect_string(__wrap_wfopen, path, LOCALFILE_STATUS);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, "test");
 
     will_return(__wrap_fread, "test");
     will_return(__wrap_fread, 1);

--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -771,8 +771,8 @@ void test_w_save_file_status_wfopen_error(void ** state) {
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_wfopen, __filename, "queue/logcollector/file_status.json");
-    expect_string(__wrap_wfopen, __modes, "w");
+    expect_string(__wrap_wfopen, path, "queue/logcollector/file_status.json");
+    expect_string(__wrap_wfopen, mode, "w");
     will_return(__wrap_wfopen, 0);
 
     expect_string(__wrap__merror_exit, formatted_msg, "(1103): Could not open file 'queue/logcollector/file_status.json' due to [(0)-(Success)].");
@@ -838,8 +838,8 @@ void test_w_save_file_status_fwrite_error(void ** state) {
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_wfopen, __filename, "queue/logcollector/file_status.json");
-    expect_string(__wrap_wfopen, __modes, "w");
+    expect_string(__wrap_wfopen, path, "queue/logcollector/file_status.json");
+    expect_string(__wrap_wfopen, mode, "w");
     will_return(__wrap_wfopen, "test");
 
     will_return(__wrap_fwrite, 0);
@@ -913,8 +913,8 @@ void test_w_save_file_status_OK(void ** state) {
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_wfopen, __filename, "queue/logcollector/file_status.json");
-    expect_string(__wrap_wfopen, __modes, "w");
+    expect_string(__wrap_wfopen, path, "queue/logcollector/file_status.json");
+    expect_string(__wrap_wfopen, mode, "w");
     will_return(__wrap_wfopen, "test");
 
     will_return(__wrap_fwrite, 1);

--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -878,9 +878,9 @@ void test_w_logcollector_state_dump_fail_open(void ** state) {
     will_return(__wrap_cJSON_Print, strdup("Test 123"));
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, LOGCOLLECTOR_STATE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, NULL);
 
     const char * error_msg = "(1103): Could not open file "
                              "'" LOGCOLLECTOR_STATE "' due to";
@@ -898,9 +898,9 @@ void test_w_logcollector_state_dump_fail_write(void ** state) {
     will_return(__wrap_cJSON_Print, strdup("Test 123"));
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE *) 100);
+    expect_string(__wrap_wfopen, path, LOGCOLLECTOR_STATE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE *) 100);
     will_return(__wrap_fwrite, 0);
 
     const char * error_msg = "(1110): Could not write file "
@@ -922,9 +922,9 @@ void test_w_logcollector_state_dump_ok(void ** state) {
     will_return(__wrap_cJSON_Print, strdup("Test 123"));
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE *) 100);
+    expect_string(__wrap_wfopen, path, LOGCOLLECTOR_STATE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE *) 100);
     will_return(__wrap_fwrite, 1);
 
     expect_value(__wrap_fclose, _File, (FILE *) 100);
@@ -1064,9 +1064,9 @@ void test_w_logcollector_state_main_ok(void ** state) {
     will_return(__wrap_cJSON_Print, strdup("Test 123"));
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE *) 100);
+    expect_string(__wrap_wfopen, path, LOGCOLLECTOR_STATE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE *) 100);
     will_return(__wrap_fwrite, 1);
 
     expect_value(__wrap_fclose, _File, (FILE *) 100);

--- a/src/unit_tests/os_auth/CMakeLists.txt
+++ b/src/unit_tests/os_auth/CMakeLists.txt
@@ -47,7 +47,7 @@ list(APPEND os_auth_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_minf
                            -Wl,--wrap,external_socket_connect ${HASH_OP_WRAPPERS}")
 list(APPEND os_auth_names "test_auth")
 list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS} \
-                           -Wl,--wrap,os_random -Wl,--wrap,GetRandomNoise -Wl,--wrap,getuname -Wl,--wrap,time")
+                           -Wl,--wrap,os_random -Wl,--wrap,GetRandomNoise -Wl,--wrap,getuname -Wl,--wrap,time -Wl,--wrap,wfopen")
 list(APPEND os_auth_names "test_generate_cert")
 list (APPEND os_auth_flags "-Wl,--wrap,PEM_write_PrivateKey -Wl,--wrap,PEM_write_X509 -Wl,--wrap,RSA_generate_key_ex \
                             -Wl,--wrap,X509_sign -Wl,--wrap,_merror -Wl,--wrap,wfopen \

--- a/src/unit_tests/os_auth/CMakeLists.txt
+++ b/src/unit_tests/os_auth/CMakeLists.txt
@@ -42,16 +42,16 @@ list(APPEND os_auth_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_minf
                            -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,close -Wl,-wrap,send -Wl,--wrap,cJSON_ParseWithOpts \
                            -Wl,--wrap,recv -Wl,--wrap,setsockopt -Wl,--wrap,fcntl -Wl,--wrap,connect -Wl,--wrap,socket \
                            -Wl,--wrap,w_request_agent_add_clustered -Wl,--wrap,sleep -Wl,--wrap,cJSON_Delete -Wl,--wrap,local_add \
-                           -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fseek \
-                           -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap=fgetc -Wl,--wrap,getpid \
+                           -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fseek \
+                           -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap=fgetc -Wl,--wrap,getpid -Wl,--wrap,wfopen \
                            -Wl,--wrap,external_socket_connect ${HASH_OP_WRAPPERS}")
 list(APPEND os_auth_names "test_auth")
 list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS} \
                            -Wl,--wrap,os_random -Wl,--wrap,GetRandomNoise -Wl,--wrap,getuname -Wl,--wrap,time")
 list(APPEND os_auth_names "test_generate_cert")
 list (APPEND os_auth_flags "-Wl,--wrap,PEM_write_PrivateKey -Wl,--wrap,PEM_write_X509 -Wl,--wrap,RSA_generate_key_ex \
-                            -Wl,--wrap,X509_sign -Wl,--wrap,_merror \
-                            -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,fread \
+                            -Wl,--wrap,X509_sign -Wl,--wrap,_merror -Wl,--wrap,wfopen \
+                            -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,fread \
                             -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,fgets \
                             -Wl,--wrap,RSA_new -Wl,--wrap,EVP_PKEY_new -Wl,--wrap,X509_new")
 list(APPEND os_auth_names "test_authd-config")

--- a/src/unit_tests/os_auth/CMakeLists.txt
+++ b/src/unit_tests/os_auth/CMakeLists.txt
@@ -42,7 +42,7 @@ list(APPEND os_auth_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_minf
                            -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,close -Wl,-wrap,send -Wl,--wrap,cJSON_ParseWithOpts \
                            -Wl,--wrap,recv -Wl,--wrap,setsockopt -Wl,--wrap,fcntl -Wl,--wrap,connect -Wl,--wrap,socket \
                            -Wl,--wrap,w_request_agent_add_clustered -Wl,--wrap,sleep -Wl,--wrap,cJSON_Delete -Wl,--wrap,local_add \
-                           -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fseek \
+                           -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fseek \
                            -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap=fgetc -Wl,--wrap,getpid \
                            -Wl,--wrap,external_socket_connect ${HASH_OP_WRAPPERS}")
 list(APPEND os_auth_names "test_auth")
@@ -51,7 +51,7 @@ list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS} \
 list(APPEND os_auth_names "test_generate_cert")
 list (APPEND os_auth_flags "-Wl,--wrap,PEM_write_PrivateKey -Wl,--wrap,PEM_write_X509 -Wl,--wrap,RSA_generate_key_ex \
                             -Wl,--wrap,X509_sign -Wl,--wrap,_merror \
-                            -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,fread \
+                            -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgetpos -Wl,--wrap,fread \
                             -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,fgets \
                             -Wl,--wrap,RSA_new -Wl,--wrap,EVP_PKEY_new -Wl,--wrap,X509_new")
 list(APPEND os_auth_names "test_authd-config")

--- a/src/unit_tests/os_auth/test_generate_cert.c
+++ b/src/unit_tests/os_auth/test_generate_cert.c
@@ -36,18 +36,18 @@ static void test_generate_cert_success(void **state) {
     will_return(__wrap_X509_new, 1);
     will_return(__wrap_X509_sign, 1);
 
-    expect_string(__wrap_fopen, path, "key_path");
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, &key_file);
+    expect_string(__wrap_wfopen, path, "key_path");
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, &key_file);
 
     will_return(__wrap_PEM_write_PrivateKey, 1);
 
     expect_value(__wrap_fclose, _File, &key_file);
     will_return(__wrap_fclose, 0);
 
-    expect_string(__wrap_fopen, path, "cert_path");
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, &cert_file);
+    expect_string(__wrap_wfopen, path, "cert_path");
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, &cert_file);
 
     will_return(__wrap_PEM_write_X509, 1);
     expect_value(__wrap_fclose, _File, &cert_file);
@@ -67,18 +67,18 @@ static void test_generate_cert_success_typo(void **state) {
     will_return(__wrap_X509_new, 1);
     will_return(__wrap_X509_sign, 1);
 
-    expect_string(__wrap_fopen, mode, "wb");
-    expect_string(__wrap_fopen, path, "key_path");
-    will_return(__wrap_fopen, &key_file);
+    expect_string(__wrap_wfopen, mode, "wb");
+    expect_string(__wrap_wfopen, path, "key_path");
+    will_return(__wrap_wfopen, &key_file);
 
     will_return(__wrap_PEM_write_PrivateKey, 1);
 
     expect_value(__wrap_fclose, _File, &key_file);
     will_return(__wrap_fclose, 0);
 
-    expect_string(__wrap_fopen, path, "cert_path");
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, &cert_file);
+    expect_string(__wrap_wfopen, path, "cert_path");
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, &cert_file);
 
     will_return(__wrap_PEM_write_X509, 1);
     expect_value(__wrap_fclose, _File, &cert_file);
@@ -98,9 +98,9 @@ static void test_save_key_fail(void **state) {
     will_return(__wrap_X509_new, 1);
     will_return(__wrap_X509_sign, 1);
 
-    expect_string(__wrap_fopen, path, "key_path");
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, &key_file);
+    expect_string(__wrap_wfopen, path, "key_path");
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, &key_file);
 
     will_return(__wrap_PEM_write_PrivateKey, 0);
     expect_string(__wrap__merror, formatted_msg, "Cannot dump private key.");
@@ -121,9 +121,9 @@ static void test_save_key_fail_fopen(void **state) {
     will_return(__wrap_X509_new, 1);
     will_return(__wrap_X509_sign, 1);
 
-    expect_string(__wrap_fopen, path, "key_path");
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, "key_path");
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, NULL);
 
     expect_string(__wrap__merror, formatted_msg, "Cannot open key_path.");
 
@@ -141,18 +141,18 @@ static void test_save_cert_fail(void **state) {
     will_return(__wrap_X509_new, 1);
     will_return(__wrap_X509_sign, 1);
 
-    expect_string(__wrap_fopen, path, "key_path");
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, &key_file);
+    expect_string(__wrap_wfopen, path, "key_path");
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, &key_file);
 
     will_return(__wrap_PEM_write_PrivateKey, 1);
 
     expect_value(__wrap_fclose, _File, &key_file);
     will_return(__wrap_fclose, 0);
 
-    expect_string(__wrap_fopen, path, "cert_path");
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, &cert_file);
+    expect_string(__wrap_wfopen, path, "cert_path");
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, &cert_file);
 
     will_return(__wrap_PEM_write_X509, 0);
     expect_string(__wrap__merror, formatted_msg, "Cannot dump certificate.");
@@ -172,18 +172,18 @@ static void test_save_cert_fail_fopen(void **state) {
     will_return(__wrap_X509_new, 1);
     will_return(__wrap_X509_sign, 1);
 
-    expect_string(__wrap_fopen, path, "key_path");
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, &key_file);
+    expect_string(__wrap_wfopen, path, "key_path");
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, &key_file);
 
     will_return(__wrap_PEM_write_PrivateKey, 1);
 
     expect_value(__wrap_fclose, _File, &key_file);
     will_return(__wrap_fclose, 0);
 
-    expect_string(__wrap_fopen, path, "cert_path");
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, "cert_path");
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, NULL);
     expect_string(__wrap__merror, formatted_msg, "Cannot open cert_path.");
 
     int ret_value = generate_cert(1024, 2048, "key_path", "cert_path", "/C=US/ST=California/CN=Wazuh/");

--- a/src/unit_tests/os_crypto/md5/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/md5/CMakeLists.txt
@@ -8,9 +8,9 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND md5_tests_names "test_md5_op")
-list(APPEND md5_tests_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+list(APPEND md5_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                              -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
-                             -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
+                             -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,wfopen")
 
 # Compiling tests
 list(LENGTH md5_tests_names count)

--- a/src/unit_tests/os_crypto/md5/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/md5/CMakeLists.txt
@@ -8,7 +8,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND md5_tests_names "test_md5_op")
-list(APPEND md5_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+list(APPEND md5_tests_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                              -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
                              -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
 

--- a/src/unit_tests/os_crypto/md5/test_md5_op.c
+++ b/src/unit_tests/os_crypto/md5/test_md5_op.c
@@ -46,9 +46,9 @@ void test_md5_file(void **state) {
 
     char path[] = "path/to/file";
 
-    expect_value(__wrap_fopen, path, path);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, path);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, string);
     will_return(__wrap_fread, 0);
@@ -65,9 +65,9 @@ void test_md5_file(void **state) {
 void test_md5_file_fail(void **state) {
     char path[] = "path/to/non-existing/file";
 
-    expect_value(__wrap_fopen, path, path);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_value(__wrap_wfopen, path, path);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     os_md5 buffer;
     assert_int_equal(OS_MD5_File(path, buffer, OS_TEXT), -1);

--- a/src/unit_tests/os_crypto/md5_sha1_sha256/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/md5_sha1_sha256/CMakeLists.txt
@@ -8,7 +8,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND md5_sha1_tests_names "test_md5_sha1_sha256_op")
-list(APPEND md5_sha1_tests_flags "-Wl,--wrap,wpopenv,--wrap,wpclose,--wrap,fread,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fopen,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,wfopen")
+list(APPEND md5_sha1_tests_flags "-Wl,--wrap,wpopenv,--wrap,wpclose,--wrap,fread,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,wfopen")
 
 # Compiling tests
 list(LENGTH md5_sha1_tests_names count)

--- a/src/unit_tests/os_crypto/md5_sha1_sha256/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/md5_sha1_sha256/CMakeLists.txt
@@ -8,7 +8,8 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND md5_sha1_tests_names "test_md5_sha1_sha256_op")
-list(APPEND md5_sha1_tests_flags "-Wl,--wrap,wpopenv,--wrap,wpclose,--wrap,fread,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,wfopen")
+list(APPEND md5_sha1_tests_flags "-Wl,--wrap,wpopenv,--wrap,wpclose,--wrap,fread,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos \
+                                  -Wl,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,fopen,--wrap,wfopen")
 
 # Compiling tests
 list(LENGTH md5_sha1_tests_names count)

--- a/src/unit_tests/os_crypto/sha1/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/sha1/CMakeLists.txt
@@ -8,7 +8,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND os_crypto_sha1_tests_names "test_sha1_op")
-list(APPEND os_crypto_sha1_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+list(APPEND os_crypto_sha1_tests_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                                         -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
                                         -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
 

--- a/src/unit_tests/os_crypto/sha1/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/sha1/CMakeLists.txt
@@ -8,9 +8,9 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND os_crypto_sha1_tests_names "test_sha1_op")
-list(APPEND os_crypto_sha1_tests_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+list(APPEND os_crypto_sha1_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                                         -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
-                                        -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
+                                        -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,wfopen")
 
 # Compiling tests
 list(LENGTH os_crypto_sha1_tests_names count)

--- a/src/unit_tests/os_crypto/sha1/test_sha1_op.c
+++ b/src/unit_tests/os_crypto/sha1/test_sha1_op.c
@@ -43,9 +43,9 @@ void OS_SHA1_File_Nbytes_unable_open_file (void **state)
 
     int mode = OS_BINARY;
 
-    expect_value(__wrap_fopen, path, path);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, NULL);
+    expect_value(__wrap_wfopen, path, path);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, NULL);
 
     int ret = OS_SHA1_File_Nbytes(path, &context, output, mode, nbytes);
     assert_int_equal(ret, -1);
@@ -60,9 +60,9 @@ void OS_SHA1_File_Nbytes_ok (void **state)
 
     int mode = OS_BINARY;
 
-    expect_value(__wrap_fopen, path, path);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, path);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test");
     will_return(__wrap_fread, 0);
@@ -86,9 +86,9 @@ void OS_SHA1_File_Nbytes_num_bytes_exceded (void **state)
 
     int mode = OS_BINARY;
 
-    expect_value(__wrap_fopen, path, path);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, path);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test");
     will_return(__wrap_fread, 0);
@@ -155,9 +155,9 @@ void test_sha1_file(void **state)
     char file_name[256];
     strncpy(file_name, "/tmp/tmp_file-XXXXXX", 256);
 
-    expect_string(__wrap_fopen, path, file_name);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, file_name);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, string);
     will_return(__wrap_fread, 0);
@@ -177,9 +177,9 @@ void test_sha1_file_fail(void **state)
     char file_name[256];
     strncpy(file_name, "not_existing_file", 256);
 
-    expect_string(__wrap_fopen, path, file_name);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, file_name);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     assert_int_equal(OS_SHA1_File(file_name, buffer, OS_TEXT), -1);
 }

--- a/src/unit_tests/os_crypto/sha256/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/sha256/CMakeLists.txt
@@ -8,9 +8,9 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND sha256_tests_names "test_sha256_op")
-list(APPEND sha256_tests_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+list(APPEND sha256_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                                 -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
-                                -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
+                                -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,wfopen")
 
 # Compiling tests
 list(LENGTH sha256_tests_names count)

--- a/src/unit_tests/os_crypto/sha256/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/sha256/CMakeLists.txt
@@ -8,7 +8,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND sha256_tests_names "test_sha256_op")
-list(APPEND sha256_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+list(APPEND sha256_tests_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                                 -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
                                 -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
 

--- a/src/unit_tests/os_crypto/sha256/test_sha256_op.c
+++ b/src/unit_tests/os_crypto/sha256/test_sha256_op.c
@@ -55,9 +55,9 @@ void test_sha256_file() {
     const char *string_sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
     char path[] = "path/to/file";
 
-    expect_value(__wrap_fopen, path, path);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, path);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, string);
     will_return(__wrap_fread, 0);
@@ -74,9 +74,9 @@ void test_sha256_file() {
 void test_sha256_file_fail() {
     char path[] = "path/to/non-existing/file";
 
-    expect_value(__wrap_fopen, path, path);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_value(__wrap_wfopen, path, path);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     os_sha256 buffer;
     assert_int_equal(OS_SHA256_File(path, buffer, OS_TEXT), -1);

--- a/src/unit_tests/os_crypto/sha512/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/sha512/CMakeLists.txt
@@ -8,9 +8,9 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND sha512_tests_names "test_sha512_op")
-list(APPEND sha512_tests_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+list(APPEND sha512_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                                 -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
-                                -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
+                                -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,wfopen")
 
 # Compiling tests
 list(LENGTH sha512_tests_names count)

--- a/src/unit_tests/os_crypto/sha512/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/sha512/CMakeLists.txt
@@ -8,7 +8,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND sha512_tests_names "test_sha512_op")
-list(APPEND sha512_tests_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+list(APPEND sha512_tests_flags "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                                 -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf \
                                 -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
 

--- a/src/unit_tests/os_crypto/shared/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/shared/CMakeLists.txt
@@ -3,7 +3,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 # Generate msgs tests
 list(APPEND os_crypto_shared_tests_names "test_msgs")
-list(APPEND os_crypto_shared_tests_flags "-Wl,--wrap,merror_exit -Wl,--wrap,linked_queue_push_ex -Wl,--wrap,fprintf -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
+list(APPEND os_crypto_shared_tests_flags "-Wl,--wrap,merror_exit -Wl,--wrap,linked_queue_push_ex -Wl,--wrap,fprintf -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
                             -Wl,--wrap,sleep -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek \
                             -Wl,--wrap,stat -Wl,--wrap,getpid -Wl,--wrap=key_lock_write -Wl,--wrap=key_unlock -Wl,--wrap=time \
                             -Wl,--wrap,fgetpos -Wl,--wrap=fgetc ${DEBUG_OP_WRAPPERS}")
@@ -11,7 +11,7 @@ list(APPEND os_crypto_shared_tests_flags "-Wl,--wrap,merror_exit -Wl,--wrap,link
 # Generate keys tests
 list(APPEND os_crypto_shared_tests_names "test_keys")
 list(APPEND os_crypto_shared_tests_flags "-Wl,--wrap,rbtree_get \
-                                -Wl,--wrap,fopen,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fread,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,fprintf \
+                                -Wl,--wrap,wfopen,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fread,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,fprintf \
                                 -Wl,--wrap,TempFile,--wrap,OS_MoveFile -Wl,--wrap,_merror \
                                 -Wl,--wrap,_mdebug2 -Wl,--wrap,unlink,--wrap,getpid -Wl,--wrap,OS_IsValidIP")
 

--- a/src/unit_tests/os_crypto/shared/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/shared/CMakeLists.txt
@@ -3,16 +3,16 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 # Generate msgs tests
 list(APPEND os_crypto_shared_tests_names "test_msgs")
-list(APPEND os_crypto_shared_tests_flags "-Wl,--wrap,merror_exit -Wl,--wrap,linked_queue_push_ex -Wl,--wrap,fprintf -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
-                            -Wl,--wrap,sleep -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek \
+list(APPEND os_crypto_shared_tests_flags "-Wl,--wrap,merror_exit -Wl,--wrap,linked_queue_push_ex -Wl,--wrap,fprintf -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
+                            -Wl,--wrap,sleep -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,wfopen \
                             -Wl,--wrap,stat -Wl,--wrap,getpid -Wl,--wrap=key_lock_write -Wl,--wrap=key_unlock -Wl,--wrap=time \
                             -Wl,--wrap,fgetpos -Wl,--wrap=fgetc ${DEBUG_OP_WRAPPERS}")
 
 # Generate keys tests
 list(APPEND os_crypto_shared_tests_names "test_keys")
 list(APPEND os_crypto_shared_tests_flags "-Wl,--wrap,rbtree_get \
-                                -Wl,--wrap,wfopen,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fread,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,fprintf \
-                                -Wl,--wrap,TempFile,--wrap,OS_MoveFile -Wl,--wrap,_merror \
+                                -Wl,--wrap,fopen,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fread,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,fprintf \
+                                -Wl,--wrap,TempFile,--wrap,OS_MoveFile -Wl,--wrap,_merror -Wl,--wrap,wfopen \
                                 -Wl,--wrap,_mdebug2 -Wl,--wrap,unlink,--wrap,getpid -Wl,--wrap,OS_IsValidIP")
 
 # Compiling tests

--- a/src/unit_tests/os_crypto/shared/test_keys.c
+++ b/src/unit_tests/os_crypto/shared/test_keys.c
@@ -91,12 +91,6 @@ int __wrap_TempFile(File *file, const char *source, int copy) {
     return mock_type(int);
 }
 
-int __wrap_OS_MoveFile(const char *src, const char *dst) {
-    check_expected(src);
-    check_expected(dst);
-    return mock_type(int);
-}
-
 // Test OS_IsAllowedID
 void test_OS_IsAllowedID_id_NULL(void **state)
 {
@@ -229,7 +223,7 @@ void test_OS_ReadTimestamps_file_missing(void **state)
 {
     keystore *keys = *(keystore **)state;
 
-    expect_fopen(TIMESTAMP_FILE, "r", NULL);
+    expect_wfopen(TIMESTAMP_FILE, "r", NULL);
     errno = ENOENT;
 
     int r = OS_ReadTimestamps(keys);
@@ -240,7 +234,7 @@ void test_OS_ReadTimestamps_file_error(void **state)
 {
     keystore *keys = *(keystore **)state;
 
-    expect_fopen(TIMESTAMP_FILE, "r", NULL);
+    expect_wfopen(TIMESTAMP_FILE, "r", NULL);
     errno = EACCES;
 
     int r = OS_ReadTimestamps(keys);
@@ -250,7 +244,7 @@ void test_OS_ReadTimestamps_file_error(void **state)
 void test_OS_ReadTimestamps_wrong_line(void **state)
 {
     keystore *keys = *(keystore **)state;
-    expect_fopen(TIMESTAMP_FILE, "r", (FILE *)1);
+    expect_wfopen(TIMESTAMP_FILE, "r", (FILE *)1);
 
     expect_fclose((FILE *)1, 0);
     expect_value(__wrap_fgets, __stream, 1);
@@ -276,7 +270,7 @@ void test_OS_ReadTimestamps_valid_line(void **state)
         .tm_isdst = -1
     };
 
-    expect_fopen(TIMESTAMP_FILE, "r", (FILE *)1);
+    expect_wfopen(TIMESTAMP_FILE, "r", (FILE *)1);
     expect_fclose((FILE *)1, 0);
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "001 agent1 1.1.1.1 2021-08-11 14:36:11\n");

--- a/src/unit_tests/os_crypto/shared/test_msgs.c
+++ b/src/unit_tests/os_crypto/shared/test_msgs.c
@@ -174,9 +174,9 @@ void test_StoreCounter_pushing_rids_fp_null(void **state)
     key->rids_node = NULL;
     keys.keyentries[0] = key;
 
-    expect_string(__wrap_fopen, path, "queue/rids/001");
-    expect_string(__wrap_fopen, mode, "r+");
-    will_return(__wrap_fopen, 1234);
+    expect_string(__wrap_wfopen, path, "queue/rids/001");
+    expect_string(__wrap_wfopen, mode, "r+");
+    will_return(__wrap_wfopen, 1234);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Opening rids for agent 001.");
 
@@ -233,13 +233,13 @@ void test_StoreCounter_fail_first_open(void **state)
     key->rids_node = NULL;
     keys.keyentries[0] = key;
 
-    expect_string(__wrap_fopen, path, "queue/rids/001");
-    expect_string(__wrap_fopen, mode, "r+");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, "queue/rids/001");
+    expect_string(__wrap_wfopen, mode, "r+");
+    will_return(__wrap_wfopen, NULL);
     errno = EACCES;
-    expect_string(__wrap_fopen, path, "queue/rids/001");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1234);
+    expect_string(__wrap_wfopen, path, "queue/rids/001");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1234);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Opening rids for agent 001.");
 

--- a/src/unit_tests/os_csyslogd/CMakeLists.txt
+++ b/src/unit_tests/os_csyslogd/CMakeLists.txt
@@ -28,7 +28,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 list(APPEND os_csyslogd_names "test_csyslogd")
 list(APPEND os_csyslogd_flags "-Wl,--wrap,jqueue_open -Wl,--wrap,jqueue_next -Wl,--wrap,FOREVER -Wl,--wrap,time ${DEBUG_OP_WRAPPERS} \
                                  -Wl,--wrap,os_random -Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,fprintf -Wl,--wrap,File_DateofChange ${STDIO_OP_WRAPPERS} \
-                                 -Wl,--wrap,merror -Wl,--wrap,minfo -Wl,--wrap,mdebug1 -Wl,--wrap,mdebug2 -Wl,--wrap,merror \
+                                 -Wl,--wrap,merror -Wl,--wrap,minfo -Wl,--wrap,mdebug1 -Wl,--wrap,mdebug2 -Wl,--wrap,merror -Wl,--wrap,wfopen \
                                  -Wl,--wrap,w_ftell -Wl,--wrap,fgets -Wl,--wrap,OS_Alert_SendSyslog_JSON -Wl,--wrap,OS_Alert_SendSyslog\
                                  -Wl,--wrap,OS_IsValidIP -Wl,--wrap,OS_ConnectUDP -Wl,--wrap,time -Wl,--wrap,Read_FileMon -Wl,--wrap,Init_FileQueue -Wl,--wrap,sleep")
 

--- a/src/unit_tests/os_execd/CMakeLists.txt
+++ b/src/unit_tests/os_execd/CMakeLists.txt
@@ -31,8 +31,8 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 if(${TARGET} STREQUAL "winagent")
     list(APPEND execd_names "test_win_execd")
     list(APPEND execd_flags "-Wl,--wrap,ReadExecConfig -Wl,--wrap,GetCommandbyName -Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,fwrite \
-                             -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
-                             -Wl,--wrap,remove -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap,fwrite \
+                             -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
+                             -Wl,--wrap,remove -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap,fwrite -Wl,--wrap,wfopen \
                              -Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck -Wl,--wrap=is_fim_shutdown \
                              -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown \
                              ${DEBUG_OP_WRAPPERS}")
@@ -43,9 +43,9 @@ if(${TARGET} STREQUAL "winagent")
                              ${DEBUG_OP_WRAPPERS}")
 else()
     list(APPEND execd_names "test_execd")
-    list(APPEND execd_flags "-Wl,--wrap,time -Wl,--wrap,select -Wl,--wrap,OS_RecvUnix \
+    list(APPEND execd_flags "-Wl,--wrap,time -Wl,--wrap,select -Wl,--wrap,OS_RecvUnix -Wl,--wrap,wfopen \
                              -Wl,--wrap,ReadExecConfig -Wl,--wrap,GetCommandbyName -Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,fwrite \
-                             -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
+                             -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
                              -Wl,--wrap,remove -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap,fwrite \
                              -Wl,--wrap,fprintf ${DEBUG_OP_WRAPPERS}")
 

--- a/src/unit_tests/os_execd/CMakeLists.txt
+++ b/src/unit_tests/os_execd/CMakeLists.txt
@@ -31,7 +31,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 if(${TARGET} STREQUAL "winagent")
     list(APPEND execd_names "test_win_execd")
     list(APPEND execd_flags "-Wl,--wrap,ReadExecConfig -Wl,--wrap,GetCommandbyName -Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,fwrite \
-                             -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
+                             -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
                              -Wl,--wrap,remove -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap,fwrite \
                              -Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck -Wl,--wrap=is_fim_shutdown \
                              -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown \
@@ -45,7 +45,7 @@ else()
     list(APPEND execd_names "test_execd")
     list(APPEND execd_flags "-Wl,--wrap,time -Wl,--wrap,select -Wl,--wrap,OS_RecvUnix \
                              -Wl,--wrap,ReadExecConfig -Wl,--wrap,GetCommandbyName -Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,fwrite \
-                             -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
+                             -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
                              -Wl,--wrap,remove -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap,fwrite \
                              -Wl,--wrap,fprintf ${DEBUG_OP_WRAPPERS}")
 

--- a/src/unit_tests/os_integrator/CMakeLists.txt
+++ b/src/unit_tests/os_integrator/CMakeLists.txt
@@ -25,7 +25,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 list(APPEND os_integrator_names "test_integrator")
 list(APPEND os_integrator_flags "-Wl,--wrap,jqueue_open -Wl,--wrap,jqueue_next -Wl,--wrap,FOREVER -Wl,--wrap,time ${DEBUG_OP_WRAPPERS} \
                                  -Wl,--wrap,os_random -Wl,--wrap,wpopenv -Wl,--wrap,wpclose -Wl,--wrap,fprintf -Wl,--wrap,unlink,--wrap,getpid \
-                                 -Wl,--wrap,File_DateofChange ${STDIO_OP_WRAPPERS}")
+                                 -Wl,--wrap,File_DateofChange -Wl,--wrap,wfopen ${STDIO_OP_WRAPPERS}")
 
 list(LENGTH os_integrator_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/os_integrator/test_integrator.c
+++ b/src/unit_tests/os_integrator/test_integrator.c
@@ -119,9 +119,9 @@ void test_OS_IntegratorD(void **state) {
 
     will_return(__wrap_os_random, 2222);
 
-    expect_string(__wrap_fopen, path, virustotal_file);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE *)1);
+    expect_string(__wrap_wfopen, path, virustotal_file);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE *)1);
 
     expect_fprintf((FILE *)1, alert_to_virustotal, 0);
 
@@ -154,9 +154,9 @@ void test_OS_IntegratorD(void **state) {
     will_return(__wrap_time, 1111);
     will_return(__wrap_os_random, 2222);
 
-    expect_string(__wrap_fopen, path, pagerduty_file);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE *)1);
+    expect_string(__wrap_wfopen, path, pagerduty_file);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE *)1);
 
     expect_fprintf((FILE *)1, alert_to_pagerduty, 0);
 
@@ -164,9 +164,9 @@ void test_OS_IntegratorD(void **state) {
 
     expect_fclose((FILE *)1, 0);
 
-    expect_string(__wrap_fopen, path, pd_options);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE *)1);
+    expect_string(__wrap_wfopen, path, pd_options);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE *)1);
 
     expect_fprintf((FILE *)1, options_to_pd, 0);
 

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -40,8 +40,8 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,checkBinaryFile -Wl,--wrap,OSHash_Set -Wl,--wrap,_minfo \
                             -Wl,--wrap,opendir -Wl,--wrap,cldir_ex_ignore -Wl,--wrap,wreaddir -Wl,--wrap=_mwarn \
                             -Wl,--wrap,closedir -Wl,--wrap,OSHash_Clean -Wl,--wrap,rmdir_ex -Wl,--wrap,mkdir -Wl,--wrap,stat\
-                            -Wl,--wrap,OS_SHA256_String -Wl,--wrap,readdir -Wl,--wrap,strerror \
-                            -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
+                            -Wl,--wrap,OS_SHA256_String -Wl,--wrap,readdir -Wl,--wrap,strerror -Wl,--wrap,wfopen \
+                            -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
                             -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
                             -Wl,--wrap,w_copy_file -Wl,--wrap,OSHash_Begin -Wl,--wrap,req_save -Wl,--wrap,send_msg \
                             -Wl,--wrap,wdb_update_agent_keepalive -Wl,--wrap,parse_agent_update_msg \
@@ -59,13 +59,13 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
 list(APPEND remoted_names "test_secure")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accept -Wl,--wrap,close \
                             -Wl,--wrap,fclose -Wl,--wrap,fcntl -Wl,--wrap,fflush -Wl,--wrap,fgetc \
-                            -Wl,--wrap,fgetpos -Wl,--wrap,fgets -Wl,--wrap,wfopen -Wl,--wrap,fread \
+                            -Wl,--wrap,fgetpos -Wl,--wrap,fgets -Wl,--wrap,fopen -Wl,--wrap,fread \
                             -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,getpid -Wl,--wrap,key_lock_read \
                             -Wl,--wrap,key_lock_write -Wl,--wrap,key_unlock -Wl,--wrap,nb_close \
                             -Wl,--wrap,nb_open -Wl,--wrap,nb_recv -Wl,--wrap,nb_send -Wl,--wrap,OS_AddSocket \
                             -Wl,--wrap,OS_DeleteSocket -Wl,--wrap,OS_IsAllowedDynamicID -Wl,--wrap,OS_IsAllowedIP \
                             -Wl,--wrap,ReadSecMSG -Wl,--wrap,recvfrom -Wl,--wrap,rem_add_recv \
-                            -Wl,--wrap,rem_add_send -Wl,--wrap,rem_dec_tcp \
+                            -Wl,--wrap,rem_add_send -Wl,--wrap,rem_dec_tcp -Wl,--wrap,wfopen \
                             -Wl,--wrap,rem_getCounter -Wl,--wrap,rem_inc_recv_ctrl \
                             -Wl,--wrap,rem_inc_recv_unknown -Wl,--wrap,rem_inc_tcp \
                             -Wl,--wrap,rem_msgpush -Wl,--wrap,rem_setCounter -Wl,--wrap,remove \

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -41,7 +41,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,opendir -Wl,--wrap,cldir_ex_ignore -Wl,--wrap,wreaddir -Wl,--wrap=_mwarn \
                             -Wl,--wrap,closedir -Wl,--wrap,OSHash_Clean -Wl,--wrap,rmdir_ex -Wl,--wrap,mkdir -Wl,--wrap,stat\
                             -Wl,--wrap,OS_SHA256_String -Wl,--wrap,readdir -Wl,--wrap,strerror \
-                            -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
+                            -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
                             -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
                             -Wl,--wrap,w_copy_file -Wl,--wrap,OSHash_Begin -Wl,--wrap,req_save -Wl,--wrap,send_msg \
                             -Wl,--wrap,wdb_update_agent_keepalive -Wl,--wrap,parse_agent_update_msg \
@@ -59,7 +59,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
 list(APPEND remoted_names "test_secure")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accept -Wl,--wrap,close \
                             -Wl,--wrap,fclose -Wl,--wrap,fcntl -Wl,--wrap,fflush -Wl,--wrap,fgetc \
-                            -Wl,--wrap,fgetpos -Wl,--wrap,fgets -Wl,--wrap,fopen -Wl,--wrap,fread \
+                            -Wl,--wrap,fgetpos -Wl,--wrap,fgets -Wl,--wrap,wfopen -Wl,--wrap,fread \
                             -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,getpid -Wl,--wrap,key_lock_read \
                             -Wl,--wrap,key_lock_write -Wl,--wrap,key_unlock -Wl,--wrap,nb_close \
                             -Wl,--wrap,nb_open -Wl,--wrap,nb_recv -Wl,--wrap,nb_send -Wl,--wrap,OS_AddSocket \

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -842,9 +842,9 @@ void test_c_group_no_changes_disk(void **state)
     expect_string(__wrap_w_parser_get_group, name, group->name);
     will_return(__wrap_w_parser_get_group, NULL);
 
-    expect_string(__wrap_fopen, path, "etc/shared/test_default/merged.mg.tmp");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE *)1);
+    expect_string(__wrap_wfopen, path, "etc/shared/test_default/merged.mg.tmp");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE *)1);
 
     expect_value(__wrap_fprintf, __stream, (FILE *)1);
     expect_string(__wrap_fprintf, formatted_msg, "#test_default\n");
@@ -946,9 +946,9 @@ void test_c_group_changes(void **state)
     will_return(__wrap_OS_MD5_File, "md5_test2");
     will_return(__wrap_OS_MD5_File, 0);
 
-    expect_string(__wrap_fopen, path, "etc/shared/test_default/merged.mg");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE *)2);
+    expect_string(__wrap_wfopen, path, "etc/shared/test_default/merged.mg");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE *)2);
 
     will_return(__wrap_fwrite, 1);
 
@@ -987,9 +987,9 @@ void test_c_group_changes_disk(void **state)
     expect_string(__wrap_w_parser_get_group, name, group->name);
     will_return(__wrap_w_parser_get_group, NULL);
 
-    expect_string(__wrap_fopen, path, "etc/shared/test_default/merged.mg.tmp");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE *)1);
+    expect_string(__wrap_wfopen, path, "etc/shared/test_default/merged.mg.tmp");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE *)1);
 
     expect_value(__wrap_fprintf, __stream, (FILE *)1);
     expect_string(__wrap_fprintf, formatted_msg, "#test_default\n");
@@ -1087,9 +1087,9 @@ void test_c_group_fail(void **state)
     will_return(__wrap_OS_MD5_File, "md5_test");
     will_return(__wrap_OS_MD5_File, -1);
 
-    expect_string(__wrap_fopen, path, "etc/shared/test_default/merged.mg");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE *)2);
+    expect_string(__wrap_wfopen, path, "etc/shared/test_default/merged.mg");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE *)2);
 
     will_return(__wrap_fwrite, 1);
 
@@ -1124,9 +1124,9 @@ void test_c_group_fail_disk(void **state)
     expect_string(__wrap_w_parser_get_group, name, group->name);
     will_return(__wrap_w_parser_get_group, NULL);
 
-    expect_string(__wrap_fopen, path, "etc/shared/test_default/merged.mg.tmp");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE *)1);
+    expect_string(__wrap_wfopen, path, "etc/shared/test_default/merged.mg.tmp");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE *)1);
 
     expect_value(__wrap_fprintf, __stream, (FILE *)1);
     expect_string(__wrap_fprintf, formatted_msg, "#test_default\n");
@@ -1480,9 +1480,9 @@ void test_c_group_invalid_share_file(void **state)
     will_return(__wrap_OS_MD5_File, "md5_test");
     will_return(__wrap_OS_MD5_File, -1);
 
-    expect_string(__wrap_fopen, path, "etc/shared/test_default/merged.mg");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, "etc/shared/test_default/merged.mg");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, NULL);
 
     will_return(__wrap_strerror, "No such file or directory");
 
@@ -1717,9 +1717,9 @@ void test_c_group_truncate_error_disk(void **state)
     expect_string(__wrap_w_parser_get_group, name, group->name);
     will_return(__wrap_w_parser_get_group, NULL);
 
-    expect_string(__wrap_fopen, path, "etc/shared/test_default/merged.mg.tmp");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, "etc/shared/test_default/merged.mg.tmp");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, NULL);
 
     will_return(__wrap_strerror, "No such file or directory");
 
@@ -2719,9 +2719,9 @@ void test_process_groups_find_group_null(void **state)
     will_return(__wrap_OS_MD5_File, "md5_test");
     will_return(__wrap_OS_MD5_File, -1);
 
-    expect_string(__wrap_fopen, path, "etc/shared/test/merged.mg");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, "etc/shared/test/merged.mg");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, NULL);
 
     will_return(__wrap_strerror, "No such file or directory");
 
@@ -2831,9 +2831,9 @@ void test_process_groups_find_group_changed(void **state)
     will_return(__wrap_OS_MD5_File, "md5_test");
     will_return(__wrap_OS_MD5_File, -1);
 
-    expect_string(__wrap_fopen, path, "etc/shared/test_default/merged.mg");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, "etc/shared/test_default/merged.mg");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, NULL);
 
     will_return(__wrap_strerror, "No such file or directory");
 

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -186,7 +186,7 @@ list(APPEND shared_tests_flags " ")
 endif()
 
 list(APPEND shared_tests_names "test_binaries_op")
-set(BINARIES_OP_BASE_FLAGS "-Wl,--wrap,IsFile")
+set(BINARIES_OP_BASE_FLAGS "-Wl,--wrap,IsFile -Wl,--wrap,wfopen")
 if(${TARGET} STREQUAL "winagent")
 list(APPEND shared_tests_flags "${BINARIES_OP_BASE_FLAGS} -Wl,--wrap,get_windows_file_time_epoch,--wrap,mdebug2 \
                                 -Wl,--wrap,syscom_dispatch -Wl,--wrap,Start_win32_Syscheck \
@@ -228,12 +228,12 @@ endif()
 list(APPEND shared_tests_names "test_syscheck_op")
 set(SYSCHECK_OP_BASE_FLAGS "-Wl,--wrap,rmdir_ex -Wl,--wrap,wreaddir -Wl,--wrap,getpwuid_r -Wl,--wrap,w_getgrgid \
                             -Wl,--wrap,wstr_split -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP \
-                            -Wl,--wrap,sysconf -Wl,--wrap,win_strerror ${DEBUG_OP_WRAPPERS}")
+                            -Wl,--wrap,sysconf -Wl,--wrap,win_strerror -Wl,--wrap,wfopen ${DEBUG_OP_WRAPPERS}")
 if(${TARGET} STREQUAL "winagent")
     # cJSON_CreateArray@0 instead of cJSON_CreateArray since linker will be looking for cdecl forma
     # More info at: (https://devblogs.microsoft.com/oldnewthing/20040108-00/?p=41163)
-    list(APPEND shared_tests_flags "${SYSCHECK_OP_BASE_FLAGS} -Wl,--wrap=syscom_dispatch \
-                                    -Wl,--wrap,cJSON_CreateArray@0 -Wl,--wrap,cJSON_CreateObject@0")
+    list(APPEND shared_tests_flags "${SYSCHECK_OP_BASE_FLAGS} -Wl,--wrap=syscom_dispatch -Wl,--wrap=is_fim_shutdown \
+                                    -Wl,--wrap,cJSON_CreateArray@0 -Wl,--wrap,cJSON_CreateObject@0 -Wl,--wrap=Start_win32_Syscheck")
 else()
     list(APPEND shared_tests_flags "${SYSCHECK_OP_BASE_FLAGS} -Wl,--wrap=cJSON_CreateArray,--wrap=cJSON_CreateObject -Wl,--wrap,getpid")
 endif()
@@ -296,7 +296,7 @@ endif()
 
 list(APPEND shared_tests_names "test_url")
 list(APPEND shared_tests_flags "-Wl,--wrap,curl_slist_free_all -Wl,--wrap,curl_easy_cleanup \
-                                -Wl,--wrap,curl_easy_init -Wl,--wrap,curl_easy_setopt \
+                                -Wl,--wrap,curl_easy_init -Wl,--wrap,curl_easy_setopt -Wl,--wrap,wfopen \
                                 -Wl,--wrap,curl_slist_append -Wl,--wrap,curl_easy_perform \
                                 -Wl,--wrap,curl_easy_getinfo -Wl,--wrap,FileSize ${DEBUG_OP_WRAPPERS}")
 

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -20,8 +20,8 @@ endif()
 
 list(APPEND shared_tests_names "test_file_op")
 if(NOT ${TARGET} STREQUAL "winagent")
-    set(FILE_OP_BASE_FLAGS "-Wl,--wrap,stat,--wrap,chmod,--wrap,getpid \
-                            -Wl,--wrap,unlink,--wrap,wfopen,--wrap,fflush,--wrap,fclose \
+    set(FILE_OP_BASE_FLAGS "-Wl,--wrap,stat,--wrap,chmod,--wrap,getpid,--wrap,wfopen \
+                            -Wl,--wrap,unlink,--wrap,fopen,--wrap,fflush,--wrap,fclose \
                             -Wl,--wrap,fread,--wrap,ftell,--wrap,fseek,--wrap,fwrite,--wrap,remove \
                             -Wl,--wrap,fprintf,--wrap,fgets,--wrap,File_DateofChange \
                             -Wl,--wrap,bzip2_uncompress,--wrap,lstat \
@@ -81,7 +81,7 @@ list(APPEND shared_tests_flags "${EXPRESSION_BASE_FLAGS}")
 endif()
 
 list(APPEND shared_tests_names "test_version_op")
-set(VERSION_OP_BASE_FLAGS "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+set(VERSION_OP_BASE_FLAGS "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,wfopen \
                            -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets \
                            -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,popen -Wl,--wrap,pclose \
                            -Wl,--wrap,get_binary_path")
@@ -131,9 +131,10 @@ list(APPEND shared_tests_names "test_enrollment_op")
 set(ENROLLMENT_OP_BASE_FLAGS "-Wl,--wrap=OS_IsValidIP,--wrap=_merror,--wrap=_mwarn,--wrap=check_x509_cert \
                               -Wl,--wrap=_minfo,--wrap=_mdebug1,--wrap=OS_GetHost,--wrap=os_ssl_keys,--wrap=OS_ConnectTCP \
                               -Wl,--wrap=SSL_new,--wrap=SSL_connect,--wrap=SSL_get_error,--wrap=SSL_set_bio \
-                              -Wl,--wrap=SSL_write,--wrap=wfopen,--wrap=fclose,--wrap=SSL_read \
+                              -Wl,--wrap=SSL_write,--wrap=fopen,--wrap=fclose,--wrap=SSL_read \
                               -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit,--wrap=TempFile,--wrap=OS_MoveFile \
-                              -Wl,--wrap=fgets -Wl,--wrap,OS_CloseSocket")
+                              -Wl,--wrap=fgets -Wl,--wrap,OS_CloseSocket,--wrap=wfopen,--wrap=fflush,--wrap=fgetpos \
+                              -Wl,--wrap=fread,--wrap=fseek,--wrap=fwrite,--wrap=remove,--wrap=fgetc")
 
 if(${TARGET} STREQUAL "winagent")
     list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS} -Wl,--wrap,syscom_dispatch -Wl,--wrap,Start_win32_Syscheck \
@@ -198,11 +199,11 @@ endif()
 
 if(${TARGET} STREQUAL "server")
 list(APPEND shared_tests_names "test_bzip2_op")
-list(APPEND shared_tests_flags "-Wl,--wrap=wfopen,--wrap=fread,--wrap=fclose,--wrap=fwrite,--wrap=BZ2_bzWriteOpen \
+list(APPEND shared_tests_flags "-Wl,--wrap=fopen,--wrap=fread,--wrap=fclose,--wrap=fwrite,--wrap=BZ2_bzWriteOpen \
                                 -Wl,--wrap=BZ2_bzWriteClose -Wl,--wrap=BZ2_bzReadClose,--wrap=BZ2_bzReadOpen \
                                 -Wl,--wrap=BZ2_bzRead,--wrap=BZ2_bzWrite,--wrap=_mdebug2,--wrap=fflush \
                                 -Wl,--wrap=fgets,--wrap=fprintf,--wrap=fseek,--wrap=remove -Wl,--wrap,fgetpos \
-                                -Wl,--wrap=fgetc")
+                                -Wl,--wrap=fgetc,--wrap=wfopen")
 
 list(APPEND shared_tests_names "test_schedule_scan")
 list(APPEND shared_tests_flags "-Wl,--wrap=OS_StrIsNum,--wrap=_merror,--wrap=w_time_delay,--wrap=time,--wrap=_mwarn \
@@ -240,8 +241,8 @@ endif()
 if(NOT ${TARGET} STREQUAL "winagent")
 list(APPEND shared_tests_names "test_json_op")
 list(APPEND shared_tests_flags "-Wl,--wrap,w_get_file_content -Wl,--wrap,cJSON_ParseWithOpts \
-                                -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,wfopen \
-                                -Wl,--wrap,fwrite -Wl,--wrap,fclose \
+                                -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,fopen \
+                                -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,wfopen \
                                 -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                 -Wl,--wrap,fgetpos -Wl,--wrap,fgetc \
                                 -Wl,--wrap,fread -Wl,--wrap,remove \
@@ -251,8 +252,8 @@ list(APPEND shared_tests_names "test_audit_op")
 list(APPEND shared_tests_flags "-Wl,--wrap,audit_send \
                                 -Wl,--wrap,select -Wl,--wrap,audit_get_reply -Wl,--wrap,wpopenv -Wl,--wrap,fgets \
                                 -Wl,--wrap,wpclose -Wl,--wrap,audit_open -Wl,--wrap,audit_add_watch_dir \
-                                -Wl,--wrap,audit_update_watch_perms -Wl,--wrap,audit_errno_to_name \
-                                -Wl,--wrap,audit_rule_fieldpair_data -Wl,--wrap,wfopen -Wl,--wrap,audit_add_rule_data \
+                                -Wl,--wrap,audit_update_watch_perms -Wl,--wrap,audit_errno_to_name -Wl,--wrap,wfopen \
+                                -Wl,--wrap,audit_rule_fieldpair_data -Wl,--wrap,fopen -Wl,--wrap,audit_add_rule_data \
                                 -Wl,--wrap,audit_delete_rule_data -Wl,--wrap,audit_close -Wl,--wrap,fclose \
                                 -Wl,--wrap,fflush -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek \
                                 -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
@@ -272,7 +273,7 @@ endif()
 
 if(${TARGET} STREQUAL "server")
 list(APPEND shared_tests_names "test_json-queue")
-list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,wfopen -Wl,--wrap,fclose \
+list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,wfopen \
                                 -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
                                 -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets -Wl,--wrap,w_ftell \
                                 -Wl,--wrap,fgetpos -Wl,--wrap,fgetc,--wrap,stat,--wrap,sleep,--wrap,getpid,--wrap,clearerr")

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 list(APPEND shared_tests_names "test_file_op")
 if(NOT ${TARGET} STREQUAL "winagent")
     set(FILE_OP_BASE_FLAGS "-Wl,--wrap,stat,--wrap,chmod,--wrap,getpid \
-                            -Wl,--wrap,unlink,--wrap,fopen,--wrap,fflush,--wrap,fclose \
+                            -Wl,--wrap,unlink,--wrap,wfopen,--wrap,fflush,--wrap,fclose \
                             -Wl,--wrap,fread,--wrap,ftell,--wrap,fseek,--wrap,fwrite,--wrap,remove \
                             -Wl,--wrap,fprintf,--wrap,fgets,--wrap,File_DateofChange \
                             -Wl,--wrap,bzip2_uncompress,--wrap,lstat \
@@ -81,7 +81,7 @@ list(APPEND shared_tests_flags "${EXPRESSION_BASE_FLAGS}")
 endif()
 
 list(APPEND shared_tests_names "test_version_op")
-set(VERSION_OP_BASE_FLAGS "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+set(VERSION_OP_BASE_FLAGS "-Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                            -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets \
                            -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,popen -Wl,--wrap,pclose \
                            -Wl,--wrap,get_binary_path")
@@ -131,7 +131,7 @@ list(APPEND shared_tests_names "test_enrollment_op")
 set(ENROLLMENT_OP_BASE_FLAGS "-Wl,--wrap=OS_IsValidIP,--wrap=_merror,--wrap=_mwarn,--wrap=check_x509_cert \
                               -Wl,--wrap=_minfo,--wrap=_mdebug1,--wrap=OS_GetHost,--wrap=os_ssl_keys,--wrap=OS_ConnectTCP \
                               -Wl,--wrap=SSL_new,--wrap=SSL_connect,--wrap=SSL_get_error,--wrap=SSL_set_bio \
-                              -Wl,--wrap=SSL_write,--wrap=fopen,--wrap=fclose,--wrap=SSL_read \
+                              -Wl,--wrap=SSL_write,--wrap=wfopen,--wrap=fclose,--wrap=SSL_read \
                               -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit,--wrap=TempFile,--wrap=OS_MoveFile \
                               -Wl,--wrap=fgets -Wl,--wrap,OS_CloseSocket")
 
@@ -198,7 +198,7 @@ endif()
 
 if(${TARGET} STREQUAL "server")
 list(APPEND shared_tests_names "test_bzip2_op")
-list(APPEND shared_tests_flags "-Wl,--wrap=fopen,--wrap=fread,--wrap=fclose,--wrap=fwrite,--wrap=BZ2_bzWriteOpen \
+list(APPEND shared_tests_flags "-Wl,--wrap=wfopen,--wrap=fread,--wrap=fclose,--wrap=fwrite,--wrap=BZ2_bzWriteOpen \
                                 -Wl,--wrap=BZ2_bzWriteClose -Wl,--wrap=BZ2_bzReadClose,--wrap=BZ2_bzReadOpen \
                                 -Wl,--wrap=BZ2_bzRead,--wrap=BZ2_bzWrite,--wrap=_mdebug2,--wrap=fflush \
                                 -Wl,--wrap=fgets,--wrap=fprintf,--wrap=fseek,--wrap=remove -Wl,--wrap,fgetpos \
@@ -240,7 +240,7 @@ endif()
 if(NOT ${TARGET} STREQUAL "winagent")
 list(APPEND shared_tests_names "test_json_op")
 list(APPEND shared_tests_flags "-Wl,--wrap,w_get_file_content -Wl,--wrap,cJSON_ParseWithOpts \
-                                -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,fopen \
+                                -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,wfopen \
                                 -Wl,--wrap,fwrite -Wl,--wrap,fclose \
                                 -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                 -Wl,--wrap,fgetpos -Wl,--wrap,fgetc \
@@ -252,7 +252,7 @@ list(APPEND shared_tests_flags "-Wl,--wrap,audit_send \
                                 -Wl,--wrap,select -Wl,--wrap,audit_get_reply -Wl,--wrap,wpopenv -Wl,--wrap,fgets \
                                 -Wl,--wrap,wpclose -Wl,--wrap,audit_open -Wl,--wrap,audit_add_watch_dir \
                                 -Wl,--wrap,audit_update_watch_perms -Wl,--wrap,audit_errno_to_name \
-                                -Wl,--wrap,audit_rule_fieldpair_data -Wl,--wrap,fopen -Wl,--wrap,audit_add_rule_data \
+                                -Wl,--wrap,audit_rule_fieldpair_data -Wl,--wrap,wfopen -Wl,--wrap,audit_add_rule_data \
                                 -Wl,--wrap,audit_delete_rule_data -Wl,--wrap,audit_close -Wl,--wrap,fclose \
                                 -Wl,--wrap,fflush -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek \
                                 -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
@@ -272,7 +272,7 @@ endif()
 
 if(${TARGET} STREQUAL "server")
 list(APPEND shared_tests_names "test_json-queue")
-list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,fopen -Wl,--wrap,fclose \
+list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,wfopen -Wl,--wrap,fclose \
                                 -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
                                 -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets -Wl,--wrap,w_ftell \
                                 -Wl,--wrap,fgetpos -Wl,--wrap,fgetc,--wrap,stat,--wrap,sleep,--wrap,getpid,--wrap,clearerr")

--- a/src/unit_tests/shared/test_bzip2_op.c
+++ b/src/unit_tests/shared/test_bzip2_op.c
@@ -50,9 +50,9 @@ void test_bzip2_compress_firstfopenfail(void **state) {
     int ret;
     char *string = "testfile";
 
-    expect_value(__wrap_fopen, path, string);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, NULL);
+    expect_value(__wrap_wfopen, path, string);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg,
                   "(1103): Could not open file 'testfile' due to [(0)-(Success)].");
@@ -65,13 +65,13 @@ void test_bzip2_compress_secondfopenfail(void **state) {
     char *file1 = "testfile";
     char *file2 = "testfile2";
 
-    expect_value(__wrap_fopen, path, file1);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, file1);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
-    expect_value(__wrap_fopen, path, file2);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, NULL);
+    expect_value(__wrap_wfopen, path, file2);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg,
                   "(1103): Could not open file 'testfile2' due to [(0)-(Success)].");
@@ -88,13 +88,13 @@ void test_bzip2_compress_bzWriteOpen(void **state) {
     char *file1 = "testfile";
     char *file2 = "testfile2";
 
-    expect_value(__wrap_fopen, path, file1);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, file1);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
-    expect_value(__wrap_fopen, path, file2);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 2);
+    expect_value(__wrap_wfopen, path, file2);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 2);
 
     expect_value(__wrap_BZ2_bzWriteOpen, f, 2);
     will_return(__wrap_BZ2_bzWriteOpen, BZ_MEM_ERROR);
@@ -118,13 +118,13 @@ void test_bzip2_compress_BZ2_bzWrite(void **state) {
     char *file1 = "testfile";
     char *file2 = "testfile2";
 
-    expect_value(__wrap_fopen, path, file1);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, file1);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
-    expect_value(__wrap_fopen, path, file2);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 2);
+    expect_value(__wrap_wfopen, path, file2);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 2);
 
     expect_value(__wrap_BZ2_bzWriteOpen, f, 2);
     will_return(__wrap_BZ2_bzWriteOpen, BZ_OK);
@@ -156,13 +156,13 @@ void test_bzip2_compress_success(void **state) {
     char *file1 = "testfile";
     char *file2 = "testfile2";
 
-    expect_value(__wrap_fopen, path, file1);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, file1);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
-    expect_value(__wrap_fopen, path, file2);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 2);
+    expect_value(__wrap_wfopen, path, file2);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 2);
 
     expect_value(__wrap_BZ2_bzWriteOpen, f, 2);
     will_return(__wrap_BZ2_bzWriteOpen, BZ_OK);
@@ -209,9 +209,9 @@ void test_bzip2_uncompress_firstfopenfail(void **state) {
     int ret;
     char *string = "testfile";
 
-    expect_value(__wrap_fopen, path, string);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, NULL);
+    expect_value(__wrap_wfopen, path, string);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg,
                   "(1103): Could not open file 'testfile' due to [(0)-(Success)].");
@@ -224,13 +224,13 @@ void test_bzip2_uncompress_secondfopenfail(void **state) {
     char *file1 = "testfile";
     char *file2 = "testfile2";
 
-    expect_value(__wrap_fopen, path, file1);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, file1);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
-    expect_value(__wrap_fopen, path, file2);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, NULL);
+    expect_value(__wrap_wfopen, path, file2);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg,
                   "(1103): Could not open file 'testfile2' due to [(0)-(Success)].");
@@ -247,13 +247,13 @@ void test_bzip2_uncompress_bzReadOpen(void **state) {
     char *file1 = "testfile";
     char *file2 = "testfile2";
 
-    expect_value(__wrap_fopen, path, file1);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, file1);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
-    expect_value(__wrap_fopen, path, file2);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 2);
+    expect_value(__wrap_wfopen, path, file2);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 2);
 
     expect_value(__wrap_BZ2_bzReadOpen, f, 1);
     will_return(__wrap_BZ2_bzReadOpen, BZ_MEM_ERROR);
@@ -277,13 +277,13 @@ void test_bzip2_uncompress_bzReadsuccess(void **state) {
     char *file1 = "testfile";
     char *file2 = "testfile2";
 
-    expect_value(__wrap_fopen, path, file1);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, file1);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
-    expect_value(__wrap_fopen, path, file2);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 2);
+    expect_value(__wrap_wfopen, path, file2);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 2);
 
     expect_value(__wrap_BZ2_bzReadOpen, f, 1);
     will_return(__wrap_BZ2_bzReadOpen, BZ_OK);
@@ -319,13 +319,13 @@ void test_bzip2_uncompress_bzReadfail(void **state) {
     char *file1 = "testfile";
     char *file2 = "testfile2";
 
-    expect_value(__wrap_fopen, path, file1);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_value(__wrap_wfopen, path, file1);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
-    expect_value(__wrap_fopen, path, file2);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 2);
+    expect_value(__wrap_wfopen, path, file2);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 2);
 
     expect_value(__wrap_BZ2_bzReadOpen, f, 1);
     will_return(__wrap_BZ2_bzReadOpen, BZ_OK);

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -40,7 +40,7 @@ extern void w_enrollment_load_pass(w_enrollment_cert *cert_cfg);
 extern SSL *__real_SSL_new(SSL_CTX *ctx);
 
 extern FILE * __real_fopen ( const char * filename, const char * mode );
-FILE * __wrap_fopen ( const char * filename, const char * mode ) {
+FILE * __wrap_wfopen ( const char * filename, const char * mode ) {
     if(!test_mode)
         return __real_fopen(filename, mode);
     check_expected(filename);
@@ -795,9 +795,9 @@ void test_w_enrollment_store_key_entry_cannot_open(void **state) {
     const char* key_string = "KEY EXAMPLE STRING";
     char key_file[1024];
 #ifdef WIN32
-    expect_string(__wrap_fopen, filename, KEYS_FILE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, filename, KEYS_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 0);
 #else
     expect_string(__wrap_TempFile, source, KEYS_FILE);
     expect_value(__wrap_TempFile, copy, 0);
@@ -838,9 +838,9 @@ void test_w_enrollment_store_key_entry_success(void **state) {
     FILE file;
     const char* key_string = "KEY EXAMPLE STRING";
 #ifdef WIN32
-    expect_string(__wrap_fopen, filename, KEYS_FILE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, &file);
+    expect_string(__wrap_wfopen, filename, KEYS_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, &file);
 
     expect_value(wrap_fprintf, __stream, &file);
     expect_string(wrap_fprintf, formatted_msg, "KEY EXAMPLE STRING\n");
@@ -898,9 +898,9 @@ void test_w_enrollment_process_agent_key_valid_key(void **state) {
     expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
     will_return(__wrap_OS_IsValidIP, 1);
 #ifdef WIN32
-    expect_string(__wrap_fopen, filename, KEYS_FILE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 4);
+    expect_string(__wrap_wfopen, filename, KEYS_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 4);
 
     expect_value(wrap_fprintf, __stream, 4);
     expect_string(wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
@@ -996,9 +996,9 @@ void test_w_enrollment_process_response_success(void **state) {
         expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
         will_return(__wrap_OS_IsValidIP, 1);
 #ifdef WIN32
-        expect_string(__wrap_fopen, filename, KEYS_FILE);
-        expect_string(__wrap_fopen, mode, "w");
-        will_return(__wrap_fopen, 4);
+        expect_string(__wrap_wfopen, filename, KEYS_FILE);
+        expect_string(__wrap_wfopen, mode, "w");
+        will_return(__wrap_wfopen, 4);
 
         expect_value(wrap_fprintf, __stream, 4);
         expect_string(wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
@@ -1110,9 +1110,9 @@ void test_w_enrollment_request_key(void **state) {
             expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
             will_return(__wrap_OS_IsValidIP, 1);
 #ifdef WIN32
-            expect_string(__wrap_fopen, filename, KEYS_FILE);
-            expect_string(__wrap_fopen, mode, "w");
-            will_return(__wrap_fopen, 4);
+            expect_string(__wrap_wfopen, filename, KEYS_FILE);
+            expect_string(__wrap_wfopen, mode, "w");
+            will_return(__wrap_wfopen, 4);
 
             expect_value(wrap_fprintf, __stream, 4);
             expect_string(wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
@@ -1185,9 +1185,9 @@ void test_w_enrollment_load_pass_null_cert(void **state) {
 void test_w_enrollment_load_pass_empty_file(void **state) {
     w_enrollment_cert *cert = *state;
 
-    expect_string(__wrap_fopen, filename, AUTHD_PASS);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 4);
+    expect_string(__wrap_wfopen, filename, AUTHD_PASS);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 4);
 #ifdef WIN32
     expect_value(wrap_fgets, __stream, 4);
     will_return(wrap_fgets, "");
@@ -1209,9 +1209,9 @@ void test_w_enrollment_load_pass_empty_file(void **state) {
 void test_w_enrollment_load_pass_file_with_content(void **state) {
     w_enrollment_cert *cert = *state;
 
-    expect_string(__wrap_fopen, filename, AUTHD_PASS);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 4);
+    expect_string(__wrap_wfopen, filename, AUTHD_PASS);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 4);
 #ifdef WIN32
     expect_value(wrap_fgets, __stream, 4);
     will_return(wrap_fgets, "content_password");

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -794,6 +794,9 @@ void test_w_enrollment_store_key_entry_success(void **state) {
     expect_string(__wrap_wfopen, mode, "w");
     will_return(__wrap_wfopen, &file);
 
+    expect_value(__wrap_fclose, _File, &file);
+    will_return(__wrap_fclose, 1);
+
     expect_value(wrap_fprintf, __stream, &file);
     expect_string(wrap_fprintf, formatted_msg, "KEY EXAMPLE STRING\n");
     will_return(wrap_fprintf, 0);
@@ -857,6 +860,9 @@ void test_w_enrollment_process_agent_key_valid_key(void **state) {
     expect_string(__wrap_wfopen, path, KEYS_FILE);
     expect_string(__wrap_wfopen, mode, "w");
     will_return(__wrap_wfopen, 4);
+
+    expect_value(__wrap_fclose, _File, 4);
+    will_return(__wrap_fclose, 1);
 
     expect_value(wrap_fprintf, __stream, 4);
     expect_string(wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
@@ -959,6 +965,9 @@ void test_w_enrollment_process_response_success(void **state) {
         expect_string(__wrap_wfopen, path, KEYS_FILE);
         expect_string(__wrap_wfopen, mode, "w");
         will_return(__wrap_wfopen, 4);
+
+        expect_value(__wrap_fclose, _File, 4);
+        will_return(__wrap_fclose, 1);
 
         expect_value(wrap_fprintf, __stream, 4);
         expect_string(wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
@@ -1078,6 +1087,9 @@ void test_w_enrollment_request_key(void **state) {
             expect_string(__wrap_wfopen, mode, "w");
             will_return(__wrap_wfopen, 4);
 
+            expect_value(__wrap_fclose, _File, 4);
+            will_return(__wrap_fclose, 1);
+
             expect_value(wrap_fprintf, __stream, 4);
             expect_string(wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
             will_return(wrap_fprintf, 0);
@@ -1157,6 +1169,9 @@ void test_w_enrollment_load_pass_empty_file(void **state) {
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 4);
 #ifdef WIN32
+    expect_value(__wrap_fclose, _File, 4);
+    will_return(__wrap_fclose, 1);
+
     expect_value(wrap_fgets, __stream, 4);
     will_return(wrap_fgets, "");
 #else
@@ -1182,6 +1197,9 @@ void test_w_enrollment_load_pass_file_with_content(void **state) {
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 4);
 #ifdef WIN32
+    expect_value(__wrap_fclose, _File, 4);
+    will_return(__wrap_fclose, 1);
+
     expect_value(wrap_fgets, __stream, 4);
     will_return(wrap_fgets, "content_password");
 #else

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -39,32 +39,6 @@ extern void w_enrollment_load_pass(w_enrollment_cert *cert_cfg);
 
 extern SSL *__real_SSL_new(SSL_CTX *ctx);
 
-extern FILE * __real_fopen ( const char * filename, const char * mode );
-FILE * __wrap_wfopen ( const char * filename, const char * mode ) {
-    if(!test_mode)
-        return __real_fopen(filename, mode);
-    check_expected(filename);
-    check_expected(mode);
-    return mock_ptr_type(FILE *);
-}
-
-extern char * __real_fgets(char * buf, int size, FILE *stream);
-char * __wrap_fgets(char * buf, int size, FILE *stream) {
-    if(!test_mode)
-        return __real_fgets(buf, size, stream);
-    snprintf(buf, size, "%s", mock_ptr_type(char*));
-    check_expected(size);
-    check_expected(stream);
-    return mock_ptr_type(char *);
-}
-
-extern int __real_fclose ( FILE * stream );
-int __wrap_fclose ( FILE * stream ) {
-    if(!test_mode)
-        return __real_fclose(stream);
-    return 0;
-}
-
 int __wrap_TempFile(File *file, const char *source, int copy) {
     file->name = mock_type(char *);
     file->fp = mock_type(FILE *);
@@ -72,31 +46,6 @@ int __wrap_TempFile(File *file, const char *source, int copy) {
     check_expected(copy);
     return mock_type(int);
 }
-
-int __wrap_OS_MoveFile(const char *src, const char *dst) {
-    check_expected(src);
-    check_expected(dst);
-    return mock_type(int);
-}
-
-#ifndef WIN32
-extern int __real_fprintf ( FILE * stream, const char * format, ... );
-int __wrap_fprintf ( FILE * stream, const char * format, ... ) {
-    char formatted_msg[OS_MAXSTR];
-    va_list args;
-
-    va_start(args, format);
-    vsnprintf(formatted_msg, OS_MAXSTR, format, args);
-    va_end(args);
-
-    if(!test_mode)
-        return __real_fprintf(stream, formatted_msg);
-
-    check_expected(stream);
-    check_expected(formatted_msg);
-    return 0;
-}
-#endif
 
 void keyentry_init (keyentry *key, char *name, char *id, char *ip, char *raw_key) {
     os_calloc(1, sizeof(os_ip), key->ip);
@@ -795,7 +744,7 @@ void test_w_enrollment_store_key_entry_cannot_open(void **state) {
     const char* key_string = "KEY EXAMPLE STRING";
     char key_file[1024];
 #ifdef WIN32
-    expect_string(__wrap_wfopen, filename, KEYS_FILE);
+    expect_string(__wrap_wfopen, path, KEYS_FILE);
     expect_string(__wrap_wfopen, mode, "w");
     will_return(__wrap_wfopen, 0);
 #else
@@ -823,6 +772,9 @@ void test_w_enrollment_store_key_entry_chmod_fail(void **state) {
     will_return(__wrap_TempFile, 6);
     will_return(__wrap_TempFile, 0);
 
+    expect_value(__wrap_fclose, _File, 6);
+    will_return(__wrap_fclose, 1);
+
     expect_string(__wrap_chmod, path, "client.keys.temp");
     will_return(__wrap_chmod, -1);
 
@@ -838,7 +790,7 @@ void test_w_enrollment_store_key_entry_success(void **state) {
     FILE file;
     const char* key_string = "KEY EXAMPLE STRING";
 #ifdef WIN32
-    expect_string(__wrap_wfopen, filename, KEYS_FILE);
+    expect_string(__wrap_wfopen, path, KEYS_FILE);
     expect_string(__wrap_wfopen, mode, "w");
     will_return(__wrap_wfopen, &file);
 
@@ -855,8 +807,12 @@ void test_w_enrollment_store_key_entry_success(void **state) {
     expect_string(__wrap_chmod, path, "client.keys.temp");
     will_return(__wrap_chmod, 0);
 
-    expect_value(__wrap_fprintf, stream, 6);
+    expect_value(__wrap_fclose, _File, 6);
+    will_return(__wrap_fclose, 1);
+
+    expect_value(__wrap_fprintf, __stream, 6);
     expect_string(__wrap_fprintf, formatted_msg, "KEY EXAMPLE STRING\n");
+    will_return(__wrap_fprintf, 0);
 
     expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
     expect_string(__wrap_OS_MoveFile, dst, KEYS_FILE);
@@ -898,7 +854,7 @@ void test_w_enrollment_process_agent_key_valid_key(void **state) {
     expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
     will_return(__wrap_OS_IsValidIP, 1);
 #ifdef WIN32
-    expect_string(__wrap_wfopen, filename, KEYS_FILE);
+    expect_string(__wrap_wfopen, path, KEYS_FILE);
     expect_string(__wrap_wfopen, mode, "w");
     will_return(__wrap_wfopen, 4);
 
@@ -915,8 +871,12 @@ void test_w_enrollment_process_agent_key_valid_key(void **state) {
     expect_string(__wrap_chmod, path, "client.keys.temp");
     will_return(__wrap_chmod, 0);
 
-    expect_value(__wrap_fprintf, stream, 4);
+    expect_value(__wrap_fclose, _File, 4);
+    will_return(__wrap_fclose, 1);
+
+    expect_value(__wrap_fprintf, __stream, 4);
     expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
+    will_return(__wrap_fprintf, 0);
 
     expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
     expect_string(__wrap_OS_MoveFile, dst, KEYS_FILE);
@@ -996,7 +956,7 @@ void test_w_enrollment_process_response_success(void **state) {
         expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
         will_return(__wrap_OS_IsValidIP, 1);
 #ifdef WIN32
-        expect_string(__wrap_wfopen, filename, KEYS_FILE);
+        expect_string(__wrap_wfopen, path, KEYS_FILE);
         expect_string(__wrap_wfopen, mode, "w");
         will_return(__wrap_wfopen, 4);
 
@@ -1013,8 +973,12 @@ void test_w_enrollment_process_response_success(void **state) {
         expect_string(__wrap_chmod, path, "client.keys.temp");
         will_return(__wrap_chmod, 0);
 
-        expect_value(__wrap_fprintf, stream, 4);
+        expect_value(__wrap_fclose, _File, 4);
+        will_return(__wrap_fclose, 1);
+
+        expect_value(__wrap_fprintf, __stream, 4);
         expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
+        will_return(__wrap_fprintf, 0);
 
         expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
         expect_string(__wrap_OS_MoveFile, dst, KEYS_FILE);
@@ -1110,7 +1074,7 @@ void test_w_enrollment_request_key(void **state) {
             expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
             will_return(__wrap_OS_IsValidIP, 1);
 #ifdef WIN32
-            expect_string(__wrap_wfopen, filename, KEYS_FILE);
+            expect_string(__wrap_wfopen, path, KEYS_FILE);
             expect_string(__wrap_wfopen, mode, "w");
             will_return(__wrap_wfopen, 4);
 
@@ -1127,8 +1091,12 @@ void test_w_enrollment_request_key(void **state) {
             expect_string(__wrap_chmod, path, "client.keys.temp");
             will_return(__wrap_chmod, 0);
 
-            expect_value(__wrap_fprintf, stream, 4);
+            expect_value(__wrap_fclose, _File, 4);
+            will_return(__wrap_fclose, 1);
+
+            expect_value(__wrap_fprintf, __stream, 4);
             expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
+            will_return(__wrap_fprintf, 0);
 
             expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
             expect_string(__wrap_OS_MoveFile, dst, KEYS_FILE);
@@ -1185,16 +1153,17 @@ void test_w_enrollment_load_pass_null_cert(void **state) {
 void test_w_enrollment_load_pass_empty_file(void **state) {
     w_enrollment_cert *cert = *state;
 
-    expect_string(__wrap_wfopen, filename, AUTHD_PASS);
+    expect_string(__wrap_wfopen, path, AUTHD_PASS);
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 4);
 #ifdef WIN32
     expect_value(wrap_fgets, __stream, 4);
     will_return(wrap_fgets, "");
 #else
-    expect_value(__wrap_fgets, size, 4095);
-    expect_value(__wrap_fgets, stream, 4);
-    will_return(__wrap_fgets, "");
+    expect_value(__wrap_fclose, _File, 4);
+    will_return(__wrap_fclose, 1);
+
+    expect_value(__wrap_fgets, __stream, 4);
     will_return(__wrap_fgets, NULL);
 #endif
     char buff[1024];
@@ -1209,16 +1178,17 @@ void test_w_enrollment_load_pass_empty_file(void **state) {
 void test_w_enrollment_load_pass_file_with_content(void **state) {
     w_enrollment_cert *cert = *state;
 
-    expect_string(__wrap_wfopen, filename, AUTHD_PASS);
+    expect_string(__wrap_wfopen, path, AUTHD_PASS);
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 4);
 #ifdef WIN32
     expect_value(wrap_fgets, __stream, 4);
     will_return(wrap_fgets, "content_password");
 #else
-    expect_value(__wrap_fgets, size, 4095);
-    expect_value(__wrap_fgets, stream, 4);
-    will_return(__wrap_fgets, "content_password");
+    expect_value(__wrap_fclose, _File, 4);
+    will_return(__wrap_fclose, 1);
+
+    expect_value(__wrap_fgets, __stream, 4);
     will_return(__wrap_fgets, "content_password");
 #endif
     char buff[1024];

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -87,9 +87,9 @@ void test_CreatePID_success(void **state)
 
     *state = content;
 
-    expect_string(__wrap_fopen, path, "var/run/test-2345.pid");
-    expect_string(__wrap_fopen, mode, "a");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/run/test-2345.pid");
+    expect_string(__wrap_wfopen, mode, "a");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fprintf, __stream, 1);
     expect_string(__wrap_fprintf, formatted_msg, "2345\n");
@@ -110,9 +110,9 @@ void test_CreatePID_failure_chmod(void **state)
     (void) state;
     int ret;
 
-    expect_string(__wrap_fopen, path, "var/run/test-2345.pid");
-    expect_string(__wrap_fopen, mode, "a");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/run/test-2345.pid");
+    expect_string(__wrap_wfopen, mode, "a");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fprintf, __stream, 1);
     expect_string(__wrap_fprintf, formatted_msg, "2345\n");
@@ -135,9 +135,9 @@ void test_CreatePID_failure_fopen(void **state)
     (void) state;
     int ret;
 
-    expect_string(__wrap_fopen, path, "var/run/test-2345.pid");
-    expect_string(__wrap_fopen, mode, "a");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, "var/run/test-2345.pid");
+    expect_string(__wrap_wfopen, mode, "a");
+    will_return(__wrap_wfopen, NULL);
 
     ret = CreatePID("test", 2345);
     assert_int_equal(-1, ret);
@@ -187,9 +187,9 @@ void test_w_is_compressed_gz_file_uncompressed(void **state) {
     char * path = "/test/file.gz";
     int ret = 0;
 
-    expect_string(__wrap_fopen, path, "/test/file.gz");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/test/file.gz");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "fake");
     will_return(__wrap_fread, 2);
@@ -207,9 +207,9 @@ void test_w_is_compressed_bz2_file_compressed(void **state) {
     char * path = "/test/file.bz2";
     int ret = 0;
 
-    expect_string(__wrap_fopen, path, "/test/file.bz2");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/test/file.bz2");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     // BZh is 0x42 0x5a 0x68
     will_return(__wrap_fread, "BZh");
@@ -226,9 +226,9 @@ void test_w_is_compressed_bz2_file_uncompressed(void **state) {
     char * path = "/test/file.bz2";
     int ret = 0;
 
-    expect_string(__wrap_fopen, path, "/test/file.bz2");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/test/file.bz2");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "fake");
     will_return(__wrap_fread, 3);
@@ -249,9 +249,9 @@ void test_w_uncompress_bz2_gz_file_bz2(void **state) {
     char * dest = "/test/file";
     int ret;
 
-    expect_string(__wrap_fopen, path, "/test/file.bz2");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/test/file.bz2");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "BZh");
     will_return(__wrap_fread, 3);
@@ -260,9 +260,9 @@ void test_w_uncompress_bz2_gz_file_bz2(void **state) {
     expect_string(__wrap_bzip2_uncompress, file, "/test/file");
     will_return(__wrap_bzip2_uncompress, 0);
 
-    expect_string(__wrap_fopen, path, "/test/file.bz2");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/test/file.bz2");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 0);
 
     expect_string(__wrap__mdebug1, formatted_msg, "The file '/test/file.bz2' was successfully uncompressed into '/test/file'");
 
@@ -280,9 +280,9 @@ void test_MergeAppendFile_open_fail(void **state) {
     int path_offset = -1;
     int ret;
 
-    expect_string(__wrap_fopen, path, file);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, file);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
 
     expect_string(__wrap__merror, formatted_msg, "Unable to open file: 'test.txt' due to [(0)-(Success)].");
 
@@ -297,9 +297,9 @@ void test_MergeAppendFile_fseek_fail(void **state) {
     int path_offset = -1;
     int ret;
 
-    expect_string(__wrap_fopen, path, file);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 6);
+    expect_string(__wrap_wfopen, path, file);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 6);
 
     will_return(__wrap_fseek, 1);
 
@@ -319,9 +319,9 @@ void test_MergeAppendFile_fseek2_fail(void **state) {
     int path_offset = -1;
     int ret;
 
-    expect_string(__wrap_fopen, path, file);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 6);
+    expect_string(__wrap_wfopen, path, file);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 6);
 
     will_return(__wrap_fseek, 0);
 
@@ -350,9 +350,9 @@ void test_MergeAppendFile_diff_ftell(void **state) {
     int path_offset = 0;
     int ret;
 
-    expect_string(__wrap_fopen, path, file);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 6);
+    expect_string(__wrap_wfopen, path, file);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 6);
 
     will_return(__wrap_fseek, 0);
 
@@ -390,9 +390,9 @@ void test_MergeAppendFile_success(void **state) {
     int path_offset = 0;
     int ret;
 
-    expect_string(__wrap_fopen, path, file);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 6);
+    expect_string(__wrap_wfopen, path, file);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 6);
 
     will_return(__wrap_fseek, 0);
 
@@ -431,9 +431,9 @@ void test_w_compress_gzfile_wfopen_fail(void **state){
     char *srcfile = "testfilesrc";
     char *dstfile = "testfiledst.gz";
 
-    expect_string(__wrap_fopen, path, srcfile);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, srcfile);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, NULL);
 
     expect_string(__wrap__merror, formatted_msg, "in w_compress_gzfile(): fopen error testfilesrc (0):'Success'");
 
@@ -447,9 +447,9 @@ void test_w_compress_gzfile_gzopen_fail(void **state){
     char *srcfile = "testfilesrc";
     char *dstfile = "testfiledst.gz";
 
-    expect_string(__wrap_fopen, path, srcfile);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, srcfile);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     expect_string(__wrap_gzopen, path, dstfile);
     expect_string(__wrap_gzopen, mode, "w");
@@ -470,9 +470,9 @@ void test_w_compress_gzfile_write_error(void **state){
     char *srcfile = "testfilesrc";
     char *dstfile = "testfiledst.gz";
 
-    expect_string(__wrap_fopen, path, srcfile);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, srcfile);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     expect_string(__wrap_gzopen, path, dstfile);
     expect_string(__wrap_gzopen, mode, "w");
@@ -506,9 +506,9 @@ void test_w_compress_gzfile_success(void **state){
     char *srcfile = "testfilesrc";
     char *dstfile = "testfiledst.gz";
 
-    expect_string(__wrap_fopen, path, srcfile);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, srcfile);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     expect_string(__wrap_gzopen, path, dstfile);
     expect_string(__wrap_gzopen, mode, "w");
@@ -560,9 +560,9 @@ void test_w_uncompress_gzfile_fopen_fail(void **state) {
     will_return(__wrap_lstat, &buf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_fopen, path, dstfile);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, dstfile);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, NULL);
 
     expect_string(__wrap__merror, formatted_msg, "in w_uncompress_gzfile(): fopen error testfiledst (0):'Success'");
 
@@ -580,9 +580,9 @@ void test_w_uncompress_gzfile_gzopen_fail(void **state) {
     will_return(__wrap_lstat, &buf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_fopen, path, dstfile);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, dstfile);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 1);
 
     expect_string(__wrap_gzopen, path, srcfile);
     expect_string(__wrap_gzopen, mode, "rb");
@@ -607,9 +607,9 @@ void test_w_uncompress_gzfile_first_read_fail(void **state) {
     will_return(__wrap_lstat, &buf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_fopen, path, dstfile);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, dstfile);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 1);
 
     expect_string(__wrap_gzopen, path, srcfile);
     expect_string(__wrap_gzopen, mode, "rb");
@@ -651,9 +651,9 @@ void test_w_uncompress_gzfile_first_read_success(void **state) {
     will_return(__wrap_lstat, &buf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_fopen, path, dstfile);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, dstfile);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 1);
 
     expect_string(__wrap_gzopen, path, srcfile);
     expect_string(__wrap_gzopen, mode, "rb");
@@ -699,9 +699,9 @@ void test_w_uncompress_gzfile_success(void **state) {
     will_return(__wrap_lstat, &buf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_fopen, path, dstfile);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, dstfile);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 1);
 
     expect_string(__wrap_gzopen, path, srcfile);
     expect_string(__wrap_gzopen, mode, "rb");
@@ -868,9 +868,9 @@ void test_get_file_content(void **state)
     const char * expected = "test string";
     const char * file_name = "test_file.txt";
 
-    expect_string(__wrap_fopen, path, file_name);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, file_name);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_ftell, 0);
     will_return(__wrap_fseek, 0);
@@ -904,9 +904,9 @@ void test_get_file_pointer_NULL(void **state)
 void test_get_file_pointer_invalid(void **state)
 {
     const char * file_name = "test_file.txt";
-    expect_string(__wrap_fopen, path, file_name);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, file_name);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
     expect_string(__wrap__mdebug1, formatted_msg, "(1103): Could not open file 'test_file.txt' due to [(0)-(Success)].");
 
     FILE * fp = w_get_file_pointer(file_name);
@@ -917,9 +917,9 @@ void test_get_file_pointer_invalid(void **state)
 void test_get_file_pointer_success(void **state)
 {
     const char * file_name = "test_file.txt";
-    expect_string(__wrap_fopen, path, file_name);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, file_name);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     FILE * fp = w_get_file_pointer(file_name);
 

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -87,9 +87,9 @@ void test_CreatePID_success(void **state)
 
     *state = content;
 
-    expect_string(__wrap_wfopen, path, "var/run/test-2345.pid");
-    expect_string(__wrap_wfopen, mode, "a");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, "var/run/test-2345.pid");
+    expect_string(__wrap_fopen, mode, "a");
+    will_return(__wrap_fopen, 1);
 
     expect_value(__wrap_fprintf, __stream, 1);
     expect_string(__wrap_fprintf, formatted_msg, "2345\n");
@@ -110,9 +110,9 @@ void test_CreatePID_failure_chmod(void **state)
     (void) state;
     int ret;
 
-    expect_string(__wrap_wfopen, path, "var/run/test-2345.pid");
-    expect_string(__wrap_wfopen, mode, "a");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, "var/run/test-2345.pid");
+    expect_string(__wrap_fopen, mode, "a");
+    will_return(__wrap_fopen, 1);
 
     expect_value(__wrap_fprintf, __stream, 1);
     expect_string(__wrap_fprintf, formatted_msg, "2345\n");
@@ -135,9 +135,9 @@ void test_CreatePID_failure_fopen(void **state)
     (void) state;
     int ret;
 
-    expect_string(__wrap_wfopen, path, "var/run/test-2345.pid");
-    expect_string(__wrap_wfopen, mode, "a");
-    will_return(__wrap_wfopen, NULL);
+    expect_string(__wrap_fopen, path, "var/run/test-2345.pid");
+    expect_string(__wrap_fopen, mode, "a");
+    will_return(__wrap_fopen, NULL);
 
     ret = CreatePID("test", 2345);
     assert_int_equal(-1, ret);
@@ -187,9 +187,9 @@ void test_w_is_compressed_gz_file_uncompressed(void **state) {
     char * path = "/test/file.gz";
     int ret = 0;
 
-    expect_string(__wrap_wfopen, path, "/test/file.gz");
-    expect_string(__wrap_wfopen, mode, "rb");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, "/test/file.gz");
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
 
     will_return(__wrap_fread, "fake");
     will_return(__wrap_fread, 2);
@@ -207,9 +207,9 @@ void test_w_is_compressed_bz2_file_compressed(void **state) {
     char * path = "/test/file.bz2";
     int ret = 0;
 
-    expect_string(__wrap_wfopen, path, "/test/file.bz2");
-    expect_string(__wrap_wfopen, mode, "rb");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, "/test/file.bz2");
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
 
     // BZh is 0x42 0x5a 0x68
     will_return(__wrap_fread, "BZh");
@@ -226,9 +226,9 @@ void test_w_is_compressed_bz2_file_uncompressed(void **state) {
     char * path = "/test/file.bz2";
     int ret = 0;
 
-    expect_string(__wrap_wfopen, path, "/test/file.bz2");
-    expect_string(__wrap_wfopen, mode, "rb");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, "/test/file.bz2");
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
 
     will_return(__wrap_fread, "fake");
     will_return(__wrap_fread, 3);
@@ -249,9 +249,9 @@ void test_w_uncompress_bz2_gz_file_bz2(void **state) {
     char * dest = "/test/file";
     int ret;
 
-    expect_string(__wrap_wfopen, path, "/test/file.bz2");
-    expect_string(__wrap_wfopen, mode, "rb");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, "/test/file.bz2");
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
 
     will_return(__wrap_fread, "BZh");
     will_return(__wrap_fread, 3);
@@ -260,9 +260,9 @@ void test_w_uncompress_bz2_gz_file_bz2(void **state) {
     expect_string(__wrap_bzip2_uncompress, file, "/test/file");
     will_return(__wrap_bzip2_uncompress, 0);
 
-    expect_string(__wrap_wfopen, path, "/test/file.bz2");
-    expect_string(__wrap_wfopen, mode, "rb");
-    will_return(__wrap_wfopen, 0);
+    expect_string(__wrap_fopen, path, "/test/file.bz2");
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 0);
 
     expect_string(__wrap__mdebug1, formatted_msg, "The file '/test/file.bz2' was successfully uncompressed into '/test/file'");
 
@@ -280,9 +280,9 @@ void test_MergeAppendFile_open_fail(void **state) {
     int path_offset = -1;
     int ret;
 
-    expect_string(__wrap_wfopen, path, file);
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, NULL);
+    expect_string(__wrap_fopen, path, file);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, NULL);
 
     expect_string(__wrap__merror, formatted_msg, "Unable to open file: 'test.txt' due to [(0)-(Success)].");
 
@@ -297,9 +297,9 @@ void test_MergeAppendFile_fseek_fail(void **state) {
     int path_offset = -1;
     int ret;
 
-    expect_string(__wrap_wfopen, path, file);
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 6);
+    expect_string(__wrap_fopen, path, file);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 6);
 
     will_return(__wrap_fseek, 1);
 
@@ -319,9 +319,9 @@ void test_MergeAppendFile_fseek2_fail(void **state) {
     int path_offset = -1;
     int ret;
 
-    expect_string(__wrap_wfopen, path, file);
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 6);
+    expect_string(__wrap_fopen, path, file);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 6);
 
     will_return(__wrap_fseek, 0);
 
@@ -350,9 +350,9 @@ void test_MergeAppendFile_diff_ftell(void **state) {
     int path_offset = 0;
     int ret;
 
-    expect_string(__wrap_wfopen, path, file);
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 6);
+    expect_string(__wrap_fopen, path, file);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 6);
 
     will_return(__wrap_fseek, 0);
 
@@ -390,9 +390,9 @@ void test_MergeAppendFile_success(void **state) {
     int path_offset = 0;
     int ret;
 
-    expect_string(__wrap_wfopen, path, file);
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 6);
+    expect_string(__wrap_fopen, path, file);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 6);
 
     will_return(__wrap_fseek, 0);
 
@@ -431,9 +431,9 @@ void test_w_compress_gzfile_wfopen_fail(void **state){
     char *srcfile = "testfilesrc";
     char *dstfile = "testfiledst.gz";
 
-    expect_string(__wrap_wfopen, path, srcfile);
-    expect_string(__wrap_wfopen, mode, "rb");
-    will_return(__wrap_wfopen, NULL);
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, NULL);
 
     expect_string(__wrap__merror, formatted_msg, "in w_compress_gzfile(): fopen error testfilesrc (0):'Success'");
 
@@ -447,9 +447,9 @@ void test_w_compress_gzfile_gzopen_fail(void **state){
     char *srcfile = "testfilesrc";
     char *dstfile = "testfiledst.gz";
 
-    expect_string(__wrap_wfopen, path, srcfile);
-    expect_string(__wrap_wfopen, mode, "rb");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
 
     expect_string(__wrap_gzopen, path, dstfile);
     expect_string(__wrap_gzopen, mode, "w");
@@ -470,9 +470,9 @@ void test_w_compress_gzfile_write_error(void **state){
     char *srcfile = "testfilesrc";
     char *dstfile = "testfiledst.gz";
 
-    expect_string(__wrap_wfopen, path, srcfile);
-    expect_string(__wrap_wfopen, mode, "rb");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
 
     expect_string(__wrap_gzopen, path, dstfile);
     expect_string(__wrap_gzopen, mode, "w");
@@ -506,9 +506,9 @@ void test_w_compress_gzfile_success(void **state){
     char *srcfile = "testfilesrc";
     char *dstfile = "testfiledst.gz";
 
-    expect_string(__wrap_wfopen, path, srcfile);
-    expect_string(__wrap_wfopen, mode, "rb");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
 
     expect_string(__wrap_gzopen, path, dstfile);
     expect_string(__wrap_gzopen, mode, "w");
@@ -560,9 +560,9 @@ void test_w_uncompress_gzfile_fopen_fail(void **state) {
     will_return(__wrap_lstat, &buf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_wfopen, path, dstfile);
-    expect_string(__wrap_wfopen, mode, "wb");
-    will_return(__wrap_wfopen, NULL);
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, NULL);
 
     expect_string(__wrap__merror, formatted_msg, "in w_uncompress_gzfile(): fopen error testfiledst (0):'Success'");
 
@@ -580,9 +580,9 @@ void test_w_uncompress_gzfile_gzopen_fail(void **state) {
     will_return(__wrap_lstat, &buf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_wfopen, path, dstfile);
-    expect_string(__wrap_wfopen, mode, "wb");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
 
     expect_string(__wrap_gzopen, path, srcfile);
     expect_string(__wrap_gzopen, mode, "rb");
@@ -607,9 +607,9 @@ void test_w_uncompress_gzfile_first_read_fail(void **state) {
     will_return(__wrap_lstat, &buf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_wfopen, path, dstfile);
-    expect_string(__wrap_wfopen, mode, "wb");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
 
     expect_string(__wrap_gzopen, path, srcfile);
     expect_string(__wrap_gzopen, mode, "rb");
@@ -651,9 +651,9 @@ void test_w_uncompress_gzfile_first_read_success(void **state) {
     will_return(__wrap_lstat, &buf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_wfopen, path, dstfile);
-    expect_string(__wrap_wfopen, mode, "wb");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
 
     expect_string(__wrap_gzopen, path, srcfile);
     expect_string(__wrap_gzopen, mode, "rb");
@@ -699,9 +699,9 @@ void test_w_uncompress_gzfile_success(void **state) {
     will_return(__wrap_lstat, &buf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_wfopen, path, dstfile);
-    expect_string(__wrap_wfopen, mode, "wb");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
 
     expect_string(__wrap_gzopen, path, srcfile);
     expect_string(__wrap_gzopen, mode, "rb");
@@ -868,9 +868,9 @@ void test_get_file_content(void **state)
     const char * expected = "test string";
     const char * file_name = "test_file.txt";
 
-    expect_string(__wrap_wfopen, path, file_name);
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, file_name);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
 
     will_return(__wrap_ftell, 0);
     will_return(__wrap_fseek, 0);
@@ -904,9 +904,9 @@ void test_get_file_pointer_NULL(void **state)
 void test_get_file_pointer_invalid(void **state)
 {
     const char * file_name = "test_file.txt";
-    expect_string(__wrap_wfopen, path, file_name);
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
+    expect_string(__wrap_fopen, path, file_name);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
     expect_string(__wrap__mdebug1, formatted_msg, "(1103): Could not open file 'test_file.txt' due to [(0)-(Success)].");
 
     FILE * fp = w_get_file_pointer(file_name);
@@ -917,9 +917,9 @@ void test_get_file_pointer_invalid(void **state)
 void test_get_file_pointer_success(void **state)
 {
     const char * file_name = "test_file.txt";
-    expect_string(__wrap_wfopen, path, file_name);
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 1);
+    expect_string(__wrap_fopen, path, file_name);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
 
     FILE * fp = w_get_file_pointer(file_name);
 

--- a/src/unit_tests/shared/test_json_op.c
+++ b/src/unit_tests/shared/test_json_op.c
@@ -137,7 +137,7 @@ static void test_json_fwrite_fail_open(void **state) {
     os_strdup(PATH_EXAMPLE, path);
 
     will_return(__wrap_cJSON_PrintUnformatted, buffer);
-    expect_fopen(path, "w", fp);
+    expect_wfopen(path, "w", fp);
     expect_memory(__wrap__mdebug1, formatted_msg, DEBUG_MESSAGE_FWRITE_COULD_NOT_OPEN_FILE, strlen(DEBUG_MESSAGE_FWRITE_COULD_NOT_OPEN_FILE));
 
     assert_int_equal(json_fwrite(path, item), -1);
@@ -159,7 +159,7 @@ static void test_json_fwrite_fail_write(void **state) {
 
     will_return(__wrap_cJSON_PrintUnformatted, buffer);
     test_mode = 0;
-    expect_fopen(path, "w", fp);
+    expect_wfopen(path, "w", fp);
     test_mode = 1;
     will_return(__wrap_fwrite, strlen(buffer)-1);
     expect_memory(__wrap__mdebug1, formatted_msg, DEBUG_MESSAGE_FWRITE_COULD_NOT_WRITE, strlen(DEBUG_MESSAGE_FWRITE_COULD_NOT_WRITE));
@@ -183,7 +183,7 @@ static void test_json_fwrite_successfully(void **state) {
 
     will_return(__wrap_cJSON_PrintUnformatted, buffer);
     test_mode = 0;
-    expect_fopen(path, "w", fp);
+    expect_wfopen(path, "w", fp);
     will_return(__wrap_fwrite, strlen(buffer));
     test_mode = 1;
     expect_fclose(fp, 1);

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -23,6 +23,7 @@
 #include "../wrappers/wazuh/os_net/os_net_wrappers.h"
 #include "../wrappers/wazuh/shared/file_op_wrappers.h"
 #include "../wrappers/wazuh/shared/privsep_op_wrappers.h"
+#include "../wrappers/common.h"
 
 #ifdef TEST_WINAGENT
 #include "../wrappers/wazuh/syscheckd/syscom_wrappers.h"
@@ -123,6 +124,7 @@ static int setup_string_array(void **state) {
         return -1;
 
     *state = array;
+    test_mode = 1;
 
     return 0;
 }
@@ -131,6 +133,7 @@ static int teardown_string_array(void **state) {
     char **array = *state;
 
     free_strarray(array);
+    test_mode = 0;
 
     return 0;
 }

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -48,9 +48,9 @@ void test_get_unix_version_Ubuntu1904(void **state)
     os_info *ret;
 
     // Open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "NAME=\"Ubuntu\"");
@@ -85,14 +85,14 @@ void test_get_unix_version_centos(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "NAME=\"CentOS Linux\"");
@@ -109,9 +109,9 @@ void test_get_unix_version_centos(void **state)
     will_return(__wrap_fclose, 1);
 
     // Open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "CentOS Linux release 7.5.1804 (Core)");
@@ -137,9 +137,9 @@ void test_get_unix_version_archlinux_distro_based(void **state)
     os_info *ret;
 
     // Open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "NAME=\"Manjaro Linux\"");
@@ -152,24 +152,24 @@ void test_get_unix_version_archlinux_distro_based(void **state)
     will_return(__wrap_fclose, 1);
 
     // Attempt to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Attempt to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Attempt to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, NULL);
@@ -193,9 +193,9 @@ void test_get_unix_version_archlinux_no_version_id(void **state)
     os_info *ret;
 
     // Open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "NAME=\"Arch Linux\"");
@@ -223,9 +223,9 @@ void test_get_unix_version_archlinux(void **state)
     os_info *ret;
 
     // Open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "NAME=\"Arch Linux\"");
@@ -255,9 +255,9 @@ void test_get_unix_version_opensuse_tumbleweed_no_version_id(void **state)
     os_info *ret;
 
     // Open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "NAME=\"openSUSE Tumbleweed\"");
@@ -285,9 +285,9 @@ void test_get_unix_version_opensuse_tumbleweed(void **state)
     os_info *ret;
 
     // Open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "NAME=\"openSUSE Tumbleweed\"");
@@ -317,9 +317,9 @@ void test_get_unix_version_alpine(void **state)
     os_info *ret;
 
     // Open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "NAME=\"Alpine Linux\"");
@@ -358,19 +358,19 @@ void test_get_unix_version_fail_os_release_centos(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "CentOS Linux release 6.2.1604 (Core)");
@@ -396,24 +396,24 @@ void test_get_unix_version_fail_os_release_fedora(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "Fedora release 7 (Moonshine)");
@@ -438,29 +438,29 @@ void test_get_unix_version_fail_os_release_redhat_centos(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "CentOS Linux Server release 7.2 (Maipo)");
@@ -486,29 +486,29 @@ void test_get_unix_version_fail_os_release_redhat_fedora(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "Fedora Linux Server release 7.2 (Maipo)");
@@ -534,29 +534,29 @@ void test_get_unix_version_fail_os_release_redhat_rhel(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "Red Hat Enterprise Linux release 7.2 (Maipo)");
@@ -582,29 +582,29 @@ void test_get_unix_version_fail_os_release_redhat_rhel_server(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "Red Hat Enterprise Linux Server release 7.2 (Maipo)");
@@ -630,39 +630,39 @@ void test_get_unix_version_fail_os_release_ubuntu(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "DISTRIB_RELEASE=20.04");
@@ -688,44 +688,44 @@ void test_get_unix_version_fail_os_release_gentoo(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "Gentoo Base System version 1.6.12");
@@ -751,49 +751,49 @@ void test_get_unix_version_fail_os_release_suse(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "VERSION = 3.5");
@@ -818,34 +818,34 @@ void test_get_unix_version_fail_os_release_arch(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "3.5.14");
@@ -871,54 +871,54 @@ void test_get_unix_version_fail_os_release_debian(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "3.5.14");
@@ -944,59 +944,59 @@ void test_get_unix_version_fail_os_release_slackware(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/slackware-version
-    expect_string(__wrap_fopen, path, "/etc/slackware-version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/slackware-version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "Slackware 14.2");
@@ -1022,64 +1022,64 @@ void test_get_unix_version_fail_os_release_alpine(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/slackware-version
-    expect_string(__wrap_fopen, path, "/etc/slackware-version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/slackware-version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Open /etc/alpine-release
-    expect_string(__wrap_fopen, path, "/etc/alpine-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/alpine-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "3.17.1");
@@ -1106,64 +1106,64 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/slackware-version
-    expect_string(__wrap_fopen, path, "/etc/slackware-version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/slackware-version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/alpine-release
-    expect_string(__wrap_fopen, path, "/etc/alpine-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/alpine-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // uname
     char *uname_path = NULL;
@@ -1269,64 +1269,64 @@ void test_get_unix_version_fail_os_release_uname_darwin_no_key(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/slackware-version
-    expect_string(__wrap_fopen, path, "/etc/slackware-version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/slackware-version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/alpine-release
-    expect_string(__wrap_fopen, path, "/etc/alpine-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/alpine-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // uname
     char *uname_path = NULL;
@@ -1426,64 +1426,64 @@ void test_get_unix_version_fail_os_release_uname_sunos(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/slackware-version
-    expect_string(__wrap_fopen, path, "/etc/slackware-version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/slackware-version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/alpine-release
-    expect_string(__wrap_fopen, path, "/etc/alpine-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/alpine-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // uname
     char *uname_path = NULL;
@@ -1500,9 +1500,9 @@ void test_get_unix_version_fail_os_release_uname_sunos(void **state)
     will_return(__wrap_fgets, "SunOS\n");
 
     // Open /etc/release
-    expect_string(__wrap_fopen, path, "/etc/release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "Oracle Solaris 11.1 SPARC");
@@ -1533,64 +1533,64 @@ void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_one(void **st
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/slackware-version
-    expect_string(__wrap_fopen, path, "/etc/slackware-version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/slackware-version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/alpine-release
-    expect_string(__wrap_fopen, path, "/etc/alpine-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/alpine-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // uname
     char *uname_path = NULL;
@@ -1607,9 +1607,9 @@ void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_one(void **st
     will_return(__wrap_fgets, "SunOS\n");
 
     // Open /etc/release
-    expect_string(__wrap_fopen, path, "/etc/release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "Solaris 10 1/13");
@@ -1640,64 +1640,64 @@ void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_two(void **st
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/slackware-version
-    expect_string(__wrap_fopen, path, "/etc/slackware-version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/slackware-version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/alpine-release
-    expect_string(__wrap_fopen, path, "/etc/alpine-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/alpine-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // uname
     char *uname_path = NULL;
@@ -1714,9 +1714,9 @@ void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_two(void **st
     will_return(__wrap_fgets, "SunOS\n");
 
     // Open /etc/release
-    expect_string(__wrap_fopen, path, "/etc/release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/etc/release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "Oracle Solaris 10 1/13");
@@ -1745,64 +1745,64 @@ void test_get_unix_version_fail_os_release_uname_hp_ux(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/slackware-version
-    expect_string(__wrap_fopen, path, "/etc/slackware-version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/slackware-version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/alpine-release
-    expect_string(__wrap_fopen, path, "/etc/alpine-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/alpine-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // uname
     char *uname_path = NULL;
@@ -1851,64 +1851,64 @@ void test_get_unix_version_fail_os_release_uname_bsd(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/slackware-version
-    expect_string(__wrap_fopen, path, "/etc/slackware-version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/slackware-version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/alpine-release
-    expect_string(__wrap_fopen, path, "/etc/alpine-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/alpine-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // uname
     char *uname_path = NULL;
@@ -1957,64 +1957,64 @@ void test_get_unix_version_zscaler(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/slackware-version
-    expect_string(__wrap_fopen, path, "/etc/slackware-version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/slackware-version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/alpine-release
-    expect_string(__wrap_fopen, path, "/etc/alpine-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/alpine-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // uname
     char *uname_path = NULL;
@@ -2060,64 +2060,64 @@ void test_get_unix_version_fail_os_release_uname_aix(void **state)
     os_info *ret;
 
     // Fail to open /etc/os-release
-    expect_string(__wrap_fopen, path, "/etc/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /usr/lib/os-release
-    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/centos-release
-    expect_string(__wrap_fopen, path, "/etc/centos-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/centos-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/fedora-release
-    expect_string(__wrap_fopen, path, "/etc/fedora-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/fedora-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/redhat-release
-    expect_string(__wrap_fopen, path, "/etc/redhat-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/redhat-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/arch-release
-    expect_string(__wrap_fopen, path, "/etc/arch-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/arch-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/lsb-release
-    expect_string(__wrap_fopen, path, "/etc/lsb-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/gentoo-release
-    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/SuSE-release
-    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/debian_version
-    expect_string(__wrap_fopen, path, "/etc/debian_version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/debian_version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/slackware-version
-    expect_string(__wrap_fopen, path, "/etc/slackware-version");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/slackware-version");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // Fail to open /etc/alpine-release
-    expect_string(__wrap_fopen, path, "/etc/alpine-release");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/etc/alpine-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     // uname
     char *uname_path = NULL;

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -158,7 +158,7 @@ endif()
 set(RUN_REALTIME_BASE_FLAGS "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watch -Wl,--wrap,fim_db_get_path -Wl,--wrap,fim_db_file_pattern_search \
                              -Wl,--wrap,read -Wl,--wrap,rbtree_insert -Wl,--wrap,fim_db_init -Wl,--wrap,fim_db_file_update \
                              -Wl,--wrap,W_Vector_insert_unique -Wl,--wrap,send_log_msg  -Wl,--wrap,fim_db_remove_path \
-                             -Wl,--wrap,rbtree_keys -Wl,--wrap,fim_realtime_event -Wl,--wrap=pthread_mutex_lock \
+                             -Wl,--wrap,rbtree_keys -Wl,--wrap,fim_realtime_event -Wl,--wrap=pthread_mutex_lock -Wl,--wrap,wfopen \
                              -Wl,--wrap=pthread_mutex_unlock -Wl,--wrap=getpid -Wl,--wrap=atexit -Wl,--wrap=os_random \
                              -Wl,--wrap,inotify_rm_watch -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_rwlock_unlock \
                              -Wl,--wrap,fim_db_file_inode_search -Wl,--wrap,fim_db_get_count_file_inode -Wl,--wrap,fim_db_get_count_file_entry \
@@ -211,7 +211,7 @@ else()
 endif()
 
 # syscheck.c tests
-set(SYSCHECK_BASE_FLAGS "-Wl,--wrap,fim_db_init -Wl,--wrap,getDefine_Int \
+set(SYSCHECK_BASE_FLAGS "-Wl,--wrap,fim_db_init -Wl,--wrap,getDefine_Int -Wl,--wrap,wfopen \
                          -Wl,--wrap=fim_db_file_pattern_search,--wrap=fim_db_remove_path -Wl,--wrap,fim_db_get_path \
                          -Wl,--wrap=fim_db_file_update,--wrap=fim_db_file_inode_search -Wl,--wrap,fim_db_get_count_file_inode \
                          -Wl,--wrap=fim_db_get_count_file_entry -Wl,--wrap=fim_run_integrity -Wl,--wrap=fim_db_transaction_start \
@@ -353,7 +353,7 @@ set(CREATE_DB_BASE_FLAGS "-Wl,--wrap,fim_send_scan_info -Wl,--wrap,send_syscheck
                           -Wl,--wrap,HasFilesystem -Wl,--wrap,fim_db_get_path \
                           -Wl,--wrap,delete_target_file -Wl,--wrap,OS_MD5_SHA1_SHA256_File \
                           -Wl,--wrap,seechanges_addfile -Wl,--wrap,fim_db_delete_not_scanned \
-                          -Wl,--wrap,get_group,--wrap,mdebug2 \
+                          -Wl,--wrap,get_group,--wrap,mdebug2 -Wl,--wrap,wfopen \
                           -Wl,--wrap,send_log_msg -Wl,--wrap,IsDir \
                           -Wl,--wrap,DirSize -Wl,--wrap,seechanges_get_diff_path -Wl,--wrap,stat \
                           -Wl,--wrap,fim_file_diff -Wl,--wrap,fim_diff_process_delete_file \

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 
 # fim_diff_changes.c tests
 set(FIM_DIFF_CHANGES_BASE_FLAGS "-Wl,--wrap,lstat -Wl,--wrap,stat \
-                                 -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fclose -Wl,--wrap,fwrite \
+                                 -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fclose -Wl,--wrap,fwrite -Wl,--wrap,wfopen \
                                  -Wl,--wrap,w_compress_gzfile -Wl,--wrap,IsDir -Wl,--wrap,mkdir_ex -Wl,--wrap,fflush \
                                  -Wl,--wrap,w_uncompress_gzfile -Wl,--wrap,OS_MD5_File -Wl,--wrap,File_DateofChange \
                                  -Wl,--wrap,rename -Wl,--wrap,system -Wl,--wrap,fseek -Wl,--wrap,remove,--wrap=fprintf \

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 
 # fim_diff_changes.c tests
 set(FIM_DIFF_CHANGES_BASE_FLAGS "-Wl,--wrap,lstat -Wl,--wrap,stat \
-                                 -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fwrite \
+                                 -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fclose -Wl,--wrap,fwrite \
                                  -Wl,--wrap,w_compress_gzfile -Wl,--wrap,IsDir -Wl,--wrap,mkdir_ex -Wl,--wrap,fflush \
                                  -Wl,--wrap,w_uncompress_gzfile -Wl,--wrap,OS_MD5_File -Wl,--wrap,File_DateofChange \
                                  -Wl,--wrap,rename -Wl,--wrap,system -Wl,--wrap,fseek -Wl,--wrap,remove,--wrap=fprintf \

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -29,8 +29,15 @@ typedef struct entry_struct_s {
     char *filerestrict;
 } entry_struct_t;
 
+static int setup_read_config(void **state) {
+    test_mode = 0;
+
+    return 0;
+}
+
 static int restart_syscheck(void **state)
 {
+    test_mode = 1;
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
@@ -104,7 +111,9 @@ void test_Read_Syscheck_Config_success(void **state)
     expect_any_always(__wrap__mwarn, formatted_msg);
 
 
+    test_mode = 0;
     ret = Read_Syscheck_Config("test_syscheck_max_dir.conf");
+    test_mode = 1;
 
     assert_int_equal(ret, 0);
     assert_int_equal(syscheck.rootcheck, 0);
@@ -891,15 +900,15 @@ void test_fim_adjust_path_convert_system32 (void **state) {
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_teardown(test_Read_Syscheck_Config_success, restart_syscheck),
-        cmocka_unit_test_teardown(test_Read_Syscheck_Config_invalid, restart_syscheck),
-        cmocka_unit_test_teardown(test_Read_Syscheck_Config_undefined, restart_syscheck),
-        cmocka_unit_test_teardown(test_Read_Syscheck_Config_unparsed, restart_syscheck),
-        cmocka_unit_test_teardown(test_getSyscheckConfig, restart_syscheck),
-        cmocka_unit_test_teardown(test_getSyscheckConfig_no_audit, restart_syscheck),
-        cmocka_unit_test_teardown(test_getSyscheckConfig_no_directories, restart_syscheck),
-        cmocka_unit_test_teardown(test_getSyscheckInternalOptions, restart_syscheck),
-        cmocka_unit_test_teardown(test_SyscheckConf_DirectoriesWithCommas, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_Read_Syscheck_Config_success, setup_read_config, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_Read_Syscheck_Config_invalid, setup_read_config, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_Read_Syscheck_Config_undefined, setup_read_config, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_Read_Syscheck_Config_unparsed, setup_read_config, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_getSyscheckConfig, setup_read_config, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_getSyscheckConfig_no_audit, setup_read_config, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_getSyscheckConfig_no_directories, setup_read_config, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_getSyscheckInternalOptions, setup_read_config, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_SyscheckConf_DirectoriesWithCommas, setup_read_config, restart_syscheck),
         cmocka_unit_test_setup_teardown(test_fim_create_directory_add_new_entry, setup_entry, teardown_entry),
         cmocka_unit_test_setup_teardown(test_fim_create_directory_OSMatch_Compile_fail_maxsize, setup_entry, teardown_entry),
         cmocka_unit_test_setup_teardown(test_fim_insert_directory_duplicate_entry, setup_entry, teardown_entry),

--- a/src/unit_tests/syscheckd/test_fim_diff_changes.c
+++ b/src/unit_tests/syscheckd/test_fim_diff_changes.c
@@ -140,7 +140,7 @@ void expect_initialize_file_diff_data(const char *path, int ret_abspath){
 
 void expect_fim_diff_registry_tmp(const char *folder, const char *file, FILE *fp, const char *value_data) {
     expect_mkdir_ex(folder, 0);
-    expect_fopen(file, "w", fp);
+    expect_wfopen(file, "w", fp);
     if (fp){
         expect_fprintf(fp, value_data, 0);
         expect_fclose(fp, 0);
@@ -1092,7 +1092,7 @@ void test_fim_diff_registry_tmp_fopen_fail(void **state) {
 
     expect_mkdir_ex(diff->tmp_folder, 0);
 
-    expect_fopen(diff->file_origin, "w", fp);
+    expect_wfopen(diff->file_origin, "w", fp);
 
     expect_string(__wrap__merror, formatted_msg, "(1103): Could not open file '/path/to/file/origin' due to [(2)-(No such file or directory)].");
 
@@ -1110,7 +1110,7 @@ void test_fim_diff_registry_tmp_REG_SZ(void **state) {
 
     expect_mkdir_ex(diff->tmp_folder, 0);
 
-    expect_fopen(diff->file_origin, "w", fp);
+    expect_wfopen(diff->file_origin, "w", fp);
 
     expect_fprintf(fp, value_data, 0);
 
@@ -1132,7 +1132,7 @@ void test_fim_diff_registry_tmp_REG_MULTI_SZ(void **state) {
 
     expect_mkdir_ex(diff->tmp_folder, 0);
 
-    expect_fopen(diff->file_origin, "w", fp);
+    expect_wfopen(diff->file_origin, "w", fp);
 
     expect_fprintf(fp, value_data_formatted, 0);
     expect_fprintf(fp, value_data_formatted2, 0);
@@ -1153,7 +1153,7 @@ void test_fim_diff_registry_tmp_REG_DWORD(void **state) {
 
     expect_mkdir_ex(diff->tmp_folder, 0);
 
-    expect_fopen(diff->file_origin, "w", fp);
+    expect_wfopen(diff->file_origin, "w", fp);
 
     expect_fprintf(fp, "12345", 0);
 
@@ -1173,7 +1173,7 @@ void test_fim_diff_registry_tmp_REG_DWORD_BIG_ENDIAN(void **state) {
 
     expect_mkdir_ex(diff->tmp_folder, 0);
 
-    expect_fopen(diff->file_origin, "w", fp);
+    expect_wfopen(diff->file_origin, "w", fp);
 
     expect_fprintf(fp, "45230100", 0);
 
@@ -1193,7 +1193,7 @@ void test_fim_diff_registry_tmp_REG_QWORD(void **state) {
 
     expect_mkdir_ex(diff->tmp_folder, 0);
 
-    expect_fopen(diff->file_origin, "w", fp);
+    expect_wfopen(diff->file_origin, "w", fp);
 
     expect_fprintf(fp, "12345", 0);
 
@@ -1213,7 +1213,7 @@ void test_fim_diff_registry_tmp_default_type(void **state) {
 
     expect_mkdir_ex(diff->tmp_folder, 0);
 
-    expect_fopen(diff->file_origin, "w", fp);
+    expect_wfopen(diff->file_origin, "w", fp);
 
     expect_string(__wrap__mwarn, formatted_msg, FIM_REG_VAL_WRONG_TYPE);
 

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -1702,11 +1702,15 @@ void test_realtime_adddir_success(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
     expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");
     will_return(__wrap_OSHash_Get_ex, 0);
+
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, syscheck.realtime->dirtb);
+    expect_string(__wrap_OSHash_Add_ex, key, "C:\\a\\path");
+    will_return(__wrap_OSHash_Add_ex, 1);
 
     expect_string(wrap_CreateFile, lpFileName, "C:\\a\\path");
     will_return(wrap_CreateFile, (HANDLE)123456);
@@ -1718,9 +1722,7 @@ void test_realtime_adddir_success(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg,
                   "(6227): Directory added for real time monitoring: 'C:\\a\\path'");
 
-    test_mode = 0;
     ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
-    test_mode = 1;
 
     assert_int_equal(ret, 1);
 }

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
     set(AUDIT_HC_FLAGS "-Wl,--wrap=_mdebug1,--wrap=_mdebug2 -Wl,--wrap,audit_add_rule \
                         -Wl,--wrap,pthread_cond_wait -Wl,--wrap,pthread_mutex_lock \
                         -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,CreateThread \
-                        -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
+                        -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
                         -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc \
                         -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink -Wl,--wrap,audit_delete_rule \
                         -Wl,--wrap,select -Wl,--wrap,audit_parse -Wl,--wrap=abspath -Wl,--wrap,atomic_int_get \
@@ -37,7 +37,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
     set(SYSCHECK_AUDIT_FLAGS "-Wl,--wrap=_mdebug1,--wrap=_mdebug2,--wrap=_merror,--wrap=_mwarn,--wrap=audit_add_rule\
                               -Wl,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock,--wrap=fim_db_init \
                               -Wl,--wrap=pthread_rwlock_rdlock,--wrap=pthread_rwlock_wrlock,--wrap=pthread_rwlock_unlock \
-                              -Wl,--wrap=fopen,--wrap=fclose,--wrap=fflush,--wrap=fgets,--wrap=fgetpos \
+                              -Wl,--wrap=wfopen,--wrap=fclose,--wrap=fflush,--wrap=fgets,--wrap=fgetpos \
                               -Wl,--wrap=fread,--wrap=fseek,--wrap=fwrite,--wrap=remove,--wrap=fgetc \
                               -Wl,--wrap=getpid,--wrap=sleep,--wrap=unlink,--wrap=audit_delete_rule \
                               -Wl,--wrap=select,--wrap=audit_parse,--wrap=audit_get_rule_list,--wrap=audit_close \
@@ -62,7 +62,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
                               -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,audit_add_rule -Wl,--wrap,audit_restart  \
                               -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,closeproc  -Wl,--wrap,recv -Wl,--wrap,IsDir \
                               -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,IsSocket -Wl,--wrap,fprintf \
-                              -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
+                              -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
                               -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc \
                               -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink -Wl,--wrap,audit_delete_rule \
                               -Wl,--wrap,select -Wl,--wrap,audit_parse -Wl,--wrap,symlink -Wl,--wrap,SendMSG \
@@ -89,7 +89,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
 
     set(AUDIT_PARSE_FLAGS "-Wl,--wrap=_mdebug1,--wrap=_mdebug2 -Wl,--wrap=_mwarn -Wl,--wrap=_minfo \
                            -Wl,--wrap,audit_add_rule -Wl,--wrap,pthread_mutex_lock \
-                           -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush \
+                           -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush \
                            -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite\
                            -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink \
                            -Wl,--wrap,audit_delete_rule -Wl,--wrap,realpath -Wl,--wrap,atexit -Wl,--wrap,audit_open\
@@ -117,7 +117,7 @@ else()
     set(WIN_WHODATA_FLAGS "-Wl,--wrap,wstr_replace -Wl,--wrap,SendMSG \
                            -Wl,--wrap,free_whodata_event -Wl,--wrap,IsFile -Wl,--wrap=remove \
                            -Wl,--wrap=fim_db_get_count_registry_data -Wl,--wrap=fim_db_get_count_registry_key -Wl,--wrap=syscom_dispatch \
-                           -Wl,--wrap,wm_exec -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,atexit \
+                           -Wl,--wrap,wm_exec -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,atexit \
                            -Wl,--wrap,check_path_type -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,fim_whodata_event \
                            -Wl,--wrap,fim_checker -Wl,--wrap,os_random -Wl,--wrap,wpopenv -Wl,--wrap,atomic_int_get\
                            -Wl,--wrap,convert_windows_string -Wl,--wrap,FOREVER -Wl,--wrap,wpclose \

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -13,8 +13,8 @@ if(NOT ${TARGET} STREQUAL "winagent")
 
     set(AUDIT_HC_FLAGS "-Wl,--wrap=_mdebug1,--wrap=_mdebug2 -Wl,--wrap,audit_add_rule \
                         -Wl,--wrap,pthread_cond_wait -Wl,--wrap,pthread_mutex_lock \
-                        -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,CreateThread \
-                        -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
+                        -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,CreateThread -Wl,--wrap,wfopen \
+                        -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
                         -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc \
                         -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink -Wl,--wrap,audit_delete_rule \
                         -Wl,--wrap,select -Wl,--wrap,audit_parse -Wl,--wrap=abspath -Wl,--wrap,atomic_int_get \
@@ -37,7 +37,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
     set(SYSCHECK_AUDIT_FLAGS "-Wl,--wrap=_mdebug1,--wrap=_mdebug2,--wrap=_merror,--wrap=_mwarn,--wrap=audit_add_rule\
                               -Wl,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock,--wrap=fim_db_init \
                               -Wl,--wrap=pthread_rwlock_rdlock,--wrap=pthread_rwlock_wrlock,--wrap=pthread_rwlock_unlock \
-                              -Wl,--wrap=wfopen,--wrap=fclose,--wrap=fflush,--wrap=fgets,--wrap=fgetpos \
+                              -Wl,--wrap=fopen,--wrap=fclose,--wrap=fflush,--wrap=fgets,--wrap=fgetpos,--wrap=wfopen \
                               -Wl,--wrap=fread,--wrap=fseek,--wrap=fwrite,--wrap=remove,--wrap=fgetc \
                               -Wl,--wrap=getpid,--wrap=sleep,--wrap=unlink,--wrap=audit_delete_rule \
                               -Wl,--wrap=select,--wrap=audit_parse,--wrap=audit_get_rule_list,--wrap=audit_close \
@@ -61,8 +61,8 @@ if(NOT ${TARGET} STREQUAL "winagent")
                               -Wl,--wrap,openproc -Wl,--wrap,readproc -Wl,--wrap,freeproc \
                               -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,audit_add_rule -Wl,--wrap,audit_restart  \
                               -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,closeproc  -Wl,--wrap,recv -Wl,--wrap,IsDir \
-                              -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,IsSocket -Wl,--wrap,fprintf \
-                              -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
+                              -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,IsSocket -Wl,--wrap,fprintf -Wl,--wrap,wfopen \
+                              -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
                               -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc \
                               -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink -Wl,--wrap,audit_delete_rule \
                               -Wl,--wrap,select -Wl,--wrap,audit_parse -Wl,--wrap,symlink -Wl,--wrap,SendMSG \
@@ -89,13 +89,13 @@ if(NOT ${TARGET} STREQUAL "winagent")
 
     set(AUDIT_PARSE_FLAGS "-Wl,--wrap=_mdebug1,--wrap=_mdebug2 -Wl,--wrap=_mwarn -Wl,--wrap=_minfo \
                            -Wl,--wrap,audit_add_rule -Wl,--wrap,pthread_mutex_lock \
-                           -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush \
+                           -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush \
                            -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite\
                            -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink \
                            -Wl,--wrap,audit_delete_rule -Wl,--wrap,realpath -Wl,--wrap,atexit -Wl,--wrap,audit_open\
                            -Wl,--wrap,get_user -Wl,--wrap,get_group -Wl,--wrap,readlink -Wl,--wrap,audit_get_rule_list \
                            -Wl,--wrap,SendMSG -Wl,--wrap,fim_whodata_event -Wl,--wrap,search_audit_rule \
-                           -Wl,--wrap,audit_close -Wl,--wrap,fim_manipulated_audit_rules \
+                           -Wl,--wrap,audit_close -Wl,--wrap,fim_manipulated_audit_rules -Wl,--wrap,wfopen \
                            -Wl,--wrap,fim_audit_reload_rules -Wl,--wrap,remove_audit_rule_syscheck \
                            -Wl,--wrap,atomic_int_get -Wl,--wrap,atomic_int_set -Wl,--wrap,atomic_int_dec \
                            -Wl,--wrap,atomic_int_inc -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_rwlock_unlock \
@@ -117,7 +117,7 @@ else()
     set(WIN_WHODATA_FLAGS "-Wl,--wrap,wstr_replace -Wl,--wrap,SendMSG \
                            -Wl,--wrap,free_whodata_event -Wl,--wrap,IsFile -Wl,--wrap=remove \
                            -Wl,--wrap=fim_db_get_count_registry_data -Wl,--wrap=fim_db_get_count_registry_key -Wl,--wrap=syscom_dispatch \
-                           -Wl,--wrap,wm_exec -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,atexit \
+                           -Wl,--wrap,wm_exec -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,atexit -Wl,--wrap,wfopen \
                            -Wl,--wrap,check_path_type -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,fim_whodata_event \
                            -Wl,--wrap,fim_checker -Wl,--wrap,os_random -Wl,--wrap,wpopenv -Wl,--wrap,atomic_int_get\
                            -Wl,--wrap,convert_windows_string -Wl,--wrap,FOREVER -Wl,--wrap,wpclose \

--- a/src/unit_tests/syscheckd/whodata/test_audit_healthcheck.c
+++ b/src/unit_tests/syscheckd/whodata/test_audit_healthcheck.c
@@ -138,9 +138,9 @@ void test_audit_health_check_fail_to_create_hc_file(void **state) {
 
     prepare_audit_healthcheck_thread();
 
-    expect_string_count(__wrap_fopen, path, AUDIT_HEALTHCHECK_FILE, 10);
-    expect_string_count(__wrap_fopen, mode, "w", 10);
-    will_return_count(__wrap_fopen, 0, 10);
+    expect_string_count(__wrap_wfopen, path, AUDIT_HEALTHCHECK_FILE, 10);
+    expect_string_count(__wrap_wfopen, mode, "w", 10);
+    will_return_count(__wrap_wfopen, 0, 10);
 
     expect_string_count(__wrap__mdebug1, formatted_msg, FIM_AUDIT_HEALTHCHECK_FILE, 10);
 
@@ -174,9 +174,9 @@ void test_audit_health_check_no_creation_event_detected(void **state) {
 
     prepare_audit_healthcheck_thread();
 
-    expect_string_count(__wrap_fopen, path, AUDIT_HEALTHCHECK_FILE, 10);
-    expect_string_count(__wrap_fopen, mode, "w", 10);
-    will_return_count(__wrap_fopen, 1, 10);
+    expect_string_count(__wrap_wfopen, path, AUDIT_HEALTHCHECK_FILE, 10);
+    expect_string_count(__wrap_wfopen, mode, "w", 10);
+    will_return_count(__wrap_wfopen, 1, 10);
 
     expect_value_count(__wrap_fclose, _File, 1, 10);
     will_return_count(__wrap_fclose, 0, 10);
@@ -213,9 +213,9 @@ void test_audit_health_check_success(void **state) {
 
     prepare_audit_healthcheck_thread();
 
-    expect_string(__wrap_fopen, path, AUDIT_HEALTHCHECK_FILE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, AUDIT_HEALTHCHECK_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 0);

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -421,9 +421,9 @@ void test_set_auditd_config_audit_plugin_tampered_configuration(void **state) {
     expect_abspath(AUDIT_SOCKET, 1);
     expect_abspath(AUDIT_CONF_FILE, 1);
 
-    expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "etc/af_wazuh.conf");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fwrite, 1);
 
@@ -480,9 +480,9 @@ void test_set_auditd_config_audit_plugin_not_created(void **state) {
     expect_abspath(AUDIT_SOCKET, 1);
     expect_abspath(AUDIT_CONF_FILE, 1);
 
-    expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "etc/af_wazuh.conf");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fwrite, 1);
 
@@ -529,9 +529,9 @@ void test_set_auditd_config_audit_plugin_not_created_fopen_error(void **state) {
     will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
     will_return(__wrap_OS_SHA1_File, 0);
 
-    expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "etc/af_wazuh.conf");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 0);
 
     expect_string(__wrap__merror, formatted_msg, "(1103): Could not open file 'etc/af_wazuh.conf' due to [(0)-(Success)].");
 
@@ -564,9 +564,9 @@ void test_set_auditd_config_audit_plugin_not_created_fclose_error(void **state) 
     will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
     will_return(__wrap_OS_SHA1_File, 0);
 
-    expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "etc/af_wazuh.conf");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fwrite, 1);
 
@@ -604,9 +604,9 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink(void **sta
     will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
     will_return(__wrap_OS_SHA1_File, 0);
 
-    expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "etc/af_wazuh.conf");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fwrite, 1);
 
@@ -661,9 +661,9 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_restart(vo
     will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
     will_return(__wrap_OS_SHA1_File, 0);
 
-    expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "etc/af_wazuh.conf");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fwrite, 1);
 
@@ -719,9 +719,9 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_error(void
     will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
     will_return(__wrap_OS_SHA1_File, 0);
 
-    expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "etc/af_wazuh.conf");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fwrite, 1);
 
@@ -773,9 +773,9 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_unlink_err
     will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
     will_return(__wrap_OS_SHA1_File, 0);
 
-    expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "etc/af_wazuh.conf");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fwrite, 1);
 
@@ -1238,9 +1238,9 @@ void test_audit_rules_to_realtime_second_search_audit_rule_fail(void **state) {
 }
 
 void test_audit_create_rules_file(void **state) {
-    expect_string(__wrap_fopen, path, AUDIT_RULES_FILE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, AUDIT_RULES_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     // Mutex inside get_real_path
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
@@ -1278,9 +1278,9 @@ void test_audit_create_rules_file(void **state) {
 void test_audit_create_rules_file_fopen_fail(void **state) {
     char error_msg[OS_SIZE_128];
 
-    expect_string(__wrap_fopen, path, AUDIT_RULES_FILE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, AUDIT_RULES_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 0);
 
     snprintf(error_msg, OS_SIZE_128, FOPEN_ERROR, AUDIT_RULES_FILE, errno, strerror(errno));
     expect_string(__wrap__merror, formatted_msg, error_msg);
@@ -1291,9 +1291,9 @@ void test_audit_create_rules_file_fopen_fail(void **state) {
 void test_audit_create_rules_file_fclose_fail(void **state) {
     char error_msg[OS_SIZE_128];
 
-    expect_string(__wrap_fopen, path, AUDIT_RULES_FILE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, AUDIT_RULES_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     // Mutex inside get_real_path
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
@@ -1324,9 +1324,9 @@ void test_audit_create_rules_file_fclose_fail(void **state) {
 }
 
 void test_audit_create_rules_file_symlink_exist(void **state) {
-    expect_string(__wrap_fopen, path, AUDIT_RULES_FILE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, AUDIT_RULES_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     // Mutex inside get_real_path
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
@@ -1373,9 +1373,9 @@ void test_audit_create_rules_file_symlink_exist(void **state) {
 void test_audit_create_rules_file_unlink_fail(void **state) {
     char error_msg[OS_SIZE_128];
 
-    expect_string(__wrap_fopen, path, AUDIT_RULES_FILE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, AUDIT_RULES_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     // Mutex inside get_real_path
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
@@ -1419,9 +1419,9 @@ void test_audit_create_rules_file_unlink_fail(void **state) {
 void test_audit_create_rules_file_symlink_fail(void **state) {
     char error_msg[OS_SIZE_256];
 
-    expect_string(__wrap_fopen, path, AUDIT_RULES_FILE);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, AUDIT_RULES_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
 
     // Mutex inside get_real_path
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -6388,13 +6388,13 @@ void test_run_whodata_scan_error_event_channel(void **state) {
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
 
-    expect_string(__wrap_fopen, path, "tmp\\backup-policies");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1234);
+    expect_string(__wrap_wfopen, path, "tmp\\backup-policies");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1234);
 
-    expect_string(__wrap_fopen, path, "tmp\\new-policies");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE*)2345);
+    expect_string(__wrap_wfopen, path, "tmp\\new-policies");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE*)2345);
 
     expect_value(wrap_fgets, __stream, (FILE*)1234);
     will_return(wrap_fgets, "some policies");
@@ -6493,13 +6493,13 @@ void test_run_whodata_scan_success(void **state) {
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
 
-    expect_string(__wrap_fopen, path, "tmp\\backup-policies");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1234);
+    expect_string(__wrap_wfopen, path, "tmp\\backup-policies");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1234);
 
-    expect_string(__wrap_fopen, path, "tmp\\new-policies");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE*)2345);
+    expect_string(__wrap_wfopen, path, "tmp\\new-policies");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE*)2345);
 
     expect_value(wrap_fgets, __stream, (FILE*)1234);
     will_return(wrap_fgets, "some policies");
@@ -6626,9 +6626,9 @@ void test_set_policies_unable_to_open_backup_file(void **state) {
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
 
-    expect_string(__wrap_fopen, path, "tmp\\backup-policies");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, "tmp\\backup-policies");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
     errno = EACCES;
 
     expect_string(__wrap__merror, formatted_msg,
@@ -6651,13 +6651,13 @@ void test_set_policies_unable_to_open_new_file(void **state) {
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
 
-    expect_string(__wrap_fopen, path, "tmp\\backup-policies");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1234);
+    expect_string(__wrap_wfopen, path, "tmp\\backup-policies");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1234);
 
-    expect_string(__wrap_fopen, path, "tmp\\new-policies");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, "tmp\\new-policies");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, NULL);
     errno = EACCES;
 
     expect_string(__wrap__merror, formatted_msg,
@@ -6683,13 +6683,13 @@ void test_set_policies_unable_to_restore_policies(void **state) {
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
 
-    expect_string(__wrap_fopen, path, "tmp\\backup-policies");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1234);
+    expect_string(__wrap_wfopen, path, "tmp\\backup-policies");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1234);
 
-    expect_string(__wrap_fopen, path, "tmp\\new-policies");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE*)2345);
+    expect_string(__wrap_wfopen, path, "tmp\\new-policies");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE*)2345);
 
     expect_value(wrap_fgets, __stream, (FILE*)1234);
     will_return(wrap_fgets, "some policies");
@@ -6739,13 +6739,13 @@ void test_set_policies_success(void **state) {
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
 
-    expect_string(__wrap_fopen, path, "tmp\\backup-policies");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1234);
+    expect_string(__wrap_wfopen, path, "tmp\\backup-policies");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1234);
 
-    expect_string(__wrap_fopen, path, "tmp\\new-policies");
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, (FILE*)2345);
+    expect_string(__wrap_wfopen, path, "tmp\\new-policies");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, (FILE*)2345);
 
     expect_value(wrap_fgets, __stream, (FILE*)1234);
     will_return(wrap_fgets, "some policies");

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -230,6 +230,7 @@ int test_group_setup(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
+    test_mode = 0;
     ret = Read_Syscheck_Config("../test_syscheck.conf");
 
     SIZE_EVENTS = sizeof(EVT_VARIANT) * NUM_EVENTS;

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -108,7 +108,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,strerror \
                              -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_Parse \
                              -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddNumberToObject \
                              -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_GetObjectItem \
-                             -Wl,--wrap,cJSON_Delete -Wl,--wrap,time -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap=fgetc\
+                             -Wl,--wrap,cJSON_Delete -Wl,--wrap,time -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap=fgetc\
                              -Wl,--wrap,fclose -Wl,--wrap,cJSON_AddArrayToObject -Wl,--wrap,remove -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,closedir \
                              -Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,wdbc_query_parse_json -Wl,--wrap,wdbc_query_parse \
                              -Wl,--wrap,wdb_create_profile -Wl,--wrap,Privsep_GetUser -Wl,--wrap,Privsep_GetGroup -Wl,--wrap,chown \
@@ -138,7 +138,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
 
 list(APPEND wdb_tests_names "test_wdb_upgrade")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_count_tables_with_name \
-                             -Wl,--wrap,wdb_sql_exec -Wl,--wrap,wdb_metadata_get_entry -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose \
+                             -Wl,--wrap,wdb_sql_exec -Wl,--wrap,wdb_metadata_get_entry -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose \
                              -Wl,--wrap,remove -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,closedir -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,fgets \
                              -Wl,--wrap,wdb_init -Wl,--wrap,wdb_close -Wl,--wrap,wdb_create_global -Wl,--wrap,wdb_pool_append -Wl,--wrap,chmod -Wl,--wrap,stat \
                              -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,time -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_close_v2 \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -108,12 +108,12 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,strerror \
                              -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_Parse \
                              -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddNumberToObject \
                              -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_GetObjectItem \
-                             -Wl,--wrap,cJSON_Delete -Wl,--wrap,time -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap=fgetc\
+                             -Wl,--wrap,cJSON_Delete -Wl,--wrap,time -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap=fgetc\
                              -Wl,--wrap,fclose -Wl,--wrap,cJSON_AddArrayToObject -Wl,--wrap,remove -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,closedir \
                              -Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,wdbc_query_parse_json -Wl,--wrap,wdbc_query_parse \
                              -Wl,--wrap,wdb_create_profile -Wl,--wrap,Privsep_GetUser -Wl,--wrap,Privsep_GetGroup -Wl,--wrap,chown \
                              -Wl,--wrap,chmod -Wl,--wrap,IsDir -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,get_node_name \
-                             -Wl,--wrap,rbtree_insert \
+                             -Wl,--wrap,rbtree_insert -Wl,--wrap,wfopen \
                              -Wl,--wrap,stat -Wl,--wrap,fgetpos ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_agents_helpers")
@@ -138,13 +138,13 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
 
 list(APPEND wdb_tests_names "test_wdb_upgrade")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_count_tables_with_name \
-                             -Wl,--wrap,wdb_sql_exec -Wl,--wrap,wdb_metadata_get_entry -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose \
+                             -Wl,--wrap,wdb_sql_exec -Wl,--wrap,wdb_metadata_get_entry -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose \
                              -Wl,--wrap,remove -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,closedir -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,fgets \
                              -Wl,--wrap,wdb_init -Wl,--wrap,wdb_close -Wl,--wrap,wdb_create_global -Wl,--wrap,wdb_pool_append -Wl,--wrap,chmod -Wl,--wrap,stat \
                              -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,time -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_close_v2 \
                              -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_finalize -Wl,--wrap,fgetpos \
                              -Wl,--wrap,fgetc -Wl,--wrap,wdb_global_create_backup -Wl,--wrap,wdb_global_get_most_recent_backup -Wl,--wrap,wdb_global_restore_backup \
-                             -Wl,--wrap,wdb_global_adjust_v4 ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,wdb_global_adjust_v4 -Wl,--wrap,wfopen ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_metadata")
 list(APPEND wdb_tests_flags "-Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_errmsg \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -87,7 +87,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int \
-                            -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_exec_stmt_sized -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text \
+                            -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_exec_stmt_sized -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wfopen \
                             -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int \
                             -Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,wdb_get_global_group_hash -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_finalize_all_statements \
                             -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,w_get_timestamp -Wl,--wrap,wdb_exec_stmt_silent -Wl,--wrap,w_compress_gzfile \

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -398,9 +398,9 @@ void test_wdb_insert_agent_success_keep_date(void **state)
     const char *response = "ok";
 
     // Opening destination database file
-    expect_string(__wrap_fopen, path, "queue/agents-timestamp");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "queue/agents-timestamp");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     // Getting data
     expect_value(__wrap_fgets, __stream, 1);
@@ -2783,9 +2783,9 @@ void test_get_agent_date_added_error_open_file(void **state) {
     int agent_id = 1;
 
     // Opening destination database file
-    expect_string(__wrap_fopen, path, "queue/agents-timestamp");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "queue/agents-timestamp");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
 
     date_add = get_agent_date_added(agent_id);
 
@@ -2797,9 +2797,9 @@ void test_get_agent_date_added_error_no_data(void **state) {
     int agent_id = 1;
 
     // Opening destination database file
-    expect_string(__wrap_fopen, path, "queue/agents-timestamp");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "queue/agents-timestamp");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     // Getting data
     expect_value(__wrap_fgets, __stream, 1);
@@ -2818,9 +2818,9 @@ void test_get_agent_date_added_error_no_date(void **state) {
     int agent_id = 1;
 
     // Opening destination database file
-    expect_string(__wrap_fopen, path, "queue/agents-timestamp");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "queue/agents-timestamp");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     // Getting data
     expect_value(__wrap_fgets, __stream, 1);
@@ -2839,9 +2839,9 @@ void test_get_agent_date_added_error_invalid_date(void **state) {
     int agent_id = 1;
 
     // Opening destination database file
-    expect_string(__wrap_fopen, path, "queue/agents-timestamp");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "queue/agents-timestamp");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     // Getting data
     expect_value(__wrap_fgets, __stream, 1);
@@ -2864,9 +2864,9 @@ void test_get_agent_date_added_success(void **state) {
     time_t date_returned = 0;
 
     // Opening destination database file
-    expect_string(__wrap_fopen, path, "queue/agents-timestamp");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "queue/agents-timestamp");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 1);
 
     // Getting data
     expect_value(__wrap_fgets, __stream, 1);

--- a/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
@@ -42,7 +42,7 @@ if(${TARGET} STREQUAL "server")
     list(APPEND upgrade_flags "-Wl,--wrap,OS_ReadXML -Wl,--wrap,OS_GetOneContentforElement -Wl,--wrap,OS_ClearXML ${DEBUG_OP_WRAPPERS}")
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_validate")
-    list(APPEND upgrade_flags "-Wl,--wrap,wurl_http_get -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wurl_request -Wl,--wrap,sleep \
+    list(APPEND upgrade_flags "-Wl,--wrap,wurl_http_get -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wurl_request -Wl,--wrap,sleep -Wl,--wrap,wfopen \
                                -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
                                ${DEBUG_OP_WRAPPERS}")
 
@@ -62,25 +62,25 @@ if(${TARGET} STREQUAL "server")
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_upgrades")
     list(APPEND upgrade_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,close \
-                            -Wl,--wrap,wm_agent_upgrade_parse_task_module_request -Wl,--wrap,wm_agent_upgrade_task_module_callback -Wl,--wrap,wm_agent_upgrade_parse_agent_response -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fclose \
+                            -Wl,--wrap,wm_agent_upgrade_parse_task_module_request -Wl,--wrap,wm_agent_upgrade_task_module_callback -Wl,--wrap,wm_agent_upgrade_parse_agent_response -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fclose \
                             -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wm_agent_upgrade_get_first_node -Wl,--wrap,wm_agent_upgrade_get_next_node -Wl,--wrap,compare_wazuh_versions -Wl,--wrap,wm_agent_upgrade_remove_entry \
                             -Wl,--wrap,wm_agent_upgrade_validate_task_status_message -Wl,--wrap,wm_agent_upgrade_validate_wpk -Wl,--wrap,wm_agent_upgrade_validate_wpk_custom -Wl,--wrap,wm_agent_upgrade_validate_wpk_version \
-                            -Wl,--wrap,linked_queue_push_ex -Wl,--wrap,linked_queue_pop_ex -Wl,--wrap,pthread_cond_signal -Wl,--wrap,pthread_cond_wait -Wl,--wrap,CreateThread \
+                            -Wl,--wrap,linked_queue_push_ex -Wl,--wrap,linked_queue_pop_ex -Wl,--wrap,pthread_cond_signal -Wl,--wrap,pthread_cond_wait -Wl,--wrap,CreateThread -Wl,--wrap,wfopen \
                             -Wl,--wrap,wm_agent_upgrade_parse_agent_upgrade_command_response -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
                             ${DEBUG_OP_WRAPPERS}")
 
 else()
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_agent")
-    list(APPEND upgrade_flags "-Wl,--wrap,wm_sendmsg -Wl,--wrap,wfopen -Wl,--wrap,fgets -Wl,--wrap,fclose -Wl,--wrap,StartMQ -Wl,--wrap,sleep -Wl,--wrap,close \
+    list(APPEND upgrade_flags "-Wl,--wrap,wm_sendmsg -Wl,--wrap,fopen -Wl,--wrap,fgets -Wl,--wrap,fclose -Wl,--wrap,StartMQ -Wl,--wrap,sleep -Wl,--wrap,close -Wl,--wrap,wfopen \
                                -Wl,--wrap,OS_BindUnixDomain -Wl,--wrap,select -Wl,--wrap,close -Wl,--wrap,accept -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,wm_agent_upgrade_process_command \
                                -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,CreateThread -Wl,--wrap,unlink -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
                                ${DEBUG_OP_WRAPPERS}")
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_com")
     list(APPEND upgrade_flags "-Wl,--wrap,w_ref_parent_folder -Wl,--wrap,w_wpk_unsign -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,gzopen \
-                               -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove \
-                               -Wl,--wrap,gzclose -Wl,--wrap,gzread -Wl,--wrap,mkstemp -Wl,--wrap,atexit -Wl,--wrap,chmod -Wl,--wrap,stat \
+                               -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove \
+                               -Wl,--wrap,gzclose -Wl,--wrap,gzread -Wl,--wrap,mkstemp -Wl,--wrap,atexit -Wl,--wrap,chmod -Wl,--wrap,stat -Wl,--wrap,wfopen \
                                -Wl,--wrap,OS_SHA1_File -Wl,--wrap,getDefine_Int -Wl,--wrap,cldir_ex -Wl,--wrap,UnmergeFiles -Wl,--wrap,wm_exec -Wl,--wrap,remove \
                                -Wl,--wrap,fgetpos -Wl,--wrap=fgetc ${DEBUG_OP_WRAPPERS}")
 

--- a/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
@@ -42,7 +42,7 @@ if(${TARGET} STREQUAL "server")
     list(APPEND upgrade_flags "-Wl,--wrap,OS_ReadXML -Wl,--wrap,OS_GetOneContentforElement -Wl,--wrap,OS_ClearXML ${DEBUG_OP_WRAPPERS}")
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_validate")
-    list(APPEND upgrade_flags "-Wl,--wrap,wurl_http_get -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wurl_request -Wl,--wrap,sleep \
+    list(APPEND upgrade_flags "-Wl,--wrap,wurl_http_get -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wurl_request -Wl,--wrap,sleep \
                                -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
                                ${DEBUG_OP_WRAPPERS}")
 
@@ -62,7 +62,7 @@ if(${TARGET} STREQUAL "server")
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_upgrades")
     list(APPEND upgrade_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,close \
-                            -Wl,--wrap,wm_agent_upgrade_parse_task_module_request -Wl,--wrap,wm_agent_upgrade_task_module_callback -Wl,--wrap,wm_agent_upgrade_parse_agent_response -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fclose \
+                            -Wl,--wrap,wm_agent_upgrade_parse_task_module_request -Wl,--wrap,wm_agent_upgrade_task_module_callback -Wl,--wrap,wm_agent_upgrade_parse_agent_response -Wl,--wrap,wfopen -Wl,--wrap,fread -Wl,--wrap,fclose \
                             -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wm_agent_upgrade_get_first_node -Wl,--wrap,wm_agent_upgrade_get_next_node -Wl,--wrap,compare_wazuh_versions -Wl,--wrap,wm_agent_upgrade_remove_entry \
                             -Wl,--wrap,wm_agent_upgrade_validate_task_status_message -Wl,--wrap,wm_agent_upgrade_validate_wpk -Wl,--wrap,wm_agent_upgrade_validate_wpk_custom -Wl,--wrap,wm_agent_upgrade_validate_wpk_version \
                             -Wl,--wrap,linked_queue_push_ex -Wl,--wrap,linked_queue_pop_ex -Wl,--wrap,pthread_cond_signal -Wl,--wrap,pthread_cond_wait -Wl,--wrap,CreateThread \
@@ -72,14 +72,14 @@ if(${TARGET} STREQUAL "server")
 else()
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_agent")
-    list(APPEND upgrade_flags "-Wl,--wrap,wm_sendmsg -Wl,--wrap,fopen -Wl,--wrap,fgets -Wl,--wrap,fclose -Wl,--wrap,StartMQ -Wl,--wrap,sleep -Wl,--wrap,close \
+    list(APPEND upgrade_flags "-Wl,--wrap,wm_sendmsg -Wl,--wrap,wfopen -Wl,--wrap,fgets -Wl,--wrap,fclose -Wl,--wrap,StartMQ -Wl,--wrap,sleep -Wl,--wrap,close \
                                -Wl,--wrap,OS_BindUnixDomain -Wl,--wrap,select -Wl,--wrap,close -Wl,--wrap,accept -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,wm_agent_upgrade_process_command \
                                -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,CreateThread -Wl,--wrap,unlink -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
                                ${DEBUG_OP_WRAPPERS}")
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_com")
     list(APPEND upgrade_flags "-Wl,--wrap,w_ref_parent_folder -Wl,--wrap,w_wpk_unsign -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,gzopen \
-                               -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove \
+                               -Wl,--wrap,wfopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove \
                                -Wl,--wrap,gzclose -Wl,--wrap,gzread -Wl,--wrap,mkstemp -Wl,--wrap,atexit -Wl,--wrap,chmod -Wl,--wrap,stat \
                                -Wl,--wrap,OS_SHA1_File -Wl,--wrap,getDefine_Int -Wl,--wrap,cldir_ex -Wl,--wrap,UnmergeFiles -Wl,--wrap,wm_exec -Wl,--wrap,remove \
                                -Wl,--wrap,fgetpos -Wl,--wrap=fgetc ${DEBUG_OP_WRAPPERS}")

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_agent.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_agent.c
@@ -213,9 +213,9 @@ void test_wm_upgrade_agent_search_upgrade_result_successful(void **state)
     int result = 0;
     wm_upgrade_agent_state upgrade_state = WM_UPGRADE_SUCCESSFUL;
 
-    expect_string(__wrap_fopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1);
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
 
 #ifdef TEST_WINAGENT
     expect_value(wrap_fgets, __stream, (FILE*)1);
@@ -259,9 +259,9 @@ void test_wm_upgrade_agent_search_upgrade_result_failed(void **state)
     int result = 0;
     wm_upgrade_agent_state upgrade_state = WM_UPGRADE_FAILED;
 
-    expect_string(__wrap_fopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1);
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
 
 #ifdef TEST_WINAGENT
     expect_value(wrap_fgets, __stream, (FILE*)1);
@@ -305,9 +305,9 @@ void test_wm_upgrade_agent_search_upgrade_result_error_open(void **state)
     int result = 0;
     wm_upgrade_agent_state upgrade_state = WM_UPGRADE_FAILED;
 
-    expect_string(__wrap_fopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
 
     int ret = wm_upgrade_agent_search_upgrade_result(&queue);
 
@@ -322,9 +322,9 @@ void test_wm_upgrade_agent_search_upgrade_result_error_code(void **state)
     int result = 0;
     wm_upgrade_agent_state upgrade_state = WM_UPGRADE_FAILED;
 
-    expect_string(__wrap_fopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1);
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
 
 #ifdef TEST_WINAGENT
     expect_value(wrap_fgets, __stream, (FILE*)1);
@@ -366,9 +366,9 @@ void test_wm_agent_upgrade_check_status_successful(void **state)
     expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_RESULT_WAIT_TIME);
 #endif
 
-    expect_string(__wrap_fopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1);
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
 
 #ifdef TEST_WINAGENT
     expect_value(wrap_fgets, __stream, (FILE*)1);
@@ -405,9 +405,9 @@ void test_wm_agent_upgrade_check_status_successful(void **state)
     expect_value(__wrap_sleep, seconds, config->upgrade_wait_start);
 #endif
 
-    expect_string(__wrap_fopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
 
     wm_agent_upgrade_check_status(config);
 
@@ -437,9 +437,9 @@ void test_wm_agent_upgrade_check_status_time_limit(void **state)
     expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_RESULT_WAIT_TIME);
 #endif
 
-    expect_string(__wrap_fopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1);
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
 
 #ifdef TEST_WINAGENT
     expect_value(wrap_fgets, __stream, (FILE*)1);
@@ -476,9 +476,9 @@ void test_wm_agent_upgrade_check_status_time_limit(void **state)
     expect_value(__wrap_sleep, seconds, config->upgrade_wait_start);
 #endif
 
-    expect_string(__wrap_fopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1);
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
 
 #ifdef TEST_WINAGENT
     expect_value(wrap_fgets, __stream, (FILE*)1);
@@ -515,9 +515,9 @@ void test_wm_agent_upgrade_check_status_time_limit(void **state)
     expect_value(__wrap_sleep, seconds, config->upgrade_wait_start * config->upgrade_wait_factor_increase);
 #endif
 
-    expect_string(__wrap_fopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1);
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
 
 #ifdef TEST_WINAGENT
     expect_value(wrap_fgets, __stream, (FILE*)1);
@@ -554,9 +554,9 @@ void test_wm_agent_upgrade_check_status_time_limit(void **state)
     expect_value(__wrap_sleep, seconds, config->upgrade_wait_start * config->upgrade_wait_factor_increase * config->upgrade_wait_factor_increase);
 #endif
 
-    expect_string(__wrap_fopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, (FILE*)1);
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
 
 #ifdef TEST_WINAGENT
     expect_value(wrap_fgets, __stream, (FILE*)1);
@@ -593,9 +593,9 @@ void test_wm_agent_upgrade_check_status_time_limit(void **state)
     expect_value(__wrap_sleep, seconds, config->upgrade_wait_max);
 #endif
 
-    expect_string(__wrap_fopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
 
     wm_agent_upgrade_check_status(config);
 

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
@@ -335,9 +335,9 @@ void test_uncompress_fopen_fail(void **state) {
 #else
     expect_string(__wrap__mterror, formatted_msg, "(8140): At uncompress(): Unable to open 'tmp/test_filename.mg.XXXXXX'");
 #endif
-    expect_any(__wrap_fopen, path);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 0);
+    expect_any(__wrap_wfopen, path);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 0);
 
     expect_value(__wrap_gzclose, file, 4);
     will_return(__wrap_gzclose, 0);
@@ -357,9 +357,9 @@ void test_uncompress_fwrite_fail(void **state) {
     expect_string(__wrap_gzopen, mode, "rb");
     will_return(__wrap_gzopen, 4);
 
-    expect_any(__wrap_fopen, path);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 5);
+    expect_any(__wrap_wfopen, path);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 5);
 
     expect_value(__wrap_gzread, gz_fd, 4);
     will_return(__wrap_gzread, 4);
@@ -394,9 +394,9 @@ void test_uncompress_gzread_fail(void **state) {
     expect_string(__wrap_gzopen, mode, "rb");
     will_return(__wrap_gzopen, 4);
 
-    expect_any(__wrap_fopen, path);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 5);
+    expect_any(__wrap_wfopen, path);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 5);
 
     expect_value(__wrap_gzread, gz_fd, 4);
     will_return(__wrap_gzread, -1);
@@ -428,9 +428,9 @@ void test_uncompress_success(void **state) {
     expect_string(__wrap_gzopen, mode, "rb");
     will_return(__wrap_gzopen, 4);
 
-    expect_any(__wrap_fopen, path);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 5);
+    expect_any(__wrap_wfopen, path);
+    expect_string(__wrap_wfopen, mode, "wb");
+    will_return(__wrap_wfopen, 5);
 
     expect_value(__wrap_gzread, gz_fd, 4);
     will_return(__wrap_gzread, 4);
@@ -549,9 +549,9 @@ void test_wm_agent_upgrade_com_open_invalid_open(void **state) {
     expect_string(__wrap_w_ref_parent_folder, path, "test_file");
     will_return(__wrap_w_ref_parent_folder, 0);
 
-    expect_any(__wrap_fopen, path);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 0);
+    expect_any(__wrap_wfopen, path);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 0);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mterror, formatted_msg,   "(1103): Could not open file 'test_file' due to [(2)-(No such file or directory)].");
@@ -571,9 +571,9 @@ void test_wm_agent_upgrade_com_open_success(void **state) {
     expect_string(__wrap_w_ref_parent_folder, path, "test_file");
     will_return(__wrap_w_ref_parent_folder, 0);
 
-    expect_any(__wrap_fopen, path);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 4);
+    expect_any(__wrap_wfopen, path);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 4);
 
     char *response = wm_agent_upgrade_com_open(command);
     cJSON *response_object = cJSON_Parse(response);
@@ -941,9 +941,9 @@ void test_wm_agent_upgrade_com_upgrade_clean_directory_error(void **state) {
         expect_string(__wrap_gzopen, mode, "rb");
         will_return(__wrap_gzopen, 4);
 
-        expect_any(__wrap_fopen, path);
-        expect_string(__wrap_fopen, mode, "wb");
-        will_return(__wrap_fopen, 5);
+        expect_any(__wrap_wfopen, path);
+        expect_string(__wrap_wfopen, mode, "wb");
+        will_return(__wrap_wfopen, 5);
 
         expect_value(__wrap_gzread, gz_fd, 4);
         will_return(__wrap_gzread, 4);
@@ -1012,9 +1012,9 @@ void test_wm_agent_upgrade_com_unmerge_error(void **state) {
         expect_string(__wrap_gzopen, mode, "rb");
         will_return(__wrap_gzopen, 4);
 
-        expect_any(__wrap_fopen, path);
-        expect_string(__wrap_fopen, mode, "wb");
-        will_return(__wrap_fopen, 5);
+        expect_any(__wrap_wfopen, path);
+        expect_string(__wrap_wfopen, mode, "wb");
+        will_return(__wrap_wfopen, 5);
 
         expect_value(__wrap_gzread, gz_fd, 4);
         will_return(__wrap_gzread, 4);
@@ -1089,9 +1089,9 @@ void test_wm_agent_upgrade_com_installer_error(void **state) {
         expect_string(__wrap_gzopen, mode, "rb");
         will_return(__wrap_gzopen, 4);
 
-        expect_any(__wrap_fopen, path);
-        expect_string(__wrap_fopen, mode, "wb");
-        will_return(__wrap_fopen, 5);
+        expect_any(__wrap_wfopen, path);
+        expect_string(__wrap_wfopen, mode, "wb");
+        will_return(__wrap_wfopen, 5);
 
         expect_value(__wrap_gzread, gz_fd, 4);
         will_return(__wrap_gzread, 4);
@@ -1170,9 +1170,9 @@ void test_wm_agent_upgrade_com_chmod_error(void **state) {
         expect_string(__wrap_gzopen, mode, "rb");
         will_return(__wrap_gzopen, 4);
 
-        expect_any(__wrap_fopen, path);
-        expect_string(__wrap_fopen, mode, "wb");
-        will_return(__wrap_fopen, 5);
+        expect_any(__wrap_wfopen, path);
+        expect_string(__wrap_wfopen, mode, "wb");
+        will_return(__wrap_wfopen, 5);
 
         expect_value(__wrap_gzread, gz_fd, 4);
         will_return(__wrap_gzread, 4);
@@ -1257,9 +1257,9 @@ void test_wm_agent_upgrade_com_execute_error(void **state) {
         expect_string(__wrap_gzopen, mode, "rb");
         will_return(__wrap_gzopen, 4);
 
-        expect_any(__wrap_fopen, path);
-        expect_string(__wrap_fopen, mode, "wb");
-        will_return(__wrap_fopen, 5);
+        expect_any(__wrap_wfopen, path);
+        expect_string(__wrap_wfopen, mode, "wb");
+        will_return(__wrap_wfopen, 5);
 
         expect_value(__wrap_gzread, gz_fd, 4);
         will_return(__wrap_gzread, 4);
@@ -1361,9 +1361,9 @@ void test_wm_agent_upgrade_com_success(void **state) {
         expect_string(__wrap_gzopen, mode, "rb");
         will_return(__wrap_gzopen, 4);
 
-        expect_any(__wrap_fopen, path);
-        expect_string(__wrap_fopen, mode, "wb");
-        will_return(__wrap_fopen, 5);
+        expect_any(__wrap_wfopen, path);
+        expect_string(__wrap_wfopen, mode, "wb");
+        will_return(__wrap_wfopen, 5);
 
         expect_value(__wrap_gzread, gz_fd, 4);
         will_return(__wrap_gzread, 4);
@@ -1636,9 +1636,9 @@ void test_wm_agent_upgrade_process_open_command(void **state) {
         expect_string(__wrap_w_ref_parent_folder, path, "test_file");
         will_return(__wrap_w_ref_parent_folder, 0);
 
-        expect_any(__wrap_fopen, path);
-        expect_string(__wrap_fopen, mode, "w");
-        will_return(__wrap_fopen, 4);
+        expect_any(__wrap_wfopen, path);
+        expect_string(__wrap_wfopen, mode, "w");
+        will_return(__wrap_wfopen, 4);
     }
 
     size_t length = wm_agent_upgrade_process_command(buffer, &output);
@@ -1762,9 +1762,9 @@ void test_wm_agent_upgrade_process_upgrade_command(void **state) {
             expect_string(__wrap_gzopen, mode, "rb");
             will_return(__wrap_gzopen, 4);
 
-            expect_any(__wrap_fopen, path);
-            expect_string(__wrap_fopen, mode, "wb");
-            will_return(__wrap_fopen, 5);
+            expect_any(__wrap_wfopen, path);
+            expect_string(__wrap_wfopen, mode, "wb");
+            will_return(__wrap_wfopen, 5);
 
             expect_value(__wrap_gzread, gz_fd, 4);
             will_return(__wrap_gzread, 4);

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
@@ -618,9 +618,9 @@ void test_wm_agent_upgrade_send_write_ok(void **state)
     char *agent_res = "ok ";
     int format = -1;
 
-    expect_string(__wrap_fopen, path, file_path);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, file_path);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, chunk);
     will_return(__wrap_fread, chunk_size);
@@ -701,9 +701,9 @@ void test_wm_agent_upgrade_send_write_ok_new(void **state)
     char *agent_res = "{\"error\":0,\"message\":\"ok\",\"data\": []}";
     int format = 1;
 
-    expect_string(__wrap_fopen, path, file_path);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, file_path);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, chunk);
     will_return(__wrap_fread, chunk_size);
@@ -785,9 +785,9 @@ void test_wm_agent_upgrade_send_write_err(void **state)
     char *agent_res2 = "err Could not write file in agent";
     int format = -1;
 
-    expect_string(__wrap_fopen, path, file_path);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, file_path);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, chunk);
     will_return(__wrap_fread, chunk_size);
@@ -861,9 +861,9 @@ void test_wm_agent_upgrade_send_write_open_err(void **state)
     int chunk_size = 5;
     int format = -1;
 
-    expect_string(__wrap_fopen, path, file_path);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, file_path);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 0);
 
     int res = wm_agent_upgrade_send_write(agent, format, wpk_file, file_path, chunk_size);
 
@@ -1407,9 +1407,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_linux_ok(void **state)
 
     // Write file
 
-    expect_string(__wrap_fopen, path, "var/upgrade/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/upgrade/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test\n");
     will_return(__wrap_fread, config->chunk_size);
@@ -1574,9 +1574,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_windows_ok(void **state)
 
     // Write file
 
-    expect_string(__wrap_fopen, path, "var/upgrade/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/upgrade/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test\n");
     will_return(__wrap_fread, config->chunk_size);
@@ -1739,9 +1739,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_custom_custom_installer_ok(
 
     // Write file
 
-    expect_string(__wrap_fopen, path, "/tmp/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/tmp/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test\n");
     will_return(__wrap_fread, config->chunk_size);
@@ -1903,9 +1903,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_custom_default_installer_ok
 
     // Write file
 
-    expect_string(__wrap_fopen, path, "/tmp/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/tmp/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test\n");
     will_return(__wrap_fread, config->chunk_size);
@@ -2070,9 +2070,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_run_upgrade_err(void **stat
 
     // Write file
 
-    expect_string(__wrap_fopen, path, "var/upgrade/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/upgrade/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test\n");
     will_return(__wrap_fread, config->chunk_size);
@@ -2236,9 +2236,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_send_sha1_err(void **state)
 
     // Write file
 
-    expect_string(__wrap_fopen, path, "var/upgrade/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/upgrade/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test\n");
     will_return(__wrap_fread, config->chunk_size);
@@ -2388,9 +2388,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_close_file_err(void **state
 
     // Write file
 
-    expect_string(__wrap_fopen, path, "var/upgrade/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/upgrade/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test\n");
     will_return(__wrap_fread, config->chunk_size);
@@ -2522,9 +2522,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_write_file_err(void **state
 
     // Write file
 
-    expect_string(__wrap_fopen, path, "var/upgrade/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/upgrade/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test\n");
     will_return(__wrap_fread, config->chunk_size);
@@ -2999,9 +2999,9 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_ok(void **state)
 
     // Write file
 
-    expect_string(__wrap_fopen, path, "var/upgrade/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/upgrade/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test\n");
     will_return(__wrap_fread, config->chunk_size);
@@ -3231,9 +3231,9 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_legacy_ok(void **state)
 
     // Write file
 
-    expect_string(__wrap_fopen, path, "var/upgrade/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/upgrade/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test\n");
     will_return(__wrap_fread, config->chunk_size);
@@ -3464,9 +3464,9 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_custom_ok(void **state)
 
     // Write file
 
-    expect_string(__wrap_fopen, path, "/tmp/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/tmp/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_fread, "test\n");
     will_return(__wrap_fread, config->chunk_size);

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -802,9 +802,9 @@ void test_wm_agent_upgrade_validate_wpk_exist(void **state)
     os_strdup("wazuh_agent_v4.0.0_windows.wpk", task->wpk_file);
     os_strdup(sha1, task->wpk_sha1);
 
-    expect_string(__wrap_fopen, path, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     expect_string(__wrap_OS_SHA1_File, fname, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
     expect_value(__wrap_OS_SHA1_File, mode, OS_BINARY);
@@ -828,9 +828,9 @@ void test_wm_agent_upgrade_validate_wpk_exist_diff_sha1(void **state)
     os_strdup("wazuh_agent_v4.0.0_windows.wpk", task->wpk_file);
     os_strdup(sha1, task->wpk_sha1);
 
-    expect_string(__wrap_fopen, path, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     expect_string(__wrap_OS_SHA1_File, fname, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
     expect_value(__wrap_OS_SHA1_File, mode, OS_BINARY);
@@ -867,9 +867,9 @@ void test_wm_agent_upgrade_validate_wpk_download_retry(void **state)
     os_strdup("wazuh_agent_v4.0.0_windows.wpk", task->wpk_file);
     os_strdup(sha1, task->wpk_sha1);
 
-    expect_string(__wrap_fopen, path, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 0);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mtdebug1, formatted_msg, "(8161): Downloading WPK file from: 'https://packages.wazuh.com/4.x/wpk/windows/wazuh_agent_v4.0.0_windows.wpk'");
@@ -905,9 +905,9 @@ void test_wm_agent_upgrade_validate_wpk_download_diff_sha1(void **state)
     os_strdup("wazuh_agent_v4.0.0_windows.wpk", task->wpk_file);
     os_strdup(sha1, task->wpk_sha1);
 
-    expect_string(__wrap_fopen, path, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 0);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mtdebug1, formatted_msg, "(8161): Downloading WPK file from: 'https://packages.wazuh.com/4.x/wpk/windows/wazuh_agent_v4.0.0_windows.wpk'");
@@ -936,9 +936,9 @@ void test_wm_agent_upgrade_validate_wpk_download_retry_max(void **state)
     os_strdup("wazuh_agent_v4.0.0_windows.wpk", task->wpk_file);
     os_strdup(sha1, task->wpk_sha1);
 
-    expect_string(__wrap_fopen, path, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "var/upgrade/wazuh_agent_v4.0.0_windows.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 0);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mtdebug1, formatted_msg, "(8161): Downloading WPK file from: 'https://packages.wazuh.com/4.x/wpk/windows/wazuh_agent_v4.0.0_windows.wpk'");
@@ -996,9 +996,9 @@ void test_wm_agent_upgrade_validate_wpk_custom_exist(void **state)
 
     os_strdup("/tmp/test.wpk", task->custom_file_path);
 
-    expect_string(__wrap_fopen, path, "/tmp/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, path, "/tmp/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 1);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 0);
@@ -1014,9 +1014,9 @@ void test_wm_agent_upgrade_validate_wpk_custom_not_exist(void **state)
 
     os_strdup("/tmp/test.wpk", task->custom_file_path);
 
-    expect_string(__wrap_fopen, path, "/tmp/test.wpk");
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, path, "/tmp/test.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, 0);
 
     int ret = wm_agent_upgrade_validate_wpk_custom(task);
 

--- a/src/unit_tests/wazuh_modules/ciscat/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/ciscat/CMakeLists.txt
@@ -9,7 +9,7 @@
 list(APPEND tests_names "test_wm_ciscat")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=os_random,--wrap=StartMQ,--wrap=FOREVER,--wrap=IsDir \
-                         -Wl,--wrap=atexit")
+                         -Wl,--wrap=atexit,--wrap=wfopen")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/unit_tests/wazuh_modules/ciscat/test_wm_ciscat.c
+++ b/src/unit_tests/wazuh_modules/ciscat/test_wm_ciscat.c
@@ -115,12 +115,14 @@ static int teardown_test_read(void **state) {
 void test_interval_execution(void **state) {
     wm_ciscat* module_data = (wm_ciscat *)ciscat_module->data;
     *state = module_data;
+    FILE *fp = NULL;
     module_data->scan_config.next_scheduled_scan_time = 0;
     module_data->scan_config.scan_day = 0;
     module_data->scan_config.scan_wday = -1;
     module_data->scan_config.interval = 120; // 2min
     module_data->scan_config.month_interval = false;
 
+    expect_wfopen("var/wodles/cis-cat", "rb", fp);
     expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 0);

--- a/src/unit_tests/wazuh_modules/database/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/database/CMakeLists.txt
@@ -13,7 +13,7 @@ list(APPEND wmdb_tests_flags "-Wl,--wrap,wdb_set_agent_groups -Wl,--wrap,opendir
                               -Wl,--wrap,closedir -Wl,--wrap,rmdir_ex -Wl,--wrap,getpid  -Wl,--wrap,w_is_single_node -Wl,--wrap,_mterror \
                               -Wl,--wrap,wdb_get_all_agents_rbtree -Wl,--wrap,rbtree_get -Wl,--wrap,wdb_get_agent_group -Wl,--wrap,OS_CIDRtoStr \
                               -Wl,--wrap,wdb_insert_agent -Wl,--wrap,rbtree_keys -Wl,--wrap,OS_IsAllowedID -Wl,--wrap,wdb_get_agent_name \
-                              -Wl,--wrap,wdb_remove_agent -Wl,--wrap,fopen \
+                              -Wl,--wrap,wdb_remove_agent -Wl,--wrap,wfopen \
                               -Wl,--wrap,wdb_get_agent_name -Wl,--wrap,wdbc_query_ex ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
 
 # Add extra compiling flags

--- a/src/unit_tests/wazuh_modules/database/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/database/CMakeLists.txt
@@ -13,7 +13,7 @@ list(APPEND wmdb_tests_flags "-Wl,--wrap,wdb_set_agent_groups -Wl,--wrap,opendir
                               -Wl,--wrap,closedir -Wl,--wrap,rmdir_ex -Wl,--wrap,getpid  -Wl,--wrap,w_is_single_node -Wl,--wrap,_mterror \
                               -Wl,--wrap,wdb_get_all_agents_rbtree -Wl,--wrap,rbtree_get -Wl,--wrap,wdb_get_agent_group -Wl,--wrap,OS_CIDRtoStr \
                               -Wl,--wrap,wdb_insert_agent -Wl,--wrap,rbtree_keys -Wl,--wrap,OS_IsAllowedID -Wl,--wrap,wdb_get_agent_name \
-                              -Wl,--wrap,wdb_remove_agent -Wl,--wrap,wfopen \
+                              -Wl,--wrap,wdb_remove_agent -Wl,--wrap,fopen -Wl,--wrap,wfopen \
                               -Wl,--wrap,wdb_get_agent_name -Wl,--wrap,wdbc_query_ex ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
 
 # Add extra compiling flags

--- a/src/unit_tests/wazuh_modules/database/test_wm_database.c
+++ b/src/unit_tests/wazuh_modules/database/test_wm_database.c
@@ -129,9 +129,9 @@ void test_wm_sync_group_file_error_opening_file(void **state) {
     const char *group_file_path = "invalid_path";
 
     // Error opening agent groups file specified by 'group_file_path'
-    expect_string(__wrap_fopen, path, group_file_path);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, group_file_path);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:database");
     expect_string(__wrap__mtdebug1, formatted_msg, "Groups file 'invalid_path' could not be opened for syncronization.");
 
@@ -148,9 +148,9 @@ void test_wm_sync_group_file_success_empty_file(void **state) {
     const char *groups_in_file = NULL;
 
     // Agent groups file opened succesfully
-    expect_string(__wrap_fopen, path, group_file_path);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, fp_group_file);
+    expect_string(__wrap_wfopen, path, group_file_path);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, fp_group_file);
     // No data when reading the file
     will_return(__wrap_fgets, groups_in_file);
     expect_value(__wrap_fgets, __stream, fp_group_file);
@@ -176,9 +176,9 @@ void test_wm_sync_group_file_success_more_than_max_groups(void **state) {
     char *groups_in_file = generate_groups_csv_string(MAX_GROUPS_PER_MULTIGROUP+1);
 
     // Agent groups file opened succesfully
-    expect_string(__wrap_fopen, path, group_file_path);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, fp_group_file);
+    expect_string(__wrap_wfopen, path, group_file_path);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, fp_group_file);
     // Reading the file
     will_return(__wrap_fgets, groups_in_file);
     expect_value(__wrap_fgets, __stream, fp_group_file);
@@ -209,9 +209,9 @@ void test_wm_sync_group_file_success_max_groups(void **state) {
     char *groups_in_file = generate_groups_csv_string(MAX_GROUPS_PER_MULTIGROUP);
 
     // Agent groups file opened succesfully
-    expect_string(__wrap_fopen, path, group_file_path);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, fp_group_file);
+    expect_string(__wrap_wfopen, path, group_file_path);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, fp_group_file);
     // Reading the file
     will_return(__wrap_fgets, groups_in_file);
     expect_value(__wrap_fgets, __stream, fp_group_file);
@@ -297,9 +297,9 @@ void test_wm_sync_legacy_groups_files_success_files_success_dir(void **state) {
     char *groups_in_file = generate_groups_csv_string(MAX_GROUPS_PER_MULTIGROUP);
     // Calling wm_sync_group_file
     // Agent groups file opened succesfully
-    expect_string(__wrap_fopen, path, group_file_path);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, fp_group_file);
+    expect_string(__wrap_wfopen, path, group_file_path);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, fp_group_file);
     // Reading the file
     will_return(__wrap_fgets, groups_in_file);
     expect_value(__wrap_fgets, __stream, fp_group_file);
@@ -347,9 +347,9 @@ void test_wm_sync_legacy_groups_files_error_files(void **state) {
     const char *group_file_path = GROUPS_DIR "/001";
     // Calling wm_sync_group_file
     // Error opening agent groups file specified by 'group_file_path'
-    expect_string(__wrap_fopen, path, group_file_path);
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, group_file_path);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:database");
     expect_string(__wrap__mtdebug1, formatted_msg, "Groups file 'queue/agent-groups/001' could not be opened for syncronization.");
 
@@ -506,9 +506,9 @@ void test_sync_keys_with_wdb_insert_delete(void **state) {
     expect_string(__wrap_unlink, file, "queue/rids/001");
     will_return(__wrap_unlink, 0);
 
-    expect_string(__wrap_fopen, path, "queue/agents-timestamp");
-    expect_string(__wrap_fopen, mode, "r");
-    will_return(__wrap_fopen, NULL);
+    expect_string(__wrap_wfopen, path, "queue/agents-timestamp");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
 
     sync_keys_with_wdb(&keys);
 }

--- a/src/unit_tests/wazuh_modules/docker/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/docker/CMakeLists.txt
@@ -9,7 +9,7 @@
 list(APPEND tests_names "test_wm_docker")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=FOREVER,--wrap=wpclose,--wrap=fgets \
-                         -Wl,--wrap=wpopenl,--wrap=fclose,--wrap=fflush,--wrap=fprintf,--wrap=fopen,--wrap=fread,--wrap=fseek \
+                         -Wl,--wrap=wpopenl,--wrap=fclose,--wrap=fflush,--wrap=fprintf,--wrap=wfopen,--wrap=fread,--wrap=fseek \
                          -Wl,--wrap=fwrite,--wrap=remove,--wrap=atexit -Wl,--wrap,fgetpos -Wl,--wrap=fgetc")
 list(APPEND use_shared_libs 1)
 

--- a/src/unit_tests/wazuh_modules/docker/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/docker/CMakeLists.txt
@@ -9,8 +9,8 @@
 list(APPEND tests_names "test_wm_docker")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=FOREVER,--wrap=wpclose,--wrap=fgets \
-                         -Wl,--wrap=wpopenl,--wrap=fclose,--wrap=fflush,--wrap=fprintf,--wrap=wfopen,--wrap=fread,--wrap=fseek \
-                         -Wl,--wrap=fwrite,--wrap=remove,--wrap=atexit -Wl,--wrap,fgetpos -Wl,--wrap=fgetc")
+                         -Wl,--wrap=wpopenl,--wrap=fclose,--wrap=fflush,--wrap=fprintf,--wrap=fopen,--wrap=fread,--wrap=fseek \
+                         -Wl,--wrap=fwrite,--wrap=remove,--wrap=atexit -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap=wfopen")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/unit_tests/wazuh_modules/gcp/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/gcp/CMakeLists.txt
@@ -17,7 +17,7 @@ list(APPEND tests_flags "-Wl,--wrap,wm_exec \
 list(APPEND use_shared_libs 0)
 
 list(APPEND tests_names "test_wmodules_gcp")
-list(APPEND tests_flags "-Wl,--wrap,sched_scan_read,--wrap,realpath,--wrap,IsFile,--wrap,atexit ${DEBUG_OP_WRAPPERS}")
+list(APPEND tests_flags "-Wl,--wrap,sched_scan_read,--wrap,realpath,--wrap,IsFile,--wrap,atexit -Wl,--wrap,wfopen ${DEBUG_OP_WRAPPERS}")
 list(APPEND use_shared_libs 0)
 
 # Generate wazuh modules library

--- a/src/unit_tests/wazuh_modules/office365/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/office365/CMakeLists.txt
@@ -12,7 +12,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 list(APPEND tests_names "test_wm_office365")
 list(APPEND tests_flags "-Wl,--wrap,access -Wl,--wrap,wurl_http_request \
                         -Wl,--wrap,wurl_free_response -Wl,--wrap,wm_sendmsg -Wl,--wrap,strftime -Wl,--wrap,gmtime_r \
-                        -Wl,--wrap,wm_state_io -Wl,--wrap,time -Wl,--wrap,StartMQ \
+                        -Wl,--wrap,wm_state_io -Wl,--wrap,time -Wl,--wrap,StartMQ -Wl,--wrap,wfopen \
                         -Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck \ -Wl,--wrap=is_fim_shutdown \
                         -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown \
                         -Wl,--wrap,fim_sync_push_msg -Wl,--wrap,fim_run_integrity -Wl,--wrap,fim_db_remove_path \

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -29,6 +29,9 @@
 #include "../../wrappers/wazuh/shared/time_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/url_wrappers.h"
 #include "../../wrappers/libc/time_wrappers.h"
+#ifdef WIN32
+#include "../../wrappers/wazuh/shared/file_op_wrappers.h"
+#endif
 
 int __wrap_access(const char *__name, int __type) {
     check_expected(__name);
@@ -1322,7 +1325,9 @@ void test_wm_office365_get_access_token_with_auth_secret_path(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
     expect_string(__wrap__mtdebug1, formatted_msg, "Unknown error while getting access token.");
 
+    test_mode = 0;
     access_token = wm_office365_get_access_token(data->office365_config->auth, max_size, &error_msg);
+    test_mode = 1;
 
     fclose(outfile);
 

--- a/src/unit_tests/wazuh_modules/sca/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/sca/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND tests_names "test_wm_sca")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=FOREVER,--wrap=IsFile,--wrap=getDefine_Int \
                          -Wl,--wrap=StartMQ,--wrap=CreateThread,--wrap=wm_exec,--wrap=wm_sendmsg,--wrap=opendir,--wrap=realpath,--wrap=atexit \
-                         -Wl,--wrap=w_expression_compile -Wl,--wrap=w_expression_match")
+                         -Wl,--wrap=w_expression_compile -Wl,--wrap=w_expression_match -Wl,--wrap,wfopen")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/unit_tests/wazuh_modules/sca/test_wm_sca.c
+++ b/src/unit_tests/wazuh_modules/sca/test_wm_sca.c
@@ -93,13 +93,13 @@ static int setup_module() {
     XML_NODE nodes = string_to_xml_node(string, lxml);
     int ret = wm_sca_read(lxml, nodes, sca_module);
     OS_ClearNode(nodes);
-    test_mode = 1;
+    test_mode = 0;
 
     return ret;
 }
 
 static int teardown_module(){
-    test_mode = 0;
+    test_mode = 1;
     wm_sca_t* module_data = (wm_sca_t *)sca_module->data;
     wmodule_cleanup(sca_module);
     OS_ClearXML(lxml);

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
@@ -99,13 +99,14 @@ void expect_w_uncompress_gzfile(const char * gzfilesrc, const char * gzfiledst, 
     will_return(__wrap_w_uncompress_gzfile, ret);
 }
 
+FILE *__real_wfopen(const char * path, const char * mode);
 FILE *__wrap_wfopen(const char * path, const char * mode) {
     if(test_mode) {
         check_expected(path);
         check_expected(mode);
         return mock_type(FILE *);
     } else {
-        return wfopen(path, mode);
+        return __real_wfopen(path, mode);
     }
 }
 

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
@@ -99,19 +99,19 @@ void expect_w_uncompress_gzfile(const char * gzfilesrc, const char * gzfiledst, 
     will_return(__wrap_w_uncompress_gzfile, ret);
 }
 
-FILE *__wrap_wfopen(const char * __filename, const char * __modes) {
+FILE *__wrap_wfopen(const char * path, const char * mode) {
     if(test_mode) {
-        check_expected(__filename);
-        check_expected(__modes);
+        check_expected(path);
+        check_expected(mode);
         return mock_type(FILE *);
     } else {
-        return wfopen(__filename, __modes);
+        return wfopen(path, mode);
     }
 }
 
-void expect_wfopen(const char * __filename, const char * __modes, FILE *ret) {
-    expect_string(__wrap_wfopen, __filename, __filename);
-    expect_string(__wrap_wfopen, __modes, __modes);
+void expect_wfopen(const char * path, const char * mode, FILE *ret) {
+    expect_string(__wrap_wfopen, path, path);
+    expect_string(__wrap_wfopen, mode, mode);
     will_return(__wrap_wfopen, ret);
 }
 

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
@@ -98,9 +98,13 @@ void expect_w_uncompress_gzfile(const char * gzfilesrc, const char * gzfiledst, 
 }
 
 FILE *__wrap_wfopen(const char * __filename, const char * __modes) {
-    check_expected(__filename);
-    check_expected(__modes);
-    return mock_type(FILE *);
+    if(test_mode) {
+        check_expected(__filename);
+        check_expected(__modes);
+        return mock_type(FILE *);
+    } else {
+        return wfopen(path, mode);
+    }
 }
 
 void expect_wfopen(const char * __filename, const char * __modes, FILE *ret) {

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
@@ -14,6 +14,8 @@
 #include <cmocka.h>
 #include <string.h>
 #include <errno.h>
+#include "file_op.h"
+#include "../../common.h"
 
 int __wrap_abspath(const char *path, char *buffer, size_t size) {
     check_expected(path);
@@ -103,7 +105,7 @@ FILE *__wrap_wfopen(const char * __filename, const char * __modes) {
         check_expected(__modes);
         return mock_type(FILE *);
     } else {
-        return wfopen(path, mode);
+        return wfopen(__filename, __modes);
     }
 }
 

--- a/src/unit_tests/wrappers/windows/fileapi_wrappers.c
+++ b/src/unit_tests/wrappers/windows/fileapi_wrappers.c
@@ -13,15 +13,21 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdio.h>
+#include "../common.h"
+
 HANDLE wrap_CreateFile(LPCSTR lpFileName,
-                       __UNUSED_PARAM(DWORD dwDesiredAccess),
-                       __UNUSED_PARAM(DWORD dwShareMode),
-                       __UNUSED_PARAM(LPSECURITY_ATTRIBUTES lpSecurityAttributes),
-                       __UNUSED_PARAM(DWORD dwCreationDisposition),
-                       __UNUSED_PARAM(DWORD dwFlagsAndAttributes),
-                       __UNUSED_PARAM(HANDLE hTemplateFile)) {
-    check_expected(lpFileName);
-    return mock_type(HANDLE);
+                       DWORD dwDesiredAccess,
+                       DWORD dwShareMode,
+                       LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+                       DWORD dwCreationDisposition,
+                       DWORD dwFlagsAndAttributes,
+                       HANDLE hTemplateFile) {
+    if (test_mode) {
+        check_expected(lpFileName);
+        return mock_type(HANDLE);
+    } else {
+        return CreateFileA(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+    }
 }
 
 void expect_CreateFile_call(const char *filename, HANDLE ret) {

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
             printf("\n%s %s. Available active responses:\n", __ossec_name, ARGV0);
         }
 
-        fp = fopen(DEFAULTAR, "r");
+        fp = wfopen(DEFAULTAR, "r");
         if (fp) {
             char buffer[256];
 
@@ -599,7 +599,7 @@ int main(int argc, char **argv)
         FILE *fp;
         int pass = 0;
 
-        if (fp = fopen(DEFAULTAR, "r"), fp) {
+        if (fp = wfopen(DEFAULTAR, "r"), fp) {
             char name[256];
             char command[256];
             unsigned timeout;

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1111,7 +1111,7 @@ time_t get_agent_date_added(int agent_id) {
 
     snprintf(path, PATH_MAX, "%s", TIMESTAMP_FILE);
 
-    fp = fopen(path, "r");
+    fp = wfopen(path, "r");
 
     if (!fp) {
         return 0;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -602,7 +602,7 @@ int wdb_create_agent_db2(const char * agent_id) {
 
     snprintf(path, OS_FLSIZE, "%s/%s", WDB2_DIR, WDB_PROF_NAME);
 
-    if (!(source = fopen(path, "r"))) {
+    if (!(source = wfopen(path, "r"))) {
         mdebug1("Profile database not found, creating.");
 
         if (wdb_create_profile(path) < 0)
@@ -610,7 +610,7 @@ int wdb_create_agent_db2(const char * agent_id) {
 
         // Retry to open
 
-        if (!(source = fopen(path, "r"))) {
+        if (!(source = wfopen(path, "r"))) {
             merror("Couldn't open profile '%s'.", path);
             return -1;
         }
@@ -618,7 +618,7 @@ int wdb_create_agent_db2(const char * agent_id) {
 
     snprintf(path, OS_FLSIZE, "%s/%s.db", WDB2_DIR, agent_id);
 
-    if (!(dest = fopen(path, "w"))) {
+    if (!(dest = wfopen(path, "w"))) {
         merror("Couldn't create database '%s': %s (%d)", path, strerror(errno), errno);
         fclose(source);
         return -1;

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -249,14 +249,14 @@ int wdb_create_backup(const char * agent_id, int version) {
 
     snprintf(path, OS_FLSIZE, "%s/%s.db", WDB2_DIR, agent_id);
 
-    if (!(source = fopen(path, "r"))) {
+    if (!(source = wfopen(path, "r"))) {
         merror("Couldn't open source '%s': %s (%d)", path, strerror(errno), errno);
         return -1;
     }
 
     snprintf(path, OS_FLSIZE, "%s/%s.db-oldv%d-%lu", WDB2_DIR, agent_id, version, (unsigned long)time(NULL));
 
-    if (!(dest = fopen(path, "w"))) {
+    if (!(dest = wfopen(path, "w"))) {
         merror("Couldn't open dest '%s': %s (%d)", path, strerror(errno), errno);
         fclose(source);
         return -1;

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.c
@@ -233,7 +233,7 @@ STATIC bool wm_upgrade_agent_search_upgrade_result(int *queue_fd) {
     char buffer[20];
     const char * PATH = WM_AGENT_UPGRADE_RESULT_FILE;
 
-    FILE *result_file = fopen(PATH, "r");
+    FILE *result_file = wfopen(PATH, "r");
     if (result_file) {
         if (fgets(buffer, 20, result_file) == NULL) {
             fclose(result_file);

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -229,7 +229,7 @@ STATIC char * wm_agent_upgrade_com_open(const cJSON* json_object) {
         return wm_agent_upgrade_command_ack(ERROR_INVALID_FILE_NAME, error_messages[ERROR_INVALID_FILE_NAME]);
     }
 
-    if (file.fp = fopen(final_path, mode_obj->valuestring), file.fp) {
+    if (file.fp = wfopen(final_path, mode_obj->valuestring), file.fp) {
         snprintf(file.path, sizeof(file.path), "%s", final_path);
         return wm_agent_upgrade_command_ack(ERROR_OK, error_messages[ERROR_OK]);
     } else {
@@ -494,7 +494,7 @@ STATIC int _uncompress(const char * source, const char *package, char dest[PATH_
         return -1;
     }
 
-    if (ftarget = fopen(dest, "wb"), !ftarget) {
+    if (ftarget = wfopen(dest, "wb"), !ftarget) {
         gzclose(fsource);
         mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_FILE_OPEN_ERROR, "uncompress()", dest);
         return -1;

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
@@ -428,7 +428,7 @@ STATIC int wm_agent_upgrade_send_write(int agent_id, int wpk_message_format, con
 
     os_calloc(OS_MAXSTR, sizeof(char), command);
 
-    FILE *file = fopen(file_path, "rb");
+    FILE *file = wfopen(file_path, "rb");
     if (file) {
         while (bytes = fread(buffer, 1, sizeof(buffer), file), bytes) {
 

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -292,7 +292,7 @@ int wm_agent_upgrade_validate_wpk(const wm_upgrade_task *task) {
         snprintf(file_url, OS_SIZE_4096, "%s%s", task->wpk_repository, task->wpk_file);
         snprintf(file_path, OS_SIZE_4096, "%s%s", WM_UPGRADE_WPK_DEFAULT_PATH, task->wpk_file);
 
-        if (wpk_file = fopen(file_path, "rb"), wpk_file) {
+        if (wpk_file = wfopen(file_path, "rb"), wpk_file) {
             if (!OS_SHA1_File(file_path, file_sha1, OS_BINARY) && !strcasecmp(file_sha1, task->wpk_sha1)) {
                 // WPK already downloaded
                 exist = 1;
@@ -336,7 +336,7 @@ int wm_agent_upgrade_validate_wpk_custom(const wm_upgrade_custom_task *task) {
     FILE *wpk_file = NULL;
 
     if (task->custom_file_path) {
-        if (wpk_file = fopen(task->custom_file_path, "rb"), !wpk_file) {
+        if (wpk_file = wfopen(task->custom_file_path, "rb"), !wpk_file) {
             return_code = WM_UPGRADE_WPK_FILE_DOES_NOT_EXIST;
         } else {
             // WPK file exists

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -689,9 +689,9 @@ char * wm_ciscat_get_profile() {
 
 
 #ifdef WIN32
-    if ((fp = fopen(file, "rb"))) {
+    if ((fp = wfopen(file, "rb"))) {
 #else
-    if ((fp = fopen(file, "r"))) {
+    if ((fp = wfopen(file, "r"))) {
 #endif
 
         do{
@@ -739,7 +739,7 @@ wm_scan_data* wm_ciscat_txt_parser(){
     snprintf(file, OS_MAXSTR - 1, "%s%s", WM_CISCAT_REPORTS, "/ciscat-report.txt");
 #endif
 
-    if ((fp = fopen(file, "r"))){
+    if ((fp = wfopen(file, "r"))){
 
         os_calloc(1, sizeof(wm_scan_data), info);
         os_calloc(1, sizeof(wm_rule_data), rule);
@@ -947,9 +947,9 @@ void wm_ciscat_preparser(){
 #endif
 
 #ifdef WIN32
-    if ((in_fp = fopen(in_file, "rb"))) {
+    if ((in_fp = wfopen(in_file, "rb"))) {
 #else
-    if ((in_fp = fopen(in_file, "r"))) {
+    if ((in_fp = wfopen(in_file, "r"))) {
 #endif
 
         os_calloc(OS_MAXSTR, sizeof(char), readbuff);
@@ -959,7 +959,7 @@ void wm_ciscat_preparser(){
             if (fgets(readbuff, OS_MAXSTR, in_fp)){}     // We want to ignore this part
         } while (!strstr(readbuff, WM_CISCAT_GROUP_START) && !strstr(readbuff, WM_CISCAT_GROUP_START2));
 
-        if ((out_fp = fopen(out_file, "w")) == NULL) {
+        if ((out_fp = wfopen(out_file, "w")) == NULL) {
 
             mterror(WM_CISCAT_LOGTAG, "Unable to open '%s' for writing: %s", in_file, strerror(errno));
             ciscat->flags.error = 1;

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -468,7 +468,7 @@ int wm_sync_group_file(const char* group_file, const char* group_file_path) {
         return OS_INVALID;
     }
 
-    FILE *fp = fopen(group_file_path, "r");
+    FILE *fp = wfopen(group_file_path, "r");
 
     if (!fp) {
         mtdebug1(WM_DATABASE_LOGTAG, "Groups file '%s' could not be opened for syncronization.", group_file_path);
@@ -615,7 +615,7 @@ int get_max_queued_events() {
     int n;
     FILE *fp;
 
-    if (!(fp = fopen(MAX_QUEUED_EVENTS_PATH, "r"))) {
+    if (!(fp = wfopen(MAX_QUEUED_EVENTS_PATH, "r"))) {
         mterror(WM_DATABASE_LOGTAG, FOPEN_ERROR, MAX_QUEUED_EVENTS_PATH, errno, strerror(errno));
         return -1;
     }
@@ -634,7 +634,7 @@ int get_max_queued_events() {
 int set_max_queued_events(int size) {
     FILE *fp;
 
-    if (!(fp = fopen(MAX_QUEUED_EVENTS_PATH, "w"))) {
+    if (!(fp = wfopen(MAX_QUEUED_EVENTS_PATH, "w"))) {
         mterror(WM_DATABASE_LOGTAG, FOPEN_ERROR, MAX_QUEUED_EVENTS_PATH, errno, strerror(errno));
         return -1;
     }

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -533,7 +533,7 @@ STATIC char* wm_office365_get_access_token(wm_office365_auth* auth, size_t max_s
     } else if (auth->client_secret_path) {
         FILE *fd = NULL;
 
-        if (fd = fopen(auth->client_secret_path, "r"), fd) {
+        if (fd = wfopen(auth->client_secret_path, "r"), fd) {
             char str[OS_SIZE_1024 -1] = {0};
             size_t size_read = 0;
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -362,7 +362,7 @@ static void wm_sca_read_files(wm_sca_t * data) {
             int cis_db_index = i;
             char **sorted_variables = NULL;
 
-            FILE *fp = fopen(data->policies[i]->policy_path, "r");
+            FILE *fp = wfopen(data->policies[i]->policy_path, "r");
 
             if(!fp) {
                 mwarn("Policy file not found: '%s'. Skipping it.", data->policies[i]->policy_path);
@@ -1549,7 +1549,7 @@ static int wm_sca_check_file_contents(const char * const file,
     }
     #endif
 
-    FILE *fp = fopen(realpath_buffer, "r");
+    FILE *fp = wfopen(realpath_buffer, "r");
     const int fopen_errno = errno;
     if (!fp) {
         if (*reason == NULL) {
@@ -2036,7 +2036,7 @@ int wm_sca_pattern_matches(const char * const str,
 
         const int minterm_result = negated ^ wm_sca_test_positive_minterm (minterm, str, reason, regex);
         w_free_expression_t(&regex);
-        
+
         test_result *= minterm_result;
         mdebug2("Testing minterm (%s%s)(%s) -> %d", negated ? "!" : "", minterm, *str != '\0' ? str : "EMPTY_LINE", minterm_result);
     }

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -205,7 +205,7 @@ int wm_state_io(const char * tag, int op, void *state, size_t size) {
     snprintf(path, PATH_MAX, "%s/%s", WM_STATE_DIR, tag);
     #endif
 
-    if (!(file = fopen(path, op == WM_IO_WRITE ? "wb" : "rb"))) {
+    if (!(file = wfopen(path, op == WM_IO_WRITE ? "wb" : "rb"))) {
         return -1;
     }
     w_file_cloexec(file);

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -315,7 +315,7 @@ void InstallAuthKeys(char *msg)
             !OS_IsValidName(entry[2]) || !OS_IsValidName(entry[3]))
             merror_exit("Invalid key received (2). Closing connection.");
 
-        fp = fopen(KEYS_FILE, "w");
+        fp = wfopen(KEYS_FILE, "w");
 
         if (!fp) {
             merror_exit("Unable to open key file: %s", KEYS_FILE);
@@ -459,7 +459,7 @@ int main(int argc, char **argv)
     /* Checking if there is a custom password file */
     if (authpass == NULL) {
         FILE *fp;
-        fp = fopen(AUTHD_PASS, "r");
+        fp = wfopen(AUTHD_PASS, "r");
         buf[0] = '\0';
 
         if (fp) {

--- a/src/win32/setup-iis.c
+++ b/src/win32/setup-iis.c
@@ -9,6 +9,7 @@
  */
 
 #include <stdio.h>
+#include "file_op.h"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/win32/setup-iis.c
+++ b/src/win32/setup-iis.c
@@ -45,7 +45,7 @@ int fileexist(char *file)
     FILE *fp;
 
     /* Open file */
-    fp = fopen(file, "r");
+    fp = wfopen(file, "r");
     if (!fp) {
         return (0);
     }
@@ -60,7 +60,7 @@ int dogrep(char *file, char *str)
     FILE *fp;
 
     /* Open file */
-    fp = fopen(file, "r");
+    fp = wfopen(file, "r");
     if (!fp) {
         return (0);
     }
@@ -111,7 +111,7 @@ int config_dir(char *name, char *dir, char *vfile)
     printf("%s: https://documentation.wazuh.com\n\n", name);
 
     /* Add IIS config */
-    fp = fopen(OSSECCONF, "a");
+    fp = wfopen(OSSECCONF, "a");
     if (!fp) {
         printf("%s: Unable to edit configuration file.\n", name);
         return (1);
@@ -155,7 +155,7 @@ int config_iis(char *name, char *file, char *vfile)
     printf("%s: Adding IIS log file to be monitored: '%s'.\n", name, vfile);
 
     /* Add iis config config */
-    fp = fopen(OSSECCONF, "a");
+    fp = wfopen(OSSECCONF, "a");
     if (!fp) {
         printf("%s: Unable to edit configuration file.\n", name);
         return (1);

--- a/src/win32/setup-shared.c
+++ b/src/win32/setup-shared.c
@@ -9,6 +9,7 @@
  */
 
 #include <stdio.h>
+#include "file_op.h"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -16,7 +17,6 @@
 #include <dirent.h>
 #include <time.h>
 #include <windows.h>
-
 #include "os_regex/os_regex.h"
 
 #define OSSECCONF   "ossec.conf"

--- a/src/win32/setup-shared.c
+++ b/src/win32/setup-shared.c
@@ -29,7 +29,7 @@ int fileexist(char *file)
     FILE *fp;
 
     /* Open file */
-    fp = fopen(file, "r");
+    fp = wfopen(file, "r");
     if (!fp) {
         return (0);
     }
@@ -45,7 +45,7 @@ int dogrep(char *file, char *str)
     FILE *fp;
 
     /* Open file */
-    fp = fopen(file, "r");
+    fp = wfopen(file, "r");
     if (!fp) {
         return (0);
     }

--- a/src/win32/ui/common.c
+++ b/src/win32/ui/common.c
@@ -57,7 +57,7 @@ char *cat_file(char *file, FILE *fp2)
     FILE *fp;
 
     if (!fp2) {
-        fp = fopen(file, "r");
+        fp = wfopen(file, "r");
     } else {
         fp = fp2;
     }
@@ -94,7 +94,7 @@ char *cat_file(char *file, FILE *fp2)
 int is_file(char *file)
 {
     FILE *fp;
-    fp = fopen(file, "r");
+    fp = wfopen(file, "r");
     if (fp) {
         fclose(fp);
         return (1);
@@ -499,7 +499,7 @@ int set_ossec_key(char *key, HWND hwnd)
         return (0);
     }
 
-    fp = fopen(tmp_path, "w");
+    fp = wfopen(tmp_path, "w");
     if (fp) {
         fprintf(fp, "%s", key);
         fclose(fp);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/internal-devel-requests/issues/744|


## Description

In this PR we will replace all fopen with wfopen, and add a small modification to avoid the misuse of paths starting with / or followed by invalid characters.
It is also necessary to modify all the unit tests that used these functions, and add some extra cases to check the new functionality.

## Configuration options

```
<agent_config>
    <localfile>
        <location>\\192.168.56.103\x\x</location>
        <log_format>syslog</log_format>
    </localfile>
</agent_config>
```

## Logs/Alerts example



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language
