### PR TITLE
Enhancements for MaxMind DB Integration in Vagrant and Wazuh-Engine Initialization

### DIFF
--- a/src/engine/tools/download_mmdbs.sh
+++ b/src/engine/tools/download_mmdbs.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Download MaxMind databases
+#
+# Usage: download_mmdbs.sh <licence_key>
+#
+# This script will download the MaxMind databases GeoLite2-City and GeoLite2-ASN
+# and place them in /var/ossec/etc. The licence key is required to download the databases,
+# you can get one for free at https://www.maxmind.com/en/geolite2/signup
+
+
+GEOIP_TMP_FILE='/tmp/geoip.tar.gz'
+BASE_URL='https://download.maxmind.com/app/geoip_download'
+
+# Download and extract
+download_and_extract() {
+    local edition=$1
+    local url="${BASE_URL}?edition_id=${edition}&license_key=${GEOIP_LICENCE_KEY}&suffix=tar.gz"
+
+    curl -sS $url > $GEOIP_TMP_FILE
+    if [ $? -ne 0 ]; then
+        echo "Error to download ${edition}"
+        exit 1
+    fi
+
+    tar -xzf $GEOIP_TMP_FILE --wildcards "*/${edition}.mmdb" --strip=1
+    if [ $? -ne 0 ]; then
+        echo "Error to extract ${edition}"
+        exit 1
+    fi
+
+    # Move to the correct location
+    mv ${edition}.mmdb /var/ossec/etc
+    chown wazuh:wazuh /var/ossec/etc/${edition}.mmdb
+
+    rm $GEOIP_TMP_FILE
+}
+
+# Trap
+trap 'rm -f $GEOIP_TMP_FILE' EXIT
+
+# Recieve the licence key from arguments
+GEOIP_LICENCE_KEY=$1
+
+# Download all if keys are set
+if [ -n "$GEOIP_LICENCE_KEY" ]; then
+    for edition in GeoLite2-City GeoLite2-ASN; do
+        download_and_extract $edition
+    done
+else
+    echo "Usage: download_mmdbs.sh <licence_key>"
+    exit 1
+fi

--- a/src/engine/tools/vagrant/Vagrantfile
+++ b/src/engine/tools/vagrant/Vagrantfile
@@ -32,7 +32,12 @@ Vagrant.configure("2") do |config|
 
     config.ssh.forward_agent = true
 
-    config.vm.provision "engineFirstRun", type: "shell", inline: <<-SHELL
+    # Import MM_LICENCE_KEY from environment variable
+    config.vm.provision "engineFirstRun", type: "shell", env: { "MM_LICENCE_KEY" => ENV['MM_LICENCE_KEY'] },
+    inline: <<-SHELL
+
+        # Uncomment the following line to forces the Maxmind license key to be set
+        # MM_LICENCE_KEY="your_maxmind_licence_key"
 
         echo "Installing dependencies to build the engine"
 
@@ -133,6 +138,12 @@ Vagrant.configure("2") do |config|
 
         WAZUH_DIR=/var/ossec
         ENGINE_DIR=$WAZUH_DIR/engine
+
+        # Download the GeoIP database if key is provided
+        if [ -n "$MM_LICENCE_KEY" ]; then
+            echo "--- Downloading the GeoIP database ---"
+            $ENGINE_SRC_DIR/tools/download_mmdbs.sh $MM_LICENCE_KEY
+        fi
 
         echo "--- Setting up the engine ---"
         systemctl stop wazuh-manager

--- a/src/engine/tools/vagrant/wazuh-bin-engine.sh
+++ b/src/engine/tools/vagrant/wazuh-bin-engine.sh
@@ -12,6 +12,16 @@ export WZE_STORE_PATH=$ENGINE_DIR/store/
 export WZE_EVENT_SOCK=$WAZUH_DIR/queue/sockets/queue
 export WZE_API_SOCK=$WAZUH_DIR/queue/sockets/engine-api
 export WZE_FLOOD_FILE=/tmp/engine-flood.log
+# TODO Temporary fix for the GeoIP database, this should be removed in the future 
+# when the database is downloaded by the manager
+WZE_MMDB_CITY_PATH=$WAZUH_DIR/etc/GeoLite2-City.mmdb
+WZE_MMDB_ASN_PATH=$WAZUH_DIR/etc/GeoLite2-ASN.mmdb
+if [ -f $WZE_MMDB_CITY_PATH ]; then
+    export WZE_MMDB_CITY_PATH
+fi
+if [ -f $WZE_MMDB_ASN_PATH ]; then
+    export WZE_MMDB_ASN_PATH
+fi
 
 # Create flood file if it does not exist
 if [ ! -e "$WZE_FLOOD_FILE" ] ; then


### PR DESCRIPTION
|Related issue|
|---|
|#21958|

### Summary

This PR introduces several key enhancements to the Vagrant setup and Wazuh-Engine initialization process to streamline the integration of MaxMind GeoIP databases. These changes allow for dynamic configuration of the MaxMind DB license key, automate the downloading of GeoIP databases, and ensure the Wazuh-Engine can utilize GeoIP data for enriched event analysis.

### Changes

- **Vagrant Environment Variable Support**: Updated the Vagrantfile to support passing the `MM_LICENCE_KEY` environment variable during setup, facilitating easy configuration of the MaxMind DB license key.
  
- **Refactored Inline Vagrant Script**: Moved the inline script within the Vagrantfile to a separate, optional setup script. This modification allows for the internal setting of the MaxMind license key if not provided via environment variables.
  
- **New Bash Script for GeoIP Database Download**: Introduced a bash script that accepts a MaxMind DB license key as an argument. This script is responsible for downloading the GeoIP databases to `/var/oseec/etc`, ensuring they are available for the Wazuh-Engine.
  
- **Enhanced Wazuh-Engine Initialization**: Modified the engine's initialization script to detect the presence of GeoIP databases. If found, the engine is configured to run with GeoIP support; otherwise, it proceeds with the standard initialization process.

### Implementation Details

- The Vagrantfile now checks for the presence of `MM_LICENCE_KEY` in the environment and passes it to the provisioning scripts.
- The new bash script for downloading GeoIP databases is designed to be robust, with error handling for various failure scenarios.
- Modifications to the Wazuh-Engine initialization script include checks for GeoIP database files and conditional configuration adjustments based on their availability.

### Testing

- Manual tests were conducted to ensure the Vagrant setup correctly processes the `MM_LICENCE_KEY` environment variable.
- The GeoIP database download script was tested with valid and invalid license keys to verify its error handling capabilities.
- The updated Wazuh-Engine initialization script was tested in environments with and without GeoIP databases to confirm its adaptive configuration behavior.

### Documentation

- Updated the README and development environment setup documentation to include instructions for the new Vagrant configuration options and the usage of the GeoIP database download script.

### Conclusion

These enhancements significantly improve the ease of integrating MaxMind GeoIP databases into the Wazuh-Engine development environment, paving the way for more sophisticated event analysis capabilities.