### PR TITLE
Fix RocksDBWrapper unit test

### DIFF
--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -311,9 +311,11 @@ namespace Utils
          */
         RocksDBIterator begin(const std::string& columnName = "")
         {
-            return RocksDBIterator {std::shared_ptr<rocksdb::Iterator>(
-                                        m_db->NewIterator(rocksdb::ReadOptions(), getColumnFamilyHandle(columnName))),
-                                    ""};
+            RocksDBIterator rocksDBIterator(std::shared_ptr<rocksdb::Iterator>(m_db->NewIterator(
+                                                rocksdb::ReadOptions(), getColumnFamilyHandle(columnName))),
+                                            "");
+            rocksDBIterator.begin();
+            return rocksDBIterator;
         }
 
         /**

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -21,6 +21,7 @@
 #include <rocksdb/utilities/transaction_db.h>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace Utils
@@ -41,7 +42,7 @@ namespace Utils
         virtual void deleteAll() = 0;
         virtual void flush() = 0;
         virtual std::vector<std::string> getAllColumns() = 0;
-        virtual RocksDBIterator seek(std::string_view key, const std::string& columnName = "") = 0;
+        virtual RocksDBIterator seek(std::string_view key, const std::string& columnName = "") = 0; // NOLINT
 
         virtual ~IRocksDBWrapper() = default;
     };
@@ -53,9 +54,9 @@ namespace Utils
     class RocksDBWrapper : public IRocksDBWrapper
     {
     public:
-        explicit RocksDBWrapper(const std::string& dbPath, const bool enableWal = true)
+        explicit RocksDBWrapper(std::string dbPath, const bool enableWal = true)
             : m_enableWal {enableWal}
-            , m_path {dbPath}
+            , m_path {std::move(dbPath)}
         {
             rocksdb::Options options;
             options.create_if_missing = true;
@@ -298,7 +299,7 @@ namespace Utils
          * @param key Key to seek.
          * @return RocksDBIterator Iterator to the database.
          */
-        RocksDBIterator seek(std::string_view key, const std::string& columnName = "") override
+        RocksDBIterator seek(std::string_view key, const std::string& columnName = "") override // NOLINT
         {
             return {std::shared_ptr<rocksdb::Iterator>(
                         m_db->NewIterator(rocksdb::ReadOptions(), getColumnFamilyHandle(columnName))),
@@ -443,7 +444,7 @@ namespace Utils
          *
          * @return std::vector<std::string>
          */
-        std::vector<std::string> getAllColumns()
+        std::vector<std::string> getAllColumns() override
         {
             std::vector<std::string> columnsNames;
             rocksdb::Options options;
@@ -740,7 +741,7 @@ namespace Utils
          * @param columnName Column family name.
          * @return RocksDBIterator  RocksDBIterator Iterator to the database.
          */
-        RocksDBIterator seek(std::string_view key, const std::string& columnName = "") override
+        RocksDBIterator seek(std::string_view key, const std::string& columnName = "") override // NOLINT
         {
             return m_dbWrapper->seek(key, columnName);
         }


### PR DESCRIPTION
|Related issue|
|---|
| #21831 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The problem arises in this [pull request](https://github.com/wazuh/wazuh/pull/21410), specifically in [this line](https://github.com/wazuh/wazuh/pull/21410/files#diff-6ec6148de6bf42ea659dbfd2828086193f35fae9fcf36692ce6da6e7c59c813aR316), where the current modification does not place the iterator in the desired position, as was previously done.

To maintain the original functionality of the iteration capability of the "RocksDBWrapper" object, the necessary logic has been added to position the iterator at the provided "prefix".

Since this functional change involves the creation of an iterator with "prefix", it is critical that @pereyra-m explain the need and purpose behind this change. In addition, it would be beneficial if you could help us understand if this addition of positioning the iterator in the "prefix" may have unidentified implications or potential problems.

## Tests

```cmd
damangold@damangold:~/Wazuh/dev/wazuh/src$ ctest -j1 --test-dir build --output-on-failure
Internal ctest changing into directory: /home/damangold/Wazuh/dev/wazuh/src/build
Test project /home/damangold/Wazuh/dev/wazuh/src/build
      Start  1: utils_unit_test
 1/11 Test  #1: utils_unit_test .........................   Passed   35.38 sec
      Start  2: utils_benchmark_test
 2/11 Test  #2: utils_benchmark_test ....................   Passed    7.10 sec

```

![image](https://github.com/wazuh/wazuh/assets/106940255/7d201dce-5965-40f8-b9d5-e7d1ff50d070)

```cmd
damangold@damangold:~/Wazuh/dev/wazuh/src$ git st
On branch dev-21831-fix-rocksDBwrapper-unit-test
Your branch is up to date with 'origin/dev-21831-fix-rocksDBwrapper-unit-test'.

nothing added to commit but untracked files present (use "git add" to track)
damangold@damangold:~/Wazuh/dev/wazuh/src$ ctest -j1 --test-dir build --output-on-failure
Internal ctest changing into directory: /home/damangold/Wazuh/dev/wazuh/src/build
Test project /home/damangold/Wazuh/dev/wazuh/src/build
      Start  1: utils_unit_test
 1/11 Test  #1: utils_unit_test .........................   Passed   40.87 sec
      Start  2: utils_benchmark_test
 2/11 Test  #2: utils_benchmark_test ....................   Passed    4.47 sec
      Start  3: router_component_tests
 3/11 Test  #3: router_component_tests ..................   Passed    0.01 sec
      Start  4: router_unit_tests
 4/11 Test  #4: router_unit_tests .......................   Passed    0.00 sec
      Start  5: content_manager_component_tests
 5/11 Test  #5: content_manager_component_tests .........   Passed   25.95 sec
      Start  6: content_manager_unit_tests
 6/11 Test  #6: content_manager_unit_tests ..............   Passed    9.00 sec
      Start  7: indexer_connector_unit_tests
 7/11 Test  #7: indexer_connector_unit_tests ............   Passed   50.04 sec
      Start  8: indexer_connector_component_tests
 8/11 Test  #8: indexer_connector_component_tests .......   Passed  101.81 sec
      Start  9: vulnerability_scanner_unit_tests
 9/11 Test  #9: vulnerability_scanner_unit_tests ........   Passed   61.18 sec
      Start 10: vulnerability_scanner_component_tests
10/11 Test #10: vulnerability_scanner_component_tests ...   Passed    0.06 sec
      Start 11: vulnerability_scanner_benchmark_tests
11/11 Test #11: vulnerability_scanner_benchmark_tests ...   Passed    2.69 sec

100% tests passed, 0 tests failed out of 11

Total Test time (real) = 296.07 sec
```
