### PR TITLE
Resolve transitive mutex locking issue in wazuh-db

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -36,7 +36,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_scan_info_get -Wl,--wrap,wdb_fim_upd
                         -Wl,--wrap,wdb_get_config -Wl,--wrap,wdb_get_internal_config -Wl,--wrap,wdb_finalize_all_statements \
                         -Wl,--wrap,wdb_global_create_backup -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_vacuum -Wl,--wrap,wdb_get_db_state \
                         -Wl,--wrap,wdb_update_last_vacuum_data -Wl,--wrap,wdb_get_db_free_pages_percentage \
-                        ${DEBUG_OP_WRAPPERS}")
+                        -Wl,--wrap,wdb_pool_leave ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -81,7 +81,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_vacuum -Wl,--wrap,wdb_get_db_state -Wl,--wrap,wdb_finalize_all_statements \
                              -Wl,--wrap,wdb_update_last_vacuum_data -Wl,--wrap,wdb_get_db_free_pages_percentage -Wl,--wrap,wdb_global_get_distinct_agent_groups \
                              -Wl,--wrap,w_inc_global_agent_get_distinct_groups -Wl,--wrap,w_inc_global_agent_get_distinct_groups_time \
-                             -Wl,--wrap,w_inc_global_open_time ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,w_inc_global_open_time -Wl,--wrap,wdb_pool_leave ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -131,7 +131,9 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,sqlite3_column_text -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_finalize -Wl,--wrap,sqlite3_reset \
                              -Wl,--wrap,sqlite3_clear_bindings -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_sql -Wl,--wrap,OS_SendSecureTCP  \
                              -Wl,--wrap,OS_SetSendTimeout -Wl,--wrap,time -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,rwlock_lock_write \
-                             -Wl,--wrap,rwlock_lock_read -Wl,--wrap,rwlock_unlock ${HASH_OP_WRAPPERS} ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,rwlock_lock_read -Wl,--wrap,rwlock_unlock -Wl,--wrap,wdb_pool_get -Wl,--wrap,wdb_pool_get_or_create \
+                             -Wl,--wrap,wdb_pool_leave -Wl,--wrap,wdb_pool_keys -Wl,--wrap,wdb_pool_clean -Wl,--wrap,getuid -Wl,--wrap,chmod \
+                             -Wl,--wrap,stat ${HASH_OP_WRAPPERS} ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_upgrade")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_count_tables_with_name \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -188,6 +188,9 @@ list(APPEND wdb_tests_flags "")
 list(APPEND wdb_tests_names "test_wdb_com")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_create_state_json -Wl,--wrap,wdb_get_config -Wl,--wrap,wdb_get_internal_config")
 
+list(APPEND wdb_tests_names "test_wdb_pool")
+list(APPEND wdb_tests_flags "-Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock")
+
 # Add extra compiling flags
 add_compile_options(-Wall)
 

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -24,6 +24,7 @@
 #include "../wrappers/libc/string_wrappers.h"
 #include "../wrappers/posix/pthread_wrappers.h"
 #include "../wrappers/posix/time_wrappers.h"
+#include "../wrappers/posix/stat_wrappers.h"
 #include "../wrappers/wazuh/os_net/os_net_wrappers.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/shared/hash_op_wrappers.h"
@@ -35,25 +36,20 @@ int wdb_select_from_temp_table(sqlite3 *db);
 int wdb_get_last_vacuum_data(wdb_t* wdb, int *last_vacuum_time, int *last_vacuum_value);
 int wdb_execute_single_int_select_query(wdb_t * wdb, const char *query, int *value);
 
-extern wdb_t * db_pool_begin;
-
 typedef struct test_struct {
     wdb_t *wdb;
     char *output;
 } test_struct_t;
+
+int __wrap_getuid(void) {
+    return mock();
+}
 
 /* setup/teardown */
 
 int setup_wdb(void **state) {
 
     test_mode = 1;
-
-    will_return(__wrap_time, 0);
-
-    open_dbs = __real_OSHash_Create();
-    if (open_dbs == NULL) {
-        return -1;
-    }
 
     test_struct_t *init_data = NULL;
     os_calloc(1,sizeof(test_struct_t),init_data);
@@ -68,10 +64,6 @@ int setup_wdb(void **state) {
 
 int teardown_wdb(void **state) {
     test_mode = 0;
-    if (open_dbs) {
-        OSHash_Free(open_dbs);
-        open_dbs = NULL;
-    }
     test_struct_t *data  = (test_struct_t *)*state;
     os_free(data->output);
     os_free(data->wdb->id);
@@ -95,38 +87,52 @@ int  wazuh_db_config_teardown() {
 
 /* Tests wdb_open_global */
 
-void test_wdb_open_tasks_pool_success(void **state)
+void test_wdb_open_tasks_pool_success_wdb_in_pool_db_open(void **state)
 {
     wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, WDB_TASK_NAME);
-    will_return(__wrap_OSHash_Get, data->wdb);
+    wdb_t *node = wdb_init(WDB_TASK_NAME);
+    node->db = (sqlite3 *)1;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_string(__wrap_wdb_pool_get_or_create, name, WDB_TASK_NAME);
+    will_return(__wrap_wdb_pool_get_or_create, node);
 
     ret = wdb_open_tasks();
 
-    assert_int_equal(ret, data->wdb);
+    assert_string_equal(ret->id, WDB_TASK_NAME);
+    assert_non_null(ret->db);
+    wdb_destroy(ret);
+}
+
+void test_wdb_open_tasks_pool_success_wdb_in_pool_db_null(void **state)
+{
+    wdb_t *ret = NULL;
+
+    wdb_t *node = wdb_init(WDB_TASK_NAME);
+    sqlite3 *db = (sqlite3 *)1;
+
+    expect_string(__wrap_wdb_pool_get_or_create, name, WDB_TASK_NAME);
+    will_return(__wrap_wdb_pool_get_or_create, node);
+
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/tasks/tasks.db");
+    will_return(__wrap_sqlite3_open_v2, db);
+    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
+    will_return(__wrap_sqlite3_open_v2, OS_SUCCESS);
+
+    ret = wdb_open_tasks();
+
+    assert_string_equal(ret->id, WDB_TASK_NAME);
+    assert_non_null(ret->db);
+    wdb_destroy(ret);
 }
 
 void test_wdb_open_tasks_create_error(void **state)
 {
     wdb_t *ret = NULL;
+    wdb_t *node = wdb_init(WDB_TASK_NAME);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, WDB_TASK_NAME);
-    will_return(__wrap_OSHash_Get, NULL);
-    expect_function_call(__wrap_rwlock_unlock);
-
-    expect_function_call(__wrap_rwlock_lock_write);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, WDB_TASK_NAME);
-    will_return(__wrap_OSHash_Get, NULL);
+    expect_string(__wrap_wdb_pool_get_or_create, name, WDB_TASK_NAME);
+    will_return(__wrap_wdb_pool_get_or_create, node);
 
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/tasks/tasks.db");
     will_return(__wrap_sqlite3_open_v2, NULL);
@@ -135,6 +141,8 @@ void test_wdb_open_tasks_create_error(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "Tasks database not found, creating.");
     will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/tasks/tasks.db");
     will_return(__wrap_sqlite3_open_v2, NULL);
@@ -146,55 +154,97 @@ void test_wdb_open_tasks_create_error(void **state)
     will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
 
     expect_string(__wrap__merror, formatted_msg, "Couldn't create SQLite database 'queue/tasks/tasks.db'");
-    expect_function_call(__wrap_rwlock_unlock);
 
     ret = wdb_open_tasks();
 
     assert_null(ret);
+    wdb_destroy(node);
 }
 
-void test_wdb_open_global_pool_success(void **state)
+void test_wdb_open_tasks_retry_open_error(void **state)
 {
     wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;
+    wdb_t *node = wdb_init(WDB_TASK_NAME);
+    sqlite3 *db = (sqlite3 *)1;
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, WDB_GLOB_NAME);
-    will_return(__wrap_OSHash_Get, data->wdb);
+    expect_string(__wrap_wdb_pool_get_or_create, name, WDB_TASK_NAME);
+    will_return(__wrap_wdb_pool_get_or_create, node);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/tasks/tasks.db");
+    will_return(__wrap_sqlite3_open_v2, NULL);
+    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
+    will_return(__wrap_sqlite3_open_v2, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Tasks database not found, creating.");
+    will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
+
+    // wdb_create_file ok
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/tasks/tasks.db");
+    will_return(__wrap_sqlite3_open_v2, db);
+    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
+    will_return(__wrap_sqlite3_open_v2, OS_SUCCESS);
+    will_return(__wrap_sqlite3_prepare_v2, 1);
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    expect_sqlite3_step_call(SQLITE_DONE);
+    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
+    will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
+    will_return(__wrap_getuid, 1);
+    expect_string(__wrap__mdebug1, formatted_msg, "Ignoring chown when creating file from SQL.");
+    expect_string(__wrap_chmod, path, "queue/tasks/tasks.db");
+    will_return(__wrap_chmod, 0);
+
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/tasks/tasks.db");
+    will_return(__wrap_sqlite3_open_v2, NULL);
+    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
+    will_return(__wrap_sqlite3_open_v2, OS_INVALID);
+
+
+    will_return(__wrap_sqlite3_errmsg, "out of memory");
+    expect_string(__wrap__merror, formatted_msg, "Can't open SQLite database 'queue/tasks/tasks.db': out of memory");
+    will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
+    expect_function_call(__wrap_wdb_pool_leave);
+
+    ret = wdb_open_tasks();
+
+    assert_null(ret);
+    wdb_destroy(node);
+}
+
+void test_wdb_open_global_pool_success_wdb_in_pool_db_open(void **state)
+{
+    wdb_t *ret = NULL;
+
+    wdb_t *node = wdb_init(WDB_GLOB_NAME);
+    node->db = (sqlite3 *)1;
+
+    expect_string(__wrap_wdb_pool_get_or_create, name, WDB_GLOB_NAME);
+    will_return(__wrap_wdb_pool_get_or_create, node);
 
     ret = wdb_open_global();
 
-    assert_int_equal(ret, data->wdb);
+    assert_string_equal(ret->id, WDB_GLOB_NAME);
+    assert_non_null(ret->db);
+    wdb_destroy(ret);
 }
 
-void test_wdb_open_global_create_fail(void **state)
+void test_wdb_open_global_create_error(void **state)
 {
     wdb_t *ret = NULL;
+    wdb_t *node = wdb_init(WDB_GLOB_NAME);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, WDB_GLOB_NAME);
-    will_return(__wrap_OSHash_Get, NULL);
-    expect_function_call(__wrap_rwlock_unlock);
-
-    expect_function_call(__wrap_rwlock_lock_write);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, WDB_GLOB_NAME);
-    will_return(__wrap_OSHash_Get, NULL);
+    expect_string(__wrap_wdb_pool_get_or_create, name, WDB_GLOB_NAME);
+    will_return(__wrap_wdb_pool_get_or_create, node);
 
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
     will_return(__wrap_sqlite3_open_v2, NULL);
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
     will_return(__wrap_sqlite3_open_v2, OS_INVALID);
+
     expect_string(__wrap__mdebug1, formatted_msg, "Global database not found, creating.");
     will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
 
-    // wdb_create_global
-    //// wdb_create_file
+    expect_function_call(__wrap_wdb_pool_leave);
+
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
     will_return(__wrap_sqlite3_open_v2, NULL);
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
@@ -205,11 +255,11 @@ void test_wdb_open_global_create_fail(void **state)
     will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
 
     expect_string(__wrap__merror, formatted_msg, "Couldn't create SQLite database 'queue/db/global.db'");
-    expect_function_call(__wrap_rwlock_unlock);
 
     ret = wdb_open_global();
 
     assert_null(ret);
+    wdb_destroy(node);
 }
 
 /* Tests wdb_exec_row_stmt_multi_column */
@@ -923,21 +973,6 @@ void test_wdb_exec_row_stmt_single_column_sql_error(){
     assert_null(ret);
 }
 
-void test_wdb_leave(){
-    wdb_t wdb;
-    wdb.refcount = 1;
-    wdb.last = 1;
-
-    will_return(__wrap_time, 0);
-
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
-    wdb_leave(&wdb);
-
-    assert_null(wdb.refcount);
-    assert_null(wdb.last);
-}
-
 void test_wdb_finalize_all_statements(){
     const int kMaxStmt = 10;
     wdb_t wdb = {0};
@@ -966,24 +1001,9 @@ void test_wdb_finalize_all_statements(){
 
 /* Tests wdb_close*/
 
-void test_wdb_close_refcount_error(){
-    wdb_t wdb = {0};
-    wdb.refcount = 1;
-    wdb.id = "agent";
-
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_string(__wrap__mdebug1, formatted_msg, "Couldn't close database for agent agent: refcount = 1");
-
-    assert_int_equal(-1, wdb_close(&wdb, 0));
-}
-
 void test_wdb_close_no_commit_sqlerror(){
     wdb_t wdb = {0};
     wdb.id = "agent";
-
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "mock_error");
@@ -999,22 +1019,10 @@ void test_wdb_close_success(){
 
     test_mode = 1;
 
-    open_dbs = (OSHash *)0xDEADBEEF;
-
-    expect_string(__wrap_OSHash_Add, key, wdb->id);
-    will_return(__wrap_OSHash_Add, 2);
-    wdb_pool_append(wdb);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    expect_value(__wrap_OSHash_Delete, self, open_dbs);
-    expect_string(__wrap_OSHash_Delete, key, wdb->id);
-    will_return(__wrap_OSHash_Delete, 1);
-
     assert_int_equal(0, wdb_close(wdb, 0));
+    wdb_destroy(wdb);
 }
 
 void test_wdb_get_db_free_pages_percentage_page_count_error(void **state) {
@@ -1667,44 +1675,38 @@ void test_wdb_update_last_vacuum_data_ok_constraint(void **state) {
 
 void test_wdb_check_fragmentation_node_null(void **state)
 {
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->stmt[0] = (sqlite3_stmt*)1;
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, NULL);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, NULL);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
 }
 
 void test_wdb_check_fragmentation_get_state_error(void **state)
 {
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->stmt[0] = (sqlite3_stmt*)1;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -1725,32 +1727,29 @@ void test_wdb_check_fragmentation_get_state_error(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Couldn't get current state for the database '000'");
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_get_last_vacuum_data_error(void **state)
 {
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->stmt[0] = (sqlite3_stmt*)1;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -1801,35 +1800,32 @@ void test_wdb_check_fragmentation_get_last_vacuum_data_error(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Couldn't get last vacuum info for the database '000'");
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_commit_error(void **state)
 {
     wconfig.max_fragmentation = 80;
     wconfig.free_pages_percentage = 5;
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->stmt[0] = (sqlite3_stmt*)1;
-    db_pool_begin->transaction = 1;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    node->transaction = 1;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -1913,34 +1909,32 @@ void test_wdb_check_fragmentation_commit_error(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Couldn't execute commit statement, before vacuum, for the database '000'");
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_vacuum_error(void **state)
 {
     wconfig.max_fragmentation = 80;
     wconfig.free_pages_percentage = 5;
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->transaction = 0;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    node->transaction = 0;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2024,34 +2018,32 @@ void test_wdb_check_fragmentation_vacuum_error(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Couldn't execute vacuum for the database '000'");
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_get_fragmentation_after_vacuum_error(void **state)
 {
     wconfig.max_fragmentation = 80;
     wconfig.free_pages_percentage = 5;
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->transaction = 0;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    node->transaction = 0;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2150,34 +2142,32 @@ void test_wdb_check_fragmentation_get_fragmentation_after_vacuum_error(void **st
 
     expect_string(__wrap__merror, formatted_msg, "Couldn't get fragmentation after vacuum for the database '000'");
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_update_last_vacuum_data_error(void **state)
 {
     wconfig.max_fragmentation = 80;
     wconfig.free_pages_percentage = 5;
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->transaction = 0;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    node->transaction = 0;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2298,34 +2288,32 @@ void test_wdb_check_fragmentation_update_last_vacuum_data_error(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Couldn't update last vacuum info for the database '000'");
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_success_with_warning(void **state)
 {
     wconfig.max_fragmentation = 80;
     wconfig.free_pages_percentage = 5;
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->transaction = 0;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    node->transaction = 0;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2426,34 +2414,32 @@ void test_wdb_check_fragmentation_success_with_warning(void **state)
 
     expect_string(__wrap__mwarn, formatted_msg, "After vacuum, the database '000' has become just as fragmented or worse");
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_success(void **state)
 {
     wconfig.max_fragmentation = 80;
     wconfig.free_pages_percentage = 5;
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->transaction = 0;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    node->transaction = 0;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2552,34 +2538,32 @@ void test_wdb_check_fragmentation_success(void **state)
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_no_vacuum_free_pages(void **state)
 {
     wconfig.max_fragmentation = 80;
     wconfig.free_pages_percentage = 5;
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->transaction = 0;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    node->transaction = 0;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2629,14 +2613,13 @@ void test_wdb_check_fragmentation_no_vacuum_free_pages(void **state)
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
     expect_string(__wrap__mdebug2, formatted_msg, "No vacuum data in metadata table.");
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_no_vacuum_current_fragmentation(void **state)
@@ -2644,20 +2627,19 @@ void test_wdb_check_fragmentation_no_vacuum_current_fragmentation(void **state)
     wconfig.max_fragmentation = 80;
     wconfig.free_pages_percentage = 5;
     wconfig.fragmentation_threshold = 75;
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->transaction = 0;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    node->transaction = 0;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2707,14 +2689,13 @@ void test_wdb_check_fragmentation_no_vacuum_current_fragmentation(void **state)
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
     expect_string(__wrap__mdebug2, formatted_msg, "No vacuum data in metadata table.");
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_no_vacuum_current_fragmentation_delta(void **state)
@@ -2723,20 +2704,19 @@ void test_wdb_check_fragmentation_no_vacuum_current_fragmentation_delta(void **s
     wconfig.free_pages_percentage = 5;
     wconfig.fragmentation_threshold = 60;
     wconfig.fragmentation_delta = 40;
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->transaction = 0;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    node->transaction = 0;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2812,14 +2792,13 @@ void test_wdb_check_fragmentation_no_vacuum_current_fragmentation_delta(void **s
     expect_sqlite3_step_call(SQLITE_DONE);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_vacuum_first(void **state)
@@ -2828,20 +2807,19 @@ void test_wdb_check_fragmentation_vacuum_first(void **state)
     wconfig.free_pages_percentage = 5;
     wconfig.fragmentation_threshold = 60;
     wconfig.fragmentation_delta = 50;
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->transaction = 0;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    node->transaction = 0;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -2940,14 +2918,13 @@ void test_wdb_check_fragmentation_vacuum_first(void **state)
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 void test_wdb_check_fragmentation_vacuum_current_fragmentation_delta(void **state)
@@ -2956,20 +2933,19 @@ void test_wdb_check_fragmentation_vacuum_current_fragmentation_delta(void **stat
     wconfig.free_pages_percentage = 5;
     wconfig.fragmentation_threshold = 90;
     wconfig.fragmentation_delta = 20;
-    os_calloc(1,sizeof(wdb_t),db_pool_begin);
-    os_strdup("000",db_pool_begin->id);
-    os_calloc(1,sizeof(sqlite3 *),db_pool_begin->db);
-    db_pool_begin->transaction = 0;
+    // wdb_pool_keys
+    rb_tree * tree = rbtree_init();
+    char *value = strdup("testing");
+    rbtree_insert(tree, "000", value);
+    char** keys = rbtree_keys(tree);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_function_call(__wrap_rwlock_unlock);
+    will_return(__wrap_wdb_pool_keys, keys);
 
-    expect_function_call(__wrap_rwlock_lock_read);
-    expect_any(__wrap_OSHash_Get, self);
-    expect_string(__wrap_OSHash_Get, key, "000");
-    will_return(__wrap_OSHash_Get, db_pool_begin);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
+    wdb_t *node = wdb_init("000");
+    node->db = (sqlite3 *)1;
+    node->transaction = 0;
+    expect_string(__wrap_wdb_pool_get, name, "000");
+    will_return(__wrap_wdb_pool_get, node);
 
     // wdb_get_db_state
     will_return(__wrap_sqlite3_prepare_v2, 1);
@@ -3094,24 +3070,25 @@ void test_wdb_check_fragmentation_vacuum_current_fragmentation_delta(void **stat
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_rwlock_unlock);
+    expect_function_call(__wrap_wdb_pool_leave);
 
     wdb_check_fragmentation();
 
-    os_free(db_pool_begin->id);
-    os_free(db_pool_begin->db);
-    os_free(db_pool_begin);
+    rbtree_destroy(tree);
+    os_free(value);
+    wdb_destroy(node);
 }
 
 int main() {
     const struct CMUnitTest tests[] = {
         // wdb_open_tasks
-        cmocka_unit_test_setup_teardown(test_wdb_open_tasks_pool_success, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_open_tasks_create_error, setup_wdb, teardown_wdb),
+        cmocka_unit_test(test_wdb_open_tasks_pool_success_wdb_in_pool_db_open),
+        cmocka_unit_test(test_wdb_open_tasks_pool_success_wdb_in_pool_db_null),
+        cmocka_unit_test(test_wdb_open_tasks_create_error),
+        cmocka_unit_test(test_wdb_open_tasks_retry_open_error),
         // wdb_open_global
-        cmocka_unit_test_setup_teardown(test_wdb_open_global_pool_success, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_open_global_create_fail, setup_wdb, teardown_wdb),
+        cmocka_unit_test(test_wdb_open_global_pool_success_wdb_in_pool_db_open),
+        cmocka_unit_test(test_wdb_open_global_create_error),
         // wdb_exec_row_stm
         cmocka_unit_test_setup_teardown(test_wdb_exec_row_stmt_multi_column_one_int, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_exec_row_stmt_multi_column_multiple_int, setup_wdb, teardown_wdb),
@@ -3157,12 +3134,9 @@ int main() {
         cmocka_unit_test(test_wdb_exec_row_stmt_single_column_success_number),
         cmocka_unit_test(test_wdb_exec_row_stmt_single_column_invalid_stmt),
         cmocka_unit_test(test_wdb_exec_row_stmt_single_column_sql_error),
-        // wdb_leave
-        cmocka_unit_test(test_wdb_leave),
         // wdb_finalize_all_statements
         cmocka_unit_test(test_wdb_finalize_all_statements),
         // wdb_close
-        cmocka_unit_test(test_wdb_close_refcount_error),
         cmocka_unit_test(test_wdb_close_no_commit_sqlerror),
         cmocka_unit_test(test_wdb_close_success),
         // wdb_get_db_free_pages_percentage

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -7355,10 +7355,14 @@ void test_wdb_global_restore_backup_success(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int result = OS_INVALID;
     wdb_t *wdb = NULL;
+    os_calloc(1,sizeof(wdb_t),wdb);
+    os_strdup("global",wdb->id);
+    os_calloc(1,sizeof(sqlite3 *),wdb->db);
 
     expect_string(__wrap_w_uncompress_gzfile, gzfilesrc, "backup/db/global.db-backup-TIMESTAMP.gz");
     expect_string(__wrap_w_uncompress_gzfile, gzfiledst, "queue/db/global.db.back");
     will_return(__wrap_w_uncompress_gzfile, OS_SUCCESS);
+    will_return(__wrap_wdb_close, 1);
     will_return(__wrap_wdb_close, OS_SUCCESS);
     expect_string(__wrap_unlink, file, "queue/db/global.db");
     will_return(__wrap_unlink, OS_SUCCESS);
@@ -7370,6 +7374,8 @@ void test_wdb_global_restore_backup_success(void **state) {
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(result, OS_SUCCESS);
+    os_free(wdb->id);
+    os_free(wdb);
 }
 
 /* Tests wdb_global_get_most_recent_backup */

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -117,6 +117,8 @@ void test_wdb_parse_global_substr_fail(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'error'");
@@ -140,6 +142,8 @@ void test_wdb_parse_global_sql_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_sql);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -175,6 +179,8 @@ void test_wdb_parse_global_sql_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_sql_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"test_field\":\"test_value\"}]");
@@ -205,6 +211,8 @@ void test_wdb_parse_global_sql_fail(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_sql_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -248,6 +256,8 @@ void test_wdb_parse_global_insert_agent_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'insert-agent'");
@@ -275,6 +285,8 @@ void test_wdb_parse_global_insert_agent_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -300,6 +312,8 @@ void test_wdb_parse_global_insert_agent_compliant_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -337,6 +351,8 @@ void test_wdb_parse_global_insert_agent_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -373,6 +389,8 @@ void test_wdb_parse_global_insert_agent_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_insert_agent_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
@@ -398,6 +416,8 @@ void test_wdb_parse_global_update_agent_name_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -426,6 +446,8 @@ void test_wdb_parse_global_update_agent_name_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -451,6 +473,8 @@ void test_wdb_parse_global_update_agent_name_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -482,6 +506,8 @@ void test_wdb_parse_global_update_agent_name_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -510,6 +536,8 @@ void test_wdb_parse_global_update_agent_name_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_name_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
@@ -535,6 +563,8 @@ void test_wdb_parse_global_update_agent_data_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -562,6 +592,8 @@ void test_wdb_parse_global_update_agent_data_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -622,6 +654,8 @@ void test_wdb_parse_global_update_agent_data_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -657,6 +691,8 @@ void test_wdb_parse_global_update_agent_data_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -717,6 +753,8 @@ void test_wdb_parse_global_update_agent_data_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_agent_data_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
@@ -742,6 +780,8 @@ void test_wdb_parse_global_get_agent_labels_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_labels_get_labels);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -770,6 +810,8 @@ void test_wdb_parse_global_get_agent_labels_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_labels_get_labels_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -807,6 +849,8 @@ void test_wdb_parse_global_get_agent_labels_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_labels_get_labels_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"id\":1,\"key\":\"test_key\",\"value\":\"test_value\"}]");
@@ -833,6 +877,8 @@ void test_wdb_parse_global_update_agent_keepalive_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -861,6 +907,8 @@ void test_wdb_parse_global_update_agent_keepalive_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -886,6 +934,8 @@ void test_wdb_parse_global_update_agent_keepalive_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -919,6 +969,8 @@ void test_wdb_parse_global_update_agent_keepalive_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -949,6 +1001,8 @@ void test_wdb_parse_global_update_agent_keepalive_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_keepalive_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
@@ -974,6 +1028,8 @@ void test_wdb_parse_global_update_connection_status_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1002,6 +1058,8 @@ void test_wdb_parse_global_update_connection_status_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -1027,6 +1085,8 @@ void test_wdb_parse_global_update_connection_status_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1061,6 +1121,8 @@ void test_wdb_parse_global_update_connection_status_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -1092,6 +1154,8 @@ void test_wdb_parse_global_update_connection_status_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_connection_status_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
@@ -1117,6 +1181,8 @@ void test_wdb_parse_global_update_status_code_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1145,6 +1211,8 @@ void test_wdb_parse_global_update_status_code_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -1170,6 +1238,8 @@ void test_wdb_parse_global_update_status_code_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1204,6 +1274,8 @@ void test_wdb_parse_global_update_status_code_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -1235,6 +1307,8 @@ void test_wdb_parse_global_update_status_code_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_update_status_code_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
@@ -1260,6 +1334,8 @@ void test_wdb_parse_global_delete_agent_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_delete_agent);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1289,6 +1365,8 @@ void test_wdb_parse_global_delete_agent_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_delete_agent_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error deleting agent from agent table in global.db.");
@@ -1316,6 +1394,8 @@ void test_wdb_parse_global_delete_agent_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_delete_agent_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
@@ -1341,6 +1421,8 @@ void test_wdb_parse_global_select_agent_name_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_name);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1369,6 +1451,8 @@ void test_wdb_parse_global_select_agent_name_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_name_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1401,6 +1485,8 @@ void test_wdb_parse_global_select_agent_name_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_name_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"name\":\"test_name\"}");
@@ -1426,6 +1512,8 @@ void test_wdb_parse_global_select_agent_group_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_group);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1454,6 +1542,8 @@ void test_wdb_parse_global_select_agent_group_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_group_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1486,6 +1576,8 @@ void test_wdb_parse_global_select_agent_group_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_select_agent_group_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"name\":\"test_name\"}");
@@ -1511,6 +1603,8 @@ void test_wdb_parse_global_find_agent_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_find_agent);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1539,6 +1633,8 @@ void test_wdb_parse_global_find_agent_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_find_agent_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -1564,6 +1660,8 @@ void test_wdb_parse_global_find_agent_invalid_data(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_find_agent_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1594,6 +1692,8 @@ void test_wdb_parse_global_find_agent_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_find_agent_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1627,6 +1727,8 @@ void test_wdb_parse_global_find_agent_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_find_agent_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"id\":1}");
@@ -1652,6 +1754,8 @@ void test_wdb_parse_global_find_group_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_find_group);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1680,6 +1784,8 @@ void test_wdb_parse_global_find_group_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_find_group_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1712,6 +1818,8 @@ void test_wdb_parse_global_find_group_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_find_group_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"id\":1}");
@@ -1737,6 +1845,8 @@ void test_wdb_parse_global_insert_agent_group_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_insert_agent_group);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1766,6 +1876,8 @@ void test_wdb_parse_global_insert_agent_group_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_insert_agent_group_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error inserting group in global.db.");
@@ -1793,6 +1905,8 @@ void test_wdb_parse_global_insert_agent_group_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_insert_agent_group_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
@@ -1818,6 +1932,8 @@ void test_wdb_parse_global_select_group_belong_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_belongs_select_group_belong);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1846,6 +1962,8 @@ void test_wdb_parse_global_select_group_belong_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_select_group_belong_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1877,6 +1995,8 @@ void test_wdb_parse_global_select_group_belong_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_select_group_belong_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [\"default\",\"new_group\"]");
@@ -1902,6 +2022,8 @@ void test_wdb_parse_global_get_group_agents_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1929,6 +2051,8 @@ void test_wdb_parse_global_get_group_agents_group_missing(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments, group name not found.");
@@ -1955,6 +2079,8 @@ void test_wdb_parse_global_get_group_agents_last_id_missing(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments, 'last_id' not found.");
@@ -1980,6 +2106,8 @@ void test_wdb_parse_global_get_group_agents_last_id_value_missing(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2012,6 +2140,8 @@ void test_wdb_parse_global_get_group_agents_failed(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting group agents from global.db.");
@@ -2043,6 +2173,8 @@ void test_wdb_parse_global_get_group_agents_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_belongs_get_group_agent_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [1,2,3]");
@@ -2068,6 +2200,8 @@ void test_wdb_parse_global_delete_group_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_group_delete_group);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2097,6 +2231,8 @@ void test_wdb_parse_global_delete_group_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_delete_group_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error deleting group in global.db.");
@@ -2123,6 +2259,8 @@ void test_wdb_parse_global_delete_group_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_delete_group_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2152,6 +2290,8 @@ void test_wdb_parse_global_select_groups_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_select_groups_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2184,6 +2324,8 @@ void test_wdb_parse_global_select_groups_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_group_select_groups_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"id\":1,\"id\":2}");
@@ -2215,6 +2357,8 @@ void test_wdb_parse_global_sync_agent_info_get_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_get_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {SYNC INFO}");
@@ -2243,6 +2387,8 @@ void test_wdb_parse_global_sync_agent_info_get_last_id_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_get_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2278,6 +2424,8 @@ void test_wdb_parse_global_sync_agent_info_get_size_limit(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_get_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     char delims[] = " ";
@@ -2310,6 +2458,8 @@ void test_wdb_parse_global_sync_agent_info_set_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'sync-agent-info-set'");
@@ -2336,6 +2486,8 @@ void test_wdb_parse_global_sync_agent_info_set_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2369,6 +2521,8 @@ void test_wdb_parse_global_sync_agent_info_set_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -2399,6 +2553,8 @@ void test_wdb_parse_global_sync_agent_info_set_id_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2434,6 +2590,8 @@ void test_wdb_parse_global_sync_agent_info_set_del_label_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2474,6 +2632,8 @@ void test_wdb_parse_global_sync_agent_info_set_set_label_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -2511,6 +2671,8 @@ void test_wdb_parse_global_sync_agent_info_set_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_info_set_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
@@ -2536,6 +2698,8 @@ void test_wdb_parse_global_set_agent_groups_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2564,6 +2728,8 @@ void test_wdb_parse_global_set_agent_groups_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
@@ -2590,6 +2756,8 @@ void test_wdb_parse_global_set_agent_groups_missing_field(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, missing required fields");
@@ -2615,6 +2783,8 @@ void test_wdb_parse_global_set_agent_groups_invalid_mode(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2645,6 +2815,8 @@ void test_wdb_parse_global_set_agent_groups_fail(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err An error occurred during the set of the groups");
@@ -2674,6 +2846,8 @@ void test_wdb_parse_global_set_agent_groups_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
@@ -2699,6 +2873,8 @@ void test_wdb_parse_global_sync_agent_groups_get_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2726,6 +2902,8 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2767,6 +2945,8 @@ void test_wdb_parse_global_sync_agent_groups_without_condition_field_succes(void
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"data\":[],\"hash\":\"random_hash\"}]");
@@ -2792,6 +2972,8 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_data_type(void 
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2819,6 +3001,8 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_negative(void *
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
@@ -2844,6 +3028,8 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_condition_data_type(voi
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2871,6 +3057,8 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_set_synced_data_type(vo
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
@@ -2896,6 +3084,8 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_get_hash_data_type(void
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2923,6 +3113,8 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delt
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
@@ -2948,6 +3140,8 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delt
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2980,6 +3174,8 @@ void test_wdb_parse_global_sync_agent_groups_get_null_response(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3020,6 +3216,8 @@ void test_wdb_parse_global_sync_agent_groups_get_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3080,6 +3278,8 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_response(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_sync_agent_groups_get_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid response from wdb_global_sync_agent_groups_get");
@@ -3105,6 +3305,8 @@ void test_wdb_parse_global_get_groups_integrity_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3132,6 +3334,8 @@ void test_wdb_parse_global_get_groups_integrity_hash_length_expected_fail(void *
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3161,6 +3365,8 @@ void test_wdb_parse_global_get_groups_integrity_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting groups integrity information from global.db.");
@@ -3188,6 +3394,8 @@ void test_wdb_parse_global_get_groups_integrity_success_syncreq(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3217,6 +3425,8 @@ void test_wdb_parse_global_get_groups_integrity_success_synced(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [\"synced\"]");
@@ -3245,6 +3455,8 @@ void test_wdb_parse_global_get_groups_integrity_success_hash_mismatch(void **sta
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_groups_integrity_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [\"hash_mismatch\"]");
@@ -3270,6 +3482,8 @@ void test_wdb_parse_global_disconnect_agents_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3297,6 +3511,8 @@ void test_wdb_parse_global_disconnect_agents_last_id_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments last id not found");
@@ -3323,6 +3539,8 @@ void test_wdb_parse_global_disconnect_agents_keepalive_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments keepalive not found");
@@ -3348,6 +3566,8 @@ void test_wdb_parse_global_disconnect_agents_sync_status_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3383,6 +3603,8 @@ void test_wdb_parse_global_disconnect_agents_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_disconnect_agents_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"id\":10}]");
@@ -3409,6 +3631,8 @@ void test_wdb_parse_global_get_all_agents_syntax_error(void **state)
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_all_agents);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-all-agents'");
@@ -3434,6 +3658,9 @@ void test_wdb_parse_global_get_all_agents_argument_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_all_agents_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments 'last_id' not found");
@@ -3459,6 +3686,8 @@ void test_wdb_parse_global_get_all_agents_argument2_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_all_agents_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3492,6 +3721,8 @@ void test_wdb_parse_global_get_all_agents_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_all_agents_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"id\":10}]");
@@ -3517,6 +3748,8 @@ void test_wdb_parse_global_get_agent_info_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agent_info);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3545,6 +3778,8 @@ void test_wdb_parse_global_get_agent_info_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agent_info_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3577,6 +3812,8 @@ void test_wdb_parse_global_get_agent_info_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agent_info_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"name\":\"test_name\"}");
@@ -3602,6 +3839,8 @@ void test_wdb_parse_reset_agents_connection_syntax_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_reset_agents_connection);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3632,6 +3871,8 @@ void test_wdb_parse_reset_agents_connection_query_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_reset_agents_connection_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
@@ -3659,6 +3900,8 @@ void test_wdb_parse_reset_agents_connection_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_reset_agents_connection_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
@@ -3684,6 +3927,8 @@ void test_wdb_parse_global_get_agents_by_connection_status_syntax_error(void **s
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3711,6 +3956,8 @@ void test_wdb_parse_global_get_agents_by_connection_status_status_error(void **s
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments 'connection_status' not found");
@@ -3737,6 +3984,8 @@ void test_wdb_parse_global_get_agents_by_connection_status_last_id_error(void **
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments 'last_id' not found");
@@ -3762,6 +4011,8 @@ void test_wdb_parse_global_get_agents_by_connection_status_limit_error(void **st
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3799,6 +4050,8 @@ void test_wdb_parse_global_get_agents_by_connection_status_limit_succes(void **s
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"id\":10}]");
@@ -3833,6 +4086,8 @@ void test_wdb_parse_global_get_agents_by_connection_status_query_success(void **
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"id\":10}]");
@@ -3862,6 +4117,8 @@ void test_wdb_parse_global_get_agents_by_connection_status_query_fail(void **sta
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_agents_by_connection_status_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -3893,6 +4150,8 @@ void test_wdb_parse_global_get_backup_failed(void **state) {
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_backup_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute backup get command, unable to open 'backup/db' folder");
@@ -3923,6 +4182,8 @@ void test_wdb_parse_global_get_backup_success(void **state) {
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_backup_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [\"global.db-backup-TIMESTAMP\"]");
@@ -3952,10 +4213,10 @@ void test_wdb_parse_global_restore_backup_invalid_syntax(void **state) {
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_backup_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -3984,10 +4245,10 @@ void test_wdb_parse_global_restore_backup_success_missing_snapshot(void **state)
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_backup_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -4016,10 +4277,10 @@ void test_wdb_parse_global_restore_backup_success_pre_restore_true(void **state)
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_backup_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -4048,10 +4309,10 @@ void test_wdb_parse_global_restore_backup_success_pre_restore_false(void **state
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_backup_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -4080,10 +4341,10 @@ void test_wdb_parse_global_restore_backup_success_pre_restore_missing(void **sta
     expect_function_call(__wrap_w_inc_global_open_time);
     expect_function_call(__wrap_w_inc_global_backup);
     expect_function_call(__wrap_gettimeofday);
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_backup_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -4121,6 +4382,8 @@ void test_wdb_parse_global_vacuum_commit_error(void **state) {
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_vacuum_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot end transaction");
@@ -4157,6 +4420,8 @@ void test_wdb_parse_global_vacuum_vacuum_error(void **state) {
 
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_vacuum_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -4196,6 +4461,8 @@ void test_wdb_parse_global_vacuum_success_get_db_state_error(void **state) {
 
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_vacuum_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -4239,6 +4506,8 @@ void test_wdb_parse_global_vacuum_success_update_vacuum_data_error(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_vacuum_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Vacuum performed, but last vacuum information couldn't be updated in the metadata table");
@@ -4279,6 +4548,8 @@ void test_wdb_parse_global_vacuum_success(void **state) {
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_vacuum_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"fragmentation_after_vacuum\":10}");
@@ -4316,6 +4587,8 @@ void test_wdb_parse_global_get_fragmentation_db_state_error(void **state) {
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_get_fragmentation_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot get database fragmentation");
@@ -4351,6 +4624,8 @@ void test_wdb_parse_global_get_fragmentation_free_pages_error(void **state) {
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_get_fragmentation_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot get database fragmentation");
@@ -4383,6 +4658,8 @@ void test_wdb_parse_global_get_fragmentation_success(void **state) {
 
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_get_fragmentation_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -4417,6 +4694,8 @@ void test_wdb_parse_global_get_distinct_agent_groups_success(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [\"GROUP INFO\"]");
@@ -4445,6 +4724,8 @@ void test_wdb_parse_global_get_distinct_agent_groups_success_with_last_hash(void
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -4476,6 +4757,8 @@ void test_wdb_parse_global_get_distinct_agent_groups_result_null(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups_time);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting agent groups from global.db.");
@@ -4505,6 +4788,8 @@ void test_wdb_parse_global_get_distinct_agent_groups_result_null_with_last_hash(
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -766,6 +766,8 @@ void test_osinfo_syntax_error(void **state) {
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Invalid DB query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "DB(000) query error near: osinfo");
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'osinfo'");
@@ -783,6 +785,8 @@ void test_osinfo_invalid_action(void **state) {
     expect_value(__wrap_wdb_open_agent2, agent_id, atoi(data->wdb->id));
     will_return(__wrap_wdb_open_agent2, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: osinfo invalid");
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -1258,6 +1262,8 @@ void test_vuln_cves_syntax_error(void **state) {
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Invalid vuln_cves query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "DB(000) vuln_cves query error near: vuln_cves");
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid vuln_cves query syntax, near 'vuln_cves'");
@@ -1275,6 +1281,8 @@ void test_vuln_cves_invalid_action(void **state) {
     expect_value(__wrap_wdb_open_agent2, agent_id, atoi(data->wdb->id));
     will_return(__wrap_wdb_open_agent2, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: vuln_cves invalid");
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     ret = wdb_parse(query, data->output, 0);
 
@@ -2528,6 +2536,8 @@ void test_wdb_parse_global_backup_invalid_syntax(void **state) {
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for backup.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: backup");
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'backup'");
@@ -2577,6 +2587,8 @@ void test_wdb_parse_global_backup_create_failed(void **state) {
     will_return(__wrap_wdb_global_create_backup, OS_INVALID);
     expect_string(__wrap__merror, formatted_msg, "Creating Global DB snapshot on demand failed: ERROR MESSAGE");
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ERROR MESSAGE");
@@ -2596,6 +2608,8 @@ void test_wdb_parse_global_backup_create_success(void **state) {
 
     will_return(__wrap_wdb_global_create_backup, "ok SNAPSHOT");
     will_return(__wrap_wdb_global_create_backup, OS_SUCCESS);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -2624,6 +2638,8 @@ void test_wdb_parse_agent_vacuum_commit_error(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot end transaction.");
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot end transaction");
@@ -2649,6 +2665,8 @@ void test_wdb_parse_agent_vacuum_vacuum_error(void **state) {
     will_return(__wrap_wdb_vacuum, OS_INVALID);
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot vacuum database.");
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -2677,6 +2695,8 @@ void test_wdb_parse_agent_vacuum_success_get_db_state_error(void **state) {
     will_return(__wrap_wdb_get_db_state, OS_INVALID);
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Couldn't get fragmentation after vacuum for the database.");
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -2710,6 +2730,8 @@ void test_wdb_parse_agent_vacuum_success_update_vacuum_error(void **state) {
     will_return(__wrap_wdb_update_last_vacuum_data, OS_INVALID);
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Couldn't update last vacuum info for the database.");
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -2746,6 +2768,8 @@ void test_wdb_parse_agent_vacuum_success(void **state) {
 
     will_return(__wrap_cJSON_PrintUnformatted, response);
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"fragmentation_after_vacuum\":10}");
@@ -2772,6 +2796,8 @@ void test_wdb_parse_agent_get_fragmentation_db_state_error(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot get database fragmentation.");
 
+    expect_function_call(__wrap_wdb_pool_leave);
+
     result = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot get database fragmentation");
@@ -2795,6 +2821,8 @@ void test_wdb_parse_agent_get_fragmentation_free_pages_error(void **state) {
     will_return(__wrap_wdb_get_db_free_pages_percentage, OS_INVALID);
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot get database fragmentation.");
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 
@@ -2822,6 +2850,8 @@ void test_wdb_parse_global_get_fragmentation_success(void **state) {
     will_return(__wrap_wdb_get_db_free_pages_percentage, 10);
 
     will_return(__wrap_cJSON_PrintUnformatted, response);
+
+    expect_function_call(__wrap_wdb_pool_leave);
 
     result = wdb_parse(query, data->output, 0);
 

--- a/src/unit_tests/wazuh_db/test_wdb_pool.c
+++ b/src/unit_tests/wazuh_db/test_wdb_pool.c
@@ -15,14 +15,9 @@
 #include <string.h>
 
 #include "../wazuh_db/wdb_pool.h"
-//#include "../wazuh_db/wdb_pool.c"
 #include "../wazuh_db/wdb.h"
 #include "../headers/shared.h"
-
 #include "../wrappers/common.h"
-
-//#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
-//#include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
 
 extern wdb_pool_t wdb_pool;
 

--- a/src/unit_tests/wazuh_db/test_wdb_pool.c
+++ b/src/unit_tests/wazuh_db/test_wdb_pool.c
@@ -1,0 +1,301 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../wazuh_db/wdb_pool.h"
+//#include "../wazuh_db/wdb_pool.c"
+#include "../wazuh_db/wdb.h"
+#include "../headers/shared.h"
+
+#include "../wrappers/common.h"
+
+//#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+//#include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
+
+extern wdb_pool_t wdb_pool;
+
+/* setup/teardowns */
+static int setup_test(void **state) {
+    wdb_pool_init();
+
+    for(int i = 1; i<4; i++) {
+        char node_name[10];
+        snprintf(node_name, 10, "node%d", i);
+        wdb_t * node = wdb_init(node_name);
+        rbtree_insert(wdb_pool.nodes, node_name, node);
+    }
+
+    test_mode = 1;
+
+    return 0;
+}
+
+static int setup_test_clean_1(void **state) {
+    wdb_pool_init();
+
+    for(int i = 1; i<4; i++) {
+        char node_name[10];
+        snprintf(node_name, 10, "node%d", i);
+        wdb_t * node = wdb_init(node_name);
+        if(i != 1) {
+            node->refcount++;
+            node->db = (sqlite3 *)1;
+        } 
+        rbtree_insert(wdb_pool.nodes, node_name, node);
+    }
+
+    test_mode = 1;
+
+    return 0;
+}
+
+static int setup_test_clean_2(void **state) {
+    wdb_pool_init();
+
+    for(int i = 1; i<4; i++) {
+        char node_name[10];
+        snprintf(node_name, 10, "node%d", i);
+        wdb_t * node = wdb_init(node_name);
+        if(i != 2) {
+            node->refcount++;
+            node->db = (sqlite3 *)1;
+        } 
+        rbtree_insert(wdb_pool.nodes, node_name, node);
+    }
+
+    test_mode = 1;
+
+    return 0;
+}
+
+static int setup_test_clean_3(void **state) {
+    wdb_pool_init();
+
+    for(int i = 1; i<4; i++) {
+        char node_name[10];
+        snprintf(node_name, 10, "node%d", i);
+        wdb_t * node = wdb_init(node_name);
+        if(i != 3) {
+            node->refcount++;
+            node->db = (sqlite3 *)1;
+        } 
+        rbtree_insert(wdb_pool.nodes, node_name, node);
+    }
+
+    test_mode = 1;
+
+    return 0;
+}
+
+static int teardown_test(void **state) {
+    char ** keys = rbtree_keys(wdb_pool.nodes);
+
+    for (int i = 0; keys[i]; i++) {
+        wdb_t * node = rbtree_get(wdb_pool.nodes, keys[i]);
+        wdb_destroy(node);
+        rbtree_delete(wdb_pool.nodes, keys[i]);
+    }
+
+    free_strarray(keys);
+
+    rbtree_destroy(wdb_pool.nodes);
+
+    test_mode = 0;
+    return 0;
+}
+
+static void test_wdb_pool_get_or_create_get(void **state) {
+    // lock pool mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    // unlock pool mutex
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    // lock node mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    wdb_t * node = wdb_pool_get_or_create("node3");
+
+    assert_string_equal(node->id, "node3");
+    char ** keys = rbtree_keys(wdb_pool.nodes);
+    assert_string_equal(keys[2], "node3");
+    assert_null(keys[3]);
+    free_strarray(keys);
+}
+
+static void test_wdb_pool_get_or_create_create(void **state) {
+    // lock pool mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    // unlock pool mutex
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    // lock node mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    wdb_t * node = wdb_pool_get_or_create("node4");
+
+    assert_string_equal(node->id, "node4");
+    char ** keys = rbtree_keys(wdb_pool.nodes);
+    assert_string_equal(keys[3], "node4");
+    free_strarray(keys);
+}
+
+static void test_wdb_pool_get_unknown(void **state) {
+    // lock pool mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    // unlock pool mutex
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    wdb_t * node = wdb_pool_get("node4");
+
+    assert_null(node);
+}
+
+static void test_wdb_pool_get_known(void **state) {
+    // lock pool mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    // unlock pool mutex
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    // lock node mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    wdb_t * node = wdb_pool_get("node3");
+
+    assert_string_equal(node->id, "node3");
+}
+
+static void test_wdb_pool_leave_node_null(void **state) {
+    wdb_pool_leave(NULL);
+}
+
+static void test_wdb_pool_leave_node_no_null(void **state) {
+    wdb_t *node = wdb_init("node");
+    node->refcount = 1;
+
+    // unlock node mutex
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    // lock pool mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    // unlock pool mutex
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    wdb_pool_leave(node);
+
+    assert_int_equal(node->refcount, 0);
+    wdb_destroy(node);
+}
+
+static void test_wdb_pool_keys(void **state) {
+    // lock pool mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    // unlock pool mutex
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    char **keys = wdb_pool_keys();
+
+    assert_string_equal(keys[0], "node1");
+    assert_string_equal(keys[1], "node2");
+    assert_string_equal(keys[2], "node3");
+    free_strarray(keys);
+}
+
+static void test_wdb_pool_clean_all(void **state) {
+    // lock pool mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    // unlock pool mutex
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    wdb_pool_clean();
+
+    char ** keys = rbtree_keys(wdb_pool.nodes);
+    assert_null(keys[0]);
+    free_strarray(keys);
+}
+
+static void test_wdb_pool_clean_1(void **state) {
+    // lock pool mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    // unlock pool mutex
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    wdb_pool_clean();
+
+    char ** keys = rbtree_keys(wdb_pool.nodes);
+    assert_string_equal(keys[0], "node2");
+    assert_string_equal(keys[1], "node3");
+    free_strarray(keys);
+}
+
+static void test_wdb_pool_clean_2(void **state) {
+    // lock pool mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    // unlock pool mutex
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    wdb_pool_clean();
+
+    char ** keys = rbtree_keys(wdb_pool.nodes);
+    assert_string_equal(keys[0], "node1");
+    assert_string_equal(keys[1], "node3");
+    free_strarray(keys);
+}
+
+static void test_wdb_pool_clean_3(void **state) {
+    // lock pool mutex
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    // unlock pool mutex
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    wdb_pool_clean();
+
+    char ** keys = rbtree_keys(wdb_pool.nodes);
+    assert_string_equal(keys[0], "node1");
+    assert_string_equal(keys[1], "node2");
+    free_strarray(keys);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        // Test wdb_pool_get_or_create
+        cmocka_unit_test_setup_teardown(test_wdb_pool_get_or_create_get, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_wdb_pool_get_or_create_create, setup_test, teardown_test),
+        // Test wdb_pool_get
+        cmocka_unit_test_setup_teardown(test_wdb_pool_get_unknown, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_wdb_pool_get_known, setup_test, teardown_test),
+        // Test wdb_pool_leave
+        cmocka_unit_test_setup_teardown(test_wdb_pool_leave_node_null, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_wdb_pool_leave_node_no_null, setup_test, teardown_test),
+        // Test wdb_pool_keys
+        cmocka_unit_test_setup_teardown(test_wdb_pool_keys, setup_test, teardown_test),
+        // Test wdb_pool_clean
+        cmocka_unit_test_setup_teardown(test_wdb_pool_clean_all, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_wdb_pool_clean_1, setup_test_clean_1, teardown_test),
+        cmocka_unit_test_setup_teardown(test_wdb_pool_clean_2, setup_test_clean_2, teardown_test),
+        cmocka_unit_test_setup_teardown(test_wdb_pool_clean_3, setup_test_clean_3, teardown_test),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/wazuh_db/test_wdb_upgrade.c
+++ b/src/unit_tests/wazuh_db/test_wdb_upgrade.c
@@ -73,11 +73,12 @@ void test_wdb_recreate_global_error_closing_wdb_struct(void **state)
     test_struct_t *data  = (test_struct_t *)*state;
 
     // Error closing the wdb struct
+    will_return(__wrap_wdb_close, 0);
     will_return(__wrap_wdb_close, OS_INVALID);
 
     ret = wdb_recreate_global(data->wdb);
 
-    assert_null(ret);
+    assert_memory_equal(data->wdb, ret, sizeof(ret));
 }
 
 void test_wdb_recreate_global_error_creating_global_db(void **state)
@@ -86,6 +87,7 @@ void test_wdb_recreate_global_error_creating_global_db(void **state)
     test_struct_t *data  = (test_struct_t *)*state;
 
     // Closing the wdb struct and removing the current database file
+    will_return(__wrap_wdb_close, 1);
     will_return(__wrap_wdb_close, OS_SUCCESS);
     expect_string(__wrap_unlink, file, "queue/db/global.db");
     will_return(__wrap_unlink, 0);
@@ -106,6 +108,7 @@ void test_wdb_recreate_global_error_opening_global_db(void **state)
     test_struct_t *data  = (test_struct_t *)*state;
 
     // Closing the wdb struct and removing the current database file
+    will_return(__wrap_wdb_close, 1);
     will_return(__wrap_wdb_close, OS_SUCCESS);
     expect_string(__wrap_unlink, file, "queue/db/global.db");
     will_return(__wrap_unlink, 0);
@@ -133,8 +136,11 @@ void test_wdb_recreate_global_success(void **state)
 {
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
+    sqlite3 *new_db = NULL;
+    os_calloc(1,sizeof(sqlite3 *),new_db);
 
     // Closing the wdb struct and removing the current database file
+    will_return(__wrap_wdb_close, 1);
     will_return(__wrap_wdb_close, OS_SUCCESS);
     expect_string(__wrap_unlink, file, "queue/db/global.db");
     will_return(__wrap_unlink, 0);
@@ -146,20 +152,13 @@ void test_wdb_recreate_global_success(void **state)
     // Opening new global.db
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
-    will_return(__wrap_sqlite3_open_v2, 1);
+    will_return(__wrap_sqlite3_open_v2, new_db);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
-
-    // Initializing and adding to the pool
-    wdb_t *new_wdb = NULL;
-    os_calloc(1, sizeof(wdb_t), new_wdb);
-    expect_string(__wrap_wdb_init, id, "global");
-    will_return(__wrap_wdb_init, new_wdb);
-    expect_value(__wrap_wdb_pool_append, wdb, new_wdb);
 
     ret = wdb_recreate_global(data->wdb);
 
-    assert_ptr_equal(new_wdb, ret);
-    os_free(new_wdb);
+    assert_ptr_equal(data->wdb, ret);
+    assert_ptr_equal(new_db, ret->db);
 }
 
 /* Tests wdb_upgrade_global */
@@ -212,6 +211,8 @@ void test_wdb_upgrade_global_success_regenerating_legacy_db(void **state)
 {
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
+    sqlite3 *new_db = NULL;
+    os_calloc(1,sizeof(sqlite3 *),new_db);
 
     expect_string(__wrap_wdb_count_tables_with_name, key, "metadata");
     will_return(__wrap_wdb_count_tables_with_name, 0);
@@ -230,6 +231,7 @@ void test_wdb_upgrade_global_success_regenerating_legacy_db(void **state)
 
     // Recreating the database
     // Closing the wdb struct and removing the current database file
+    will_return(__wrap_wdb_close, 1);
     will_return(__wrap_wdb_close, OS_SUCCESS);
     expect_string(__wrap_unlink, file, "queue/db/global.db");
     will_return(__wrap_unlink, 0);
@@ -241,20 +243,21 @@ void test_wdb_upgrade_global_success_regenerating_legacy_db(void **state)
     // Opening new global.db
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
-    will_return(__wrap_sqlite3_open_v2, 1);
+    will_return(__wrap_sqlite3_open_v2, new_db);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
 
     // Initializing and adding to the pool
-    wdb_t *new_wdb = NULL;
-    os_calloc(1, sizeof(wdb_t), new_wdb);
-    expect_string(__wrap_wdb_init, id, "global");
-    will_return(__wrap_wdb_init, new_wdb);
-    expect_value(__wrap_wdb_pool_append, wdb, new_wdb);
+    //wdb_t *new_wdb = NULL;
+    //os_calloc(1, sizeof(wdb_t), new_wdb);
+    //expect_string(__wrap_wdb_init, id, "global");
+    //will_return(__wrap_wdb_init, new_wdb);
+    //expect_value(__wrap_wdb_pool_append, wdb, new_wdb);
 
     ret = wdb_upgrade_global(data->wdb);
 
-    assert_ptr_equal(new_wdb, ret);
-    os_free(new_wdb);
+    assert_ptr_equal(data->wdb, ret);
+    assert_ptr_equal(new_db, ret->db);
+    //os_free(new_wdb);
 }
 
 void test_wdb_upgrade_global_error_getting_database_version(void **state)
@@ -272,6 +275,14 @@ void test_wdb_upgrade_global_error_getting_database_version(void **state)
     will_return(__wrap_wdb_metadata_get_entry, str_db_version);
     will_return(__wrap_wdb_metadata_get_entry, OS_INVALID);
     expect_string(__wrap__mwarn, formatted_msg, "DB(global): Error trying to get DB version");
+
+    // Error creating pre upgrade backup
+    will_return(__wrap_wdb_global_create_backup, "global.db");
+    will_return(__wrap_wdb_global_create_backup, OS_INVALID);
+    expect_string(__wrap__merror,
+                  formatted_msg,
+                  "Creating pre-upgrade Global DB snapshot failed: "
+                  "global.db-pre_upgrade");
 
     ret = wdb_upgrade_global(data->wdb);
 
@@ -761,6 +772,14 @@ void test_wdb_upgrade_global_fail_backup_fail(void **state)
     will_return(__wrap_wdb_metadata_get_entry, OS_INVALID);
 
     expect_string(__wrap__mwarn, formatted_msg, "DB(global): Error trying to get DB version");
+
+    // Error creating pre upgrade backup
+    will_return(__wrap_wdb_global_create_backup, "global.db");
+    will_return(__wrap_wdb_global_create_backup, OS_INVALID);
+    expect_string(__wrap__merror,
+                  formatted_msg,
+                  "Creating pre-upgrade Global DB snapshot failed: "
+                  "global.db-pre_upgrade");
 
     ret = wdb_upgrade_global(data->wdb);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_pool_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_pool_wrappers.c
@@ -1,0 +1,37 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#include "wdb_pool_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+wdb_t * __wrap_wdb_pool_get(const char * name) {
+    check_expected(name);
+    return mock_ptr_type(wdb_t*);
+}
+
+wdb_t * __wrap_wdb_pool_get_or_create(const char * name) {
+    check_expected(name);
+    return mock_ptr_type(wdb_t*);
+}
+
+void __wrap_wdb_pool_leave(__attribute__((unused))wdb_t * node) {
+    function_called();
+}
+
+char ** __wrap_wdb_pool_keys() {
+    return mock_type(char **);
+}
+
+void __wrap_wdb_pool_clean() {
+    function_called();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_pool_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_pool_wrappers.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef WDB_POOL_WRAPPERS_H
+#define WDB_POOL_WRAPPERS_H
+
+#include "../wazuh_db/wdb.h"
+
+wdb_t * __wrap_wdb_pool_get(const char * name);
+
+wdb_t * __wrap_wdb_pool_get_or_create(const char * name);
+
+void __wrap_wdb_pool_leave(__attribute__((unused))wdb_t * node);
+
+char ** __wrap_wdb_pool_keys();
+
+void __wrap_wdb_pool_clean();
+
+#endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -243,6 +243,12 @@ wdb_t* __wrap_wdb_init(__attribute__((unused)) sqlite3* db, const char* id) {
 }
 
 int __wrap_wdb_close(__attribute__((unused)) wdb_t * wdb, __attribute__((unused))bool commit) {
+    int free_db = mock_type(int);
+
+    if (free_db) {
+        os_free(wdb->db);
+    }
+
     return mock();
 }
 

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -434,6 +434,7 @@ void * run_gc(__attribute__((unused)) void * args) {
         }
 
         wdb_close_old();
+        wdb_pool_clean();
 
         sleep(1);
     }

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -124,6 +124,8 @@ int main(int argc, char ** argv)
 
     // Initialize variables
 
+    wdb_pool_init();
+
     if (!run_foreground) {
         goDaemon();
         nowDaemon();

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -326,7 +326,7 @@ STATIC int wdb_execute_single_int_select_query(wdb_t * wdb, const char *query, i
 STATIC int wdb_get_last_vacuum_data(wdb_t* wdb, int *last_vacuum_time, int *last_vacuum_value);
 
 wdb_config wconfig;
-int wdb_open_count;
+_Atomic(int) wdb_open_count;
 
 // Opens global database and stores it in DB pool. It returns a locked database or NULL
 wdb_t * wdb_open_global() {

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -356,7 +356,7 @@ wdb_t * wdb_open_global() {
                 return NULL;
             }
         } else {
-            if (wdb_upgrade_global(wdb) == NULL) {
+            if (wdb_upgrade_global(wdb) == NULL || wdb->db == NULL) {
                 wdb_pool_leave(wdb);
                 return NULL;
             }

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -879,10 +879,9 @@ int wdb_insert_info(const char *key, const char *value) {
     return result;
 }
 
-wdb_t * wdb_init(sqlite3 * db, const char * id) {
+wdb_t * wdb_init(const char * id) {
     wdb_t * wdb;
     os_calloc(1, sizeof(wdb_t), wdb);
-    wdb->db = db;
     w_mutex_init(&wdb->mutex, NULL);
     os_strdup(id, wdb->id);
     wdb->enabled = true;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -356,7 +356,10 @@ wdb_t * wdb_open_global() {
                 return NULL;
             }
         } else {
-            wdb_upgrade_global(wdb);
+            if (wdb_upgrade_global(wdb) == NULL) {
+                wdb_pool_leave(wdb);
+                return NULL;
+            }
         }
 
         wdb_open_count++;
@@ -424,7 +427,10 @@ wdb_t * wdb_open_agent2(int agent_id) {
             return NULL;
         }
     } else {
-        wdb_upgrade(wdb);
+        if (wdb_upgrade(wdb) == NULL) {
+            wdb_pool_leave(wdb);
+            return NULL;
+        }
     }
 
     wdb_open_count++;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -325,145 +325,67 @@ STATIC int wdb_execute_single_int_select_query(wdb_t * wdb, const char *query, i
  */
 STATIC int wdb_get_last_vacuum_data(wdb_t* wdb, int *last_vacuum_time, int *last_vacuum_value);
 
-/**
- * @brief Get a database from the database group
- *
- * @param[in] db_name Name of the database to search in the database pool.
- * @return Returns the wdb object if it exists or NULL if it does not exist.
- */
-STATIC wdb_t * wdb_get_db_from_pool(const char* db_name);
-
 wdb_config wconfig;
-rwlock_t pool_mutex;
-wdb_t * db_pool_begin;
-wdb_t * db_pool_last;
 int wdb_open_count;
-OSHash * open_dbs;
-
-STATIC wdb_t * wdb_get_db_from_pool(const char* db_name) {
-    wdb_t * wdb = NULL;
-
-    if (db_name == NULL) {
-        merror("The database name cannot be null.");
-        return NULL;
-    }
-
-    // Finds DB in pool, locking pool_mutex for read
-    rwlock_lock_read(&pool_mutex);
-    if (wdb = (wdb_t *)OSHash_Get(open_dbs, db_name), wdb) {
-        // The corresponding w_mutex_unlock(&wdb->mutex) is called in wdb_leave(wdb_t * wdb)
-        w_mutex_lock(&wdb->mutex);
-        wdb->refcount++;
-    }
-    rwlock_unlock(&pool_mutex);
-    return wdb;
-}
 
 // Opens global database and stores it in DB pool. It returns a locked database or NULL
 wdb_t * wdb_open_global() {
     char path[PATH_MAX + 1] = "";
-    sqlite3 *db = NULL;
-    wdb_t * wdb = NULL;
+    wdb_t * wdb = wdb_pool_get_or_create(WDB_GLOB_NAME);
 
-    // Finds DB in pool, locking pool_mutex for read
-    if (wdb = wdb_get_db_from_pool(WDB_GLOB_NAME), wdb) {
-        return wdb;
-    }
-
-    // Now try locking pool_mutex for writing
-    rwlock_lock_write(&pool_mutex);
-
-    // Finds DB in pool
-    if (wdb = (wdb_t *)OSHash_Get(open_dbs, WDB_GLOB_NAME), wdb) {
-        // The corresponding w_mutex_unlock(&wdb->mutex) is called in wdb_leave(wdb_t * wdb)
-        w_mutex_lock(&wdb->mutex);
-        wdb->refcount++;
-        rwlock_unlock(&pool_mutex);
-        return wdb;
-    } else {
+    if (wdb->db == NULL) {
         // Try to open DB
         snprintf(path, sizeof(path), "%s/%s.db", WDB2_DIR, WDB_GLOB_NAME);
 
-        if (sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE, NULL)) {
+        if (sqlite3_open_v2(path, &wdb->db, SQLITE_OPEN_READWRITE, NULL)) {
             mdebug1("Global database not found, creating.");
-            sqlite3_close_v2(db);
+            wdb_close(wdb, false);
 
             // Creating database
             if (OS_SUCCESS != wdb_create_global(path)) {
                 merror("Couldn't create SQLite database '%s'", path);
-                rwlock_unlock(&pool_mutex);
-                return wdb;
+                wdb_pool_leave(wdb);
+                return NULL;
             }
 
             // Retry to open
-            if (sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE, NULL)) {
-                merror("Can't open SQLite database '%s': %s", path, sqlite3_errmsg(db));
-                sqlite3_close_v2(db);
-                rwlock_unlock(&pool_mutex);
-                return wdb;
+            if (sqlite3_open_v2(path, &wdb->db, SQLITE_OPEN_READWRITE, NULL)) {
+                merror("Can't open SQLite database '%s': %s", path, sqlite3_errmsg(wdb->db));
+                wdb_close(wdb, false);
+                wdb_pool_leave(wdb);
+                return NULL;
             }
-
-            wdb = wdb_init(db, WDB_GLOB_NAME);
-            wdb_pool_append(wdb);
-            w_mutex_lock(&wdb->mutex);
-            wdb->refcount++;
-        }
-        else {
-            wdb = wdb_init(db, WDB_GLOB_NAME);
-            wdb_pool_append(wdb);
-            w_mutex_lock(&wdb->mutex);
-            wdb->refcount++;
-            if (wdb = wdb_upgrade_global(wdb), !wdb) {
-                rwlock_unlock(&pool_mutex);
-                return wdb;
-            }
+        } else {
+            wdb_upgrade_global(wdb);
         }
 
+        wdb_open_count++;
         wdb_enable_foreign_keys(wdb->db);
     }
 
-    rwlock_unlock(&pool_mutex);
     return wdb;
 }
 
 wdb_t * wdb_open_mitre() {
     char path[PATH_MAX + 1];
-    sqlite3 *db;
-    wdb_t * wdb = NULL;
+    wdb_t * wdb = wdb_pool_get_or_create(WDB_MITRE_NAME);
 
-    // Finds DB in pool, locking pool_mutex for read
-    if (wdb = wdb_get_db_from_pool(WDB_MITRE_NAME), wdb) {
+    if (wdb->db != NULL) {
         return wdb;
-    }
-
-    // Find BD in pool
-
-    rwlock_lock_write(&pool_mutex);
-
-    if (wdb = (wdb_t *)OSHash_Get(open_dbs, WDB_MITRE_NAME), wdb) {
-        goto success;
     }
 
     // Try to open DB
 
     snprintf(path, sizeof(path), "%s/%s.db", WDB_DIR, WDB_MITRE_NAME);
 
-    if (sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE, NULL)) {
-        merror("Can't open SQLite database '%s': %s", path, sqlite3_errmsg(db));
-        sqlite3_close_v2(db);
-        goto end;
-
-    } else {
-        wdb = wdb_init(db, WDB_MITRE_NAME);
-        wdb_pool_append(wdb);
+    if (sqlite3_open_v2(path, &wdb->db, SQLITE_OPEN_READWRITE, NULL)) {
+        merror("Can't open SQLite database '%s': %s", path, sqlite3_errmsg(wdb->db));
+        wdb_close(wdb, false);
+        wdb_pool_leave(wdb);
+        return NULL;
     }
 
-success:
-    w_mutex_lock(&wdb->mutex);
-    wdb->refcount++;
-
-end:
-    rwlock_unlock(&pool_mutex);
+    wdb_open_count++;
     return wdb;
 }
 
@@ -471,123 +393,75 @@ end:
 wdb_t * wdb_open_agent2(int agent_id) {
     char sagent_id[64];
     char path[PATH_MAX + 1];
-    sqlite3 * db;
-    wdb_t * wdb = NULL;
 
     snprintf(sagent_id, sizeof(sagent_id), "%03d", agent_id);
+    wdb_t * wdb = wdb_pool_get_or_create(sagent_id);
 
-    // Finds DB in pool, locking pool_mutex for read
-    if (wdb = wdb_get_db_from_pool(sagent_id), wdb) {
+    if (wdb->db != NULL) {
         return wdb;
-    }
-
-    // Find BD in pool
-
-    rwlock_lock_write(&pool_mutex);
-
-    if (wdb = (wdb_t *)OSHash_Get(open_dbs, sagent_id), wdb) {
-        goto success;
     }
 
     // Try to open DB
 
     snprintf(path, sizeof(path), "%s/%s.db", WDB2_DIR, sagent_id);
 
-    if (sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE, NULL)) {
+    if (sqlite3_open_v2(path, &wdb->db, SQLITE_OPEN_READWRITE, NULL)) {
         mdebug1("No SQLite database found for agent '%s', creating.", sagent_id);
-        sqlite3_close_v2(db);
+        wdb_close(wdb, false);
 
         if (wdb_create_agent_db2(sagent_id) < 0) {
             merror("Couldn't create SQLite database '%s'", path);
-            goto end;
+            wdb_pool_leave(wdb);
+            return NULL;
         }
 
         // Retry to open
 
-        if (sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE, NULL)) {
-            merror("Can't open SQLite database '%s': %s", path, sqlite3_errmsg(db));
-            sqlite3_close_v2(db);
-            goto end;
+        if (sqlite3_open_v2(path, &wdb->db, SQLITE_OPEN_READWRITE, NULL)) {
+            merror("Can't open SQLite database '%s': %s", path, sqlite3_errmsg(wdb->db));
+            wdb_close(wdb, false);
+            wdb_pool_leave(wdb);
+            return NULL;
         }
-
-        wdb = wdb_init(db, sagent_id);
-        wdb_pool_append(wdb);
-    }
-    else {
-        wdb = wdb_init(db, sagent_id);
-        wdb_pool_append(wdb);
-        wdb = wdb_upgrade(wdb);
-
-        if (wdb == NULL) {
-            goto end;
-        }
+    } else {
+        wdb_upgrade(wdb);
     }
 
-success:
-    w_mutex_lock(&wdb->mutex);
-    wdb->refcount++;
-
-end:
-    rwlock_unlock(&pool_mutex);
+    wdb_open_count++;
     return wdb;
 }
 
 // Opens tasks database and stores it in DB pool. It returns a locked database or NULL
 wdb_t * wdb_open_tasks() {
     char path[PATH_MAX + 1] = "";
-    sqlite3 *db = NULL;
-    wdb_t * wdb = NULL;
+    wdb_t * wdb = wdb_pool_get_or_create(WDB_TASK_NAME);
 
-    // Finds DB in pool, locking pool_mutex for read
-    if (wdb = wdb_get_db_from_pool(WDB_TASK_NAME), wdb) {
-        return wdb;
-    }
-
-    rwlock_lock_write(&pool_mutex);
-
-    // Finds DB in pool
-    if (wdb = (wdb_t *)OSHash_Get(open_dbs, WDB_TASK_NAME), wdb) {
-        // The corresponding w_mutex_unlock(&wdb->mutex) is called in wdb_leave(wdb_t * wdb)
-        w_mutex_lock(&wdb->mutex);
-        wdb->refcount++;
-        rwlock_unlock(&pool_mutex);
-        return wdb;
-    } else {
+    if (wdb->db == NULL) {
         // Try to open DB
         snprintf(path, sizeof(path), "%s/%s.db", WDB_TASK_DIR, WDB_TASK_NAME);
 
-        if (sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE, NULL)) {
+        if (sqlite3_open_v2(path, &wdb->db, SQLITE_OPEN_READWRITE, NULL)) {
             mdebug1("Tasks database not found, creating.");
-            sqlite3_close_v2(db);
+            wdb_close(wdb, false);
 
             // Creating database
             if (OS_SUCCESS != wdb_create_file(path, schema_task_manager_sql)) {
                 merror("Couldn't create SQLite database '%s'", path);
-                rwlock_unlock(&pool_mutex);
-                return wdb;
+                wdb_pool_leave(wdb);
+                return NULL;
             }
 
             // Retry to open
-            if (sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE, NULL)) {
-                merror("Can't open SQLite database '%s': %s", path, sqlite3_errmsg(db));
-                sqlite3_close_v2(db);
-                rwlock_unlock(&pool_mutex);
-                return wdb;
+            if (sqlite3_open_v2(path, &wdb->db, SQLITE_OPEN_READWRITE, NULL)) {
+                merror("Can't open SQLite database '%s': %s", path, sqlite3_errmsg(wdb->db));
+                wdb_close(wdb, false);
+                wdb_pool_leave(wdb);
+                return NULL;
             }
-
-            wdb = wdb_init(db, WDB_TASK_NAME);
-            wdb_pool_append(wdb);
-        }
-        else {
-            wdb = wdb_init(db, WDB_TASK_NAME);
-            wdb_pool_append(wdb);
         }
     }
 
-    // The corresponding w_mutex_unlock(&wdb->mutex) is called in wdb_leave(wdb_t * wdb)
-    w_mutex_lock(&wdb->mutex);
-    wdb->refcount++;
-    rwlock_unlock(&pool_mutex);
+    wdb_open_count++;
     return wdb;
 }
 
@@ -1021,108 +895,32 @@ void wdb_destroy(wdb_t * wdb) {
     free(wdb);
 }
 
-void wdb_pool_append(wdb_t * wdb) {
-    int r;
-
-    if (db_pool_begin) {
-        db_pool_last->next = wdb;
-        db_pool_last = wdb;
-    } else {
-        db_pool_begin = db_pool_last = wdb;
-    }
-
-    wdb_open_count++;
-
-    if (r = OSHash_Add(open_dbs, wdb->id, wdb), r != 2) {
-        merror_exit("OSHash_Add(%s) returned %d.", wdb->id, r);
-    }
-}
-
-void wdb_pool_remove(wdb_t * wdb) {
-    wdb_t * prev;
-
-    if (!OSHash_Delete(open_dbs, wdb->id)) {
-        merror("Database for agent '%s' was not in hash table.", wdb->id);
-    }
-
-    if (wdb == db_pool_begin) {
-        db_pool_begin = wdb->next;
-
-        if (wdb == db_pool_last) {
-            db_pool_last = NULL;
-        }
-
-        wdb_open_count--;
-    } else if (prev = wdb_pool_find_prev(wdb), prev) {
-        prev->next = wdb->next;
-
-        if (wdb == db_pool_last) {
-            db_pool_last = prev;
-        }
-
-        wdb_open_count--;
-    } else {
-        merror("Database for agent '%s' not found in the pool.", wdb->id);
-    }
-}
-
-// Duplicate the database pool
-wdb_t * wdb_pool_copy() {
-    wdb_t *copy = NULL;
-    wdb_t *last;
-
-    for (wdb_t *i = db_pool_begin; i != NULL; i = i->next) {
-        wdb_t * t = wdb_init(NULL, i->id);
-
-        if (copy == NULL) {
-            copy = last = t;
-        } else {
-            last->next = t;
-            last = t;
-        }
-    }
-
-    return copy;
-}
-
 void wdb_close_all() {
-    wdb_t * node;
+    char ** keys = wdb_pool_keys();
 
-    mdebug1("Closing all databases...");
-    rwlock_lock_write(&pool_mutex);
+    for (int i = 0; keys[i]; i++) {
+        wdb_t * node = wdb_pool_get(keys[i]);
 
-    while (node = db_pool_begin, node) {
-        mdebug2("Closing database for agent %s", node->id);
-
-        if (wdb_close(node, TRUE) < 0) {
-            merror("Couldn't close DB for agent %s", node->id);
-
+        if (node != NULL && node->db != NULL) {
+            wdb_close(node, true);
         }
+
+        wdb_pool_leave(node);
     }
 
-    rwlock_unlock(&pool_mutex);
+    free_strarray(keys);
 }
 
 void wdb_commit_old() {
-    wdb_t * node;
-    wdb_t * next;
+    char ** keys = wdb_pool_keys();
 
-    rwlock_lock_read(&pool_mutex);
-    wdb_t *copy = wdb_pool_copy();
-    rwlock_unlock(&pool_mutex);
-
-    for (wdb_t *i = copy; i != NULL; wdb_destroy(i), i = next) {
-        next = i->next;
-
-        rwlock_lock_read(&pool_mutex);
-        node = (wdb_t *)OSHash_Get(open_dbs, i->id);
+    for (int i = 0; keys[i]; i++) {
+        wdb_t * node = wdb_pool_get(keys[i]);
 
         if (node == NULL) {
-            rwlock_unlock(&pool_mutex);
             continue;
         }
 
-        w_mutex_lock(&node->mutex);
         time_t cur_time = time(NULL);
 
         // Commit condition: more than commit_time_min seconds elapsed from the last query, or more than commit_time_max elapsed from the transaction began.
@@ -1137,36 +935,33 @@ void wdb_commit_old() {
             mdebug2("Agent '%s' database commited. Time: %.3f ms.", node->id, time_diff(&ts_start, &ts_end) * 1e3);
         }
 
-        w_mutex_unlock(&node->mutex);
-        rwlock_unlock(&pool_mutex);
+        wdb_pool_leave(node);
     }
+
+    free_strarray(keys);
 }
 
 void wdb_check_fragmentation() {
-    wdb_t * node;
-    wdb_t * next;
+    char ** keys = wdb_pool_keys();
 
-    rwlock_lock_read(&pool_mutex);
-    wdb_t *copy = wdb_pool_copy();
-    rwlock_unlock(&pool_mutex);
-
-    for (wdb_t *i = copy; i != NULL; wdb_destroy(i), i = next) {
+    for (int i = 0; keys[i]; i++) {
         int last_vacuum_time;
         int last_vacuum_value;
         int current_fragmentation;
         int current_free_pages_percentage;
         int fragmentation_after_vacuum;
-        next = i->next;
 
-        rwlock_lock_read(&pool_mutex);
-        node = (wdb_t *)OSHash_Get(open_dbs, i->id);
+        wdb_t * node = wdb_pool_get(keys[i]);
 
         if (node == NULL) {
-            rwlock_unlock(&pool_mutex);
             continue;
         }
 
-        w_mutex_lock(&node->mutex);
+        if (node->db == NULL) {
+            wdb_pool_leave(node);
+            continue;
+        }
+
         current_fragmentation = wdb_get_db_state(node);
         current_free_pages_percentage = wdb_get_db_free_pages_percentage(node);
         if (current_fragmentation == OS_INVALID || current_free_pages_percentage == OS_INVALID) {
@@ -1191,8 +986,7 @@ void wdb_check_fragmentation() {
 
                     if (wdb_commit2(node) < 0) {
                         merror("Couldn't execute commit statement, before vacuum, for the database '%s'", node->id);
-                        w_mutex_unlock(&node->mutex);
-                        rwlock_unlock(&pool_mutex);
+                        wdb_pool_leave(node);
                         continue;
                     }
 
@@ -1201,8 +995,7 @@ void wdb_check_fragmentation() {
                     gettime(&ts_start);
                     if (wdb_vacuum(node->db) < 0) {
                         merror("Couldn't execute vacuum for the database '%s'", node->id);
-                        w_mutex_unlock(&node->mutex);
-                        rwlock_unlock(&pool_mutex);
+                        wdb_pool_leave(node);
                         continue;
                     }
                     gettime(&ts_end);
@@ -1229,9 +1022,10 @@ void wdb_check_fragmentation() {
             }
         }
 
-        w_mutex_unlock(&node->mutex);
-        rwlock_unlock(&pool_mutex);
+        wdb_pool_leave(node);
     }
+
+    free_strarray(keys);
 }
 
 STATIC int wdb_get_last_vacuum_data(wdb_t* wdb, int *last_vacuum_time, int *last_vacuum_value) {
@@ -1311,36 +1105,25 @@ int wdb_update_last_vacuum_data(wdb_t* wdb, const char *last_vacuum_time, const 
 }
 
 void wdb_close_old() {
-    wdb_t * node;
-    wdb_t * next;
+    char ** keys = wdb_pool_keys();
 
-    rwlock_lock_read(&pool_mutex);
-    wdb_t *copy = wdb_pool_copy();
-    rwlock_unlock(&pool_mutex);
+    for (int i = 0; keys[i] && wdb_open_count > wconfig.open_db_limit; i++) {
+        wdb_t * node = wdb_pool_get(keys[i]);
 
-    for (wdb_t *i = copy; i != NULL; wdb_destroy(i), i = next) {
-        next = i->next;
-
-        rwlock_lock_write(&pool_mutex);
-        node = (wdb_t *)OSHash_Get(open_dbs, i->id);
-
-        if (node == NULL || wdb_open_count <= wconfig.open_db_limit) {
-            rwlock_unlock(&pool_mutex);
+        if (node == NULL) {
             continue;
         }
 
-        w_mutex_lock(&node->mutex);
-
-        if (node->refcount == 0 && !node->transaction) {
-            w_mutex_unlock(&node->mutex);
+        if (node->db != NULL && node->refcount == 1 && strcmp(node->id, WDB_GLOB_NAME) != 0) {
             mdebug2("Closing database for agent %s", node->id);
-            wdb_close(node, FALSE);
-        } else {
-            w_mutex_unlock(&node->mutex);
+            wdb_close(node, true);
         }
 
-        rwlock_unlock(&pool_mutex);
+        wdb_pool_leave(node);
+
     }
+
+    free_strarray(keys);
 }
 
 int wdb_exec_stmt_silent(sqlite3_stmt* stmt) {
@@ -1577,29 +1360,19 @@ cJSON* wdb_exec(sqlite3* db, const char * sql) {
 int wdb_close(wdb_t * wdb, bool commit) {
     int result;
 
-    w_mutex_lock(&wdb->mutex);
+    if (wdb->transaction && commit) {
+        wdb_commit2(wdb);
+    }
 
-    if (wdb->refcount == 0) {
-        if (wdb->transaction && commit) {
-            wdb_commit2(wdb);
-        }
+    wdb_finalize_all_statements(wdb);
+    result = sqlite3_close_v2(wdb->db);
 
-        wdb_finalize_all_statements(wdb);
-
-        result = sqlite3_close_v2(wdb->db);
-        w_mutex_unlock(&wdb->mutex);
-
-        if (result == SQLITE_OK) {
-            wdb_pool_remove(wdb);
-            wdb_destroy(wdb);
-            return OS_SUCCESS;
-        } else {
-            merror("DB(%s) wdb_close(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-            return OS_INVALID;
-        }
+    if (result == SQLITE_OK) {
+        wdb->db = NULL;
+        wdb_open_count--;
+        return OS_SUCCESS;
     } else {
-        w_mutex_unlock(&wdb->mutex);
-        mdebug1("Couldn't close database for agent %s: refcount = %u", wdb->id, wdb->refcount);
+        merror("DB(%s) wdb_close(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }
 }
@@ -1628,26 +1401,6 @@ void wdb_finalize_all_statements(wdb_t * wdb) {
     }
 
     wdb->cache_list = NULL;
-}
-
-void wdb_leave(wdb_t * wdb) {
-    if(wdb) {
-        wdb->refcount--;
-        wdb->last = time(NULL);
-        w_mutex_unlock(&wdb->mutex);
-    }
-}
-
-wdb_t * wdb_pool_find_prev(wdb_t * wdb) {
-    wdb_t * node;
-
-    for (node = db_pool_begin; node && node->next; node = node->next) {
-        if (node->next == wdb) {
-            return node;
-        }
-    }
-
-    return NULL;
 }
 
 int wdb_stmt_cache(wdb_t * wdb, int index) {
@@ -1736,16 +1489,13 @@ cJSON *wdb_remove_multiple_agents(char *agent_list) {
 
                 // Close the database only if it was open
 
-                rwlock_lock_write(&pool_mutex);
-
-                wdb = (wdb_t *)OSHash_Get(open_dbs, agent);
+                wdb = wdb_pool_get(agent);
                 if (wdb) {
                     if (wdb_close(wdb, FALSE) < 0) {
                         result = "Can't close";
                     }
+                    wdb_pool_leave(wdb);
                 }
-
-                rwlock_unlock(&pool_mutex);
 
                 mdebug1("Removing db for agent '%s'", agent);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -440,7 +440,7 @@ extern char *schema_global_upgrade_v5_sql;
 extern wdb_config wconfig;
 extern rwlock_t pool_mutex;
 extern wdb_t * db_pool;
-extern int db_pool_size;
+extern int wdb_open_count;
 extern OSHash * open_dbs;
 
 typedef struct os_data {

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1598,14 +1598,15 @@ int wdb_scan_info_get(wdb_t * wdb, const char *module, char *field, long *output
 int wdb_scan_info_fim_checks_control (wdb_t * wdb, const char *last_check);
 
 // Upgrade agent database to last version
-void wdb_upgrade(wdb_t *wdb);
+wdb_t * wdb_upgrade(wdb_t *wdb);
 
 /**
  * @brief Function to upgrade Global DB to the latest version.
  *
  * @param [in] wdb The global.db database to upgrade.
+ * @return wdb The global.db database updated on success.
  */
-void wdb_upgrade_global(wdb_t *wdb);
+wdb_t * wdb_upgrade_global(wdb_t *wdb);
 
 // Create backup and generate an empty DB
 wdb_t * wdb_backup(wdb_t *wdb, int version);
@@ -1617,8 +1618,9 @@ int wdb_create_backup(const char * agent_id, int version);
  * @brief Function to recreate Global DB in case of an upgrading an old version.
  *
  * @param [in] wdb The global.db database to backup.
+ * @return wdb The new empty global.db database on success or NULL on error
  */
-void wdb_recreate_global(wdb_t *wdb);
+wdb_t * wdb_recreate_global(wdb_t *wdb);
 
 /**
  * @brief Check if the db version is older than 3.10

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -440,7 +440,7 @@ extern char *schema_global_upgrade_v4_sql;
 extern char *schema_global_upgrade_v5_sql;
 
 extern wdb_config wconfig;
-extern int wdb_open_count;
+extern _Atomic(int) wdb_open_count;
 
 typedef struct os_data {
     char *os_name;

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -415,6 +415,8 @@ typedef enum {
     WDB_GENERIC_COMPONENT,           ///< Miscellaneous component
 } wdb_component_t;
 
+#include "wdb_pool.h"
+
 extern char *schema_global_sql;
 extern char *schema_agents_sql;
 extern char *schema_task_manager_sql;
@@ -438,10 +440,7 @@ extern char *schema_global_upgrade_v4_sql;
 extern char *schema_global_upgrade_v5_sql;
 
 extern wdb_config wconfig;
-extern rwlock_t pool_mutex;
-extern wdb_t * db_pool;
 extern int wdb_open_count;
-extern OSHash * open_dbs;
 
 typedef struct os_data {
     char *os_name;
@@ -988,8 +987,6 @@ int wdb_close(wdb_t * wdb, bool commit);
  * @param wdb The database struct pointer.
  */
 void wdb_finalize_all_statements(wdb_t * wdb);
-
-void wdb_leave(wdb_t * wdb);
 
 wdb_t * wdb_pool_find_prev(wdb_t * wdb);
 
@@ -1601,15 +1598,14 @@ int wdb_scan_info_get(wdb_t * wdb, const char *module, char *field, long *output
 int wdb_scan_info_fim_checks_control (wdb_t * wdb, const char *last_check);
 
 // Upgrade agent database to last version
-wdb_t * wdb_upgrade(wdb_t *wdb);
+void wdb_upgrade(wdb_t *wdb);
 
 /**
  * @brief Function to upgrade Global DB to the latest version.
  *
  * @param [in] wdb The global.db database to upgrade.
- * @return wdb The global.db database updated on success.
  */
-wdb_t * wdb_upgrade_global(wdb_t *wdb);
+void wdb_upgrade_global(wdb_t *wdb);
 
 // Create backup and generate an empty DB
 wdb_t * wdb_backup(wdb_t *wdb, int version);
@@ -1621,9 +1617,8 @@ int wdb_create_backup(const char * agent_id, int version);
  * @brief Function to recreate Global DB in case of an upgrading an old version.
  *
  * @param [in] wdb The global.db database to backup.
- * @return wdb The new empty global.db database on success or NULL on error
  */
-wdb_t * wdb_recreate_global(wdb_t *wdb);
+void wdb_recreate_global(wdb_t *wdb);
 
 /**
  * @brief Check if the db version is older than 3.10

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -857,7 +857,7 @@ int wdb_ciscat_insert(wdb_t * wdb, const char * scan_id, const char * scan_time,
 // Delete old information from the 'ciscat_results' table
 int wdb_ciscat_del(wdb_t * wdb, const char * scan_id);
 
-wdb_t * wdb_init(sqlite3 * db, const char * id);
+wdb_t * wdb_init(const char * id);
 
 void wdb_destroy(wdb_t * wdb);
 

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -2106,8 +2106,9 @@ int wdb_global_restore_backup(wdb_t** wdb, char* snapshot, bool save_pre_restore
 
         if (!w_uncompress_gzfile(backup_to_restore_path, global_tmp_path)) {
             // Preparing DB for restoration.
-            wdb_leave(*wdb);
+
             wdb_close(*wdb, true);
+            wdb_pool_leave(*wdb);
             *wdb = NULL;
 
             unlink(global_path);

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -2108,9 +2108,6 @@ int wdb_global_restore_backup(wdb_t** wdb, char* snapshot, bool save_pre_restore
             // Preparing DB for restoration.
 
             wdb_close(*wdb, true);
-            wdb_pool_leave(*wdb);
-            *wdb = NULL;
-
             unlink(global_path);
 
             if (rename(global_tmp_path, global_path) != OS_SUCCESS) {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -746,6 +746,22 @@ int wdb_parse(char * input, char * output, int peer) {
             gettimeofday(&end, 0);
             timersub(&end, &begin, &diff);
             w_inc_agent_get_fragmentation_time(diff);
+        } else if (strcmp(query, "sleep") == 0) {
+            unsigned long delay_ms;
+            w_inc_agent_sleep();
+            gettimeofday(&begin, 0);
+            if (!next || (delay_ms = strtoul(next, NULL, 10)) == ULONG_MAX) {
+                mdebug1("DB(%s) Invalid DB query syntax.", sagent_id);
+                mdebug2("DB(%s) query error near: %s", sagent_id, query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                result = OS_INVALID;
+            } else {
+                w_time_delay(delay_ms);
+                snprintf(output, OS_MAXSTR + 1, "ok ");
+            }
+            gettimeofday(&end, 0);
+            timersub(&end, &begin, &diff);
+            w_inc_agent_sleep_time(diff);
         } else {
             mdebug1("DB(%s) Invalid DB query syntax.", sagent_id);
             mdebug2("DB(%s) query error near: %s", sagent_id, query);
@@ -1364,6 +1380,22 @@ int wdb_parse(char * input, char * output, int peer) {
             gettimeofday(&end, 0);
             timersub(&end, &begin, &diff);
             w_inc_global_get_fragmentation_time(diff);
+        } else if (strcmp(query, "sleep") == 0) {
+            unsigned long delay_ms;
+            w_inc_global_sleep();
+            gettimeofday(&begin, 0);
+            if (!next || (delay_ms = strtoul(next, NULL, 10)) == ULONG_MAX) {
+                mdebug1("Global DB Invalid DB query syntax.");
+                mdebug2("Global DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                result = OS_INVALID;
+            } else {
+                w_time_delay(delay_ms);
+                snprintf(output, OS_MAXSTR + 1, "ok ");
+            }
+            gettimeofday(&end, 0);
+            timersub(&end, &begin, &diff);
+            w_inc_global_sleep_time(diff);
         } else {
             mdebug1("Invalid DB query syntax.");
             mdebug2("Global DB query error near: %s", query);

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -44,7 +44,8 @@ wdb_t * wdb_pool_get_or_create(const char * name) {
     wdb_t * node = rbtree_get(wdb_pool.nodes, name);
 
     if (node == NULL) {
-        node =  wdb_init(name);
+        node = wdb_init(name);
+        rbtree_insert(wdb_pool.nodes, name, node);
     }
 
     node->refcount++;

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -1,0 +1,95 @@
+/*
+ * Wazuh DB pool handler definition
+ * Copyright (C) 2015, Wazuh Inc.
+ * February 16, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "wdb_pool.h"
+
+static wdb_pool_t wdb_pool;
+
+// Initialize global pool.
+
+void wdb_pool_init() {
+    wdb_pool.nodes = rbtree_init();
+    w_mutex_init(&wdb_pool.mutex, NULL)
+}
+
+// Find a node in the pool by name.
+
+wdb_t * wdb_pool_get(const char * name) {
+   w_mutex_lock(&wdb_pool.mutex);
+    wdb_t * node = rbtree_get(wdb_pool.nodes, name);
+
+    if (node != NULL) {
+        node->refcount++;
+    }
+
+    w_mutex_unlock(&wdb_pool.mutex);
+    w_mutex_lock(&node->mutex);
+
+    return node;
+}
+
+// Find a node in the pool by name, or create if it does not exist.
+
+wdb_t * wdb_pool_get_or_create(const char * name) {
+    w_mutex_lock(&wdb_pool.mutex);
+    wdb_t * node = rbtree_get(wdb_pool.nodes, name);
+
+    if (node == NULL) {
+        node =  wdb_init(NULL, name);
+    }
+
+    node->refcount++;
+    w_mutex_unlock(&wdb_pool.mutex);
+    w_mutex_lock(&node->mutex);
+
+    return node;
+}
+
+// Leave a node.
+
+void wdb_pool_leave(wdb_t * node) {
+    w_mutex_unlock(&node->mutex);
+
+    if (node) {
+        w_mutex_lock(&wdb_pool.mutex);
+        node->refcount--;
+        node->last = time(NULL);
+        w_mutex_unlock(&wdb_pool.mutex);
+    }
+}
+
+// Get all the existing names in the pool.
+
+char ** wdb_pool_keys() {
+    w_mutex_lock(&wdb_pool.mutex);
+    char ** keys = rbtree_keys(wdb_pool.nodes);
+    w_mutex_unlock(&wdb_pool.mutex);
+
+    return keys;
+}
+
+// Remove closed databases from the pool.
+
+void wdb_pool_clean() {
+    w_mutex_lock(&wdb_pool.mutex);
+    char ** keys = rbtree_keys(wdb_pool.nodes);
+
+    for (int i = 0; keys[i]; i++) {
+        wdb_t * node = rbtree_get(wdb_pool.nodes, keys[i]);
+
+        if (node->refcount == 0) {
+            wdb_destroy(node);
+        }
+    }
+
+    free_strarray(keys);
+    w_mutex_unlock(&wdb_pool.mutex);
+}

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -31,7 +31,7 @@ void wdb_pool_init() {
 // Find a node in the pool by name.
 
 wdb_t * wdb_pool_get(const char * name) {
-   w_mutex_lock(&wdb_pool.mutex);
+    w_mutex_lock(&wdb_pool.mutex);
     wdb_t * node = rbtree_get(wdb_pool.nodes, name);
 
     if (node == NULL) {
@@ -94,6 +94,11 @@ void wdb_pool_clean() {
 
     for (int i = 0; keys[i]; i++) {
         wdb_t * node = rbtree_get(wdb_pool.nodes, keys[i]);
+
+        if (node == NULL) {
+            merror("Null node found when cleaning database files. This is a bug.");
+            continue;
+        }
 
         if (node->refcount == 0 && node->db == NULL) {
             wdb_destroy(node);

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -22,6 +22,7 @@ STATIC wdb_pool_t wdb_pool;
 
 // Initialize global pool.
 
+__attribute__((no_thread_safety_analysis))
 void wdb_pool_init() {
     wdb_pool.nodes = rbtree_init();
     w_mutex_init(&wdb_pool.mutex, NULL)

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -27,6 +27,7 @@ wdb_t * wdb_pool_get(const char * name) {
     wdb_t * node = rbtree_get(wdb_pool.nodes, name);
 
     if (node == NULL) {
+        w_mutex_unlock(&wdb_pool.mutex);
         return NULL;
     }
 

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -43,7 +43,7 @@ wdb_t * wdb_pool_get_or_create(const char * name) {
     wdb_t * node = rbtree_get(wdb_pool.nodes, name);
 
     if (node == NULL) {
-        node =  wdb_init(NULL, name);
+        node =  wdb_init(name);
     }
 
     node->refcount++;

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -11,7 +11,14 @@
 
 #include "wdb_pool.h"
 
-static wdb_pool_t wdb_pool;
+#ifdef WAZUH_UNIT_TESTING
+// Remove static qualifier when unit testing
+#define STATIC
+#else
+#define STATIC static
+#endif
+
+STATIC wdb_pool_t wdb_pool;
 
 // Initialize global pool.
 

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -87,7 +87,7 @@ void wdb_pool_clean() {
     for (int i = 0; keys[i]; i++) {
         wdb_t * node = rbtree_get(wdb_pool.nodes, keys[i]);
 
-        if (node->refcount == 0) {
+        if (node->refcount == 0 && node->db == NULL) {
             wdb_destroy(node);
             rbtree_delete(wdb_pool.nodes, keys[i]);
         }

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -89,6 +89,7 @@ void wdb_pool_clean() {
 
         if (node->refcount == 0) {
             wdb_destroy(node);
+            rbtree_delete(wdb_pool.nodes, keys[i]);
         }
     }
 

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -58,13 +58,12 @@ wdb_t * wdb_pool_get_or_create(const char * name) {
 // Leave a node.
 
 void wdb_pool_leave(wdb_t * node) {
-    w_mutex_unlock(&node->mutex);
-
     if (node) {
+        w_mutex_unlock(&node->mutex);
         w_mutex_lock(&wdb_pool.mutex);
         node->refcount--;
-        node->last = time(NULL);
         w_mutex_unlock(&wdb_pool.mutex);
+        node->last = time(NULL);
     }
 }
 

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -26,10 +26,11 @@ wdb_t * wdb_pool_get(const char * name) {
    w_mutex_lock(&wdb_pool.mutex);
     wdb_t * node = rbtree_get(wdb_pool.nodes, name);
 
-    if (node != NULL) {
-        node->refcount++;
+    if (node == NULL) {
+        return NULL;
     }
 
+    node->refcount++;
     w_mutex_unlock(&wdb_pool.mutex);
     w_mutex_lock(&node->mutex);
 

--- a/src/wazuh_db/wdb_pool.h
+++ b/src/wazuh_db/wdb_pool.h
@@ -1,0 +1,69 @@
+/*
+ * Wazuh DB pool handler headers
+ * Copyright (C) 2015, Wazuh Inc.
+ * February 16, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include "wdb.h"
+
+typedef struct {
+    rb_tree * nodes;
+    pthread_mutex_t mutex;
+} wdb_pool_t;
+
+/**
+ * @brief Initialize global pool.
+ */
+void wdb_pool_init();
+
+/**
+ * @brief Find a node in the pool by name.
+ *
+ * @param name Database identifier
+ * @post The node's reference counter gets incremented.
+ * @post The node's mutex gets locked (when found).
+ * @return Pointer to the selected database node
+ * @retval null The database does not exist in the pool.
+ */
+wdb_t * wdb_pool_get(const char * name);
+
+/**
+ * @brief Find a node in the pool by name, or create if it does not exist.
+ *
+ * @param name Database identifier
+ * @post The node's reference counter gets incremented.
+ * @post The node's mutex gets locked.
+ * @return Pointer to the selected database node
+ */
+wdb_t * wdb_pool_get_or_create(const char * name);
+
+/**
+ * @brief Leave a node
+ *
+ * @param node Pointer to a database node.
+ * @pre The node's mutex must stay locked.
+ * @post The node's reference counter gets decremented.
+ * @post The node's mutex gets unlocked.
+ */
+void wdb_pool_leave(wdb_t * node);
+
+/**
+ * @brief Get all the existing names in the pool.
+ *
+ * @return String array containing the names of all contained nodes.
+ */
+char ** wdb_pool_keys();
+
+/**
+ * @brief Remove closed databases from the pool.
+ *
+ * Scans the pool and destroys all nodes associated to closed databases.
+ */
+void wdb_pool_clean();

--- a/src/wazuh_db/wdb_state.c
+++ b/src/wazuh_db/wdb_state.c
@@ -478,6 +478,18 @@ void w_inc_agent_syscollector_deprecated_osinfo_time(struct timeval time) {
     w_mutex_unlock(&db_state_t_mutex);
 }
 
+void w_inc_agent_sleep() {
+    w_mutex_lock(&db_state_t_mutex);
+    wdb_state.queries_breakdown.agent_breakdown.sleep_queries++;
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
+void w_inc_agent_sleep_time(struct timeval time) {
+    w_mutex_lock(&db_state_t_mutex);
+    timeradd(&wdb_state.queries_breakdown.agent_breakdown.sleep_time, &time, &wdb_state.queries_breakdown.agent_breakdown.sleep_time);
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
 void w_inc_global() {
     w_mutex_lock(&db_state_t_mutex);
     wdb_state.queries_breakdown.global_queries++;
@@ -874,6 +886,19 @@ void w_inc_global_get_fragmentation_time(struct timeval time) {
     w_mutex_unlock(&db_state_t_mutex);
 }
 
+void w_inc_global_sleep() {
+    w_mutex_lock(&db_state_t_mutex);
+    wdb_state.queries_breakdown.global_breakdown.sleep_queries++;
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
+void w_inc_global_sleep_time(struct timeval time) {
+    w_mutex_lock(&db_state_t_mutex);
+    timeradd(&wdb_state.queries_breakdown.global_breakdown.sleep_time, &time, &wdb_state.queries_breakdown.global_breakdown.sleep_time);
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
+
 void w_inc_task() {
     w_mutex_lock(&db_state_t_mutex);
     wdb_state.queries_breakdown.task_queries++;
@@ -1047,6 +1072,7 @@ cJSON* wdb_create_state_json() {
     cJSON_AddNumberToObject(_agent_db, "sql", wdb_state_cpy.queries_breakdown.agent_breakdown.sql_queries);
     cJSON_AddNumberToObject(_agent_db, "vacuum", wdb_state_cpy.queries_breakdown.agent_breakdown.vacuum_queries);
     cJSON_AddNumberToObject(_agent_db, "get_fragmentation", wdb_state_cpy.queries_breakdown.agent_breakdown.get_fragmentation_queries);
+    cJSON_AddNumberToObject(_agent_db, "sleep", wdb_state_cpy.queries_breakdown.agent_breakdown.sleep_queries);
 
     cJSON *_agent_tables = cJSON_CreateObject();
     cJSON_AddItemToObject(_agent_breakdown, "tables", _agent_tables);
@@ -1123,6 +1149,7 @@ cJSON* wdb_create_state_json() {
     cJSON_AddNumberToObject(_global_db, "sql", wdb_state_cpy.queries_breakdown.global_breakdown.sql_queries);
     cJSON_AddNumberToObject(_global_db, "vacuum", wdb_state_cpy.queries_breakdown.global_breakdown.vacuum_queries);
     cJSON_AddNumberToObject(_global_db, "get_fragmentation", wdb_state_cpy.queries_breakdown.global_breakdown.get_fragmentation_queries);
+    cJSON_AddNumberToObject(_global_db, "sleep", wdb_state_cpy.queries_breakdown.global_breakdown.sleep_queries);
 
     cJSON *_global_tables = cJSON_CreateObject();
     cJSON_AddItemToObject(_global_breakdown, "tables", _global_tables);
@@ -1240,6 +1267,7 @@ cJSON* wdb_create_state_json() {
     cJSON_AddNumberToObject(_agent_db_t, "sql", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.sql_time));
     cJSON_AddNumberToObject(_agent_db_t, "vacuum", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.vacuum_time));
     cJSON_AddNumberToObject(_agent_db_t, "get_fragmentation", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.get_fragmentation_time));
+    cJSON_AddNumberToObject(_agent_db_t, "sleep", timeval_to_milis(wdb_state_cpy.queries_breakdown.agent_breakdown.sleep_time));
 
     cJSON *_agent_tables_t = cJSON_CreateObject();
     cJSON_AddItemToObject(_agent_breakdown_t, "tables", _agent_tables_t);
@@ -1317,6 +1345,7 @@ cJSON* wdb_create_state_json() {
     cJSON_AddNumberToObject(_global_db_t, "sql", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.sql_time));
     cJSON_AddNumberToObject(_global_db_t, "vacuum", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.vacuum_time));
     cJSON_AddNumberToObject(_global_db_t, "get_fragmentation", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.get_fragmentation_time));
+    cJSON_AddNumberToObject(_global_db_t, "sleep", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.sleep_time));
 
     cJSON *_global_tables_t = cJSON_CreateObject();
     cJSON_AddItemToObject(_global_breakdown_t, "tables", _global_tables_t);
@@ -1420,6 +1449,7 @@ STATIC uint64_t get_agent_time(wdb_state_t *state){
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.open_calls_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.vacuum_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.get_fragmentation_time, &task_time);
+    timeradd(&task_time, &state->queries_breakdown.agent_breakdown.sleep_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.begin_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.commit_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.agent_breakdown.close_time, &task_time);
@@ -1462,6 +1492,7 @@ STATIC uint64_t get_global_time(wdb_state_t *state){
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.open_calls_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.vacuum_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.get_fragmentation_time, &task_time);
+    timeradd(&task_time, &state->queries_breakdown.global_breakdown.sleep_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.insert_agent_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.update_agent_data_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.update_agent_name_time, &task_time);

--- a/src/wazuh_db/wdb_state.h
+++ b/src/wazuh_db/wdb_state.h
@@ -106,6 +106,7 @@ typedef struct _agent_breakdown_t {
     uint64_t sql_queries;
     uint64_t vacuum_queries;
     uint64_t get_fragmentation_queries;
+    uint64_t sleep_queries;
     struct timeval begin_time;
     struct timeval close_time;
     struct timeval commit_time;
@@ -114,6 +115,7 @@ typedef struct _agent_breakdown_t {
     struct timeval vacuum_time;
     struct timeval get_fragmentation_time;
     struct timeval open_calls_time;
+    struct timeval sleep_time;
     agent_ciscat_t ciscat;
     agent_rootcheck_t rootcheck;
     agent_sca_t sca;
@@ -196,11 +198,13 @@ typedef struct _global_breakdown_t {
     uint64_t sql_queries;
     uint64_t vacuum_queries;
     uint64_t get_fragmentation_queries;
+    uint64_t sleep_queries;
     struct timeval backup_time;
     struct timeval sql_time;
     struct timeval vacuum_time;
     struct timeval get_fragmentation_time;
     struct timeval open_calls_time;
+    struct timeval sleep_time;
     global_agent_t agent;
     global_belongs_t belongs;
     global_group_t group;
@@ -702,6 +706,19 @@ void w_inc_agent_syscollector_deprecated_osinfo();
 void w_inc_agent_syscollector_deprecated_osinfo_time(struct timeval time);
 
 /**
+ * @brief Increment deprecated syscollector OS information agent queries counter
+ *
+ */
+void w_inc_agent_sleep();
+
+/**
+ * @brief Increment deprecated OS information syscollector agent time counter
+ *
+ * @param time Value to increment the counter.
+ */
+void w_inc_agent_sleep_time(struct timeval time);
+
+/**
  * @brief Increment total global queries counter
  *
  */
@@ -1129,6 +1146,19 @@ void w_inc_global_get_fragmentation();
  * @param time Value to increment the counter.
  */
 void w_inc_global_get_fragmentation_time(struct timeval time);
+
+/**
+ * @brief Increment sleep global queries counter
+ *
+ */
+void w_inc_global_sleep();
+
+/**
+ * @brief Increment sleep global time counter
+ *
+ * @param time Value to increment the counter.
+ */
+void w_inc_global_sleep_time(struct timeval time);
 
 /**
  * @brief Increment task queries counter


### PR DESCRIPTION
|Related issue|
|---|
|Closes #17737|

This pull request addresses a performance degradation issue in our concurrent database management system caused by transitive mutex locking within the database pool. We have identified that the individual mutex locks were leading to unnecessary blocking, impacting the overall service performance.

To mitigate this issue, we have encapsulated the database pool structure and introduced some key invariants:

- Each node in the pool can represent either an open or closed database connection.
- The pool is designed to never be blocked due to the possession of a mutex by any individual node.

By implementing these changes, we ensure that the database pool operates efficiently even under concurrent access, without encountering unnecessary locking conflicts. This enhancement significantly improves the overall performance and reliability of our database management system.


## Tests

- [X] Unit tests for new pool encapsulation.
- [X] Coverity @ manager.
- [X] Valgrind @ wazuh-db.
- [X] ThreadSanitizer @ wazuh-db.