### PR TITLE
Fix /groups total affected items

### DIFF
--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -2542,9 +2542,6 @@ stages:
 ---
 test_name: GET /groups
 
-marks:
-  - xfail
-
 stages:
 
   - name: Basic response agents groups

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -632,7 +632,10 @@ def get_agent_groups(group_list: list = None, offset: int = 0, limit: int = None
                             complementary_search=complementary_search, q=q, allowed_select_fields=GROUP_FIELDS,
                             select=select, distinct=distinct, required_fields=GROUP_REQUIRED_FIELDS)
         result.affected_items = data['items']
-        result.total_affected_items = query_data['totalItems'] if limit == data['totalItems'] else data['totalItems']
+        total_items = query_data['totalItems']
+        if q is not None or search_text is not None:
+            total_items = data['totalItems']
+        result.total_affected_items = total_items
 
     return result
 


### PR DESCRIPTION
|Related issue|
|---|
 | Closes https://github.com/wazuh/wazuh/issues/21912 |

## Description

Changes the `total_affected_items` number calculation.

## Configuration options

Environment with 505 groups created, plus the default one.

## Logs/Alerts example

<details><summary>Offset 10, limit 10</summary>

`GET /groups?offset=10&limit=10`

```json
{
    "data": {
        "affected_items": [
            {
                "name": "0xaw1pCuoQ3PA",
                "count": 0,
                "mergedSum": "238ee0cbaf75b6341debe2fb5a5aaa1c",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "18oEAAaOaBLvb",
                "count": 0,
                "mergedSum": "39bf220f553fa2f425ce81e977890b3e",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "1aSRQsVEctluM",
                "count": 0,
                "mergedSum": "000f5729581a463e8e5fe0a71e6a5205",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "1c0kPFLdhqIXe",
                "count": 0,
                "mergedSum": "1a208db793992920f9dd8e2958a5984e",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "1f2B0iEEyuGFi",
                "count": 0,
                "mergedSum": "036a823cb465734d44cd60b2ff1ae2ca",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "1fk9Q4a3z6MgT",
                "count": 0,
                "mergedSum": "438c2a0d4ef464b0bcbe2211f9157300",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "1rHCPTMGHst6t",
                "count": 0,
                "mergedSum": "a587ff0516e346caa8ba48e4a5786fe0",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "1UQnDNq4ae09g",
                "count": 0,
                "mergedSum": "d84734a73d47129ef9404cfd7d79efe2",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "1vwWGoYSmhDHV",
                "count": 0,
                "mergedSum": "c71d601c45b4511e2e8e4fba23fc7a34",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "1W9KJLvl8DIv2",
                "count": 0,
                "mergedSum": "e7e91910912b7e9b81534bd075ef992b",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            }
        ],
        "total_affected_items": 506,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected groups information was returned",
    "error": 0
}
```

</details>

<details><summary>Offset 500, limit 10</summary>

`GET /groups?offset=500&limit=10`

```json
{
    "data": {
        "affected_items": [
            {
                "name": "ziDyVNcgkIGq4",
                "count": 0,
                "mergedSum": "a71b4b3ca33435e039031aea96d8fc76",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zK9dT3Wa2OWrl",
                "count": 0,
                "mergedSum": "65ef33c85e4348dc9131bafee63a39d3",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zOPLNtcIzUgfm",
                "count": 0,
                "mergedSum": "bf69cd5fe3d82abbaddd287d44c53966",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zWPNHL80YjQc2",
                "count": 0,
                "mergedSum": "80f9237f9f45c061dc1e57e7c03578d2",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zysXKvJBE4CEs",
                "count": 0,
                "mergedSum": "b6f7a78480c9fb9afe39d2207c6629da",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zznsP2AEnfjNE",
                "count": 0,
                "mergedSum": "f3e946c8b6f548db9d2ea816702f67c0",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            }
        ],
        "total_affected_items": 506,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected groups information was returned",
    "error": 0
}
```

</details>

<details><summary>Offset 500, no limit</summary>

`GET /groups?offset=500`

```json
{
    "data": {
        "affected_items": [
            {
                "name": "ziDyVNcgkIGq4",
                "count": 0,
                "mergedSum": "a71b4b3ca33435e039031aea96d8fc76",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zK9dT3Wa2OWrl",
                "count": 0,
                "mergedSum": "65ef33c85e4348dc9131bafee63a39d3",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zOPLNtcIzUgfm",
                "count": 0,
                "mergedSum": "bf69cd5fe3d82abbaddd287d44c53966",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zWPNHL80YjQc2",
                "count": 0,
                "mergedSum": "80f9237f9f45c061dc1e57e7c03578d2",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zysXKvJBE4CEs",
                "count": 0,
                "mergedSum": "b6f7a78480c9fb9afe39d2207c6629da",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zznsP2AEnfjNE",
                "count": 0,
                "mergedSum": "f3e946c8b6f548db9d2ea816702f67c0",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            }
        ],
        "total_affected_items": 506,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected groups information was returned",
    "error": 0
}
```

</details>


<details><summary>Search</summary>

`GET /groups?search=00ySCPopdsyQX`

```json
{
    "data": {
        "affected_items": [
            {
                "name": "00ySCPopdsyQX",
                "count": 0,
                "mergedSum": "dbe5e4960ef5fa94bfaaedc39fbef734",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected groups information was returned",
    "error": 0
}
```

</details>

<details><summary>Filter by name</summary>

`GET /groups?q=name=0bQbsu9gdV0sp`

```json
{
    "data": {
        "affected_items": [
            {
                "name": "0bQbsu9gdV0sp",
                "count": 0,
                "mergedSum": "946c89d7e957c75d8541e31092ac0167",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected groups information was returned",
    "error": 0
}
```

</details>

## Tests

<details><summary>test_agent_GET_endpoints.tavern.yaml</summary>

Artifacts: [artifacts.zip](https://github.com/wazuh/wazuh/files/14335878/artifacts.zip)

```console
============================= test session starts ==============================
platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-1.2.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.6', 'Platform': 'Linux-5.19.0-1028-aws-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.2.0'}, 'Plugins': {'asyncio': '0.18.1', 'html': '2.1.1', 'trio': '0.7.0', 'metadata': '3.0.0', 'tavern': '1.23.5', 'aiohttp': '1.0.4'}}
rootdir: /tmp/Test_integration_endpoints_B4347_test_files/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, html-2.1.1, trio-0.7.0, metadata-3.0.0, tavern-1.23.5, aiohttp-1.0.4
asyncio: mode=auto
collecting ... collected 96 items

test_agent_GET_endpoints.tavern.yaml::GET /agents PASSED                 [  1%]
test_agent_GET_endpoints.tavern.yaml::GET /agents with single agent id PASSED [  2%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED [  3%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} (only cluster configuration) PASSED [  4%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED [  5%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED  [  6%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED [  7%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED [  8%]
test_agent_GET_endpoints.tavern.yaml::GET /groups PASSED                 [  9%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED [ 10%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED [ 11%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED [ 12%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED [ 13%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED [ 14%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED [ 15%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED [ 16%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED [ 17%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED [ 18%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED [ 19%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED [ 20%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED [ 21%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED [ 22%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED [ 23%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED [ 25%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED [ 26%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED [ 27%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED [ 28%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED [ 29%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED [ 30%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED [ 31%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED [ 32%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED [ 33%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED [ 34%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED [ 35%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED [ 36%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED [ 37%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED [ 38%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED [ 39%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED [ 40%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED [ 41%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED [ 42%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED [ 43%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED [ 44%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED [ 45%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status_code] PASSED [ 46%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED [ 47%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED [ 48%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED [ 50%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED [ 51%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED [ 52%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED [ 53%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED [ 54%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED [ 55%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED [ 56%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED [ 57%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED [ 58%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED [ 59%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED [ 60%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED [ 61%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED [ 62%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED [ 63%]
test_agent_GET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED [ 64%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group PASSED        [ 65%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED [ 66%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED [ 67%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED [ 68%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED [ 69%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED [ 70%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED [ 71%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED [ 72%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status_code] PASSED [ 73%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/outdated PASSED        [ 75%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED  [ 76%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED [ 77%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED [ 78%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED [ 79%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED [ 80%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED [ 81%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED [ 82%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED [ 83%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED [ 84%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED [ 85%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED [ 86%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED [ 87%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED [ 88%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED [ 89%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED [ 90%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED [ 91%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED [ 92%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED [ 93%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED [ 94%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED [ 95%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status_code] PASSED [ 96%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/status PASSED  [ 97%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/os PASSED      [ 98%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED  [100%]

=============================== warnings summary ===============================
../../../../../home/ubuntu/.local/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/ubuntu/.local/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_agent_GET_endpoints.tavern.yaml: 96 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- generated html file: file:///tmp/Test_integration_endpoints_B4347_test_files/api/test/integration/Test_integration_endpoints_B4347_test_agent_GET_endpoints.html -
================= 96 passed, 97 warnings in 382.72s (0:06:22) ==================
```

</details>

