### PR TITLE
Add `--build-managers-only` parameter in conftest.py

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -96,7 +96,7 @@ def build_and_up(env_mode: str, interval: int = 10, interval_build_env: int = 10
     build : bool
         Flag to indicate if images need to be built.
     build_managers_only : bool
-        Flag to indicate if only the managers image needs to be built.
+        Whether to build only the manager images.
 
     Returns
     -------
@@ -126,11 +126,10 @@ def build_and_up(env_mode: str, interval: int = 10, interval_build_env: int = 10
                     "--no-cache"],
                     stdout=f_docker, stderr=subprocess.STDOUT, universal_newlines=True)
                 current_process.wait()
-            if build_managers_only:
-                current_process = subprocess.Popen(["docker", "compose", "--profile", env_mode,
-                    "build", "wazuh-master", "wazuh-worker1", "wazuh-worker2",
-                    "--build-arg", f"WAZUH_BRANCH={current_branch}", "--build-arg",
-                    f"ENV_MODE={env_mode}"],
+            if build and build_managers_only:
+                current_process = subprocess.Popen(["docker", "compose","build",
+                    "--profile", "managers", "--build-arg", f"WAZUH_BRANCH={current_branch}",
+                    "--build-arg", f"ENV_MODE={env_mode}"],
                     stdout=f_docker, stderr=subprocess.STDOUT, universal_newlines=True)
                 current_process.wait()
             current_process = subprocess.Popen(

--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -127,7 +127,7 @@ def build_and_up(env_mode: str, interval: int = 10, interval_build_env: int = 10
                     stdout=f_docker, stderr=subprocess.STDOUT, universal_newlines=True)
                 current_process.wait()
             if build and build_managers_only:
-                current_process = subprocess.Popen(["docker", "compose","build",
+                current_process = subprocess.Popen(["docker", "compose", "build",
                     "--profile", "managers", "--build-arg", f"WAZUH_BRANCH={current_branch}",
                     "--build-arg", f"ENV_MODE={env_mode}"],
                     stdout=f_docker, stderr=subprocess.STDOUT, universal_newlines=True)

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     profiles:
       - standalone
       - cluster
+      - managers
     build:
       context: .
       dockerfile: base/manager/manager.Dockerfile
@@ -25,6 +26,7 @@ services:
   wazuh-worker1:
     profiles:
       - cluster
+      - managers
     build:
       context: .
       dockerfile: base/manager/manager.Dockerfile
@@ -42,6 +44,7 @@ services:
   wazuh-worker2:
     profiles:
       - cluster
+      - managers
     build:
       context: .
       dockerfile: base/manager/manager.Dockerfile


### PR DESCRIPTION
|Related issue|
|---|
| #21775  |



## Description

The parameter `--build-managers-only` was added so that once the test environment of the AITs is up, only the manager images are recreated



## Tests

When launching the test with the new parameter, it is verified that the image of the managers `integration_test_wazuh-manager` is recreated:

```console
wazuh@javier:~$ docker images
REPOSITORY                         TAG       IMAGE ID       CREATED          SIZE
integration_test_wazuh-manager     latest    f214e48a25ad   19 seconds ago   2.37GB
integration_test_wazuh-agent_old   latest    bc81a5d9ef9e   33 minutes ago   160MB
integration_test_wazuh-agent       latest    a46e49a2ee90   33 minutes ago   1.29GB
integration_test_nginx-lb          latest    f575d76dfc0a   35 minutes ago   187MB
```
  
```console
(api-it) wazuh@javier:~/Git/wazuh/api/test/integration$ pytest -vv test_active_response_endpoints.tavern.yaml --build-managers-only
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.2.0 -- /home/wazuh/venv/api-it/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-37-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'metadata': '3.0.0', 'aiohttp': '1.0.4', 'html': '2.1.1', 'trio': '0.7.0', 'asyncio': '0.18.1', 'tavern': '1.23.5'}}
rootdir: /home/wazuh/Git/wazuh/api/test/integration
configfile: pytest.ini
plugins: metadata-3.0.0, aiohttp-1.0.4, html-2.1.1, trio-0.7.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 2 items                                                                                                                                                                                          

test_active_response_endpoints.tavern.yaml::PUT /active-response/{:agent_id} PASSED
test_active_response_endpoints.tavern.yaml::PUT /active-response PASSED

============================================================================================= warnings summary =============================================================================================
../../../../../venv/api-it/lib/python3.9/site-packages/_pytest/nodes.py:642
  /home/wazuh/venv/api-it/lib/python3.9/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= 2 passed, 1 warning in 89.03s (0:01:29) ==================================================================================
```