### PR TITLE
Verify last_update_check response conditionally

### DIFF
--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -511,8 +511,8 @@ def healthcheck_agent_restart(response, agents_list):
 
 
 def validate_update_check_response(response, current_version, update_check):
-    """Check that the update check response contains the fields expected and 
-    if the last_available_* dicts have the correct keys and values.
+    """Check that the update check response contains the expected fields, and verify if the 'last_available_*'
+    dictionaries have the correct keys and values.
 
     Parameters
     ----------

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -510,19 +510,35 @@ def healthcheck_agent_restart(response, agents_list):
     check_agent_active_status(agents_list)
 
 
-def validate_update_check_response(response):
-    """Check if the last_available_* dicts have the correct keys and values.
+def validate_update_check_response(response, current_version, update_check):
+    """Check that the update check response contains the fields expected and 
+    if the last_available_* dicts have the correct keys and values.
 
     Parameters
     ----------
     response : Request response
     """
+    error_code = response.json()['error']
+    if response.status_code == 500:
+        assert error_code == 2100
+        return
+
     available_update_keys = ["last_available_major", "last_available_minor", "last_available_patch"]
     keys_to_check = [
         ("tag", str), ("description", (str, type(None))), ("title", str), ("published_date", str), ("semver", dict)
     ]
 
     data = response.json()['data']
+
+    assert error_code == 0
+    assert data['current_version'] == current_version
+    assert data['update_check'] == update_check
+    last_check_date = data['last_check_date']
+    if update_check:
+        assert data['uuid'] is not None
+        assert last_check_date is not None
+    else:
+        assert last_check_date == ''
 
     for available_update in available_update_keys:
         available_update_data = data[available_update]

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1566,16 +1566,14 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          last_check_date: !anystr
+      status_code:
+        - 200
+        - 500
+      verify_response_with:
+        function: tavern_utils:validate_update_check_response
+        extra_kwargs:
           current_version: "v{wazuh_version:s}"
           update_check: true
-          uuid: !anystr
-      verify_response_with:
-        - function: tavern_utils:validate_update_check_response
 
   - name: Get available updates with force option
     request:
@@ -1587,16 +1585,14 @@ stages:
       params:
         force_query: "true"
     response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          last_check_date: !anystr
+      status_code:
+        - 200
+        - 500
+      verify_response_with:
+        function: tavern_utils:validate_update_check_response
+        extra_kwargs:
           current_version: "v{wazuh_version:s}"
           update_check: true
-          uuid: !anystr
-      verify_response_with:
-        - function: tavern_utils:validate_update_check_response
 
 
 ---
@@ -1665,14 +1661,11 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
-      json:
-        error: 0
-        data:
-          last_check_date: ''
+      verify_response_with:
+        function: tavern_utils:validate_update_check_response
+        extra_kwargs:
           current_version: "v{wazuh_version:s}"
           update_check: false
-      verify_response_with:
-        - function: tavern_utils:validate_update_check_response
 
   - name: Get available updates with force option
     request:
@@ -1685,14 +1678,11 @@ stages:
         force_query: "true"
     response:
       status_code: 200
-      json:
-        error: 0
-        data:
-          last_check_date: ''
+      verify_response_with:
+        function: tavern_utils:validate_update_check_response
+        extra_kwargs:
           current_version: "v{wazuh_version:s}"
           update_check: false
-      verify_response_with:
-        - function: tavern_utils:validate_update_check_response
 
   - name: Enable the update check
     request:


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/21822 |

## Description

Modifies the function used to validate last update check responses to consider failures because of the CTI service being unavailable for unreleased versions.

### Tests

> The check failed because https://github.com/wazuh/wazuh/issues/21743 is not fixed in 4.8.1 yet

<details><summary>test_manager_endpoints.tavern.yaml</summary>

> I had to make some modifications to make all stages run successfully but they are not related to the issue so I didn't include them.
>
> It's expected that the tests fail in the check.

```console
(venv10) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_manager_endpoints.tavern.yaml --nobuild
====================================================== test session starts =======================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-6.6.10-76060610-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'trio': '0.8.0', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.8.0, asyncio-0.18.1, tavern-1.23.5, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 35 items                                                                                                               

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                             [  2%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                               [  5%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                    [  8%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                      [ 11%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                   [ 14%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                   [ 17%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                   [ 20%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                    [ 22%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                 [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                   [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                    [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                 [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                   [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                       [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                  [ 42%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                              [ 45%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detection] PASSED                   [ 48%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[indexer] PASSED                                   [ 51%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                      [ 54%]
test_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                      [ 57%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                              [ 60%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                       [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                       [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                    [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                      [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                               [ 74%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                       [ 77%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                         [ 80%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                      [ 82%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                          [ 85%]
test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                      [ 88%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check PASSED                                                      [ 91%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check with update_check disabled PASSED                           [ 94%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check with update check service error PASSED                      [ 97%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                            [100%]

========================================= 35 passed, 36 warnings in 216.31s (0:03:36) ===========================================
```

</details>