### PR TITLE
Only report alerts from delta events in the new vulnerability detector

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -451,6 +451,20 @@ public:
                             m_operationType = OperationType::SingleDeleteAndInsert;
                             m_messageType = MessageType::DataJSON;
                         }
+                        // Used for the RSync deleted events from Wazuh-DB
+                        else if (actionValue == "deletePackage")
+                        {
+                            m_type = ScannerType::PackageDelete;
+                            m_operationType = OperationType::Delete;
+                            m_messageType = MessageType::DataJSON;
+                        }
+                        // Used for the RSync deleted events from Wazuh-DB
+                        else if (actionValue == "deleteHotfix")
+                        {
+                            m_type = ScannerType::HotfixDelete;
+                            m_operationType = OperationType::Delete;
+                            m_messageType = MessageType::DataJSON;
+                        }
                         else
                         {
                             throw std::runtime_error("Unable to build scan context. Unknown action");
@@ -520,7 +534,8 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->name()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->name()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData) { return jsonData->value("/data/name"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -540,7 +555,8 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->version()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->version()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData) { return jsonData->value("/data/version"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -559,7 +575,8 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->vendor()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->vendor()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData) { return jsonData->value("/data/vendor"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -580,7 +597,9 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->install_time()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->install_time()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData)
+            { return jsonData->value("/data/install_time"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -600,7 +619,8 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->location()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->location()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData) { return jsonData->value("/data/location"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -621,7 +641,9 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->architecture()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->architecture()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData)
+            { return jsonData->value("/data/architecture"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -640,7 +662,8 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->groups()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->groups()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData) { return jsonData->value("/data/groups"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -661,7 +684,9 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->description()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->description()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData)
+            { return jsonData->value("/data/description"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -673,7 +698,8 @@ public:
         return extractData<uint64_t>(
             [](const SyscollectorDeltas::Delta* delta) { return delta->data_as_dbsync_packages()->size(); },
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
-            { return syncMsg->data_as_state()->attributes_as_syscollector_packages()->size(); });
+            { return syncMsg->data_as_state()->attributes_as_syscollector_packages()->size(); },
+            [](const nlohmann::json* jsonData) { return jsonData->value("/data/size"_json_pointer, 0); });
     }
 
     /**
@@ -693,7 +719,8 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->priority()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->priority()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData) { return jsonData->value("/data/priority"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -713,7 +740,8 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->multiarch()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->multiarch()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData) { return jsonData->value("/data/multiarch"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -732,7 +760,8 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->source()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->source()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData) { return jsonData->value("/data/source"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -751,7 +780,8 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->format()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->format()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData) { return jsonData->value("/data/format"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -771,7 +801,8 @@ public:
                 return syncMsg->data_as_state()->attributes_as_syscollector_packages()->item_id()
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->item_id()->c_str()
                            : "";
-            });
+            },
+            [](const nlohmann::json* jsonData) { return jsonData->value("/data/item_id"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -785,8 +816,8 @@ public:
             { return delta->agent_info()->agent_id() ? delta->agent_info()->agent_id()->c_str() : ""; },
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_id() ? syncMsg->agent_info()->agent_id()->c_str() : ""; },
-            [](const nlohmann::json* message)
-            { return message->at("agent_info").at("agent_id").get_ref<const std::string&>(); });
+            [](const nlohmann::json* jsonData)
+            { return jsonData->value("/agent_info/agent_id"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -801,8 +832,8 @@ public:
             { return delta->agent_info()->agent_ip() ? delta->agent_info()->agent_ip()->c_str() : ""; },
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_ip() ? syncMsg->agent_info()->agent_ip()->c_str() : ""; },
-            [](const nlohmann::json* message)
-            { return message->at("agent_info").at("agent_ip").get_ref<const std::string&>(); });
+            [](const nlohmann::json* jsonData)
+            { return jsonData->value("/agent_info/agent_ip"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -817,8 +848,8 @@ public:
             { return delta->agent_info()->agent_name() ? delta->agent_info()->agent_name()->c_str() : ""; },
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_name() ? syncMsg->agent_info()->agent_name()->c_str() : ""; },
-            [](const nlohmann::json* message)
-            { return message->at("agent_info").at("agent_name").get_ref<const std::string&>(); });
+            [](const nlohmann::json* jsonData)
+            { return jsonData->value("/agent_info/agent_name"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -833,8 +864,8 @@ public:
             { return delta->agent_info()->agent_version() ? delta->agent_info()->agent_version()->c_str() : ""; },
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_version() ? syncMsg->agent_info()->agent_version()->c_str() : ""; },
-            [](const nlohmann::json* message)
-            { return message->at("agent_info").at("agent_version").get_ref<const std::string&>(); });
+            [](const nlohmann::json* jsonData)
+            { return jsonData->value("/agent_info/agent_version"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -848,8 +879,8 @@ public:
             { return delta->agent_info()->node_name() ? delta->agent_info()->node_name()->c_str() : ""; },
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->node_name() ? syncMsg->agent_info()->node_name()->c_str() : ""; },
-            [](const nlohmann::json* message)
-            { return message->at("agent_info").at("node_name").get_ref<const std::string&>(); });
+            [](const nlohmann::json* jsonData)
+            { return jsonData->value("/agent_info/node_name"_json_pointer, "").c_str(); });
     }
 
     /**
@@ -1012,6 +1043,16 @@ public:
     std::string_view osCPEName() const
     {
         return m_osData.cpeName;
+    }
+
+    /**
+     * @brief Gets the message type.
+     *
+     * @return MessageType The type of message of the context.
+     */
+    MessageType messageType() const
+    {
+        return m_messageType;
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -535,7 +535,12 @@ public:
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->name()->c_str()
                            : "";
             },
-            [](const nlohmann::json* jsonData) { return jsonData->value("/data/name"_json_pointer, "").c_str(); });
+            [](const nlohmann::json* jsonData)
+            {
+                return jsonData->contains("/data/name"_json_pointer)
+                           ? jsonData->at("/data/name"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -556,7 +561,12 @@ public:
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->version()->c_str()
                            : "";
             },
-            [](const nlohmann::json* jsonData) { return jsonData->value("/data/version"_json_pointer, "").c_str(); });
+            [](const nlohmann::json* jsonData)
+            {
+                return jsonData->contains("/data/version"_json_pointer)
+                           ? jsonData->at("/data/version"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -576,7 +586,12 @@ public:
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->vendor()->c_str()
                            : "";
             },
-            [](const nlohmann::json* jsonData) { return jsonData->value("/data/vendor"_json_pointer, "").c_str(); });
+            [](const nlohmann::json* jsonData)
+            {
+                return jsonData->contains("/data/vendor"_json_pointer)
+                           ? jsonData->at("/data/vendor"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -599,7 +614,11 @@ public:
                            : "";
             },
             [](const nlohmann::json* jsonData)
-            { return jsonData->value("/data/install_time"_json_pointer, "").c_str(); });
+            {
+                return jsonData->contains("/data/install_time"_json_pointer)
+                           ? jsonData->at("/data/install_time"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -620,7 +639,12 @@ public:
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->location()->c_str()
                            : "";
             },
-            [](const nlohmann::json* jsonData) { return jsonData->value("/data/location"_json_pointer, "").c_str(); });
+            [](const nlohmann::json* jsonData)
+            {
+                return jsonData->contains("/data/location"_json_pointer)
+                           ? jsonData->at("/data/location"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -643,7 +667,11 @@ public:
                            : "";
             },
             [](const nlohmann::json* jsonData)
-            { return jsonData->value("/data/architecture"_json_pointer, "").c_str(); });
+            {
+                return jsonData->contains("/data/architecture"_json_pointer)
+                           ? jsonData->at("/data/architecture"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -663,7 +691,12 @@ public:
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->groups()->c_str()
                            : "";
             },
-            [](const nlohmann::json* jsonData) { return jsonData->value("/data/groups"_json_pointer, "").c_str(); });
+            [](const nlohmann::json* jsonData)
+            {
+                return jsonData->contains("/data/groups"_json_pointer)
+                           ? jsonData->at("/data/groups"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -686,7 +719,11 @@ public:
                            : "";
             },
             [](const nlohmann::json* jsonData)
-            { return jsonData->value("/data/description"_json_pointer, "").c_str(); });
+            {
+                return jsonData->contains("/data/description"_json_pointer)
+                           ? jsonData->at("/data/description"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -699,7 +736,12 @@ public:
             [](const SyscollectorDeltas::Delta* delta) { return delta->data_as_dbsync_packages()->size(); },
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->data_as_state()->attributes_as_syscollector_packages()->size(); },
-            [](const nlohmann::json* jsonData) { return jsonData->value("/data/size"_json_pointer, 0); });
+            [](const nlohmann::json* jsonData)
+            {
+                return jsonData->contains("/data/size"_json_pointer)
+                           ? jsonData->at("/data/size"_json_pointer).get<uint64_t>()
+                           : 0;
+            });
     }
 
     /**
@@ -720,7 +762,12 @@ public:
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->priority()->c_str()
                            : "";
             },
-            [](const nlohmann::json* jsonData) { return jsonData->value("/data/priority"_json_pointer, "").c_str(); });
+            [](const nlohmann::json* jsonData)
+            {
+                return jsonData->contains("/data/priority"_json_pointer)
+                           ? jsonData->at("/data/priority"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -741,7 +788,12 @@ public:
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->multiarch()->c_str()
                            : "";
             },
-            [](const nlohmann::json* jsonData) { return jsonData->value("/data/multiarch"_json_pointer, "").c_str(); });
+            [](const nlohmann::json* jsonData)
+            {
+                return jsonData->contains("/data/multiarch"_json_pointer)
+                           ? jsonData->at("/data/multiarch"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -761,7 +813,12 @@ public:
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->source()->c_str()
                            : "";
             },
-            [](const nlohmann::json* jsonData) { return jsonData->value("/data/source"_json_pointer, "").c_str(); });
+            [](const nlohmann::json* jsonData)
+            {
+                return jsonData->contains("/data/source"_json_pointer)
+                           ? jsonData->at("/data/source"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -781,7 +838,12 @@ public:
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->format()->c_str()
                            : "";
             },
-            [](const nlohmann::json* jsonData) { return jsonData->value("/data/format"_json_pointer, "").c_str(); });
+            [](const nlohmann::json* jsonData)
+            {
+                return jsonData->contains("/data/format"_json_pointer)
+                           ? jsonData->at("/data/format"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -802,7 +864,12 @@ public:
                            ? syncMsg->data_as_state()->attributes_as_syscollector_packages()->item_id()->c_str()
                            : "";
             },
-            [](const nlohmann::json* jsonData) { return jsonData->value("/data/item_id"_json_pointer, "").c_str(); });
+            [](const nlohmann::json* jsonData)
+            {
+                return jsonData->contains("/data/item_id"_json_pointer)
+                           ? jsonData->at("/data/item_id"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -817,7 +884,11 @@ public:
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_id() ? syncMsg->agent_info()->agent_id()->c_str() : ""; },
             [](const nlohmann::json* jsonData)
-            { return jsonData->value("/agent_info/agent_id"_json_pointer, "").c_str(); });
+            {
+                return jsonData->contains("/agent_info/agent_id"_json_pointer)
+                           ? jsonData->at("/agent_info/agent_id"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -833,7 +904,11 @@ public:
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_ip() ? syncMsg->agent_info()->agent_ip()->c_str() : ""; },
             [](const nlohmann::json* jsonData)
-            { return jsonData->value("/agent_info/agent_ip"_json_pointer, "").c_str(); });
+            {
+                return jsonData->contains("/agent_info/agent_ip"_json_pointer)
+                           ? jsonData->at("/agent_info/agent_ip"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -849,7 +924,11 @@ public:
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_name() ? syncMsg->agent_info()->agent_name()->c_str() : ""; },
             [](const nlohmann::json* jsonData)
-            { return jsonData->value("/agent_info/agent_name"_json_pointer, "").c_str(); });
+            {
+                return jsonData->contains("/agent_info/agent_name"_json_pointer)
+                           ? jsonData->at("/agent_info/agent_name"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**
@@ -865,7 +944,13 @@ public:
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->agent_version() ? syncMsg->agent_info()->agent_version()->c_str() : ""; },
             [](const nlohmann::json* jsonData)
-            { return jsonData->value("/agent_info/agent_version"_json_pointer, "").c_str(); });
+            {
+                return jsonData->contains("/agent_info/agent_version"_json_pointer)
+                           ? jsonData->at("/agent_info/agent_version"_json_pointer)
+                                 .get_ref<const std::string&>()
+                                 .c_str()
+                           : "";
+            });
     }
 
     /**
@@ -880,7 +965,11 @@ public:
             [](const SyscollectorSynchronization::SyncMsg* syncMsg)
             { return syncMsg->agent_info()->node_name() ? syncMsg->agent_info()->node_name()->c_str() : ""; },
             [](const nlohmann::json* jsonData)
-            { return jsonData->value("/agent_info/node_name"_json_pointer, "").c_str(); });
+            {
+                return jsonData->contains("/agent_info/node_name"_json_pointer)
+                           ? jsonData->at("/agent_info/node_name"_json_pointer).get_ref<const std::string&>().c_str()
+                           : "";
+            });
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/sendReport.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/sendReport.hpp
@@ -42,44 +42,44 @@ public:
      */
     std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
     {
-        for (const auto& [key, value] : data->m_alerts)
+        // We only generate alerts for real time events
+        if (data->messageType() == MessageType::Delta)
         {
-            try
+            for (const auto& [key, value] : data->m_alerts)
             {
-                std::ostringstream oss;
-
-                std::string agentId = std::string(data->agentId());
-                std::string packageName;
-                if (data->getType() != ScannerType::IntegrityClear)
+                try
                 {
-                    packageName = std::string(data->packageName());
+                    std::ostringstream oss;
+
+                    std::string agentId = std::string(data->agentId());
+                    std::string packageName = std::string(data->packageName());
+
+                    // 1:[001] (agent_name) ip->location:
+                    oss << LOCALFILE_MQ << ":"
+                        << "[" << agentId << "] (" << std::string(data->agentName()) << ") "
+                        << std::string(data->agentIp()) << "->"
+                        << "vulnerability-detector"
+                        << ":"
+                        // Vulnerability report.
+                        << value.dump().c_str();
+
+                    const std::string message = oss.str();
+                    logDebug2(WM_VULNSCAN_LOGTAG,
+                              "Vulnerability %s report for agent ID %s, package: %s, cve: %s",
+                              data->getType() == ScannerType::PackageInsert   ? "detected"
+                              : data->getType() == ScannerType::PackageDelete ? "solved"
+                                                                              : "",
+                              agentId.c_str(),
+                              packageName.c_str(),
+                              key.c_str());
+
+                    // The report is sent in another thread.
+                    m_reportDispatcher->push(message);
                 }
-
-                // 1:[001] (agent_name) ip->location:
-                oss << LOCALFILE_MQ << ":"
-                    << "[" << agentId << "] (" << std::string(data->agentName()) << ") " << std::string(data->agentIp())
-                    << "->"
-                    << "vulnerability-detector"
-                    << ":"
-                    // Vulnerability report.
-                    << value.dump().c_str();
-
-                const std::string message = oss.str();
-                logDebug2(WM_VULNSCAN_LOGTAG,
-                          "Vulnerability %s report for agent ID %s, package: %s, cve: %s",
-                          data->getType() == ScannerType::PackageInsert   ? "detected"
-                          : data->getType() == ScannerType::PackageDelete ? "solved"
-                                                                          : "clear",
-                          agentId.c_str(),
-                          data->getType() != ScannerType::IntegrityClear ? packageName.c_str() : "all",
-                          data->getType() != ScannerType::IntegrityClear ? key.c_str() : "all");
-
-                // The report is sent in another thread.
-                m_reportDispatcher->push(message);
-            }
-            catch (...)
-            {
-                logWarn(WM_VULNSCAN_LOGTAG, "Couldn't send vulnerability JSON report for %s:", key.c_str());
+                catch (...)
+                {
+                    logWarn(WM_VULNSCAN_LOGTAG, "Couldn't send vulnerability JSON report for %s:", key.c_str());
+                }
             }
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanContext_test.cpp
@@ -1439,3 +1439,100 @@ TEST_F(ScanContextTest, TestBuildCPENameFedora)
     EXPECT_NO_THROW(scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(msg));
     EXPECT_STREQ(scanContext->osCPEName().data(), "cpe:/o:fedoraproject:fedora:37");
 }
+
+TEST_F(ScanContextTest, TestJSONMessagePackageDelete)
+{
+    const auto message = nlohmann::json::parse(
+        R"({
+            "agent_info": {
+                "agent_id" : "001",
+                "agent_ip" : "10.0.0.1",
+                "agent_name" : "agent1",
+                "agent_version" : "v4.8.0",
+                "node_name" : "node01"
+            },
+            "action": "deletePackage",
+            "data": {
+                "name" : "packageName",
+                "version" : "1.0.0",
+                "location" : "/usr/bin/packageName",
+                "architecture": "x86_64",
+                "format": "rpm",
+                "item_id" : "2509fc973210e58bec81a497a2e0cdb8681b7d77"
+            }
+        })");
+
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        msg = &message;
+    std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContext;
+    EXPECT_NO_THROW(scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(msg));
+
+    EXPECT_EQ(scanContext->getType(), ScannerType::PackageDelete);
+    EXPECT_EQ(scanContext->operationType(), OperationType::Delete);
+    EXPECT_EQ(scanContext->messageType(), MessageType::DataJSON);
+    EXPECT_EQ(scanContext->agentId(), "001");
+    EXPECT_EQ(scanContext->agentIp(), "10.0.0.1");
+    EXPECT_EQ(scanContext->agentName(), "agent1");
+    EXPECT_EQ(scanContext->agentVersion(), "v4.8.0");
+    EXPECT_EQ(scanContext->agentNodeName(), "node01");
+    EXPECT_EQ(scanContext->packageName(), "packageName");
+    EXPECT_EQ(scanContext->packageVersion(), "1.0.0");
+    EXPECT_EQ(scanContext->packageLocation(), "/usr/bin/packageName");
+    EXPECT_EQ(scanContext->packageArchitecture(), "x86_64");
+    EXPECT_EQ(scanContext->packageFormat(), "rpm");
+    EXPECT_EQ(scanContext->packageItemId(), "2509fc973210e58bec81a497a2e0cdb8681b7d77");
+    EXPECT_EQ(scanContext->packageVendor(), "");
+    EXPECT_EQ(scanContext->packageInstallTime(), "");
+    EXPECT_EQ(scanContext->packageGroups(), "");
+    EXPECT_EQ(scanContext->packageDescription(), "");
+    EXPECT_EQ(scanContext->packageSize(), 0);
+    EXPECT_EQ(scanContext->packagePriority(), "");
+    EXPECT_EQ(scanContext->packageMultiarch(), "");
+    EXPECT_EQ(scanContext->packageSource(), "");
+}
+
+TEST_F(ScanContextTest, TestJSONMessageHotfixDelete)
+{
+    const auto message = nlohmann::json::parse(
+        R"({
+            "agent_info": {
+                "agent_id" : "001",
+                "agent_ip" : "10.0.0.1",
+                "agent_name" : "agent1",
+                "agent_version" : "v4.8.0",
+                "node_name" : "node01"
+            },
+            "action": "deleteHotfix",
+            "data": {
+                "hotfix" : "KB1234"
+            }
+        })");
+
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        msg = &message;
+    std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContext;
+    EXPECT_NO_THROW(scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(msg));
+
+    EXPECT_EQ(scanContext->getType(), ScannerType::HotfixDelete);
+    EXPECT_EQ(scanContext->operationType(), OperationType::Delete);
+    EXPECT_EQ(scanContext->messageType(), MessageType::DataJSON);
+    EXPECT_EQ(scanContext->agentId(), "001");
+    EXPECT_EQ(scanContext->agentIp(), "10.0.0.1");
+    EXPECT_EQ(scanContext->agentName(), "agent1");
+    EXPECT_EQ(scanContext->agentVersion(), "v4.8.0");
+    EXPECT_EQ(scanContext->agentNodeName(), "node01");
+    EXPECT_EQ(scanContext->packageName(), "");
+    EXPECT_EQ(scanContext->packageVersion(), "");
+    EXPECT_EQ(scanContext->packageLocation(), "");
+    EXPECT_EQ(scanContext->packageArchitecture(), "");
+    EXPECT_EQ(scanContext->packageFormat(), "");
+    EXPECT_EQ(scanContext->packageItemId(), "");
+    EXPECT_EQ(scanContext->packageVendor(), "");
+    EXPECT_EQ(scanContext->packageInstallTime(), "");
+    EXPECT_EQ(scanContext->packageGroups(), "");
+    EXPECT_EQ(scanContext->packageDescription(), "");
+    EXPECT_EQ(scanContext->packageSize(), 0);
+    EXPECT_EQ(scanContext->packagePriority(), "");
+    EXPECT_EQ(scanContext->packageMultiarch(), "");
+    EXPECT_EQ(scanContext->packageSource(), "");
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/sendReport_test.cpp
@@ -187,9 +187,7 @@ const std::string DELTA_DELETE_ALERT {
 
 TEST_F(SendReportTest, SendFormattedMsg)
 {
-    const std::string report =
-        R"({"vulnerability":{"category":"Packages","classification":"CVSS","cve":"CVE-2020-14343","description":"A vulnerability was discovered in the PyYAML library in versions before 5.4, where it is susceptible to arbitrary code execution when it processes untrusted YAML files through the full_load method or with the FullLoader loader. Applications that use the library to process untrusted input may be vulnerable to this flaw. This flaw allows an attacker to execute arbitrary code on the system by abusing the python/object/new constructor. This flaw is due to an incomplete fix for CVE-2020-1747.","enumeration":"CVE","package":{"architecture":" ","build_version":"","checksum":"","description":" ","install_scope":"","install_time":" ","license":"","name":"PyYAML","path":"/usr/lib/python3/dist-packages/PyYAML-5.3.1.egg-info","reference":"","size":0,"type":"pypi","version":"5.3.1"},"reference":"https://bugzilla.redhat.com/show_bug.cgi?id=1860466, https://github.com/SeldonIO/seldon-core/issues/2252, https://github.com/yaml/pyyaml/issues/420, https://www.oracle.com/security-alerts/cpuapr2022.html, https://www.oracle.com/security-alerts/cpujul2022.html","score":{"base":9.800000190734863,"environmental":0.0,"temporal":0.0,"version":"3.1"},"severity":"Critical","status":"Active"}})";
-    std::string expectedStr = "1:[001] (focal) 192.168.33.20->vulnerability-detector:" + report;
+    std::string expectedString {"Message not delivered."};
 
     // Fake socket server
     auto thread = std::thread(
@@ -220,7 +218,7 @@ TEST_F(SendReportTest, SendFormattedMsg)
             ASSERT_NE(bytesReceived, -1);
             buffer[bytesReceived] = '\0';
 
-            EXPECT_STREQ(buffer, expectedStr.c_str());
+            EXPECT_STREQ(buffer, expectedString.c_str());
 
             close(socketServer);
             std::filesystem::remove(TEST_PATH);
@@ -295,6 +293,9 @@ TEST_F(SendReportTest, SendFormattedMsg)
 
     // Send report.
     sendReport.handleRequest(scanContext);
+
+    // The report was not sent. A dummy message is sent to close the server socket.
+    send(socketClient->getSocketDescriptor(), expectedString.c_str(), expectedString.size(), 0);
 
     thread.join();
 }
@@ -401,8 +402,8 @@ TEST_F(SendReportTest, InvalidEncodingValue)
 
     // Mock scanContext.
     flatbuffers::Parser parser;
-    ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
-    ASSERT_TRUE(parser.Parse(SYNC_STATE_MSG.c_str()));
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_DELETE_MSG.c_str()));
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorSync = SyscollectorSynchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
@@ -416,119 +417,6 @@ TEST_F(SendReportTest, InvalidEncodingValue)
 
     // The report was not sent. A dummy message is sent to close the server socket.
     send(socketClient->getSocketDescriptor(), expectedString.c_str(), expectedString.size(), 0);
-
-    thread.join();
-}
-
-TEST_F(SendReportTest, SendFormattedClearMsg)
-{
-    const std::string report = R"({"vulnerability":{"category":"Packages","status":"Clear"}})";
-    std::string expectedStr = "1:[001] (focal) 192.168.33.20->vulnerability-detector:" + report;
-
-    // Fake socket server
-    auto thread = std::thread(
-        [&]()
-        {
-            struct sockaddr_un serverAddr
-            {
-            };
-            struct sockaddr_un clientAddr
-            {
-            };
-
-            int socketServer = socket(AF_UNIX, SOCK_DGRAM, 0);
-            ASSERT_NE(socketServer, -1);
-
-            serverAddr.sun_family = AF_UNIX;
-            std::strcpy(serverAddr.sun_path, TEST_PATH.c_str());
-
-            ASSERT_NE(bind(socketServer, (struct sockaddr*)&serverAddr, sizeof(serverAddr)), -1);
-
-            char buffer[65536];
-            size_t bytesReceived;
-            socklen_t clientSize = sizeof(clientAddr);
-
-            bytesReceived =
-                recvfrom(socketServer, buffer, sizeof(buffer), 0, (struct sockaddr*)&clientAddr, &clientSize);
-
-            ASSERT_NE(bytesReceived, -1);
-            buffer[bytesReceived] = '\0';
-
-            EXPECT_STREQ(buffer, expectedStr.c_str());
-
-            close(socketServer);
-            std::filesystem::remove(TEST_PATH);
-        });
-
-    // Socket client instance.
-    std::shared_ptr<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>> socketClient =
-        std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(TEST_PATH);
-
-    // Wait for server.
-    struct stat fileStat
-    {
-    };
-    int statRet;
-    size_t retries = 0;
-    do
-    {
-        ++retries;
-        std::this_thread::sleep_for(std::chrono::milliseconds(100 * retries));
-        statRet = stat(TEST_PATH.c_str(), &fileStat);
-    } while (statRet != 0 && retries < MAX_RETRIES);
-
-    // Connect to server.
-    socketClient->connect(
-        [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader) {}, []() {}, SOCK_DGRAM);
-    auto reportDispatcher = std::make_shared<ReportDispatcher>(
-        [&](std::queue<std::string>& dataQueue)
-        {
-            while (!dataQueue.empty())
-            {
-                auto data = dataQueue.front();
-                dataQueue.pop();
-                socketClient->send(data.c_str(), data.size());
-            }
-        },
-        TEST_REPORTS_QUEUE_PATH,
-        TEST_REPORTS_BULK_SIZE,
-        TEST_REPORTS_THREADS_NUMBER);
-
-    // Send report instance.
-    TSendReport<TScanContext<TrampolineOsDataCache>> sendReport(reportDispatcher);
-
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
-
-    // Mock scanContext.
-    flatbuffers::Parser parser;
-    ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
-    ASSERT_TRUE(parser.Parse(INTEGRITY_CLEAR_MSG.c_str()));
-    uint8_t* buffer = parser.builder_.GetBufferPointer();
-    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
-        syscollectorSync = SyscollectorSynchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
-    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorSync);
-    nlohmann::json detectionJson = nlohmann::json::parse(INTEGRITY_CLEAR_ALERT);
-    scanContext->m_alerts["CVE-2020-14343"] = detectionJson;
-
-    // Send report.
-    sendReport.handleRequest(scanContext);
 
     thread.join();
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21659 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR handles the RSync deleted events in JSON format.
Also, it prevents any event except delta ones from generating alerts. 

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

**Manual testing**

The code was temporary modified to ignore the delta `DELETED` events in Wazuh-DB and the forwarded events to vulnerability detector:
- The `DELETED` section of `process_dbsync_data()` (src/wazuh_db/wdb_parser.c) was removed
- The `adapt_delta_message()` method (src/shared/agent_messages_adapter.c) was modified to early return in case there is a `DELETED` event.

This will force the RSync mechanism to sync a package deletion.

Then, the manager (Ubuntu 22.04) was scanned with the last available content and one vulnerability was selected: package `dmidecode`, CVE-2023-30630. The CVE was successfully published in Opensearch. 

The **syscollector** frequency was set to 30s and the `dmidecode` package was removed.
The generated message from Wazuh-DB properly removes the vulnerability from the inventory and from the indexer.

```
2024/02/21 03:50:25 wazuh-modulesd:vulnerability-scanner[98683] inventorySync.hpp:99 at handleRequest(): DEBUG: Deleting agent package key: node01_000_2509fc973210e58bec81a497a2e0cdb8681b7d77
2024/02/21 03:50:25 wazuh-modulesd:vulnerability-scanner[98683] resultIndexer.hpp:56 at handleRequest(): DEBUG: Processing and publish key: node01_000_2509fc973210e58bec81a497a2e0cdb8681b7d77_CVE-2023-30630
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

- [x] Added unit tests (for new features)
