### PR TITLE
Contribution : New case for ssh authentication attempt

### DIFF
--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -217,6 +217,17 @@
   <order>srcip</order>
 </decoder>
 
+<!-- connection closed sshd -->
+<!-- Feb  8 15:15:44 hostname sshd[3364]: Connection closed by authenticating user root 192.168.1.1 port 51992 [preauth] -->
+<!-- When a user is allowed to authenticate only with publickey but the client forces only password authentication -->
+<!-- this is the only log line that shows that someone attempted to login -->
+<decoder name="sshd-closed">
+  <parent>sshd</parent>
+  <prematch>^Connection closed by authenticating user \S+ \S+ port (\d+)</prematch>
+  <regex>authenticating user (\S+) (\S+) port (\d+)</regex>
+  <order>user, srcip, srcport</order>
+</decoder>
+
 <!-- connection reset -->
 <!-- 2020-03-25 08:23:20.933154-0700  localhost sshd[9265]: Connection reset by authenticating user user 192.168.33.1 port 51772 [preauth] -->
 <decoder name="sshd-reset">

--- a/ruleset/rules/0095-sshd_rules.xml
+++ b/ruleset/rules/0095-sshd_rules.xml
@@ -147,7 +147,7 @@
 
   <rule id="5716" level="5">
     <if_sid>5700</if_sid>
-    <match>^Failed|^error: PAM: Authentication</match>
+    <match>^Failed|^error: PAM: Authentication|Connection closed by authenticating user</match>
     <description>sshd: authentication failed.</description>
     <mitre>
       <id>T1110</id>
@@ -198,7 +198,7 @@
 
   <rule id="5722" level="0">
     <if_sid>5700</if_sid>
-    <match>Connection closed</match>
+    <match>Connection closed by \d+.\d+.\d+.\d+</match>
     <description>sshd: ssh connection closed.</description>
     <group>gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>


### PR DESCRIPTION
|contribution|
George Kissandrakis gkissand@gmail.com    
| |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

I updated a rule for sshd. 
The case is that if a user is allowed to authenticate only with PublicKey but a client forces only password authentication, login fails, is logged but not picked up by wazuh
I added a new decoder to pick up this log line
I added the case in rule 5716
I modified rule 5722 not to shadow that log line



## Configuration options

Allow only publickeyauthentication
/etc/ssh/sshd_config
PasswordAuthentication no
#PubkeyAuthentication yes (default)


Client command
attackerhost:~# ssh -v -o PubkeyAuthentication=no -o PreferredAuthentications=password  root@sshserver


## Logs/Alerts example

The only log line that is shown is this
Wazuh ignores it because it matches the rule 5722

Feb  8 15:15:44 hostname sshd[3364]: Connection closed by authenticating user root 192.168.1.1 port 51992 [preauth] 

## Tests

root@siem:/var/ossec/etc/rules# /var/ossec/bin/wazuh-logtest
Starting wazuh-logtest v4.7.2
Type one log per line

Feb  8 13:13:15 sshserver sshd[181717]: Connection closed by authenticating user root 192.168.1.1 port 33442 [preauth]

**Phase 1: Completed pre-decoding.
        full event: 'Feb  8 13:13:15 sshserver sshd[181717]: Connection closed by authenticating user root 192.168.1.1 port 33442 [preauth]'
        timestamp: 'Feb  8 13:13:15'
        hostname: 'sshserver'
        program_name: 'sshd'

**Phase 2: Completed decoding.
        name: 'sshd'
        parent: 'sshd'
        dstuser: 'root'
        srcip: '192.168.1.1'
        srcport: '33442'

**Phase 3: Completed filtering (rules).
        id: '5716'
        level: '5'
        description: 'sshd: authentication failed.'
        groups: '['syslog', 'sshd', 'authentication_failed']'
        firedtimes: '1'
        gdpr: '['IV_35.7.d', 'IV_32.2']'
        gpg13: '['7.1']'
        hipaa: '['164.312.b']'
        mail: 'False'
        mitre.id: '['T1110']'
        mitre.tactic: '['Credential Access']'
        mitre.technique: '['Brute Force']'
        nist_800_53: '['AU.14', 'AC.7']'
        pci_dss: '['10.2.4', '10.2.5']'
        tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']'
**Alert to be generated.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors