### PR TITLE
Add array validation at indexer's configuration node

### DIFF
--- a/src/config/indexer-config.c
+++ b/src/config/indexer-config.c
@@ -59,7 +59,7 @@ int indexer_config_subnode_read(const OS_XML *xml, XML_NODE node, cJSON *output_
     size_t subnode_keypath_len;
 
     if (!node)
-        return OS_SUCCESS
+        return OS_SUCCESS;
 
     // Iterate over elements
     for (i = 0; node[i]; i++) {

--- a/src/config/indexer-config.c
+++ b/src/config/indexer-config.c
@@ -22,11 +22,23 @@ static const char * special_array_keys[] = {
     NULL
 };
 
+static const char * valid_paths[] = {
+    "indexer.enabled",
+    "indexer.hosts",
+    "indexer.ssl",
+    "indexer.ssl.certificate_authorities",
+    "indexer.ssl.certificate",
+    "indexer.ssl.key",
+    NULL
+};
+
 cJSON * indexer_config = NULL;
 
-bool indexer_config_is_special_array_key(const char * keypath)
+bool key_is_in_array(const char * keypath, const char ** psearch)
 {
-    const char ** psearch = special_array_keys;
+    if(!psearch)
+        return false;
+
     while(*psearch)
     {
         if(strcmp(keypath, *psearch) == 0)
@@ -67,7 +79,13 @@ int indexer_config_subnode_read(const OS_XML *xml, XML_NODE node, cJSON *output_
         os_calloc(1, subnode_keypath_len, subnode_keypath);
         snprintf(subnode_keypath, subnode_keypath_len, "%s.%s", current_keypath, node[i]->element);
 
-        if(indexer_config_is_special_array_key(subnode_keypath))
+       /* Unknown paths are ignored */
+        if(!key_is_in_array(subnode_keypath, valid_paths)){
+            mwarn(XML_INVELEM, subnode_keypath);
+            continue;
+        }
+
+        if(key_is_in_array(subnode_keypath, special_array_keys))
         {
             if(cJSON_GetObjectItem(output_json, node[i]->element))
             {

--- a/src/config/indexer-config.c
+++ b/src/config/indexer-config.c
@@ -103,6 +103,7 @@ int indexer_config_subnode_read(const OS_XML *xml, XML_NODE node, cJSON *output_
             if(cJSON_GetArraySize(subnode) <= 0){
                 merror("%s is empty in module 'indexer'. Check configuration", subnode_keypath);
                 os_free(subnode_keypath);
+                os_free(subnode);
                 return OS_MISVALUE;
             }
 

--- a/src/config/wmodules-vulnerability-detection.c
+++ b/src/config/wmodules-vulnerability-detection.c
@@ -18,6 +18,8 @@ static const char * valid_paths[] = {
     "enabled",
     "index-status",
     "feed-update-interval",
+    "offline-url",
+    "cti-url",
     NULL
 };
 

--- a/src/config/wmodules-vulnerability-detection.c
+++ b/src/config/wmodules-vulnerability-detection.c
@@ -50,8 +50,10 @@ void wm_vulnerability_detection_subnode_read(const OS_XML *xml, XML_NODE nodes, 
         /* Unknown paths are ignored */
         if(!key_is_in_array(subnode_keypath, valid_paths)){
             mwarn(XML_INVELEM, subnode_keypath);
+            free(subnode_keypath);
             continue;
         }
+        free(subnode_keypath);
 
         const bool config_enabled = (strcmp(nodes[i]->element, "enabled") == 0);
         if (old_vd && !config_enabled)

--- a/src/config/wmodules-vulnerability-detection.c
+++ b/src/config/wmodules-vulnerability-detection.c
@@ -14,6 +14,13 @@
 #include "wazuh_modules/wmodules.h"
 #include "config/global-config.h"
 
+static const char * valid_paths[] = {
+    "enabled",
+    "index-status",
+    "feed-update-interval",
+    NULL
+};
+
 /**
  * @brief Function used to read, recursively, the configuration related to vulnerability detection.
  *
@@ -27,6 +34,8 @@ void wm_vulnerability_detection_subnode_read(const OS_XML *xml, XML_NODE nodes, 
     cJSON * existing_item;
     cJSON * array_item;
     _Config global_config;
+    char * subnode_keypath;
+    size_t subnode_keypath_len;
     memset(&global_config, 0, sizeof(_Config));
 
     if (!nodes)
@@ -34,6 +43,15 @@ void wm_vulnerability_detection_subnode_read(const OS_XML *xml, XML_NODE nodes, 
 
     // Iterate over elements
     for (i = 0; nodes[i]; i++) {
+        subnode_keypath_len = strlen(nodes[i]->element) + 2;
+        os_calloc(1, subnode_keypath_len, subnode_keypath);
+        snprintf(subnode_keypath, subnode_keypath_len, "%s", nodes[i]->element);
+
+        /* Unknown paths are ignored */
+        if(!key_is_in_array(subnode_keypath, valid_paths)){
+            mwarn(XML_INVELEM, subnode_keypath);
+            continue;
+        }
 
         const bool config_enabled = (strcmp(nodes[i]->element, "enabled") == 0);
         if (old_vd && !config_enabled)

--- a/src/unit_tests/config/CMakeLists.txt
+++ b/src/unit_tests/config/CMakeLists.txt
@@ -34,7 +34,7 @@ list(APPEND config_flags "-Wl,--wrap,OS_GetHost -Wl,--wrap=Start_win32_Syscheck 
 
 if(${TARGET} STREQUAL "server")
     list(APPEND config_names "test_indexer")
-    list(APPEND config_flags " ")
+    list(APPEND config_flags "${DEBUG_OP_WRAPPERS}")
 endif()
 
 # Compiling tests

--- a/src/unit_tests/config/test_indexer.c
+++ b/src/unit_tests/config/test_indexer.c
@@ -150,6 +150,7 @@ void test_read_multiple_configuration(void **state) {
 void test_read_empty_configuration(void **state) {
     const char *string = "";
     test_structure *test = *state;
+    expect_string(__wrap__mdebug1, formatted_msg, "Empty configuration for module 'indexer'");
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
@@ -181,7 +182,7 @@ void test_read_empty_field_configuration(void **state) {
     cJSON_free(json_result);
 }
 
-void test_read_field_host_0_entries_configuration(void **state) {
+void test_read_field_host_0_entries_configuration_fail(void **state) {
     const char *string =
         "<enabled>yes</enabled>"
         "<hosts>"
@@ -196,10 +197,11 @@ void test_read_field_host_0_entries_configuration(void **state) {
         "</ssl>"
     ;
     test_structure *test = *state;
+    expect_string(__wrap__merror, formatted_msg, "indexer.hosts is empty in module 'indexer'. Check configuration");
     test->nodes = string_to_xml_node(string, &(test->xml));
-    assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
+    assert_int_equal(Read_Indexer(&(test->xml), test->nodes), OS_MISVALUE);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[],\"ssl\":{\"certificate_authorities\":[\"/var/ossec/\",\"/var/ossec_cert/\"],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\"}");
     cJSON_free(json_result);
 }
 
@@ -226,7 +228,7 @@ void test_read_field_host_1_entries_configuration(void **state) {
     cJSON_free(json_result);
 }
 
-void test_read_field_certificate_authorities_0_entries_configuration(void **state) {
+void test_read_field_certificate_authorities_0_entries_configuration_fail(void **state) {
     const char *string =
         "<enabled>yes</enabled>"
         "<hosts>"
@@ -241,10 +243,11 @@ void test_read_field_certificate_authorities_0_entries_configuration(void **stat
         "</ssl>"
     ;
     test_structure *test = *state;
+    expect_string(__wrap__merror, formatted_msg, "indexer.ssl.certificate_authorities is empty in module 'indexer'. Check configuration");
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(Read_Indexer(&(test->xml), test->nodes), 0);
     char * json_result = cJSON_PrintUnformatted(indexer_config);
-    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"ssl\":{\"certificate_authorities\":[],\"certificate\":\"cert\",\"key\":\"key_example\"}}");
+    assert_string_equal(json_result, "{\"enabled\":\"yes\",\"hosts\":[\"http://10.2.20.2:9200\",\"https://10.2.20.42:9200\"],\"ssl\":{}}");
     cJSON_free(json_result);
 }
 
@@ -278,9 +281,9 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_read_multiple_configuration, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_empty_configuration, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_empty_field_configuration, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_read_field_host_0_entries_configuration, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_field_host_0_entries_configuration_fail, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_field_host_1_entries_configuration, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_read_field_certificate_authorities_0_entries_configuration, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_field_certificate_authorities_0_entries_configuration_fail, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_field_certificate_authorities_1_entries_configuration, setup_test_read, teardown_test_read),
     };
     return cmocka_run_group_tests(tests_configuration, NULL, NULL);

--- a/src/unit_tests/wazuh_modules/vulnerability_detection/test_wm_vulnerability_detection.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detection/test_wm_vulnerability_detection.c
@@ -304,8 +304,8 @@ void test_read_old_vd_config(void **state) {
 void test_read_old_vd_config_with_ignored_keys(void **state) {
     const char *old_vd_config = 
         "<enabled>no</enabled>"
-        "<ignored_config>true</ignored_config>"
-        "<another_ignored_config>0</another_ignored_config>"
+        "<index-status>true</index-status>"
+        "feed-update-interval>0</feed-update-interval>"
     ;
     test_structure *test = *state;
     test->nodes = string_to_xml_node(old_vd_config, &(test->xml));

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -197,30 +197,6 @@ private:
     // LCOV_EXCL_STOP
 
     /**
-     * @brief Detects and warns about invalid or mispelled tags
-     *
-     * This function takes a JSON object and a list of valid tags paths as input, and then validates
-     * that all JSON objects are present in the valid tag list
-     *
-     * @param vdObj  A constant reference to a JSON object representing the vulnerability detection's configuration.
-     * @param vdTags A constant reference to a list of valid tags
-     */
-    void validateTags(const nlohmann::json& vdObj, const std::vector<std::string>& vdTags, std::string path) const
-    {
-        for (auto it = vdObj.begin(); it != vdObj.end(); ++it)
-        {
-            path += it.key();
-            validateTags(vdObj[it.key()], vdTags, path);
-            if (std::find(vdTags.begin(), vdTags.end(), it.key()) == vdTags.end())
-            {
-                logWarn(WM_VULNSCAN_LOGTAG,
-                        "Unkown tag '%s'. Check the configuration. This tag will be ignored",
-                        it.key().c_str());
-            }
-        }
-    }
-
-    /**
      * @brief Validates and configures the vulnerability detection based on the provided JSON object.
      *
      * This function takes a JSON object as input, which is expected to contain configuration
@@ -387,12 +363,6 @@ public:
         {
             // Validate vulnerability-detection configuration
             validateVulnerabilityDetectionConfiguration(configuration.at("vulnerability-detection"));
-
-            std::vector<std::string> validVulnerabilityDetectionTags = {
-                "enabled", "clusterName", "index-status", "feed-update-interval", "offline-url", "cti-url"};
-            validateTags(configuration.at("vulnerability-detection"),
-                         validVulnerabilityDetectionTags,
-                         "vulnerability-detection");
         }
         else
         {
@@ -403,12 +373,6 @@ public:
         if (configuration.contains("indexer"))
         {
             validateIndexerConfiguration(configuration);
-            std::vector<std::string> validVulnerabilityDetectionTags = {
-                "enabled",
-                "hosts",
-                "ssl",
-            };
-            validateTags(configuration.at("indexer"), validVulnerabilityDetectionTags, "indexer");
         }
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -198,21 +198,24 @@ private:
 
     /**
      * @brief Detects and warns about invalid or mispelled tags
-     * 
+     *
      * This function takes a JSON object and a list of valid tags paths as input, and then validates
      * that all JSON objects are present in the valid tag list
-     * 
+     *
      * @param vdObj  A constant reference to a JSON object representing the vulnerability detection's configuration.
-     * @param vdTags A constant reference to a list of valid tags 
-    */
-    void validateTags(const nlohmann::json& vdObj, std::vector<std::string>& vdTags, std::string path) const
+     * @param vdTags A constant reference to a list of valid tags
+     */
+    void validateTags(const nlohmann::json& vdObj, const std::vector<std::string>& vdTags, std::string path) const
     {
-        for(auto it = vdObj.begin(); it != vdObj.end(); ++it){
+        for (auto it = vdObj.begin(); it != vdObj.end(); ++it)
+        {
             path += it.key();
             validateTags(vdObj[it.key()], vdTags, path);
             if (std::find(vdTags.begin(), vdTags.end(), it.key()) == vdTags.end())
             {
-                logWarn(WM_VULNSCAN_LOGTAG, "Unkown tag '%s'. Check the configuration. This tag will be ignored", it.key().c_str());
+                logWarn(WM_VULNSCAN_LOGTAG,
+                        "Unkown tag '%s'. Check the configuration. This tag will be ignored",
+                        it.key().c_str());
             }
         }
     }
@@ -381,19 +384,15 @@ public:
     {
         // If the configuration is empty, throw an exception.
         if (configuration.contains("vulnerability-detection"))
-        {        
+        {
             // Validate vulnerability-detection configuration
             validateVulnerabilityDetectionConfiguration(configuration.at("vulnerability-detection"));
 
             std::vector<std::string> validVulnerabilityDetectionTags = {
-                "enabled",
-                "clusterName",
-                "index-status",
-                "feed-update-interval",
-                "offline-url",
-                "cti-url"
-            };
-            validateTags(configuration.at("vulnerability-detection"), validVulnerabilityDetectionTags, "vulnerability-detection");
+                "enabled", "clusterName", "index-status", "feed-update-interval", "offline-url", "cti-url"};
+            validateTags(configuration.at("vulnerability-detection"),
+                         validVulnerabilityDetectionTags,
+                         "vulnerability-detection");
         }
         else
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -197,6 +197,25 @@ private:
     // LCOV_EXCL_STOP
 
     /**
+     * @brief Detects and warns about invalid or mispelled tags
+     * 
+     * This function takes a JSON object and a list of valid tags paths as input, and then validates
+     * that all JSON objects are present in the valid tag list
+     * 
+     * @param vdObj  A constant reference to a JSON object representing the vulnerability detection's configuration.
+     * @param vdTags A constant reference to a list of valid tags 
+    */
+    void validateTags(const nlohmann::json& vdObj, std::vector<std::string>& vdTags) const
+    {
+        for(auto it = vdObj.begin(); it != vdObj.end(); ++it){
+            if (std::find(vdTags.begin(), vdTags.end(), it.key()) == vdTags.end())
+            {
+                logWarn(WM_VULNSCAN_LOGTAG, "Unkown tag '%s'. Check the configuration. This tag will be ignored", it.key().c_str());
+            }
+        }
+    }
+
+    /**
      * @brief Validates and configures the vulnerability detection based on the provided JSON object.
      *
      * This function takes a JSON object as input, which is expected to contain configuration
@@ -360,9 +379,19 @@ public:
     {
         // If the configuration is empty, throw an exception.
         if (configuration.contains("vulnerability-detection"))
-        {
+        {        
             // Validate vulnerability-detection configuration
             validateVulnerabilityDetectionConfiguration(configuration.at("vulnerability-detection"));
+
+            std::vector<std::string> validVulnerabilityDetectionTags = {
+                "enabled",
+                "clusterName",
+                "index-status",
+                "feed-update-interval",
+                "offline-url",
+                "cti-url"
+            };
+            validateTags(configuration.at("vulnerability-detection"), validVulnerabilityDetectionTags);
         }
         else
         {
@@ -373,6 +402,12 @@ public:
         if (configuration.contains("indexer"))
         {
             validateIndexerConfiguration(configuration);
+            std::vector<std::string> validVulnerabilityDetectionTags = {
+                "enabled",
+                "hosts",
+                "ssl",
+            };
+            validateTags(configuration.at("indexer"), validVulnerabilityDetectionTags);
         }
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -205,9 +205,11 @@ private:
      * @param vdObj  A constant reference to a JSON object representing the vulnerability detection's configuration.
      * @param vdTags A constant reference to a list of valid tags 
     */
-    void validateTags(const nlohmann::json& vdObj, std::vector<std::string>& vdTags) const
+    void validateTags(const nlohmann::json& vdObj, std::vector<std::string>& vdTags, std::string path) const
     {
         for(auto it = vdObj.begin(); it != vdObj.end(); ++it){
+            path += it.key();
+            validateTags(vdObj[it.key()], vdTags, path);
             if (std::find(vdTags.begin(), vdTags.end(), it.key()) == vdTags.end())
             {
                 logWarn(WM_VULNSCAN_LOGTAG, "Unkown tag '%s'. Check the configuration. This tag will be ignored", it.key().c_str());
@@ -391,7 +393,7 @@ public:
                 "offline-url",
                 "cti-url"
             };
-            validateTags(configuration.at("vulnerability-detection"), validVulnerabilityDetectionTags);
+            validateTags(configuration.at("vulnerability-detection"), validVulnerabilityDetectionTags, "vulnerability-detection");
         }
         else
         {
@@ -407,7 +409,7 @@ public:
                 "hosts",
                 "ssl",
             };
-            validateTags(configuration.at("indexer"), validVulnerabilityDetectionTags);
+            validateTags(configuration.at("indexer"), validVulnerabilityDetectionTags, "indexer");
         }
     }
 

--- a/src/wazuh_modules/wm_content_manager.c
+++ b/src/wazuh_modules/wm_content_manager.c
@@ -49,7 +49,7 @@ void* wm_content_manager_main()
         }
         else
         {
-            mtwarn(WM_CONTENT_MANAGER_LOGTAG, "Unable to tart content manager.");
+            mtwarn(WM_CONTENT_MANAGER_LOGTAG, "Unable to start content manager.");
         }
     }
     else


### PR DESCRIPTION
|Related issue|
|---|
|#21852|

## Description

The indexer's node in the ossec.conf file contains 2 array nodes, hosts and certificate_authorities.
In both cases, if the node array exists, but no items are specified in it, it generates a unhandled error which erases modulesd.

This PR fixes this issue by validating that, if the array node exits, it contains at least 1 item.
In case this situation is not achieved, it will return with error and inform in the console that the configuration has errors.

### Valid configuration:

```xml
  <indexer>
    <enabled>yes</enabled>
    <hosts>
      <host>https://0.0.0.0:9200</host>
    </hosts>
    <ssl>
      <certificate_authorities>
        <ca>/etc/filebeat/certs/root-ca.pem</ca>
      </certificate_authorities>
      <certificate>/etc/filebeat/certs/filebeat.pem</certificate>
      <key>/etc/filebeat/certs/filebeat-key.pem</key>
    </ssl>
  </indexer>
```

### Invalid configuration 1

```xml
  <indexer>
    <enabled>yes</enabled>
    <hosts>
    </hosts>
    <ssl>
      <certificate_authorities>
        <ca>/etc/filebeat/certs/root-ca.pem</ca>
      </certificate_authorities>
      <certificate>/etc/filebeat/certs/filebeat.pem</certificate>
      <key>/etc/filebeat/certs/filebeat-key.pem</key>
    </ssl>
  </indexer>
```

Output:

```console
2024/02/19 08:28:01 wazuh-modulesd: ERROR: indexer.hosts is empty in module 'indexer'. Check configuration
2024/02/19 08:28:01 wazuh-modulesd: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
wazuh-modulesd: Configuration error. Exiting
```

### Invalid configuration 2

```xml
  <indexer>
    <enabled>yes</enabled>
    <hosts>
      <host>https://0.0.0.0:9200</host>
    </hosts>
    <ssl>
      <certificate_authorities>
      </certificate_authorities>
      <certificate>/etc/filebeat/certs/filebeat.pem</certificate>
      <key>/etc/filebeat/certs/filebeat-key.pem</key>
    </ssl>
  </indexer>
```

Output:

```console
2024/02/19 08:32:07 wazuh-modulesd: ERROR: indexer.ssl.certificate_authorities is empty in module 'indexer'. Check configuration
2024/02/19 08:32:07 wazuh-modulesd:router: INFO: Loaded router module.
2024/02/19 08:32:07 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Started wazuh-modulesd...
Completed.
```

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors