### PR TITLE
Upgrade Cryptography from `41.0.7` to `42.0.2`

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.1
+aiohttp==3.9.3
 aiohttp-cache==2.2.0
 aiohttp-cors==0.7.0
 aiohttp-jinja2==1.5.1
@@ -20,7 +20,7 @@ charset-normalizer==2.0.4
 click==8.1.3
 clickclick==20.10.2
 connexion==2.14.2
-cryptography==41.0.7
+cryptography==42.0.2
 Cython==0.29.21
 defusedxml==0.6.0
 docker==6.0.0


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/21844|


## Description

Upgrade Cryptography from `41.0.7` to `42.0.2`.
