### PR TITLE
Fixed hexa decode helper and added router's callback execution safeguard

### DIFF
--- a/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.cpp
+++ b/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.cpp
@@ -748,7 +748,8 @@ MapOp opBuilderHelperStringFromHexa(const std::vector<OpArg>& opArgs, const std:
     const std::string failureTrace2 {fmt::format(TRACE_REFERENCE_TYPE_IS_NOT, "array", traceName, hexRef.dotPath())};
     const std::string failureTrace3 {
         fmt::format("[{}] -> Failure: Hexa string has not an even quantity of digits", traceName)};
-    const std::string failureTrace4 {fmt::format("[{}] -> Failure: ", traceName)};
+    const std::string failureTrace4 {fmt::format("{} -> Failure: ", traceName)};
+    const auto failureTrace5 = fmt::format("{} -> Found non ascii character", traceName);
 
     // Return Op
     return [=, runState = buildCtx->runState(), sourceField = hexRef.jsonPath()](base::ConstEvent event) -> MapResult
@@ -791,6 +792,11 @@ MapOp opBuilderHelperStringFromHexa(const std::vector<OpArg>& opArgs, const std:
                 RETURN_FAILURE(runState,
                                json::Json {},
                                failureTrace4 + fmt::format("Character '{}' is not a valid hexa digit", err));
+            }
+
+            if (chr < 0 || chr > 127)
+            {
+                RETURN_FAILURE(runState, json::Json {}, failureTrace5);
             }
 
             strASCII[iASCII] = chr;

--- a/src/engine/source/builder/test/src/unit/builders/opmap/strTransform_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opmap/strTransform_test.cpp
@@ -341,6 +341,7 @@ INSTANTIATE_TEST_SUITE_P(
              {makeRef("ref")},
              FAILURE(customRefExpected())),
         MapT(R"({"ref": null})", opBuilderHelperStringFromHexa, {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapT(R"({"ref": "FF"})", opBuilderHelperStringFromHexa, {makeRef("ref")}, FAILURE(customRefExpected())),
         /*** Hex to Number*/
         MapT(R"({"ref": "48656C"})",
              opBuilderHelperHexToNumber,

--- a/src/engine/source/router/src/worker.cpp
+++ b/src/engine/source/router/src/worker.cpp
@@ -26,7 +26,14 @@ void Worker::start()
                 {
                     auto& [event, opt, callback] = *testEvent;
                     auto output = m_tester->ingestTest(std::move(event), opt);
-                    callback(std::move(output));
+                    try
+                    {
+                        callback(std::move(output));
+                    }
+                    catch (const std::exception& e)
+                    {
+                        LOG_ERROR("Error when executing API callback: ", e.what());
+                    }
                 }
 
                 // Process production queue


### PR DESCRIPTION
This PR fixes:
- The decode hexa helper to ensure only valid ASCII characters are decoded, failing otherwise.
- Adds safeguard exception handling to the API tester callback execution inside the worker threads.