### PR TITLE
Normalizing version and ID for indexed vulnerabilities

### DIFF
--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -429,6 +429,27 @@ namespace Utils
             return -1;
         }
     }
+    /**
+     * @brief Add size padding to a string.
+     *
+     * @param str Original string.
+     * @param padCharacter Character to use for padding.
+     * @param minSize Minimum size of the string.
+     * @return std::string Padded string.
+     */
+    static std::string padString(const std::string& str, const char padCharacter, const int64_t minSize)
+    {
+        std::string out;
+        const auto strLength = minSize - static_cast<int64_t>(str.length());
+
+        for (auto i = 0ll; i < strLength; ++i)
+        {
+            out += padCharacter;
+        }
+        out += str;
+        return out;
+    }
+
 } // namespace Utils
 
 #pragma GCC diagnostic pop

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -19,35 +19,35 @@ void StringUtilsTest::TearDown() {};
 
 TEST_F(StringUtilsTest, CheckReplacement)
 {
-    std::string string_base { "hello_world" };
-    const auto retVal { Utils::replaceAll(string_base, "hello_", "bye_") };
+    std::string string_base {"hello_world"};
+    const auto retVal {Utils::replaceAll(string_base, "hello_", "bye_")};
     EXPECT_EQ(string_base, "bye_world");
     EXPECT_TRUE(retVal);
 }
 
 TEST_F(StringUtilsTest, CheckNotReplacement)
 {
-    std::string string_base {"hello_world" };
-    const auto retVal { Utils::replaceAll(string_base, "nothing_", "bye_") };
+    std::string string_base {"hello_world"};
+    const auto retVal {Utils::replaceAll(string_base, "nothing_", "bye_")};
     EXPECT_EQ(string_base, "hello_world");
     EXPECT_FALSE(retVal);
 }
 
 TEST_F(StringUtilsTest, SplitEmptyString)
 {
-    auto splitTextVector { Utils::split("", '.') };
+    auto splitTextVector {Utils::split("", '.')};
     EXPECT_EQ(0ull, splitTextVector.size());
 }
 
 TEST_F(StringUtilsTest, SplitDelimiterNoCoincidence)
 {
-    const auto splitTextVector { Utils::split("hello_world", '.') };
+    const auto splitTextVector {Utils::split("hello_world", '.')};
     EXPECT_EQ(1ull, splitTextVector.size());
 }
 
 TEST_F(StringUtilsTest, SplitDelimiterCoincidence)
 {
-    const auto splitTextVector { Utils::split("hello.world", '.') };
+    const auto splitTextVector {Utils::split("hello.world", '.')};
     EXPECT_EQ(2ull, splitTextVector.size());
     EXPECT_EQ(splitTextVector[0], "hello");
     EXPECT_EQ(splitTextVector[1], "world");
@@ -55,7 +55,7 @@ TEST_F(StringUtilsTest, SplitDelimiterCoincidence)
 
 TEST_F(StringUtilsTest, SplitIndex)
 {
-    const auto splitTextVector { Utils::splitIndex("hello.world", '.', 0) };
+    const auto splitTextVector {Utils::splitIndex("hello.world", '.', 0)};
     EXPECT_EQ(5ull, splitTextVector.size());
     EXPECT_EQ(splitTextVector, "hello");
 }
@@ -67,24 +67,25 @@ TEST_F(StringUtilsTest, SplitIndexRuntimeError)
 
 TEST_F(StringUtilsTest, AsciiToHexString)
 {
-    const std::vector<unsigned char> data{0x2d, 0x53, 0x3b, 0x9d, 0x9f, 0x0f, 0x06, 0xef, 0x4e, 0x3c, 0x23, 0xfd, 0x49, 0x6c, 0xfe, 0xb2, 0x78, 0x0e, 0xda, 0x7f};
-    const std::string expected { "2d533b9d9f0f06ef4e3c23fd496cfeb2780eda7f" };
+    const std::vector<unsigned char> data {0x2d, 0x53, 0x3b, 0x9d, 0x9f, 0x0f, 0x06, 0xef, 0x4e, 0x3c,
+                                           0x23, 0xfd, 0x49, 0x6c, 0xfe, 0xb2, 0x78, 0x0e, 0xda, 0x7f};
+    const std::string expected {"2d533b9d9f0f06ef4e3c23fd496cfeb2780eda7f"};
     const auto result {Utils::asciiToHex(data)};
     EXPECT_EQ(expected, result);
 }
 
 TEST_F(StringUtilsTest, CheckFirstReplacement)
 {
-    std::string string_base { "bye_bye" };
-    const auto retVal { Utils::replaceFirst(string_base, "bye", "hello") };
+    std::string string_base {"bye_bye"};
+    const auto retVal {Utils::replaceFirst(string_base, "bye", "hello")};
     EXPECT_EQ(string_base, "hello_bye");
     EXPECT_TRUE(retVal);
 }
 
 TEST_F(StringUtilsTest, CheckNotFirstReplacement)
 {
-    std::string string_base {"hello_world" };
-    const auto retVal { Utils::replaceFirst(string_base, "nothing_", "bye_") };
+    std::string string_base {"hello_world"};
+    const auto retVal {Utils::replaceFirst(string_base, "nothing_", "bye_")};
     EXPECT_EQ(string_base, "hello_world");
     EXPECT_FALSE(retVal);
 }
@@ -102,7 +103,6 @@ TEST_F(StringUtilsTest, RightTrim)
     EXPECT_EQ("", Utils::rightTrim(""));
     EXPECT_EQ("", Utils::rightTrim(" "));
     EXPECT_EQ("", Utils::rightTrim("           "));
-
 }
 
 TEST_F(StringUtilsTest, LeftTrim)
@@ -157,11 +157,12 @@ TEST_F(StringUtilsTest, ToSentenceCase)
 
 TEST_F(StringUtilsTest, StartsWith)
 {
-    const std::string start{"Package_"};
-    const std::string item1{"Package_6_for_KB4565554~31bf3856ad364e35~amd64~~18362.957.1.3"};
-    const std::string item2{"Package_5_for_KB4569073~31bf3856ad364e35~amd64~~18362.1012.1.1"};
-    const std::string item3{"Microsoft-Windows-IIS-WebServer-AddOn-Package~31bf3856ad364e35~amd64~~10.0.18362.815"};
-    const std::string item4{"Microsoft-Windows-HyperV-OptionalFeature-VirtualMachinePlatform-Package_31bf3856ad364e35~amd64~~10.0.18362.1139.mum"};
+    const std::string start {"Package_"};
+    const std::string item1 {"Package_6_for_KB4565554~31bf3856ad364e35~amd64~~18362.957.1.3"};
+    const std::string item2 {"Package_5_for_KB4569073~31bf3856ad364e35~amd64~~18362.1012.1.1"};
+    const std::string item3 {"Microsoft-Windows-IIS-WebServer-AddOn-Package~31bf3856ad364e35~amd64~~10.0.18362.815"};
+    const std::string item4 {"Microsoft-Windows-HyperV-OptionalFeature-VirtualMachinePlatform-Package_31bf3856ad364e35~"
+                             "amd64~~10.0.18362.1139.mum"};
     EXPECT_TRUE(Utils::startsWith(start, start));
     EXPECT_TRUE(Utils::startsWith(item1, start));
     EXPECT_TRUE(Utils::startsWith(item2, start));
@@ -172,11 +173,12 @@ TEST_F(StringUtilsTest, StartsWith)
 
 TEST_F(StringUtilsTest, EndsWith)
 {
-    const std::string end{"_package"};
-    const std::string item1{"KB4565554~31bf3856ad364e35~amd64~~18362.957.1.3_package"};
-    const std::string item2{"KB4569073~31bf3856ad364e35~amd64~~18362.1012.1.1_package"};
-    const std::string item3{"Microsoft-Windows-IIS-WebServer-AddOn-Package~31bf3856ad364e35~amd64~~10.0.18362.815"};
-    const std::string item4{"Microsoft-Windows-HyperV-OptionalFeature-VirtualMachinePlatform-Package_31bf3856ad364e35~amd64~~10.0.18362.1139.mum"};
+    const std::string end {"_package"};
+    const std::string item1 {"KB4565554~31bf3856ad364e35~amd64~~18362.957.1.3_package"};
+    const std::string item2 {"KB4569073~31bf3856ad364e35~amd64~~18362.1012.1.1_package"};
+    const std::string item3 {"Microsoft-Windows-IIS-WebServer-AddOn-Package~31bf3856ad364e35~amd64~~10.0.18362.815"};
+    const std::string item4 {"Microsoft-Windows-HyperV-OptionalFeature-VirtualMachinePlatform-Package_31bf3856ad364e35~"
+                             "amd64~~10.0.18362.1139.mum"};
     EXPECT_TRUE(Utils::endsWith(end, end));
     EXPECT_TRUE(Utils::endsWith(item1, end));
     EXPECT_TRUE(Utils::endsWith(item2, end));
@@ -188,7 +190,7 @@ TEST_F(StringUtilsTest, EndsWith)
 TEST_F(StringUtilsTest, SplitDelimiterNullTerminated)
 {
     const char buffer[] {'h', 'e', 'l', 'l', 'o', '\0', 'w', 'o', 'r', 'l', 'd', '\0', '\0'};
-    const auto tokens{Utils::splitNullTerminatedStrings(buffer)};
+    const auto tokens {Utils::splitNullTerminatedStrings(buffer)};
     EXPECT_EQ(2ull, tokens.size());
     EXPECT_EQ(tokens[0], "hello");
     EXPECT_EQ(tokens[1], "world");
@@ -251,8 +253,8 @@ UBUNTU_CODENAME=jammy\n");
 
 TEST_F(StringUtilsTest, CheckMultiReplacement)
 {
-    std::string string_base { "hello         world" };
-    const auto retVal { Utils::replaceAll(string_base, "  ", " ") };
+    std::string string_base {"hello         world"};
+    const auto retVal {Utils::replaceAll(string_base, "  ", " ")};
     EXPECT_EQ(string_base, "hello world");
     EXPECT_TRUE(retVal);
 }
@@ -294,56 +296,56 @@ TEST_F(StringUtilsTest, substrOnFirstOccurrenceCorrectEscapeCharacterEmptyResult
 
 TEST_F(StringUtilsTest, splitKeyValueNonEscapedSimple)
 {
-    std::string stringBase { "hello:world" };
-    const auto retVal { Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\') };
+    std::string stringBase {"hello:world"};
+    const auto retVal {Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\')};
     EXPECT_EQ(retVal.first, "hello");
     EXPECT_EQ(retVal.second, "world");
 }
 
 TEST_F(StringUtilsTest, splitKeyValueNonEscapedSimpleEnd)
 {
-    std::string stringBase { "hello:" };
-    const auto retVal { Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\') };
+    std::string stringBase {"hello:"};
+    const auto retVal {Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\')};
     EXPECT_EQ(retVal.first, "hello");
     EXPECT_EQ(retVal.second, "");
 }
 
 TEST_F(StringUtilsTest, splitKeyValueNonEscapedSimpleDoubleDelimiterEnd)
 {
-    std::string stringBase { "hello:world:" };
-    const auto retVal { Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\') };
+    std::string stringBase {"hello:world:"};
+    const auto retVal {Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\')};
     EXPECT_EQ(retVal.first, "hello");
     EXPECT_EQ(retVal.second, "world:");
 }
 
 TEST_F(StringUtilsTest, splitKeyValueNonEscapedSimpleDoubleEnd)
 {
-    std::string stringBase { "hello::" };
-    const auto retVal { Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\') };
+    std::string stringBase {"hello::"};
+    const auto retVal {Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\')};
     EXPECT_EQ(retVal.first, "hello");
     EXPECT_EQ(retVal.second, ":");
 }
 
 TEST_F(StringUtilsTest, splitKeyValueNonEscapedSimpleEmptyDoubleEnd)
 {
-    std::string stringBase { "::" };
-    const auto retVal { Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\') };
+    std::string stringBase {"::"};
+    const auto retVal {Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\')};
     EXPECT_EQ(retVal.first, "");
     EXPECT_EQ(retVal.second, ":");
 }
 
 TEST_F(StringUtilsTest, splitKeyValueNonEscapedComplex)
 {
-    std::string stringBase { "he\\:llo:world" };
-    const auto retVal { Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\') };
+    std::string stringBase {"he\\:llo:world"};
+    const auto retVal {Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\')};
     EXPECT_EQ(retVal.first, "he\\:llo");
     EXPECT_EQ(retVal.second, "world");
 }
 
 TEST_F(StringUtilsTest, splitKeyValueNonEscapedComplexEnd)
 {
-    std::string stringBase { "he\\:llo:" };
-    const auto retVal { Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\') };
+    std::string stringBase {"he\\:llo:"};
+    const auto retVal {Utils::splitKeyValueNonEscapedDelimiter(stringBase, ':', '\\')};
     EXPECT_EQ(retVal.first, "he\\:llo");
     EXPECT_EQ(retVal.second, "");
 }
@@ -351,8 +353,8 @@ TEST_F(StringUtilsTest, splitKeyValueNonEscapedComplexEnd)
 TEST_F(StringUtilsTest, findRegexInStringNotStartWith)
 {
     std::string matchedValue;
-    const auto valueToCheck{"PREFIX Some random content"};
-    const auto regex{std::regex(R"(PREFIX Some random content)")};
+    const auto valueToCheck {"PREFIX Some random content"};
+    const auto regex {std::regex(R"(PREFIX Some random content)")};
     EXPECT_FALSE(Utils::findRegexInString(valueToCheck, matchedValue, regex, 0, "OTHERPREFIX"));
     EXPECT_TRUE(matchedValue.empty());
 }
@@ -360,8 +362,8 @@ TEST_F(StringUtilsTest, findRegexInStringNotStartWith)
 TEST_F(StringUtilsTest, findRegexInStringStartWith)
 {
     std::string matchedValue;
-    const auto valueToCheck{"PREFIX Some random content"};
-    const auto regex{std::regex(R"(PREFIX Some random content)")};
+    const auto valueToCheck {"PREFIX Some random content"};
+    const auto regex {std::regex(R"(PREFIX Some random content)")};
     EXPECT_TRUE(Utils::findRegexInString(valueToCheck, matchedValue, regex, 0, "PREFIX"));
     EXPECT_EQ(matchedValue, valueToCheck);
 }
@@ -369,8 +371,8 @@ TEST_F(StringUtilsTest, findRegexInStringStartWith)
 TEST_F(StringUtilsTest, findRegexInStringMatchingRegexWithoutGroup)
 {
     std::string matchedValue;
-    const auto valueToCheck{"This string should not be extracted"};
-    const auto regex{std::regex(R"(^This string should not be extracted$)")};
+    const auto valueToCheck {"This string should not be extracted"};
+    const auto regex {std::regex(R"(^This string should not be extracted$)")};
     EXPECT_TRUE(Utils::findRegexInString(valueToCheck, matchedValue, regex));
     EXPECT_EQ(matchedValue, valueToCheck);
 }
@@ -378,8 +380,8 @@ TEST_F(StringUtilsTest, findRegexInStringMatchingRegexWithoutGroup)
 TEST_F(StringUtilsTest, findRegexInStringNoExtractingFirstGroup)
 {
     std::string matchedValue;
-    const auto valueToCheck{"This string should be extracted"};
-    const auto regex{std::regex(R"(^This (\S+) should be (\S+)$)")};
+    const auto valueToCheck {"This string should be extracted"};
+    const auto regex {std::regex(R"(^This (\S+) should be (\S+)$)")};
     EXPECT_TRUE(Utils::findRegexInString(valueToCheck, matchedValue, regex));
     EXPECT_EQ(matchedValue, valueToCheck);
 }
@@ -387,8 +389,8 @@ TEST_F(StringUtilsTest, findRegexInStringNoExtractingFirstGroup)
 TEST_F(StringUtilsTest, findRegexInStringExtractingFirstGroup)
 {
     std::string matchedValue;
-    const auto valueToCheck{"This string should be extracted"};
-    const auto regex{std::regex(R"(^This (\S+) should be (\S+)$)")};
+    const auto valueToCheck {"This string should be extracted"};
+    const auto regex {std::regex(R"(^This (\S+) should be (\S+)$)")};
     EXPECT_TRUE(Utils::findRegexInString(valueToCheck, matchedValue, regex, 1));
     EXPECT_EQ(matchedValue, "string");
 }
@@ -396,15 +398,15 @@ TEST_F(StringUtilsTest, findRegexInStringExtractingFirstGroup)
 TEST_F(StringUtilsTest, findRegexInStringExtractingSecondGroup)
 {
     std::string matchedValue;
-    const auto valueToCheck{"This string should be extracted"};
-    const auto regex{std::regex(R"(^This (\S+) should be (\S+)$)")};
+    const auto valueToCheck {"This string should be extracted"};
+    const auto regex {std::regex(R"(^This (\S+) should be (\S+)$)")};
     EXPECT_TRUE(Utils::findRegexInString(valueToCheck, matchedValue, regex, 2));
     EXPECT_EQ(matchedValue, "extracted");
 }
 
 TEST_F(StringUtilsTest, convertToUTF8NoChanges)
 {
-    std::string noUnicodeString{"This is a test"};
+    std::string noUnicodeString {"This is a test"};
     Utils::ISO8859ToUTF8(noUnicodeString);
     EXPECT_EQ("This is a test", noUnicodeString);
 }
@@ -413,34 +415,33 @@ TEST_F(StringUtilsTest, rawUnicodeToUTF8)
 {
     std::stringstream fileContent;
     // Set buffer in ISO8859-1
-    fileContent <<
-                R"(CLASSES=none)"
-                R"(BASEDIR=/opt/csw)"
-                R"(INSTDATE=Jan 09 2023 14:35)"
-                R"(PKGSAV=/var/sadm/pkg/CSWschilybase/save)"
-                R"(PKGINST=CSWschilybase)"
-                R"(PSTAMP=joerg@unstable9x-20130619141117)"
-                R"(EMAIL=joerg@opencsw.org)"
-                R"(HOTLINE=http://www.opencsw.org/bugtrack/)"
-                R"(VENDOR=http://cdrecord.berlios.de/old/private/  packaged for CSW by J)" <<
-                "\xF6" <<
-                R"(rg Schilling)"
-                R"(CATEGORY=application)"
-                R"(NAME=schilybase - A collection of common files from J. Schilling)"
-                R"(PKG=CSWschilybase)"
-                R"(VERSION=1.01,REV=2013.06.19)"
-                R"(ARCH=i386)"
-                R"(OAMBASE=/usr/sadm/sysadm)"
-                R"(PATH=/sbin:/usr/sbin:/usr/bin:/usr/sadm/install/bin)"
-                R"(TZ=localtime)"
-                R"(LANG=C)"
-                R"(LC_ALL=)"
-                R"(LC_MONETARY=)"
-                R"(LC_MESSAGES=)"
-                R"(LC_COLLATE=)"
-                R"(LC_TIME=)"
-                R"(LC_NUMERIC=)"
-                R"(LC_CTYPE=)";
+    fileContent << R"(CLASSES=none)"
+                   R"(BASEDIR=/opt/csw)"
+                   R"(INSTDATE=Jan 09 2023 14:35)"
+                   R"(PKGSAV=/var/sadm/pkg/CSWschilybase/save)"
+                   R"(PKGINST=CSWschilybase)"
+                   R"(PSTAMP=joerg@unstable9x-20130619141117)"
+                   R"(EMAIL=joerg@opencsw.org)"
+                   R"(HOTLINE=http://www.opencsw.org/bugtrack/)"
+                   R"(VENDOR=http://cdrecord.berlios.de/old/private/  packaged for CSW by J)"
+                << "\xF6"
+                << R"(rg Schilling)"
+                   R"(CATEGORY=application)"
+                   R"(NAME=schilybase - A collection of common files from J. Schilling)"
+                   R"(PKG=CSWschilybase)"
+                   R"(VERSION=1.01,REV=2013.06.19)"
+                   R"(ARCH=i386)"
+                   R"(OAMBASE=/usr/sadm/sysadm)"
+                   R"(PATH=/sbin:/usr/sbin:/usr/bin:/usr/sadm/install/bin)"
+                   R"(TZ=localtime)"
+                   R"(LANG=C)"
+                   R"(LC_ALL=)"
+                   R"(LC_MONETARY=)"
+                   R"(LC_MESSAGES=)"
+                   R"(LC_COLLATE=)"
+                   R"(LC_TIME=)"
+                   R"(LC_NUMERIC=)"
+                   R"(LC_CTYPE=)";
 
     std::string content;
 
@@ -512,42 +513,42 @@ TEST_F(StringUtilsTest, parseStrToBoolNo)
 
 TEST_F(StringUtilsTest, parseStrToBoolSarasa)
 {
-    EXPECT_THROW(Utils::parseStrToBool("Sarasa"),std::runtime_error);
+    EXPECT_THROW(Utils::parseStrToBool("Sarasa"), std::runtime_error);
 }
 
 TEST_F(StringUtilsTest, parseStrToTimeEmpty)
 {
-  EXPECT_EQ(Utils::parseStrToTime("1"),1);
+    EXPECT_EQ(Utils::parseStrToTime("1"), 1);
 }
 
-TEST_F(StringUtilsTest,parseStrToTimeOneSec)
+TEST_F(StringUtilsTest, parseStrToTimeOneSec)
 {
-  EXPECT_EQ(Utils::parseStrToTime("1s"),1);
+    EXPECT_EQ(Utils::parseStrToTime("1s"), 1);
 }
 
-TEST_F(StringUtilsTest,parseStrToTimeOneMin)
+TEST_F(StringUtilsTest, parseStrToTimeOneMin)
 {
-  EXPECT_EQ(Utils::parseStrToTime("1m"),60);
+    EXPECT_EQ(Utils::parseStrToTime("1m"), 60);
 }
 
-TEST_F(StringUtilsTest,parseStrToTimeOneHour)
+TEST_F(StringUtilsTest, parseStrToTimeOneHour)
 {
-  EXPECT_EQ(Utils::parseStrToTime("1h"),3600);
+    EXPECT_EQ(Utils::parseStrToTime("1h"), 3600);
 }
 
-TEST_F(StringUtilsTest,parseStrToTimeOneDay)
+TEST_F(StringUtilsTest, parseStrToTimeOneDay)
 {
-  EXPECT_EQ(Utils::parseStrToTime("1d"),86400);
+    EXPECT_EQ(Utils::parseStrToTime("1d"), 86400);
 }
 
-TEST_F(StringUtilsTest,parseStrToTimeOneWeek)
+TEST_F(StringUtilsTest, parseStrToTimeOneWeek)
 {
-  EXPECT_EQ(Utils::parseStrToTime("1w"),604800);
+    EXPECT_EQ(Utils::parseStrToTime("1w"), 604800);
 }
 
-TEST_F(StringUtilsTest,parseStrToTimeOneSarasa)
+TEST_F(StringUtilsTest, parseStrToTimeOneSarasa)
 {
-  EXPECT_EQ(Utils::parseStrToTime("1invalid"),-1);
+    EXPECT_EQ(Utils::parseStrToTime("1invalid"), -1);
 }
 
 /*
@@ -564,7 +565,7 @@ TEST_F(StringUtilsTest, IsAlphaNumericWithSpecialCharacters)
     const std::string stringBase2 {"r4nd0mS7r1n6"};
     const std::string stringBase3 {"random-_-string"};
     const std::string stringBase4 {"random*string"};
-    const std::string stringBase5 {""};
+    const std::string stringBase5;
     EXPECT_TRUE(Utils::isAlphaNumericWithSpecialCharacters(stringBase1, "_"));
     EXPECT_TRUE(Utils::isAlphaNumericWithSpecialCharacters(stringBase1, "__"));
     EXPECT_TRUE(Utils::isAlphaNumericWithSpecialCharacters(stringBase2, ""));
@@ -572,3 +573,12 @@ TEST_F(StringUtilsTest, IsAlphaNumericWithSpecialCharacters)
     EXPECT_TRUE(Utils::isAlphaNumericWithSpecialCharacters(stringBase4, "*"));
     EXPECT_FALSE(Utils::isAlphaNumericWithSpecialCharacters(stringBase5, "-_*"));
 }
+
+TEST_F(StringUtilsTest, padString)
+{
+    EXPECT_EQ(Utils::padString("test", '0', 10), "000000test");
+    EXPECT_EQ(Utils::padString("test", '0', 2), "test");
+    EXPECT_EQ(Utils::padString("test", '0', 4), "test");
+    EXPECT_EQ(Utils::padString("", '0', 4), "0000");
+}
+

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/queryAllPackages.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/queryAllPackages.hpp
@@ -75,6 +75,9 @@ public:
             // Validate the response
             if (!response.empty())
             {
+                // The global.db stores the agent version with the prefix "Wazuh " when the keepalive is parsed
+                std::string normalizedAgentVersion = Utils::leftTrim(data->agentVersion(), "Wazuh ");
+
                 for (auto package : response)
                 {
                     flatbuffers::FlatBufferBuilder fbBuilder;
@@ -83,7 +86,7 @@ public:
                                                                            idAgent.c_str(),
                                                                            std::string(data->agentIp()).c_str(),
                                                                            std::string(data->agentName()).c_str(),
-                                                                           std::string(data->agentVersion()).c_str(),
+                                                                           std::string(normalizedAgentVersion).c_str(),
                                                                            std::string(data->agentNodeName()).c_str());
                     auto syscollectorPackage = SyscollectorSynchronization::Createsyscollector_packagesDirect(
                         fbBuilder,

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/queryAllPackages.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/queryAllPackages.hpp
@@ -76,9 +76,9 @@ public:
             if (!response.empty())
             {
                 // The global.db stores the agent version with the prefix "Wazuh " when the keepalive is parsed
-                std::string normalizedAgentVersion = Utils::leftTrim(data->agentVersion(), "Wazuh ");
+                std::string normalizedAgentVersion = Utils::leftTrim(data->agentVersion().data(), "Wazuh ");
 
-                for (auto package : response)
+                for (const auto& package : response)
                 {
                     flatbuffers::FlatBufferBuilder fbBuilder;
                     auto agentInfo =

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -780,13 +780,22 @@ public:
      */
     std::string_view agentId() const
     {
-        return extractData<std::string_view>(
-            [](const SyscollectorDeltas::Delta* delta)
-            { return delta->agent_info()->agent_id() ? delta->agent_info()->agent_id()->c_str() : ""; },
-            [](const SyscollectorSynchronization::SyncMsg* syncMsg)
-            { return syncMsg->agent_info()->agent_id() ? syncMsg->agent_info()->agent_id()->c_str() : ""; },
-            [](const nlohmann::json* message)
-            { return message->at("agent_info").at("agent_id").get_ref<const std::string&>(); });
+        if (m_agentId.empty())
+        {
+            m_agentId = Utils::padString(
+                extractData<std::string_view>(
+                    [](const SyscollectorDeltas::Delta* delta)
+                    { return delta->agent_info()->agent_id() ? delta->agent_info()->agent_id()->c_str() : ""; },
+                    [](const SyscollectorSynchronization::SyncMsg* syncMsg)
+                    { return syncMsg->agent_info()->agent_id() ? syncMsg->agent_info()->agent_id()->c_str() : ""; },
+                    [](const nlohmann::json* message)
+                    { return message->at("agent_info").at("agent_id").get_ref<const std::string&>(); })
+                    .data(),
+                '0',
+                3);
+        }
+
+        return m_agentId;
     }
 
     /**
@@ -1061,6 +1070,12 @@ private:
      *
      */
     Os m_osData {};
+
+    /**
+     * @brief Agent id.
+     *
+     */
+    mutable std::string m_agentId;
 };
 
 using ScanContext = TScanContext<>;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21744|


## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR:
- Removes the `Wazuh ` word if found from the version collected from the `global.db`
- Unifies the agent ID format to make the string and integer representation equal


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

**Manual tests**
In progress

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Source installation

- [ ] Added unit tests (for new features)
