### PR TITLE
Update AmazonLinux2023 SCA checks for squashfs and UDF

### DIFF
--- a/ruleset/sca/amazon/cis_amazon_linux_2023.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2023.yml
@@ -55,7 +55,7 @@ checks:
       - mitre_mitigations: ["M1050"]
     condition: all
     rules:
-      - "c:modprobe -n -v squashfs -> r:install /bin/false|Module squashfs not found"
+      - "c:modprobe -n -v squashfs -> r:install /bin/false|install /bin/true|Module squashfs not found"
       - "not c:lsmod -> r:squashfs"
       - 'd:/etc/modprobe.d -> r:\.*.conf -> r:blacklist\t*\s*squashfs'
 
@@ -81,7 +81,7 @@ checks:
       - mitre_mitigations: ["M1050"]
     condition: all
     rules:
-      - "c:modprobe -n -v udf -> r:install /bin/false|Module udf not found"
+      - "c:modprobe -n -v udf -> r:install /bin/false|install /bin/true|Module udf not found"
       - "not c:lsmod -> r:udf"
       - 'd:/etc/modprobe.d -> r:\.*.conf -> r:blacklist\t*\s*udf'
 


### PR DESCRIPTION
Added 'install /bin/true' as an acceptable response for blacklisting squashfs and UDF modules, in addition to 'bin/false', as many online tutorials and Ansible roles (such as ansible-lockdown) use the '/bin/true' approach for blacklisting the required modules.

|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Added 'install /bin/true' as an acceptable response for blacklisting squashfs and UDF modules, in addition to 'bin/false', as many online tutorials and Ansible roles (such as ansible-lockdown) use the '/bin/true' approach for blacklisting the required modules.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors