### PR TITLE
Remove depecrated linker option on macOS 13 Ventura 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1870,7 +1870,7 @@ ifeq (${uname_S},Darwin)
 WAZUH_SHFLAGS=-install_name @rpath/libwazuhext.$(SHARED)
 
 $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
-	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $(WAZUH_SHFLAGS) -o $@ -Wl,-all_load $^ -Wl,-noall_load $(OSSEC_LIBS)
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $(WAZUH_SHFLAGS) -o $@ -Wl,-all_load $^ $(OSSEC_LIBS)
 else
 ifeq (${TARGET}, winagent)
 $(WAZUHEXT_LIB): $(WAZUHEXT_DLL) $(WAZUHEXT_LIB_DEF)
@@ -2102,7 +2102,7 @@ ifeq (${uname_S},Darwin)
 WAZUH_SHARED_SHFLAGS=-install_name @rpath/libwazuhshared.$(SHARED)
 
 $(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
-	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $(WAZUH_SHARED_SHFLAGS) -o $@ -Wl,-all_load $^ -Wl,-noall_load $(OSSEC_LIBS)
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $(WAZUH_SHARED_SHFLAGS) -o $@ -Wl,-all_load $^ $(OSSEC_LIBS)
 else
 ifeq (${TARGET}, winagent)
 $(WAZUH_DLL) $(WAZUH_DEF) : $(WAZUHEXT_DLL) $(AR_PROGRAMS_DEPS) win32/version-dll.o


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21830 |

## Description
The unknown parameter `-noall_load` reported in the MacOS 13 build (ventura) is a deprecated option even in previous versions (bigsur and moterrey).
While in previous versions quotes were reported as a warning.
![image](https://github.com/wazuh/wazuh/assets/93778492/bb882ef6-344e-44fe-8436-8d0f0808a55e)

In this case it has been completely eliminated and is treated as an error.
![image](https://github.com/wazuh/wazuh/assets/93778492/cd064881-4e3f-4306-bff8-04c37004294d)

This option has been removed in the creation of `Darwin` systems since it was not being considered anyway.
 
## Analisys
The removed option `-noall_load` is intended to prevent the selective incorporation of references to external objects.

But even in old versions, when this facility was incorporated, the strategy is not correct, since the `-all_load` option includes all objects and does not take into account those declared immediately after.

The correct option to selectively incorporate external objects is using the `-force_load` options next to each object that you want to add.

But unfortunately this option is not available in the repertoire available for `Darwin` systems in [gcc](https://gcc.gnu.org/onlinedocs/gcc-9.5.0/gcc/Darwin-Options.html#Darwin-Options).

I leave [here](https://pewpewthespells.com/blog/objc_linker_flags.html) a reference that explains the behavior of `-all_load` and `-force_load`

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [X] MAC OS X