### PR TITLE
Roll back ISM rollover and alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ All notable changes to this project will be documented in this file.
 - Improved wazuh-db detection of deleted database files. ([#18476](https://github.com/wazuh/wazuh/pull/18476))
 - Added timeout and retry parameters to the VirusTotal integration. ([#16893](https://github.com/wazuh/wazuh/pull/16893))
 - Extended wazuh-analysisd EPS metrics with events dropped by overload and remaining credits in the previous cycle. ([#18988](https://github.com/wazuh/wazuh/pull/18988))
-- Replaced Filebeat's date index name processor. ([#19819](https://github.com/wazuh/wazuh/pull/19819))
 - Updated API and framework packages installation commands to use pip instead of direct invocation of setuptools. ([#18466](https://github.com/wazuh/wazuh/pull/18466))
 - Upgraded docker-compose V1 to V2 in API Integration test scripts. ([#17750](https://github.com/wazuh/wazuh/pull/17750))
 - Refactored how cluster status dates are treated in the cluster. ([#17015](https://github.com/wazuh/wazuh/pull/17015))

--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -102,8 +102,13 @@
     },
     {
       "set": {
-        "field": "_index",
-        "value": "wazuh-alerts"
+        "date_index_name": {
+          "field": "timestamp",
+          "date_rounding": "d",
+          "index_name_prefix": "{{fields.index_prefix}}",
+          "index_name_format": "yyyy.MM.dd",
+          "ignore_failure": false
+        }
       }
     },
     { "remove": { "field": "message", "ignore_missing": true, "ignore_failure": true } },

--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -101,14 +101,12 @@
       }
     },
     {
-      "set": {
-        "date_index_name": {
-          "field": "timestamp",
-          "date_rounding": "d",
-          "index_name_prefix": "{{fields.index_prefix}}",
-          "index_name_format": "yyyy.MM.dd",
-          "ignore_failure": false
-        }
+      "date_index_name": {
+        "field": "timestamp",
+        "date_rounding": "d",
+        "index_name_prefix": "{{fields.index_prefix}}",
+        "index_name_format": "yyyy.MM.dd",
+        "ignore_failure": false
       }
     },
     { "remove": { "field": "message", "ignore_missing": true, "ignore_failure": true } },

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -102,8 +102,13 @@
     },
     {
       "set": {
-        "field": "_index",
-        "value": "wazuh-archives"
+        "date_index_name": {
+          "field": "timestamp",
+          "date_rounding": "d",
+          "index_name_prefix": "{{fields.index_prefix}}",
+          "index_name_format": "yyyy.MM.dd",
+          "ignore_failure": false
+        }
       }
     },
     { "remove": { "field": "message", "ignore_missing": true, "ignore_failure": true } },

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -101,14 +101,12 @@
       }
     },
     {
-      "set": {
-        "date_index_name": {
-          "field": "timestamp",
-          "date_rounding": "d",
-          "index_name_prefix": "{{fields.index_prefix}}",
-          "index_name_format": "yyyy.MM.dd",
-          "ignore_failure": false
-        }
+      "date_index_name": {
+        "field": "timestamp",
+        "date_rounding": "d",
+        "index_name_prefix": "{{fields.index_prefix}}",
+        "index_name_format": "yyyy.MM.dd",
+        "ignore_failure": false
       }
     },
     { "remove": { "field": "message", "ignore_missing": true, "ignore_failure": true } },


### PR DESCRIPTION
|Related issue|
|---|
| #21963  |

## Description

This PR rolls back the changes in the ingest pipelines for Filebeat for the ISM rollover + alias project. 

```
filebeat setup --pipelines
Loaded Ingest pipelines
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors