### PR TITLE
Enhancement/21751 malformed msg segfault modulesd

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -786,7 +786,7 @@ public:
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_id() ? syncMsg->agent_info()->agent_id()->c_str() : ""; },
             [](const nlohmann::json* message)
-            { return message->at("agentData").at("agent_info").at("agent_id").get_ref<const std::string&>(); });
+            { return message->at("agent_info").at("agent_id").get_ref<const std::string&>(); });
     }
 
     /**
@@ -802,7 +802,7 @@ public:
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_ip() ? syncMsg->agent_info()->agent_ip()->c_str() : ""; },
             [](const nlohmann::json* message)
-            { return message->at("agentData").at("agent_info").at("agent_ip").get_ref<const std::string&>(); });
+            { return message->at("agent_info").at("agent_ip").get_ref<const std::string&>(); });
     }
 
     /**
@@ -818,7 +818,7 @@ public:
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_name() ? syncMsg->agent_info()->agent_name()->c_str() : ""; },
             [](const nlohmann::json* message)
-            { return message->at("agentData").at("agent_info").at("agent_name").get_ref<const std::string&>(); });
+            { return message->at("agent_info").at("agent_name").get_ref<const std::string&>(); });
     }
 
     /**
@@ -834,7 +834,7 @@ public:
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_version() ? syncMsg->agent_info()->agent_version()->c_str() : ""; },
             [](const nlohmann::json* message)
-            { return message->at("agentData").at("agent_info").at("agent_version").get_ref<const std::string&>(); });
+            { return message->at("agent_info").at("agent_version").get_ref<const std::string&>(); });
     }
 
     /**
@@ -849,7 +849,7 @@ public:
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->node_name() ? syncMsg->agent_info()->node_name()->c_str() : ""; },
             [](const nlohmann::json* message)
-            { return message->at("agentData").at("agent_info").at("node_name").get_ref<const std::string&>(); });
+            { return message->at("agent_info").at("node_name").get_ref<const std::string&>(); });
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -471,20 +471,21 @@ void VulnerabilityScannerFacade::start(
         m_performReScanSubscription->subscribe(
             [scanOrchestrator](const std::vector<char>& message)
             {
+                // Create a variant 'data' to store the re-scan action information.
                 std::variant<const SyscollectorDeltas::Delta*,
                              const SyscollectorSynchronization::SyncMsg*,
                              const nlohmann::json*>
                     data;
 
-                nlohmann::json dataValue;
-                dataValue["action"] = "upgradeAgentDB";
-                // The data should be the agentId, agentNodeName, agentVersion and agentIp.
-                dataValue["agentData"] = nlohmann::json::parse(message.data(), message.data() + message.size());
-
-                data = &dataValue;
-
                 try
                 {
+                    // Create a JSON object 'dataValue'
+                    nlohmann::json dataValue = nlohmann::json::parse(message.data(), message.data() + message.size());
+
+                    // Assign a reference to 'dataValue' to the 'data' variant.
+                    data = &dataValue;
+
+                    // Execute the scan orchestrator with the re-scan action data.
                     scanOrchestrator->run(data);
                 }
                 catch (const std::exception& e)


### PR DESCRIPTION
|Related issue|
|---|
|#21751|

## Description

This PR captures the nlohmann::json exception to avoid hanging and undesired behavior. Also the JSON was formatted to avoid duplicate information.

## Logs/Alerts example

After a valid message arrives, the agent 1 is scanned successfully
![2024-02-19_17-33](https://github.com/wazuh/wazuh/assets/13010397/37f6eccb-35c2-4c84-adb6-960dc6df83b6)
![2024-02-19_17-34](https://github.com/wazuh/wazuh/assets/13010397/16c8116e-72ba-49c5-a664-41c9f042d6e2)
Any wrong formatted message won't affect scanner execution.
![2024-02-19_17-34_1](https://github.com/wazuh/wazuh/assets/13010397/39685225-3e94-4292-ac39-57aa3db8848d)
![2024-02-19_17-35](https://github.com/wazuh/wazuh/assets/13010397/792dfb36-28f5-46f0-8a1d-0dddb520caba)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade