### PR TITLE
Move Vulnerability Detection Template to Templates Folder

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1083,10 +1083,11 @@ InstallLocal()
 
     # Install Vulnerability Detector files
     ${INSTALL} -d -m 0660 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/vd
+    ${INSTALL} -d -m 0440 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/indexer
 
     # Install templates files
-    ${INSTALL} -d -m 0440 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/indexer
-    ${INSTALL} -m 0440 -o root -g ${WAZUH_GROUP} wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json ${INSTALLDIR}/queue/indexer/vd_states_template.json
+    ${INSTALL} -d -m 0440 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/templates
+    ${INSTALL} -m 0440 -o root -g ${WAZUH_GROUP} wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json ${INSTALLDIR}/templates/vd_states_template.json
 
     # Install Task Manager files
     ${INSTALL} -d -m 0770 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/tasks

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -17,7 +17,7 @@
 #include "vulnerabilityScanner.hpp"
 #include "wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp"
 
-constexpr auto VULNERABILITY_SCANNER_TEMPLATE = "queue/indexer/vd_states_template.json";
+constexpr auto VULNERABILITY_SCANNER_TEMPLATE = "templates/vd_states_template.json";
 constexpr auto DEFAULT_QUEUE_PATH = "queue/sockets/queue";
 constexpr auto REPORTS_QUEUE_PATH = "queue/vd/reports";
 constexpr auto REPORTS_BULK_SIZE {1};


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21955|


## Description

This PR aims to move the Vulnerability Detection template `vd_states_template.json` from `/var/ossec/queue/indexer/` to a `templates` folder located in `/var/ossec/` and update its references.

Related PR for Wazuh-Packages: https://github.com/wazuh/wazuh-packages/pull/2836

## Logs/Alerts example

```console
root@ubuntu:/# ls /var/ossec/
active-response  agentless  api  backup  bin  etc  framework  integrations  lib  logs  queue  ruleset  stats  templates  tmp  var  wodles
root@ubuntu:/# ls /var/ossec/templates/
vd_states_template.json
```


## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Review logs syntax and correct languag
