### PR TITLE
Engine builder helper parser refactor

### DIFF
--- a/src/engine/ruleset/integrations/apache-http/decoders/apache-access.yml
+++ b/src/engine/ruleset/integrations/apache-http/decoders/apache-access.yml
@@ -48,7 +48,7 @@ normalize:
 
       - source.ip: $source.address
       - _tls: split($network.protocol, 'v')
-      - _tls-1: $_tls.1
+      - _tls_1: $_tls.1
       - _client_ip: split($_forwarded_for, ',')
       - client.ip: $_client_ip.0
       - network.forwarded_ip: $_client_ip.0
@@ -59,14 +59,14 @@ normalize:
       - <http.request.method> <url.original> HTTP/<http.version>
 
   - check:
-      - _tls-1: regex_match(\\d+\\.\\d+)
+      - _tls_1: regex_match(\\d+\\.\\d+)
     map:
-      - tls.version: $_tls-1
+      - tls.version: $_tls_1
 
   - check:
-      - _tls-1: regex_not_match(\\d+\\.\\d+)
+      - _tls_1: regex_not_match(\\d+\\.\\d+)
     map:
-      - tls.version: concat($_tls-1, .0)
+      - tls.version: concat($_tls_1, '.0')
 
   - check: int_less($http.response.status_code, 400)
     map:
@@ -82,7 +82,7 @@ normalize:
       - source.domain: parse_fqdn($source.address)
 
   - map:
-      - url.extension: regex_extract($url.original, .*\\.([a-zA-Z0-9]+\)(?:\\?|$\))
+      - url.extension: regex_extract($url.original, '.*\\.([a-zA-Z0-9]+)(?:\\?|$)')
       - url.path: $url.original
-      - url.query: regex_extract($url.original, \\?(.*\))
+      - url.query: regex_extract($url.original, '\\?(.*)')
       - url.domain: $destination.domain

--- a/src/engine/ruleset/integrations/suricata/decoders/suricata.yml
+++ b/src/engine/ruleset/integrations/suricata/decoders/suricata.yml
@@ -192,22 +192,26 @@ normalize:
   - check: $network.protocol == tls
     map:
       # Subject
-      - _subject: parse_key_value($suricata.tls.subject, '=', ',' , "'", \\)
-      - tls.server.x509.subject.common_name: array_append($_subject. CN)
+      - _subject: $suricata.tls.subject
+      - _subject: replace(', ', ',')
+      - _subject: parse_key_value($_subject, '=', ',' , "'", \\)
+      - tls.server.x509.subject.common_name: array_append($_subject.CN)
       - tls.server.x509.subject.country: array_append($_subject.C)
-      - tls.server.x509.subject.locality: array_append($_subject. L)
-      - tls.server.x509.subject.organization: array_append($_subject. O)
-      - tls.server.x509.subject.organizational_unit: array_append($_subject. OU)
-      - tls.server.x509.subject.state_or_province: array_append($_subject. ST)
+      - tls.server.x509.subject.locality: array_append($_subject.L)
+      - tls.server.x509.subject.organization: array_append($_subject.O)
+      - tls.server.x509.subject.organizational_unit: array_append($_subject.OU)
+      - tls.server.x509.subject.state_or_province: array_append($_subject.ST)
 
       # Issuer
-      - _issuer: parse_key_value($suricata.tls.issuerdn, '=', ',' , "'", \\)
+      - _issuer: $suricata.tls.issuerdn
+      - _issuer: replace(', ', ',')
+      - _issuer: parse_key_value($_issuer, '=', ',' , "'", \\)
       - tls.server.x509.issuer.country: array_append($_issuer.C)
-      - tls.server.x509.issuer.common_name: array_append($_issuer. CN)
-      - tls.server.x509.issuer.locality: array_append($_issuer. L)
-      - tls.server.x509.issuer.organization: array_append($_issuer. O)
-      - tls.server.x509.issuer.organizational_unit: array_append($_issuer. OU)
-      - tls.server.x509.issuer.state_or_province: array_append($_issuer. ST)
+      - tls.server.x509.issuer.common_name: array_append($_issuer.CN)
+      - tls.server.x509.issuer.locality: array_append($_issuer.L)
+      - tls.server.x509.issuer.organization: array_append($_issuer.O)
+      - tls.server.x509.issuer.organizational_unit: array_append($_issuer.OU)
+      - tls.server.x509.issuer.state_or_province: array_append($_issuer.ST)
 
       - tls.resumed: $suricata.tls.session_resumed
       - tls.server.hash.sha1: upcase($suricata.tls.fingerprint)

--- a/src/engine/ruleset/integrations/suricata/test/small_expected.json
+++ b/src/engine/ruleset/integrations/suricata/test/small_expected.json
@@ -719,6 +719,12 @@
         "subject": "CN=*.icloud.com, OU=management:idms.group.506364, O=Apple Inc., ST=California, C=US",
         "x509": {
           "issuer": {
+            "common_name": [
+              "Apple IST CA 2 - G1"
+            ],
+            "country": [
+              "US"
+            ],
             "organization": [
               "Apple Inc."
             ],
@@ -730,6 +736,12 @@
           "not_before": "2017-02-27T17:54:31.000Z",
           "serial_number": "5C9CE1097887F807",
           "subject": {
+            "common_name": [
+              "*.icloud.com"
+            ],
+            "country": [
+              "US"
+            ],
             "organization": [
               "Apple Inc."
             ],

--- a/src/engine/ruleset/integrations/system/decoders/system-auth.yml
+++ b/src/engine/ruleset/integrations/system/decoders/system-auth.yml
@@ -40,8 +40,6 @@ normalize:
       - event.outcome: success
       - wazuh.decoders: array_append(system-auth)
 
-      - _empty: ''
-
   - check:
       - process.name: sshd
     parse|message:
@@ -131,7 +129,7 @@ normalize:
       - "error: PAM: <~> authentication <~> user <user.name> from <source.address>"
 
   - check:
-      - _system.auth.pam.byuser.name: string_not_equal($_empty)
+      - _system.auth.pam.byuser.name: string_not_equal('')
     map:
       - user.name: $_system.auth.pam.byuser.name
       - user.effective.name: $_system.auth.pam.foruser.name
@@ -186,10 +184,10 @@ normalize:
       - event.type: array_append(change)
 
   - map:
-      - user.name: replace(",)
-      - user.name: replace(',)
-      - user.effective.name: replace(",)
-      - user.effective.name: replace(',)
+      - user.name: replace(", '')
+      - user.name: replace("'", '')
+      - user.effective.name: replace(", '')
+      - user.effective.name: replace("'", '')
       - source.address: $source.ip
       - source.domain: parse_fqdn($source.address)
       - related.user: array_append($user.name, $user.effective.name)

--- a/src/engine/ruleset/integrations/windows/decoders/windows-powershell.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-powershell.yml
@@ -21,7 +21,7 @@ check:
 normalize:
  - map:
    # TODO: check this replaces
-   - windows.EventData.2: replace(\\t, )
+   - windows.EventData.2: replace(\\t, '')
    - windows.EventData.2: replace(\   , \  )
    - windows.EventData.2: replace(\  ,\,)
  - parse|windows.EventData.2:

--- a/src/engine/ruleset/integrations/windows/decoders/windows-sysmon.yml
+++ b/src/engine/ruleset/integrations/windows/decoders/windows-sysmon.yml
@@ -392,12 +392,12 @@ normalize:
  - check: ($event.code == '12' OR $event.code == '13' OR $event.code == '14') AND starts_with($windows.EventData.Details,DWORD)
    map:
     - registry.data.type: SZ_DWORD
-    - _value: regex_extract($windows.EventData.Details, DWORD \\((0x[0-9A-F]{8}\)\\\))
+    - _value: regex_extract($windows.EventData.Details, 'DWORD \\((0x[0-9A-F]{8})\\)')
     # This mappping is wrong, strings is an array, not a string
     # - registry.data.strings: hex_to_number($_value)
 
  - check:
-    - windows.EventData.Details: starts_with(Binary Data)
+    - windows.EventData.Details: starts_with('Binary Data')
    map:
     - _is_binary_data: true
 

--- a/src/engine/ruleset/integrations/windows/rules/defense-evasion-deleting-websvr-access-logs.yml
+++ b/src/engine/ruleset/integrations/windows/rules/defense-evasion-deleting-websvr-access-logs.yml
@@ -13,11 +13,11 @@ metadata:
 
 check : >-
     array_contains($event.type, deletion) AND array_contains($event.category, file)
-    AND (regex_match($file.path, '^[A-Za-z]:\\\\inetpub\\\\logs\\\\LogFiles\\\\[0-9A-Za-z_]+\.log')
-        OR regex_match($file.path, '^/var/log/apache[0-9A-Za-z_]+/access\.log')
+    AND (regex_match($file.path, '^[A-Za-z]:\\\\inetpub\\\\logs\\\\LogFiles\\\\[0-9A-Za-z_]+\\.log')
+        OR regex_match($file.path, '^/var/log/apache[0-9A-Za-z_]+/access\\.log')
         OR $file.path == /etc/httpd/logs/access_log
         OR $file.path == /var/log/httpd/access_log
-        OR regex_match($file.path, '^/var/www/[0-9A-Za-z_]+/logs/access\.log'))
+        OR regex_match($file.path, '^/var/www/[0-9A-Za-z_]+/logs/access\\.log'))
 
 normalize:
   - map:
@@ -30,10 +30,10 @@ normalize:
 
       - threat.framework: MITRE ATT&CK
       - threat.tactic.id: array_append(TA0005)
-      - threat.tactic.name: array_append(Defense Evasion)
+      - threat.tactic.name: array_append('Defense Evasion')
       - threat.tactic.reference: array_append(https://attack.mitre.org/tactics/TA0005/)
       - threat.technique.id: array_append(T1070)
-      - threat.technique.name: array_append(Indicator Removal)
+      - threat.technique.name: array_append('Indicator Removal')
       - threat.technique.reference: array_append(https://attack.mitre.org/techniques/T1070/)
 
       - vulnerability.severity: medium

--- a/src/engine/ruleset/integrations/windows/rules/defense-evasion-disabling-windows-logs.yml
+++ b/src/engine/ruleset/integrations/windows/rules/defense-evasion-disabling-windows-logs.yml
@@ -46,13 +46,13 @@ normalize:
 
       - threat.framework: MITRE ATT&CK
       - threat.tactic.id: array_append(TA0005)
-      - threat.tactic.name: array_append(Defense Evasion)
+      - threat.tactic.name: array_append('Defense Evasion')
       - threat.tactic.reference: array_append(https://attack.mitre.org/tactics/TA0005/)
       - threat.technique.id: array_append(T1070, T1562)
-      - threat.technique.name: array_append(Indicator Removal, Impair Defenses)
+      - threat.technique.name: array_append('Indicator Removal', 'Impair Defenses')
       - threat.technique.reference: array_append(https://attack.mitre.org/techniques/T1070/, https://attack.mitre.org/techniques/T1562/)
       - threat.technique.subtechnique.id: array_append(T1070.001, T1562.006)
-      - threat.technique.subtechnique.name: array_append(Clear Windows Event Logs, Indicator Blocking)
+      - threat.technique.subtechnique.name: array_append('Clear Windows Event Logs', 'Indicator Blocking')
       - threat.technique.subtechnique.reference: array_append(https://attack.mitre.org/techniques/T1070/001/, https://attack.mitre.org/techniques/T1562/006/)
 
       - vulnerability.severity: low

--- a/src/engine/ruleset/integrations/windows/rules/defense-evasion-timestomp-sysmon.yml
+++ b/src/engine/ruleset/integrations/windows/rules/defense-evasion-timestomp-sysmon.yml
@@ -12,19 +12,19 @@ metadata:
 
 check: >-
     array_contains($event.category, file) AND array_contains($event.type, change) AND $event.code == '2'
-    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\Program Files\\\\([0-9A-Za-z_]+)')
-    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\Program Files (x86)\\\\([0-9A-Za-z_]+)')
-    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\Windows\\\\system32\\\\msiexec\.exe')
-    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\Windows\\\\syswow64\\\\msiexec\.exe')
-    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\Windows\\\\syswow64\\\\svchost\.exe')
-    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\WINDOWS\\\\syswow64\\\\backgroundTaskHost\.exe')
-    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\Users\\\\[0-9A-Za-z_]+\\\\AppData\\\\Local\\\\Google\\\\Chrome\\\\Application\\\\chrome\.exe')
-    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\Users\\\\[0-9A-Za-z_]+\\\\AppData\\\\Local\\\\slack\\\\app-[0-9A-Za-z_]+\\\\slack\.exe')
-    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\Users\\\\[0-9A-Za-z_]+\\\\AppData\\\\Local\\\\GitHubDesktop\\\\app-[0-9A-Za-z_]+\\\\GitHubDesktop\.exe')
-    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\Users\\\\[0-9A-Za-z_]+\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams\.exe')
-    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\Users\\\\[0-9A-Za-z_]+\\\\AppData\\\\Local\\\\Microsoft\\\\OneDrive\\\\OneDrive\.exe')
+    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\\\\\Program Files\\\\\\\\([0-9A-Za-z_]+)')
+    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\\\\\Program Files (x86)\\\\\\\\([0-9A-Za-z_]+)')
+    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\\\\\Windows\\\\\\\\system32\\\\\\\\msiexec\\.exe')
+    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\\\\\Windows\\\\\\\\syswow64\\\\\\\\msiexec\\.exe')
+    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\\\\\Windows\\\\\\\\syswow64\\\\\\\\svchost\\.exe')
+    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\\\\\WINDOWS\\\\\\\\syswow64\\\\\\\\backgroundTaskHost\\.exe')
+    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\\\\\Users\\\\\\\\[0-9A-Za-z_]+\\\\\\\\AppData\\\\\\\\Local\\\\\\\\Google\\\\\\\\Chrome\\\\\\\\Application\\\\\\\\chrome\\.exe')
+    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\\\\\Users\\\\\\\\[0-9A-Za-z_]+\\\\\\\\AppData\\\\\\\\Local\\\\\\\\slack\\\\\\\\app-[0-9A-Za-z_]+\\\\\\\\slack\\.exe')
+    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\\\\\Users\\\\\\\\[0-9A-Za-z_]+\\\\\\\\AppData\\\\\\\\Local\\\\\\\\GitHubDesktop\\\\\\\\app-[0-9A-Za-z_]+\\\\\\\\GitHubDesktop\\.exe')
+    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\\\\\Users\\\\\\\\[0-9A-Za-z_]+\\\\\\\\AppData\\\\\\\\Local\\\\\\\\Microsoft\\\\\\\\Teams\\\\\\\\current\\\\\\\\Teams\\.exe')
+    AND NOT regex_match($process.executable, '(^[A-Za-z]:)?\\\\\\\\Users\\\\\\\\[0-9A-Za-z_]+\\\\\\\\AppData\\\\\\\\Local\\\\\\\\Microsoft\\\\\\\\OneDrive\\\\\\\\OneDrive\\.exe')
     AND NOT contains($file.extension, tmp) AND NOT contains($file.extension, ~tmp) AND NOT contains($file.extension, ~tmp)
-    AND NOT contains($user.name, SYSTEM) AND NOT contains($user.name, Local Service) AND NOT contains($user.name, Network Service)
+    AND NOT contains($user.name, SYSTEM) AND NOT contains($user.name, 'Local Service') AND NOT contains($user.name, 'Network Service')
 
 normalize:
   - map:
@@ -38,10 +38,10 @@ normalize:
 
       - threat.framework: MITRE ATT&CK
       - threat.tactic.id: array_append(TA0005)
-      - threat.tactic.name: array_append(Defense Evasion)
+      - threat.tactic.name: array_append('Defense Evasion')
       - threat.tactic.reference: array_append(https://attack.mitre.org/tactics/TA0005/)
       - threat.technique.id: array_append(T1070)
-      - threat.technique.name: array_append(Indicator Removal)
+      - threat.technique.name: array_append('Indicator Removal')
       - threat.technique.reference: array_append(https://attack.mitre.org/techniques/T1070/)
       - threat.technique.subtechnique.id: array_append(T1070.006)
       - threat.technique.subtechnique.name: array_append(Timestomp)

--- a/src/engine/ruleset/integrations/windows/rules/execution-python-script-in-cmdline.yml
+++ b/src/engine/ruleset/integrations/windows/rules/execution-python-script-in-cmdline.yml
@@ -29,10 +29,10 @@ normalize:
       - threat.tactic.name: array_append(Execution)
       - threat.tactic.reference: array_append(https://attack.mitre.org/tactics/TA0002)
       - threat.technique.id: array_append(T1059)
-      - threat.technique.name: array_append(Command and Scripting Interpreter)
+      - threat.technique.name: array_append('Command and Scripting Interpreter')
       - threat.technique.reference: array_append(https://attack.mitre.org/techniques/T1059/)
       - threat.technique.subtechnique.id: array_append(T1059.006, T1059.003)
-      - threat.technique.subtechnique.name: array_append(Python, Windows Command Shell)
+      - threat.technique.subtechnique.name: array_append(Python, 'Windows Command Shell')
       - threat.technique.subtechnique.reference: array_append(https://attack.mitre.org/techniques/T1059/003/, https://attack.mitre.org/techniques/T1059/003/)
 
       - vulnerability.severity: medium

--- a/src/engine/ruleset/integrations/windows/test/security_5145_expected.json
+++ b/src/engine/ruleset/integrations/windows/test/security_5145_expected.json
@@ -27,8 +27,8 @@
       "directory": "\\\\??\\\\C:\\\\Documents",
       "extension": "exe",
       "name": "Bginfo.exe",
-      "path": "\\\\??\\\\C:\\\\Documents'\\'Bginfo.exe",
-      "target_path": "\\\\\\\\\\*\\\\Documents'\\'Bginfo.exe"
+      "path": "\\\\??\\\\C:\\\\Documents\\Bginfo.exe",
+      "target_path": "\\\\\\\\\\*\\\\Documents\\Bginfo.exe"
     },
     "host": {
       "id": "001",

--- a/src/engine/ruleset/wazuh-core/decoders/ciscat/ciscat.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/ciscat/ciscat.yml
@@ -95,5 +95,5 @@ normalize:
       - json_event.cis.score: "NULL"
 
   - map:
-      - _query: concat(agent , $agent.id,  ciscat save , $json_event.scan_id, |, $json_event.cis.timestamp, |, $json_event.cis.benchmark, |, $json_event.cis.profile, |, $json_event.cis.pass, |, $json_event.cis.fail, |, $json_event.cis.error, |, $json_event.cis.notchecked, |, $json_event.cis.unknown, |, $json_event.cis.score)
+      - _query: concat(agent , $agent.id, 'ciscat save', $json_event.scan_id, |, $json_event.cis.timestamp, |, $json_event.cis.benchmark, |, $json_event.cis.profile, |, $json_event.cis.pass, |, $json_event.cis.fail, |, $json_event.cis.error, |, $json_event.cis.notchecked, |, $json_event.cis.unknown, |, $json_event.cis.score)
       - _query_response: wdb_update($_query)

--- a/src/engine/ruleset/wazuh-core/decoders/fim/fim-event.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/fim/fim-event.yml
@@ -49,12 +49,12 @@ normalize:
       - json_event.data.old_attributes: delete()
       - json_event.data.type: delete()
       - json_event.data.tags: delete()
-      - _query: concat(agent , $agent.id,  syscheck save2 , $json_event.data)
+      - _query: concat('agent ', $agent.id, ' syscheck save2 ', $json_event.data)
       - _query_result: wdb_query($_query)
 
   - check:
       - _do_save: false
       - json_event.data.type: string_equal(deleted)
     map:
-      - _query: concat(agent , $agent.id,  syscheck delete , $json_event.data.path)
+      - _query: concat('agent ', $agent.id, ' syscheck delete ', $json_event.data.path)
       - _query_result: wdb_query($_query)

--- a/src/engine/ruleset/wazuh-core/decoders/fim/fim-scan.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/fim/fim-scan.yml
@@ -36,11 +36,11 @@ normalize:
       - json_event.type: string_equal(scan_start)
     map:
       # TODO: adapt concat to first try to convert value from double if possible, otherwise convert it to int
-      - _query: concat(agent , $agent.id,  syscheck scan_info_update start_scan , $json_event.data.timestamp)
+      - _query: concat('agent ', $agent.id, ' syscheck scan_info_update start_scan ', $json_event.data.timestamp)
       - _query_result: wdb_query($_query)
 
   - check:
       - json_event.type: string_equal(scan_end)
     map:
-      - _query: concat(agent , $agent.id,  syscheck scan_info_update end_scan , $json_event.data.timestamp)
+      - _query: concat('agent ', $agent.id, ' syscheck scan_info_update end_scan ', $json_event.data.timestamp)
       - _query_result: wdb_query($_query)

--- a/src/engine/ruleset/wazuh-core/decoders/rootcheck/rootcheck.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/rootcheck/rootcheck.yml
@@ -24,10 +24,12 @@ parents:
 normalize:
   - map:
       - _time: system_epoch()
-      - _query: concat(agent , $agent.id,  rootcheck save , $_time,  , $event.original)
+      - _query: concat(agent , $agent.id,  'rootcheck save' , $_time, '', $event.original)
       - _result: wdb_query($_query)
-      - wazuh.rootcheck.file: "regex_extract($event.original, (?:f|F\\)ile '(.*?\\)')"
-      - _title: "regex_extract($event.original, (.*?\\)(?:(?: {\\)|$\\))"
+      - wazuh.rootcheck.file: >-
+          regex_extract($event.original, '(?:f|F)ile \'(.*?)\'')
+      - _title: >-
+          regex_extract($event.original, '(.*?)(?:(?: {)|$)')
 
   - check:
       - _result: "1"
@@ -43,19 +45,20 @@ normalize:
       - wazuh.rootcheck.file: not_exists()
     map:
       - wazuh.rootcheck.file: >-
-          regex_extract($event.original, File: (.*?\)(?:(?:\\. \)|(?:\\.$\)\))
+          regex_extract($event.original, 'File: (.*?)(?:(?:\\. )|(?:\\.$))')
 
   - map:
-      - _title: "regex_extract($_title, System Audit: (.*? - .*\\))"
+      - _title: >-
+          regex_extract($_title, 'System Audit: (.*? - .*)')
 
   - map:
-      - _title: regex_extract($_title, ^(.*\\.\) )
+      - _title: regex_extract($_title, '^(.*\\.)')
 
   - check:
-      - _title: "regex_match((?:f|F\\)ile )"
+      - _title: regex_match('(?:f|F)ile')
     map:
-      - _pre_file: "regex_extract($_title, (.*?(?:f|F\\)ile\\) )"
-      - _pos_file: "regex_extract($_title, (?:f|F\\)ile '(?:.*?\\)'(.*\\))"
+      - _pre_file: regex_extract($_title, '(.*?(?:f|F)ile)')
+      - _pos_file: regex_extract($_title, '(?:f|F)ile \'(?:.*?)\'(.*)')
       - _title: concat($_pre_file, $_pos_file)
 
   - check:

--- a/src/engine/ruleset/wazuh-core/decoders/syscollector/syscollector-dbsync.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/syscollector/syscollector-dbsync.yml
@@ -52,7 +52,7 @@ normalize:
       - wazuh.decoders: array_append(syscollector-dbsync)
 
       - do_update_kvdb: false
-      - _empty: ""
+      - _empty: "''"
 
   - check: exists($json_event.data.address) OR exists($json_event.data.mac) OR exists($json_event.data.os_version) OR exists($json_event.data.release) OR string_not_equal($json_event.data.hostname,$_empty) OR string_not_equal($json_event.data.os_name,$_empty) OR string_not_equal($json_event.data.os_platform,$_empty) OR string_not_equal($json_event.data.sysname,$_empty)
     map:
@@ -65,8 +65,8 @@ normalize:
 
 # TODO: shouldn't we here check if the wdb must be updated?
   - map:
-      - json_event.type: replace(dbsync_,)
-      - _query: concat(agent , $agent.id,  dbsync , $json_event.type,  , $json_event.operation,  , $json_event.data)
+      - json_event.type: replace(dbsync_, '')
+      - _query: concat('agent ', $agent.id, ' dbsync ', $json_event.type, ' ', $json_event.operation, ' ', $json_event.data)
       - _query_response: wdb_update($_query)
       - json_event.data.checksum: delete()
 

--- a/src/engine/source/builder/src/builders/baseHelper.cpp
+++ b/src/engine/source/builder/src/builders/baseHelper.cpp
@@ -309,7 +309,18 @@ baseHelperBuilder(const json::Json& definition, const std::shared_ptr<const IBui
             }
             else
             {
-                opArgs.emplace_back(std::make_shared<Value>(json::Json(jValue)));
+                // Look if the reference is scaped
+                if (strValue.size() >= 2 && strValue[0] == syntax::helper::DEFAULT_ESCAPE
+                    && strValue[1] == syntax::field::REF_ANCHOR)
+                {
+                    json::Json newValue;
+                    newValue.setString(strValue.substr(1));
+                    opArgs.emplace_back(std::make_shared<Value>(std::move(newValue)));
+                }
+                else
+                {
+                    opArgs.emplace_back(std::make_shared<Value>(json::Json(jValue)));
+                }
             }
 
             // Default helper names

--- a/src/engine/source/builder/src/syntax.hpp
+++ b/src/engine/source/builder/src/syntax.hpp
@@ -38,10 +38,10 @@ constexpr auto ASSET_NAME = "asset"; ///< Name of the asset expression to be dis
 // Field syntax
 namespace field
 {
-constexpr auto REF_ANCHOR = '$';      ///< Char used to indicate a reference.
-constexpr auto SEPARATOR = '.';       ///< Char used to separate levels in a fields path.
-constexpr auto VAR_ANCHOR = '_';      ///< Char used to indicate a variable.
-constexpr auto NAME_EXTENDED = "_@#"; ///< Extended allowed chars in a field name.
+constexpr auto REF_ANCHOR = '$';       ///< Char used to indicate a reference.
+constexpr auto SEPARATOR = '.';        ///< Char used to separate levels in a fields path.
+constexpr auto VAR_ANCHOR = '_';       ///< Char used to indicate a variable.
+constexpr auto NAME_EXTENDED = "_@#-"; ///< Extended allowed chars in a field name.
 } // namespace field
 
 // Function helpers syntax

--- a/src/engine/source/builder/test/src/unit/builders/helperParser_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/helperParser_test.cpp
@@ -39,7 +39,7 @@ template<typename T, typename CmpFn>
 void parserTest(const std::string& input, Parser<T> parser, Result<T> expected, CmpFn&& cmpFn)
 {
     auto result = parser(input, 0);
-    std::cout << parsec::detailedTrace(result.trace(), true) << std::endl;
+    // std::cout << parsec::detailedTrace(result.trace(), true) << std::endl;
 
     ASSERT_EQ(result.success(), expected.success());
     ASSERT_EQ(result.index(), expected.index());
@@ -468,11 +468,10 @@ INSTANTIATE_TEST_SUITE_P(
                                                    val(R"z("DWORD \\((0x[0-9A-F]{8})\\)")z")}},
                                          72)),
         HelperT(R"(regex_extract($event.original, '(?:f|F)ile \'(.*?)\''))",
-                makeSuccess<HelperToken>({.name = "regex_extract",
-                                          .args = {ref("event.original"), val(R"z("(?:f|F)ile '(.*?)'")z")}},
-                                          54))
+                makeSuccess<HelperToken>(
+                    {.name = "regex_extract", .args = {ref("event.original"), val(R"z("(?:f|F)ile '(.*?)'")z")}}, 54))
 
-                                         ));
+            ));
 
 INSTANTIATE_TEST_SUITE_P(Builder,
                          IsDefaultHelperTest,
@@ -743,10 +742,10 @@ INSTANTIATE_TEST_SUITE_P(
                                         Reference("field"),
                                         {val(R"({"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})")}},
                                        73)),
+        TermT(R"($field->123)", makeSuccess<HelperToken>({"int_greater", Reference("field-"), {val(R"(123)")}}, 11)),
         // Expression fail - bad operator
         TermT(R"($field=!123)", makeError<HelperToken>("", 0)),
         TermT(R"($field=123)", makeError<HelperToken>("", 0)),
-        TermT(R"($field->123)", makeError<HelperToken>("", 0)),
         TermT(R"($field.123)", makeError<HelperToken>("", 0)),
         TermT(R"($field!123)", makeError<HelperToken>("", 0)),
         TermT(R"($field|123)", makeError<HelperToken>("", 0)),

--- a/src/engine/source/builder/test/src/unit/builders/helperParser_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/helperParser_test.cpp
@@ -2,421 +2,919 @@
 
 #include "builders/helperParser.hpp"
 
-std::shared_ptr<builder::builders::Argument> val(const std::string& jsonStr = "")
+using namespace builder::builders;
+using namespace builder::builders::parsers;
+using namespace parsec;
+
+/******************************************************************************/
+/* Helper functions */
+/******************************************************************************/
+std::shared_ptr<Argument> val(const std::string& jsonStr = "")
 {
     if (jsonStr.empty())
     {
-        return std::make_shared<builder::builders::Value>();
+        return std::make_shared<Value>();
     }
 
-    return std::make_shared<builder::builders::Value>(json::Json(jsonStr.c_str()));
+    return std::make_shared<Value>(json::Json(jsonStr.c_str()));
 }
 
-std::shared_ptr<builder::builders::Argument> ref(const std::string& dotPath)
+std::shared_ptr<Argument> ref(const std::string& dotPath)
 {
-    return std::make_shared<builder::builders::Reference>(dotPath);
+    return std::make_shared<Reference>(dotPath);
 }
 
-using HelperParserT = std::tuple<bool, std::string, builder::builders::detail::HelperToken>;
-class HelperParserTest : public ::testing::TestWithParam<HelperParserT>
+/******************************************************************************/
+/* Tests definitions */
+/******************************************************************************/
+template<typename T>
+using ArgsT = std::tuple<std::string, Result<T>>;
+
+template<typename T>
+class Test : public ::testing::TestWithParam<ArgsT<T>>
 {
 };
 
-TEST_P(HelperParserTest, parse)
+template<typename T, typename CmpFn>
+void parserTest(const std::string& input, Parser<T> parser, Result<T> expected, CmpFn&& cmpFn)
 {
-    auto& [shouldPass, input, expected] = GetParam();
+    auto result = parser(input, 0);
+    std::cout << parsec::detailedTrace(result.trace(), true) << std::endl;
 
-    auto result = builder::builders::detail::parseHelper(input);
-
-    if (shouldPass)
+    ASSERT_EQ(result.success(), expected.success());
+    ASSERT_EQ(result.index(), expected.index());
+    if (result.success())
     {
-        ASSERT_TRUE(std::holds_alternative<builder::builders::detail::HelperToken>(result));
-        ASSERT_EQ(std::get<builder::builders::detail::HelperToken>(result).name, expected.name);
-        // Arguments are stored in shared_ptr, so we need to manually compare them
-        ASSERT_EQ(std::get<builder::builders::detail::HelperToken>(result).args.size(), expected.args.size());
-        auto gotArgs = std::get<builder::builders::detail::HelperToken>(result).args;
-        for (auto i = 0; i < gotArgs.size(); ++i)
+        cmpFn(result.value(), expected.value());
+    }
+}
+
+using ParseHelperNameTest = Test<std::string>;
+using NameT = ArgsT<std::string>;
+TEST_P(ParseHelperNameTest, parse)
+{
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const std::string& got, const std::string& expected)
+    {
+        ASSERT_EQ(got, expected);
+    };
+    parserTest<std::string>(input, getHelperNameParser(), expected, cmpFn);
+}
+
+using ParseHelperQuotedArgTest = Test<OpArg>;
+using QuotedArgT = ArgsT<OpArg>;
+TEST_P(ParseHelperQuotedArgTest, parse)
+{
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const OpArg& got, const OpArg& expected)
+    {
+        ASSERT_TRUE(got->isValue());
+        ASSERT_TRUE(expected->isValue());
+        auto gotValue = std::static_pointer_cast<Value>(got);
+        auto expectedValue = std::static_pointer_cast<Value>(expected);
+        ASSERT_EQ(gotValue->value(), expectedValue->value());
+    };
+    parserTest<OpArg>(input, getHelperQuotedArgParser(), expected, cmpFn);
+}
+
+using ParseHelperRefArgTest = Test<OpArg>;
+using RefArgT = ArgsT<OpArg>;
+TEST_P(ParseHelperRefArgTest, parse)
+{
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const OpArg& got, const OpArg& expected)
+    {
+        if (expected->isReference())
         {
-            auto gotArg = gotArgs[i];
+            ASSERT_TRUE(got->isReference());
+            auto gotRef = std::static_pointer_cast<Reference>(got);
+            auto expectedRef = std::static_pointer_cast<Reference>(expected);
+            ASSERT_EQ(gotRef->dotPath(), expectedRef->dotPath());
+        }
+        else
+        {
+            ASSERT_TRUE(got->isValue());
+            auto gotValue = std::static_pointer_cast<Value>(got);
+            auto expectedValue = std::static_pointer_cast<Value>(expected);
+            ASSERT_EQ(gotValue->value(), expectedValue->value());
+        }
+    };
+    parserTest<OpArg>(input, getHelperRefArgParser(), expected, cmpFn);
+}
+
+using ParseHelperJsonArgTest = Test<OpArg>;
+using JsonArgT = ArgsT<OpArg>;
+TEST_P(ParseHelperJsonArgTest, parse)
+{
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const OpArg& got, const OpArg& expected)
+    {
+        ASSERT_TRUE(got->isValue());
+        ASSERT_TRUE(expected->isValue());
+        auto gotValue = std::static_pointer_cast<Value>(got);
+        auto expectedValue = std::static_pointer_cast<Value>(expected);
+        ASSERT_EQ(gotValue->value(), expectedValue->value());
+    };
+    parserTest<OpArg>(input, getHelperJsonArgParser(), expected, cmpFn);
+}
+
+using ParseHelperRawArgTest = Test<OpArg>;
+using RawArgT = ArgsT<OpArg>;
+TEST_P(ParseHelperRawArgTest, parse)
+{
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const OpArg& got, const OpArg& expected)
+    {
+        ASSERT_TRUE(got->isValue());
+        ASSERT_TRUE(expected->isValue());
+        auto gotValue = std::static_pointer_cast<Value>(got);
+        auto expectedValue = std::static_pointer_cast<Value>(expected);
+        ASSERT_TRUE(gotValue->value().isString() || gotValue->value().isNull());
+        ASSERT_EQ(gotValue->value(), expectedValue->value());
+    };
+    parserTest<OpArg>(input, getHelperRawArgParser(), expected, cmpFn);
+}
+
+using ParseDefaultHelperRawArgTest = Test<OpArg>;
+TEST_P(ParseDefaultHelperRawArgTest, parse)
+{
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const OpArg& got, const OpArg& expected)
+    {
+        ASSERT_TRUE(got->isValue());
+        ASSERT_TRUE(expected->isValue());
+        auto gotValue = std::static_pointer_cast<Value>(got);
+        auto expectedValue = std::static_pointer_cast<Value>(expected);
+        ASSERT_TRUE(gotValue->value().isString() || gotValue->value().isNull());
+        ASSERT_EQ(gotValue->value(), expectedValue->value());
+    };
+    parserTest<OpArg>(input, getHelperRawArgParser(true), expected, cmpFn);
+}
+
+using ParseHelperArgTest = Test<OpArg>;
+using ArgT = ArgsT<OpArg>;
+TEST_P(ParseHelperArgTest, parse)
+{
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const OpArg& got, const OpArg& expected)
+    {
+        if (expected->isReference())
+        {
+            ASSERT_TRUE(got->isReference());
+            auto gotRef = std::static_pointer_cast<Reference>(got);
+            auto expectedRef = std::static_pointer_cast<Reference>(expected);
+            ASSERT_EQ(gotRef->dotPath(), expectedRef->dotPath());
+        }
+        else
+        {
+            ASSERT_TRUE(got->isValue());
+            auto gotValue = std::static_pointer_cast<Value>(got);
+            auto expectedValue = std::static_pointer_cast<Value>(expected);
+            ASSERT_EQ(gotValue->value(), expectedValue->value());
+        }
+    };
+    parserTest<OpArg>(input, getHelperArgParser(), expected, cmpFn);
+}
+
+using ParseDefaultHelperArgTest = Test<OpArg>;
+TEST_P(ParseDefaultHelperArgTest, parse)
+{
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const OpArg& got, const OpArg& expected)
+    {
+        if (expected->isReference())
+        {
+            ASSERT_TRUE(got->isReference());
+            auto gotRef = std::static_pointer_cast<Reference>(got);
+            auto expectedRef = std::static_pointer_cast<Reference>(expected);
+            ASSERT_EQ(gotRef->dotPath(), expectedRef->dotPath());
+        }
+        else
+        {
+            ASSERT_TRUE(got->isValue());
+            auto gotValue = std::static_pointer_cast<Value>(got);
+            auto expectedValue = std::static_pointer_cast<Value>(expected);
+            ASSERT_EQ(gotValue->value(), expectedValue->value());
+        }
+    };
+    parserTest<OpArg>(input, getHelperArgParser(true), expected, cmpFn);
+}
+
+using ParseHelperTest = Test<HelperToken>;
+using HelperT = ArgsT<HelperToken>;
+TEST_P(ParseHelperTest, parse)
+{
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const HelperToken& got, const HelperToken& expected)
+    {
+        ASSERT_EQ(got.name, expected.name);
+        ASSERT_EQ(got.args.size(), expected.args.size());
+        for (auto i = 0; i < got.args.size(); ++i)
+        {
+            auto gotArg = got.args[i];
             auto expectedArg = expected.args[i];
 
             if (expectedArg->isReference())
             {
                 ASSERT_TRUE(gotArg->isReference());
-                ASSERT_EQ(std::static_pointer_cast<builder::builders::Reference>(gotArg)->dotPath(),
-                          std::static_pointer_cast<builder::builders::Reference>(expectedArg)->dotPath());
-                ASSERT_EQ(std::static_pointer_cast<builder::builders::Reference>(gotArg)->jsonPath(),
-                          std::static_pointer_cast<builder::builders::Reference>(expectedArg)->jsonPath());
+                ASSERT_EQ(std::static_pointer_cast<Reference>(gotArg)->dotPath(),
+                          std::static_pointer_cast<Reference>(expectedArg)->dotPath());
+                ASSERT_EQ(std::static_pointer_cast<Reference>(gotArg)->jsonPath(),
+                          std::static_pointer_cast<Reference>(expectedArg)->jsonPath());
             }
             else
             {
                 ASSERT_TRUE(gotArg->isValue());
-                ASSERT_EQ(std::static_pointer_cast<builder::builders::Value>(gotArg)->value(),
-                          std::static_pointer_cast<builder::builders::Value>(expectedArg)->value());
+                ASSERT_EQ(std::static_pointer_cast<Value>(gotArg)->value(),
+                          std::static_pointer_cast<Value>(expectedArg)->value());
             }
         }
-    }
-    else
-    {
-        ASSERT_TRUE(std::holds_alternative<base::Error>(result));
-    }
+    };
+    parserTest<HelperToken>(input, getHelperParser(true), expected, cmpFn);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    Builder,
-    HelperParserTest,
-    ::testing::Values(
-        HelperParserT(true, "stringValue", {.name = "", .args = {val("\"stringValue\"")}}),
-        HelperParserT(true, "123", {.name = "", .args = {val("123")}}),
-        HelperParserT(true, "123.456", {.name = "", .args = {val("123.456")}}),
-        HelperParserT(true, "true", {.name = "", .args = {val("true")}}),
-        HelperParserT(true, "false", {.name = "", .args = {val("false")}}),
-        HelperParserT(true, "{}", {.name = "", .args = {val("{}")}}),
-        HelperParserT(true, "[]", {.name = "", .args = {val("[]")}}),
-        HelperParserT(true, "$ref", {.name = "", .args = {ref("ref")}}),
-        HelperParserT(true, "helper()", {.name = "helper"}),
-        HelperParserT(true, "helper('')", {.name = "helper", .args = {val("\"\"")}}),
-        HelperParserT(true, "helper( '')", {.name = "helper", .args = {val("\"\"")}}),
-        HelperParserT(true, "helper( ''  )", {.name = "helper", .args = {val("\"\"")}}),
-        HelperParserT(true, "helper(arg1)", {.name = "helper", .args = {val("\"arg1\"")}}),
-        HelperParserT(true, "helper(arg1, '')", {.name = "helper", .args = {val("\"arg1\""), val("\"\"")}}),
-        HelperParserT(true, "helper(arg1, )", {.name = "helper", .args = {val("\"arg1\""), val("\"\"")}}),
-        HelperParserT(true, "helper(arg1,arg2)", {.name = "helper", .args = {val("\"arg1\""), val("\"arg2\"")}}),
-        HelperParserT(true, "helper(arg1,  \"\")", {.name = "helper", .args = {val("\"arg1\""), val("\"\"")}}),
-        HelperParserT(true,
-                      "helper(arg1, '', arg3)",
-                      {.name = "helper", .args = {val("\"arg1\""), val("\"\""), val("\"arg3\"")}}),
-        HelperParserT(true,
-                      "helper(arg1, '' , arg3)",
-                      {.name = "helper", .args = {val("\"arg1\""), val("\"\""), val("\"arg3\"")}}),
-        HelperParserT(true,
-                      "helper(arg1, arg2, arg3)",
-                      {.name = "helper", .args = {val("\"arg1\""), val("\"arg2\""), val("\"arg3\"")}}),
-        HelperParserT(true,
-                      "helper(arg1, arg2\\,arg3)",
-                      {.name = "helper", .args = {val("\"arg1\""), val("\"arg2,arg3\"")}}), // Testing escaped comma
-        HelperParserT(true,
-                      "helper(arg1,\\ arg2)",
-                      {.name = "helper", .args = {val("\"arg1\""), val("\" arg2\"")}}), // Testing escaped space
-        HelperParserT(false, "helper(arg1", {}),                                        // Missing closing parenthesis
-        HelperParserT(true, "'helper(arg1'", {.name = "", .args = {val("\"helper(arg1\"")}}),
-        HelperParserT(true, "test arg1)", {.name = "", .args = {val("\"test arg1)\"")}}), // Missing opening parenthesis
-        HelperParserT(false, "", {}),                                                     // Empty string
-        HelperParserT(true, "()", {.name = "", .args = {val("\"()\"")}}),                 // No function name
-        HelperParserT(true, "test(,)", {.name = "test", .args {val("\"\""), val("\"\"")}}),
-        HelperParserT(true, "test(,,)", {.name = "test", .args {val("\"\""), val("\"\""), val("\"\"")}}),
-        HelperParserT(true, "test(, ,)", {.name = "test", .args {val("\"\""), val("\"\""), val("\"\"")}}),
-        HelperParserT(true, "test(arg1,)", {.name = "test", .args {val("\"arg1\""), val("\"\"")}}),
-        HelperParserT(true, "test(arg1, )", {.name = "test", .args {val("\"arg1\""), val("\"\"")}}),
-        HelperParserT(true, "test(arg1,\\ )", {.name = "test", .args {val("\"arg1\""), val("\" \"")}}),
-        HelperParserT(true, "test(arg1,' ')", {.name = "test", .args {val("\"arg1\""), val("\" \"")}}),
-        HelperParserT(true, "test(arg1,  )", {.name = "test", .args {val("\"arg1\""), val("\"\"")}}),
-        HelperParserT(false, "test(arg1, ())", {}),
-        HelperParserT(true, "test(arg1, (\\))", {.name = "test", .args {val("\"arg1\""), val("\"()\"")}}),
-        HelperParserT(true, "test(arg1, ( arg2)", {.name = "test", .args = {val("\"arg1\""), val("\"( arg2\"")}}),
-        HelperParserT(true, "test(arg1, \\) arg2)", {.name = "test", .args = {val("\"arg1\""), val("\") arg2\"")}}),
-        HelperParserT(true,
-                      "test(arg1, \\)\\ arg2\\)\\)\\))",
-                      {.name = "test", .args = {val("\"arg1\""), val("\") arg2)))\"")}}),
-        HelperParserT(false, "test(arg1)leftover", {}),
-        HelperParserT(true, "test(arg1, ' , ( ) ' )", {.name = "test", .args {val("\"arg1\""), val("\" , ( ) \"")}})));
-
-using TermParserT = std::tuple<bool, std::string, builder::builders::detail::BuildToken>;
-class TermParserTest : public ::testing::TestWithParam<TermParserT>
+using IsDefaultT = std::tuple<std::string, bool>;
+class IsDefaultHelperTest : public ::testing::TestWithParam<IsDefaultT>
 {
 };
 
-using expToken = builder::builders::detail::ExpressionToken;
-using helpToken = builder::builders::detail::HelperToken;
-
-TEST_P(TermParserTest, parse)
+TEST_P(IsDefaultHelperTest, parse)
 {
+    auto [input, expected] = GetParam();
+    auto result = isDefaultHelper(input);
+    ASSERT_EQ(result, expected);
+}
 
-    auto& [shouldPass, input, expected] = GetParam();
-
-    auto result = builder::builders::detail::getTermParser()(input, 0);
-
-    if (shouldPass)
+using ParseOperatorTest = Test<Operator>;
+using OperatorT = ArgsT<Operator>;
+TEST_P(ParseOperatorTest, parse)
+{
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const Operator& got, const Operator& expected)
     {
-        ASSERT_TRUE(result.success());
-        const auto&& resultVToken = result.value();
+        ASSERT_EQ(got, expected);
+    };
+    parserTest<Operator>(input, getOperatorParser(), expected, cmpFn);
+}
 
-        // Expression expected
-        if (std::holds_alternative<expToken>(expected))
+using ParseOperationTest = Test<OperationToken>;
+using OperationT = ArgsT<OperationToken>;
+TEST_P(ParseOperationTest, parse)
+{
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const OperationToken& got, const OperationToken& expected)
+    {
+        auto gotFieldRef = std::static_pointer_cast<Reference>(got.field);
+        auto expectedFieldRef = std::static_pointer_cast<Reference>(expected.field);
+        ASSERT_EQ(gotFieldRef->dotPath(), expectedFieldRef->dotPath());
+        ASSERT_EQ(got.op, expected.op);
+        if (expected.value->isValue())
         {
-            ASSERT_TRUE(std::holds_alternative<expToken>(resultVToken)) << "Expected ExpressionToken";
-            const auto& expectedToken = std::get<expToken>(expected);
-            const auto& resultToken = std::get<expToken>(resultVToken);
-
-            ASSERT_EQ(resultToken.op, expectedToken.op);
-            ASSERT_EQ(resultToken.field, expectedToken.field);
-            ASSERT_EQ(resultToken.value, expectedToken.value);
-        }
-        else if (std::holds_alternative<helpToken>(expected))
-        {
-            ASSERT_TRUE(std::holds_alternative<helpToken>(resultVToken)) << "Expected HelperToken";
-            const auto& expectedToken = std::get<helpToken>(expected);
-            const auto& resultToken = std::get<helpToken>(resultVToken);
-
-            ASSERT_EQ(resultToken.name, expectedToken.name);
-            ASSERT_EQ(resultToken.targetField.dotPath(), expectedToken.targetField.dotPath());
-            ASSERT_EQ(resultToken.targetField.jsonPath(), expectedToken.targetField.jsonPath());
-
-            // Arguments are stored in shared_ptr, so we need to manually compare them
-            ASSERT_EQ(resultToken.args.size(), expectedToken.args.size());
-            auto gotArgs = resultToken.args;
-
-            for (auto i = 0; i < gotArgs.size(); ++i)
-            {
-                auto gotArg = gotArgs[i];
-                auto expectedArg = expectedToken.args[i];
-
-                if (expectedArg->isReference())
-                {
-                    ASSERT_TRUE(gotArg->isReference());
-                    ASSERT_EQ(std::static_pointer_cast<builder::builders::Reference>(gotArg)->dotPath(),
-                              std::static_pointer_cast<builder::builders::Reference>(expectedArg)->dotPath());
-                    ASSERT_EQ(std::static_pointer_cast<builder::builders::Reference>(gotArg)->jsonPath(),
-                              std::static_pointer_cast<builder::builders::Reference>(expectedArg)->jsonPath());
-                }
-                else
-                {
-                    ASSERT_TRUE(gotArg->isValue());
-                    ASSERT_EQ(std::static_pointer_cast<builder::builders::Value>(gotArg)->value(),
-                              std::static_pointer_cast<builder::builders::Value>(expectedArg)->value());
-                }
-            }
+            ASSERT_TRUE(got.value->isValue());
+            ASSERT_EQ(std::static_pointer_cast<Value>(got.value)->value(),
+                      std::static_pointer_cast<Value>(expected.value)->value());
         }
         else
         {
-            FAIL() << "Expected ExpressionToken";
+            ASSERT_TRUE(got.value->isReference());
+            ASSERT_EQ(std::static_pointer_cast<Reference>(got.value)->dotPath(),
+                      std::static_pointer_cast<Reference>(expected.value)->dotPath());
         }
-    }
-    else
-    {
-        ASSERT_TRUE(result.failure());
-    }
+    };
+    parserTest<OperationToken>(input, getOperationParser(), expected, cmpFn);
 }
 
-builder::builders::Reference target(const std::string& dotPath)
+using ParseTermTest = Test<HelperToken>;
+using TermT = ArgsT<HelperToken>;
+TEST_P(ParseTermTest, parse)
 {
-    return builder::builders::Reference(dotPath);
+    auto [input, expected] = GetParam();
+    auto cmpFn = [](const HelperToken& got, const HelperToken& expected)
+    {
+        ASSERT_EQ(got.name, expected.name);
+        ASSERT_EQ(got.args.size(), expected.args.size());
+        for (auto i = 0; i < got.args.size(); ++i)
+        {
+            auto gotArg = got.args[i];
+            auto expectedArg = expected.args[i];
+
+            if (expectedArg->isReference())
+            {
+                ASSERT_TRUE(gotArg->isReference());
+                ASSERT_EQ(std::static_pointer_cast<Reference>(gotArg)->dotPath(),
+                          std::static_pointer_cast<Reference>(expectedArg)->dotPath());
+                ASSERT_EQ(std::static_pointer_cast<Reference>(gotArg)->jsonPath(),
+                          std::static_pointer_cast<Reference>(expectedArg)->jsonPath());
+            }
+            else
+            {
+                ASSERT_TRUE(gotArg->isValue());
+                ASSERT_EQ(std::static_pointer_cast<Value>(gotArg)->value(),
+                          std::static_pointer_cast<Value>(expectedArg)->value());
+            }
+        }
+    };
+    parserTest<HelperToken>(input, getTermParser(), expected, cmpFn);
 }
 
-using eOp = builder::builders::detail::ExpressionOperator;
+/******************************************************************************/
+/* Tests Instantiations */
+/******************************************************************************/
+INSTANTIATE_TEST_SUITE_P(Builder,
+                         ParseHelperNameTest,
+                         testing::Values(NameT("helper", makeSuccess<std::string>("helper", 6)),
+                                         NameT("", makeError<std::string>("", 0)),
+                                         NameT("hel}leftover", makeSuccess<std::string>("hel", 3)),
+                                         NameT("helper_name", makeSuccess<std::string>("helper_name", 11)),
+                                         NameT("helper", makeSuccess<std::string>("helper", 6)),
+                                         NameT("}leftover", makeError<std::string>("", 0)),
+                                         NameT("01234_56789", makeSuccess<std::string>("01234_56789", 11))));
+
 INSTANTIATE_TEST_SUITE_P(
     Builder,
-    TermParserTest,
-    ::testing::Values(
-        //**************************
-        // Expression TEST
-        // TODO check $field op $Field should failt, y think it is sufficient with helper with field comparison
-        //**************************
-        TermParserT(true, R"($field==123)", expToken {"$field", eOp::EQUAL, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field=="123")", expToken {"$field", eOp::EQUAL, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field==$field2)", expToken {"$field", eOp::EQUAL, json::Json {R"("$field2")"}}),
-        TermParserT(true, R"($field=={})", expToken {"$field", eOp::EQUAL, json::Json {R"({})"}}),
-        TermParserT(true, R"($field==null)", expToken {"$field", eOp::EQUAL, json::Json {R"(null)"}}),
-        TermParserT(true, R"($field==true)", expToken {"$field", eOp::EQUAL, json::Json {R"(true)"}}),
-        TermParserT(true, R"($field>=123)", expToken {"$field", eOp::GREATER_THAN_OR_EQUAL, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field>123)", expToken {"$field", eOp::GREATER_THAN, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field<="123")", expToken {"$field", eOp::LESS_THAN_OR_EQUAL, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field<"123")", expToken {"$field", eOp::LESS_THAN, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field!=$field2)", expToken {"$field", eOp::NOT_EQUAL, json::Json {R"("$field2")"}}),
-        TermParserT(true, R"($field<$field2)", expToken {"$field", eOp::LESS_THAN, json::Json {R"("$field2")"}}),
-        TermParserT(true,
-                    R"($field=={"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})",
-                    expToken {"$field",
-                              eOp::EQUAL,
-                              json::Json {R"({"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})"}}),
+    ParseHelperQuotedArgTest,
+    testing::Values(QuotedArgT(R"("unquoted")", makeError<OpArg>("", 0)),
+                    QuotedArgT(R"('quoted')", makeSuccess<OpArg>(val(R"("quoted")"), 8)),
+                    QuotedArgT(R"('missing_end_quote)", makeError<OpArg>("", 18)),
+                    QuotedArgT(R"('missing_end_quote\')", makeError<OpArg>("", 20)),
+                    QuotedArgT(R"(missing_start_quote')", makeError<OpArg>("", 0)),
+                    QuotedArgT(R"()", makeError<OpArg>("", 0)),
+                    QuotedArgT(R"('')", makeSuccess<OpArg>(val(R"("")"), 2)),
+                    QuotedArgT(R"(' ')", makeSuccess<OpArg>(val(R"(" ")"), 3)),
+                    QuotedArgT(R"('escaped\'quote')", makeSuccess<OpArg>(val(R"("escaped'quote")"), 16)),
+                    QuotedArgT(R"('invalid\scape')", makeError<OpArg>("", 9)),
+                    QuotedArgT(R"('escaped\\')", makeSuccess<OpArg>(val(R"("escaped\\")"), 11)),
+                    QuotedArgT(R"('1')", makeSuccess<OpArg>(val(R"("1")"), 3)),
+                    QuotedArgT(R"('true')", makeSuccess<OpArg>(val(R"("true")"), 6)),
+                    QuotedArgT(R"('[1]')", makeSuccess<OpArg>(val(R"("[1]")"), 5)),
+                    QuotedArgT(R"('{"key":"value"}')", makeSuccess<OpArg>(val(R"("{\"key\":\"value\"}")"), 17)),
+                    QuotedArgT(R"('null')", makeSuccess<OpArg>(val(R"("null")"), 6)),
+                    QuotedArgT(R"(\'escaped_quote')", makeError<OpArg>("", 0)),
+                    QuotedArgT(R"('quoted'leftover)", makeSuccess<OpArg>(val(R"("quoted")"), 8)),
+                    QuotedArgT(R"('$ref')", makeSuccess<OpArg>(val(R"("$ref")"), 6))));
 
+INSTANTIATE_TEST_SUITE_P(
+    Builder,
+    ParseHelperRefArgTest,
+    testing::Values(RefArgT("", makeError<OpArg>("", 0)),
+                    RefArgT(R"($ref)", makeSuccess<OpArg>(ref("ref"), 4)),
+                    RefArgT(R"($ref_extended)", makeSuccess<OpArg>(ref("ref_extended"), 13)),
+                    RefArgT(R"($ref@extended)", makeSuccess<OpArg>(ref("ref@extended"), 13)),
+                    RefArgT(R"($ref#extended)", makeSuccess<OpArg>(ref("ref#extended"), 13)),
+                    RefArgT(R"($ref.name)", makeSuccess<OpArg>(ref("ref.name"), 9)),
+                    RefArgT(R"($ref_extended.name)", makeSuccess<OpArg>(ref("ref_extended.name"), 18)),
+                    RefArgT(R"($ref}invalid)", makeSuccess<OpArg>(ref("ref"), 4)),
+                    RefArgT(R"($ref_extended.name$leftover)", makeSuccess<OpArg>(ref("ref_extended.name"), 18)),
+                    RefArgT(R"(ref)", makeError<OpArg>("", 0)),
+                    RefArgT(R"(\$ref)", makeError<OpArg>("", 0))));
+
+INSTANTIATE_TEST_SUITE_P(
+    Builder,
+    ParseHelperJsonArgTest,
+    testing::Values(JsonArgT("", makeError<OpArg>("", 0)),
+                    JsonArgT(R"(123)", makeSuccess<OpArg>(val(R"(123)"), 3)),
+                    JsonArgT(R"(123.456)", makeSuccess<OpArg>(val(R"(123.456)"), 7)),
+                    JsonArgT(R"(true)", makeSuccess<OpArg>(val(R"(true)"), 4)),
+                    JsonArgT(R"(false)", makeSuccess<OpArg>(val(R"(false)"), 5)),
+                    JsonArgT(R"({})", makeSuccess<OpArg>(val(R"({})"), 2)),
+                    JsonArgT(R"([])", makeSuccess<OpArg>(val(R"([])"), 2)),
+                    JsonArgT(R"("string")", makeSuccess<OpArg>(val(R"("string")"), 8)),
+                    JsonArgT(R"("")", makeSuccess<OpArg>(val(R"("")"), 2)),
+                    JsonArgT(R"("string with spaces")", makeSuccess<OpArg>(val(R"("string with spaces")"), 20)),
+                    JsonArgT(R"("string with \t escape")", makeSuccess<OpArg>(val(R"("string with \t escape")"), 23)),
+                    JsonArgT(R"("string with , ")", makeSuccess<OpArg>(val(R"("string with , ")"), 16)),
+                    JsonArgT(R"(["value", "value2"])", makeSuccess<OpArg>(val(R"(["value", "value2"])"), 19)),
+                    JsonArgT(R"(["value", "value2"]leftover)", makeSuccess<OpArg>(val(R"(["value", "value2"])"), 19)),
+                    JsonArgT(R"({"key":"value"})", makeSuccess<OpArg>(val(R"({"key":"value"})"), 15)),
+                    JsonArgT(R"({"key":"value"}leftover)", makeSuccess<OpArg>(val(R"({"key":"value"})"), 15)),
+                    JsonArgT(R"(")", makeError<OpArg>("", 0)),
+                    JsonArgT(R"({"key":"value")", makeError<OpArg>("", 0))));
+
+INSTANTIATE_TEST_SUITE_P(
+    Builder,
+    ParseHelperRawArgTest,
+    testing::Values(RawArgT("", makeError<OpArg>("", 0)),
+                    RawArgT(",", makeSuccess<OpArg>(val(), 0)),
+                    RawArgT(" ", makeSuccess<OpArg>(val(), 0)),
+                    RawArgT(")", makeSuccess<OpArg>(val(), 0)),
+                    RawArgT("a", makeSuccess<OpArg>(val(R"("a")"), 1)),
+                    RawArgT("a,", makeSuccess<OpArg>(val(R"("a")"), 1)),
+                    RawArgT("a ", makeSuccess<OpArg>(val(R"("a")"), 1)),
+                    RawArgT("a)", makeSuccess<OpArg>(val(R"("a")"), 1)),
+                    RawArgT("a$", makeSuccess<OpArg>(val(R"("a$")"), 2)),
+                    RawArgT("$a", makeSuccess<OpArg>(val(R"("$a")"), 2)),
+                    RawArgT(R"(a\$)", makeSuccess<OpArg>(val(R"("a$")"), 3)),
+                    RawArgT(R"(\$a)", makeSuccess<OpArg>(val(R"("$a")"), 3)),
+                    RawArgT(R"({"key":"value")", makeSuccess<OpArg>(val(R"("{\"key\":\"value\"")"), 14)),
+                    RawArgT(R"({"key": "value")", makeSuccess<OpArg>(val(R"("{\"key\":")"), 7)),
+                    RawArgT(R"({"key":,"value")", makeSuccess<OpArg>(val(R"("{\"key\":")"), 7)),
+                    RawArgT(R"z({"key":)"value")z", makeSuccess<OpArg>(val(R"("{\"key\":")"), 7)),
+                    RawArgT(R"({"key":)", makeSuccess<OpArg>(val(R"("{\"key\":")"), 7)),
+                    RawArgT(R"({"key":\ "value")", makeSuccess<OpArg>(val(R"("{\"key\": \"value\"")"), 16)),
+                    RawArgT(R"({"key":\,"value")", makeSuccess<OpArg>(val(R"("{\"key\":,\"value\"")"), 16)),
+                    RawArgT(R"z({"key":\)"value")z", makeSuccess<OpArg>(val(R"z("{\"key\":)\"value\"")z"), 16)),
+                    RawArgT(R"(invalid\scape)", makeError<OpArg>("", 8)),
+                    RawArgT(R"(escaped\\)", makeSuccess<OpArg>(val(R"("escaped\\")"), 9)),
+                    RawArgT(R"(1234)", makeSuccess<OpArg>(val(R"("1234")"), 4))));
+
+INSTANTIATE_TEST_SUITE_P(
+    Builder,
+    ParseDefaultHelperRawArgTest,
+    testing::Values(RawArgT("", makeError<OpArg>("", 0)),
+                    RawArgT(",", makeSuccess<OpArg>(val(R"(",")"), 1)),
+                    RawArgT(" ", makeSuccess<OpArg>(val(R"(" ")"), 1)),
+                    RawArgT(")", makeSuccess<OpArg>(val(R"z(")")z"), 1)),
+                    RawArgT("a", makeSuccess<OpArg>(val(R"("a")"), 1)),
+                    RawArgT("a,", makeSuccess<OpArg>(val(R"("a,")"), 2)),
+                    RawArgT("a ", makeSuccess<OpArg>(val(R"("a ")"), 2)),
+                    RawArgT("a)", makeSuccess<OpArg>(val(R"z("a)")z"), 2)),
+                    RawArgT("a$", makeSuccess<OpArg>(val(R"("a$")"), 2)),
+                    RawArgT("$a", makeSuccess<OpArg>(val(R"("$a")"), 2)),
+                    RawArgT(R"(a\$)", makeSuccess<OpArg>(val(R"("a$")"), 3)),
+                    RawArgT(R"(\$a)", makeSuccess<OpArg>(val(R"("$a")"), 3)),
+                    RawArgT(R"({"key":"value")", makeSuccess<OpArg>(val(R"("{\"key\":\"value\"")"), 14)),
+                    RawArgT(R"({"key": "value")", makeSuccess<OpArg>(val(R"("{\"key\": \"value\"")"), 15)),
+                    RawArgT(R"({"key":,"value")", makeSuccess<OpArg>(val(R"("{\"key\":,\"value\"")"), 15)),
+                    RawArgT(R"z({"key":)"value")z", makeSuccess<OpArg>(val(R"("{\"key\":)\"value\"")"), 15)),
+                    RawArgT(R"({"key":)", makeSuccess<OpArg>(val(R"("{\"key\":")"), 7)),
+                    RawArgT(R"({"key":\ "value")", makeError<OpArg>("", 8)),
+                    RawArgT(R"({"key":\,"value")", makeError<OpArg>("", 8)),
+                    RawArgT(R"z({"key":\)"value")z", makeError<OpArg>("", 8)),
+                    RawArgT(R"(invalid\scape)", makeError<OpArg>("", 8)),
+                    RawArgT(R"(escaped\\)", makeSuccess<OpArg>(val(R"("escaped\\")"), 9)),
+                    RawArgT(R"(1234)", makeSuccess<OpArg>(val(R"("1234")"), 4))));
+
+INSTANTIATE_TEST_SUITE_P(Builder,
+                         ParseHelperArgTest,
+                         testing::Values(ArgT(R"('quoted')", makeSuccess<OpArg>(val(R"("quoted")"), 8)),
+                                         ArgT(R"($ref)", makeSuccess<OpArg>(ref("ref"), 4)),
+                                         ArgT(R"(123)", makeSuccess<OpArg>(val(R"(123)"), 3)),
+                                         ArgT(R"(\$ref)", makeSuccess<OpArg>(val(R"("$ref")"), 5)),
+                                         ArgT(R"(invalid\scape)", makeError<OpArg>("", 0)),
+                                         ArgT(R"("")", makeSuccess<OpArg>(val(R"("")"), 2)),
+                                         ArgT("", makeError<OpArg>("", 0)),
+                                         ArgT(" ", makeSuccess<OpArg>(val(), 0)),
+                                         ArgT("'' )", makeSuccess<OpArg>(val(R"("")"), 2))));
+
+INSTANTIATE_TEST_SUITE_P(Builder,
+                         ParseDefaultHelperArgTest,
+                         testing::Values(ArgT(R"('quoted')", makeSuccess<OpArg>(val(R"("quoted")"), 8)),
+                                         ArgT(R"($ref)", makeSuccess<OpArg>(ref("ref"), 4)),
+                                         ArgT(R"(123)", makeSuccess<OpArg>(val(R"(123)"), 3)),
+                                         ArgT(R"(\$ref)", makeSuccess<OpArg>(val(R"("$ref")"), 5)),
+                                         ArgT(R"(invalid\scape)", makeError<OpArg>("", 0)),
+                                         ArgT(R"("")", makeSuccess<OpArg>(val(R"("")"), 2)),
+                                         ArgT("", makeError<OpArg>("", 0)),
+                                         ArgT(" ", makeSuccess<OpArg>(val(R"(" ")"), 1)),
+                                         ArgT("'' )", makeError<OpArg>("", 2))));
+
+INSTANTIATE_TEST_SUITE_P(
+    Builder,
+    ParseHelperTest,
+    testing::Values(
+        HelperT("stringValue", makeError<HelperToken>("", 11)),
+        HelperT("123", makeError<HelperToken>("", 3)),
+        HelperT("123.456", makeError<HelperToken>("", 3)),
+        HelperT("true", makeError<HelperToken>("", 4)),
+        HelperT("false", makeError<HelperToken>("", 5)),
+        HelperT("{}", makeError<HelperToken>("", 0)),
+        HelperT("[]", makeError<HelperToken>("", 0)),
+        HelperT("$ref", makeError<HelperToken>("", 0)),
+        HelperT("helper()", makeSuccess<HelperToken>({.name = "helper", .args = {}}, 8)),
+        HelperT("helper('')", makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("")")}}, 10)),
+        HelperT("helper( '')", makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("")")}}, 11)),
+        HelperT("helper( ''  )", makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("")")}}, 13)),
+        HelperT("helper(arg1)", makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("arg1")")}}, 12)),
+        HelperT("helper(arg1, '')",
+                makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("arg1")"), val(R"("")")}}, 16)),
+        HelperT("helper(arg1, )", makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("arg1")"), val()}}, 14)),
+        HelperT("helper(arg1,arg2)",
+                makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("arg1")"), val(R"("arg2")")}}, 17)),
+        HelperT(R"(helper(arg1,  ""))",
+                makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("arg1")"), val(R"("")")}}, 17)),
+        HelperT("helper(arg1, '', arg3)",
+                makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("arg1")"), val(R"("")"), val(R"("arg3")")}},
+                                         22)),
+        HelperT("helper(arg1, '' , arg3)",
+                makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("arg1")"), val(R"("")"), val(R"("arg3")")}},
+                                         23)),
+        HelperT("helper(arg1, arg2, arg3)",
+                makeSuccess<HelperToken>(
+                    {.name = "helper", .args = {val(R"("arg1")"), val(R"("arg2")"), val(R"("arg3")")}}, 24)),
+        HelperT(R"(helper(arg1, arg2\,arg3))",
+                makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("arg1")"), val(R"("arg2,arg3")")}},
+                                         24)), // Testing escaped comma
+        HelperT(R"(helper(arg1,\ arg2))",
+                makeSuccess<HelperToken>({.name = "helper", .args = {val(R"("arg1")"), val(R"(" arg2")")}},
+                                         19)),                  // Testing escaped space
+        HelperT("helper(arg1", makeError<HelperToken>("", 11)), // Missing closing parenthesis
+        HelperT("'helper(arg1'", makeError<HelperToken>("", 0)),
+        HelperT("test arg1)", makeError<HelperToken>("", 4)), // Missing opening parenthesis
+        HelperT("", makeError<HelperToken>("", 0)),           // Empty string
+        HelperT("()", makeError<HelperToken>("", 0)),         // No function name
+        HelperT("test(,)", makeSuccess<HelperToken>({.name = "test", .args {val(), val()}}, 7)),
+        HelperT("test(,,)", makeSuccess<HelperToken>({.name = "test", .args {val(), val(), val()}}, 8)),
+        HelperT("test(, ,)", makeSuccess<HelperToken>({.name = "test", .args {val(), val(), val()}}, 9)),
+        HelperT("test(arg1,)", makeSuccess<HelperToken>({.name = "test", .args {val(R"("arg1")"), val()}}, 11)),
+        HelperT("test(arg1, )", makeSuccess<HelperToken>({.name = "test", .args {val(R"("arg1")"), val()}}, 12)),
+        HelperT(R"(test(arg1,\ ))",
+                makeSuccess<HelperToken>({.name = "test", .args {val(R"("arg1")"), val(R"(" ")")}}, 13)),
+        HelperT("test(arg1,' ')",
+                makeSuccess<HelperToken>({.name = "test", .args {val(R"("arg1")"), val(R"(" ")")}}, 14)),
+        HelperT("test(arg1,  )", makeSuccess<HelperToken>({.name = "test", .args {val(R"("arg1")"), val()}}, 13)),
+        HelperT("test(arg1, ())", makeError<HelperToken>("", 13)),
+        HelperT(R"(test(arg1, (\)))",
+                makeSuccess<HelperToken>({.name = "test", .args {val(R"("arg1")"), val(R"z("()")z")}}, 15)),
+        HelperT("test(arg1, ( arg2)", makeError<HelperToken>("", 13)),
+        HelperT(R"(test(arg1, \) arg2))", makeError<HelperToken>("", 14)),
+        HelperT(R"(test(arg1, \)\ arg2))",
+                makeSuccess<HelperToken>({.name = "test", .args = {val(R"("arg1")"), val(R"(") arg2")")}}, 20)),
+        HelperT(R"(test(arg1, \)\ arg2\)\)\)))",
+                makeSuccess<HelperToken>({.name = "test", .args = {val(R"("arg1")"), val(R"z(") arg2)))")z")}}, 26)),
+        HelperT("test(arg1)leftover", makeError<HelperToken>("", 10)),
+        HelperT("test(arg1, ' , ( ) ' )",
+                makeSuccess<HelperToken>({.name = "test", .args {val(R"("arg1")"), val(R"(" , ( ) ")")}}, 22)),
+        HelperT("test(arg1, $ref, ' , ( ) ' , 123)",
+                makeSuccess<HelperToken>(
+                    {.name = "test", .args {val(R"("arg1")"), ref("ref"), val(R"(" , ( ) ")"), val("123")}}, 33))));
+
+INSTANTIATE_TEST_SUITE_P(Builder,
+                         IsDefaultHelperTest,
+                         testing::Values(IsDefaultT("helper", true),
+                                         IsDefaultT("helper(", false),
+                                         IsDefaultT("$ref", true),
+                                         IsDefaultT("", true)));
+
+INSTANTIATE_TEST_SUITE_P(Builder,
+                         ParseOperatorTest,
+                         testing::Values(OperatorT("==", makeSuccess<Operator>(Operator::EQUAL, 2)),
+                                         OperatorT("!=", makeSuccess<Operator>(Operator::NOT_EQUAL, 2)),
+                                         OperatorT(">=", makeSuccess<Operator>(Operator::GREATER_THAN_OR_EQUAL, 2)),
+                                         OperatorT(">", makeSuccess<Operator>(Operator::GREATER_THAN, 1)),
+                                         OperatorT("<=", makeSuccess<Operator>(Operator::LESS_THAN_OR_EQUAL, 2)),
+                                         OperatorT("<", makeSuccess<Operator>(Operator::LESS_THAN, 1)),
+                                         OperatorT("=", makeError<Operator>("", 1)),
+                                         OperatorT("!", makeError<Operator>("", 1)),
+                                         OperatorT("  ==", makeSuccess<Operator>(Operator::EQUAL, 4)),
+                                         OperatorT("  !=", makeSuccess<Operator>(Operator::NOT_EQUAL, 4)),
+                                         OperatorT("  >=", makeSuccess<Operator>(Operator::GREATER_THAN_OR_EQUAL, 4)),
+                                         OperatorT("  >", makeSuccess<Operator>(Operator::GREATER_THAN, 3)),
+                                         OperatorT("  <=", makeSuccess<Operator>(Operator::LESS_THAN_OR_EQUAL, 4)),
+                                         OperatorT("  <", makeSuccess<Operator>(Operator::LESS_THAN, 3)),
+                                         OperatorT("  ==  ", makeSuccess<Operator>(Operator::EQUAL, 6)),
+                                         OperatorT("  !=  ", makeSuccess<Operator>(Operator::NOT_EQUAL, 6)),
+                                         OperatorT("  >=  ", makeSuccess<Operator>(Operator::GREATER_THAN_OR_EQUAL, 6)),
+                                         OperatorT("  >  ", makeSuccess<Operator>(Operator::GREATER_THAN, 5)),
+                                         OperatorT("  <=  ", makeSuccess<Operator>(Operator::LESS_THAN_OR_EQUAL, 6)),
+                                         OperatorT("  <  ", makeSuccess<Operator>(Operator::LESS_THAN, 5))));
+
+INSTANTIATE_TEST_SUITE_P(
+    Builder,
+    ParseOperationTest,
+    testing::Values(
+        // Equal
+        OperationT(R"($field==123)",
+                   makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::EQUAL, .value = val("123")},
+                                               11)),
+        OperationT(R"($field =="123")",
+                   makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::EQUAL, .value = val(R"("123")")},
+                                               14)),
+        OperationT(R"($field== true)",
+                   makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::EQUAL, .value = val(R"(true)")},
+                                               13)),
+        OperationT(R"($field == null)",
+                   makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::EQUAL, .value = val(R"(null)")},
+                                               14)),
+        OperationT(R"($field=={} )",
+                   makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::EQUAL, .value = val(R"({})")},
+                                               10)),
+        OperationT(R"($field==[])",
+                   makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::EQUAL, .value = val(R"([])")},
+                                               10)),
+        OperationT(R"($field==$ref)",
+                   makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::EQUAL, .value = ref("ref")},
+                                               12)),
+        // Greater than or equal
+        OperationT(R"($field>=123)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN_OR_EQUAL, .value = val("123")}, 11)),
+        OperationT(R"($field >="123")",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN_OR_EQUAL, .value = val(R"("123")")}, 14)),
+        OperationT(R"($field>= true)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN_OR_EQUAL, .value = val(R"(true)")}, 13)),
+        OperationT(R"($field >= null)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN_OR_EQUAL, .value = val(R"(null)")}, 14)),
+        OperationT(R"($field>={} )",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN_OR_EQUAL, .value = val(R"({})")}, 10)),
+        OperationT(R"($field>=[])",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN_OR_EQUAL, .value = val(R"([])")}, 10)),
+        OperationT(R"($field>=$ref)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN_OR_EQUAL, .value = ref("ref")}, 12)),
+        // Greater than
+        OperationT(R"($field>123)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN, .value = val("123")}, 10)),
+        OperationT(R"($field >"123")",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN, .value = val(R"("123")")}, 13)),
+        OperationT(R"($field> true)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN, .value = val(R"(true)")}, 12)),
+        OperationT(R"($field > null)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN, .value = val(R"(null)")}, 13)),
+        OperationT(R"($field>{} )",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN, .value = val(R"({})")}, 9)),
+        OperationT(R"($field>[] )",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN, .value = val(R"([])")}, 9)),
+        OperationT(R"($field>$ref)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::GREATER_THAN, .value = ref("ref")}, 11)),
+        // Less than or equal
+        OperationT(R"($field<=123)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::LESS_THAN_OR_EQUAL, .value = val("123")}, 11)),
+        OperationT(R"($field <="123")",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::LESS_THAN_OR_EQUAL, .value = val(R"("123")")}, 14)),
+        OperationT(R"($field<= true)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::LESS_THAN_OR_EQUAL, .value = val(R"(true)")}, 13)),
+        OperationT(R"($field <= null)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::LESS_THAN_OR_EQUAL, .value = val(R"(null)")}, 14)),
+        OperationT(R"($field<={} )",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::LESS_THAN_OR_EQUAL, .value = val(R"({})")}, 10)),
+        OperationT(R"($field<=[])",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::LESS_THAN_OR_EQUAL, .value = val(R"([])")}, 10)),
+        OperationT(R"($field<=$ref)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::LESS_THAN_OR_EQUAL, .value = ref("ref")}, 12)),
+        // Less than
+        OperationT(R"($field<123)",
+                   makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::LESS_THAN, .value = val("123")},
+                                               10)),
+        OperationT(R"($field <"123")",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::LESS_THAN, .value = val(R"("123")")}, 13)),
+        OperationT(R"($field< true)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::LESS_THAN, .value = val(R"(true)")}, 12)),
+        OperationT(R"($field < null)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::LESS_THAN, .value = val(R"(null)")}, 13)),
+        OperationT(
+            R"($field<{} )",
+            makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::LESS_THAN, .value = val(R"({})")}, 9)),
+        OperationT(
+            R"($field<[])",
+            makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::LESS_THAN, .value = val(R"([])")}, 9)),
+        OperationT(R"($field<$ref)",
+                   makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::LESS_THAN, .value = ref("ref")},
+                                               11)),
+        // Not equal
+        OperationT(R"($field!=123)",
+                   makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::NOT_EQUAL, .value = val("123")},
+                                               11)),
+        OperationT(R"($field !="123")",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::NOT_EQUAL, .value = val(R"("123")")}, 14)),
+        OperationT(R"($field!= true)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::NOT_EQUAL, .value = val(R"(true)")}, 13)),
+        OperationT(R"($field != null)",
+                   makeSuccess<OperationToken>(
+                       {.field = ref("field"), .op = Operator::NOT_EQUAL, .value = val(R"(null)")}, 14)),
+        OperationT(
+            R"($field!={} )",
+            makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::NOT_EQUAL, .value = val(R"({})")}, 10)),
+        OperationT(
+            R"($field!=[])",
+            makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::NOT_EQUAL, .value = val(R"([])")}, 10)),
+        OperationT(R"($field!=$ref)",
+                   makeSuccess<OperationToken>({.field = ref("field"), .op = Operator::NOT_EQUAL, .value = ref("ref")},
+                                               12)),
+        // Invalid
+        OperationT(R"($field=123)", makeError<OperationToken>("", 7)),
+        OperationT(R"(not_ref==123)", makeError<OperationToken>("", 0)),
+        OperationT(R"($field==)", makeError<OperationToken>("", 8))));
+
+INSTANTIATE_TEST_SUITE_P(
+    Builder,
+    ParseTermTest,
+    testing::Values(
+        //**************************
+        // Expression TESTS
+        //**************************
+        TermT(R"($field==123)",
+              makeSuccess<HelperToken>(HelperToken {"filter", Reference("field"), {val(R"(123)")}}, 11)),
+        TermT(R"($field=="123")",
+              makeSuccess<HelperToken>(HelperToken {"filter", Reference("field"), {val(R"("123")")}}, 13)),
+        TermT(R"($field==$field2)",
+              makeSuccess<HelperToken>(HelperToken {"filter", Reference("field"), {ref("field2")}}, 15)),
+        TermT(R"($field=={})",
+              makeSuccess<HelperToken>(HelperToken {"filter", Reference("field"), {val(R"({})")}}, 10)),
+        TermT(R"($field==null)",
+              makeSuccess<HelperToken>(HelperToken {"filter", Reference("field"), {val(R"(null)")}}, 12)),
+        TermT(R"($field==true)",
+              makeSuccess<HelperToken>(HelperToken {"filter", Reference("field"), {val(R"(true)")}}, 12)),
+        TermT(R"($field>=123)",
+              makeSuccess<HelperToken>(HelperToken {"int_greater_or_equal", Reference("field"), {val(R"(123)")}}, 11)),
+        TermT(R"($field>123)",
+              makeSuccess<HelperToken>(HelperToken {"int_greater", Reference("field"), {val(R"(123)")}}, 10)),
+        TermT(R"($field<="123")",
+              makeSuccess<HelperToken>(HelperToken {"string_less_or_equal", Reference("field"), {val(R"("123")")}},
+                                       13)),
+        TermT(R"($field<"123")",
+              makeSuccess<HelperToken>(HelperToken {"string_less", Reference("field"), {val(R"("123")")}}, 12)),
+        TermT(R"($field!=$field2)", makeError<HelperToken>("", 0)),
+        TermT(R"($field<$field2)", makeError<HelperToken>("", 0)),
+        TermT(R"($field=={"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})",
+              makeSuccess<HelperToken>({"filter",
+                                        Reference("field"),
+                                        {val(R"({"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})")}},
+                                       69)),
         // Expression Ok - with spaces
-        TermParserT(true, R"($field == 123)", expToken {"$field", eOp::EQUAL, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field == "123")", expToken {"$field", eOp::EQUAL, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field == $field2)", expToken {"$field", eOp::EQUAL, json::Json {R"("$field2")"}}),
-        TermParserT(true, R"($field == {})", expToken {"$field", eOp::EQUAL, json::Json {R"({})"}}),
-        TermParserT(true, R"($field == null)", expToken {"$field", eOp::EQUAL, json::Json {R"(null)"}}),
-        TermParserT(true, R"($field == true)", expToken {"$field", eOp::EQUAL, json::Json {R"(true)"}}),
-        TermParserT(true, R"($field >= 123)", expToken {"$field", eOp::GREATER_THAN_OR_EQUAL, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field > 123)", expToken {"$field", eOp::GREATER_THAN, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field <= "123")", expToken {"$field", eOp::LESS_THAN_OR_EQUAL, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field < "123")", expToken {"$field", eOp::LESS_THAN, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field != $field2)", expToken {"$field", eOp::NOT_EQUAL, json::Json {R"("$field2")"}}),
-        TermParserT(true, R"($field < $field2)", expToken {"$field", eOp::LESS_THAN, json::Json {R"("$field2")"}}),
-        TermParserT(true,
-                    R"($field == {"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})",
-                    expToken {"$field",
-                              eOp::EQUAL,
-                              json::Json {R"({"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})"}}),
+        TermT(R"($field == 123)", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"(123)")}}, 13)),
+        TermT(R"($field == "123")", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"("123")")}}, 15)),
+        TermT(R"($field == $field2)", makeSuccess<HelperToken>({"filter", Reference("field"), {ref("field2")}}, 17)),
+        TermT(R"($field == {})", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"({})")}}, 12)),
+        TermT(R"($field == null)", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"(null)")}}, 14)),
+        TermT(R"($field == true)", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"(true)")}}, 14)),
+        TermT(R"($field >= 123)",
+              makeSuccess<HelperToken>({"int_greater_or_equal", Reference("field"), {val(R"(123)")}}, 13)),
+        TermT(R"($field > 123)", makeSuccess<HelperToken>({"int_greater", Reference("field"), {val(R"(123)")}}, 12)),
+        TermT(R"($field <= "123")",
+              makeSuccess<HelperToken>({"string_less_or_equal", Reference("field"), {val(R"("123")")}}, 15)),
+        TermT(R"($field < "123")",
+              makeSuccess<HelperToken>({"string_less", Reference("field"), {val(R"("123")")}}, 14)),
+        TermT(R"($field != $field2)", makeError<HelperToken>("", 0)),
+        TermT(R"($field < $field2)", makeError<HelperToken>("", 0)),
+        TermT(R"($field == {"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})",
+              makeSuccess<HelperToken>({"filter",
+                                        Reference("field"),
+                                        {val(R"({"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})")}},
+                                       71)),
         // Expression Ok - with spaces after field only
-        TermParserT(true, R"($field   ==123)", expToken {"$field", eOp::EQUAL, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field   =="123")", expToken {"$field", eOp::EQUAL, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field   ==$field2)", expToken {"$field", eOp::EQUAL, json::Json {R"("$field2")"}}),
-        TermParserT(true, R"($field   =={})", expToken {"$field", eOp::EQUAL, json::Json {R"({})"}}),
-        TermParserT(true, R"($field   ==null)", expToken {"$field", eOp::EQUAL, json::Json {R"(null)"}}),
-        TermParserT(true, R"($field   ==true)", expToken {"$field", eOp::EQUAL, json::Json {R"(true)"}}),
-        TermParserT(true, R"($field   >=123)", expToken {"$field", eOp::GREATER_THAN_OR_EQUAL, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field   >123)", expToken {"$field", eOp::GREATER_THAN, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field   <="123")", expToken {"$field", eOp::LESS_THAN_OR_EQUAL, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field   <"123")", expToken {"$field", eOp::LESS_THAN, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field   !=$field2)", expToken {"$field", eOp::NOT_EQUAL, json::Json {R"("$field2")"}}),
-        TermParserT(true, R"($field   <$field2)", expToken {"$field", eOp::LESS_THAN, json::Json {R"("$field2")"}}),
-        TermParserT(true,
-                    R"($field =={"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})",
-                    expToken {"$field",
-                              eOp::EQUAL,
-                              json::Json {R"({"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})"}}),
+        TermT(R"($field   ==123)", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"(123)")}}, 14)),
+        TermT(R"($field   =="123")", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"("123")")}}, 16)),
+        TermT(R"($field   ==$field2)", makeSuccess<HelperToken>({"filter", Reference("field"), {ref("field2")}}, 18)),
+        TermT(R"($field   =={})", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"({})")}}, 13)),
+        TermT(R"($field   ==null)", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"(null)")}}, 15)),
+        TermT(R"($field   ==true)", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"(true)")}}, 15)),
+        TermT(R"($field   >=123)",
+              makeSuccess<HelperToken>({"int_greater_or_equal", Reference("field"), {val(R"(123)")}}, 14)),
+        TermT(R"($field   >123)", makeSuccess<HelperToken>({"int_greater", Reference("field"), {val(R"(123)")}}, 13)),
+        TermT(R"($field   <="123")",
+              makeSuccess<HelperToken>({"string_less_or_equal", Reference("field"), {val(R"("123")")}}, 16)),
+        TermT(R"($field   <"123")",
+              makeSuccess<HelperToken>({"string_less", Reference("field"), {val(R"("123")")}}, 15)),
+        TermT(R"($field   !=$field2)", makeError<HelperToken>("", 0)),
+        TermT(R"($field   <$field2)", makeError<HelperToken>("", 0)),
+        TermT(R"($field =={"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})",
+              makeSuccess<HelperToken>({"filter",
+                                        Reference("field"),
+                                        {val(R"({"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})")}},
+                                       70)),
         // Expression Ok - with spaces after operator only
-        TermParserT(true, R"($field==   123)", expToken {"$field", eOp::EQUAL, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field==  "123")", expToken {"$field", eOp::EQUAL, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field==   $field2)", expToken {"$field", eOp::EQUAL, json::Json {R"("$field2")"}}),
-        TermParserT(true, R"($field==   {})", expToken {"$field", eOp::EQUAL, json::Json {R"({})"}}),
-        TermParserT(true, R"($field==   null)", expToken {"$field", eOp::EQUAL, json::Json {R"(null)"}}),
-        TermParserT(true, R"($field==   true)", expToken {"$field", eOp::EQUAL, json::Json {R"(true)"}}),
-        TermParserT(true, R"($field>=   123)", expToken {"$field", eOp::GREATER_THAN_OR_EQUAL, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field>    123)", expToken {"$field", eOp::GREATER_THAN, json::Json {R"(123)"}}),
-        TermParserT(true, R"($field<=   "123")", expToken {"$field", eOp::LESS_THAN_OR_EQUAL, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field<   "123")", expToken {"$field", eOp::LESS_THAN, json::Json {R"("123")"}}),
-        TermParserT(true, R"($field!=   $field2)", expToken {"$field", eOp::NOT_EQUAL, json::Json {R"("$field2")"}}),
-        TermParserT(true, R"($field<   $field2)", expToken {"$field", eOp::LESS_THAN, json::Json {R"("$field2")"}}),
-        TermParserT(true,
-                    R"($field==    {"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})",
-                    expToken {"$field",
-                              eOp::EQUAL,
-                              json::Json {R"({"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})"}}),
+        TermT(R"($field==   123)", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"(123)")}}, 14)),
+        TermT(R"($field==  "123")", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"("123")")}}, 15)),
+        TermT(R"($field==   $field2)", makeSuccess<HelperToken>({"filter", Reference("field"), {ref("field2")}}, 18)),
+        TermT(R"($field==   {})", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"({})")}}, 13)),
+        TermT(R"($field==   null)", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"(null)")}}, 15)),
+        TermT(R"($field==   true)", makeSuccess<HelperToken>({"filter", Reference("field"), {val(R"(true)")}}, 15)),
+        TermT(R"($field>=   123)",
+              makeSuccess<HelperToken>({"int_greater_or_equal", Reference("field"), {val(R"(123)")}}, 14)),
+        TermT(R"($field>    123)", makeSuccess<HelperToken>({"int_greater", Reference("field"), {val(R"(123)")}}, 14)),
+        TermT(R"($field<=   "123")",
+              makeSuccess<HelperToken>({"string_less_or_equal", Reference("field"), {val(R"("123")")}}, 16)),
+        TermT(R"($field<   "123")",
+              makeSuccess<HelperToken>({"string_less", Reference("field"), {val(R"("123")")}}, 15)),
+        TermT(R"($field!=   $field2)", makeError<HelperToken>("", 0)),
+        TermT(R"($field<   $field2)", makeError<HelperToken>("", 0)),
+        TermT(R"($field==    {"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})",
+              makeSuccess<HelperToken>({"filter",
+                                        Reference("field"),
+                                        {val(R"({"key_str":"asd","key_num":123,"key_obj":{"custom_key":true}})")}},
+                                       73)),
         // Expression fail - bad operator
-        TermParserT(false, R"($field=!123)", expToken {}),
-        TermParserT(false, R"($field=123)", expToken {}),
-        TermParserT(false, R"($field->123)", expToken {}),
-        TermParserT(false, R"($field.123)", expToken {}),
-        TermParserT(false, R"($field!123)", expToken {}),
-        TermParserT(false, R"($field|123)", expToken {}),
-        TermParserT(false, R"($field?123)", expToken {}),
-        TermParserT(false, R"($field =! 123)", expToken {}),
-        TermParserT(false, R"($field = 123)", expToken {}),
-        TermParserT(false, R"($field -> 123)", expToken {}),
+        TermT(R"($field=!123)", makeError<HelperToken>("", 0)),
+        TermT(R"($field=123)", makeError<HelperToken>("", 0)),
+        TermT(R"($field->123)", makeError<HelperToken>("", 0)),
+        TermT(R"($field.123)", makeError<HelperToken>("", 0)),
+        TermT(R"($field!123)", makeError<HelperToken>("", 0)),
+        TermT(R"($field|123)", makeError<HelperToken>("", 0)),
+        TermT(R"($field?123)", makeError<HelperToken>("", 0)),
+        TermT(R"($field =! 123)", makeError<HelperToken>("", 0)),
+        TermT(R"($field = 123)", makeError<HelperToken>("", 0)),
+        TermT(R"($field -> 123)", makeError<HelperToken>("", 0)),
         // Expression fail - bad field
-        TermParserT(false, R"(field == 123)", expToken {}),
-        TermParserT(false, R"(field == "123")", expToken {}),
-        TermParserT(false, R"(field == $field2)", expToken {}),
-        TermParserT(false, R"(field == {})", expToken {}),
-        TermParserT(false, R"(field == null)", expToken {}),
-        TermParserT(false, R"(field == true)", expToken {}),
-        TermParserT(false, R"(field >= 123)", expToken {}),
-        TermParserT(false, R"(field > 123)", expToken {}),
-        TermParserT(false, R"(field <= "123")", expToken {}),
-        TermParserT(false, R"(field < "123")", expToken {}),
-        TermParserT(false, R"(field != $field2)", expToken {}),
+        TermT(R"(field == 123)", makeError<HelperToken>("", 0)),
+        TermT(R"(field == "123")", makeError<HelperToken>("", 0)),
+        TermT(R"(field == $field2)", makeError<HelperToken>("", 0)),
+        TermT(R"(field == {})", makeError<HelperToken>("", 0)),
+        TermT(R"(field == null)", makeError<HelperToken>("", 0)),
+        TermT(R"(field == true)", makeError<HelperToken>("", 0)),
+        TermT(R"(field >= 123)", makeError<HelperToken>("", 0)),
+        TermT(R"(field > 123)", makeError<HelperToken>("", 0)),
+        TermT(R"(field <= "123")", makeError<HelperToken>("", 0)),
+        TermT(R"(field < "123")", makeError<HelperToken>("", 0)),
+        TermT(R"(field != $field2)", makeError<HelperToken>("", 0)),
         // Expression fail - Missing field
-        TermParserT(false, R"($field == )", expToken {}),
-        TermParserT(false, R"($ == 123)", expToken {}),
-        TermParserT(false, R"($field 123)", expToken {}),
+        TermT(R"($field == )", makeError<HelperToken>("", 0)),
+        TermT(R"($ == 123)", makeError<HelperToken>("", 0)),
+        TermT(R"($field 123)", makeError<HelperToken>("", 0)),
         //**************************
         // Helper TEST
         //**************************
         // Helper Ok - spaces after separator
-        TermParserT(true, R"(helper_name123($target_field1))", helpToken {"helper_name123", target("target_field1")}),
-        TermParserT(true,
-                    R"(helper_name123($target_field1, ))",
-                    helpToken {"helper_name123", target("target_field1"), {val("\"\"")}}),
-        TermParserT(true, R"(hp($f1, $f2, $f3))", helpToken {"hp", target("f1"), {ref("f2"), ref("f3")}}),
-        TermParserT(true,
-                    R"(hp($f1, $f2, $f3, ))",
-                    helpToken {"hp", target("f1"), {ref("f2"), ref("f3"), val("\"\"")}}),
-        TermParserT(true,
-                    R"(hp($f1, f2, f3, f4))",
-                    helpToken {"hp", target("f1"), {val("\"f2\""), val("\"f3\""), val("\"f4\"")}}),
-        TermParserT(true,
-                    R"(hp($f1, f2, f3, f4, ))",
-                    helpToken {"hp", target("f1"), {val("\"f2\""), val("\"f3\""), val("\"f4\""), val("\"\"")}}),
-        TermParserT(true,
-                    R"(hp($f1, , , f4, ))",
-                    helpToken {"hp", target("f1"), {val("\"\""), val("\"\""), val("\"f4\""), val("\"\"")}}),
-        TermParserT(true,
-                    R"(hp($f1, , , f4, ))",
-                    helpToken {"hp", target("f1"), {val("\"\""), val("\"\""), val("\"f4\""), val("\"\"")}}),
+        TermT(R"(helper_name123($target_field1))",
+              makeSuccess<HelperToken>({"helper_name123", Reference("target_field1")}, 30)),
+        TermT(R"(helper_name123($target_field1, ))",
+              makeSuccess<HelperToken>({"helper_name123", Reference("target_field1"), {val()}}, 32)),
+        TermT(R"(hp($f1, $f2, $f3))", makeSuccess<HelperToken>({"hp", Reference("f1"), {ref("f2"), ref("f3")}}, 17)),
+        TermT(R"(hp($f1, $f2, $f3, ))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {ref("f2"), ref("f3"), val()}}, 19)),
+        TermT(R"(hp($f1, f2, f3, f4))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {val(R"("f2")"), val(R"("f3")"), val(R"("f4")")}}, 19)),
+        TermT(R"(hp($f1, f2, f3, f4, ))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {val(R"("f2")"), val(R"("f3")"), val(R"("f4")"), val()}},
+                                       21)),
+        TermT(R"(hp($f1, , , f4, ))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {val(), val(), val(R"("f4")"), val()}}, 17)),
         // Helper Ok - without spaces
-        TermParserT(true, R"(hp($f1,$f2,$f3))", helpToken {"hp", target("f1"), {ref("f2"), ref("f3")}}),
-        TermParserT(true, R"(hp($f1,$f2,$f3, ))", helpToken {"hp", target("f1"), {ref("f2"), ref("f3"), val("\"\"")}}),
-        TermParserT(true,
-                    R"(hp($f1,f2,f3,f4))",
-                    helpToken {"hp", target("f1"), {val("\"f2\""), val("\"f3\""), val("\"f4\"")}}),
-        TermParserT(true,
-                    R"(hp($f1,f2,f3,f4,))",
-                    helpToken {"hp", target("f1"), {val("\"f2\""), val("\"f3\""), val("\"f4\""), val("\"\"")}}),
-        TermParserT(true,
-                    R"(hp($f1,,,f4,))",
-                    helpToken {"hp", target("f1"), {val("\"\""), val("\"\""), val("\"f4\""), val("\"\"")}}),
+        TermT(R"(hp($f1,$f2,$f3))", makeSuccess<HelperToken>({"hp", Reference("f1"), {ref("f2"), ref("f3")}}, 15)),
+        TermT(R"(hp($f1,$f2,$f3, ))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {ref("f2"), ref("f3"), val()}}, 17)),
+        TermT(R"(hp($f1,f2,f3,f4))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {val(R"("f2")"), val(R"("f3")"), val(R"("f4")")}}, 16)),
+        TermT(R"(hp($f1,f2,f3,f4,))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {val(R"("f2")"), val(R"("f3")"), val(R"("f4")"), val()}},
+                                       17)),
+        TermT(R"(hp($f1,,,f4,))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {val(), val(), val(R"("f4")"), val()}}, 13)),
         // Helper Ok - with spaces before separator
-        TermParserT(true, R"(hp(   $f1,   $f2,   $f3))", helpToken {"hp", target("f1"), {ref("f2"), ref("f3")}}),
-        TermParserT(true,
-                    R"(hp(   $f1,   $f2,   $f3,   ))",
-                    helpToken {"hp", target("f1"), {ref("f2"), ref("f3"), val("\"\"")}}),
-        TermParserT(true,
-                    R"(hp(   $f1,   f2,   f3,   f4))",
-                    helpToken {"hp", target("f1"), {val("\"f2\""), val("\"f3\""), val("\"f4\"")}}),
-        TermParserT(true,
-                    R"(hp(   $f1,   f2,   f3,   f4,   ))",
-                    helpToken {"hp", target("f1"), {val("\"f2\""), val("\"f3\""), val("\"f4\""), val("\"\"")}}),
-        TermParserT(true,
-                    R"(hp(   $f1,\   ,  \ ,   f4,   ))",
-                    helpToken {"hp", target("f1"), {val("\"   \""), val("\" \""), val("\"f4\""), val("\"\"")}}),
-        TermParserT(true,
-                    R"(hp(   $f1,   ,   ,   f4,   ))",
-                    helpToken {"hp", target("f1"), {val("\"\""), val("\"\""), val("\"f4\""), val("\"\"")}}),
+        TermT(R"(hp(   $f1,   $f2,   $f3))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {ref("f2"), ref("f3")}}, 24)),
+        TermT(R"(hp(   $f1,   $f2,   $f3,   ))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {ref("f2"), ref("f3"), val()}}, 28)),
+        TermT(R"(hp(   $f1,   f2,   f3,   f4))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {val(R"("f2")"), val(R"("f3")"), val(R"("f4")")}}, 28)),
+        TermT(R"(hp(   $f1,   f2,   f3,   f4,   ))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {val(R"("f2")"), val(R"("f3")"), val(R"("f4")"), val()}},
+                                       32)),
+        TermT(R"(hp(   $f1,\   ,  \ ,   f4,   ))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {val(R"(" ")"), val(R"(" ")"), val(R"("f4")"), val()}},
+                                       30)),
+        TermT(R"(hp(   $f1,   ,   ,   f4,   ))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {val(), val(), val(R"("f4")"), val()}}, 28)),
         // Helper Ok - with spaces before and after separator
-        TermParserT(true,
-                    R"(hp(   $f1   ,   $f2   ,   $f3   ))",
-                    helpToken {"hp", target("f1   "), {ref("f2   "), ref("f3   ")}}),
-        TermParserT(true,
-                    R"(hp(   $f1   ,   $f2   ,   $f3   ,   ))",
-                    helpToken {"hp", target("f1   "), {ref("f2   "), ref("f3   "), val("\"\"")}}),
-        TermParserT(true,
-                    R"(hp(   $f1   ,   f2   ,   f3   ,   f4   ))",
-                    helpToken {"hp", target("f1   "), {val("\"f2   \""), val("\"f3   \""), val("\"f4   \"")}}),
-        TermParserT(true,
-                    R"(hp(   $f1   ,\   f2   ,   f3   ,   f4   ,   ))",
-                    helpToken {
-                        "hp", target("f1   "), {val("\"   f2   \""), val("\"f3   \""), val("\"f4   \""), val("\"\"")}}),
+        TermT(R"(hp(   $f1   ,   $f2   ,   $f3   ))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {ref("f2"), ref("f3")}}, 33)),
+        TermT(R"(hp(   $f1   ,   $f2   ,   $f3   ,   ))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {ref("f2"), ref("f3"), val()}}, 37)),
+        TermT(R"(hp(   $f1   ,   f2   ,   f3   ,   f4   ))",
+              makeSuccess<HelperToken>({"hp", Reference("f1"), {val(R"("f2")"), val(R"("f3")"), val(R"("f4")")}}, 40)),
+        TermT(R"(hp(   $f1   ,\   f2   ,   f3   ,   f4   ,   ))", makeError<HelperToken>("", 0)),
         // Scape characters
-        TermParserT(false, R"(hp(\ \, ,,,\,\,,\,\,\,))", {}),
-        TermParserT(true,
-                    R"(hp($f1,\ \, ,,,\,\,,\,\,\,))",
-                    helpToken {
-                        "hp", target("f1"), {val("\" , \""), val("\"\""), val("\"\""), val("\",,\""), val("\",,,\"")}}),
-        TermParserT(true,
-                    R"(hp($f1,   \ \, ,  ,  ,  \,\, ,  \,\,\\\,))",
-                    helpToken {"hp",
-                               target("f1"),
-                               {val("\" , \""), val("\"\""), val("\"\""), val("\",, \""), val("\",,\\\\,\"")}}),
+        TermT(R"(hp(\ \, ,,,\,\,,\,\,\,))", makeError<HelperToken>("", 0)),
+        TermT(R"(hp($f1,\ \, ,,,\,\,,\,\,\,))",
+              makeSuccess<HelperToken>(
+                  {"hp", Reference("f1"), {val(R"(" ,")"), val(), val(), val(R"(",,")"), val(R"(",,,")")}}, 27)),
+        TermT(R"(hp($f1,   \ \, ,  ,  ,  \,\, ,  \,\,\\\,))",
+              makeSuccess<HelperToken>(
+                  {"hp", Reference("f1"), {val(R"(" ,")"), val(), val(), val(R"(",,")"), val(R"(",,\\,")")}}, 41)),
         // Helper Ok - Check in builder time the validity of the helper name and content of parameters
-        TermParserT(false, R"(helper_name123())", {}),
-        TermParserT(false, R"(helper_name123(rawvalue))", {}),
-        TermParserT(true, R"(hp($wazuh.queue) )", helpToken {"hp", target("wazuh.queue")}),
-        TermParserT(true, R"(hp($wazuh.queue) ())", helpToken {"hp", target("wazuh.queue")}),
-        TermParserT(true, R"(hp($wazuh.queue)==())", helpToken {"hp", target("wazuh.queue")}),
-        TermParserT(true, R"(hp($wazuh.queue) AND)", helpToken {"hp", target("wazuh.queue")}),
-        TermParserT(true, R"(hp($wazuh.queue)==)", helpToken {"hp", target("wazuh.queue")}),
-        TermParserT(true, R"(hp($wazuh.queue)!!)", helpToken {"hp", target("wazuh.queue")}),
-        TermParserT(true, R"(hp($wazuh.queue)>)", helpToken {"hp", target("wazuh.queue")}),
-        TermParserT(true,
-                    R"(hp($wazuh.queue, ,\ \,) )",
-                    helpToken {"hp", target("wazuh.queue"), {val("\"\""), val("\" ,\"")}}),
-        TermParserT(true,
-                    R"(hp($wazuh.queue, ,\ \,) ())",
-                    helpToken {"hp", target("wazuh.queue"), {val("\"\""), val("\" ,\"")}}),
-        TermParserT(true,
-                    R"(hp($wazuh.queue, ,\ \,)==())",
-                    helpToken {"hp", target("wazuh.queue"), {val("\"\""), val("\" ,\"")}}),
-        TermParserT(true,
-                    R"(hp($wazuh.queue, ,\ \,) AND)",
-                    helpToken {"hp", target("wazuh.queue"), {val("\"\""), val("\" ,\"")}}),
-        TermParserT(true,
-                    R"(hp($wazuh.queue, ,\ \,)==)",
-                    helpToken {"hp", target("wazuh.queue"), {val("\"\""), val("\" ,\"")}}),
-        TermParserT(true,
-                    R"(hp($wazuh.queue, ,\ \,)!!)",
-                    helpToken {"hp", target("wazuh.queue"), {val("\"\""), val("\" ,\"")}}),
-        TermParserT(true,
-                    R"(hp($wazuh.queue, ,\ \,)>)",
-                    helpToken {"hp", target("wazuh.queue"), {val("\"\""), val("\" ,\"")}})));
+        TermT(R"(helper_name123())", makeError<HelperToken>("", 0)),
+        TermT(R"(helper_name123(rawvalue))", makeError<HelperToken>("", 0)),
+        TermT(R"(hp($wazuh.queue) )", makeSuccess<HelperToken>({"hp", Reference("wazuh.queue")}, 16)),
+        TermT(R"(hp($wazuh.queue) ())", makeSuccess<HelperToken>({"hp", Reference("wazuh.queue")}, 16)),
+        TermT(R"(hp($wazuh.queue)==())", makeSuccess<HelperToken>({"hp", Reference("wazuh.queue")}, 16)),
+        TermT(R"(hp($wazuh.queue) AND)", makeSuccess<HelperToken>({"hp", Reference("wazuh.queue")}, 16)),
+        TermT(R"(hp($wazuh.queue)==)", makeSuccess<HelperToken>({"hp", Reference("wazuh.queue")}, 16)),
+        TermT(R"(hp($wazuh.queue)!!)", makeSuccess<HelperToken>({"hp", Reference("wazuh.queue")}, 16)),
+        TermT(R"(hp($wazuh.queue)>)", makeSuccess<HelperToken>({"hp", Reference("wazuh.queue")}, 16)),
+        TermT(R"(hp($wazuh.queue, ,\ \,) )",
+              makeSuccess<HelperToken>({"hp", Reference("wazuh.queue"), {val(), val(R"(" ,")")}}, 23)),
+        TermT(R"(hp($wazuh.queue, ,\ \,) ())",
+              makeSuccess<HelperToken>({"hp", Reference("wazuh.queue"), {val(), val(R"(" ,")")}}, 23)),
+        TermT(R"(hp($wazuh.queue, ,\ \,)==())",
+              makeSuccess<HelperToken>({"hp", Reference("wazuh.queue"), {val(), val(R"(" ,")")}}, 23)),
+        TermT(R"(hp($wazuh.queue, ,\ \,) AND)",
+              makeSuccess<HelperToken>({"hp", Reference("wazuh.queue"), {val(), val(R"(" ,")")}}, 23)),
+        TermT(R"(hp($wazuh.queue, ,\ \,)==)",
+              makeSuccess<HelperToken>({"hp", Reference("wazuh.queue"), {val(), val(R"(" ,")")}}, 23)),
+        TermT(R"(hp($wazuh.queue, ,\ \,)!!)",
+              makeSuccess<HelperToken>({"hp", Reference("wazuh.queue"), {val(), val(R"(" ,")")}}, 23)),
+        TermT(R"(hp($wazuh.queue, ,\ \,)>)",
+              makeSuccess<HelperToken>({"hp", Reference("wazuh.queue"), {val(), val(R"(" ,")")}}, 23))));

--- a/src/engine/source/parsec/interface/parsec/parsec.hpp
+++ b/src/engine/source/parsec/interface/parsec/parsec.hpp
@@ -362,12 +362,12 @@ struct is_parser<Parser<T>> : std::true_type
 };
 
 template<typename T, typename R>
-struct is_parser_ret: std::false_type
+struct is_parser_ret : std::false_type
 {
 };
 
 template<typename T, typename R>
-struct is_parser_ret<Parser<T>, R>: std::is_base_of<R, T>
+struct is_parser_ret<Parser<T>, R> : std::is_base_of<R, T>
 {
 };
 } // namespace traits
@@ -401,7 +401,6 @@ Parser<T> opt(const Parser<T>& p)
     };
 }
 
-
 /**
  * @brief Creates a parser that succeeds if the given parser fails, and fails if the
  * given parser succeeds. The resulting parser consumes no input.
@@ -426,7 +425,6 @@ Parser<T> negativeLook(const Parser<T>& p)
         }
     };
 }
-
 
 /**
  * @brief Creates a parser that succeeds if the given parser succeeds, and fails if the
@@ -676,8 +674,8 @@ Parser<Values<T>> many(const Parser<T>& p)
             else
             {
                 values.push_back(innerRes.value());
+                innerI = innerRes.index();
             }
-            innerI = innerRes.index();
             traces.value().push_back(std::move(innerRes.trace()));
         }
 

--- a/src/engine/source/parsec/interface/parsec/parsec.hpp
+++ b/src/engine/source/parsec/interface/parsec/parsec.hpp
@@ -319,7 +319,11 @@ inline std::string formatTrace(std::string_view text, const Trace& trace, size_t
         tr += "\nList of errors:\n";
         for (auto e : errors)
         {
-            tr += fmt::format("{} at {}\n", e->message().value(), e->index());
+            tr += fmt::format("{} at {}\n{}\n{}^\n",
+                                e->message().value(),
+                                e->index(),
+                                text,
+                                std::string(e->index(), '-'));
         }
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|#21907|

This PR refactors the Builder helper parsers to expose each individual parser for maintainability and testability.

Also addresses the technical debt of the parsers, now the final HelperToken is returned by all parsers without the previous redundant transformations.

Parsing rules:
When using a helper function in a map or check stage:
```yml
target.field: helper_name(args...)
```

Each argument is tried to be parsed in the following order:
- Quoted argument: `'value'` if it starts with a single quote it parses until the closing single quote, allowed scaped characters are: `\` and `'`
- Reference: `$reference` if it starts with the dollar symbol a reference is parsed, which is any alphanumeric plus the extended symbols `#`, `_`, `@`, and `-` separated by dots.
- JSON value: parses a JSON string, any JSON string with JSON escaping rules.
- Raw string: if the other parsers fail a string value will be assigned, here we allow the escaping of the symbols: `$`, `'`, `,`, ` `, `)`, and `\`.

Invalid escape sequences will always fail.

When parsing a helper function inside a logical check expression the same rules apply adding that at least one argument is expected for the helper, specifying the target field:
```yml
check: helper_name($target.field, args...)
```
Added we can specify comparison helpers as operators:
```yml
check: $target.field<op><value>
```
Where `value` is parsed as a single helper argument following the same escaping rules and order. 
Where `op` is any of the following:
```
==
!=
<
<=
>
>=
```
When using any operator that is not the equality operator only string or integer values are allowed.

When using the default map or filter functions for strings, i.e. direct string mapping or filtering:
```yml
check:
  - target.field: string value
map:
  - target.field: string value
```
If the value starts with the reference symbol ´$` a valid reference is parsed, failing to build otherwise.
If not, a raw string value is assigned, allowing the escaping of the reference symbol only if it appears at the beginning of the string.