### PR TITLE
Implementing agent deletion orchestration

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
@@ -109,6 +109,8 @@ public:
                 orchestration->setNext(std::make_shared<TQueryAllPackages>(subOrchestration));
                 break;
 
+            case ScannerType::CleanupAgentData: break;
+
             default: throw std::runtime_error("Invalid scanner type");
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
@@ -73,7 +73,7 @@ public:
                     json["id"] = elementKey;
                     data->m_elements[elementKey] = std::move(json);
                 }
-                logDebug2(WM_VULNSCAN_LOGTAG, "Deleting all agent packages key: %s", dbQuery.first.c_str());
+                logDebug2(WM_VULNSCAN_LOGTAG, "Deleting all agent vulnerabilities key: %s", dbQuery.first.c_str());
                 m_inventoryDatabase.delete_(dbQuery.first);
             }
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -46,6 +46,7 @@ enum class ScannerType
     ReScanAllAgents = 7,
     ReScanSingleAgent = 8,
     CleanupAllData = 9,
+    CleanupAgentData = 10,
 };
 
 enum class OperationType
@@ -55,7 +56,7 @@ enum class OperationType
     InsertAll = 2,
     Delete = 3,
     DeleteAll = 4,
-    SingleDeleteAndInsert = 5,
+    SingleDeleteAndInsert = 5
 };
 
 const static std::map<std::string, std::string> OS_CPE_MAP {
@@ -463,6 +464,13 @@ public:
                         {
                             m_type = ScannerType::HotfixDelete;
                             m_operationType = OperationType::Delete;
+                            m_messageType = MessageType::DataJSON;
+                        }
+                        // This is used to trigger a delete of all data for a single agent, used if a agent is removed.
+                        else if (actionValue == "deleteAgent")
+                        {
+                            m_type = ScannerType::CleanupAgentData;
+                            m_operationType = OperationType::DeleteAll;
                             m_messageType = MessageType::DataJSON;
                         }
                         else

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -76,6 +76,8 @@ public:
                                                              inventoryDatabase,
                                                              reportDispatcher,
                                                              m_packageInsertOrchestration);
+        m_deleteAgentScanOrchestration = TFactoryOrchestrator::create(
+            ScannerType::CleanupAgentData, databaseFeedManager, indexerConnector, inventoryDatabase, reportDispatcher);
         m_cleanUpDataOrchestration = TFactoryOrchestrator::create(ScannerType::CleanupAllData,
                                                                   std::move(databaseFeedManager),
                                                                   std::move(indexerConnector),
@@ -112,6 +114,9 @@ public:
             case ScannerType::CleanupAllData: m_cleanUpDataOrchestration->handleRequest(std::move(context)); break;
             case ScannerType::ReScanAllAgents: m_reScanAllOrchestration->handleRequest(std::move(context)); break;
             case ScannerType::ReScanSingleAgent: m_reScanOrchestration->handleRequest(std::move(context)); break;
+            case ScannerType::CleanupAgentData:
+                m_deleteAgentScanOrchestration->handleRequest(std::move(context));
+                break;
             default: break;
         }
     }
@@ -133,6 +138,7 @@ private:
     std::shared_ptr<TOrchestrationNode> m_reScanAllOrchestration;
     std::shared_ptr<TOrchestrationNode> m_reScanOrchestration;
     std::shared_ptr<TOrchestrationNode> m_cleanUpDataOrchestration;
+    std::shared_ptr<TOrchestrationNode> m_deleteAgentScanOrchestration;
     std::shared_mutex& m_mutex;
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
@@ -237,6 +237,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsert)
         std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
     EXPECT_CALL(*spFetchAllGlobalDb, handleRequest(_)).Times(0);
 
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
+
     auto spCleanUpAllOrchestrationMock =
         std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
     EXPECT_CALL(*spCleanUpAllOrchestrationMock, handleRequest(_)).Times(0);
@@ -253,6 +257,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsert)
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
         .WillOnce(testing::Return(spFetchAllGlobalDb))
         .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
         .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -331,6 +336,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageDelete)
         std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
     EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
 
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
+
     spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
     EXPECT_CALL(*spFactoryOrchestratorMock, create())
         .WillOnce(testing::Return(spOsOrchestrationMock))
@@ -339,6 +348,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageDelete)
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
         .WillOnce(testing::Return(spFetchAllGlobalDb))
         .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
         .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -417,6 +427,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixInsert)
         std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
     EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
 
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
+
     spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
     EXPECT_CALL(*spFactoryOrchestratorMock, create())
         .WillOnce(testing::Return(spOsOrchestrationMock))
@@ -425,6 +439,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixInsert)
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
         .WillOnce(testing::Return(spFetchAllGlobalDb))
         .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
         .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -503,6 +518,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixDelete)
         std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
     EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
 
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
+
     spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
     EXPECT_CALL(*spFactoryOrchestratorMock, create())
         .WillOnce(testing::Return(spOsOrchestrationMock))
@@ -511,6 +530,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixDelete)
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
         .WillOnce(testing::Return(spFetchAllGlobalDb))
         .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
         .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -573,6 +593,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeOs)
         std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
     EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
 
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
+
     spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
     EXPECT_CALL(*spFactoryOrchestratorMock, create())
         .WillOnce(testing::Return(spOsOrchestrationMock))
@@ -581,6 +605,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeOs)
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
         .WillOnce(testing::Return(spFetchAllGlobalDb))
         .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
         .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
@@ -659,6 +684,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeIntegrityClear)
         std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
     EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
 
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
+
     spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
     EXPECT_CALL(*spFactoryOrchestratorMock, create())
         .WillOnce(testing::Return(spOsOrchestrationMock))
@@ -667,6 +696,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeIntegrityClear)
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
         .WillOnce(testing::Return(spFetchAllGlobalDb))
         .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
         .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();


### PR DESCRIPTION
|Related issue|
|---|
|#21921|

## Objective
This PR introduces a robust solution to the previously identified issue of a missing mechanism for the deletion of agents and their associated data. This new orchestration ensures that when a `deleteAgent` message is received, the system will securely and efficiently remove the specified agent and all its related data, enhancing the platform's manageability and security posture.

## Description
- Implemented a new orchestration chain that listens for `deleteAgent` messages, which are triggered under specific conditions outlined in PR #22006. Upon receiving such a message, this orchestration invokes the necessary processes to safely remove the targeted agent from the system along with any related data stored in the database, logs, and any other repositories where agent data may reside.
- Special attention was paid to ensuring that the deletion process is thorough, and secure, and leaves no residual data that could compromise privacy or system integrity. This includes the secure erasure of sensitive information and the verification of data deletion.
- The implementation also includes mechanisms for logging and auditing the deletion process, providing transparent oversight of when and how agent data is removed.

## Quality Assurance

### Static Analysis
- Conducted static code analysis to ensure the new orchestration adheres to coding standards and best practices, focusing on security and efficiency. The analysis helped refine the code for better performance and reliability.

### Testing

#### Unit Testing
N/A

#### Integration Testing

Steps to reproduce

- Clone this branch
- Compile with DEBUG mode
- Run this script in a terminal

```bash
BINARY="./src/build/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_scanner_testtool"
CONFIG="src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.json"
TEMPLATE="src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json"
INPUT_FILE="src/wazuh_modules/vulnerability_scanner/testtool/scanner/TC-001/step_0.json,src/wazuh_modules/vulnerability_scanner/testtool/scanner/TC-001/step_1.json"
FAKE_OS_DATA="src/wazuh_modules/vulnerability_scanner/testtool/scanner/fakeAgentData/agentOsData.json"
FAKE_GLOBAL_DATA="src/wazuh_modules/vulnerability_scanner/testtool/scanner/fakeGlobalData/globalData.json"
FAKE_PKGS_DATA="src/wazuh_modules/vulnerability_scanner/testtool/scanner/fakeAgentData/agentPkgsData.json"

# Check if the binary exists
if [[ ! -f ${BINARY} ]]; then
  echo "Error: Binary '${BINARY}' not found."
  exit 1
fi

# Execute the binary with the provided options
"${BINARY}" -c "${CONFIG}" -t "${TEMPLATE}" -i "${INPUT_FILE}" -r -b "${FAKE_OS_DATA}" -g "${FAKE_GLOBAL_DATA}" -p "${FAKE_PKGS_DATA}"
```
- Await until scan ends
- Open another terminal and run

```bash

BINARY_ROUTER="./src/build/shared_modules/router/testtool/router_test_tool"

MSG='{ "agent_info": { "agent_id": "000", "agent_version": "4.8.0", "agent_name": "test_agent_name", "agent_ip": "10.0.0.1", "node_name": "test_node_name" }, "action": "deleteAgent" }'

echo "$MSG" | "${BINARY_ROUTER}" -m publisher -t wdb-agent-events
```

- Check the delete operation

```text
wazuh-modulesd:vulnerability-scanner:inventorySync.hpp:76 handleRequest : Deleting all agent vulnerabilities key: test_node_name_000_040334345fd47ab6e72026cf3c45640456198fb4
wazuh-modulesd:vulnerability-scanner:resultIndexer.hpp:56 handleRequest : Processing and publish key: test_node_name_000_040334345fd47ab6e72026cf3c45640456198fb4_CVE-2022-1271
```