### PR TITLE
Content Manager - Improve robustness of CTI metadata fetching

### DIFF
--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -178,7 +178,14 @@ private:
         if (0 == spUpdaterContext->currentOffset && "cti-offset" == contentSource)
 
         {
-            runFullContentDownload(spUpdaterContext);
+            try
+            {
+                runFullContentDownload(spUpdaterContext);
+            }
+            catch (const std::exception e)
+            {
+                logWarn(WM_CONTENTUPDATER, "Couldn't run full content download: %s", e.what());
+            }
         }
 
         // Store last file hash.

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -182,7 +182,7 @@ private:
             {
                 runFullContentDownload(spUpdaterContext);
             }
-            catch (const std::exception e)
+            catch (const std::exception& e)
             {
                 logWarn(WM_CONTENTUPDATER, "Couldn't run full content download: %s", e.what());
             }

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -178,6 +178,9 @@ private:
         if (0 == spUpdaterContext->currentOffset && "cti-offset" == contentSource)
 
         {
+            // Copy original data.
+            auto originalData = spUpdaterContext->data;
+
             try
             {
                 runFullContentDownload(spUpdaterContext);
@@ -186,6 +189,9 @@ private:
             {
                 logWarn(WM_CONTENTUPDATER, "Couldn't run full content download: %s", e.what());
             }
+
+            // Restore original data.
+            spUpdaterContext->data = std::move(originalData);
         }
 
         // Store last file hash.
@@ -219,14 +225,8 @@ private:
         fullContentConfig.at("contentSource") = "cti-snapshot";
         fullContentConfig.at("compressionType") = "zip";
 
-        // Copy original data.
-        auto originalData = spUpdaterContext->data;
-
         // Trigger orchestration.
         FactoryContentUpdater::create(fullContentConfig)->handleRequest(spUpdaterContext);
-
-        // Restore original data.
-        spUpdaterContext->data = std::move(originalData);
     }
 };
 

--- a/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
@@ -138,12 +138,11 @@ protected:
 
         CtiBaseParameters parameters;
         parameters.lastOffset =
-            isKeyValueValid("last_offset") ? std::optional(rawMetadata.at("last_offset").get<int>()) : std::nullopt;
-        parameters.lastSnapshotLink = isKeyValueValid("last_snapshot_link")
-                                          ? std::optional(rawMetadata.at("last_snapshot_link").get<std::string>())
-                                          : std::nullopt;
+            isKeyValueValid("last_offset") ? std::optional(rawMetadata.at("last_offset")) : std::nullopt;
+        parameters.lastSnapshotLink =
+            isKeyValueValid("last_snapshot_link") ? std::optional(rawMetadata.at("last_snapshot_link")) : std::nullopt;
         parameters.lastSnapshotOffset = isKeyValueValid("last_snapshot_offset")
-                                            ? std::optional(rawMetadata.at("last_snapshot_offset").get<int>())
+                                            ? std::optional(rawMetadata.at("last_snapshot_offset"))
                                             : std::nullopt;
         return parameters;
     }

--- a/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
@@ -118,7 +118,7 @@ protected:
             }
 
             const auto& data {rawMetadata.at(key)};
-            if (data.is_null() || (data.is_string() && data.empty()))
+            if (data.is_null() || (data.is_string() && data.get_ref<const std::string&>().empty()))
             {
                 throw std::runtime_error {"Null or empty CTI metadata value for key: " + key};
             }

--- a/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
@@ -97,7 +97,13 @@ protected:
                                       throw std::runtime_error {"Invalid CTI metadata format"};
                                   }
 
-                                  rawMetadata = nlohmann::json::parse(response).at("data");
+                                  auto responseJSON = nlohmann::json::parse(response);
+                                  if (!responseJSON.contains("data"))
+                                  {
+                                      throw std::runtime_error {"No 'data' field in CTI metadata"};
+                                  }
+
+                                  rawMetadata = std::move(responseJSON.at("data"));
                               }};
 
         // Make a get request to the API to get the consumer offset.

--- a/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
@@ -57,7 +57,7 @@ private:
         {
             throw std::runtime_error {"Can't download offsets due to missing CTI metadata"};
         }
-        const auto consumerLastOffset {getCtiBaseParameters(m_url).lastOffset.value()};
+        const auto& consumerLastOffset {ctiParameters.lastOffset.value()};
 
         // Iterate until the current offset is equal to the consumer offset.
         auto pathsArray = nlohmann::json::array();

--- a/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiOffsetDownloader.hpp
@@ -44,11 +44,23 @@ private:
         getParameters(context);
 
         // First, make a get request to the API to get the consumer offset.
-        const auto consumerLastOffset {getCtiBaseParameters(m_url).lastOffset};
+        const auto ctiParameters {getCtiBaseParameters(m_url)};
+        auto& stopCondition {m_spUpdaterContext->spUpdaterBaseContext->spStopCondition};
+        if (stopCondition->check())
+        {
+            logWarn(WM_CONTENTUPDATER, "The offsets download has been interrupted");
+            return;
+        }
+
+        // Validate and set the consumer last offset.
+        if (!ctiParameters.lastOffset.has_value())
+        {
+            throw std::runtime_error {"Can't download offsets due to missing CTI metadata"};
+        }
+        const auto consumerLastOffset {getCtiBaseParameters(m_url).lastOffset.value()};
 
         // Iterate until the current offset is equal to the consumer offset.
         auto pathsArray = nlohmann::json::array();
-        auto& stopCondition {m_spUpdaterContext->spUpdaterBaseContext->spStopCondition};
         while (context.currentOffset < consumerLastOffset)
         {
             if (stopCondition->check())

--- a/src/shared_modules/content_manager/src/components/CtiSnapshotDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiSnapshotDownloader.hpp
@@ -39,8 +39,14 @@ private:
 
         // Get and use the CTI base parameters.
         const auto baseParameters {getCtiBaseParameters(baseURL)};
-        const auto lastSnapshotURL {std::filesystem::path(baseParameters.lastSnapshotLink)};
-        context.currentOffset = baseParameters.lastSnapshotOffset;
+
+        if (!baseParameters.lastSnapshotLink.has_value() || !baseParameters.lastSnapshotOffset.has_value())
+        {
+            throw std::runtime_error {"Can't download snapshot due to missing CTI metadata"};
+        }
+
+        const auto lastSnapshotURL {std::filesystem::path(baseParameters.lastSnapshotLink.value())};
+        context.currentOffset = baseParameters.lastSnapshotOffset.value();
 
         // Set output path. The snapshot is always compressed, so the output folder is the downloads folder.
         const auto outputFilepath {context.spUpdaterBaseContext->downloadsFolder / lastSnapshotURL.filename()};

--- a/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
@@ -365,3 +365,34 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastOffsetKey)
     expectedData["offset"] = 0;
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
 }
+
+/**
+ * @brief Tests the download of metadata with an empty last_snapshot_link key.
+ *
+ */
+TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataEmptyLastSnapshotLinkKey)
+{
+    auto mockMetadata = R"(
+        {
+            "data":
+            {
+                "ignored_key": true,
+                "last_snapshot_link": "",
+                "last_snapshot_offset": 50,
+                "last_offset": 100
+            }
+        }
+    )"_json.dump();
+    m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
+
+    auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
+    ASSERT_THROW(downloader.handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    // Check expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = FAIL_STATUS;
+    expectedData["type"] = CONTENT_TYPE;
+    expectedData["offset"] = 0;
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}

--- a/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
@@ -254,3 +254,114 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadInterrupted)
     EXPECT_EQ(downloader.getLastSnapshotLink(), DEFAULT_LAST_SNAPSHOT_LINK);
     EXPECT_EQ(downloader.getLastSnapshotOffset(), DEFAULT_LAST_OFFSET);
 }
+
+/**
+ * @brief Tests the download of metadata with invalid JSON format.
+ *
+ */
+TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataInvalidFormat)
+{
+    auto mockMetadata = R"({data":{})";
+    m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
+
+    auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
+    ASSERT_THROW(downloader.handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    // Check expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = FAIL_STATUS;
+    expectedData["type"] = CONTENT_TYPE;
+    expectedData["offset"] = 0;
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}
+
+/**
+ * @brief Tests the download of metadata with missing last_snapshot_offset key.
+ *
+ */
+TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastSnapshotOffsetKey)
+{
+    auto mockMetadata = R"(
+        {
+            "data":
+            {
+                "ignored_key": true,
+                "last_offset": 100,
+                "last_snapshot_link": "some_link"
+            }
+        }
+    )"_json.dump();
+    m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
+
+    auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
+    ASSERT_THROW(downloader.handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    // Check expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = FAIL_STATUS;
+    expectedData["type"] = CONTENT_TYPE;
+    expectedData["offset"] = 0;
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}
+
+/**
+ * @brief Tests the download of metadata with missing last_snapshot_link key.
+ *
+ */
+TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastSnapshotLinkKey)
+{
+    auto mockMetadata = R"(
+        {
+            "data":
+            {
+                "ignored_key": true,
+                "last_offset": 100,
+                "last_snapshot_offset": 50
+            }
+        }
+    )"_json.dump();
+    m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
+
+    auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
+    ASSERT_THROW(downloader.handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    // Check expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = FAIL_STATUS;
+    expectedData["type"] = CONTENT_TYPE;
+    expectedData["offset"] = 0;
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}
+
+/**
+ * @brief Tests the download of metadata with missing last_offset key.
+ *
+ */
+TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastOffsetKey)
+{
+    auto mockMetadata = R"(
+        {
+            "data":
+            {
+                "ignored_key": true,
+                "last_snapshot_link": "some_link",
+                "last_snapshot_offset": 50
+            }
+        }
+    )"_json.dump();
+    m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
+
+    auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
+    ASSERT_THROW(downloader.handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    // Check expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = FAIL_STATUS;
+    expectedData["type"] = CONTENT_TYPE;
+    expectedData["offset"] = 0;
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}

--- a/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
@@ -396,3 +396,34 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataEmptyLastSnapshotLinkKey
     expectedData["offset"] = 0;
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
 }
+
+/**
+ * @brief Tests the download of metadata without 'data' key.
+ *
+ */
+TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingDataKey)
+{
+    auto mockMetadata = R"(
+        {
+            "metadata":
+            {
+                "ignored_key": true,
+                "last_snapshot_link": "some_link",
+                "last_snapshot_offset": 50,
+                "last_offset": 100
+            }
+        }
+    )"_json.dump();
+    m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
+
+    auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
+    ASSERT_THROW(downloader.handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    // Check expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = FAIL_STATUS;
+    expectedData["type"] = CONTENT_TYPE;
+    expectedData["offset"] = 0;
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}

--- a/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
@@ -236,7 +236,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadInterrupted)
  */
 TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataInvalidFormat)
 {
-    auto mockMetadata = R"({data":{})";
+    std::string mockMetadata = R"({data":{})";
     m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
 
     auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
@@ -257,7 +257,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataInvalidFormat)
  */
 TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastSnapshotOffsetKey)
 {
-    auto mockMetadata = R"(
+    std::string mockMetadata = R"(
         {
             "data":
             {
@@ -266,7 +266,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastSnapshotOffse
                 "last_snapshot_link": "some_link"
             }
         }
-    )"_json.dump();
+    )";
     m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
 
     auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
@@ -293,7 +293,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastSnapshotOffse
  */
 TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastSnapshotLinkKey)
 {
-    auto mockMetadata = R"(
+    std::string mockMetadata = R"(
         {
             "data":
             {
@@ -302,7 +302,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastSnapshotLinkK
                 "last_snapshot_offset": 50
             }
         }
-    )"_json.dump();
+    )";
     m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
 
     auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
@@ -329,7 +329,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastSnapshotLinkK
  */
 TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastOffsetKey)
 {
-    auto mockMetadata = R"(
+    std::string mockMetadata = R"(
         {
             "data":
             {
@@ -338,7 +338,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastOffsetKey)
                 "last_snapshot_offset": 50
             }
         }
-    )"_json.dump();
+    )";
     m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
 
     auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
@@ -365,7 +365,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingLastOffsetKey)
  */
 TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataEmptyLastSnapshotLinkKey)
 {
-    auto mockMetadata = R"(
+    std::string mockMetadata = R"(
         {
             "data":
             {
@@ -375,7 +375,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataEmptyLastSnapshotLinkKey
                 "last_offset": 100
             }
         }
-    )"_json.dump();
+    )";
     m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
 
     auto downloader {CtiDummyDownloader(HTTPRequest::instance())};
@@ -402,7 +402,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataEmptyLastSnapshotLinkKey
  */
 TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingDataKey)
 {
-    auto mockMetadata = R"(
+    std::string mockMetadata = R"(
         {
             "metadata":
             {
@@ -412,7 +412,7 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadMetadataMissingDataKey)
                 "last_offset": 100
             }
         }
-    )"_json.dump();
+    )";
     m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
 
     auto downloader {CtiDummyDownloader(HTTPRequest::instance())};

--- a/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.cpp
@@ -241,3 +241,23 @@ TEST_F(CtiOffsetDownloaderTest, DownloadInterrupted)
     expectedData["offset"] = 0;
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
 }
+
+/**
+ * @brief Tests the download of metadata with invalid JSON format.
+ *
+ */
+TEST_F(CtiOffsetDownloaderTest, DownloadMetadataInvalidFormat)
+{
+    auto mockMetadata = R"({data":{})";
+    m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
+
+    ASSERT_THROW(m_spCtiOffsetDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    // Check expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = FAIL_STATUS;
+    expectedData["type"] = DEFAULT_TYPE;
+    expectedData["offset"] = 0;
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}

--- a/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.cpp
@@ -243,17 +243,26 @@ TEST_F(CtiOffsetDownloaderTest, DownloadInterrupted)
 }
 
 /**
- * @brief Tests the download of metadata with invalid JSON format.
+ * @brief Tests the download of the offsets when last_offset metadata is missing.
  *
  */
-TEST_F(CtiOffsetDownloaderTest, DownloadMetadataInvalidFormat)
+TEST_F(CtiOffsetDownloaderTest, MissingLastOffsetMetadata)
 {
-    auto mockMetadata = R"({data":{})";
+    auto mockMetadata = R"(
+        {
+            "data":
+            {
+                "ignored_key": true,
+                "last_snapshot_link": "some_link",
+                "last_snapshot_offset": 50
+            }
+        }
+    )"_json.dump();
     m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
 
     ASSERT_THROW(m_spCtiOffsetDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);
 
-    // Check expected data.
+    // Set expected data.
     nlohmann::json expectedData;
     expectedData["paths"] = m_spUpdaterContext->data.at("paths");
     expectedData["stageStatus"] = FAIL_STATUS;

--- a/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiOffsetDownloader_test.cpp
@@ -248,7 +248,7 @@ TEST_F(CtiOffsetDownloaderTest, DownloadInterrupted)
  */
 TEST_F(CtiOffsetDownloaderTest, MissingLastOffsetMetadata)
 {
-    auto mockMetadata = R"(
+    std::string mockMetadata = R"(
         {
             "data":
             {
@@ -257,7 +257,7 @@ TEST_F(CtiOffsetDownloaderTest, MissingLastOffsetMetadata)
                 "last_snapshot_offset": 50
             }
         }
-    )"_json.dump();
+    )";
     m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
 
     ASSERT_THROW(m_spCtiOffsetDownloader->handleRequest(m_spUpdaterContext), std::runtime_error);

--- a/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.cpp
@@ -126,7 +126,7 @@ TEST_F(CtiSnapshotDownloaderTest, SnapshotDownloadWithRetry)
  */
 TEST_F(CtiSnapshotDownloaderTest, MissingLastSnapshotLinkMetadata)
 {
-    auto mockMetadata = R"(
+    std::string mockMetadata = R"(
         {
             "data":
             {
@@ -135,7 +135,7 @@ TEST_F(CtiSnapshotDownloaderTest, MissingLastSnapshotLinkMetadata)
                 "last_snapshot_offset": 0
             }
         }
-    )"_json.dump();
+    )";
     m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
 
     ASSERT_THROW(CtiSnapshotDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext), std::runtime_error);
@@ -155,7 +155,7 @@ TEST_F(CtiSnapshotDownloaderTest, MissingLastSnapshotLinkMetadata)
  */
 TEST_F(CtiSnapshotDownloaderTest, MissingLastSnapshotOffsetMetadata)
 {
-    auto mockMetadata = R"(
+    std::string mockMetadata = R"(
         {
             "data":
             {
@@ -164,7 +164,7 @@ TEST_F(CtiSnapshotDownloaderTest, MissingLastSnapshotOffsetMetadata)
                 "last_snapshot_link": "some_link"
             }
         }
-    )"_json.dump();
+    )";
     m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
 
     ASSERT_THROW(CtiSnapshotDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext), std::runtime_error);

--- a/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiSnapshotDownloader_test.cpp
@@ -119,3 +119,23 @@ TEST_F(CtiSnapshotDownloaderTest, SnapshotDownloadWithRetry)
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
     EXPECT_TRUE(std::filesystem::exists(expectedContentPath));
 }
+
+/**
+ * @brief Tests the download of metadata with invalid JSON format.
+ *
+ */
+TEST_F(CtiSnapshotDownloaderTest, DownloadMetadataInvalidFormat)
+{
+    auto mockMetadata = R"({data":{})";
+    m_spFakeServer->setCtiMetadata(std::move(mockMetadata));
+
+    ASSERT_THROW(CtiSnapshotDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext), std::runtime_error);
+
+    // Check expected data.
+    nlohmann::json expectedData;
+    expectedData["paths"] = m_spUpdaterContext->data.at("paths");
+    expectedData["stageStatus"] = FAIL_STATUS;
+    expectedData["type"] = CONTENT_TYPE;
+    expectedData["offset"] = 0;
+    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
+}

--- a/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
+++ b/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
@@ -36,6 +36,7 @@ private:
     std::string m_host;
     int m_port;
     std::queue<unsigned long> m_errorsQueue; ///< Errors queue used to return error codes for some queries.
+    std::string m_ctiMetadataMock;
 
     /**
      * @brief Pops and returns the last error code from the error queue.
@@ -95,6 +96,11 @@ public:
     {
         std::queue<unsigned long> emptyQueue;
         std::swap(m_errorsQueue, emptyQueue);
+    }
+
+    void setCtiMetadata(std::string ctiMetadata)
+    {
+        m_ctiMetadataMock = std::move(ctiMetadata);
     }
 
     /**
@@ -172,18 +178,29 @@ public:
         m_server.Get("/raw/consumers",
                      [this](const httplib::Request& req, httplib::Response& res)
                      {
-                         auto response = R"(
-                            {
-                                "data": 
+                         std::string response;
+                         if (m_ctiMetadataMock.empty())
+                         {
+                             auto responseJSON = R"(
                                 {
-                                    "last_offset": 3,
-                                    "last_snapshot_offset": 3
+                                    "data": 
+                                    {
+                                        "last_offset": 3,
+                                        "last_snapshot_offset": 3
+                                    }
                                 }
-                            }
-                         )"_json;
-                         response["data"]["last_snapshot_link"] = "localhost:" + std::to_string(m_port) + "/raw";
+                            )"_json;
+                             responseJSON["data"]["last_snapshot_link"] =
+                                 "localhost:" + std::to_string(m_port) + "/raw";
+                             response = responseJSON.dump();
+                         }
+                         else
+                         {
+                             response = std::move(m_ctiMetadataMock);
+                             m_ctiMetadataMock.clear();
+                         }
 
-                         res.set_content(response.dump(), "text/plain");
+                         res.set_content(response, "text/plain");
                      });
         m_server.Get("/raw/consumers/changes",
                      [this](const httplib::Request& req, httplib::Response& res)
@@ -261,19 +278,29 @@ public:
                              return;
                          }
 
-                         auto response = R"(
-                            {
-                                "data": 
+                         std::string response;
+                         if (m_ctiMetadataMock.empty())
+                         {
+                             auto responseJSON = R"(
                                 {
-                                    "last_offset": 3,
-                                    "last_snapshot_offset": 3
+                                    "data": 
+                                    {
+                                        "last_offset": 3,
+                                        "last_snapshot_offset": 3
+                                    }
                                 }
-                            }
-                         )"_json;
-                         response["data"]["last_snapshot_link"] =
-                             "localhost:" + std::to_string(m_port) + "/" + SNAPSHOT_FILE_NAME;
+                            )"_json;
+                             responseJSON["data"]["last_snapshot_link"] =
+                                 "localhost:" + std::to_string(m_port) + "/" + SNAPSHOT_FILE_NAME;
+                             response = responseJSON.dump();
+                         }
+                         else
+                         {
+                             response = std::move(m_ctiMetadataMock);
+                             m_ctiMetadataMock.clear();
+                         }
 
-                         res.set_content(response.dump(), "text/plain");
+                         res.set_content(response, "text/plain");
                      });
 
         // Endpoint that responses with a dummy snapshot file.

--- a/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
+++ b/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
@@ -98,6 +98,11 @@ public:
         std::swap(m_errorsQueue, emptyQueue);
     }
 
+    /**
+     * @brief Sets the CTI metadata to be returned in the next query.
+     *
+     * @param ctiMetadata New metadata to be used.
+     */
     void setCtiMetadata(std::string ctiMetadata)
     {
         m_ctiMetadataMock = std::move(ctiMetadata);


### PR DESCRIPTION
|Related issue|
|---|
| Closes #21931 |

# Description

This PR improves how the Content Manager parses the metadata from the CTI API (last offset and snapshot metadata). The idea is to make the module to be more robust in case of an error arrives.

# Results

## Manager execution with a local CTI API

The API returns an empty `last_snapshot_link` field.

Log with debug=2:
```bash
# cat /var/ossec/logs/ossec.log | grep updater
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] actionOrchestrator.hpp:61 at ActionOrchestrator(): DEBUG: Creating 'vulnerability_feed_manager' Content Updater orchestration
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] executionContext.hpp:202 at handleRequest(): DEBUG: ExecutionContext - Starting process
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] executionContext.hpp:128 at createRocksDB(): DEBUG: Column 'current_offset' doesn't exist so it will be created
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] executionContext.hpp:128 at createRocksDB(): DEBUG: Column 'downloaded_file_hash' doesn't exist so it will be created
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] executionContext.hpp:184 at createOutputFolder(): DEBUG: Creating output folders at 'queue/vd_updater/tmp'
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] factoryContentUpdater.hpp:44 at create(): DEBUG: FactoryContentUpdater - Starting process
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] factoryDownloader.hpp:46 at create(): DEBUG: Creating 'cti-offset' downloader
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] factoryDecompressor.hpp:73 at create(): DEBUG: Creating 'raw' decompressor
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] factoryVersionUpdater.hpp:41 at create(): DEBUG: Creating 'false' version updater
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] factoryCleaner.hpp:41 at create(): DEBUG: Content cleaner created
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] actionOrchestrator.hpp:71 at ActionOrchestrator(): DEBUG: Content updater orchestration created
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] action.hpp:128 at runActionScheduled(): INFO: Starting scheduled action for 'vulnerability_feed_manager'
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] action.hpp:224 at runAction(): INFO: Action for 'vulnerability_feed_manager' started
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] actionOrchestrator.hpp:158 at runContentUpdate(): DEBUG: Running 'vulnerability_feed_manager' content update
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] actionOrchestrator.hpp:221 at runFullContentDownload(): DEBUG: Performing full-content download
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] factoryContentUpdater.hpp:44 at create(): DEBUG: FactoryContentUpdater - Starting process
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] factoryDownloader.hpp:46 at create(): DEBUG: Creating 'cti-snapshot' downloader
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] factoryDecompressor.hpp:73 at create(): DEBUG: Creating 'zip' decompressor
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] factoryVersionUpdater.hpp:41 at create(): DEBUG: Creating 'false' version updater
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] factoryCleaner.hpp:41 at create(): DEBUG: Content cleaner created
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] CtiDownloader.hpp:244 at handleRequest(): DEBUG: CtiSnapshotDownloader - Starting process
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] CtiDownloader.hpp:94 at operator()(): DEBUG: CTI raw metadata: '{"data": {"last_offset": 1, "last_snapshot_link": "", "last_snapshot_offset": 0}}'
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] CtiDownloader.hpp:132 at operator()(): WARNING: Null or empty CTI metadata value for key: last_snapshot_link
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] actionOrchestrator.hpp:190 at runContentUpdate(): WARNING: Couldn't run full content download: Can't download snapshot due to missing CTI metadata
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] CtiDownloader.hpp:244 at handleRequest(): DEBUG: CtiOffsetDownloader - Starting process
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] CtiOffsetDownloader.hpp:42 at download(): DEBUG: Initial API offset: 0
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] CtiDownloader.hpp:94 at operator()(): DEBUG: CTI raw metadata: '{"data": {"last_offset": 1, "last_snapshot_link": "", "last_snapshot_offset": 0}}'
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] CtiDownloader.hpp:132 at operator()(): WARNING: Null or empty CTI metadata value for key: last_snapshot_link
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] CtiOffsetDownloader.hpp:134 at downloadContent(): DEBUG: Downloading offsets from: 'http://localhost:4041//changes?from_offset=0&to_offset=1'
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] skipStep.hpp:48 at handleRequest(): DEBUG: SkipStep - Starting process
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] pubSubPublisher.hpp:61 at handleRequest(): DEBUG: PubSubPublisher - Starting process
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] pubSubPublisher.hpp:42 at publish(): DEBUG: Data to be published: '{"offset":1,"paths":["queue/vd_updater/tmp/contents/1-api_file.json"],"stageStatus":[{"stage":"CtiOffsetDownloader","status":"ok"}],"type":"offsets"}'
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] pubSubPublisher.hpp:45 at publish(): INFO: Data published
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] skipStep.hpp:48 at handleRequest(): DEBUG: SkipStep - Starting process
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] cleanUpContent.hpp:63 at handleRequest(): DEBUG: CleanUpContent - Starting process
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] action.hpp:235 at runAction(): INFO: Action for 'vulnerability_feed_manager' finished
2024/02/22 15:32:36 wazuh-modulesd:vulnerability-scanner[56889] databaseFeedManager.hpp:126 at processMessage(): INFO: Processing file: queue/vd_updater/tmp/contents/1-api_file.json
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] action.hpp:189 at runActionOnDemand(): INFO: Starting on-demand action for 'vulnerability_feed_manager'
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] action.hpp:224 at runAction(): INFO: Action for 'vulnerability_feed_manager' started
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] actionOrchestrator.hpp:138 at runOffsetUpdate(): DEBUG: Running 'vulnerability_feed_manager' offset update
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] factoryOffsetUpdater.hpp:41 at create(): DEBUG: FactoryOffsetUpdater - Starting process
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] updateCtiApiOffset.hpp:70 at handleRequest(): DEBUG: UpdateCtiApiOffset - Starting process
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] updateCtiApiOffset.hpp:42 at update(): DEBUG: Updating offset with value: 1
2024/02/22 15:32:36 wazuh-modulesd:content-updater[56889] action.hpp:235 at runAction(): INFO: Action for 'vulnerability_feed_manager' finished
```

:green_circle: Snapshot download failed (with a user-friendly error message) and offset download performed correctly.

## Manager execution with default CTI API (remote)

Log with debug=2:
```bash
# cat /var/ossec/logs/ossec.log | grep updater
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] actionOrchestrator.hpp:61 at ActionOrchestrator(): DEBUG: Creating 'vulnerability_feed_manager' Content Updater orchestration
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] executionContext.hpp:202 at handleRequest(): DEBUG: ExecutionContext - Starting process
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] executionContext.hpp:128 at createRocksDB(): DEBUG: Column 'current_offset' doesn't exist so it will be created
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] executionContext.hpp:128 at createRocksDB(): DEBUG: Column 'downloaded_file_hash' doesn't exist so it will be created
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] executionContext.hpp:184 at createOutputFolder(): DEBUG: Creating output folders at 'queue/vd_updater/tmp'
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] factoryContentUpdater.hpp:44 at create(): DEBUG: FactoryContentUpdater - Starting process
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] factoryDownloader.hpp:46 at create(): DEBUG: Creating 'cti-offset' downloader
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] factoryDecompressor.hpp:73 at create(): DEBUG: Creating 'raw' decompressor
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] factoryVersionUpdater.hpp:41 at create(): DEBUG: Creating 'false' version updater
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] factoryCleaner.hpp:41 at create(): DEBUG: Content cleaner created
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] actionOrchestrator.hpp:71 at ActionOrchestrator(): DEBUG: Content updater orchestration created
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] action.hpp:128 at runActionScheduled(): INFO: Starting scheduled action for 'vulnerability_feed_manager'
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] action.hpp:224 at runAction(): INFO: Action for 'vulnerability_feed_manager' started
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] actionOrchestrator.hpp:158 at runContentUpdate(): DEBUG: Running 'vulnerability_feed_manager' content update
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] actionOrchestrator.hpp:215 at runFullContentDownload(): DEBUG: Performing full-content download
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] factoryContentUpdater.hpp:44 at create(): DEBUG: FactoryContentUpdater - Starting process
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] factoryDownloader.hpp:46 at create(): DEBUG: Creating 'cti-snapshot' downloader
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] factoryDecompressor.hpp:73 at create(): DEBUG: Creating 'zip' decompressor
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] factoryVersionUpdater.hpp:41 at create(): DEBUG: Creating 'false' version updater
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] factoryCleaner.hpp:41 at create(): DEBUG: Content cleaner created
2024/02/22 15:13:01 wazuh-modulesd:content-updater[45390] CtiDownloader.hpp:244 at handleRequest(): DEBUG: CtiSnapshotDownloader - Starting process
2024/02/22 15:13:03 wazuh-modulesd:content-updater[45390] CtiDownloader.hpp:94 at operator()(): DEBUG: CTI raw metadata: '{"data":{"id":4,"name":"vd_4.8.0","context":"vd_1.0.0","operations":null,"inserted_at":"2023-11-23T19:34:18.698495Z","updated_at":"2024-02-05T12:03:44.014816Z","paths_filter":null,"last_offset":239277,"changes_url":"cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes","last_snapshot_at":"2024-02-05T11:59:54.501799Z","last_snapshot_link":"https://s3.us-east-1.amazonaws.com/cti-snapshots-pro/store/contexts/vd_1.0.0/consumers/vd_4.8.0/239277_1707134394.zip","last_snapshot_offset":239277}}'
2024/02/22 15:13:03 wazuh-modulesd:content-updater[45390] CtiSnapshotDownloader.hpp:61 at download(): DEBUG: Downloading snapshot from 'https://s3.us-east-1.amazonaws.com/cti-snapshots-pro/store/contexts/vd_1.0.0/consumers/vd_4.8.0/239277_1707134394.zip'
2024/02/22 15:13:43 wazuh-modulesd:content-updater[45390] zipDecompressor.hpp:74 at handleRequest(): DEBUG: ZipDecompressor - Starting process
2024/02/22 15:13:43 wazuh-modulesd:content-updater[45390] zipDecompressor.hpp:49 at decompress(): DEBUG: Decompressing 'queue/vd_updater/tmp/downloads/239277_1707134394.zip' into 'queue/vd_updater/tmp/contents'
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] pubSubPublisher.hpp:61 at handleRequest(): DEBUG: PubSubPublisher - Starting process
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] pubSubPublisher.hpp:42 at publish(): DEBUG: Data to be published: '{"offset":239277,"paths":["queue/vd_updater/tmp/contents/vd_1.0.0_vd_4.8.0_239277_1707134394.json"],"stageStatus":[{"stage":"CtiSnapshotDownloader","status":"ok"},{"stage":"ZipDecompressor","status":"ok"}],"type":"raw"}'
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] pubSubPublisher.hpp:45 at publish(): INFO: Data published
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] skipStep.hpp:48 at handleRequest(): DEBUG: SkipStep - Starting process
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] cleanUpContent.hpp:63 at handleRequest(): DEBUG: CleanUpContent - Starting process
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] CtiDownloader.hpp:244 at handleRequest(): DEBUG: CtiOffsetDownloader - Starting process
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] CtiOffsetDownloader.hpp:42 at download(): DEBUG: Initial API offset: 239277
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] CtiDownloader.hpp:94 at operator()(): DEBUG: CTI raw metadata: '{"data":{"id":4,"name":"vd_4.8.0","context":"vd_1.0.0","operations":null,"inserted_at":"2023-11-23T19:34:18.698495Z","updated_at":"2024-02-05T12:03:44.014816Z","paths_filter":null,"last_offset":239277,"changes_url":"cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes","last_snapshot_at":"2024-02-05T11:59:54.501799Z","last_snapshot_link":"https://s3.us-east-1.amazonaws.com/cti-snapshots-pro/store/contexts/vd_1.0.0/consumers/vd_4.8.0/239277_1707134394.zip","last_snapshot_offset":239277}}'
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] skipStep.hpp:48 at handleRequest(): DEBUG: SkipStep - Starting process
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] pubSubPublisher.hpp:61 at handleRequest(): DEBUG: PubSubPublisher - Starting process
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] pubSubPublisher.hpp:49 at publish(): DEBUG: No data to publish
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] skipStep.hpp:48 at handleRequest(): DEBUG: SkipStep - Starting process
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] cleanUpContent.hpp:63 at handleRequest(): DEBUG: CleanUpContent - Starting process
2024/02/22 15:13:58 wazuh-modulesd:content-updater[45390] action.hpp:235 at runAction(): INFO: Action for 'vulnerability_feed_manager' finished
2024/02/22 15:15:18 wazuh-modulesd:vulnerability-scanner[45390] databaseFeedManager.hpp:189 at processMessage(): INFO: Processing file: queue/vd_updater/tmp/contents/vd_1.0.0_vd_4.8.0_239277_1707134394.json
```

:green_circle: Manager working without errors, as expected