### PR TITLE
Implement nftables active response in default-firewall-drop

### DIFF
--- a/src/active-response/firewalls/default-firewall-drop.c
+++ b/src/active-response/firewalls/default-firewall-drop.c
@@ -48,6 +48,7 @@ int main (int argc, char **argv) {
 
         action2 = send_keys_and_check_message(argv, keys);
 
+        os_free(keys[0]);
         os_free(keys);
 
         // If necessary, abort execution
@@ -97,8 +98,8 @@ int main (int argc, char **argv) {
          */
 
         // Following variables are both used for ip(6)tables and nftables
-        char lock_path[COMMANDSIZE_4096];
-        char lock_pid_path[COMMANDSIZE_4096];
+        char lock_path[COMMANDSIZE_4096] = "";
+        char lock_pid_path[COMMANDSIZE_4096] = "";
         wfd_t *wfd = NULL;
 
         // Checking if iptables is present
@@ -288,7 +289,7 @@ int main (int argc, char **argv) {
                             i--; // Decrement i so the next iteration would still be i
                         }
                     } else {
-                        char nft_stdout_buf[OS_MAXSTR];
+                        char nft_stdout_buf[OS_MAXSTR] = "";
                         memset(nft_stdout_buf, '\0', OS_MAXSTR);
 
                         // Read and replace on the fly the stdout stream to scan it later
@@ -306,8 +307,8 @@ int main (int argc, char **argv) {
                         // once per delete command only.
 
                         // We first prepare our sscanf format
-                        char format_tmp[OS_MAXSTR] = "\0";
-                        snprintf(format_tmp, OS_MAXSTR - 1, "%s saddr %s drop", ip_version == 6 ? "ip6" : "ip", srcip);
+                        char format_tmp[200] = ""; format_tmp[199] = '\0';
+                        snprintf(format_tmp, 199, "%s saddr %s drop", ip_version == 6 ? "ip6" : "ip", srcip);
 
                         // We now look for our rule in the nft output to scan it afterward
                         char *scan_base = strstr(nft_stdout_buf, format_tmp);
@@ -333,10 +334,10 @@ int main (int argc, char **argv) {
                         }
 
                         // Prepare the format for the scan, now that we have located the rule in the ruleset
-                        snprintf(format_tmp, OS_MAXSTR - 1, "%s saddr %s drop # handle %%s",
+                        snprintf(format_tmp, 199, "%s saddr %s drop # handle %%s",
                                  ip_version == 6 ? "ip6" : "ip", srcip);
                         // We use a 21 maximum chars integer, which is sufficient for 8-bytes long storage
-                        char handle_tmp[21];
+                        char handle_tmp[21] = "";
                         errno = 0; // Explicitly set errno to check matching error later
                         if (sscanf(scan_base, format_tmp, handle_tmp) <= 0) {
                             memset(log_msg, '\0', OS_MAXSTR);

--- a/src/active-response/firewalls/default-firewall-drop.c
+++ b/src/active-response/firewalls/default-firewall-drop.c
@@ -13,10 +13,13 @@
 #define LOCK_FILE "active-response/bin/fw-drop/pid"
 #define IP4TABLES "iptables"
 #define IP6TABLES "ip6tables"
+#define NFTABLES "nft"
 
 int main (int argc, char **argv) {
     (void)argc;
+    // iptables specific command selection (it must be iptables for IPv4 and ip6tables for IPv6)
     char iptables_tmp[COMMANDSIZE_4096 - 5] = "";
+    // log message buffer
     char log_msg[OS_MAXSTR];
     int action = OS_INVALID;
     cJSON *input_json = NULL;
@@ -80,85 +83,340 @@ int main (int argc, char **argv) {
     }
 
     if (!strcmp("Linux", uname_buffer.sysname)) {
+        /* The behaviour for linux systems has changed with nftables compatibility. The active response
+         * now follows this workflow :
+         * 1. Try to find the ip(6)tables binary and perform the block
+         * 2. Try to find the nftables binary, upsert the wazuh-agent inet table then perform the block
+         * 3. Fail if we cannot find both binaries
+         *
+         * We must prioritize ip(6)tables over nftables as some compatibility modules exist (e.g. iptables-nft
+         * under Debian). Some nftables concept unreachable in iptables, so we cannot use them while assuming
+         * administrators did entirely migrate to nftables, especially when iptables-nft packages exist.
+         * We should store the errno when checking if iptables can be found. If we cannot find ip(6)tables nor nftables,
+         * providing extra debugging information for each binary is important.
+         */
+
+        // Following variables are both used for ip(6)tables and nftables
         char lock_path[COMMANDSIZE_4096];
         char lock_pid_path[COMMANDSIZE_4096];
-        char *iptables = NULL;
         wfd_t *wfd = NULL;
 
         // Checking if iptables is present
-        if (get_binary_path(iptables_tmp, &iptables) < 0) {
-            memset(log_msg, '\0', OS_MAXSTR);
-            snprintf(log_msg, OS_MAXSTR -1, "The iptables file '%s' is not accessible: %s (%d)", iptables, strerror(errno), errno);
-            write_debug_file(argv[0], log_msg);
-            cJSON_Delete(input_json);
+        char *iptables = NULL;
+        if (!get_binary_path(iptables_tmp, &iptables)) {
+            char arg[3] = {0};
+            if (action == ADD_COMMAND) {
+                strcpy(arg, "-I");
+            } else {
+                strcpy(arg, "-D");
+            }
+
+            memset(lock_path, '\0', COMMANDSIZE_4096);
+            memset(lock_pid_path, '\0', COMMANDSIZE_4096);
+            snprintf(lock_path, COMMANDSIZE_4096 - 1, "%s", LOCK_PATH);
+            snprintf(lock_pid_path, COMMANDSIZE_4096 - 1, "%s", LOCK_FILE);
+
+            // Taking lock
+            if (lock(lock_path, lock_pid_path, argv[0], basename(argv[0])) == OS_INVALID) {
+                memset(log_msg, '\0', OS_MAXSTR);
+                snprintf(log_msg, OS_MAXSTR - 1, "Unable to take lock. End.");
+                write_debug_file(argv[0], log_msg);
+                cJSON_Delete(input_json);
+                os_free(iptables);
+                return OS_INVALID;
+            }
+
+            int count = 0;
+            bool flag = true;
+            while (flag) {
+                char *exec_cmd1[8] = {iptables, arg, "INPUT", "-s", (char *) srcip, "-j", "DROP", NULL};
+
+                wfd = wpopenv(iptables, exec_cmd1, W_BIND_STDERR);
+                if (!wfd) {
+                    count++;
+                    if (count > 4) {
+                        flag = false;
+                        write_debug_file(argv[0], "Unable to run iptables");
+                    } else {
+                        sleep(count);
+                    }
+                } else {
+                    flag = false;
+                    wpclose(wfd);
+                }
+            }
+
+            count = 0;
+            flag = true;
+            while (flag) {
+                char *exec_cmd2[8] = {iptables, arg, "FORWARD", "-s", (char *) srcip, "-j", "DROP", NULL};
+
+                wfd = wpopenv(iptables, exec_cmd2, W_BIND_STDERR);
+                if (!wfd) {
+                    count++;
+                    if (count > 4) {
+                        flag = false;
+                        write_debug_file(argv[0], "Unable to run iptables");
+                    } else {
+                        sleep(count);
+                    }
+                } else {
+                    flag = false;
+                    wpclose(wfd);
+                }
+            }
+            unlock(lock_path, argv[0]);
             os_free(iptables);
             return OS_SUCCESS;
-        }
-
-        char arg[3] = {0};
-        if (action == ADD_COMMAND) {
-            strcpy(arg, "-I");
         } else {
-            strcpy(arg, "-D");
-        }
-
-        memset(lock_path, '\0', COMMANDSIZE_4096);
-        memset(lock_pid_path, '\0', COMMANDSIZE_4096);
-        snprintf(lock_path, COMMANDSIZE_4096 - 1, "%s", LOCK_PATH);
-        snprintf(lock_pid_path, COMMANDSIZE_4096 - 1, "%s", LOCK_FILE);
-
-        // Taking lock
-        if (lock(lock_path, lock_pid_path, argv[0], basename(argv[0])) == OS_INVALID) {
-            memset(log_msg, '\0', OS_MAXSTR);
-            snprintf(log_msg, OS_MAXSTR -1, "Unable to take lock. End.");
-            write_debug_file(argv[0], log_msg);
-            cJSON_Delete(input_json);
+            // Store the iptables binary search errno for later, if we need to log it
+            int iptables_errno = errno;
+            // We do not really need the iptables variable as we already have the wanted binary string in iptables_tmp
             os_free(iptables);
-            return OS_INVALID;
-        }
 
-        int count = 0;
-        bool flag = true;
-        while (flag) {
-            char *exec_cmd1[8] = { iptables, arg, "INPUT", "-s", (char *)srcip, "-j", "DROP", NULL };
+            // Directly try to find nftables and handle the "no binary found" stuff, it's much easier to read
+            char *nftables = NULL;
+            if (get_binary_path(NFTABLES, &nftables) < 0) {
+                memset(log_msg, '\0', OS_MAXSTR);
+                snprintf(log_msg, OS_MAXSTR - 1,
+                         "Cannot find the iptables file '%s': %s (%d) nor the nftables file '%s': %s (%d)",
+                         iptables_tmp, strerror(iptables_errno), iptables_errno,
+                         NFTABLES, strerror(errno), errno);
+                write_debug_file(argv[0], log_msg);
+                cJSON_Delete(input_json);
+                os_free(nftables);
+                return OS_SUCCESS;
+            }
 
-            wfd = wpopenv(iptables, exec_cmd1, W_BIND_STDERR);
-            if (!wfd) {
-                count++;
-                if (count > 4) {
-                    flag = false;
-                    write_debug_file(argv[0], "Unable to run iptables");
+            memset(lock_path, '\0', COMMANDSIZE_4096);
+            memset(lock_pid_path, '\0', COMMANDSIZE_4096);
+            snprintf(lock_path, COMMANDSIZE_4096 - 1, "%s", LOCK_PATH);
+            snprintf(lock_pid_path, COMMANDSIZE_4096 - 1, "%s", LOCK_FILE);
+
+            // Taking lock
+            if (lock(lock_path, lock_pid_path, argv[0], basename(argv[0])) == OS_INVALID) {
+                memset(log_msg, '\0', OS_MAXSTR);
+                snprintf(log_msg, OS_MAXSTR - 1, "Unable to take lock. End.");
+                write_debug_file(argv[0], log_msg);
+                cJSON_Delete(input_json);
+                os_free(iptables);
+                return OS_INVALID;
+            }
+
+            // We now create if it does not already exist the inet table wazuh-agent with two chains, input and forward
+            // Note that we use the "add" keyword instead of the "create" keyword, the later returns an error
+            // if the table already exist, which we want to avoid here
+            char *exec_cmd[5][17] = {
+                    {nftables, "add", "table", "inet", "wazuh-agent", NULL},
+                    {nftables, "add", "chain", "inet", "wazuh-agent", "input",   "{", "type", "filter", "hook", "input",   "priority", "filter;", "policy", "accept;", "}", NULL},
+                    {nftables, "add", "chain", "inet", "wazuh-agent", "forward", "{", "type", "filter", "hook", "forward", "priority", "filter;", "policy", "accept;", "}", NULL},
+
+            };
+
+            // All commands must return in order successfully, execute them in loop
+            // We also write a retry counter, resetting for each successful command
+            // This variable is reused afterward
+            int retry_counter = 0;
+            for (int i = 0; i < 3; i++) {
+                wfd = wpopenv(nftables, exec_cmd[i], W_BIND_STDERR);
+                if (!wfd) {
+                    if (++retry_counter > 4) {
+                        write_debug_file(argv[0], "Unable to run nftables");
+                        unlock(lock_path, argv[0]);
+                        cJSON_Delete(input_json);
+                        os_free(nftables);
+                        return OS_SUCCESS;
+                    } else {
+                        i--; // Decrement i so the next loop iteration will be using the same command
+                        sleep(retry_counter);
+                    }
                 } else {
-                    sleep(count);
+                    wpclose(wfd);
+                    retry_counter = 0; // As this command was successfully executed, set the retry counter to 0
+                }
+            }
+
+            if (action == ADD_COMMAND) {
+                char *ban_cmd[2][17] = {
+                        // The last two cmd_exec are the effective ban rules
+                        {nftables, "add", "rule", "inet", "wazuh-agent", "input",
+                                                                                    ip_version == 6 ? "ip6"
+                                                                                                    : "ip", "saddr", (char *) srcip, "drop", NULL},
+                        {nftables, "add", "rule", "inet", "wazuh-agent", "forward", ip_version == 6 ? "ip6"
+                                                                                                    : "ip", "saddr", (char *) srcip, "drop", NULL}
+                };
+
+                retry_counter = 0;
+                for (int i = 0; i < 2; i++) {
+                    wfd = wpopenv(nftables, ban_cmd[i], W_BIND_STDERR);
+                    if (!wfd) {
+                        if (++retry_counter > 4) {
+                            write_debug_file(argv[0], "Unable to run nftables");
+                            unlock(lock_path, argv[0]);
+                            cJSON_Delete(input_json);
+                            os_free(nftables);
+                            return OS_SUCCESS;
+                        } else {
+                            i--; // Decrement i so the next loop iteration will be using the same command
+                            sleep(retry_counter);
+                        }
+                    } else {
+                        wpclose(wfd);
+                        retry_counter = 0; // As this command was successfully executed, set the retry counter to 0
+                    }
                 }
             } else {
-                flag = false;
-                wpclose(wfd);
-            }
-        }
+                char *chains[2] = {"input", "forward"};
+                // Deleting our rules is trickier because nftables doesn't support passive removal (i.e. removing a rule
+                // by passing its content). We need to get the id assigned to the rule (a.k.a the handle) beforehand.
+                // To do that, we parse the output of the command using nft -a, which includes handles
 
-        count = 0;
-        flag = true;
-        while (flag) {
-            char *exec_cmd2[8] = { iptables, arg, "FORWARD", "-s", (char *)srcip, "-j", "DROP", NULL };
+                retry_counter = 0;
+                for (int i = 0; i < 2; i++) {
+                    char *list_cmd[8] = {nftables, "-a",
+                                         "list", "chain", "inet", "wazuh-agent", (char *) chains[i], NULL};
+                    wfd = wpopenv(nftables, list_cmd, W_BIND_STDOUT | W_BIND_STDERR);
+                    if (!wfd) {
+                        if (++retry_counter > 4) {
+                            write_debug_file(argv[0], "Unable to run nftables");
+                            unlock(lock_path, argv[0]);
+                            cJSON_Delete(input_json);
+                            os_free(nftables);
+                            return OS_SUCCESS;
+                        } else {
+                            sleep(retry_counter);
+                            i--; // Decrement i so the next iteration would still be i
+                        }
+                    } else {
+                        char nft_stdout_buf[OS_MAXSTR];
+                        memset(nft_stdout_buf, '\0', OS_MAXSTR);
 
-            wfd = wpopenv(iptables, exec_cmd2, W_BIND_STDERR);
-            if (!wfd) {
-                count++;
-                if (count > 4) {
-                    flag = false;
-                    write_debug_file(argv[0], "Unable to run iptables");
-                } else {
-                    sleep(count);
+                        // Read and replace on the fly the stdout stream to scan it later
+                        char *ptr = nft_stdout_buf;
+                        while (((*ptr) = (char) fgetc(wfd->file_out)) != EOF && ptr < nft_stdout_buf + OS_MAXSTR - 1) {
+                            if (*ptr == '\n' || *ptr == '\t') {
+                                *ptr = 0x20; //ASCII space
+                            }
+                            ptr++;
+                        }
+                        *ptr = '\0';
+
+                        // Scan the content, looking for the 'ip saddr <IP> drop # handle %d' syntax.
+                        // We only look for one handle at a time, so if a drop is duplicated, it will be removed
+                        // once per delete command only.
+
+                        // We first prepare our sscanf format
+                        char format_tmp[OS_MAXSTR] = "\0";
+                        snprintf(format_tmp, OS_MAXSTR - 1, "%s saddr %s drop", ip_version == 6 ? "ip6" : "ip", srcip);
+
+                        // We now look for our rule in the nft output to scan it afterward
+                        char *scan_base = strstr(nft_stdout_buf, format_tmp);
+
+                        if (scan_base == NULL) {
+                            memset(log_msg, '\0', OS_MAXSTR);
+                            snprintf(log_msg, OS_MAXSTR - 1,
+                                     "Unable to fetch rule handles from nftables, cannot find the rule '%s' in chain '%s'",
+                                     format_tmp, chains[i]);
+                            write_debug_file(argv[0], log_msg);
+
+                            if (++retry_counter > 4) {
+                                wpclose(wfd);
+                                write_debug_file(argv[0], "Unable to run nftables");
+                                unlock(lock_path, argv[0]);
+                                cJSON_Delete(input_json);
+                                os_free(nftables);
+                                return OS_SUCCESS;
+                            } else {
+                                sleep(retry_counter);
+                                i--; // Decrement i so the next iteration would still be i
+                            }
+                        }
+
+                        // Prepare the format for the scan, now that we have located the rule in the ruleset
+                        snprintf(format_tmp, OS_MAXSTR - 1, "%s saddr %s drop # handle %%s",
+                                 ip_version == 6 ? "ip6" : "ip", srcip);
+                        // We use a 21 maximum chars integer, which is sufficient for 8-bytes long storage
+                        char handle_tmp[21];
+                        errno = 0; // Explicitly set errno to check matching error later
+                        if (sscanf(scan_base, format_tmp, handle_tmp) <= 0) {
+                            memset(log_msg, '\0', OS_MAXSTR);
+                            snprintf(log_msg, OS_MAXSTR - 1,
+                                     "Unable to run nftables, read error when trying to get input rule handle from nftables output for IP '%s': %s (%d)",
+                                     srcip, errno == 0 ? "Matching error" : strerror(errno), errno);
+                            write_debug_file(argv[0], log_msg);
+
+                            if (++retry_counter > 4) {
+                                wpclose(wfd);
+                                write_debug_file(argv[0], "Unable to run nftables");
+                                unlock(lock_path, argv[0]);
+                                cJSON_Delete(input_json);
+                                os_free(nftables);
+                                return OS_SUCCESS;
+                            } else {
+                                sleep(retry_counter);
+                                i--; // Decrement i so the next iteration would still be i
+                            }
+
+                        } else {
+                            // Parse using strtol the obtained handle
+                            errno = 0;
+                            long handle = strtol(handle_tmp, NULL, 10);
+                            if (errno != 0) {
+                                memset(log_msg, '\0', OS_MAXSTR);
+                                snprintf(log_msg, OS_MAXSTR - 1,
+                                         "Unable to get handles from nftables, parse error on handle string: %s (%d)",
+                                         strerror(errno), errno);
+                                write_debug_file(argv[0], log_msg);
+
+                                if (++retry_counter > 4) {
+                                    wpclose(wfd);
+                                    write_debug_file(argv[0], "Unable to run nftables");
+                                    unlock(lock_path, argv[0]);
+                                    cJSON_Delete(input_json);
+                                    os_free(nftables);
+                                    return OS_SUCCESS;
+                                } else {
+                                    sleep(retry_counter);
+                                    i--; // Decrement i so the next iteration would still be i
+                                }
+                            }
+
+                            wpclose(wfd);
+
+                            // Now, we can remove the rule. Note that we convert the handle back to string
+                            // One may think that we could just pass the handle string obtained before, but parsing it
+                            // allows us to make sure we deal with an integer. If someday the handle comment changes,
+                            // this would prevent unwanted side effects as we do not catch nft command results
+                            snprintf(handle_tmp, 20, "%ld", handle);
+                            char *remove_cmd[9] = {nftables, "delete", "rule", "inet", "wazuh-agent", chains[i],
+                                                   "handle", handle_tmp, NULL};
+
+                            wfd = wpopenv(nftables, remove_cmd, W_BIND_STDERR);
+                            if (!wfd) {
+                                if (++retry_counter > 4) {
+                                    write_debug_file(argv[0], "Unable to run nftables");
+                                    unlock(lock_path, argv[0]);
+                                    cJSON_Delete(input_json);
+                                    os_free(nftables);
+                                    return OS_SUCCESS;
+                                } else {
+                                    sleep(retry_counter);
+                                    i--; // Decrement i so the next iteration would still be i
+                                }
+                            } else {
+                                wpclose(wfd);
+                            }
+                        }
+                    }
                 }
-            } else {
-                flag = false;
-                wpclose(wfd);
             }
-        }
-        unlock(lock_path, argv[0]);
-        os_free(iptables);
 
+
+            unlock(lock_path, argv[0]);
+            cJSON_Delete(input_json);
+            os_free(nftables);
+            return OS_SUCCESS;
+        }
     } else if (!strcmp("FreeBSD", uname_buffer.sysname) || !strcmp("SunOS", uname_buffer.sysname) || !strcmp("NetBSD", uname_buffer.sysname)) {
         char arg1[COMMANDSIZE_4096];
         char arg2[COMMANDSIZE_4096];


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/10669|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

*Note: This is a Linux only pull request, the BSD code was not modified.*

This PR updates the default-firewall-drop behaviour to make it compatible with the nftables framework. As nftables is step by step replacing nftables, the idea is to introduce smooth compatibility based on iptables/ip6tables availability.

The rationale behind this choice is avoiding compatibilities issues and avoid people scratching their head on unwanted behaviours considering those points :
1. iptables chains `INPUT`, `FORWARD` and `OUTPUT` are default chains that are used in iptables. We can safely use them as they will exist, even if administrators did some customization. As `nftables` is more flexible, those chains might not exist.
2. If we want to work if `nftables`, one safe way is "upserting" an inet table (IPv4 & IPv6) dedicated to the wazuh-agent and adding two chains (`INPUT` and `FORWARD` like). If we choose to prioritize nftables over iptables, those chains will be visible by printing the ruleset with the nft utility, but not with iptables : 

```
# iptables -L
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
# iptables -A INPUT -i 192.168.1.223 -j DROP
# iptables -L
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         
DROP       all  --  anywhere             anywhere            

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
# nft list ruleset
table ip nat {
	chain POSTROUTING {
		type nat hook postrouting priority srcnat; policy accept;
	}

	chain PREROUTING {
		type nat hook prerouting priority dstnat; policy accept;
	}

	chain OUTPUT {
		type nat hook output priority -100; policy accept;
	}
}
table ip filter {
	chain FORWARD {
		type filter hook forward priority filter; policy accept;
	}

	chain INPUT {
		type filter hook input priority filter; policy accept;
		iifname "192.168.1.223" counter packets 0 bytes 0 drop
	}

	chain OUTPUT {
		type filter hook output priority filter; policy accept;
	}
}
# nft add table inet wazuh-agent
# nft add chain inet wazuh-agent input '{ type filter hook input priority filter; policy accept; }'
# nft add rule inet wazuh-agent input ip saddr 192.168.1.224 drop
# nft list ruleset
table ip nat {
	chain POSTROUTING {
		type nat hook postrouting priority srcnat; policy accept;
	}

	chain PREROUTING {
		type nat hook prerouting priority dstnat; policy accept;
	}

	chain OUTPUT {
		type nat hook output priority -100; policy accept;
	}
}
table ip filter {
	chain FORWARD {
		type filter hook forward priority filter; policy accept;
	}

	chain INPUT {
		type filter hook input priority filter; policy accept;
		iifname "192.168.1.223" counter packets 0 bytes 0 drop
	}

	chain OUTPUT {
		type filter hook output priority filter; policy accept;
	}
}
table inet wazuh-agent {
	chain input {
		type filter hook input priority filter; policy accept;
		ip saddr 192.168.1.224 drop
	}
}
# iptables -vnL
Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 DROP       0    --  192.168.1.223 *       0.0.0.0/0            0.0.0.0/0           

Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         

Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
# 
```

Here I added a convenient table for adding custom rules, but we cannot read it using iptables. To prevent administrators scratching their head agains't "ghost rules" if they do not work yet with nftables, I think we shouldn't use nftables while iptables is available.

I implemented the nftables in this perspective. With this PR, the new behaviour is as follows :
1. We check if iptables/ip6tables is available. If so, we use it
2. As a fallback, we try to use nftables. If it is available, we use it
3. Else, we fail and I kept the old logging line telling that iptables/ip6tables was not found, but added at the end the nftables lookup error.

The selection, as before is based on the binary search in the PATH environment variable, as it is currently done for iptables/ip6tables.

### Nftables implementation considerations

Because nftables is designed to be more flexible than iptables, when creating an active response, the implementation uses standard filtering for nftables in the following ways :
* A dedicated inet table named `wazuh-agent` is created
* This table holds two chains, `input` and `forward` hooked according to their name and using the standard priority `filter`. The policy for those chains is by default an `accept` policy. I chose to explicitely write it, even if this is a default behaviour.
* Rules are added in those chains, one for each chain.

Implementing it in this way makes clear for any administrator that the purpose of this table is not to replace a well-made firewall policy but to add an active response layer like intended.

However, it is not strictly equivalent to the iptables behaviour. In the iptables implementation, we insert at the head of the `INPUT` and `FORWARD` chains the drop statement. In nftables, as anybody can choose to work with different priorities, they can explicitely add some chains that will be evaluated before our chains using the standard `filter` (which is `0`) priority. According to the nftables manual :

>        accept       Terminate ruleset evaluation and accept the packet. The packet can still be dropped later by another hook, for instance accept in the
>                    forward hook still allows one to drop the packet later in the postrouting hook, or another forward base chain that has a higher priority
>                    number and is evaluated afterwards in the processing pipeline.

That being said, if a higher priority chain (the lowest value, the more priority) decides to `accept` the packet, it will terminate the ruleset evaluation but a later chain (like ours) will still drop it so in terms of strict security, the packet would still be dropped.

An unwanted side effect would be if non-terminal statements like the log statement (see `man nftables`) are used **after** our chain is evaluated.
When the packet is previously accepted, the remaining chains are still evaluated, looking for a packet refusal (`drop` or `reject`). However, non-terminal statements won't be executed.

Take this configuration as example : 
```
table inet filter {
	chain input {
		type filter hook input priority filter; policy accept;
		iif "lo" accept
		ct state established,related accept
		ip protocol icmp accept
		icmpv6 type { echo-request, echo-reply, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
		tcp dport 22 accept
	}

	chain forward {
		type filter hook forward priority filter; policy drop;
	}

	chain output {
		type filter hook output priority filter; policy accept;
	}
}
table inet custom-policy {
	chain good-logging {
		type filter hook input priority filter - 1; policy accept;
		ip saddr 172.16.2.0/24 log prefix "Good monitor" group 0
	}

	chain bad-logging {
		type filter hook input priority filter + 1; policy accept;
		ip saddr 172.16.2.0/24 log prefix "Bad monitor" group 0
	}
}
table inet wazuh-agent {
	chain input {
		type filter hook input priority filter; policy accept;
		ip saddr 172.16.2.8 drop
	}
}
```

We do have 3 tables, one for the policy filter, one for our custom logging policy and one for the Wazuh agent active response.
The second one, the `custom-policy` contains 2 chains :
 - The first one is evaluated **before** the filter priority, so the log statement is effective because when evaluated, we don't have yet a terminal statement used.
 - The second one is evaluated **after** the filter priority, so when trafic is dropped by the wazuh-agent table, it is not logged.

I sent a ping from 172.16.2.8 (Both this host and 172.16.2.8 are EACC hosts of my network for this test) to our host, and we can see that only the "Good monitor" prefix is present in logs. The trafic was obviously dropped for this host.

```
Feb  7 12:25:31 gateway Good monitor IN=eth0 OUT= MAC=<redacted> SRC=172.16.2.8 DST=172.16.1.9 LEN=84 TOS=00 PREC=0x00 TTL=62 ID=50138 DF PROTO=ICMP TYPE=8 CODE=0 ID=4041 SEQ=7 MARK=0x0 
Feb  7 12:25:32 gateway Good monitor IN=eth0 OUT= MAC=<redacted> SRC=172.16.2.8 DST=172.16.1.9 LEN=84 TOS=00 PREC=0x00 TTL=62 ID=50201 DF PROTO=ICMP TYPE=8 CODE=0 ID=4041 SEQ=8 MARK=0x0 
Feb  7 12:25:33 gateway Good monitor IN=eth0 OUT= MAC=<redacted> SRC=172.16.2.8 DST=172.16.1.9 LEN=84 TOS=00 PREC=0x00 TTL=62 ID=50344 DF PROTO=ICMP TYPE=8 CODE=0 ID=4041 SEQ=9 MARK=0x0 
Feb  7 12:25:34 gateway Good monitor IN=eth0 OUT= MAC=<redacted> SRC=172.16.2.8 DST=172.16.1.9 LEN=84 TOS=00 PREC=0x00 TTL=62 ID=50591 DF PROTO=ICMP TYPE=8 CODE=0 ID=4041 SEQ=10 MARK=0x0 
Feb  7 12:25:35 gateway Good monitor IN=eth0 OUT= MAC=<redacted> SRC=172.16.2.8 DST=172.16.1.9 LEN=84 TOS=00 PREC=0x00 TTL=62 ID=50600 DF PROTO=ICMP TYPE=8 CODE=0 ID=4041 SEQ=11 MARK=0x0
```

Even if using correct priorities is not related to specific wazuh implementation but good nftables practices, it seems necessary to have in the wazuh documentation some notes regarding the chosen priority for the active response.

Regarding persistency, like the iptables implementation, if there is no external persistency system in the host, the added rules will be flushed upon nftables reload/restart or system reboot.

## Configuration options

There is no additionnal configuration option added as this implementation relies on the stateful active-response system.

## Logs/Alerts example

I used the example message provided in the [Wazuh documentation for implementing custom AR scripts](https://documentation.wazuh.com/current/user-manual/capabilities/active-response/custom-active-response-scripts.html). I made 3 tests cases, depending on the packages installed where I manually give sample JSON data to the stdin to the default-firewall-drop program.
As I'm compiling and not installing the wazuh shared module on my computer, I exported the LD_LIBRARY_PATH to allow dynamic links. Also, I set the lang to C because dpkg/strerror output would be in french otherwise.

### Both iptables and nftables installed

```
# export LD_LIBRARY_PATH="$PWD"; export LANG=C
# dpkg -l '??tables'
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version         Architecture Description
+++-==============-===============-============-==============================================================
un  ebtables       <none>          <none>       (no description available)
ii  iptables       1.8.9-2         amd64        administration tools for packet filtering and NAT
ii  nftables       1.0.6-2+deb12u2 amd64        Program to control packet filtering rules by Netfilter project
# truncate -s 0 logs/active-responses.log 
# ./default-firewall-drop 
{"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.0.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}
{"version":1,"origin":{"name":"default-firewall-drop","module":"active-response"},"command":"check_keys","parameters":{"keys":["192.168.0.223"]}}
{"version":1,"origin":{"name":"node01","module":"wazuh-execd"},"command":"continue","parameters":{}}
# iptables -vnL 
Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 DROP       0    --  *      *       192.168.0.223        0.0.0.0/0           

Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 DROP       0    --  *      *       192.168.0.223        0.0.0.0/0           

Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
# ./default-firewall-drop 
{"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"delete","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.0.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}
# iptables -vnL
Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         

Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         

Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
# cat logs/active-responses.log 
2024/02/08 00:15:45 ./default-firewall-drop: Starting
2024/02/08 00:15:50 ./default-firewall-drop: {"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.0.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}

2024/02/08 00:15:50 ./default-firewall-drop: {"version":1,"origin":{"name":"default-firewall-drop","module":"active-response"},"command":"check_keys","parameters":{"keys":["192.168.0.223"]}}
2024/02/08 00:15:54 ./default-firewall-drop: {"version":1,"origin":{"name":"node01","module":"wazuh-execd"},"command":"continue","parameters":{}}

2024/02/08 00:16:04 ./default-firewall-drop: Starting
2024/02/08 00:16:04 ./default-firewall-drop: {"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"delete","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.0.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}
```

### Only nftables is installed

```
# export LD_LIBRARY_PATH="$PWD"; export LANG=C
# dpkg -l '??tables'
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version         Architecture Description
+++-==============-===============-============-==============================================================
un  ebtables       <none>          <none>       (no description available)
un  iptables       <none>          <none>       (no description available)
ii  nftables       1.0.6-2+deb12u2 amd64        Program to control packet filtering rules by Netfilter project
# truncate -s 0 logs/active-responses.log 
# ./default-firewall-drop
{"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.0.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}
{"version":1,"origin":{"name":"default-firewall-drop","module":"active-response"},"command":"check_keys","parameters":{"keys":["192.168.0.223"]}}
{"version":1,"origin":{"name":"node01","module":"wazuh-execd"},"command":"continue","parameters":{}}
# cat logs/active-responses.log 
2024/02/08 00:11:41 ./default-firewall-drop: Starting
2024/02/08 00:11:46 ./default-firewall-drop: {"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.0.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}

2024/02/08 00:11:46 ./default-firewall-drop: {"version":1,"origin":{"name":"default-firewall-drop","module":"active-response"},"command":"check_keys","parameters":{"keys":["192.168.0.223"]}}
2024/02/08 00:11:50 ./default-firewall-drop: {"version":1,"origin":{"name":"node01","module":"wazuh-execd"},"command":"continue","parameters":{}}

# nft list ruleset
table inet wazuh-agent {
	chain input {
		type filter hook input priority filter; policy accept;
		ip saddr 192.168.0.223 drop
	}

	chain forward {
		type filter hook forward priority filter; policy accept;
		ip saddr 192.168.0.223 drop
	}
}
# ./default-firewall-drop
{"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"delete","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.0.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}
# nft list ruleset
table inet wazuh-agent {
	chain input {
		type filter hook input priority filter; policy accept;
	}

	chain forward {
		type filter hook forward priority filter; policy accept;
	}
}
# cat logs/active-responses.log 
2024/02/08 00:11:41 ./default-firewall-drop: Starting
2024/02/08 00:11:46 ./default-firewall-drop: {"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.0.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}

2024/02/08 00:11:46 ./default-firewall-drop: {"version":1,"origin":{"name":"default-firewall-drop","module":"active-response"},"command":"check_keys","parameters":{"keys":["192.168.0.223"]}}
2024/02/08 00:11:50 ./default-firewall-drop: {"version":1,"origin":{"name":"node01","module":"wazuh-execd"},"command":"continue","parameters":{}}

2024/02/08 00:12:13 ./default-firewall-drop: Starting
2024/02/08 00:12:22 ./default-firewall-drop: {"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"delete","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.0.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}
```

# Neither iptables or nftables installed

This one is just here to show the new log line when no binary is found.

```
# export LD_LIBRARY_PATH="$PWD"; export LANG=C
# dpkg -l '??tables'
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version         Architecture Description
+++-==============-===============-============-==============================================================
un  ebtables       <none>          <none>       (no description available)
un  iptables       <none>          <none>       (no description available)
rc  nftables       1.0.6-2+deb12u2 amd64        Program to control packet filtering rules by Netfilter project
# truncate -s 0 logs/active-responses.log 
# ./default-firewall-drop 
{"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.0.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}
{"version":1,"origin":{"name":"default-firewall-drop","module":"active-response"},"command":"check_keys","parameters":{"keys":["192.168.0.223"]}}
{"version":1,"origin":{"name":"node01","module":"wazuh-execd"},"command":"continue","parameters":{}}
# cat logs/active-responses.log 
2024/02/08 00:14:08 ./default-firewall-drop: Starting
2024/02/08 00:14:20 ./default-firewall-drop: {"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.0.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}

2024/02/08 00:14:20 ./default-firewall-drop: {"version":1,"origin":{"name":"default-firewall-drop","module":"active-response"},"command":"check_keys","parameters":{"keys":["192.168.0.223"]}}
2024/02/08 00:14:26 ./default-firewall-drop: {"version":1,"origin":{"name":"node01","module":"wazuh-execd"},"command":"continue","parameters":{}}

2024/02/08 00:14:26 ./default-firewall-drop: Cannot find the iptables file 'iptables': No such file or directory (2) nor the nftables file 'nft': No such file or directory (2)
# 
```

## Tests

As I'm not familiar with Wazuh releasing/development process, I can only provide the following data :

### Compilation warnings

There are no compilation warnings reported by the make target `default-firewall-drop` :

```
$ make default-firewall-drop 
Makefile:2588: warning: overriding recipe for target 'win32/ui_resource.o'
Makefile:2528: warning: ignoring old recipe for target 'win32/ui_resource.o'
Makefile:2591: warning: overriding recipe for target 'win32/auth_resource.o'
Makefile:2531: warning: ignoring old recipe for target 'win32/auth_resource.o'
    CC active-response/active_responses.o
    CC default-firewall-drop
```

### AddressSanitizer

The ASAN tests reported a previous memory leak existing prior the nftables implementation.
I fixed it in , when sending the control message with the keys, a call to strdup was not freed : 

```
=================================================================
==15123==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 14 byte(s) in 1 object(s) allocated from:
    #0 0x7f744a07077b in __interceptor_strdup ../../../../src/libsanitizer/asan/asan_interceptors.cpp:439
    #1 0x561b5fca6495  (/home/<redacted>/CLionProjects/wazuh/src/default-firewall-drop+0x2495)

SUMMARY: AddressSanitizer: 14 byte(s) leaked in 1 allocation(s).
```

### Valgrind full check

```
# valgrind --leak-check=full ./default-firewall-drop < <(echo '{"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.123.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}'; sleep 2s; echo '{"version":1,"origin":{"name":"node01","module":"wazuh-execd"},"command":"continue","parameters":{}}')
==16185== Memcheck, a memory error detector
==16185== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==16185== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==16185== Command: ./default-firewall-drop
==16185== 
==16185==ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.
==16185== 
==16185== HEAP SUMMARY:
==16185==     in use at exit: 0 bytes in 0 blocks
==16185==   total heap usage: 0 allocs, 0 frees, 0 bytes allocated
==16185== 
==16185== All heap blocks were freed -- no leaks are possible
==16185== 
==16185== For lists of detected and suppressed errors, rerun with: -s
==16185== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Seems ok on the valgrind side !

### Dr. Memory

The Dr Memory report is kinda weird, it reports unitialized reads... within Dr Memory binaries !? 

```
# drmemory -- ./default-firewall-drop < <(echo '{"version":1,"origin":{"name":"worker01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"timestamp":"2021-02-01T20:58:44.830+0000","rule":{"level":15,"description":"Shellshock attack detected","id":"31168","mitre":{"id":["T1068","T1190"],"tactic":["Privilege Escalation","Initial Access"],"technique":["Exploitation for Privilege Escalation","Exploit Public-Facing Application"]},"info":"CVE-2014-6271https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271","firedtimes":2,"mail":true,"groups":["web","accesslog","attack"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh-server"},"manager":{"name":"wazuh-server"},"id":"1612213124.6448363","full_log":"192.168.0.223 - - [01/Feb/2021:20:58:43 +0000] \"GET / HTTP/1.1\" 200 612 \"-\" \"() { :; }; /bin/cat /etc/passwd\"","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.123.223","id":"200","url":"/"},"location":"/var/log/nginx/access.log"},"program":"/var/ossec/active-response/bin/firewall-drop"}}'; sleep 2s; echo '{"version":1,"origin":{"name":"node01","module":"wazuh-execd"},"command":"continue","parameters":{}}')
~~Dr.M~~ Dr. Memory version 2.6.0
{"version":1,"origin":{"name":"default-firewall-drop","module":"active-response"},"command":"check_keys","parameters":{"keys":["192.168.123.223"]}}
~~Dr.M~~ 
~~Dr.M~~ Error #1: UNINITIALIZED READ: reading register al
~~Dr.M~~ # 0 replace_strcmp               [/home/runner/work/drmemory/drmemory/drmemory/replace.c:493]
~~Dr.M~~ # 1 main                 
~~Dr.M~~ Note: @0:00:02.012 in thread 204748
~~Dr.M~~ Note: instruction: test   %al %al
~~Dr.M~~ 
~~Dr.M~~ Error #2: UNINITIALIZED READ: reading register al
~~Dr.M~~ # 0 replace_strcmp               [/home/runner/work/drmemory/drmemory/drmemory/replace.c:495]
~~Dr.M~~ # 1 main                 
~~Dr.M~~ Note: @0:00:02.012 in thread 204748
~~Dr.M~~ Note: instruction: cmp    %dl %al
~~Dr.M~~ 
~~Dr.M~~ Error #3: UNINITIALIZED READ: reading register al
~~Dr.M~~ # 0 replace_strcmp               [/home/runner/work/drmemory/drmemory/drmemory/replace.c:497]
~~Dr.M~~ # 1 main                 
~~Dr.M~~ Note: @0:00:02.012 in thread 204748
~~Dr.M~~ Note: instruction: cmp    %dl %al
~~Dr.M~~ 
~~Dr.M~~ Error #4: UNINITIALIZED READ: reading register al
~~Dr.M~~ # 0 replace_strcmp               [/home/runner/work/drmemory/drmemory/drmemory/replace.c:489]
~~Dr.M~~ # 1 main                 
~~Dr.M~~ Note: @0:00:02.012 in thread 204748
~~Dr.M~~ Note: instruction: test   %al %al
~~Dr.M~~ 
~~Dr.M~~ ERRORS FOUND:
~~Dr.M~~       0 unique,     0 total unaddressable access(es)
~~Dr.M~~       4 unique,    16 total uninitialized access(es)
~~Dr.M~~       0 unique,     0 total invalid heap argument(s)
~~Dr.M~~       0 unique,     0 total warning(s)
~~Dr.M~~       0 unique,     0 total,      0 byte(s) of leak(s)
~~Dr.M~~       0 unique,     0 total,      0 byte(s) of possible leak(s)
~~Dr.M~~ ERRORS IGNORED:
~~Dr.M~~       6 unique,    11 total,   7096 byte(s) of still-reachable allocation(s)
~~Dr.M~~          (re-run with "-show_reachable" for details)
```

### Other tests

I'm not able to provide anything else, mainly because I don't know enough the Wazuh development guidelines and my C is too rusty for that. I think I provided enough elements for helping with this implementation. If I can do anything else, please tell. I wrote the nftables implementation earlier, I'm already using it in my environments but trying to write a better version can only help everyone, so I'm sharing it.

Regards,