### PR TITLE
Wazuh db triggers normalization

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug1 -Wl,--wrap,wdb_stmt_cache -Wl,-
                          -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,EVP_DigestInit_ex -Wl,--wrap,EVP_DigestUpdate -Wl,--wrap,_DigestFinal_ex \
                          -Wl,--wrap,sqlite3_bind_int64 -Wl,--wrap,sqlite3_column_text -Wl,--wrap,_mdebug2 -Wl,--wrap,wdb_exec_stmt \
                          -Wl,--wrap,time -Wl,--wrap,_mwarn -Wl,--wrap,_merror -Wl,--wrap,wdb_init_stmt_in_cache ${DEBUG_OP_WRAPPERS} \
-                         -Wl,--wrap,router_provider_send_fb")
+                         -Wl,--wrap,router_provider_send")
 
 # Add server specific tests to the list
 list(APPEND wdb_tests_names "test_wdb_fim")

--- a/src/unit_tests/wazuh_db/test_wdb_integrity.c
+++ b/src/unit_tests/wazuh_db/test_wdb_integrity.c
@@ -1779,8 +1779,8 @@ void test_wdbi_report_removed_packages_success(void **state) {
     wdb_component_t component = WDB_SYSCOLLECTOR_PACKAGES;
     sqlite3_stmt* stmt = NULL;
     router_agent_events_handle = (ROUTER_PROVIDER_HANDLE)1;
-    const char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"\"},\"data_type\":\"dbsync_packages\","
-                                   "\"data\":{\"name\":\"name\",\"version\":\"version\",\"architecture\":\"architecture\",\"format\":\"format\",\"location\":\"location\",\"item_id\":\"item_id\"},\"operation\":\"DELETED\"}";
+    const char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"\"},\"action\":\"deletePackage\","
+                                   "\"data\":{\"name\":\"name\",\"version\":\"version\",\"architecture\":\"architecture\",\"format\":\"format\",\"location\":\"location\",\"item_id\":\"item_id\"}}";
 
     expect_value(__wrap_sqlite3_column_text, iCol, 0);
     will_return(__wrap_sqlite3_column_text, "name");
@@ -1795,9 +1795,9 @@ void test_wdbi_report_removed_packages_success(void **state) {
     expect_value(__wrap_sqlite3_column_text, iCol, 5);
     will_return(__wrap_sqlite3_column_text, "item_id");
 
-    expect_string(__wrap_router_provider_send_fb, msg, expected_message);
-    expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
-    will_return(__wrap_router_provider_send_fb, 0);
+    expect_string(__wrap_router_provider_send, message, expected_message);
+    expect_value(__wrap_router_provider_send, message_size, strlen(expected_message));
+    will_return(__wrap_router_provider_send, 0);
 
     will_return(__wrap_sqlite3_step, 0);
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
@@ -1810,15 +1810,15 @@ void test_wdbi_report_removed_hotfixes_success(void **state) {
     wdb_component_t component = WDB_SYSCOLLECTOR_HOTFIXES;
     sqlite3_stmt* stmt = NULL;
     router_agent_events_handle = (ROUTER_PROVIDER_HANDLE)1;
-    const char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"\"},\"data_type\":\"dbsync_hotfixes\","
-                                   "\"data\":{\"hotfix\":\"hotfix\"},\"operation\":\"DELETED\"}";
+    const char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"\"},\"action\":\"deleteHotfix\","
+                                   "\"data\":{\"hotfix\":\"hotfix\"}}";
 
     expect_value(__wrap_sqlite3_column_text, iCol, 0);
     will_return(__wrap_sqlite3_column_text, "hotfix");
 
-    expect_string(__wrap_router_provider_send_fb, msg, expected_message);
-    expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
-    will_return(__wrap_router_provider_send_fb, 0);
+    expect_string(__wrap_router_provider_send, message, expected_message);
+    expect_value(__wrap_router_provider_send, message_size, strlen(expected_message));
+    will_return(__wrap_router_provider_send, 0);
 
     will_return(__wrap_sqlite3_step, 0);
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
@@ -1831,19 +1831,19 @@ void test_wdbi_report_removed_hotfixes_success_multiple_steps(void **state) {
     wdb_component_t component = WDB_SYSCOLLECTOR_HOTFIXES;
     sqlite3_stmt* stmt = NULL;
     router_agent_events_handle = (ROUTER_PROVIDER_HANDLE)1;
-    const char* expected_message_1 = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"\"},\"data_type\":\"dbsync_hotfixes\","
-                                     "\"data\":{\"hotfix\":\"hotfix1\"},\"operation\":\"DELETED\"}";
+    const char* expected_message_1 = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"\"},\"action\":\"deleteHotfix\","
+                                     "\"data\":{\"hotfix\":\"hotfix1\"}}";
 
-    const char* expected_message_2 = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"\"},\"data_type\":\"dbsync_hotfixes\","
-                                     "\"data\":{\"hotfix\":\"hotfix2\"},\"operation\":\"DELETED\"}";
+    const char* expected_message_2 = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"\"},\"action\":\"deleteHotfix\","
+                                     "\"data\":{\"hotfix\":\"hotfix2\"}}";
 
     // First hotfix
     expect_value(__wrap_sqlite3_column_text, iCol, 0);
     will_return(__wrap_sqlite3_column_text, "hotfix1");
 
-    expect_string(__wrap_router_provider_send_fb, msg, expected_message_1);
-    expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
-    will_return(__wrap_router_provider_send_fb, 0);
+    expect_string(__wrap_router_provider_send, message, expected_message_1);
+    expect_value(__wrap_router_provider_send, message_size, strlen(expected_message_1));
+    will_return(__wrap_router_provider_send, 0);
 
     will_return(__wrap_sqlite3_step, 0);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
@@ -1853,9 +1853,9 @@ void test_wdbi_report_removed_hotfixes_success_multiple_steps(void **state) {
     expect_value(__wrap_sqlite3_column_text, iCol, 0);
     will_return(__wrap_sqlite3_column_text, "hotfix2");
 
-    expect_string(__wrap_router_provider_send_fb, msg, expected_message_2);
-    expect_string(__wrap_router_provider_send_fb, schema, syscollector_deltas_SCHEMA);
-    will_return(__wrap_router_provider_send_fb, 0);
+    expect_string(__wrap_router_provider_send, message, expected_message_2);
+    expect_value(__wrap_router_provider_send, message_size, strlen(expected_message_2));
+    will_return(__wrap_router_provider_send, 0);
 
     will_return(__wrap_sqlite3_step, 0);
     will_return(__wrap_sqlite3_step, SQLITE_DONE);

--- a/src/unit_tests/wazuh_db/test_wdb_integrity.c
+++ b/src/unit_tests/wazuh_db/test_wdb_integrity.c
@@ -1767,7 +1767,7 @@ void test_wdbi_report_removed_no_handle(void **state) {
     const char* agent_id = "001";
     wdb_component_t component = WDB_SYSCOLLECTOR_PACKAGES;
     sqlite3_stmt* stmt = NULL;
-    router_syscollector_handle = NULL;
+    router_agent_events_handle = NULL;
 
     expect_string(__wrap__mdebug2, formatted_msg, "Router handle not available.");
 
@@ -1778,7 +1778,7 @@ void test_wdbi_report_removed_packages_success(void **state) {
     const char* agent_id = "001";
     wdb_component_t component = WDB_SYSCOLLECTOR_PACKAGES;
     sqlite3_stmt* stmt = NULL;
-    router_syscollector_handle = (ROUTER_PROVIDER_HANDLE)1;
+    router_agent_events_handle = (ROUTER_PROVIDER_HANDLE)1;
     const char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"\"},\"data_type\":\"dbsync_packages\","
                                    "\"data\":{\"name\":\"name\",\"version\":\"version\",\"architecture\":\"architecture\",\"format\":\"format\",\"location\":\"location\",\"item_id\":\"item_id\"},\"operation\":\"DELETED\"}";
 
@@ -1809,7 +1809,7 @@ void test_wdbi_report_removed_hotfixes_success(void **state) {
     const char* agent_id = "001";
     wdb_component_t component = WDB_SYSCOLLECTOR_HOTFIXES;
     sqlite3_stmt* stmt = NULL;
-    router_syscollector_handle = (ROUTER_PROVIDER_HANDLE)1;
+    router_agent_events_handle = (ROUTER_PROVIDER_HANDLE)1;
     const char* expected_message = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"\"},\"data_type\":\"dbsync_hotfixes\","
                                    "\"data\":{\"hotfix\":\"hotfix\"},\"operation\":\"DELETED\"}";
 
@@ -1830,7 +1830,7 @@ void test_wdbi_report_removed_hotfixes_success_multiple_steps(void **state) {
     const char* agent_id = "001";
     wdb_component_t component = WDB_SYSCOLLECTOR_HOTFIXES;
     sqlite3_stmt* stmt = NULL;
-    router_syscollector_handle = (ROUTER_PROVIDER_HANDLE)1;
+    router_agent_events_handle = (ROUTER_PROVIDER_HANDLE)1;
     const char* expected_message_1 = "{\"agent_info\":{\"agent_id\":\"001\",\"node_name\":\"\"},\"data_type\":\"dbsync_hotfixes\","
                                      "\"data\":{\"hotfix\":\"hotfix1\"},\"operation\":\"DELETED\"}";
 

--- a/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
@@ -18,9 +18,10 @@
 #include "router.h"
 
 int __wrap_router_provider_send(__attribute__((unused)) ROUTER_PROVIDER_HANDLE handle,
-                                __attribute__((unused)) const char* message,
-                                __attribute__((unused)) unsigned int message_size) {
-    function_called();
+                                const char* message,
+                                unsigned int message_size) {
+    check_expected(message);
+    check_expected(message_size);
     return mock();
 }
 

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -13,7 +13,7 @@
 #include "wdb_state.h"
 #include <os_net/os_net.h>
 
-#define WDB_SYSCOLLECTOR_DELTAS_TOPIC "deltas-syscollector"
+#define WDB_AGENT_EVENTS_TOPIC "wdb-agent-events"
 
 static void wdb_help() __attribute__ ((noreturn));
 static void handler(int signum);
@@ -205,8 +205,8 @@ int main(int argc, char ** argv)
     router_initialize(taggedLogFunction);
 
     // Router provider initialization
-    if (router_syscollector_handle = router_provider_create(WDB_SYSCOLLECTOR_DELTAS_TOPIC, false), !router_syscollector_handle) {
-        mdebug2("Failed to create router handle for 'syscollector'.");
+    if (router_agent_events_handle = router_provider_create(WDB_AGENT_EVENTS_TOPIC, false), !router_agent_events_handle) {
+        mdebug2("Failed to create router handle for 'wdb-agent-events'.");
     }
 
     if (notify_queue = wnotify_init(1), !notify_queue) {

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -31,7 +31,7 @@
 #define MAX_ATTEMPTS 1000
 
 // Router provider variables
-ROUTER_PROVIDER_HANDLE router_syscollector_handle = NULL;
+ROUTER_PROVIDER_HANDLE router_agent_events_handle = NULL;
 
 static const char *SQL_CREATE_TEMP_TABLE = "CREATE TEMP TABLE IF NOT EXISTS s(rowid INTEGER PRIMARY KEY, pageno INT);";
 static const char *SQL_TRUNCATE_TEMP_TABLE = "DELETE FROM s;";

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -102,7 +102,7 @@ typedef enum wdb_global_group_hash_operations_t {
 #define SYSCOLLECTOR_LEGACY_CHECKSUM_VALUE "legacy"
 
 // Router provider variables
-extern ROUTER_PROVIDER_HANDLE router_syscollector_handle;
+extern ROUTER_PROVIDER_HANDLE router_agent_events_handle;
 
 typedef enum wdb_stmt {
     WDB_STMT_FIM_LOAD,

--- a/src/wazuh_db/wdb_integrity.c
+++ b/src/wazuh_db/wdb_integrity.c
@@ -81,11 +81,11 @@ void wdbi_report_removed(const char* agent_id, wdb_component_t component, sqlite
         switch (component)
         {
             case WDB_SYSCOLLECTOR_HOTFIXES:
-                type = "dbsync_hotfixes";
+                cJSON_AddStringToObject(j_msg_to_send, "action", "deleteHotfix");
                 cJSON_AddItemToObject(j_data, "hotfix", cJSON_CreateString((const char*) sqlite3_column_text(stmt, 0)));
                 break;
             case WDB_SYSCOLLECTOR_PACKAGES:
-                type = "dbsync_packages";
+                cJSON_AddStringToObject(j_msg_to_send, "action", "deletePackage");
                 cJSON_AddItemToObject(j_data, "name", cJSON_CreateString((const char*) sqlite3_column_text(stmt, 0)));
                 cJSON_AddItemToObject(j_data, "version", cJSON_CreateString((const char*) sqlite3_column_text(stmt, 1)));
                 cJSON_AddItemToObject(j_data, "architecture", cJSON_CreateString((const char*) sqlite3_column_text(stmt, 2)));
@@ -97,16 +97,14 @@ void wdbi_report_removed(const char* agent_id, wdb_component_t component, sqlite
                 break;
         }
 
-        cJSON_AddItemToObject(j_msg_to_send, "data_type", cJSON_CreateString(type));
         cJSON_AddItemToObject(j_msg_to_send, "data", j_data);
-        cJSON_AddItemToObject(j_msg_to_send, "operation", cJSON_CreateString("DELETED"));
 
         msg_to_send = cJSON_PrintUnformatted(j_msg_to_send);
 
         if (msg_to_send) {
-            router_provider_send_fb(router_agent_events_handle, msg_to_send, syscollector_deltas_SCHEMA);
+            router_provider_send(router_agent_events_handle, msg_to_send, strlen(msg_to_send));
         } else {
-            mdebug2("Unable to dump delete message to publish agent %s", agent_id);
+            mdebug2("Unable to dump delete message to publish. Agent %s", agent_id);
         }
 
         cJSON_Delete(j_msg_to_send);

--- a/src/wazuh_db/wdb_integrity.c
+++ b/src/wazuh_db/wdb_integrity.c
@@ -57,7 +57,7 @@ extern void mock_assert(const int result, const char* const expression,
 #endif
 
 void wdbi_report_removed(const char* agent_id, wdb_component_t component, sqlite3_stmt* stmt) {
-    if (!router_syscollector_handle) {
+    if (!router_agent_events_handle) {
         mdebug2("Router handle not available.");
         return;
     }
@@ -104,7 +104,7 @@ void wdbi_report_removed(const char* agent_id, wdb_component_t component, sqlite
         msg_to_send = cJSON_PrintUnformatted(j_msg_to_send);
 
         if (msg_to_send) {
-            router_provider_send_fb(router_syscollector_handle, msg_to_send, syscollector_deltas_SCHEMA);
+            router_provider_send_fb(router_agent_events_handle, msg_to_send, syscollector_deltas_SCHEMA);
         } else {
             mdebug2("Unable to dump delete message to publish agent %s", agent_id);
         }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5507,7 +5507,7 @@ int wdb_parse_global_delete_agent(wdb_t * wdb, char * input, char * output) {
         if (msg_to_send) {
             router_provider_send(router_agent_events_handle, msg_to_send, strlen(msg_to_send));
         } else {
-            mdebug2("Unable to dump agent db upgrade message to publish agent %s", wdb->id);
+            mdebug2("Unable to dump agent db upgrade message to publish. Agent %s", wdb->id);
         }
 
         cJSON_Delete(j_msg_to_send);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5488,6 +5488,33 @@ int wdb_parse_global_delete_agent(wdb_t * wdb, char * input, char * output) {
         return OS_INVALID;
     }
 
+    if (router_agent_events_handle) {
+        cJSON* j_msg_to_send = NULL;
+        cJSON* j_agent_info = NULL;
+        char* msg_to_send = NULL;
+
+        j_msg_to_send = cJSON_CreateObject();
+        j_agent_info = cJSON_CreateObject();
+
+        cJSON_AddStringToObject(j_agent_info, "agent_id", input);
+        cJSON_AddStringToObject(j_agent_info, "node_name", gconfig.node_name ? gconfig.node_name : "");
+        cJSON_AddItemToObject(j_msg_to_send, "agent_info", j_agent_info);
+
+        cJSON_AddStringToObject(j_msg_to_send, "action", "deleteAgent");
+
+        msg_to_send = cJSON_PrintUnformatted(j_msg_to_send);
+
+        if (msg_to_send) {
+            router_provider_send(router_agent_events_handle, msg_to_send, strlen(msg_to_send));
+        } else {
+            mdebug2("Unable to dump agent db upgrade message to publish agent %s", wdb->id);
+        }
+
+        cJSON_Delete(j_msg_to_send);
+        cJSON_free(msg_to_send);
+    }
+
+
     wdb_global_group_hash_cache(WDB_GLOBAL_GROUP_HASH_CLEAR, NULL);
 
     snprintf(output, OS_MAXSTR + 1, "ok");

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -63,13 +63,14 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
 
         for (unsigned i = version; i < sizeof(UPDATES) / sizeof(char *); i++) {
             mdebug2("Updating database '%s' to version %d", wdb->id, i + 1);
-            database_updated = true;
+            database_updated = false;
 
             if (wdb_sql_exec(wdb, UPDATES[i]) == -1 ||
                 wdb_adjust_upgrade(wdb, i)) {
                 wdb = wdb_backup(wdb, version);
                 break;
             }
+            database_updated = true;
         }
     }
 

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -87,7 +87,7 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
         cJSON_AddStringToObject(j_agent_info, "node_name", gconfig.node_name ? gconfig.node_name : "");
         cJSON_AddItemToObject(j_msg_to_send, "agent_info", j_agent_info);
 
-        cJSON_AddStringToObject(j_msg_to_send, "action", "agentDBUpgrade");
+        cJSON_AddStringToObject(j_msg_to_send, "action", "upgradeAgentDB");
 
         cJSON_AddNumberToObject(j_data, "db_version", version);
         cJSON_AddNumberToObject(j_data, "new_db_version", sizeof(UPDATES) / sizeof(char *));

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -98,7 +98,7 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
         if (msg_to_send) {
             router_provider_send(router_agent_events_handle, msg_to_send, strlen(msg_to_send));
         } else {
-            mdebug2("Unable to dump agent db upgrade message to publish agent %s", wdb->id);
+            mdebug2("Unable to dump agent db upgrade message to publish. Agent %s", wdb->id);
         }
 
         cJSON_Delete(j_msg_to_send);


### PR DESCRIPTION
|Related issue|
|---|
|#17901|

This PR aims to add a layer of normalization under the events triggered by the wazuh-db module.

### General
- All events have the json format (as wazuh-db use)
- All events have the action field, that specify the event type.
- All events have the agent_info field with the agent context.
- The data field depends on the nature of the event. For hotfixDelete, packageDelete is crucial, for upgradeAgentDB is context, and deleteAgent don't have this field.