### PR TITLE
Change max `iam_role_duration` aws

### DIFF
--- a/wodles/aws/aws_tools.py
+++ b/wodles/aws/aws_tools.py
@@ -209,8 +209,8 @@ def arg_valid_iam_role_duration(arg_string):
 
     # Convert to integer and check range
     num_seconds = int(arg_string)
-    if not (900 <= num_seconds <= 3600):
-        raise argparse.ArgumentTypeError("Invalid session duration specified. Value must be between 900 and 3600.")
+    if not (900 <= num_seconds <= 43200):
+        raise argparse.ArgumentTypeError("Invalid session duration specified. Value must be between 900 and 43200.")
 
     return num_seconds
 

--- a/wodles/aws/tests/test_tools.py
+++ b/wodles/aws/tests/test_tools.py
@@ -126,7 +126,7 @@ def test_arg_valid_regions_raises_exception_when_invalid_region_provided():
         aws_tools.arg_valid_regions('invalid-region')
 
 
-@pytest.mark.parametrize('arg_string', ["900", "3600"])
+@pytest.mark.parametrize('arg_string', ["900", "43200"])
 def test_arg_valid_iam_role_duration(arg_string: str):
     """Test 'arg_valid_iam_role_duration' function returns the expected duration.
 
@@ -148,7 +148,7 @@ def test_arg_valid_bucket_name_raises_exception_when_invalid_bucket_name_provide
         aws_tools.arg_valid_bucket_name('--ol-s3-invalid')
 
 
-@pytest.mark.parametrize('arg_string', ["899", "3601"])
+@pytest.mark.parametrize('arg_string', ["899", "43201"])
 def test_arg_valid_iam_role_duration_raises_exception_when_invalid_duration_provided(arg_string):
     """Test 'arg_valid_iam_role_duration' function raises an 'ArgumentTypeError' error
     when the duration is not between 15m and 12h.


### PR DESCRIPTION
|Related issue|
|---|
| #21689  |

## Description

- The maximum time of `iam_role_duration` was modified, increasing its maximum range to 12 hours (43200s).

- The related documentation was also modified accordingly by updating the value


## Logs/Alerts example

After making the changes, the functionality of `iam_role_duration` was tested.

It was manually verified by adding `-rd 900` for testing purposes:

```console
root@wazuh-master:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 --subscriber security_lake --queue AmazonSecurityLake-f38b8aff-fec5-4705-a05a-3d62abdfc439-Main-Queue --external_id wazuh-external-id -rd 900 --iam_role_arn arn:aws:iam::xxxxxxx:role/AmazonSecurityLake-f38b8aff-fec5-4705-a05a-3d62abdfc439 --debug 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'default' configuration
DEBUG: The SQS queue is: https://queue.amazonaws.com/567970947422/AmazonSecurityLake-f38b8aff-fec5-4705-a05a-3d62abdfc439-Main-Queue
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'default' configuration
DEBUG: Retrieving messages from: AmazonSecurityLake-f38b8aff-fec5-4705-a05a-3d62abdfc439-Main-Queue
DEBUG: The message is: {'source': 'aws.s3', 'time': '2024-02-08T04:23:14Z', 'account': 'xxxxxxxxxxxx', 'region': 'us-east-1', 'resources': ['arn:aws:s3:::aws-security-data-lake-us-east-1-gbxqoxxxxxx'], 'detail': {'bucket': {'name': 'aws-security-data-lake-us-east-1-gbxqofxxxrxxxx'}, 'object': {'key': 'aws/S3_DATA/1.0/region=us-east-1/accountId=xxxxxxxxxxxx/eventDay=20240208/eaxxxxxxxx.gz.parquet', 'size': 20717, 'etag': '1096cxxxxxxxx'}, 'request-id': '02XW3FWKF13F3AXR', 'requester': 'securitylake.amazonaws.com'}}
DEBUG: Processing file aws/S3_DATA/1.0/region=us-east-1/accountId=6xxxxxxxx/eventDay=20240209/6axxxxxxxxxxxxxx.gz.parquet in aws-security-data-lake-us-east-1-gxxxxxxx
DEBUG: Found 20 events in file aws/S3_DATA/1.0/region=us-east-1/accountId=6xxxxxxxxxx/eventDay=20240209/6axxxxx7xxxxxxxx.gz.parquet
DEBUG: 20 events sent to Analysisd
DEBUG: ERROR: Error deleting message from SQS: An error occurred (ExpiredToken) when calling the DeleteMessage operation: The security token included in the request is expired
```
The following error message indicates that the `token` expired after `900` seconds, which confirms its proper functioning:

```console
DEBUG: ERROR: Error deleting message from SQS: An error occurred (ExpiredToken) when calling the DeleteMessage operation: The security token included in the request is expired
```


## Tests

**The unit tests related were modified and run**

<details>

<summary>Unit_test_aws </summary>

```console
(unittest-env) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest wodles/aws/tests/
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0
rootdir: /home/wazuh/Git/wazuh/wodles/aws/tests
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.8.0, html-2.1.1, metadata-3.1.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 641 items                                                                                                                                                                                        

wodles/aws/tests/test_aws_bucket.py ................................................................................................................................................................ [ 24%]
.................................................                                                                                                                                                    [ 32%]
wodles/aws/tests/test_aws_s3.py ....................                                                                                                                                                 [ 35%]
wodles/aws/tests/test_aws_service.py ....                                                                                                                                                            [ 36%]
wodles/aws/tests/test_cloudtrail.py ..                                                                                                                                                               [ 36%]
wodles/aws/tests/test_cloudwatchlogs.py .....................................................                                                                                                        [ 44%]
wodles/aws/tests/test_config.py ..............................................................................                                                                                       [ 57%]
wodles/aws/tests/test_guardduty.py .................                                                                                                                                                 [ 59%]
wodles/aws/tests/test_inspector.py ......                                                                                                                                                            [ 60%]
wodles/aws/tests/test_load_balancers.py ............                                                                                                                                                 [ 62%]
wodles/aws/tests/test_s3_log_handler.py ................                                                                                                                                             [ 65%]
wodles/aws/tests/test_server_access.py .................................                                                                                                                             [ 70%]
wodles/aws/tests/test_sqs_message_processor.py ........                                                                                                                                              [ 71%]
wodles/aws/tests/test_sqs_queue.py .......                                                                                                                                                           [ 72%]
wodles/aws/tests/test_tools.py ..................................                                                                                                                                    [ 77%]
wodles/aws/tests/test_umbrella.py ......                                                                                                                                                             [ 78%]
wodles/aws/tests/test_vpcflow.py ...........................                                                                                                                                         [ 82%]
wodles/aws/tests/test_waf.py .......                                                                                                                                                                 [ 84%]
wodles/aws/tests/test_wazuh_integration.py ......................................................................................................                                                    [100%]

=========================================================================================== 641 passed in 2.73s ============================================================================================
```
</details>

